### PR TITLE
chore(core): consistent logging of table/view names

### DIFF
--- a/core/src/main/java/io/questdb/Telemetry.java
+++ b/core/src/main/java/io/questdb/Telemetry.java
@@ -151,8 +151,8 @@ public class Telemetry<T extends AbstractTelemetryTask> implements Closeable {
             writer = engine.getWriter(tableToken, "telemetry");
         } catch (CairoException ex) {
             LOG.error()
-                    .$("could not open [table=`").$(tableToken)
-                    .$("`, msg=").$safe(ex.getFlyweightMessage())
+                    .$("could not open [table=").$(tableToken)
+                    .$(", msg=").$safe(ex.getFlyweightMessage())
                     .$(", errno=").$(ex.getErrno())
                     .$(']').$();
         }

--- a/core/src/main/java/io/questdb/TelemetryConfigLogger.java
+++ b/core/src/main/java/io/questdb/TelemetryConfigLogger.java
@@ -99,7 +99,7 @@ public class TelemetryConfigLogger implements PreferencesUpdateListener, Closeab
             );
             updateTelemetryConfig(engine, compiler, sqlExecutionContext, configTableToken);
         } catch (Throwable th) {
-            LOG.error().$("could not update config telemetry [table=`").$safe(TELEMETRY_CONFIG_TABLE_NAME).$("]").$(th).$();
+            LOG.error().$("could not update config telemetry [table=").$(configTableToken).$("]").$(th).$();
         }
     }
 
@@ -191,8 +191,8 @@ public class TelemetryConfigLogger implements PreferencesUpdateListener, Closeab
             }
         } catch (CairoException ex) {
             LOG.error()
-                    .$("could not update config telemetry [table=`").$safe(TELEMETRY_CONFIG_TABLE_NAME)
-                    .$("`, msg=").$safe(ex.getFlyweightMessage())
+                    .$("could not update config telemetry [table=").$(tableToken)
+                    .$(", msg=").$safe(ex.getFlyweightMessage())
                     .$(", errno=").$(ex.getErrno())
                     .I$();
         }

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -1097,8 +1097,8 @@ public class CairoEngine implements Closeable, WriterSource {
                 if (lockedReason == null) {
                     // not locked
                     if (readerPool.lock(tableToken)) {
-                        LOG.info().$("locked [table=`").$(tableToken)
-                                .$("`, thread=").$(Thread.currentThread().getId())
+                        LOG.info().$("locked [table=").$(tableToken)
+                                .$(", thread=").$(Thread.currentThread().getId())
                                 .I$();
                         return null;
                     }
@@ -1475,7 +1475,7 @@ public class CairoEngine implements Closeable, WriterSource {
     ) {
         verifyTableToken(tableToken);
         unlockTableUnsafe(tableToken, writer, newTable);
-        LOG.info().$("unlocked [table=`").$(tableToken).$("`]").$();
+        LOG.info().$("unlocked [table=").$(tableToken).$("]").$();
     }
 
     public void unlockReaders(TableToken tableToken) {
@@ -1684,7 +1684,7 @@ public class CairoEngine implements Closeable, WriterSource {
                             // in concurrent threads
                             unlockTableUnsafe(tableToken, null, true);
                             locked = false;
-                            LOG.info().$("unlocked [table=`").$(tableToken).$("`]").$();
+                            LOG.info().$("unlocked [table=").$(tableToken).$("]").$();
                         }
                         tableNameRegistry.registerName(tableToken);
                     } catch (Throwable e) {
@@ -1693,7 +1693,7 @@ public class CairoEngine implements Closeable, WriterSource {
                     } finally {
                         if (!keepLock && locked) {
                             unlockTableUnsafe(tableToken, null, false);
-                            LOG.info().$("unlocked [table=`").$(tableToken).$("`]").$();
+                            LOG.info().$("unlocked [table=").$(tableToken).$("]").$();
                         }
                     }
                 } else {

--- a/core/src/main/java/io/questdb/cairo/ColumnPurgeOperator.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnPurgeOperator.java
@@ -156,7 +156,7 @@ public class ColumnPurgeOperator implements Closeable {
         } catch (CairoException ex) {
             // Scoreboard can be over allocated, don't stall purge because of that, re-schedule another run instead
             LOG.error().$("cannot lock last txn in scoreboard, column purge will re-run [table=")
-                    .$safe(task.getTableToken().getTableName())
+                    .$(task.getTableToken())
                     .$(", txn=").$(updateTxn)
                     .$(", msg=").$safe(ex.getFlyweightMessage())
                     .$(", errno=").$(ex.getErrno())

--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -494,7 +494,7 @@ public class MetadataCache implements QuietCloseable {
             CairoTable entry = tableMap.get(tableName);
             if (entry != null && tableToken.equals(entry.getTableToken())) {
                 tableMap.remove(tableName);
-                LOG.info().$("dropped [table=").$safe(tableName).I$();
+                LOG.info().$("dropped [table=").$(tableToken).I$();
             }
         }
 

--- a/core/src/main/java/io/questdb/cairo/O3CopyJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3CopyJob.java
@@ -741,7 +741,7 @@ public class O3CopyJob extends AbstractQueueConsumerJob<O3CopyTask> {
             }
         } catch (Throwable e) {
             LOG.error()
-                    .$("sync error [table=").$safe(tableWriter.getTableToken().getTableName())
+                    .$("sync error [table=").$(tableWriter.getTableToken())
                     .$(", e=").$(e)
                     .I$();
             tableWriter.o3BumpErrorCount(false);
@@ -816,7 +816,7 @@ public class O3CopyJob extends AbstractQueueConsumerJob<O3CopyTask> {
             }
         } catch (Throwable e) {
             LOG.error()
-                    .$("index error [table=").$safe(tableWriter.getTableToken().getTableName())
+                    .$("index error [table=").$(tableWriter.getTableToken())
                     .$(", e=").$(e)
                     .I$();
             tableWriter.o3BumpErrorCount(false);
@@ -909,7 +909,7 @@ public class O3CopyJob extends AbstractQueueConsumerJob<O3CopyTask> {
     ) {
         final int columnsRemaining = columnCounter.decrementAndGet();
         LOG.debug()
-                .$("idle [table=").$safe(tableWriter.getTableToken().getTableName())
+                .$("idle [table=").$(tableWriter.getTableToken())
                 .$(", columnsRemaining=").$(columnsRemaining)
                 .I$();
         if (columnsRemaining == 0) {

--- a/core/src/main/java/io/questdb/cairo/O3OpenColumnJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3OpenColumnJob.java
@@ -511,7 +511,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                 partCount++;
             }
         } catch (Throwable e) {
-            LOG.error().$("merge var error [table=").$safe(tableWriter.getTableToken().getTableName())
+            LOG.error().$("merge var error [table=").$(tableWriter.getTableToken())
                     .$(", e=").$(e)
                     .I$();
             tableWriter.o3BumpErrorCount(CairoException.isCairoOomError(e));
@@ -1356,7 +1356,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                 dstDataAdjust = dstDataMem.getAppendOffset();
             }
         } catch (Throwable e) {
-            LOG.error().$("append var error [table=").$safe(tableWriter.getTableToken().getTableName())
+            LOG.error().$("append var error [table=").$(tableWriter.getTableToken())
                     .$(", e=").$(e)
                     .I$();
             O3Utils.unmapAndClose(ff, activeFixFd, dstAuxAddr, dstAuxSize);
@@ -1840,7 +1840,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                 dstVFd = openRW(ff, BitmapIndexUtils.valueFileName(pathToNewPartition.trimTo(pNewLen), columnName, columnNameTxn), LOG, tableWriter.getConfiguration().getWriterFileOpenOpts());
             }
         } catch (Throwable e) {
-            LOG.error().$("append fix error [table=").$safe(tableWriter.getTableToken().getTableName())
+            LOG.error().$("append fix error [table=").$(tableWriter.getTableToken())
                     .$(", e=").$(e)
                     .I$();
             if (dstFixSize > 0) {
@@ -1989,7 +1989,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                 // open data file now
                 dstVarFd = openRW(ff, dFile(pathToNewPartition.trimTo(pNewLen), columnName, columnNameTxn), LOG, tableWriter.getConfiguration().getWriterFileOpenOpts());
             } catch (Throwable e) {
-                LOG.error().$("append mid partition error 2 [table=").$safe(tableWriter.getTableToken().getTableName())
+                LOG.error().$("append mid partition error 2 [table=").$(tableWriter.getTableToken())
                         .$(", e=").$(e)
                         .I$();
                 O3Utils.close(ff, dstFixFd);
@@ -2062,7 +2062,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
             try {
                 dstFixFd = openRW(ff, dFile(pathToNewPartition.trimTo(pNewLen), columnName, columnNameTxn), LOG, tableWriter.getConfiguration().getWriterFileOpenOpts());
             } catch (Throwable e) {
-                LOG.error().$("append mid partition error 3 [table=").$safe(tableWriter.getTableToken().getTableName())
+                LOG.error().$("append mid partition error 3 [table=").$(tableWriter.getTableToken())
                         .$(", e=").$(e)
                         .I$();
                 O3Utils.close(ff, dstFixFd);
@@ -2170,7 +2170,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                 }
             }
         } catch (Throwable e) {
-            LOG.error().$("append new partition error [table=").$safe(tableWriter.getTableToken().getTableName())
+            LOG.error().$("append new partition error [table=").$(tableWriter.getTableToken())
                     .$(", e=").$(e)
                     .I$();
             tableWriter.o3BumpErrorCount(CairoException.isCairoOomError(e));
@@ -2286,7 +2286,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                 dstFixSize = -dstFixSize;
             }
         } catch (Throwable e) {
-            LOG.error().$("append ts error [table=").$safe(tableWriter.getTableToken().getTableName())
+            LOG.error().$("append ts error [table=").$(tableWriter.getTableToken())
                     .$(", e=").$(e)
                     .I$();
             O3Utils.close(ff, dstFixFd);
@@ -2536,7 +2536,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                 partCount++;
             }
         } catch (Throwable e) {
-            LOG.error().$("merge fix error [table=").$safe(tableWriter.getTableToken().getTableName())
+            LOG.error().$("merge fix error [table=").$(tableWriter.getTableToken())
                     .$(", e=").$(e)
                     .I$();
             O3Utils.unmapAndClose(ff, srcDataFixFd, srcDataFixAddr, srcDataFixSize);
@@ -2808,7 +2808,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
             try {
                 srcDataTop = Math.min(tableWriter.getColumnTop(oldPartitionTimestamp, columnIndex, srcDataMax), srcDataMax);
             } catch (Throwable e) {
-                LOG.error().$("merge mid partition error 1 [table=").$safe(tableWriter.getTableToken().getTableName())
+                LOG.error().$("merge mid partition error 1 [table=").$(tableWriter.getTableToken())
                         .$(", e=").$(e)
                         .I$();
                 freeTimestampIndex(
@@ -2833,7 +2833,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                 srcDataFixFd = openRW(ff, iFile(pathToOldPartition.trimTo(plen), columnName, columnNameTxn), LOG, tableWriter.getConfiguration().getWriterFileOpenOpts());
                 srcDataVarFd = openRW(ff, dFile(pathToOldPartition.trimTo(plen), columnName, columnNameTxn), LOG, tableWriter.getConfiguration().getWriterFileOpenOpts());
             } catch (Throwable e) {
-                LOG.error().$("merge mid partition error 2 [table=").$safe(tableWriter.getTableToken().getTableName())
+                LOG.error().$("merge mid partition error 2 [table=").$(tableWriter.getTableToken())
                         .$(", e=").$(e)
                         .I$();
                 O3Utils.close(ff, srcDataFixFd);
@@ -2905,7 +2905,7 @@ public class O3OpenColumnJob extends AbstractQueueConsumerJob<O3OpenColumnTask> 
                     srcDataFixFd = openRW(ff, dFile(pathToOldPartition.trimTo(plen), columnName, columnNameTxn), LOG, tableWriter.getConfiguration().getWriterFileOpenOpts());
                 }
             } catch (Throwable e) {
-                LOG.error().$("merge mid partition error 3 [table=").$safe(tableWriter.getTableToken().getTableName())
+                LOG.error().$("merge mid partition error 3 [table=").$(tableWriter.getTableToken())
                         .$(", e=").$(e)
                         .I$();
                 freeTimestampIndex(

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -286,7 +286,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                     rowGroupBuffers
             );
         } catch (Throwable th) {
-            LOG.error().$("process partition error [table=").$safe(tableWriter.getTableToken().getTableName())
+            LOG.error().$("process partition error [table=").$(tableWriter.getTableToken())
                     .$(", e=").$(th)
                     .I$();
             // the file is re-opened here because PartitionUpdater owns the file descriptor
@@ -397,7 +397,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                     TableUtils.setPathForNativePartition(path.trimTo(pathToTable.size()), partitionBy, partitionTimestamp, txn - 1);
                     createDirsOrFail(ff, path.slash(), tableWriter.getConfiguration().getMkDirMode());
                 } catch (Throwable e) {
-                    LOG.error().$("process new partition error [table=").$safe(tableWriter.getTableToken().getTableName())
+                    LOG.error().$("process new partition error [table=").$(tableWriter.getTableToken())
                             .$(", e=").$(e)
                             .I$();
                     tableWriter.o3BumpErrorCount(CairoException.isCairoOomError(e));
@@ -879,7 +879,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                                             o3RangeLo,
                                             o3RangeHi
                                     )) {
-                                        LOG.info().$("replace commit resulted in identical data [table=").$safe(tableWriter.getTableToken().getTableName())
+                                        LOG.info().$("replace commit resulted in identical data [table=").$(tableWriter.getTableToken())
                                                 .$(", partitionTimestamp=").$ts(partitionTimestamp)
                                                 .$(", srcNameTxn=").$(srcNameTxn)
                                                 .I$();
@@ -1078,7 +1078,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                     }
                 }
             } catch (Throwable e) {
-                LOG.error().$("process existing partition error [table=").$safe(tableWriter.getTableToken().getTableName())
+                LOG.error().$("process existing partition error [table=").$(tableWriter.getTableToken())
                         .$(", e=").$(e)
                         .I$();
                 O3Utils.unmap(ff, srcTimestampAddr, srcTimestampSize);
@@ -2181,7 +2181,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
 
                         if (o3SplitPartitionSize > 0) {
                             LOG.info().$("dedup resulted in no merge, undo partition split [table=")
-                                    .$safe(tableWriter.getTableToken().getTableName())
+                                    .$(tableWriter.getTableToken())
                                     .$(", partition=").$ts(oldPartitionTimestamp)
                                     .$(", split=").$ts(partitionTimestamp)
                                     .I$();
@@ -2214,7 +2214,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                         srcDataNewPartitionSize -= duplicateCount;
                     }
                     LOG.info()
-                            .$("dedup row reduction [table=").$safe(tableWriter.getTableToken().getTableName())
+                            .$("dedup row reduction [table=").$(tableWriter.getTableToken())
                             .$(", partition=").$ts(partitionTimestamp)
                             .$(", duplicateCount=").$(duplicateCount)
                             .$(", srcDataNewPartitionSize=").$(srcDataNewPartitionSize)
@@ -2235,7 +2235,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                 }
             } catch (Throwable e) {
                 tableWriter.o3BumpErrorCount(CairoException.isCairoOomError(e));
-                LOG.error().$("open column error [table=").$safe(tableWriter.getTableToken().getTableName())
+                LOG.error().$("open column error [table=").$(tableWriter.getTableToken())
                         .$(", e=").$(e)
                         .I$();
 
@@ -2415,7 +2415,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                     }
                 } catch (Throwable e) {
                     tableWriter.o3BumpErrorCount(CairoException.isCairoOomError(e));
-                    LOG.critical().$("open column error [table=").$safe(tableWriter.getTableToken().getTableName())
+                    LOG.critical().$("open column error [table=").$(tableWriter.getTableToken())
                             .$(", e=").$(e)
                             .I$();
                     columnsInFlight = i + 1;

--- a/core/src/main/java/io/questdb/cairo/O3PartitionPurgeJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionPurgeJob.java
@@ -90,7 +90,7 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
     private static void parsePartitionDateVersion(
             Utf8StringSink fileNameSink,
             DirectLongList partitionList,
-            CharSequence tableName,
+            TableToken tableToken,
             DateFormat partitionByFormat
     ) {
         int index = Utf8s.lastIndexOfAscii(fileNameSink, '.');
@@ -121,12 +121,12 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
             } catch (NumericException e) {
                 if (!Utf8s.startsWithAscii(fileNameSink, WalUtils.WAL_NAME_BASE) && !Utf8s.equalsAscii(WalUtils.SEQ_DIR, fileNameSink)
                         && !Utf8s.equalsAscii("seq", fileNameSink)) {
-                    LOG.info().$("unknown directory [table=").$safe(tableName).$(", dir=").$(fileNameSink).I$();
+                    LOG.info().$("unknown directory [table=").$(tableToken).$(", dir=").$(fileNameSink).I$();
                 }
                 partitionList.setPos(partitionList.size() - 1); // remove partition version record
             }
         } catch (NumericException e) {
-            LOG.error().$("unknown directory [table=").$safe(tableName).$(", dir=").$(fileNameSink).I$();
+            LOG.error().$("unknown directory [table=").$(tableToken).$(", dir=").$(fileNameSink).I$();
         }
     }
 
@@ -149,7 +149,7 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
             try {
                 do {
                     if (ff.isDirOrSoftLinkDirNoDots(path, plimit, ff.findName(p), ff.findType(p), fileNameSink)) {
-                        parsePartitionDateVersion(fileNameSink, partitionList, tableToken.getDirName(), partitionByFormat);
+                        parsePartitionDateVersion(fileNameSink, partitionList, tableToken, partitionByFormat);
                         path.trimTo(plimit).$();
                     }
                 } while (ff.findNext(p) > 0);
@@ -222,8 +222,8 @@ public class O3PartitionPurgeJob extends AbstractQueueConsumerJob<O3PartitionPur
             // It is possible that the table is dropped while this async job was in the queue.
             // so it can be not too bad. Log error and continue work on the queue
             LOG.error()
-                    .$("could not purge partition open [table=`").$(tableToken)
-                    .$("`, msg=").$safe(ex.getFlyweightMessage())
+                    .$("could not purge partition open [table=").$(tableToken)
+                    .$(", msg=").$safe(ex.getFlyweightMessage())
                     .$(", errno=").$(ex.getErrno())
                     .I$();
             LOG.error().$safe(ex.getFlyweightMessage()).$();

--- a/core/src/main/java/io/questdb/cairo/PartitionOverwriteControl.java
+++ b/core/src/main/java/io/questdb/cairo/PartitionOverwriteControl.java
@@ -40,7 +40,7 @@ public class PartitionOverwriteControl {
 
     public void acquirePartitions(TableReader reader) {
         if (enabled) {
-            LOG.info().$("acquiring partitions [table=").$safe(reader.getTableToken().getTableName())
+            LOG.info().$("acquiring partitions [table=").$(reader.getTableToken())
                     .$(", readerTxn=").$(reader.getTxn())
                     .I$();
             assert reader.isActive();
@@ -105,7 +105,7 @@ public class PartitionOverwriteControl {
 
     public void releasePartitions(TableReader reader) {
         if (enabled) {
-            LOG.info().$("releasing partitions [table=").$safe(reader.getTableToken().getTableName())
+            LOG.info().$("releasing partitions [table=").$(reader.getTableToken())
                     .$(", readerTxn=").$(reader.getTxn())
                     .I$();
 
@@ -123,7 +123,7 @@ public class PartitionOverwriteControl {
                 }
             }
 
-            LOG.error().$("reader not found in partition usage map [table=").$safe(reader.getTableToken().getTableName())
+            LOG.error().$("reader not found in partition usage map [table=").$(reader.getTableToken())
                     .$(", readerTxn=").$(reader.getTxn())
                     .I$();
         }

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -239,7 +239,7 @@ public class TableReader implements Closeable, SymbolTableSource {
             Misc.free(txnScoreboard);
             Misc.free(path);
             Misc.free(columnVersionReader);
-            LOG.debug().$("closed '").$safe(tableToken.getTableName()).$('\'').$();
+            LOG.debug().$("closed [table=").$(tableToken).I$();
         }
     }
 
@@ -814,7 +814,7 @@ public class TableReader implements Closeable, SymbolTableSource {
         long newNameTxn = txFile.getPartitionNameTxnByPartitionTimestamp(partitionTs);
         long newSize = txFile.getPartitionRowCountByTimestamp(partitionTs);
         if (existingPartitionNameTxn != newNameTxn || newSize < 0) {
-            LOG.debug().$("close outdated partition files [table=").$safe(tableToken.getTableName()).$(", ts=").$ts(partitionTs).$(", nameTxn=").$(newNameTxn).$();
+            LOG.debug().$("close outdated partition files [table=").$(tableToken).$(", ts=").$ts(partitionTs).$(", nameTxn=").$(newNameTxn).$();
             // Close all columns, partition is overwritten. Partition reconciliation process will re-open correct files
             if (getPartitionFormat(partitionIndex) == PartitionFormat.NATIVE) {
                 for (int i = 0; i < columnCount; i++) {
@@ -907,7 +907,7 @@ public class TableReader implements Closeable, SymbolTableSource {
     }
 
     private void createNewColumnList(int columnCount, TableReaderMetadataTransitionIndex transitionIndex, int columnCountShl) {
-        LOG.debug().$("resizing columns file list [table=").$safe(tableToken.getTableName()).I$();
+        LOG.debug().$("resizing columns file list [table=").$(tableToken).I$();
         int capacity = partitionCount << columnCountShl;
         final ObjList<MemoryCMR> toColumns = new ObjList<>(capacity + 2);
         final LongList toColumnTops = new LongList(capacity / 2);
@@ -1630,7 +1630,7 @@ public class TableReader implements Closeable, SymbolTableSource {
                 }
             } catch (CairoException ex) {
                 // This is a temporary solution until we can get multiple versions of metadata not overwriting each other
-                TableUtils.handleMetadataLoadException(tableToken.getTableName(), deadline, ex, configuration.getMillisecondClock(), configuration.getSpinLockTimeout());
+                TableUtils.handleMetadataLoadException(tableToken, deadline, ex, configuration.getMillisecondClock(), configuration.getSpinLockTimeout());
                 continue;
             }
 
@@ -1732,7 +1732,7 @@ public class TableReader implements Closeable, SymbolTableSource {
     }
 
     private void reshuffleColumns(int columnCount, TableReaderMetadataTransitionIndex transitionIndex) {
-        LOG.debug().$("reshuffling columns file list [table=").$safe(tableToken.getTableName()).I$();
+        LOG.debug().$("reshuffling columns file list [table=").$(tableToken).I$();
         int iterateCount = Math.max(columnCount, this.columnCount);
 
         for (int partitionIndex = 0; partitionIndex < partitionCount; partitionIndex++) {

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -848,7 +848,7 @@ public final class TableUtils {
     }
 
     public static void handleMetadataLoadException(
-            CharSequence tableName,
+            TableToken tableToken,
             long deadline,
             CairoException ex,
             MillisecondClock millisecondClock,
@@ -857,7 +857,7 @@ public final class TableUtils {
         // This is temporary solution until we can get multiple version of metadata not overwriting each other
         if (ex.errnoFileCannotRead()) {
             if (millisecondClock.getTicks() < deadline) {
-                LOG.info().$("error reloading metadata [table=").$safe(tableName)
+                LOG.info().$("error reloading metadata [table=").$(tableToken)
                         .$(", msg=").$safe(ex.getFlyweightMessage())
                         .$(", errno=").$(ex.getErrno())
                         .I$();

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -372,7 +372,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             CairoEngine cairoEngine,
             TxnScoreboardPool txnScoreboardPool
     ) {
-        LOG.info().$("open '").$safe(tableToken.getTableName()).$('\'').$();
+        LOG.info().$("open '").$(tableToken).$('\'').$();
         this.configuration = configuration;
         this.ddlListener = ddlListener;
         this.checkpointStatus = checkpointStatus;
@@ -781,7 +781,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 rollback(); // rollback seqTxn
             } catch (Throwable th2) {
                 LOG.critical().$("could not rollback, table is distressed [table=")
-                        .$safe(tableToken.getTableName()).$(", error=").$(th2).I$();
+                        .$(tableToken).$(", error=").$(th2).I$();
             }
             throw th;
         }
@@ -823,7 +823,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
         if (inTransaction()) {
             assert !tableToken.isWal();
-            LOG.info().$("committing open transaction before applying attach partition command [table=").$safe(tableToken.getTableName())
+            LOG.info().$("committing open transaction before applying attach partition command [table=").$(tableToken)
                     .$(", partition=").$ts(timestamp).I$();
             commit();
 
@@ -932,11 +932,11 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             txWriter.setColumnVersion(columnVersionWriter.getVersion());
             txWriter.commit(denseSymbolMapWriters);
 
-            LOG.info().$("partition attached [table=").$safe(tableToken.getTableName())
+            LOG.info().$("partition attached [table=").$(tableToken)
                     .$(", partition=").$ts(timestamp).I$();
 
             if (appendPartitionAttached) {
-                LOG.info().$("switch partition after partition attach [tableName=").$safe(tableToken.getTableName())
+                LOG.info().$("switch partition after partition attach [tableName=").$(tableToken)
                         .$(", partition=").$ts(timestamp).I$();
                 freeColumns(true);
                 configureAppendPosition();
@@ -945,7 +945,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         } catch (Throwable e) {
             // This is pretty serious; after partition copied, there are no OS operations to fail.
             // Do full rollback to clean up the state
-            LOG.critical().$("failed on attaching partition to the table and rolling back [tableName=").$safe(tableToken.getTableName())
+            LOG.critical().$("failed on attaching partition to the table and rolling back [tableName=").$(tableToken)
                     .$(", error=").$(e).I$();
             rollback();
             throw e;
@@ -1069,7 +1069,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
             clearTodoAndCommitMetaStructureVersion();
         } catch (Throwable th) {
-            LOG.critical().$("could not change column type [table=").$safe(tableToken.getTableName()).$(", column=").$safe(columnName)
+            LOG.critical().$("could not change column type [table=").$(tableToken).$(", column=").$safe(columnName)
                     .$(", error=").$(th).I$();
             distressed = true;
             throw th;
@@ -1194,7 +1194,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 }
             }
         } catch (Throwable th) {
-            LOG.critical().$("could not change column type [table=").$safe(tableToken.getTableName()).$(", column=").$safe(columnName)
+            LOG.critical().$("could not change column type [table=").$(tableToken).$(", column=").$safe(columnName)
                     .$(", error=").$(th).I$();
             distressed = true;
             throw th;
@@ -1225,7 +1225,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     public void closeActivePartition(boolean truncate) {
-        LOG.debug().$("closing last partition [table=").$safe(tableToken.getTableName()).I$();
+        LOG.debug().$("closing last partition [table=").$(tableToken).I$();
         closeAppendMemoryTruncate(truncate);
         freeIndexers();
     }
@@ -1347,7 +1347,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             assert !tableToken.isWal();
             LOG.info()
                     .$("committing open transaction before applying convert partition to parquet command [table=")
-                    .$safe(tableToken.getTableName())
+                    .$(tableToken)
                     .$(", partition=").$ts(partitionTimestamp)
                     .I$();
             commit();
@@ -1359,7 +1359,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             // The partition is active; conversion is currently unsupported.
             LOG.info()
                     .$("skipping active partition as it cannot be converted to parquet format [table=")
-                    .$safe(tableToken.getTableName())
+                    .$(tableToken)
                     .$(", partition=").$ts(partitionTimestamp)
                     .I$();
             return true;
@@ -1528,7 +1528,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 parquetFileLength = ff.length(other.$());
             }
         } catch (CairoException e) {
-            LOG.error().$("could not convert partition to parquet [table=").$safe(tableToken.getTableName())
+            LOG.error().$("could not convert partition to parquet [table=").$(tableToken)
                     .$(", partition=").$ts(partitionTimestamp)
                     .$(", error=").$safe(e.getMessage()).I$();
 
@@ -1575,7 +1575,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         if (inTransaction()) {
             LOG.info()
                     .$("committing open transaction before applying convert partition to parquet command [table=")
-                    .$safe(tableToken.getTableName())
+                    .$(tableToken)
                     .$(", partition=").$ts(partitionTimestamp)
                     .I$();
             commit();
@@ -1700,7 +1700,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 }
             }
         } catch (CairoException e) {
-            LOG.error().$("could not convert partition to native [table=").$safe(tableToken.getTableName())
+            LOG.error().$("could not convert partition to native [table=").$(tableToken)
                     .$(", partition=").$ts(partitionTimestamp)
                     .$(", error=").$safe(e.getMessage()).I$();
 
@@ -1763,7 +1763,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             assert !tableToken.isWal();
             LOG.info()
                     .$("committing open transaction before applying detach partition command [table=")
-                    .$safe(tableToken.getTableName())
+                    .$(tableToken)
                     .$(", partition=").$ts(timestamp)
                     .I$();
             commit();
@@ -1926,7 +1926,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     public void disableDeduplication() {
         assert txWriter.getLagRowCount() == 0;
         checkDistressed();
-        LOG.info().$("disabling row deduplication [table=").$safe(tableToken.getTableName()).I$();
+        LOG.info().$("disabling row deduplication [table=").$(tableToken).I$();
         for (int i = 0; i < columnCount; i++) {
             metadata.getColumnMetadata(i).setDedupKeyFlag(false);
         }
@@ -1962,7 +1962,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             assert !tableToken.isWal();
             LOG.info()
                     .$("committing current transaction before DROP INDEX execution [txn=").$(txWriter.getTxn())
-                    .$(", table=").$safe(tableToken.getTableName())
+                    .$(", table=").$(tableToken)
                     .$(", column=").$safe(columnName)
                     .I$();
             commit();
@@ -1970,7 +1970,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
         try {
             LOG.info().$("removing index [txn=").$(txWriter.getTxn())
-                    .$(", table=").$safe(tableToken.getTableName())
+                    .$(", table=").$(tableToken)
                     .$(", column=").$safe(columnName)
                     .I$();
             // drop index
@@ -2003,13 +2003,13 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             }
 
             LOG.info().$("END DROP INDEX [txn=").$(txWriter.getTxn())
-                    .$(", table=").$safe(tableToken.getTableName())
+                    .$(", table=").$(tableToken)
                     .$(", column=").$safe(columnName)
                     .I$();
         } catch (CairoException e) {
             // LOG original exception detail
             LOG.critical().$("exception on index drop [txn=").$(txWriter.getTxn())
-                    .$(", table=").$safe(tableToken.getTableName())
+                    .$(", table=").$(tableToken)
                     .$(", column=").$safe(columnName)
                     .$(", errno=").$(e.errno)
                     .$(", error=").$((Throwable) e).I$();
@@ -2022,7 +2022,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         } catch (Throwable e) {
             // LOG original exception detail
             LOG.critical().$("exception on index drop [txn=").$(txWriter.getTxn())
-                    .$(", table=").$safe(tableToken.getTableName())
+                    .$(", table=").$(tableToken)
                     .$(", column=").$safe(columnName)
                     .$(", error=").$(e).I$();
 
@@ -2038,7 +2038,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     public boolean enableDeduplicationWithUpsertKeys(LongList columnsIndexes) {
         assert txWriter.getLagRowCount() == 0;
         checkDistressed();
-        LogRecord logRec = LOG.info().$("enabling row deduplication [table=").$safe(tableToken.getTableName()).$(", columns=[");
+        LogRecord logRec = LOG.info().$("enabling row deduplication [table=").$(tableToken).$(", columns=[");
 
         boolean isSubsetOfOldKeys = true;
         try {
@@ -2123,7 +2123,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     : Timestamps.getMonthsBetween(partitionCeiling, maxTimestamp) >= -ttl;
             if (shouldEvict) {
                 LOG.info()
-                        .$("Partition's TTL expired, evicting. table=").$safe(metadata.getTableName())
+                        .$("Partition's TTL expired, evicting. table=").$(metadata.getTableToken())
                         .$(" partitionTs=").microTime(partitionTimestamp)
                         .$();
                 dropped |= dropPartitionByExactTimestamp(partitionTimestamp);
@@ -2584,7 +2584,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     .$("not my command [cmdTableId=").$(cmd.getTableId())
                     .$(", cmdTableName=").$(cmd.getTableToken())
                     .$(", myTableId=").$(getMetadata().getTableId())
-                    .$(", myTableName=").$safe(tableToken.getTableName())
+                    .$(", myTableName=").$(tableToken)
                     .I$();
             commandSubSeq.done(cursor);
         }
@@ -2645,7 +2645,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         closeActivePartition(false);
         processPartitionRemoveCandidates();
 
-        LOG.info().$("removed all partitions (soft truncated) [name=").$safe(tableToken.getTableName()).I$();
+        LOG.info().$("removed all partitions (soft truncated) [name=").$(tableToken).I$();
     }
 
     @Override
@@ -2820,7 +2820,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         checkDistressed();
         if (o3InError || inTransaction()) {
             try {
-                LOG.info().$("tx rollback [name=").$safe(tableToken.getTableName()).I$();
+                LOG.info().$("tx rollback [name=").$(tableToken).I$();
                 partitionRemoveCandidates.clear();
                 o3CommitBatchTimestampMin = Long.MAX_VALUE;
                 if ((masterRef & 1) != 0) {
@@ -3637,7 +3637,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 if (tableColType != attachColType) {
                     // This is very suspicious. The column was deleted in the detached partition,
                     // but it exists in the target table.
-                    LOG.info().$("detached partition has column deleted while the table has the same column alive [tableName=").$safe(tableToken.getTableName())
+                    LOG.info().$("detached partition has column deleted while the table has the same column alive [tableName=").$(tableToken)
                             .$(", column=").$safe(columnName)
                             .$(", columnType=").$(ColumnType.nameOf(tableColType))
                             .I$();
@@ -4129,7 +4129,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 }
             }
         } catch (CairoException e) {
-            LOG.error().$("could not copy index files [table=").$safe(tableToken.getTableName())
+            LOG.error().$("could not copy index files [table=").$(tableToken)
                     .$(", partition=").$ts(partitionTimestamp)
                     .$(", error=").$safe(e.getMessage()).I$();
 
@@ -5403,7 +5403,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             Throwable e
     ) {
         o3ErrorCount.incrementAndGet();
-        LogRecord logRecord = LOG.critical().$(message + " [table=").$safe(tableToken.getTableName())
+        LogRecord logRecord = LOG.critical().$(message + " [table=").$(tableToken)
                 .$(", column=").$safe(getColumnNameSafe(columnIndex))
                 .$(", type=").$(ColumnType.nameOf(columnType))
                 .$(", long0=").$(long0)
@@ -5734,7 +5734,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     private Row newRowO3(long timestamp) {
-        LOG.info().$("switched to o3 [table=").$safe(tableToken.getTableName()).I$();
+        LOG.info().$("switched to o3 [table=").$(tableToken).I$();
         txWriter.beginPartitionSizeUpdate();
         o3OpenColumns();
         o3InError = false;
@@ -5771,7 +5771,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             // to determine that 'ooTimestampLo' goes into the current partition
             // we need to compare 'partitionTimestampHi', which is appropriately truncated to DAY/MONTH/YEAR
             // to this.maxTimestamp, which isn't truncated yet. So we need to truncate it first
-            LOG.debug().$("sorting o3 [table=").$safe(tableToken.getTableName()).I$();
+            LOG.debug().$("sorting o3 [table=").$(tableToken).I$();
             final long sortedTimestampsAddr = o3TimestampMem.getAddress();
 
             // resize timestamp memory if needed
@@ -5867,7 +5867,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     }
                 }
 
-                LOG.info().$("o3 commit [table=").$safe(tableToken.getTableName())
+                LOG.info().$("o3 commit [table=").$(tableToken)
                         .$(", maxUncommittedRows=").$(maxUncommittedRows)
                         .$(", o3TimestampMin=").$ts(o3TimestampMin)
                         .$(", o3TimestampMax=").$ts(o3TimestampMax)
@@ -5883,7 +5883,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
             } else {
                 LOG.info()
-                        .$("o3 commit [table=").$safe(tableToken.getTableName())
+                        .$("o3 commit [table=").$(tableToken)
                         .$(", o3RowCount=").$(o3RowCount)
                         .I$();
                 srcOooMax = o3RowCount;
@@ -5907,7 +5907,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             dispatchColumnTasks(sortedTimestampsAddr, sortedTimestampsRowCount, IGNORE, IGNORE, IGNORE, cthO3SortColumnRef);
             swapO3ColumnsExcept(timestampColumnIndex);
             LOG.info()
-                    .$("sorted [table=").$safe(tableToken.getTableName())
+                    .$("sorted [table=").$(tableToken)
                     .$(", o3RowCount=").$(o3RowCount)
                     .I$();
 
@@ -6111,7 +6111,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
                 if (newPartitionTimestamp != partitionTimestamp) {
                     LOG.info()
-                            .$("o3 split partition [table=").$safe(tableToken.getTableName())
+                            .$("o3 split partition [table=").$(tableToken)
                             .$(", part1=").$(
                                     formatPartitionForTimestamp(
                                             partitionTimestamp,
@@ -6136,8 +6136,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 if (partitionMutates && newPartitionTimestamp == partitionTimestamp) {
                     final long srcNameTxn = txWriter.getPartitionNameTxnByRawIndex(partitionIndexRaw);
                     LOG.info()
-                            .$("merged partition [table=`").$safe(tableToken.getTableName())
-                            .$("`, ts=").$ts(partitionTimestamp)
+                            .$("merged partition [table=").$(tableToken)
+                            .$(", ts=").$ts(partitionTimestamp)
                             .$(", txn=").$(txWriter.txn)
                             .$(", rows=").$(srcDataNewPartitionSize)
                             .I$();
@@ -6496,7 +6496,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         final long transientRowsAdded = Math.min(transientRowCount, rowsAdded);
         if (transientRowsAdded > 0) {
             LOG.debug()
-                    .$("o3 move uncommitted [table=").$safe(tableToken.getTableName())
+                    .$("o3 move uncommitted [table=").$(tableToken)
                     .$(", transientRowsAdded=").$(transientRowsAdded)
                     .I$();
             final long committedTransientRowCount = transientRowCount - transientRowsAdded;
@@ -6812,7 +6812,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             errorMsg = ex.getFlyweightMessage();
         } catch (Throwable ex) {
             LOG.error().$("error on processing async cmd [type=").$(cmdType)
-                    .$(", tableName=").$safe(tableToken.getTableName())
+                    .$(", tableName=").$(tableToken)
                     .$(", ex=").$(ex)
                     .I$();
             errorCode = UNEXPECTED_ERROR;
@@ -6997,7 +6997,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
                     pCount++;
 
-                    LOG.info().$("o3 partition task [table=").$safe(tableToken.getTableName())
+                    LOG.info().$("o3 partition task [table=").$(tableToken)
                             .$(", partitionTs=").$ts(partitionTimestamp)
                             .$(", partitionIndex=").$(partitionIndexRaw)
                             .$(", last=").$(last)
@@ -7021,7 +7021,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     if (partitionIsReadOnly) {
                         // move over read-only partitions
                         LOG.critical()
-                                .$("o3 ignoring write on read-only partition [table=").$safe(tableToken.getTableName())
+                                .$("o3 ignoring write on read-only partition [table=").$(tableToken)
                                 .$(", timestamp=").$ts(partitionTimestamp)
                                 .$(", numRows=").$(srcOooBatchRowSize)
                                 .$();
@@ -7225,7 +7225,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         } finally {
             // we are stealing work here it is possible we get exception from this method
             LOG.debug()
-                    .$("o3 expecting updates [table=").$safe(tableToken.getTableName())
+                    .$("o3 expecting updates [table=").$(tableToken)
                     .$(", partitionsPublished=").$(pCount)
                     .I$();
 
@@ -7243,7 +7243,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
 
         if (o3LagRowCount > 0 && !metadata.isWalEnabled()) {
-            LOG.info().$("shifting lag rows up [table=").$safe(tableToken.getTableName()).$(", lagCount=").$(o3LagRowCount).I$();
+            LOG.info().$("shifting lag rows up [table=").$(tableToken).$(", lagCount=").$(o3LagRowCount).I$();
             dispatchColumnTasks(
                     o3LagRowCount,
                     IGNORE,
@@ -7306,9 +7306,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             // Any more complicated case involve looking at what folders are present on disk before removing
             // do it async in O3PartitionPurgeJob
             if (schedulePurgeO3Partitions(messageBus, tableToken, partitionBy)) {
-                LOG.debug().$("scheduled to purge partitions [table=").$safe(tableToken.getTableName()).I$();
+                LOG.debug().$("scheduled to purge partitions [table=").$(tableToken).I$();
             } else {
-                LOG.error().$("could not queue for purge, queue is full [table=").$safe(tableToken.getTableName()).I$();
+                LOG.error().$("could not queue for purge, queue is full [table=").$(tableToken).I$();
             }
         }
     }
@@ -7800,7 +7800,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             long minTs = segmentCopyInfo.getMinTimestamp();
             long maxTs = segmentCopyInfo.getMaxTimestamp();
 
-            LOG.debug().$("sorting [table=").$safe(tableToken.getTableName())
+            LOG.debug().$("sorting [table=").$(tableToken)
                     .$(", rows=").$(segmentCopyInfo.getTotalRows())
                     .$(", segments=").$(segmentCopyInfo.getSegmentCount())
                     .$(", minTs=").$ts(minTs)
@@ -8103,7 +8103,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
                 destinationColumn.jumpTo((rowsOffset + totalRows) << shl);
 
-                LOG.debug().$("remapping WAL symbols [table=").$safe(tableToken.getTableName())
+                LOG.debug().$("remapping WAL symbols [table=").$(tableToken)
                         .$(", column=").$safe(metadata.getColumnName(columnIndex))
                         .$(", rows=").$(totalRows)
                         .$(", txnCount=").$(txnCount)
@@ -8129,7 +8129,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             } else {
                 // Save the hint that symbol column is not re-mapped
                 Unsafe.getUnsafe().putLong(mappedAddrBuffPrimary, 0);
-                LOG.debug().$("no new symbols, no remapping needed [table=").$safe(tableToken.getTableName())
+                LOG.debug().$("no new symbols, no remapping needed [table=").$(tableToken)
                         .$(", column=").$safe(metadata.getColumnName(columnIndex))
                         .$(", rows=").$(totalRows)
                         .I$();
@@ -8942,7 +8942,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             path.trimTo(pathSize);
         } else {
             LOG.critical()
-                    .$("o3 ignoring removal of column in read-only partition [table=").$safe(tableToken.getTableName())
+                    .$("o3 ignoring removal of column in read-only partition [table=").$(tableToken)
                     .$(", column=").$safe(columnName)
                     .$(", timestamp=").$ts(partitionTimestamp)
                     .$();
@@ -9180,7 +9180,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             final long expectedSize = txWriter.unsafeReadFixedRowCount();
             if (expectedSize != fixedRowCount || maxTimestamp != this.txWriter.getMaxTimestamp()) {
                 LOG.info()
-                        .$("actual table size has been adjusted [name=`").$safe(tableToken.getTableName()).$('`')
+                        .$("actual table size has been adjusted [name=`").$(tableToken).$('`')
                         .$(", expectedFixedSize=").$(expectedSize)
                         .$(", actualFixedSize=").$(fixedRowCount)
                         .I$();
@@ -9633,7 +9633,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
 
         if (checkpointStatus.partitionsLocked()) {
-            LOG.info().$("cannot squash partition [table=").$safe(tableToken.getTableName())
+            LOG.info().$("cannot squash partition [table=").$(tableToken)
                     .$("], checkpoint in progress").$();
             return;
         }
@@ -9917,7 +9917,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         this.minSplitPartitionTimestamp = Long.MAX_VALUE;
         processPartitionRemoveCandidates();
 
-        LOG.info().$("truncated [name=").$safe(tableToken.getTableName()).I$();
+        LOG.info().$("truncated [name=").$(tableToken).I$();
 
         try (MetadataCacheWriter metadataRW = engine.getMetadataCache().writeLock()) {
             metadataRW.hydrateTable(metadata);
@@ -9953,7 +9953,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         final Sequence indexPubSequence = this.messageBus.getIndexerPubSequence();
         final RingQueue<ColumnIndexerTask> indexerQueue = this.messageBus.getIndexerQueue();
 
-        LOG.info().$("parallel indexing [table=").$safe(tableToken.getTableName())
+        LOG.info().$("parallel indexing [table=").$(tableToken)
                 .$(", indexCount=").$(indexCount)
                 .$(", rowCount=").$(hi - lo)
                 .I$();
@@ -10031,7 +10031,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     private void updateIndexesSerially(long lo, long hi) {
-        LOG.debug().$("serial indexing [table=").$safe(tableToken.getTableName())
+        LOG.debug().$("serial indexing [table=").$(tableToken)
                 .$(", indexCount=").$(indexCount)
                 .$(", rowCount=").$(hi - lo)
                 .I$();
@@ -10043,7 +10043,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 throwDistressException(e);
             }
         }
-        LOG.debug().$("serial indexing done [table=").$safe(tableToken.getTableName()).I$();
+        LOG.debug().$("serial indexing done [table=").$(tableToken).I$();
     }
 
     private void updateIndexesSlow() {

--- a/core/src/main/java/io/questdb/cairo/pool/AbstractMultiTenantPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/AbstractMultiTenantPool.java
@@ -178,7 +178,7 @@ public abstract class AbstractMultiTenantPool<T extends PoolTenant<T>> extends A
         }
 
         notifyListener(thread, tableToken, PoolListener.EV_UNLOCKED, -1, -1);
-        LOG.debug().$("unlocked [table=`").$(tableToken).I$();
+        LOG.debug().$("unlocked [table=").$(tableToken).I$();
     }
 
     private void checkClosed() {

--- a/core/src/main/java/io/questdb/cairo/pool/TableReaderMetadataTenantImpl.java
+++ b/core/src/main/java/io/questdb/cairo/pool/TableReaderMetadataTenantImpl.java
@@ -211,7 +211,7 @@ class TableReaderMetadataTenantImpl extends TableReaderMetadata implements PoolT
                 }
             } catch (CairoException ex) {
                 // This is temporary solution until we can get multiple version of metadata not overwriting each other
-                TableUtils.handleMetadataLoadException(getTableToken().getTableName(), deadline, ex, configuration.getMillisecondClock(), configuration.getSpinLockTimeout());
+                TableUtils.handleMetadataLoadException(getTableToken(), deadline, ex, configuration.getMillisecondClock(), configuration.getSpinLockTimeout());
                 continue;
             }
 

--- a/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/WriterPool.java
@@ -564,8 +564,8 @@ public class WriterPool extends AbstractPool {
         }
 
         if (e.owner != UNALLOCATED) {
-            LOG.debug().$("<< [table=`").$(tableToken)
-                    .$("`, thread=").$(thread).$(']').$();
+            LOG.debug().$("<< [table=").$(tableToken)
+                    .$(", thread=").$(thread).$(']').$();
 
             e.ownershipReason = OWNERSHIP_REASON_NONE;
             e.lastReleaseTime = configuration.getMicrosecondClock().getTicks();

--- a/core/src/main/java/io/questdb/cairo/sql/TableReferenceOutOfDateException.java
+++ b/core/src/main/java/io/questdb/cairo/sql/TableReferenceOutOfDateException.java
@@ -31,7 +31,7 @@ import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8Sequence;
 
 public class TableReferenceOutOfDateException extends RuntimeException implements FlyweightMessageContainer {
-    private static final String prefix = "cached query plan cannot be used because table schema has changed [table='";
+    private static final String prefix = "cached query plan cannot be used because table schema has changed [table=";
     private static final ThreadLocal<TableReferenceOutOfDateException> tlException = new ThreadLocal<>(TableReferenceOutOfDateException::new);
     private final StringSink message = (StringSink) new StringSink().put(prefix);
 
@@ -40,7 +40,7 @@ public class TableReferenceOutOfDateException extends RuntimeException implement
         // This is to have correct stack trace in local debugging with -ea option
         assert (ex = new TableReferenceOutOfDateException()) != null;
         ex.message.clear(prefix.length());
-        ex.message.put(outdatedTableName).put("']");
+        ex.message.put(outdatedTableName).put(']');
         return ex;
     }
 

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -514,7 +514,7 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
             logRecord.$(", error=").$(throwable).I$();
             engine.getTableSequencerAPI().suspendTable(tableToken, errorTag, errorMessage);
         } catch (CairoException e) {
-            LOG.critical().$("could not suspend table [table=").$(tableToken.getTableName())
+            LOG.critical().$("could not suspend table [table=").$(tableToken)
                     .$(", error=").$safe(e.getFlyweightMessage())
                     .I$();
         }

--- a/core/src/main/java/io/questdb/cairo/wal/WalReader.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalReader.java
@@ -82,7 +82,7 @@ public class WalReader implements Closeable {
             metadata.open(path.slash().put(segmentId), rootLen, tableToken);
             columnCount = metadata.getColumnCount();
             events = new WalEventReader(ff);
-            LOG.debug().$("open [table=").$safe(tableName).I$();
+            LOG.debug().$("open [table=").$(tableToken).I$();
             int pathLen = path.size();
             eventCursor = events.of(path.slash().put(segmentId), -1);
             path.trimTo(pathLen);

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpConnectionContext.java
@@ -158,14 +158,14 @@ public class LineTcpConnectionContext extends IOContext<LineTcpConnectionContext
                 } catch (CommitFailedException ex) {
                     if (ex.isTableDropped()) {
                         // table dropped, nothing to worry about
-                        LOG.info().$("closing writer because table has been dropped (2) [table=").$safe(tud.getTableNameUtf16()).I$();
+                        LOG.info().$("closing writer because table has been dropped (2) [table=").$(tud.getTableToken()).I$();
                         tud.setWriterInError();
                         tud.releaseWriter(false);
                     } else {
-                        LOG.critical().$("commit failed [table=").$safe(tud.getTableNameUtf16()).$(",ex=").$(ex).I$();
+                        LOG.critical().$("commit failed [table=").$(tud.getTableToken()).$(",ex=").$(ex).I$();
                     }
                 } catch (Throwable ex) {
-                    LOG.critical().$("commit failed [table=").$safe(tud.getTableNameUtf16()).$(",ex=").$(ex).I$();
+                    LOG.critical().$("commit failed [table=").$(tud.getTableToken()).$(",ex=").$(ex).I$();
                 }
             }
         }

--- a/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserImpl.java
+++ b/core/src/main/java/io/questdb/cutlass/line/udp/LineUdpParserImpl.java
@@ -457,7 +457,7 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
                 columnValues.add(value.getCacheAddress());
                 geoHashBitsSizeByColIdx.add(geoHashBits);
             } else {
-                LOG.error().$("mismatched column and value types [table=").$safe(writer.getTableToken().getTableName())
+                LOG.error().$("mismatched column and value types [table=").$(writer.getTableToken())
                         .$(", column=").$safe(metadata.getColumnName(columnIndex))
                         .$(", columnType=").$(ColumnType.nameOf(columnType))
                         .$(", valueType=").$(ColumnType.nameOf(valueType))
@@ -479,7 +479,7 @@ public class LineUdpParserImpl implements LineUdpParser, Closeable {
                         .put(", columnName=").put(colNameAsChars)
                         .put(']');
             } else {
-                LOG.error().$("invalid column name [table=").$safe(writer.getTableToken().getTableName())
+                LOG.error().$("invalid column name [table=").$(writer.getTableToken())
                         .$(", columnName=").$safe(colNameAsChars)
                         .$(']').$();
                 switchModeToSkipLine();

--- a/core/src/main/java/io/questdb/cutlass/text/TextDelimiterScanner.java
+++ b/core/src/main/java/io/questdb/cutlass/text/TextDelimiterScanner.java
@@ -228,8 +228,8 @@ public class TextDelimiterScanner implements Closeable {
         // exclude '.' as delimiter
         if (delimiter != '.' && lastDelimiterStdDev < maxRequiredDelimiterStdDev) {
             LOG.info()
-                    .$("scan result [table=`").$safe(tableName)
-                    .$("`, delimiter='").$((char) delimiter)
+                    .$("scan result [table=").$safe(tableName)
+                    .$(", delimiter='").$((char) delimiter)
                     .$("', priority=").$(lastDelimiterPriority)
                     .$(", mean=").$(lastDelimiterMean)
                     .$(", stddev=").$(lastDelimiterStdDev)

--- a/core/src/main/java/io/questdb/cutlass/text/TextLoader.java
+++ b/core/src/main/java/io/questdb/cutlass/text/TextLoader.java
@@ -162,8 +162,8 @@ public class TextLoader implements Closeable, Mutable {
         }
 
         LOG.info()
-                .$("configured [table=`").$(tableName)
-                .$("`, overwrite=").$(overwrite)
+                .$("configured [table=").$(tableName)
+                .$(", overwrite=").$(overwrite)
                 .$(", atomicity=").$(atomicity)
                 .$(", partitionBy=").$(PartitionBy.toString(partitionBy))
                 .$(", timestamp=").$(timestampColumn)

--- a/core/src/main/java/io/questdb/griffin/PurgingOperator.java
+++ b/core/src/main/java/io/questdb/griffin/PurgingOperator.java
@@ -175,12 +175,12 @@ public final class PurgingOperator {
                     );
                     cleanupColumnVersions.setPos(cleanupVersionSize);
 
-                    log.info().$("column purge scheduled [table=").$safe(tableToken.getTableName())
+                    log.info().$("column purge scheduled [table=").$(tableToken)
                             .$(", column=").$safe(columnName)
                             .$(", updateTxn=").$(txn)
                             .I$();
                 } else {
-                    log.info().$("column purge complete [table=").$safe(tableToken.getTableName())
+                    log.info().$("column purge complete [table=").$(tableToken)
                             .$(", column=").$safe(columnName)
                             .$(", newColumnVersion=").$(txn - 1)
                             .I$();

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -2147,7 +2147,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                 throw SqlException.$(lexer.lastTokenPosition(), ALTER_TABLE_EXPECTED_TOKEN_DESCR).put(" expected");
             }
         } catch (CairoException e) {
-            LOG.info().$("could not alter table [table=").$(tableToken.getTableName())
+            LOG.info().$("could not alter table [table=").$(tableToken)
                     .$(", msg=").$safe(e.getFlyweightMessage())
                     .$(", errno=").$(e.getErrno())
                     .I$();
@@ -4253,7 +4253,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             Misc.free(dstPath);
         }
 
-        private void backupTable(@NotNull TableToken tableToken) throws SqlException {
+        private void backupTable(@NotNull final TableToken tableToken) throws SqlException {
             LOG.info().$("starting backup of ").$(tableToken).$();
 
             // the table is copied to a TMP folder and then this folder is moved to the final destination (dstPath)
@@ -4266,7 +4266,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                 cachedBackupTmpRoot = Utf8s.toString(auxPath); // absolute path to the TMP folder
             }
 
-            String tableName = tableToken.getTableName();
+            final String tableName = tableToken.getTableName();
             auxPath.of(cachedBackupTmpRoot).concat(tableToken).slash();
             int tableRootLen = auxPath.size();
             try {
@@ -4433,7 +4433,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                                     break;
                                 } catch (TableReferenceOutOfDateException ex) {
                                     // Sometimes table can be out of data when a DDL is committed concurrently, we need to retry
-                                    LOG.info().$("retrying backup due to concurrent metadata update [table=").$safe(tableName)
+                                    LOG.info().$("retrying backup due to concurrent metadata update [table=").$(tableToken)
                                             .$(", ex=").$(ex.getFlyweightMessage())
                                             .I$();
                                 }
@@ -4447,13 +4447,13 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                 try {
                     dstPath.trimTo(renameRootLen).concat(tableToken);
                     TableUtils.renameOrFail(ff, auxPath.trimTo(tableRootLen).$(), dstPath.$());
-                    LOG.info().$("backup complete [table=").$safe(tableName).$(", to=").$(dstPath).I$();
+                    LOG.info().$("backup complete [table=").$(tableToken).$(", to=").$(dstPath).I$();
                 } finally {
                     dstPath.trimTo(renameRootLen).$();
                 }
             } catch (CairoException e) {
                 LOG.info()
-                        .$("could not backup [table=").$safe(tableName)
+                        .$("could not backup [table=").$(tableToken)
                         .$(", msg=").$safe(e.getFlyweightMessage())
                         .$(", errno=").$(e.getErrno())
                         .I$();

--- a/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
+++ b/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
@@ -338,7 +338,7 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
             // In this scenario, the returned pool entry got used by another query and
             // readers.clear() came in tangentially to this query.
             LOG.critical().$("returned reader is not in supervisor's list [tableName=")
-                    .$(resource.getTableToken().getTableName()).I$();
+                    .$(resource.getTableToken()).I$();
         }
     }
 
@@ -374,7 +374,7 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
 
     private static void appendLeakedReaderNames(ObjList<TableReader> leakedReaders, int leakedReadersCount, LogRecord log) {
         for (int i = 0; i < leakedReadersCount; i++) {
-            log.$(", leaked=").$(leakedReaders.getQuick(i).getTableToken().getTableName());
+            log.$(", leaked=").$(leakedReaders.getQuick(i).getTableToken());
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/MatViewsFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/MatViewsFunctionFactory.java
@@ -204,7 +204,7 @@ public class MatViewsFunctionFactory implements FunctionFactory {
                                 viewStateFileReader.of(path.trimTo(pathLen).concat(viewToken.getDirName()).concat(MatViewState.MAT_VIEW_STATE_FILE_NAME).$());
                                 viewStateReader.of(viewStateFileReader, viewToken);
                             } catch (CairoException e) {
-                                LOG.info().$("could not read materialized view state file [view=").$safe(viewToken.getTableName())
+                                LOG.info().$("could not read materialized view state file [view=").$(viewToken)
                                         .$(", msg=").$safe(e.getFlyweightMessage())
                                         .$(", errno=").$(e.getErrno())
                                         .I$();

--- a/core/src/main/java/io/questdb/griffin/engine/ops/AlterOperation.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/AlterOperation.java
@@ -590,7 +590,7 @@ public class AlterOperation extends AbstractOperation implements Mutable {
         try {
             svc.setMetaO3MaxLag(o3MaxLag);
         } catch (CairoException e) {
-            LOG.error().$("could not change o3MaxLag [table=").$safe(getTableToken().getTableName())
+            LOG.error().$("could not change o3MaxLag [table=").$(getTableToken())
                     .$(", msg=").$safe(e.getFlyweightMessage())
                     .$(", errno=").$(e.getErrno())
                     .I$();

--- a/core/src/main/java/io/questdb/griffin/engine/ops/InsertAsSelectOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/InsertAsSelectOperationImpl.java
@@ -171,7 +171,7 @@ public class InsertAsSelectOperationImpl implements InsertOperation {
                         writer.rollback();
                     } catch (Throwable e2) {
                         // Writer is distressed, exception already logged, the pool will handle it when writer is returned
-                        LOG.error().$("could not rollback, writer must be distressed [table=").$(tableToken.getTableName()).I$();
+                        LOG.error().$("could not rollback, writer must be distressed [table=").$(tableToken).I$();
                     }
                     throw e;
                 } finally {


### PR DESCRIPTION
1. Logging now consistently uses table tokens as table names. There are some exceptions - typically parsers (ILP, text) that get table names from input and don't always have access to corresponding table tokens. Sometimes the target table doesn't exist yet.

2. Tables are no longer enclosed in quotes or backticks.