### PR TITLE
test(core): skip FilesTest.testAllocateConcurrent() on tmpfs

### DIFF
--- a/core/src/main/java/io/questdb/std/Files.java
+++ b/core/src/main/java/io/questdb/std/Files.java
@@ -62,6 +62,8 @@ public final class Files {
     public static final int POSIX_MADV_RANDOM;
     public static final int POSIX_MADV_SEQUENTIAL;
     public static final char SEPARATOR;
+    // https://github.com/torvalds/linux/blob/e2f48c48090dea172c0c571101041de64634dae5/include/uapi/linux/magic.h#L18
+    public static final int TMPFS_MAGIC = 0x01021994;
     public static final Charset UTF_8;
     public static final int WINDOWS_ERROR_FILE_EXISTS = 0x50;
     private static final int VIRTIO_FS_MAGIC = 0x6a656a63;

--- a/core/src/test/java/io/questdb/test/FilesTest.java
+++ b/core/src/test/java/io/questdb/test/FilesTest.java
@@ -1521,6 +1521,11 @@ public class FilesTest {
     }
 
     private static void assumeIsNotTmpFs(String path) {
+        // Assumption to skip a test if we run on 'tmpfs' filesystem.
+        // Background: tmpfs doesn't support sparse files - when posix_fallocate() is called,
+        // tmpfs immediately materializes the entire allocation in RAM rather than
+        // just reserving space like ext4 and other filesystems do. This can cause
+        // memory exhaustion for tests that allocate large files.
         if (!Os.isLinux()) {
             return;
         }

--- a/core/src/test/java/io/questdb/test/FilesTest.java
+++ b/core/src/test/java/io/questdb/test/FilesTest.java
@@ -49,6 +49,7 @@ import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.AssumptionViolatedException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -104,6 +105,7 @@ public class FilesTest {
         FilesFacade ff = TestFilesFacadeImpl.INSTANCE;
 
         String tmpFolder = temporaryFolder.newFolder("allocate").getAbsolutePath();
+        assumeIsNotTmpFs(tmpFolder);
         AtomicInteger errors = new AtomicInteger();
 
         for (int i = 0; i < 10; i++) {
@@ -1515,6 +1517,15 @@ public class FilesTest {
         } finally {
             Files.close(fd);
             Unsafe.free(buffPtr, buffSize, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    private static void assumeIsNotTmpFs(String path) {
+        if (!Os.isLinux()) {
+            return;
+        }
+        if (Files.getFileSystemStatus(Path.getThreadLocal(path).$()) == Files.TMPFS_MAGIC) {
+            throw new AssumptionViolatedException("Path is on tmpfs: " + path);
         }
     }
 


### PR DESCRIPTION
The test starts 2 threads, each attempting to allocate 2/3 of free space using posix_fallocate(). On filesystems like ext4, this creates sparse files that reserve space without consuming it immediately. However, tmpfs doesn't support sparse files and materializes the entire allocation in RAM, causing memory exhaustion that affects other processes and /tmp operations.

Skip this test when running on tmpfs to prevent system instability.