### PR TITLE
fix(core): fix incorrect error handling, which can leave table reader in an inconsistent state

### DIFF
--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCMRImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCMRImpl.java
@@ -143,19 +143,14 @@ public class MemoryCMRImpl extends AbstractMemoryCR implements MemoryCMR {
     }
 
     private void setSize0(long newSize) {
-        try {
-            if (size > 0) {
-                pageAddress = TableUtils.mremap(ff, fd, pageAddress, size, newSize, Files.MAP_RO, memoryTag);
-            } else {
-                assert pageAddress == 0;
-                pageAddress = TableUtils.mapRO(ff, fd, newSize, memoryTag);
-            }
-            ff.madvise(pageAddress, newSize, madviseOpts);
-            size = newSize;
-        } catch (Throwable e) {
-            close();
-            throw e;
+        if (size > 0) {
+            pageAddress = TableUtils.mremap(ff, fd, pageAddress, size, newSize, Files.MAP_RO, memoryTag);
+        } else {
+            assert pageAddress == 0;
+            pageAddress = TableUtils.mapRO(ff, fd, newSize, memoryTag);
         }
+        ff.madvise(pageAddress, newSize, madviseOpts);
+        size = newSize;
     }
 
     protected void map(FilesFacade ff, LPSZ name, final long size) {

--- a/core/src/main/java/io/questdb/cairo/vm/MemoryCMRImpl.java
+++ b/core/src/main/java/io/questdb/cairo/vm/MemoryCMRImpl.java
@@ -149,8 +149,8 @@ public class MemoryCMRImpl extends AbstractMemoryCR implements MemoryCMR {
             assert pageAddress == 0;
             pageAddress = TableUtils.mapRO(ff, fd, newSize, memoryTag);
         }
-        ff.madvise(pageAddress, newSize, madviseOpts);
         size = newSize;
+        ff.madvise(pageAddress, size, madviseOpts);
     }
 
     protected void map(FilesFacade ff, LPSZ name, final long size) {

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -2309,11 +2309,11 @@ public class SqlOptimiser implements Mutable {
         return -1;
     }
 
-    private CharSequence findQueryColumnByAst(ObjList<QueryColumn> bottomUpColumns, ExpressionNode node) {
+    private QueryColumn findQueryColumnByAst(ObjList<QueryColumn> bottomUpColumns, ExpressionNode node) {
         for (int i = 0, max = bottomUpColumns.size(); i < max; i++) {
             QueryColumn qc = bottomUpColumns.getQuick(i);
             if (compareNodesExact(qc.getAst(), node)) {
-                return qc.getAlias();
+                return qc;
             }
         }
         return null;
@@ -2781,11 +2781,17 @@ public class SqlOptimiser implements Mutable {
             for (int i = 0; i < n; i++) {
                 ExpressionNode node = orderBy.getQuick(i);
                 if (node.type == FUNCTION || node.type == OPERATION) {
-                    CharSequence alias = findQueryColumnByAst(model.getBottomUpColumns(), node);
-                    if (alias == null) {
+                    var qc = findQueryColumnByAst(model.getBottomUpColumns(), node);
+                    if (qc == null) {
                         // add this function to bottom-up columns and replace this expression with index
-                        alias = SqlUtil.createColumnAlias(characterStore, node.token, Chars.indexOfLastUnquoted(node.token, '.'), model.getAliasToColumnMap(), true);
-                        QueryColumn qc = queryColumnPool.next().of(
+                        CharSequence alias = SqlUtil.createColumnAlias(
+                                characterStore,
+                                node.token,
+                                Chars.indexOfLastUnquoted(node.token, '.'),
+                                model.getAliasToColumnMap(),
+                                true
+                        );
+                        qc = queryColumnPool.next().of(
                                 alias,
                                 node,
                                 false
@@ -2797,7 +2803,7 @@ public class SqlOptimiser implements Mutable {
                     // on "else" branch, when order by expression matched projection
                     // we can just replace order by with projection alias without having to
                     // add an extra model
-                    orderBy.setQuick(i, nextLiteral(alias));
+                    orderBy.setQuick(i, nextLiteral(qc.getAlias()));
                 }
             }
 


### PR DESCRIPTION
found by a fuzz test:

```
testWalWriteTinyO3Memory - random seeds: 990968392657L, 1757173721663L
```

----

Removed implicit contract that failure to extend memory will close the memory.