### PR TITLE
chore(sql): NPE in AsyncTopKRecordCursor#toTop()

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/TimestampShuffleFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/TimestampShuffleFunctionFactory.java
@@ -94,7 +94,5 @@ public class TimestampShuffleFunctionFactory implements FunctionFactory {
         public void toTop() {
             rnd.reset();
         }
-
-
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncTopKRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncTopKRecordCursor.java
@@ -130,7 +130,9 @@ class AsyncTopKRecordCursor implements RecordCursor {
 
     @Override
     public void toTop() {
-        chainCursor.toTop();
+        if (isChainBuilt && chainCursor != null) {
+            chainCursor.toTop();
+        }
     }
 
     private void buildChain() {

--- a/core/src/test/java/io/questdb/test/griffin/engine/orderby/OrderByLimitTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/orderby/OrderByLimitTest.java
@@ -28,6 +28,55 @@ import io.questdb.test.AbstractCairoTest;
 import org.junit.Test;
 
 public class OrderByLimitTest extends AbstractCairoTest {
+
+    @Test
+    public void testAsOfJoinWithNestedTopK() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE 'trades' (" +
+                            "  ts TIMESTAMP," +
+                            "  price DOUBLE," +
+                            "  size INT" +
+                            ") TIMESTAMP(ts) PARTITION BY day;"
+            );
+            execute(
+                    "CREATE TABLE 'order_book' (" +
+                            "  ts TIMESTAMP," +
+                            "  bid_price DOUBLE," +
+                            "  bid_size INT," +
+                            "  task_price DOUBLE," +
+                            "  task_size INT" +
+                            ") TIMESTAMP(ts) PARTITION BY day;"
+            );
+
+            execute("INSERT INTO 'trades' VALUES ('2020-01-01T01:01', 42, 42);");
+            execute("INSERT INTO 'trades' VALUES ('2020-01-01T01:02', 42, 42);");
+            execute("INSERT INTO 'order_book' VALUES ('2020-01-01T01:00', 1, 1, 2, 2);");
+            execute("INSERT INTO 'order_book' VALUES ('2020-01-01T01:01', 3, 3, 4, 4);");
+
+            assertQuery(
+                    "ts\tprice\tsize\tts1\tbid_price\tbid_size\ttask_price\ttask_size\n" +
+                            "2020-01-01T01:01:00.000000Z\t42.0\t42\t2020-01-01T01:01:00.000000Z\t3.0\t3\t4.0\t4\n",
+                    "SELECT * " +
+                            "FROM (" +
+                            "  SELECT *" +
+                            "  FROM (" +
+                            "    SELECT *" +
+                            "    FROM trades" +
+                            "    WHERE price = '42.0'" +
+                            "    ORDER BY price, size, ts" +
+                            "    LIMIT 1" +
+                            "  )" +
+                            "  ORDER BY ts" +
+                            ")" +
+                            "ASOF JOIN order_book",
+                    "ts",
+                    false,
+                    true
+            );
+        });
+    }
+
     @Test
     public void testNegativeLimitDescOrderBy() throws Exception {
         assertQuery(


### PR DESCRIPTION
`AsyncTopKRecordCursor` was calling potentially uninitialized `chainCursor` field in its `toTop()` method.

Spotted by @siddharth0815