### PR TITLE
chore(core): allow TableToken lookups by CharSequence

### DIFF
--- a/core/src/main/java/io/questdb/cairo/AbstractTableNameRegistry.java
+++ b/core/src/main/java/io/questdb/cairo/AbstractTableNameRegistry.java
@@ -57,7 +57,7 @@ public abstract class AbstractTableNameRegistry implements TableNameRegistry {
     }
 
     @Override
-    public TableToken getTableTokenByDirName(String dirName) {
+    public TableToken getTableTokenByDirName(CharSequence dirName) {
         ReverseTableMapItem rmi = dirNameToTableTokenMap.get(dirName);
         if (rmi != null && !rmi.isDropped()) {
             return rmi.getToken();

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -936,7 +936,7 @@ public class CairoEngine implements Closeable, WriterSource {
         return getTableStatus(Path.getThreadLocal(configuration.getDbRoot()), tableName);
     }
 
-    public TableToken getTableTokenByDirName(String dirName) {
+    public TableToken getTableTokenByDirName(CharSequence dirName) {
         return tableNameRegistry.getTableTokenByDirName(dirName);
     }
 

--- a/core/src/main/java/io/questdb/cairo/TableNameRegistry.java
+++ b/core/src/main/java/io/questdb/cairo/TableNameRegistry.java
@@ -80,7 +80,7 @@ public interface TableNameRegistry extends Closeable {
      * @param dirName directory name
      * @return resolves private table name to TableToken. If no token exists, returns null
      */
-    TableToken getTableTokenByDirName(String dirName);
+    TableToken getTableTokenByDirName(CharSequence dirName);
 
     /**
      * Returns total count of table tokens. Among live tables it can count dropped tables which are not fully deleted yet.


### PR DESCRIPTION
Relaxes the type for looking up `TableToken` objects from `String` to `CharSequence`.
This can avoid additional `.toString()` allocations in certain cases.

The changes here are non-breaking to Enterprise, but are required for the tandem PR 
 https://github.com/questdb/questdb-enterprise/pull/657