### PR TITLE
fix(core): fix table reading timeout error after non-wal table dropped and re-created

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TxnScoreboardV2.java
+++ b/core/src/main/java/io/questdb/cairo/TxnScoreboardV2.java
@@ -224,33 +224,34 @@ public class TxnScoreboardV2 implements TxnScoreboard {
 
     @Override
     public boolean isRangeAvailable(long fromTxn, long toTxn) {
-        // Push max txn to the latest, to avoid races with acquireTxn()
-        // but don't stop checking if it's not the max.
-        updateMax(toTxn);
-
         if (getActiveReaderCount() == 0) {
             return true;
         }
 
-        for (int i = 0; i < bitmapCount; i++) {
-            long bitmap = Unsafe.getUnsafe().getLongVolatile(null, bitmapMem + (long) i * Long.BYTES);
-            if (bitmap == 0) {
-                continue;
-            }
-
-            int base = i * Long.SIZE;
-            while (bitmap != 0) {
-                final long lowestBit = Long.lowestOneBit(bitmap);
-                final int bit = Long.numberOfTrailingZeros(lowestBit);
-                int internalId = base + bit;
-                long lockedTxn = Unsafe.getUnsafe().getLongVolatile(null, entriesMem + (long) internalId * Long.BYTES);
-                if (lockedTxn > UNLOCKED && lockedTxn >= fromTxn && lockedTxn < toTxn) {
-                    return false;
+        long max;
+        do {
+            max = getMax();
+            for (int i = 0; i < bitmapCount; i++) {
+                long bitmap = Unsafe.getUnsafe().getLongVolatile(null, bitmapMem + (long) i * Long.BYTES);
+                if (bitmap == 0) {
+                    continue;
                 }
 
-                bitmap ^= lowestBit;
+                int base = i * Long.SIZE;
+                while (bitmap != 0) {
+                    final long lowestBit = Long.lowestOneBit(bitmap);
+                    final int bit = Long.numberOfTrailingZeros(lowestBit);
+                    int internalId = base + bit;
+                    long lockedTxn = Unsafe.getUnsafe().getLongVolatile(null, entriesMem + (long) internalId * Long.BYTES);
+                    if (lockedTxn > UNLOCKED && lockedTxn >= fromTxn && lockedTxn < toTxn) {
+                        return false;
+                    }
+
+                    bitmap ^= lowestBit;
+                }
             }
-        }
+            // max changed, need to re-check
+        } while (max <= toTxn && max != getMax());
         return true;
     }
 


### PR DESCRIPTION
Found by fuzz tests.
When a non-WAL table is dropped and re-created, purge jobs can push max txn using `TxnScoreboardPoolV2.isRangeAvailable()` and it can lead to a timeout on opening TableReader, where it cannot lock the latest transaction in the scoreboard.

The fix is not to modify the max in `TxnScoreboardPoolV2.isRangeAvailable()`, making it a read-only scoreboard operation.