### PR TITLE
fix(sql): fix divide by 0 exception when adding index to an empty mat view.

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -660,10 +660,14 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         return rowCount;
     }
 
-    private static int estimateIndexValueBlockSizeFromReader(SqlExecutionContext executionContext, TableToken matViewToken, int columnIndex) {
+    private static int estimateIndexValueBlockSizeFromReader(CairoConfiguration configuration, SqlExecutionContext executionContext, TableToken matViewToken, int columnIndex) {
         final int indexValueBlockSize;
         try (TableReader reader = executionContext.getReader(matViewToken)) {
             int symbolCount = reader.getSymbolMapReader(columnIndex).getSymbolCount();
+            if (reader.getPartitionCount() == 0 || symbolCount == 0) {
+                // No data to estimate accurately, fall back to default.
+                return Numbers.ceilPow2(configuration.getIndexValueBlockSize());
+            }
             // we are looking to estimate how many rowids we will need to store for each
             // symbol per partition. To do that wee are assuming the following formula:
             // max(2, table_row_count / table_partition_count / symbol_count / 4)
@@ -1657,7 +1661,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
 
                     tok = SqlUtil.fetchNext(lexer);
                     if (tok == null) {
-                        indexValueBlockSize = estimateIndexValueBlockSizeFromReader(executionContext, matViewToken, columnIndex);
+                        indexValueBlockSize = estimateIndexValueBlockSizeFromReader(configuration, executionContext, matViewToken, columnIndex);
                         sizeInferred = true;
                     } else {
                         if (!SqlKeywords.isCapacityKeyword(tok)) {

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -2971,6 +2971,11 @@ public class MatViewTest extends AbstractCairoTest {
                     false
             );
 
+            assertSql("indexBlockCapacity\n" +
+                            "2\n",
+                    "select indexBlockCapacity from (show columns from price_1h) where column = 'sym'"
+            );
+
             assertSql(
                     "QUERY PLAN\n" +
                             "DeferredSingleSymbolFilterPageFrame\n" +
@@ -2997,7 +3002,7 @@ public class MatViewTest extends AbstractCairoTest {
                 assertSql(
                         "QUERY PLAN\n" +
                                 "Async JIT Filter workers: 1\n" +
-                                "  filter: sym='eurusd' [pre-touch]\n" +
+                                "  filter: sym='eurusd'\n" +
                                 "    PageFrame\n" +
                                 "        Row forward scan\n" +
                                 "        Frame forward scan on: price_1h\n",
@@ -3007,7 +3012,7 @@ public class MatViewTest extends AbstractCairoTest {
                 assertSql(
                         "QUERY PLAN\n" +
                                 "Async Filter workers: 1\n" +
-                                "  filter: sym='eurusd' [pre-touch]\n" +
+                                "  filter: sym='eurusd'\n" +
                                 "    PageFrame\n" +
                                 "        Row forward scan\n" +
                                 "        Frame forward scan on: price_1h\n",
@@ -3026,6 +3031,70 @@ public class MatViewTest extends AbstractCairoTest {
                             "      filter: sym=2\n" +
                             "    Frame forward scan on: price_1h\n",
                     "explain " + sql
+            );
+        });
+    }
+
+    @Test
+    public void testIndexEmptyMV() throws Exception {
+        assertMemoryLeak(() -> {
+            setProperty(PropertyKey.CAIRO_INDEX_VALUE_BLOCK_SIZE, 312);
+
+            execute(
+                    "create table base_price (" +
+                            "sym symbol, price double, ts timestamp" +
+                            ") timestamp(ts) partition by DAY WAL"
+            );
+
+            execute("create materialized view price_1h as (select sym, last(price) as price, ts from base_price sample by 1h) partition by DAY");
+
+
+            drainQueues();
+
+            execute("alter materialized view price_1h alter column sym add index");
+
+            drainQueues();
+
+            // index already exists - exception
+            assertExceptionNoLeakCheck(
+                    "alter materialized view price_1h alter column sym add index",
+                    46,
+                    "column 'sym' already indexed"
+            );
+
+            execute(
+                    "insert into base_price values('gbpusd', 1.310, '2024-09-10T12:05')" +
+                            ",('gbpusd', 1.311, '2024-09-11T13:03')" +
+                            ",('eurusd', 1.312, '2024-09-12T13:03')" +
+                            ",('gbpusd', 1.313, '2024-09-13T13:03')" +
+                            ",('eurusd', 1.314, '2024-09-14T13:03')"
+            );
+
+            drainQueues();
+
+            String sql = "select * from price_1h where sym = 'eurusd';";
+            assertQueryNoLeakCheck(
+                    "sym\tprice\tts\n" +
+                            "eurusd\t1.312\t2024-09-12T13:00:00.000000Z\n" +
+                            "eurusd\t1.314\t2024-09-14T13:00:00.000000Z\n",
+                    sql,
+                    "ts",
+                    true,
+                    false
+            );
+
+            assertSql(
+                    "QUERY PLAN\n" +
+                            "DeferredSingleSymbolFilterPageFrame\n" +
+                            "    Index forward scan on: sym\n" +
+                            "      filter: sym=2\n" +
+                            "    Frame forward scan on: price_1h\n",
+                    "explain " + sql
+            );
+
+            assertSql("indexBlockCapacity\n" +
+                            Numbers.ceilPow2(configuration.getIndexValueBlockSize()) + "\n",
+                    "select indexBlockCapacity from (show columns from price_1h) where column = 'sym'"
             );
         });
     }


### PR DESCRIPTION
Fix divide by 0 exception when index is added to empty mat view introduced in #5961

```
java.lang.ArithmeticException: / by zero
	at io.questdb.griffin.SqlCompilerImpl.estimateIndexValueBlockSizeFromReader(SqlCompilerImpl.java:678)
	at io.questdb.griffin.SqlCompilerImpl.compileAlterMatView(SqlCompilerImpl.java:1664)
	at io.questdb.griffin.SqlCompilerImpl.compileAlter(SqlCompilerImpl.java:1599)
	at io.questdb.griffin.SqlCompilerImpl.compileInner(SqlCompilerImpl.java:2463)
	at io.questdb.griffin.SqlCompilerImpl.compile(SqlCompilerImpl.java:355)
	at io.questdb.cairo.pool.SqlCompilerPool$C.compile(SqlCompilerPool.java:139)
	at io.questdb.cairo.CairoEngine.execute(CairoEngine.java:245)
	at io.questdb.cairo.CairoEngine.execute(CairoEngine.java:611)
```