### PR TITLE
fix(sql): memory leak when querying a table which is being ALTERed concurrently

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -2412,6 +2412,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                         final boolean forceScalar = executionContext.getJitMode() == SqlJitMode.JIT_MODE_FORCE_SCALAR;
                         jitIRSerializer.of(jitIRMem, executionContext, factory.getMetadata(), cursor, bindVarFunctions);
                         jitOptions = jitIRSerializer.serialize(filterExpr, forceScalar, enableJitDebug, enableJitNullChecks);
+                    } catch (Throwable e) {
+                        Misc.free(factory);
+                        throw e;
                     }
 
                     compiledFilter = new CompiledFilter();


### PR DESCRIPTION
In rare cases where queries execute while a table is being ALTERed simultaneously, memory could leak during internal query retries. This edge case only affected systems with concurrent schema modifications and queries on the same table. While queries completed successfully through automatic retries, memory from failed attempts was not released.


### Implementation details
The issue occurred when the SQL compiler attempted to create a filter during query compilation:
1. Compiler creates a factory
2. Attempts to wrap it in a filter
3. Filter creation tries to obtain a cursor, which can fail due to `TableReferenceOutOfDateException`
4. On failure, the factory wasn't being freed before the retry