### PR TITLE
test(ilp): fix flaky testInfluxStreamingRetriesOnServerRestart()

### DIFF
--- a/compat/src/test/java/io/questdb/compat/InfluxDBClientStreamingTest.java
+++ b/compat/src/test/java/io/questdb/compat/InfluxDBClientStreamingTest.java
@@ -126,7 +126,10 @@ public class InfluxDBClientStreamingTest extends AbstractTest {
                     influxDB.enableBatch(
                             BatchOptions.DEFAULTS
                                     .actions(batchSize)
-                                    .bufferLimit(batchSize * 1024)
+                                    .bufferLimit(Integer.MAX_VALUE)
+                                    .exceptionHandler((p, t) -> {
+                                        LOG.error().$("Error sending points ").$(p).$(" ").$(t).$();
+                                    })
                     );
 
                     while (!stop.get()) {


### PR DESCRIPTION
Problem:
The InfluxDB client has a bufferLimit that sets the maximum number of points in its retry buffer. The test originally configured this as 10x batchSize, allowing only 10 batches in the retry buffer. When QuestDB server is slow to restart, the test driver generates more than 10 batches, causing the client to silently drop older points and making the test fail intermittently.

Reproduction:
This issue can be reproduced locally by setting batch-size to 1.

Solution:
Set the retry buffer size to the maximum possible value to prevent point drops during server restart. While this introduces a theoretical OOM risk, we'll address it if it becomes an actual issue.

Fixes #4741