### PR TITLE
fix(core): fix rare index reader memory on partition drop

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -727,19 +727,13 @@ public class TableReader implements Closeable, SymbolTableSource {
         final int offset = partitionIndex * PARTITIONS_SLOT_SIZE;
         long partitionTimestamp = openPartitionInfo.getQuick(offset);
         long partitionSize = openPartitionInfo.getQuick(offset + PARTITIONS_SLOT_OFFSET_SIZE);
-        int columnBase = getColumnBase(partitionIndex);
+        closePartitionResources(partitionIndex, offset);
         if (partitionSize > -1) {
-            closePartitionResources(partitionIndex, offset);
             openPartitionCount--;
         }
+        int columnBase = getColumnBase(partitionIndex);
         int baseIndex = getPrimaryColumnIndex(columnBase, 0);
         int newBaseIndex = getPrimaryColumnIndex(getColumnBase(partitionIndex + 1), 0);
-        for (int i = baseIndex, n = newBaseIndex - 1; i < n; i++) {
-            // Close columns before deleting the objects.
-            // FD leak caught by failing fuzz tests.
-            Misc.free(columns.get(i));
-            Misc.free(bitmapIndexes.get(i));
-        }
         columns.remove(baseIndex, newBaseIndex - 1);
         bitmapIndexes.remove(baseIndex, newBaseIndex - 1);
 

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -738,8 +738,10 @@ public class TableReader implements Closeable, SymbolTableSource {
             // Close columns before deleting the objects.
             // FD leak caught by failing fuzz tests.
             Misc.free(columns.get(i));
+            Misc.free(bitmapIndexes.get(i));
         }
         columns.remove(baseIndex, newBaseIndex - 1);
+        bitmapIndexes.remove(baseIndex, newBaseIndex - 1);
 
         int colTopStart = columnBase / 2;
         int columnSlotSize = getColumnBase(1);


### PR DESCRIPTION
A partition removal followed by a schema change could cause a memory and file descriptor leak
It's fixing a FD and memory leak found by a fuzz test. 


WIP. 
Scenario:
1. Partition gets deleted -> stale bitmap indexes left in `bitmapIndexes` list beyond a valid range (at position not references by any column)
2. Eventually, a table schema change triggers `createNewColumnList()`
3. `createNewColumnList()` creates a new  `bitmapIndexes` list but only copies indexes from the old list within a valid range
4. The stale indexes beyond the range are not included in the new bitmap index list
5. When old arrays are replaced with new ones, those stale indexes are orphaned - they remain open but unreachable
6. FD leak - the file descriptors for those bitmap indexes are never closed

Note: 
I am not quite sure if `Misc.free(bitmapIndexes.get(i));` is needed. I added it only because of the `Misc.free(columns.get(i));` above. but it appears to me that both columns and indexes should be closed above at `closePartitionResource()`:

```java
if (partitionSize > -1) {
    closePartitionResources(partitionIndex, offset);
    openPartitionCount--;
}
int baseIndex = getPrimaryColumnIndex(columnBase, 0);
int newBaseIndex = getPrimaryColumnIndex(getColumnBase(partitionIndex + 1), 0);
for (int i = baseIndex, n = newBaseIndex - 1; i < n; i++) {
    // Close columns before deleting the objects.
    // FD leak caught by failing fuzz tests.
    Misc.free(columns.get(i)); <--- pre-existing line. is it needed? why? 
    Misc.free(bitmapIndexes.get(i)); <-- is this needed? why? 
}
```
but the `partitionSize > -1` guard prevents the resources to be closed? 
