### PR TITLE
chore(core): improve TableWriter logging consistency

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -5089,7 +5089,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             if (tempMem16b != 0) {
                 tempMem16b = Unsafe.free(tempMem16b, 16, MemoryTag.NATIVE_TABLE_WRITER);
             }
-            LOG.info().$("closed '").$(tableToken).I$();
+            LOG.info().$("closed [table=").$(tableToken).I$();
         }
     }
 


### PR DESCRIPTION
The old version was missing a closing quote. VS.Code syntax highlighting was really confused and log scrappers probably too. 

<img width="2936" height="1569" alt="Screenshot From 2025-08-22 17-28-15" src="https://github.com/user-attachments/assets/af6f4d00-9458-4dee-80ae-8fbc2929cdea" />
