### PR TITLE
fix(core): fix suspended tables showing wrong writerTxn in wal_tables

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -452,7 +452,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                 // be returned to the pool and dirty writes will be rolled back. We have to update the sequencer
                 // on the state of the writer and revert any dirty txns that might have advanced. We do that
                 // by equalizing writerTxn and dirtyWriterTxn.
-                engine.getTableSequencerAPI().updateWriterTxns(tableToken, writer.getTxn(), writer.getTxn());
+                engine.getTableSequencerAPI().updateWriterTxns(tableToken, writer.getSeqTxn(), writer.getAppliedSeqTxn());
                 throw th;
             } finally {
                 Misc.free(structuralChangeCursor);

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -452,7 +452,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                 // be returned to the pool and dirty writes will be rolled back. We have to update the sequencer
                 // on the state of the writer and revert any dirty txns that might have advanced. We do that
                 // by equalizing writerTxn and dirtyWriterTxn.
-                engine.getTableSequencerAPI().updateWriterTxns(tableToken, writer.getSeqTxn(), writer.getAppliedSeqTxn());
+                engine.getTableSequencerAPI().updateWriterTxns(tableToken, writer.getSeqTxn(), writer.getSeqTxn());
                 throw th;
             } finally {
                 Misc.free(structuralChangeCursor);

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalTableSqlTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalTableSqlTest.java
@@ -1977,12 +1977,18 @@ public class WalTableSqlTest extends AbstractCairoTest {
                     " from long_sequence(1)" +
                     ") timestamp(ts) partition by DAY WAL"
             );
+            execute("insert into " + tableName + " values (101, 'dfd', '2022-02-24T01')");
+            execute("insert into " + tableName + " values (101, 'dfd', '2022-02-24T02')");
+            execute("insert into " + tableName + " values (101, 'dfd', '2022-02-24T03')");
             execute("alter table " + tableName + " add column fail int");
             long walNotification = engine.getMessageBus().getWalTxnNotificationPubSequence().current();
 
             drainWalQueue();
             TableToken tableToken = engine.verifyTableName(tableName);
             Assert.assertTrue(engine.getTableSequencerAPI().isSuspended(tableToken));
+            Assert.assertEquals(4, engine.getTableSequencerAPI().getTxnTracker(tableToken).getWriterTxn());
+            Assert.assertEquals(5, engine.getTableSequencerAPI().getTxnTracker(tableToken).getSeqTxn());
+
             long notifications = engine.getMessageBus().getWalTxnNotificationPubSequence().current();
             Assert.assertEquals(walNotification, notifications);
 


### PR DESCRIPTION
After the table got suspended because of a corrupt WAL, the `wal_tables` query displayed a very out-of-date number on writerTxn. This fixes the bug where, while handling exceptions, the Seq Table Tracker is updated to the table `txn` number rather than `seqTxn`.