### PR TITLE
fix(core): incorrect year rounding in case of leap years

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/YearTimestampSampler.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/YearTimestampSampler.java
@@ -64,9 +64,10 @@ public class YearTimestampSampler implements TimestampSampler {
 
     @Override
     public long round(long value) {
-        final int y = Timestamps.getYear(value);
+        int y = Timestamps.getYear(value);
+        y = y - y % stepYears;
         return Timestamps.toMicros(
-                y - y % stepYears,
+                y,
                 Timestamps.isLeapYear(y),
                 startDay,
                 startMonth,

--- a/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/Timestamps.java
@@ -1300,7 +1300,7 @@ public final class Timestamps {
      * equivalent to parsing "2008-01-01T00:00:00.000Z", except this method is faster.
      *
      * @param year the year
-     * @param leap true if give year is leap year
+     * @param leap true if given year is leap year
      * @return millis for start of year.
      */
     public static long yearMicros(int year, boolean leap) {

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -3356,6 +3356,45 @@ public class MatViewTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testLargeSampleByInterval() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE Samples (" +
+                            "  Time TIMESTAMP," +
+                            "  DeviceId INT," +
+                            "  Register SYMBOL INDEX," +
+                            "  Value DOUBLE" +
+                            ") timestamp(Time) PARTITION BY MONTH WAL " +
+                            "DEDUP UPSERT KEYS(Time, DeviceId, Register);"
+            );
+            execute(
+                    "CREATE MATERIALIZED VIEW Samples_latest AS" +
+                            "  SELECT" +
+                            "    Time as UnixEpoch," +
+                            "    last(Time) AS Time," +
+                            "    DeviceId," +
+                            "    Register," +
+                            "    last(Value) AS Value" +
+                            "  FROM" +
+                            "    Samples" +
+                            "  SAMPLE BY 2y;"
+            );
+            execute("INSERT INTO Samples (Time, DeviceId, Register, Value) VALUES ('2025-08-08T12:57:07.388314Z', 1, 'hello', 123);");
+
+            drainQueues();
+
+            assertQueryNoLeakCheck(
+                    "UnixEpoch\tTime\tDeviceId\tRegister\tValue\n" +
+                            "2024-01-01T00:00:00.000000Z\t2025-08-08T12:57:07.388314Z\t1\thello\t123.0\n",
+                    "Samples_latest",
+                    "UnixEpoch",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testManualDeferredMatView() throws Exception {
         assertMemoryLeak(() -> {
             execute(

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/YearTimestampSamplerTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/YearTimestampSamplerTest.java
@@ -33,12 +33,27 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class YearTimestampSamplerTest {
+    private static final String FIXED_PART = "-11-16T15:00:00.000000Z\n";
 
-    public static final String FIXED_PART = "-11-16T15:00:00.000000Z\n";
+    @Test
+    public void testRound() throws NumericException {
+        testRound(1, "2023-01-01T00:00:00.000000Z", "2023-01-01T00:00:00.000000Z");
+        testRound(1, "2023-01-01T00:00:00.000001Z", "2023-01-01T00:00:00.000000Z");
+        testRound(1, "2024-08-08T12:57:07.388314Z", "2024-01-01T00:00:00.000000Z");
+
+        testRound(2, "2024-01-01T00:00:00.000000Z", "2024-01-01T00:00:00.000000Z");
+        testRound(2, "2025-08-08T12:57:07.388314Z", "2024-01-01T00:00:00.000000Z");
+        testRound(2, "2025-12-31T23:59:59.999999Z", "2024-01-01T00:00:00.000000Z");
+
+        testRound(10, "2020-01-01T00:00:00.000000Z", "2020-01-01T00:00:00.000000Z");
+        testRound(10, "2024-01-01T00:00:00.000000Z", "2020-01-01T00:00:00.000000Z");
+        testRound(10, "2025-12-31T23:59:59.999999Z", "2020-01-01T00:00:00.000000Z");
+    }
 
     @Test
     public void testSingleStep() throws NumericException {
-        testSampler(1,
+        testSampler(
+                1,
                 "2022" + FIXED_PART +
                         "2026" + FIXED_PART +
                         "2030" + FIXED_PART +
@@ -64,7 +79,8 @@ public class YearTimestampSamplerTest {
 
     @Test
     public void testTripleStep() throws NumericException {
-        testSampler(3,
+        testSampler(
+                3,
                 "2030" + FIXED_PART +
                         "2042" + FIXED_PART +
                         "2054" + FIXED_PART +
@@ -86,6 +102,13 @@ public class YearTimestampSamplerTest {
                         "2246" + FIXED_PART +
                         "2258" + FIXED_PART
         );
+    }
+
+    private void testRound(int stepYears, String timestamp, String expectedRounded) throws NumericException {
+        final YearTimestampSampler sampler = new YearTimestampSampler(stepYears);
+        sampler.setStart(0);
+        final long ts = TimestampFormatUtils.parseUTCTimestamp(timestamp);
+        Assert.assertEquals(TimestampFormatUtils.parseUTCTimestamp(expectedRounded), sampler.round(ts));
     }
 
     private void testSampler(int stepSize, String expected) throws NumericException {


### PR DESCRIPTION
Fixes #6029

`YearTimestampSampler` sampler had a bug around rounding. Namely, when the rounded year was a leap year and the input year wasn't, the returned result was incorrect.

This bug manifested itself in materialized view refresh where the lo value of a range replace commit could end up being greater than the minimal timestamp of the transaction. The reason is that the range replace lo was calculated based on `YearTimestampSampler#round()`.