### PR TITLE
feat(sql): support negative index in array access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.log
 .idea
 .ignore
+CLAUDE.md
 out
 benchmarks/target
 core/target

--- a/core/src/main/java/io/questdb/cairo/arr/DerivedArrayView.java
+++ b/core/src/main/java/io/questdb/cairo/arr/DerivedArrayView.java
@@ -238,20 +238,13 @@ public class DerivedArrayView extends ArrayView {
      * (upper-exclusive), and the new index 0 corresponds to the previous index
      * {@code lo}.
      *
-     * @param dim    the dimension to slice
-     * @param lo     lower bound of the slice
-     * @param hi     upper bound of the slice (exclusive)
-     * @param argPos SQL syntax position where to report an error if needed
+     * @param dim the dimension to slice
+     * @param lo  lower bound of the slice
+     * @param hi  upper bound of the slice (exclusive)
      */
-    public void slice(int dim, int lo, int hi, int argPos) {
-        if (lo < 0 || hi < 0) {
-            throw new IllegalArgumentException("lo and hi must be non-negative");
-        }
-        if (dim < 0 || dim >= getDimCount()) {
-            throw CairoException.nonCritical().position(argPos)
-                    .put("array dimension doesn't exist [dim=").put(dim + 1)
-                    .put(", nDims=").put(getDimCount()).put(']');
-        }
+    public void slice(int dim, int lo, int hi) {
+        assert lo >= 0 && hi >= 0 : "lo and hi must be non-negative";
+
         int dimLen = getDimLen(dim);
         if (hi > dimLen) {
             hi = dimLen;
@@ -284,12 +277,11 @@ public class DerivedArrayView extends ArrayView {
      * array at dimension {@code dim} that contains just the provided {@code index},
      * and then removing the dimension {@code dim} from the array's shape.
      *
-     * @param dim    the dimension at which the sub-array is found
-     * @param index  the index of the sub-array within that dimension
-     * @param argPos the SQL syntax position to report an error if needed
+     * @param dim   the dimension at which the sub-array is found
+     * @param index the index of the sub-array within that dimension
      */
-    public void subArray(int dim, int index, int argPos) {
-        slice(dim, index, index + 1, argPos);
+    public void subArray(int dim, int index) {
+        slice(dim, index, index + 1);
         if (getDimLen(dim) != 0) {
             removeDim(dim);
         } else {

--- a/core/src/main/java/io/questdb/cairo/arr/DerivedArrayView.java
+++ b/core/src/main/java/io/questdb/cairo/arr/DerivedArrayView.java
@@ -244,6 +244,9 @@ public class DerivedArrayView extends ArrayView {
      * @param argPos SQL syntax position where to report an error if needed
      */
     public void slice(int dim, int lo, int hi, int argPos) {
+        if (lo < 0 || hi < 0) {
+            throw new IllegalArgumentException("lo and hi must be non-negative");
+        }
         if (dim < 0 || dim >= getDimCount()) {
             throw CairoException.nonCritical().position(argPos)
                     .put("array dimension doesn't exist [dim=").put(dim + 1)
@@ -252,17 +255,6 @@ public class DerivedArrayView extends ArrayView {
         int dimLen = getDimLen(dim);
         if (hi > dimLen) {
             hi = dimLen;
-        }
-        if (lo < 0 || hi < 0) {
-            // Report bounds + 1 because that's what the user entered, the caller subtracted 1
-            // to align with Postgres' 1-based array indexing
-            throw CairoException.nonCritical()
-                    .position(argPos)
-                    .put("array slice bounds must be positive [dim=").put(dim + 1)
-                    .put(", dimLen=").put(dimLen)
-                    .put(", lowerBound=").put(lo + 1)
-                    .put(", upperBound=").put(hi + 1)
-                    .put(']');
         }
         if (lo == 0 && hi == dimLen) {
             return;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/array/DoubleArrayAccessFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/array/DoubleArrayAccessFunctionFactory.java
@@ -410,6 +410,7 @@ public class DoubleArrayAccessFunctionFactory implements FunctionFactory {
             if (indexLong == Long.MAX_VALUE) {
                 return Integer.MAX_VALUE;
             }
+            // the "a:b" operator only accepts INT, guaranteeing narrowing cast success
             int index = (int) indexLong;
             assert index == indexLong : "int overflow on interval " + boundName + " bound: " + indexLong;
             if (index < 0) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/array/DoubleArrayAccessFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/array/DoubleArrayAccessFunctionFactory.java
@@ -102,8 +102,8 @@ public class DoubleArrayAccessFunctionFactory implements FunctionFactory {
         if (nArgs > nDims) {
             throw SqlException
                     .position(argPositionsCopy.get(nDims + 1))
-                    .put("too many array access arguments [nArgs=").put(nArgs)
-                    .put(", nDims=").put(nDims)
+                    .put("too many array access arguments [nDims=").put(nDims)
+                    .put(", nArgs=").put(nArgs)
                     .put(']');
         }
         int resultNDims = nDims;
@@ -385,7 +385,7 @@ public class DoubleArrayAccessFunctionFactory implements FunctionFactory {
 
                     // Decrement the index in the argument because Postgres uses 1-based array indexing
                     lo--;
-                    derivedArray.slice(dim++, lo, hi, argPos);
+                    derivedArray.slice(dim++, lo, hi);
                 } else {
                     // Decrement the index in the argument because Postgres uses 1-based array indexing
                     int index = rangeFn.getInt(rec) - 1;
@@ -397,7 +397,7 @@ public class DoubleArrayAccessFunctionFactory implements FunctionFactory {
                                 .put(", dimLen=").put(dimLen)
                                 .put(']');
                     }
-                    derivedArray.subArray(dim, index, argPos);
+                    derivedArray.subArray(dim, index);
                     if (derivedArray.isNull()) {
                         return derivedArray;
                     }

--- a/core/src/test/java/io/questdb/test/cairo/ArrayTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/ArrayTest.java
@@ -148,13 +148,21 @@ public class ArrayTest extends AbstractCairoTest {
             assertExceptionNoLeakCheck("SELECT arr1[1, true] FROM tango",
                     15, "invalid type for array access [type=1]");
             assertExceptionNoLeakCheck("SELECT arr1[1, 1, 1] FROM tango",
-                    18, "too many array access arguments [nArgs=3, nDims=2]");
+                    18, "too many array access arguments [nDims=2, nArgs=3]");
+            assertExceptionNoLeakCheck("SELECT arr1[0] FROM tango",
+                    12, "array index must be positive [dim=1, index=0]");
             assertExceptionNoLeakCheck("SELECT arr1[0, 1] FROM tango",
                     12, "array index must be positive [dim=1, index=0]");
             assertExceptionNoLeakCheck("SELECT arr1[1:2, 0] FROM tango",
                     17, "array index must be positive [dim=2, index=0]");
             assertExceptionNoLeakCheck("SELECT arr1[1, 0] FROM tango",
                     15, "array index must be positive [dim=2, index=0]");
+            assertExceptionNoLeakCheck("SELECT arr1[1, 1, 1] FROM tango",
+                    18, "too many array access arguments [nDims=2, nArgs=3]");
+            assertExceptionNoLeakCheck("SELECT arr1[1][1, 1] FROM tango",
+                    18, "too many array access arguments [nDims=2, nArgs=3]");
+            assertExceptionNoLeakCheck("SELECT arr1[1][1][1] FROM tango",
+                    17, "there is no matching function `[]` with the argument types: (DOUBLE, INT)");
             assertExceptionNoLeakCheck("SELECT arr1[1, arr2[1]::int] FROM tango",
                     22, "array index must be positive [dim=2, index=-1, dimLen=2]");
             assertExceptionNoLeakCheck("SELECT arr1[1:2][arr2[1]::int] FROM tango",
@@ -2493,6 +2501,9 @@ public class ArrayTest extends AbstractCairoTest {
             assertExceptionNoLeakCheck("SELECT arr[1:0] FROM tango",
                     12, "upper bound for array slicing must be non-zero [dim=1, upperBound=0]"
             );
+            assertExceptionNoLeakCheck("SELECT arr[1:2, 1:2, 1:2] FROM tango",
+                    22, "too many array access arguments [nDims=2, nArgs=3]"
+            );
             assertExceptionNoLeakCheck("SELECT arr[1:(arr[1, 1] - 1)::int] FROM tango",
                     12, "upper bound for array slicing must be non-zero [dim=1, upperBound=0]"
             );
@@ -2565,19 +2576,6 @@ public class ArrayTest extends AbstractCairoTest {
                             "    PageFrame\n" +
                             "        Row forward scan\n" +
                             "        Frame forward scan on: tango\n"
-            );
-        });
-    }
-
-    @Test
-    public void testSubArrayInvalid() throws Exception {
-        assertMemoryLeak(() -> {
-            execute("CREATE TABLE tango AS (SELECT ARRAY[[[1.0, 2], [3.0, 4]], [[5.0, 6], [7.0, 8]]] arr FROM long_sequence(1))");
-            assertExceptionNoLeakCheck("SELECT arr[0] FROM tango",
-                    11, "array index must be positive [dim=1, index=0]"
-            );
-            assertExceptionNoLeakCheck("SELECT arr[1, 0] FROM tango",
-                    14, "array index must be positive [dim=2, index=0]"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/cairo/ArrayTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/ArrayTest.java
@@ -230,7 +230,7 @@ public class ArrayTest extends AbstractCairoTest {
             assertSql("x\n[]\n", "SELECT arr[3:3] x FROM tango");
             assertSql("x\n[]\n", "SELECT arr[3:5] x FROM tango");
             assertSql("x\n[]\n", "SELECT arr[3:-5] x FROM tango");
-//            assertSql("x\n[]\n", "SELECT arr[-3:3] x FROM tango");
+            assertSql("x\n[]\n", "SELECT arr[-1:-2] x FROM tango");
 
             assertSql("x\n[]\n", "SELECT arr[1, 1:1] x FROM tango");
             assertSql("x\n[]\n", "SELECT arr[1, 2:1] x FROM tango");

--- a/core/src/test/java/io/questdb/test/cairo/ArrayTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/ArrayTest.java
@@ -153,6 +153,12 @@ public class ArrayTest extends AbstractCairoTest {
                     12, "array index must be non-zero [dim=1, index=0]");
             assertExceptionNoLeakCheck("SELECT arr1[0, 1] FROM tango",
                     12, "array index must be non-zero [dim=1, index=0]");
+            assertExceptionNoLeakCheck("SELECT arr1[1:999_999_999_999] FROM tango",
+                    13, "there is no matching operator `:` with the argument types: INT : LONG");
+            assertExceptionNoLeakCheck("SELECT arr1[999_999_999_999:1] FROM tango",
+                    27, "there is no matching operator `:` with the argument types: LONG : INT");
+            assertExceptionNoLeakCheck("SELECT arr1[999_999_999_999:999_999_999_999] FROM tango",
+                    27, "there is no matching operator `:` with the argument types: LONG : LONG");
             assertExceptionNoLeakCheck("SELECT arr1[1:2, 0] FROM tango",
                     17, "array index must be non-zero [dim=2, index=0]");
             assertExceptionNoLeakCheck("SELECT arr1[1, 0] FROM tango",

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -6949,6 +6949,7 @@ nodejs code:
                     Assert.assertEquals(2489.1431526879937, sum, 0.00000001);
                 },
                 () -> {
+                    staticOverrides.setProperty(PropertyKey.CAIRO_WAL_APPLY_ENABLED, "false");
                     sendBufferSize = Math.max(sendBufferSize, 2048);
                     recvBufferSize = Math.max(recvBufferSize, 5000);
                 }
@@ -7000,7 +7001,7 @@ nodejs code:
                             "where isym = ? and type = 'X' latest on ts partition by isym" +
                             ") where stat='Y'"
             );
-        });
+        }, () -> staticOverrides.setProperty(PropertyKey.CAIRO_WAL_APPLY_ENABLED, "false"));
     }
 
     @Test
@@ -7213,7 +7214,7 @@ nodejs code:
                     );
                 }
             }
-        });
+        }, () -> staticOverrides.setProperty(PropertyKey.CAIRO_WAL_APPLY_ENABLED, "false"));
     }
 
     @Test
@@ -7980,7 +7981,6 @@ nodejs code:
     @Test
     public void testPreparedStatementInsertSelectNullDesignatedColumn() throws Exception {
         skipOnWalRun();
-        final AtomicInteger count = new AtomicInteger();
         assertWithPgServer(CONN_AWARE_ALL, (connection, binary, mode, port) -> {
             {
                 try (
@@ -8023,7 +8023,7 @@ nodejs code:
                     mayDrainWalQueue();
                 }
             }
-        });
+        }, () -> staticOverrides.setProperty(PropertyKey.CAIRO_WAL_APPLY_ENABLED, "false"));
     }
 
     @Test
@@ -8416,7 +8416,7 @@ nodejs code:
                     }
                 }
             }
-        });
+        }, () -> staticOverrides.setProperty(PropertyKey.CAIRO_WAL_APPLY_ENABLED, "false"));
     }
 
     @Test
@@ -8450,7 +8450,7 @@ nodejs code:
                 }
             }
             Assert.assertTrue("Exception is not thrown", caught);
-        });
+        }, () -> staticOverrides.setProperty(PropertyKey.CAIRO_WAL_APPLY_ENABLED, "false"));
     }
 
     @Test
@@ -8489,7 +8489,7 @@ nodejs code:
                 }
             }
             Assert.assertTrue("Exception is not thrown", caught);
-        });
+        }, () -> staticOverrides.setProperty(PropertyKey.CAIRO_WAL_APPLY_ENABLED, "false"));
     }
 
     @Test
@@ -8505,7 +8505,7 @@ nodejs code:
                     statement.execute();
                 }
             }
-        });
+        }, () -> staticOverrides.setProperty(PropertyKey.CAIRO_WAL_APPLY_ENABLED, "false"));
     }
 
     @Test
@@ -8530,7 +8530,7 @@ nodejs code:
             try (PreparedStatement statement = connection.prepareStatement("drop table xts")) {
                 statement.execute();
             }
-        });
+        }, () -> staticOverrides.setProperty(PropertyKey.CAIRO_WAL_APPLY_ENABLED, "false"));
     }
 
     @Test


### PR DESCRIPTION
Negative array index selects elements from the back, so -1 is the last element.

Given

```sql
CREATE TABLE tango (arr DOUBLE[]);
INSERT INTO tango VALUES (ARRAY[1.0, 2, 3, 4]);
```

These now work:

```
> SELECT arr[-1] FROM tango;
4.0
> SELECT arr[-2] FROM tango;
3.0
> SELECT arr[1:-1] FROM tango;
[1.0,2.0,3.0]
> SELECT arr[-2:5] FROM tango;
[3.0,4.0]
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array access and slicing to support 1-based and negative indices, aligning with Postgres-style behavior.
  * Enhanced error messages for invalid array access, including clearer handling of zero and out-of-bounds indices.
  * Fixed issues with index overflow and argument validation in array functions.

* **New Features**
  * Added support for negative and null indices in array access, allowing more flexible querying.

* **Tests**
  * Expanded test coverage for negative, null, and out-of-bounds array indices.
  * Updated and refined tests for array access, slicing, and supported data types.
  * Improved test configuration by disabling Cairo WAL apply in select database tests.

* **Chores**
  * Updated `.gitignore` to exclude additional files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->