### PR TITLE
fix(sql): fix NPE when distinct query contains columns with dependencies.

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -306,8 +306,8 @@ import static io.questdb.cairo.ColumnType.*;
 import static io.questdb.cairo.sql.PartitionFrameCursorFactory.*;
 import static io.questdb.griffin.SqlKeywords.*;
 import static io.questdb.griffin.model.ExpressionNode.*;
-import static io.questdb.griffin.model.QueryModel.QUERY;
 import static io.questdb.griffin.model.QueryModel.*;
+import static io.questdb.griffin.model.QueryModel.QUERY;
 
 public class SqlCodeGenerator implements Mutable, Closeable {
     public static final int GKK_HOUR_INT = 1;
@@ -407,10 +407,12 @@ public class SqlCodeGenerator implements Mutable, Closeable {
     private final IntList tempAggIndex = new IntList();
     private final ObjList<QueryColumn> tempColumnsList = new ObjList<>();
     private final ObjList<ExpressionNode> tempExpressionNodeList = new ObjList<>();
+    private final ObjList<Function> tempInnerProjectionFunctions = new ObjList<>();
     private final IntList tempKeyIndex = new IntList();
     private final IntList tempKeyIndexesInBase = new IntList();
     private final IntList tempKeyKinds = new IntList();
     private final GenericRecordMetadata tempMetadata = new GenericRecordMetadata();
+    private final ObjList<Function> tempOuterProjectionFunctions = new ObjList<>();
     private final IntList tempSymbolSkewIndexes = new IntList();
     private final ObjList<VectorAggregateFunction> tempVaf = new ObjList<>();
     private final IntList tempVecConstructorArgIndexes = new IntList();
@@ -3897,8 +3899,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
                 final int columnCount = baseMetadata.getColumnCount();
                 final ObjList<GroupByFunction> groupByFunctions = new ObjList<>(columnCount);
-                final ObjList<Function> outerProjectionFunctions = new ObjList<>(columnCount);
-                final ObjList<Function> innerProjectionFunctions = new ObjList<>(columnCount);
+                tempOuterProjectionFunctions.clear();
+                tempInnerProjectionFunctions.clear();
                 final GenericRecordMetadata projectionMetadata = new GenericRecordMetadata();
                 final PriorityMetadata priorityMetadata = new PriorityMetadata(columnCount, baseMetadata);
                 final IntList projectionFunctionFlags = new IntList(columnCount);
@@ -3913,8 +3915,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                         false,
                         groupByFunctions,
                         groupByFunctionPositions,
-                        outerProjectionFunctions,
-                        innerProjectionFunctions,
+                        tempOuterProjectionFunctions,
+                        tempInnerProjectionFunctions,
                         recordFunctionPositions,
                         projectionFunctionFlags,
                         projectionMetadata,
@@ -3932,7 +3934,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                         factory,
                         projectionMetadata,
                         groupByFunctions,
-                        outerProjectionFunctions,
+                        new ObjList<>(tempOuterProjectionFunctions),
                         timestampSampler,
                         model,
                         listColumnFilterA,
@@ -3952,8 +3954,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
             final int columnCount = model.getColumns().size();
             final ObjList<GroupByFunction> groupByFunctions = new ObjList<>(columnCount);
+            tempInnerProjectionFunctions.clear();
             final ObjList<Function> outerProjectionFunctions = new ObjList<>(columnCount);
-            final ObjList<Function> innerProjectionFunctions = new ObjList<>(columnCount);
             final GenericRecordMetadata projectionMetadata = new GenericRecordMetadata();
             final PriorityMetadata priorityMetadata = new PriorityMetadata(columnCount, baseMetadata);
             final IntList projectionFunctionFlags = new IntList(columnCount);
@@ -3969,7 +3971,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     groupByFunctions,
                     groupByFunctionPositions,
                     outerProjectionFunctions,
-                    innerProjectionFunctions,
+                    tempInnerProjectionFunctions,
                     recordFunctionPositions,
                     projectionFunctionFlags,
                     projectionMetadata,
@@ -4648,8 +4650,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
             final int columnCount = model.getColumns().size();
             final ObjList<GroupByFunction> groupByFunctions = new ObjList<>(columnCount);
-            final ObjList<Function> outerProjectionFunctions = new ObjList<>(columnCount);
-            final ObjList<Function> innerProjectionFunctions = new ObjList<>(columnCount);
+            tempInnerProjectionFunctions.clear();
+            tempOuterProjectionFunctions.clear();
             final GenericRecordMetadata outerProjectionMetadata = new GenericRecordMetadata();
             final PriorityMetadata priorityMetadata = new PriorityMetadata(columnCount, baseMetadata);
             final IntList projectionFunctionFlags = new IntList(columnCount);
@@ -4664,8 +4666,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     true,
                     groupByFunctions,
                     groupByFunctionPositions,
-                    outerProjectionFunctions,
-                    innerProjectionFunctions,
+                    tempOuterProjectionFunctions,
+                    tempInnerProjectionFunctions,
                     recordFunctionPositions,
                     projectionFunctionFlags,
                     outerProjectionMetadata,
@@ -4688,7 +4690,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 enableParallelGroupBy = false;
             }
 
-            ObjList<Function> keyFunctions = extractVirtualFunctionsFromProjection(innerProjectionFunctions, projectionFunctionFlags);
+            ObjList<Function> keyFunctions = extractVirtualFunctionsFromProjection(tempInnerProjectionFunctions, projectionFunctionFlags);
             if (
                     enableParallelGroupBy
                             && SqlUtil.isParallelismSupported(keyFunctions)
@@ -4723,7 +4725,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
                     if (keyTypesCopy.getColumnCount() == 0) {
                         assert keyFunctions.size() == 0;
-                        assert outerProjectionFunctions.size() == groupByFunctions.size();
+                        assert tempOuterProjectionFunctions.size() == groupByFunctions.size();
 
                         return new AsyncGroupByNotKeyedRecordCursorFactory(
                                 asm,
@@ -4761,7 +4763,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     ObjList<ObjList<Function>> perWorkerInnerProjectionFunctions = compilePerWorkerInnerProjectionFunctions(
                             executionContext,
                             model.getColumns(),
-                            innerProjectionFunctions,
+                            tempInnerProjectionFunctions,
                             executionContext.getSharedQueryWorkerCount(),
                             baseMetadata
                     );
@@ -4779,7 +4781,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                     valueTypesCopy,
                                     groupByFunctions,
                                     extractWorkerFunctionsConditionally(
-                                            innerProjectionFunctions,
+                                            tempInnerProjectionFunctions,
                                             projectionFunctionFlags,
                                             perWorkerInnerProjectionFunctions,
                                             GroupByUtils.PROJECTION_FUNCTION_FLAG_GROUP_BY
@@ -4787,12 +4789,12 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                     ),
                                     keyFunctions,
                                     extractWorkerFunctionsConditionally(
-                                            innerProjectionFunctions,
+                                            tempInnerProjectionFunctions,
                                             projectionFunctionFlags,
                                             perWorkerInnerProjectionFunctions,
                                             GroupByUtils.PROJECTION_FUNCTION_FLAG_VIRTUAL
                                     ),
-                                    outerProjectionFunctions,
+                                    new ObjList<>(tempOuterProjectionFunctions),
                                     compiledFilter,
                                     bindVarMemory,
                                     bindVarFunctions,
@@ -4813,7 +4815,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             }
 
             if (keyTypes.getColumnCount() == 0) {
-                assert outerProjectionFunctions.size() == groupByFunctions.size();
+                assert tempOuterProjectionFunctions.size() == groupByFunctions.size();
                 return new GroupByNotKeyedRecordCursorFactory(
                         asm,
                         configuration,
@@ -4838,7 +4840,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             outerProjectionMetadata,
                             groupByFunctions,
                             keyFunctions,
-                            outerProjectionFunctions
+                            new ObjList<>(tempOuterProjectionFunctions)
                     ),
                     executionContext
             );

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -4215,6 +4215,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         } catch (Throwable e) {
             Misc.free(factory);
             throw e;
+        } finally {
+            tempInnerProjectionFunctions.clear();
+            tempOuterProjectionFunctions.clear();
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -1139,11 +1139,15 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
      *
      * @param baseModel baseModel containing columns mapped into the referenced baseModel.
      */
-    public void mergePartially(QueryModel baseModel, ObjectPool<QueryColumn> queryColumnPool) {
+    public void mergePartially(QueryModel baseModel, ObjectPool<QueryColumn> queryColumnPool) throws SqlException {
         for (int i = 0, n = bottomUpColumns.size(); i < n; i++) {
             QueryColumn thisColumn = bottomUpColumns.getQuick(i);
             if (thisColumn.getAst().type == ExpressionNode.LITERAL) {
                 QueryColumn thatColumn = baseModel.getAliasToColumnMap().get(thisColumn.getAst().token);
+                // skip if baseModel does not have this column
+                if (thatColumn == null) {
+                    continue;
+                }
                 // We cannot mutate the column on this baseModel, because columns might be shared between
                 // models. The bottomUpColumns are also referenced by `aliasToColumnMap`. Typically,
                 // `thisColumn` alias should let us lookup, the column's reference

--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -1139,7 +1139,7 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
      *
      * @param baseModel baseModel containing columns mapped into the referenced baseModel.
      */
-    public void mergePartially(QueryModel baseModel, ObjectPool<QueryColumn> queryColumnPool) throws SqlException {
+    public void mergePartially(QueryModel baseModel, ObjectPool<QueryColumn> queryColumnPool) {
         for (int i = 0, n = bottomUpColumns.size(); i < n; i++) {
             QueryColumn thisColumn = bottomUpColumns.getQuick(i);
             if (thisColumn.getAst().type == ExpressionNode.LITERAL) {

--- a/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlCompilerImplTest.java
@@ -3646,6 +3646,21 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testDistinctDependencyColumnsThrowError() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "create table tab (" +
+                            "  x1 int," +
+                            "  ts TIMESTAMP" +
+                            ") timestamp(ts);"
+            );
+
+            assertExceptionNoLeakCheck("select distinct x1 as a, a from tab", 25, "Invalid column: a");
+            assertExceptionNoLeakCheck("select distinct x1 - 1 as a, a + 1 from tab", 29, "Invalid column: a");
+        });
+    }
+
+    @Test
     public void testDuplicateTableName() throws Exception {
         assertMemoryLeak(() -> {
             execute(


### PR DESCRIPTION
Try to close #6078 
```
select distinct x1 as a, a from tab1;
ERROR:  Cannot invoke "io.questdb.griffin.model.QueryColumn.getAst()" because "thatColumn" is null
LINE 1: select distinct x1 as a, a from tab1;
```