### PR TITLE
chore(core): add db name into table token to optionally include it in the logs

### DIFF
--- a/benchmarks/src/main/java/org/questdb/TableReaderReloadBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/TableReaderReloadBenchmark.java
@@ -100,7 +100,7 @@ public class TableReaderReloadBenchmark {
 
     @Setup(Level.Iteration)
     public void setup() throws NumericException {
-        TableToken tableToken = new TableToken("test", "test", 0, false, false, false);
+        TableToken tableToken = new TableToken("test", "test", null, 0, false, false, false);
         writer = new TableWriter(
                 configuration,
                 tableToken,

--- a/benchmarks/src/main/java/org/questdb/TableWriterBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/TableWriterBenchmark.java
@@ -96,9 +96,9 @@ public class TableWriterBenchmark {
 
         LogFactory.haltInstance();
 
-        TableToken tableToken1 = new TableToken("test1", "test1", 0, false, false, false);
-        TableToken tableToken2 = new TableToken("test2", "test2", 0, false, false, false);
-        TableToken tableToken3 = new TableToken("test3", "test3", 0, false, false, false);
+        TableToken tableToken1 = new TableToken("test1", "test1", null, 0, false, false, false);
+        TableToken tableToken2 = new TableToken("test2", "test2", null, 0, false, false, false);
+        TableToken tableToken3 = new TableToken("test3", "test3", null, 0, false, false, false);
 
         writer = new TableWriter(
                 configuration,

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -199,6 +199,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int createAsSelectRetryCount;
     private final int dateAdapterPoolCapacity;
     private final String dbDirectory;
+    private final String dbLogName;
     private final String dbRoot;
     private final boolean debugWalApplyBlockFailureNoRetry;
     private final int defaultSeqPartTxnCount;
@@ -819,6 +820,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
         this.installRoot = installRoot;
         this.dbDirectory = getString(properties, env, PropertyKey.CAIRO_ROOT, DB_DIRECTORY);
+        this.dbLogName = getString(properties, env, PropertyKey.DEBUG_DB_LOG_NAME, null);
         String tmpRoot;
         boolean absDbDir = new File(this.dbDirectory).isAbsolute();
         if (absDbDir) {
@@ -2975,6 +2977,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public @NotNull String getDbRoot() {
             return dbRoot;
+        }
+
+        @Override
+        public @Nullable String getDbLogName() {
+            return dbLogName;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -574,6 +574,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     MAT_VIEW_REFRESH_WORKER_YIELD_THRESHOLD("mat.view.refresh.worker.yield.threshold"),
     CAIRO_TXN_SCOREBOARD_FORMAT("cairo.txn.scoreboard.format"),
     DEBUG_WAL_APPLY_BLOCK_FAILURE_NO_RETRY("debug.wal.apply.block.failure.no.retry", false, true),
+    DEBUG_DB_LOG_NAME("debug.db.log.name", false, true),
     CAIRO_SQL_COLUMN_ALIAS_EXPRESSION_ENABLED("cairo.sql.column.alias.expression.enabled"),
     CAIRO_SQL_COLUMN_ALIAS_GENERATED_MAX_SIZE("cairo.sql.column.alias.generated.max.size"),
     CAIRO_FILE_DESCRIPTOR_CACHE_ENABLED("cairo.file.descriptor.cache.enabled");

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -188,6 +188,9 @@ public interface CairoConfiguration {
     @NotNull
     String getDbRoot(); // some folder with suffix env['cairo.root'] e.g. /.../db
 
+    @Nullable
+    String getDbLogName();
+
     boolean getDebugWalApplyBlockFailureNoRetry();
 
     @NotNull

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -257,6 +257,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public @Nullable String getDbLogName() {
+        return getDelegate().getDbLogName();
+    }
+
+    @Override
     public @NotNull String getDbRoot() {
         return getDelegate().getDbRoot();
     }
@@ -302,13 +307,13 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
-    public int getFileOperationRetryCount() {
-        return getDelegate().getFileOperationRetryCount();
+    public boolean getFileDescriptorCacheEnabled() {
+        return getDelegate().getFileDescriptorCacheEnabled();
     }
 
     @Override
-    public boolean getFileDescriptorCacheEnabled() {
-        return getDelegate().getFileDescriptorCacheEnabled();
+    public int getFileOperationRetryCount() {
+        return getDelegate().getFileOperationRetryCount();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -285,6 +285,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public @Nullable String getDbLogName() {
+        return null;
+    }
+
+    @Override
     public @NotNull String getDbRoot() {
         return dbRoot;
     }
@@ -330,13 +335,13 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
-    public int getFileOperationRetryCount() {
-        return 30;
+    public boolean getFileDescriptorCacheEnabled() {
+        return true;
     }
 
     @Override
-    public boolean getFileDescriptorCacheEnabled() {
-        return true;
+    public int getFileOperationRetryCount() {
+        return 30;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/TableConverter.java
+++ b/core/src/main/java/io/questdb/cairo/TableConverter.java
@@ -104,7 +104,7 @@ public class TableConverter {
                                 boolean isSystem = tableFlagResolver.isSystem(tableName);
                                 boolean isPublic = tableFlagResolver.isPublic(tableName);
                                 boolean isMatView = isMatViewDefinitionFileExists(configuration, path, dirName);
-                                final TableToken token = new TableToken(tableName, dirName, tableId, isMatView, walEnabled, isSystem, isProtected, isPublic);
+                                final TableToken token = new TableToken(tableName, dirName, engine.getConfiguration().getDbLogName(), tableId, isMatView, walEnabled, isSystem, isProtected, isPublic);
 
                                 if (txWriter == null) {
                                     txWriter = new TxWriter(ff, configuration);

--- a/core/src/main/java/io/questdb/cairo/TableNameRegistry.java
+++ b/core/src/main/java/io/questdb/cairo/TableNameRegistry.java
@@ -37,13 +37,13 @@ public interface TableNameRegistry extends Closeable {
      * calling code should treat it as table does not exist on queries, table already exists on "create" operations
      * and table does not exit on "drop" operations.
      */
-    TableToken LOCKED_DROP_TOKEN = new TableToken("__locked_drop__", "__locked_drop__", Integer.MAX_VALUE - 1, false, false, false);
+    TableToken LOCKED_DROP_TOKEN = new TableToken("__locked_drop__", "__locked_drop__", null, Integer.MAX_VALUE - 1, false, false, false);
     /**
      * Table token that is used to lock table name during table creation. It is not a valid table token and the
      * calling code should treat it as table does not exist on queries, table retry on "create" operations
      * and table does not exit on "drop" operations.
      */
-    TableToken LOCKED_TOKEN = new TableToken("__locked__", "__locked__", Integer.MAX_VALUE, false, false, false);
+    TableToken LOCKED_TOKEN = new TableToken("__locked__", "__locked__", null, Integer.MAX_VALUE, false, false, false);
 
     static boolean isLocked(TableToken tableToken) {
         return tableToken == LOCKED_TOKEN || tableToken == LOCKED_DROP_TOKEN;

--- a/core/src/main/java/io/questdb/cairo/TableNameRegistryRW.java
+++ b/core/src/main/java/io/questdb/cairo/TableNameRegistryRW.java
@@ -83,7 +83,8 @@ public class TableNameRegistryRW extends AbstractTableNameRegistry {
             boolean isProtected = tableFlagResolver.isProtected(tableName);
             boolean isSystem = tableFlagResolver.isSystem(tableName);
             boolean isPublic = tableFlagResolver.isPublic(tableName);
-            return new TableToken(tableName, dirName, tableId, isMatView, isWal, isSystem, isProtected, isPublic);
+            String dbLogName = engine.getConfiguration().getDbLogName();
+            return new TableToken(tableName, dirName, dbLogName, tableId, isMatView, isWal, isSystem, isProtected, isPublic);
         } else {
             return null;
         }

--- a/core/src/main/java/io/questdb/cairo/TableNameRegistryStore.java
+++ b/core/src/main/java/io/questdb/cairo/TableNameRegistryStore.java
@@ -376,7 +376,8 @@ public class TableNameRegistryStore extends GrowOnlyTableNameRegistryStore {
                             boolean isSystem = tableFlagResolver.isSystem(tableName);
                             boolean isPublic = tableFlagResolver.isPublic(tableName);
                             boolean isMatView = isMatViewDefinitionFileExists(configuration, path, dirName);
-                            TableToken token = new TableToken(tableName, dirName, tableId, isMatView, isWal, isSystem, isProtected, isPublic);
+                            String dbLogName = configuration.getDbLogName();
+                            TableToken token = new TableToken(tableName, dirName, dbLogName, tableId, isMatView, isWal, isSystem, isProtected, isPublic);
                             TableToken existingTableToken = tableNameToTableTokenMap.get(tableName);
 
                             if (existingTableToken != null) {
@@ -475,7 +476,8 @@ public class TableNameRegistryStore extends GrowOnlyTableNameRegistryStore {
                         boolean isPublic = tableFlagResolver.isPublic(tableName);
                         boolean isMatView = tableType == TableUtils.TABLE_TYPE_MAT;
                         boolean isWal = tableType == TableUtils.TABLE_TYPE_WAL || isMatView;
-                        token = new TableToken(tableName, dirName, tableId, isMatView, isWal, isSystem, isProtected, isPublic);
+                        String dbLogName = configuration.getDbLogName();
+                        token = new TableToken(tableName, dirName, dbLogName, tableId, isMatView, isWal, isSystem, isProtected, isPublic);
                     }
                     dirNameToTableTokenMap.put(dirName, ReverseTableMapItem.ofDropped(token));
                 }
@@ -503,7 +505,8 @@ public class TableNameRegistryStore extends GrowOnlyTableNameRegistryStore {
                     boolean isPublic = tableFlagResolver.isPublic(tableName);
                     boolean isMatView = tableType == TableUtils.TABLE_TYPE_MAT;
                     boolean isWal = tableType == TableUtils.TABLE_TYPE_WAL || isMatView;
-                    final TableToken token = new TableToken(tableName, dirName, tableId, isMatView, isWal, isSystem, isProtected, isPublic);
+                    String dbLogName = configuration.getDbLogName();
+                    final TableToken token = new TableToken(tableName, dirName, dbLogName, tableId, isMatView, isWal, isSystem, isProtected, isPublic);
                     tableNameToTableTokenMap.put(tableName, token);
                     if (!Chars.startsWith(token.getDirName(), token.getTableName())) {
                         // This table is renamed, log system to real table name mapping

--- a/core/src/main/java/io/questdb/cairo/TableToken.java
+++ b/core/src/main/java/io/questdb/cairo/TableToken.java
@@ -30,11 +30,13 @@ import io.questdb.std.str.DirectUtf8Sequence;
 import io.questdb.std.str.GcUtf8String;
 import io.questdb.std.str.Sinkable;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Stands for a WAL table, or a non-WAL table, or a materialized view.
  */
 public class TableToken implements Sinkable {
+    private final String dbLogName;
     @NotNull
     private final GcUtf8String dirName;
     private final boolean dirNameSameAsTableName;
@@ -47,15 +49,15 @@ public class TableToken implements Sinkable {
     @NotNull
     private final String tableName;
 
-    public TableToken(@NotNull String tableName, @NotNull String dirName, int tableId, boolean isWal, boolean isSystem, boolean isProtected) {
-        this(tableName, new GcUtf8String(dirName), tableId, false, isWal, isSystem, isProtected, false);
+    public TableToken(@NotNull String tableName, @NotNull String dirName, @Nullable String dbLogName, int tableId, boolean isWal, boolean isSystem, boolean isProtected) {
+        this(tableName, new GcUtf8String(dirName), dbLogName, tableId, false, isWal, isSystem, isProtected, false);
     }
 
-    public TableToken(@NotNull String tableName, @NotNull String dirName, int tableId, boolean isMatView, boolean isWal, boolean isSystem, boolean isProtected, boolean isPublic) {
-        this(tableName, new GcUtf8String(dirName), tableId, isMatView, isWal, isSystem, isProtected, isPublic);
+    public TableToken(@NotNull String tableName, @NotNull String dirName, @Nullable String dbLogName, int tableId, boolean isMatView, boolean isWal, boolean isSystem, boolean isProtected, boolean isPublic) {
+        this(tableName, new GcUtf8String(dirName), dbLogName, tableId, isMatView, isWal, isSystem, isProtected, isPublic);
     }
 
-    private TableToken(@NotNull String tableName, @NotNull GcUtf8String dirName, int tableId, boolean isMatView, boolean isWal, boolean isSystem, boolean isProtected, boolean isPublic) {
+    private TableToken(@NotNull String tableName, @NotNull GcUtf8String dirName, @Nullable String dbLogName, int tableId, boolean isMatView, boolean isWal, boolean isSystem, boolean isProtected, boolean isPublic) {
         this.tableName = tableName;
         this.dirName = dirName;
         this.tableId = tableId;
@@ -64,6 +66,7 @@ public class TableToken implements Sinkable {
         this.isSystem = isSystem;
         this.isProtected = isProtected;
         this.isPublic = isPublic;
+        this.dbLogName = dbLogName;
         String dirNameString = dirName.toString();
         this.dirNameSameAsTableName = Chars.startsWith(dirNameString, tableName) &&
                 (dirNameString.length() == tableName.length() ||
@@ -156,7 +159,7 @@ public class TableToken implements Sinkable {
     }
 
     public TableToken renamed(String newName) {
-        return new TableToken(newName, dirName, tableId, isMatView, isWal, isSystem, isProtected, isPublic);
+        return new TableToken(newName, dirName, dbLogName, tableId, isMatView, isWal, isSystem, isProtected, isPublic);
     }
 
     @Override
@@ -167,6 +170,9 @@ public class TableToken implements Sinkable {
             sink.put("TableToken{tableName=").put(tableName)
                     .put(", dirName=").put(dirName)
                     .put('}');
+        }
+        if (dbLogName != null) {
+            sink.put(", db=").put(dbLogName);
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -393,7 +393,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         try {
             this.path = new Path();
             path.of(root);
-            this.pathRootSize = path.size();
+            this.pathRootSize = configuration.getDbLogName() == null ? path.size() : 0;
             path.concat(tableToken);
             this.other = new Path();
             other.of(root).concat(tableToken);

--- a/core/src/main/java/io/questdb/cairo/pool/SqlCompilerPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/SqlCompilerPool.java
@@ -50,9 +50,9 @@ public final class SqlCompilerPool extends AbstractMultiTenantPool<SqlCompilerPo
     // It also should be kept in mind that some details of these fake tokens can make it into
     // logs, such as the directory names, and they do not (and really should not) exist on disk.
     private static final TableToken[] TOKENS = {
-            new TableToken("blue", "/compilers/blue/", 0, false, false, false),
-            new TableToken("red", "/compilers/red/", 0, false, false, false),
-            new TableToken("green", "/compilers/green/", 0, false, false, false)
+            new TableToken("blue", "/compilers/blue/", null, 0, false, false, false),
+            new TableToken("red", "/compilers/red/", null,0, false, false, false),
+            new TableToken("green", "/compilers/green/", null,0, false, false, false)
     };
     private final CairoEngine engine;
     private final Rnd rnd = new Rnd();

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -189,7 +189,7 @@ public class WalWriter implements TableWriterAPI {
         this.walId = walId;
         this.path = new Path();
         path.of(configuration.getDbRoot());
-        this.pathRootSize = path.size();
+        this.pathRootSize = configuration.getDbLogName() == null ? path.size() : 0;
         this.path.concat(tableToken).concat(walName);
         this.pathSize = path.size();
         this.metrics = configuration.getMetrics();

--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
@@ -242,6 +242,7 @@ public class TableSequencerAPI implements QuietCloseable {
         }
     }
 
+    @NotNull
     public SeqTxnTracker getTxnTracker(TableToken tableToken) {
         return getSeqTxnTracker(tableToken);
     }
@@ -465,6 +466,7 @@ public class TableSequencerAPI implements QuietCloseable {
         throw CairoException.critical(0).put("sequencer is distressed [table=").put(tableToken.getDirName()).put(']');
     }
 
+    @NotNull
     private SeqTxnTracker getSeqTxnTracker(TableToken tt) {
         return seqTxnTrackers.computeIfAbsent(tt.getDirName(), createTxnTracker);
     }

--- a/core/src/main/java/io/questdb/cutlass/text/CopyTask.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CopyTask.java
@@ -524,7 +524,8 @@ public class CopyTask {
             tableNameSink.clear();
             tableNameSink.put(tableStructure.getTableName()).put('_').put(index);
             String tableName = tableNameSink.toString();
-            TableToken tableToken = new TableToken(tableName, tableName, cairoEngine.getNextTableId(), false, false, false);
+            String dbLogName = configuration.getDbLogName();
+            TableToken tableToken = new TableToken(tableName, tableName, dbLogName, cairoEngine.getNextTableId(), false, false, false);
 
             final int columnCount = metadata.getColumnCount();
             try (
@@ -910,7 +911,8 @@ public class CopyTask {
             tableNameSink.clear();
             tableNameSink.put(targetTableStructure.getTableName()).put('_').put(index);
             String publicTableName = tableNameSink.toString();
-            TableToken tableToken = new TableToken(publicTableName, publicTableName, engine.getNextTableId(), false, false, false);
+            String dbLogName = engine.getConfiguration().getDbLogName();
+            TableToken tableToken = new TableToken(publicTableName, publicTableName, dbLogName, engine.getNextTableId(), false, false, false);
             createTable(ff, configuration.getMkDirMode(), importRoot, tableToken.getDirName(), publicTableName, targetTableStructure, 0, AllowAllSecurityContext.INSTANCE);
 
             try (

--- a/core/src/main/java/io/questdb/griffin/engine/functions/test/TestDataUnavailableFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/test/TestDataUnavailableFunctionFactory.java
@@ -109,7 +109,7 @@ public class TestDataUnavailableFunctionFactory implements FunctionFactory {
                 if (eventCallback != null) {
                     eventCallback.onSuspendEvent(event);
                 }
-                throw DataUnavailableException.instance(new TableToken("foo", "foo", 1, false, false, false), "2022-01-01", event);
+                throw DataUnavailableException.instance(new TableToken("foo", "foo", null, 1, false, false, false), "2022-01-01", event);
             }
             rows++;
             record.of(rows);

--- a/core/src/test/java/io/questdb/test/cairo/CairoExceptionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoExceptionTest.java
@@ -44,6 +44,6 @@ public class CairoExceptionTest extends AbstractTest {
 
     @Test
     public void testTableDroppedIsNotCriticial() {
-        Assert.assertFalse(CairoException.tableDropped(new TableToken("x", "x", 123, false, false, false)).isCritical());
+        Assert.assertFalse(CairoException.tableDropped(new TableToken("x", "x", null, 123, false, false, false)).isCritical());
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/SecurityContextTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/SecurityContextTest.java
@@ -45,7 +45,7 @@ public class SecurityContextTest {
     private static final LongList permissions = new LongList();
     private final static String tableName = "tab";
     private static final Object[] THREE_PARAM_ARGS = {permissions, tableName, columns};
-    private static final TableToken userTableToken = new TableToken(tableName, tableName, 0, false, false, false);
+    private static final TableToken userTableToken = new TableToken(tableName, tableName, null, 0, false, false, false);
     private static final Object[] ONE_PARAM_ARGS = {userTableToken};
     private static final Object[] TWO_PARAM_ARGS = {userTableToken, columns};
 

--- a/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
@@ -894,7 +894,7 @@ public class TableNameRegistryTest extends AbstractCairoTest {
             )) {
                 store.lock();
                 store.reload(new ConcurrentHashMap<>(1), new ConcurrentHashMap<>(1), null);
-                store.writeEntry(new TableToken("tab1", "tab1~1", 1, true, false, false), OPERATION_ADD);
+                store.writeEntry(new TableToken("tab1", "tab1~1", null, 1, true, false, false), OPERATION_ADD);
             }
 
             simulateEngineRestart();

--- a/core/src/test/java/io/questdb/test/cairo/TableTokenTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableTokenTest.java
@@ -35,7 +35,7 @@ public class TableTokenTest {
 
     @Test
     public void testBasics() {
-        final TableToken t1 = new TableToken("table1", "dir1", 1, true, false, false);
+        final TableToken t1 = new TableToken("table1", "dir1", null, 1, true, false, false);
         Assert.assertEquals("table1", t1.getTableName());
         Assert.assertEquals("dir1", t1.getDirName());
         final boolean dirNameIdentity = t1.getDirName() == t1.getDirNameUtf8().toString();
@@ -54,11 +54,11 @@ public class TableTokenTest {
         Assert.assertTrue(t2.isWal());
 
         Assert.assertNotEquals(t1, t2);
-        final TableToken t1b = new TableToken("table1", "dir1", 1, true, false, false);
+        final TableToken t1b = new TableToken("table1", "dir1", null, 1, true, false, false);
 
         Assert.assertEquals(t1, t1b);
 
-        final TableToken t3 = new TableToken("table3", "dir3", 3, false, true, true);
+        final TableToken t3 = new TableToken("table3", "dir3", null, 3, false, true, true);
         Assert.assertEquals("table3", t3.getTableName());
         Assert.assertEquals("dir3", t3.getDirName());
         Assert.assertEquals(3, t3.getTableId());
@@ -82,7 +82,7 @@ public class TableTokenTest {
         };
 
         for (String str : strings) {
-            final TableToken tt1 = new TableToken(str, "dir1", 1, false, false, false);
+            final TableToken tt1 = new TableToken(str, "dir1", null, 1, false, false, false);
             LOG.xinfo().$("Testing logging a fancy pants table token: >>>").$(tt1).$("<<<").$();
         }
     }

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewGraphAndStateStoreTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewGraphAndStateStoreTest.java
@@ -238,13 +238,13 @@ public class MatViewGraphAndStateStoreTest extends AbstractCairoTest {
     }
 
     private TableToken newTableToken(String tableName) {
-        TableToken t = new TableToken(tableName, tableName, 0, false, true, false, false, true);
+        TableToken t = new TableToken(tableName, tableName, null, 0, false, true, false, false, true);
         tableTokens.add(t);
         return t;
     }
 
     private TableToken newViewToken(String tableName) {
-        TableToken v = new TableToken(tableName, tableName, 0, true, true, false, false, true);
+        TableToken v = new TableToken(tableName, tableName, null, 0, true, true, false, false, true);
         tableTokens.add(v);
         return v;
     }

--- a/core/src/test/java/io/questdb/test/cairo/pool/ReaderPoolTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/pool/ReaderPoolTest.java
@@ -1106,7 +1106,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
             CyclicBarrier barrier = new CyclicBarrier(2);
             CountDownLatch stopLatch = new CountDownLatch(2);
 
-            TableToken xTableToken = new TableToken("x", "x", 123, false, false, false);
+            TableToken xTableToken = new TableToken("x", "x", null, 123, false, false, false);
 
             final Runnable runnable = () -> {
                 try {
@@ -1300,7 +1300,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
     @Test
     public void testUnlockByAnotherThread() throws Exception {
         assertWithPool(pool -> {
-            TableToken tableToken = new TableToken("Ургант", "Ургант", 123, false, false, false);
+            TableToken tableToken = new TableToken("Ургант", "Ургант", null, 123, false, false, false);
             Assert.assertTrue(pool.lock(tableToken));
             AtomicInteger errors = new AtomicInteger();
 
@@ -1343,7 +1343,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
                 }
             });
 
-            TableToken tableToken = new TableToken("xyz", "xyz", 123, false, false, false);
+            TableToken tableToken = new TableToken("xyz", "xyz", null, 123, false, false, false);
             pool.unlock(tableToken);
             Assert.assertEquals(1, counter.get());
         });

--- a/core/src/test/java/io/questdb/test/cairo/pool/WriterPoolTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/pool/WriterPoolTest.java
@@ -535,7 +535,7 @@ public class WriterPoolTest extends AbstractCairoTest {
                 final AtomicInteger writerCount = new AtomicInteger();
 
                 for (int i = 0; i < N; i++) {
-                    TableToken tableName = new TableToken("table_" + i, "table_" + i, i, false, false, false);
+                    TableToken tableName = new TableToken("table_" + i, "table_" + i, null, i, false, false, false);
                     new Thread(() -> {
                         try {
                             barrier.await();

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalPurgeJobTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalPurgeJobTest.java
@@ -403,7 +403,7 @@ public class WalPurgeJobTest extends AbstractCairoTest {
          */
         TestDeleter deleter = new TestDeleter();
         WalPurgeJob.Logic logic = new WalPurgeJob.Logic(deleter, 0);
-        TableToken tableToken = new TableToken("test", "test~1", 42, true, false, false);
+        TableToken tableToken = new TableToken("test", "test~1", null, 42, true, false, false);
         logic.reset(tableToken);
         logic.trackDiscoveredSegment(1, 1, 1);
         logic.trackDiscoveredSegment(1, 2, 2);
@@ -453,7 +453,7 @@ public class WalPurgeJobTest extends AbstractCairoTest {
          */
         TestDeleter deleter = new TestDeleter();
         WalPurgeJob.Logic logic = new WalPurgeJob.Logic(deleter, 0);
-        TableToken tableToken = new TableToken("test", "test~1", 42, true, false, false);
+        TableToken tableToken = new TableToken("test", "test~1", null, 42, true, false, false);
         logic.reset(tableToken);
         logic.trackDiscoveredSegment(1, 1, 1);
         logic.trackDiscoveredSegment(1, 2, -1);

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalTableFailureTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalTableFailureTest.java
@@ -1039,7 +1039,7 @@ public class WalTableFailureTest extends AbstractCairoTest {
     public void testNonWalTableTransactionNotificationIsIgnored() throws Exception {
         assertMemoryLeak(() -> {
             String tableName = testName.getMethodName();
-            TableToken ignored = new TableToken(tableName, tableName, 123, false, false, false);
+            TableToken ignored = new TableToken(tableName, tableName, null, 123, false, false, false);
             createStandardWalTable(tableName);
 
             drainWalQueue();

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -8819,7 +8819,7 @@ public class IODispatcherTest extends AbstractTest {
         DefaultCairoConfiguration configuration = new DefaultTestCairoConfiguration(baseDir);
 
         String dirName = TableUtils.getTableDir(mangleTableDirNames, tableName, 1, false);
-        TableToken tableToken = new TableToken(tableName, dirName, 1, false, false, false);
+        TableToken tableToken = new TableToken(tableName, dirName, null, 1, false, false, false);
         try (
                 TableReader reader = new TableReader(OFF_POOL_READER_ID.getAndIncrement(), configuration, tableToken, TxnScoreboardPoolFactory.createPool(configuration));
                 TestTableReaderRecordCursor cursor = new TestTableReaderRecordCursor()
@@ -8839,7 +8839,7 @@ public class IODispatcherTest extends AbstractTest {
         DefaultCairoConfiguration configuration = new DefaultTestCairoConfiguration(baseDir);
 
         String telemetry = TelemetryTask.TABLE_NAME;
-        TableToken telemetryTableName = new TableToken(telemetry, telemetry, 0, false, false, false, false, true);
+        TableToken telemetryTableName = new TableToken(telemetry, telemetry, null, 0, false, false, false, false, true);
         try (
                 TableReader reader = new TableReader(OFF_POOL_READER_ID.getAndIncrement(), configuration, telemetryTableName, TxnScoreboardPoolFactory.createPool(configuration));
                 TestTableReaderRecordCursor cursor = new TestTableReaderRecordCursor()

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/SymbolCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/SymbolCacheTest.java
@@ -779,7 +779,7 @@ public class SymbolCacheTest extends AbstractCairoTest {
 
     private static class TestTableWriterAPI implements TableWriterAPI {
 
-        private final static TableToken emptyTableToken = new TableToken("", "", 0, false, false, false);
+        private final static TableToken emptyTableToken = new TableToken("", "", null, 0, false, false, false);
         private final int watermark;
 
         public TestTableWriterAPI() {

--- a/core/src/test/java/io/questdb/test/griffin/ColumnPurgeJobTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ColumnPurgeJobTest.java
@@ -311,12 +311,12 @@ public class ColumnPurgeJobTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             setCurrentMicros(0);
             try (ColumnPurgeJob purgeJob = createPurgeJob()) {
-                TableToken tn1 = new TableToken("tbl_name", "tbl_name", 123, false, false, false);
+                TableToken tn1 = new TableToken("tbl_name", "tbl_name", null, 123, false, false, false);
                 ColumnPurgeTask task = createTask(tn1, "col", 1, ColumnType.INT, 43, 11, "2022-03-29", -1);
                 task.appendColumnInfo(-1, IntervalUtils.parseFloorPartialTimestamp("2022-04-05"), 2);
                 appendTaskToQueue(task);
 
-                TableToken tn2 = new TableToken("tbl_name2", "tbl_name2", 123, false, false, false);
+                TableToken tn2 = new TableToken("tbl_name2", "tbl_name2", null, 123, false, false, false);
                 ColumnPurgeTask task2 = createTask(tn2, "col2", 2, ColumnType.SYMBOL, 33, -1, "2022-02-13", 3);
                 appendTaskToQueue(task2);
 
@@ -968,13 +968,13 @@ public class ColumnPurgeJobTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             setCurrentMicros(0);
             try (ColumnPurgeJob purgeJob = createPurgeJob()) {
-                TableToken tn1 = new TableToken("tbl_name", "tbl_name", 123, false, false, false);
+                TableToken tn1 = new TableToken("tbl_name", "tbl_name", null, 123, false, false, false);
                 ColumnPurgeTask task = createTask(tn1, "col", 1, ColumnType.INT, 43, 11, "2022-03-29", -1);
                 task.appendColumnInfo(-1, IntervalUtils.parseFloorPartialTimestamp("2022-04-05"), 2);
                 appendTaskToQueue(task);
 
 
-                TableToken tn2 = new TableToken("tbl_name2", "tbl_name2", 123, false, false, false);
+                TableToken tn2 = new TableToken("tbl_name2", "tbl_name2", null, 123, false, false, false);
                 ColumnPurgeTask task2 = createTask(tn2, "col2", 2, ColumnType.SYMBOL, 33, -1, "2022-02-13", 3);
                 appendTaskToQueue(task2);
 

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -11485,7 +11485,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testTableNameLocked() throws Exception {
         assertMemoryLeak(() -> {
             String dirName = "tab" + TableUtils.SYSTEM_TABLE_NAME_SUFFIX;
-            TableToken tableToken = new TableToken("tab", dirName, 1 + getSystemTablesCount(engine), false, false, false);
+            TableToken tableToken = new TableToken("tab", dirName, null, 1 + getSystemTablesCount(engine), false, false, false);
             CharSequence lockedReason = engine.lockAll(tableToken, "testing", true);
             Assert.assertNull(lockedReason);
             try {

--- a/core/src/test/java/io/questdb/test/std/str/PathTest.java
+++ b/core/src/test/java/io/questdb/test/std/str/PathTest.java
@@ -104,7 +104,7 @@ public class PathTest {
 
     @Test
     public void testConcatTableToken() {
-        path.concat(new TableToken("root", "root", 0, false, false, false)).$();
+        path.concat(new TableToken("root", "root", null, 0, false, false, false)).$();
         Assert.assertEquals("root", path.toString());
     }
 


### PR DESCRIPTION
When running multiple instances of QuestDB in tests, it's very hard to investigate failures.

This change adds an optional `dbLogName` into TableToken to be logged with each table name. Also, it switches to log full paths for the same purpose.

To enable such logging, one should add a config property

```
debug.db.log.name=red_instance
```