### PR TITLE
docs(core): fix the description of the number of readers per segment

### DIFF
--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -282,7 +282,7 @@ query.timeout=1m
 # minimum number of rows before allowing use of parallel indexation
 #cairo.parallel.index.threshold=100000
 
-# number of segments in the TableReader pool; each segment holds up to 16 readers
+# number of segments in the TableReader pool; each segment holds up to 32 readers
 #cairo.reader.pool.max.segments=10
 
 # timeout in milliseconds when attempting to get atomic memory snapshots, e.g. in BitmapIndexReaders

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -218,7 +218,7 @@ query.timeout.sec=60
 # minimum number of rows before allowing use of parallel indexation
 #cairo.parallel.index.threshold=100000
 
-# number of segments in the TableReader pool; each segment holds up to 16 readers
+# number of segments in the TableReader pool; each segment holds up to 32 readers
 #cairo.reader.pool.max.segments=10
 
 # timeout when attempting to get BitmapIndexReaders. In microsecond


### PR DESCRIPTION
The description in server.conf specifies 16 readers, but the actual implementation in AbstractMultiTenantPool has 32 readers per segment.