### PR TITLE
fix(core): fix potential File Descriptor leak on table drop

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -7652,8 +7652,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             throw CairoException.txnApplyBlockError(tableToken);
         }
 
+        // Don't move the line to mmap Wal column inside the following try block,
+        // This call, if failed will close the WAL files correctly on its own
+        // putting it inside the try block will cause the WAL files to be closed twice in the finally block
+        // in case of the exception.
+        segmentFileCache.mmapWalColumns(segmentCopyInfo, metadata, path);
         try {
-            segmentFileCache.mmapWalColumns(segmentCopyInfo, metadata, path);
             final long timestampAddr;
             final boolean copiedToMemory;
             final long o3Lo;

--- a/core/src/main/java/io/questdb/cairo/TableWriterSegmentFileCache.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterSegmentFileCache.java
@@ -298,14 +298,11 @@ public class TableWriterSegmentFileCache {
             walMappedColumns.setPos(initialSize);
             throw th;
         } finally {
-            if (fds != null) {
+            if (fds != null && fdCacheKey < 0) {
                 // Now that the FDs are used in the column objects, remove them from the cache.
                 // to avoid double close in case of exceptions.
                 walFdCache.removeAt(fdCacheKey);
-                if (fdCacheKey < 0) {
-                    walFdCache.removeAt(fdCacheKey);
-                    walFdCacheSize--;
-                }
+                walFdCacheSize--;
                 fds.clear();
                 walFdCacheListPool.push(fds);
             }

--- a/core/src/main/java/io/questdb/cairo/TableWriterSegmentFileCache.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterSegmentFileCache.java
@@ -205,6 +205,7 @@ public class TableWriterSegmentFileCache {
         if (fdCacheKey < 0) {
             fds = walFdCache.valueAt(fdCacheKey);
         }
+        int initialSize = walMappedColumns.size();
 
         try {
             int file = 0;
@@ -293,8 +294,18 @@ public class TableWriterSegmentFileCache {
                 }
             }
         } catch (Throwable th) {
-            closeWalFiles(true, walSegmentId, 0);
+            closeWalFiles(true, walSegmentId, initialSize);
+            walMappedColumns.setPos(initialSize);
             throw th;
+        } finally {
+            if (fds != null) {
+                // Now that the FDs are used in the column objects, remove them from the cache.
+                // to avoid double close in case of exceptions.
+                walFdCache.removeAt(fdCacheKey);
+                walFdCacheSize--;
+                fds.clear();
+                walFdCacheListPool.push(fds);
+            }
         }
     }
 
@@ -312,14 +323,22 @@ public class TableWriterSegmentFileCache {
         try {
             path.concat(WalUtils.WAL_NAME_BASE);
             int walBaseLen = path.size();
-            for (int i = 0; i < segmentCopyInfo.getSegmentCount(); i++) {
-                int walId = segmentCopyInfo.getWalId(i);
-                int segmentId = segmentCopyInfo.getSegmentId(i);
-                path.trimTo(walBaseLen).put(walId).put(SEPARATOR).put(segmentId);
-                long rowLo = segmentCopyInfo.getRowLo(i);
-                long rowHi = segmentCopyInfo.getRowHi(i);
-                long walIdSegmentId = Numbers.encodeLowHighInts(segmentId, walId);
-                mmapSegments(metadata, path, walIdSegmentId, rowLo, rowHi);
+            try {
+                for (int i = 0; i < segmentCopyInfo.getSegmentCount(); i++) {
+                    int walId = segmentCopyInfo.getWalId(i);
+                    int segmentId = segmentCopyInfo.getSegmentId(i);
+                    path.trimTo(walBaseLen).put(walId).put(SEPARATOR).put(segmentId);
+                    long rowLo = segmentCopyInfo.getRowLo(i);
+                    long rowHi = segmentCopyInfo.getRowHi(i);
+                    long walIdSegmentId = Numbers.encodeLowHighInts(segmentId, walId);
+                    mmapSegments(metadata, path, walIdSegmentId, rowLo, rowHi);
+                }
+            } catch (Throwable th) {
+                // Close all the columns without placing into the cache.
+                Misc.freeObjList(walMappedColumns);
+                walMappedColumns.clear();
+                closeWalFiles();
+                throw th;
             }
         } finally {
             path.trimTo(pathSize1);

--- a/core/src/main/java/io/questdb/cairo/TableWriterSegmentFileCache.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterSegmentFileCache.java
@@ -329,7 +329,7 @@ public class TableWriterSegmentFileCache {
             path.concat(WalUtils.WAL_NAME_BASE);
             int walBaseLen = path.size();
             try {
-                for (int i = 0; i < segmentCopyInfo.getSegmentCount(); i++) {
+                for (int i = 0, n = segmentCopyInfo.getSegmentCount(); i < n; i++) {
                     int walId = segmentCopyInfo.getWalId(i);
                     int segmentId = segmentCopyInfo.getSegmentId(i);
                     path.trimTo(walBaseLen).put(walId).put(SEPARATOR).put(segmentId);
@@ -340,8 +340,7 @@ public class TableWriterSegmentFileCache {
                 }
             } catch (Throwable th) {
                 // Close all the columns without placing into the cache.
-                Misc.freeObjList(walMappedColumns);
-                walMappedColumns.clear();
+                Misc.freeObjListAndClear(walMappedColumns);
                 closeWalFiles();
                 throw th;
             }

--- a/core/src/main/java/io/questdb/cairo/TableWriterSegmentFileCache.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterSegmentFileCache.java
@@ -302,7 +302,10 @@ public class TableWriterSegmentFileCache {
                 // Now that the FDs are used in the column objects, remove them from the cache.
                 // to avoid double close in case of exceptions.
                 walFdCache.removeAt(fdCacheKey);
-                walFdCacheSize--;
+                if (fdCacheKey < 0) {
+                    walFdCache.removeAt(fdCacheKey);
+                    walFdCacheSize--;
+                }
                 fds.clear();
                 walFdCacheListPool.push(fds);
             }


### PR DESCRIPTION
A file descriptor leak was found by fuzz tests. This PR fixes a file descriptor leak that occurs when a table is dropped and WAL (Write-Ahead Log) files are being purged concurrently with TableWriter operations. The leak happens due to double-closing of file descriptors when exceptions occur during WAL file operations. The scenario is

- A table is dropped
- WAL Purge job starts deleting the WAL files
- TableWriter may be at this moment try to open the WAL files that are being deleted
- TableWriter gets an exception on WAL file open and closes the open WAL files
- Then, on closing the TableWriter object, the WAL files are closed the second time and fail because of the double close guard in FdCache.
- The last exception aborts TableWriter cleanup and leads to a file descriptor leak.

The fix is to prevent double close attempt of WAL files in this situation.