### PR TITLE
Add DB Activity Tracking

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoException.java
+++ b/core/src/main/java/io/questdb/cairo/CairoException.java
@@ -50,6 +50,7 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
     public static final int TABLE_DOES_NOT_EXIST = PARTITION_MANIPULATION_RECOVERABLE - 1;
     public static final int MAT_VIEW_DOES_NOT_EXIST = TABLE_DOES_NOT_EXIST - 1;
     public static final int TXN_BLOCK_APPLY_FAILED = MAT_VIEW_DOES_NOT_EXIST - 1;
+    public static final int ERRNO_INVALID_WAL_SYMBOL_KEY = TXN_BLOCK_APPLY_FAILED - 1;
     public static final int NON_CRITICAL = -1;
     private static final StackTraceElement[] EMPTY_STACK_TRACE = {};
     private static final ThreadLocal<CairoException> tlException = new ThreadLocal<>(CairoException::new);

--- a/core/src/main/java/io/questdb/cairo/wal/WalTxnDetails.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalTxnDetails.java
@@ -783,7 +783,16 @@ public class WalTxnDetails implements QuietCloseable {
 
             while ((entry = symbolMapDiff.nextEntry()) != null) {
                 final int key = entry.getKey() - cleanSymbolCount;
-                assert key == symbolIndex;
+                if (key != symbolIndex) {
+                    throw CairoException.critical(CairoException.ERRNO_INVALID_WAL_SYMBOL_KEY)
+                        .put("Invalid symbol key in WAL transaction [expected=").put(symbolIndex)
+                        .put(", actual=").put(key)
+                        .put(", seqTxn=").put(seqTxn)
+                        .put(", columnIndex=").put(symbolMapDiff.getColumnIndex())
+                        .put(", cleanSymbolCount=").put(cleanSymbolCount)
+                        .put(", entryKey=").put(entry.getKey())
+                        .put(']');
+                }
                 symbolIndex++;
                 entry.appendSymbolTo(symbolMem);
             }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/table/PgStatActivityFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/table/PgStatActivityFunctionFactory.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.table;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.CursorFunction;
+import io.questdb.griffin.engine.table.PgStatActivityRecordCursorFactory;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public final class PgStatActivityFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "pg_stat_activity()";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new CursorFunction(new PgStatActivityRecordCursorFactory());
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/table/PgStatDatabaseFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/table/PgStatDatabaseFunctionFactory.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.table;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.CursorFunction;
+import io.questdb.griffin.engine.table.PgStatDatabaseRecordCursorFactory;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public final class PgStatDatabaseFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "pg_stat_database()";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new CursorFunction(new PgStatDatabaseRecordCursorFactory());
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/PgStatDatabaseRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/PgStatDatabaseRecordCursorFactory.java
@@ -1,0 +1,295 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+
+package io.questdb.griffin.engine.table;
+
+
+import io.questdb.cairo.AbstractRecordCursorFactory;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.GenericRecordMetadata;
+import io.questdb.cairo.TableColumnMetadata;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.metrics.DatabaseActivityRegistry;
+import io.questdb.std.BinarySequence;
+import io.questdb.std.Long256;
+import io.questdb.std.Os;
+import io.questdb.std.str.CharSink;
+
+
+public final class PgStatDatabaseRecordCursorFactory extends AbstractRecordCursorFactory {
+    private static final RecordMetadata METADATA;
+    private final PgStatDatabaseRecordCursor cursor = new PgStatDatabaseRecordCursor();
+
+
+    public PgStatDatabaseRecordCursorFactory() {
+        super(METADATA);
+    }
+
+
+    @Override
+    public RecordCursor getCursor(SqlExecutionContext executionContext) {
+        cursor.of();
+        return cursor;
+    }
+
+
+    @Override
+    public boolean recordCursorSupportsRandomAccess() {
+        return true;
+    }
+
+
+    @Override
+    public void toPlan(PlanSink sink) {
+        sink.type("pg_stat_database");
+    }
+
+
+    private static class PgStatDatabaseRecordCursor implements RecordCursor {
+        private final PgStatDatabaseRecord record = new PgStatDatabaseRecord();
+        private boolean hasData = false;
+
+
+        public void of() {
+            this.hasData = true;
+        }
+
+
+        @Override
+        public void close() {
+        }
+
+
+        @Override
+        public Record getRecord() {
+            return record;
+        }
+
+
+        @Override
+        public boolean hasNext() {
+            if (hasData) {
+                hasData = false;
+                return true;
+            }
+            return false;
+        }
+
+
+        @Override
+        public Record getRecordB() {
+            return record;
+        }
+
+
+        @Override
+        public void recordAt(long rowId) {
+            // Single row result
+        }
+
+
+        @Override
+        public long size() {
+            return 1;
+        }
+
+
+        @Override
+        public void toTop() {
+            hasData = true;
+        }
+    }
+
+
+    private static class PgStatDatabaseRecord implements Record {
+        private final DatabaseActivityRegistry registry = DatabaseActivityRegistry.getInstance();
+
+
+        @Override
+        public BinarySequence getBin(int col) {
+            return null;
+        }
+
+
+        @Override
+        public long getBinLen(int col) {
+            return -1;
+        }
+
+
+        @Override
+        public boolean getBool(int col) {
+            return false;
+        }
+
+
+        @Override
+        public byte getByte(int col) {
+            return 0;
+        }
+
+
+        @Override
+        public char getChar(int col) {
+            return 0;
+        }
+
+
+        @Override
+        public long getDate(int col) {
+            return -1;
+        }
+
+
+        @Override
+        public double getDouble(int col) {
+            return Double.NaN;
+        }
+
+
+        @Override
+        public float getFloat(int col) {
+            return Float.NaN;
+        }
+
+
+        @Override
+        public int getInt(int col) {
+            return Integer.MIN_VALUE;
+        }
+
+
+        @Override
+        public long getLong(int col) {
+            return switch (col) {
+                case 1 -> registry.getConnectionCount(); // numbackends
+                case 2 -> registry.getTotalCommits(); // xact_commit
+                case 3 -> registry.getTotalRollbacks(); // xact_rollback
+                case 4 -> registry.getTotalQueries(); // tup_fetched (using total queries as proxy)
+                case 5 -> registry.getTotalQueries(); // tup_returned (using total queries as proxy)
+                case 6 -> (Os.currentTimeMicros() - registry.getServerStartTime()) / 1_000_000; // uptime_seconds
+                default -> Long.MIN_VALUE;
+            };
+        }
+
+
+        @Override
+        public long getLong128Hi(int col) {
+            return Long.MIN_VALUE;
+        }
+
+
+        @Override
+        public long getLong128Lo(int col) {
+            return Long.MIN_VALUE;
+        }
+
+
+        @Override
+        public void getLong256(int col, CharSink sink) {
+        }
+
+
+        @Override
+        public Long256 getLong256A(int col) {
+            return null;
+        }
+
+
+        @Override
+        public Long256 getLong256B(int col) {
+            return null;
+        }
+
+
+        @Override
+        public short getShort(int col) {
+            return 0;
+        }
+
+
+        @Override
+        public CharSequence getStr(int col) {
+            return switch (col) {
+                case 0 -> "questdb"; // datname
+                default -> null;
+            };
+        }
+
+
+        @Override
+        public int getStrLen(int col) {
+            CharSequence str = getStr(col);
+            return str != null ? str.length() : -1;
+        }
+
+
+        @Override
+        public CharSequence getStrB(int col) {
+            return getStr(col);
+        }
+
+
+        @Override
+        public int getStrLenB(int col) {
+            return getStrLen(col);
+        }
+
+
+        @Override
+        public long getTimestamp(int col) {
+            return Long.MIN_VALUE;
+        }
+
+
+        @Override
+        public CharSequence getVarchar(int col) {
+            return getStr(col);
+        }
+
+
+        @Override
+        public int getVarcharLen(int col) {
+            return getStrLen(col);
+        }
+    }
+
+
+    static {
+        final GenericRecordMetadata metadata = new GenericRecordMetadata();
+        metadata.add(0, new TableColumnMetadata("datname", ColumnType.STRING));
+        metadata.add(1, new TableColumnMetadata("numbackends", ColumnType.LONG));
+        metadata.add(2, new TableColumnMetadata("xact_commit", ColumnType.LONG));
+        metadata.add(3, new TableColumnMetadata("xact_rollback", ColumnType.LONG));
+        metadata.add(4, new TableColumnMetadata("tup_fetched", ColumnType.LONG));
+        metadata.add(5, new TableColumnMetadata("tup_returned", ColumnType.LONG));
+        metadata.add(6, new TableColumnMetadata("uptime_seconds", ColumnType.LONG));
+        METADATA = metadata;
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/parquet/PgStatActivityRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/parquet/PgStatActivityRecordCursorFactory.java
@@ -1,0 +1,278 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.table;
+
+import io.questdb.cairo.AbstractRecordCursorFactory;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.GenericRecordMetadata;
+import io.questdb.cairo.TableColumnMetadata;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.metrics.DatabaseActivityRegistry;
+import io.questdb.std.BinarySequence;
+import io.questdb.std.Long256;
+import io.questdb.std.Os;
+import io.questdb.std.str.CharSink;
+
+public final class PgStatActivityRecordCursorFactory extends AbstractRecordCursorFactory {
+    private static final RecordMetadata METADATA;
+    private final PgStatActivityRecordCursor cursor = new PgStatActivityRecordCursor();
+
+    public PgStatActivityRecordCursorFactory() {
+        super(METADATA);
+    }
+
+    @Override
+    public RecordCursor getCursor(SqlExecutionContext executionContext) {
+        DatabaseActivityRegistry registry = DatabaseActivityRegistry.getInstance();
+        DatabaseActivityRegistry.ConnectionInfo[] connections = registry.getActiveConnections();
+        cursor.of(connections);
+        return cursor;
+    }
+
+    @Override
+    public boolean recordCursorSupportsRandomAccess() {
+        return true;
+    }
+
+    @Override
+    public void toPlan(PlanSink sink) {
+        sink.type("pg_stat_activity");
+    }
+
+    private static class PgStatActivityRecordCursor implements RecordCursor {
+        private final PgStatActivityRecord record = new PgStatActivityRecord();
+        private DatabaseActivityRegistry.ConnectionInfo[] connections;
+        private int currentIndex = 0;
+
+        public void of(DatabaseActivityRegistry.ConnectionInfo[] connections) {
+            this.connections = connections;
+            this.currentIndex = 0;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public Record getRecord() {
+            return record;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (currentIndex < connections.length) {
+                record.of(connections[currentIndex]);
+                currentIndex++;
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public Record getRecordB() {
+            return record;
+        }
+
+        @Override
+        public void recordAt(long rowId) {
+            if (rowId >= 0 && rowId < connections.length) {
+                record.of(connections[(int) rowId]);
+            }
+        }
+
+        @Override
+        public long size() {
+            return connections.length;
+        }
+
+        @Override
+        public void toTop() {
+            currentIndex = 0;
+        }
+    }
+
+    private static class PgStatActivityRecord implements Record {
+        private DatabaseActivityRegistry.ConnectionInfo connectionInfo;
+
+        public void of(DatabaseActivityRegistry.ConnectionInfo connectionInfo) {
+            this.connectionInfo = connectionInfo;
+        }
+
+        @Override
+        public BinarySequence getBin(int col) {
+            return null;
+        }
+
+        @Override
+        public long getBinLen(int col) {
+            return -1;
+        }
+
+        @Override
+        public boolean getBool(int col) {
+            return false;
+        }
+
+        @Override
+        public byte getByte(int col) {
+            return 0;
+        }
+
+        @Override
+        public char getChar(int col) {
+            return 0;
+        }
+
+        @Override
+        public long getDate(int col) {
+            return switch (col) {
+                case 5 -> connectionInfo.connectionStartTime / 1000; // backend_start (convert micros to millis)
+                case 6 -> connectionInfo.queryStartTime > 0 ? connectionInfo.queryStartTime / 1000 : -1; // query_start
+                default -> -1;
+            };
+        }
+
+        @Override
+        public double getDouble(int col) {
+            return Double.NaN;
+        }
+
+        @Override
+        public float getFloat(int col) {
+            return Float.NaN;
+        }
+
+        @Override
+        public int getInt(int col) {
+            return switch (col) {
+                case 0 -> connectionInfo.connectionId; // pid
+                default -> Integer.MIN_VALUE;
+            };
+        }
+
+        @Override
+        public long getLong(int col) {
+            return switch (col) {
+                case 0 -> connectionInfo.connectionId; // pid
+                case 5 -> connectionInfo.connectionStartTime / 1000; // backend_start
+                case 6 -> connectionInfo.queryStartTime > 0 ? connectionInfo.queryStartTime / 1000 : -1; // query_start
+                default -> Long.MIN_VALUE;
+            };
+        }
+
+        @Override
+        public long getLong128Hi(int col) {
+            return Long.MIN_VALUE;
+        }
+
+        @Override
+        public long getLong128Lo(int col) {
+            return Long.MIN_VALUE;
+        }
+
+        @Override
+        public void getLong256(int col, CharSink sink) {
+        }
+
+        @Override
+        public Long256 getLong256A(int col) {
+            return null;
+        }
+
+        @Override
+        public Long256 getLong256B(int col) {
+            return null;
+        }
+
+        @Override
+        public short getShort(int col) {
+            return 0;
+        }
+
+        @Override
+        public CharSequence getStr(int col) {
+            return switch (col) {
+                case 1 -> connectionInfo.database; // datname
+                case 2 -> connectionInfo.username; // usename
+                case 3 -> connectionInfo.remoteAddress; // client_addr
+                case 4 -> connectionInfo.state; // state
+                case 7 -> connectionInfo.currentQuery != null ? connectionInfo.currentQuery : ""; // query
+                default -> null;
+            };
+        }
+
+        @Override
+        public int getStrLen(int col) {
+            CharSequence str = getStr(col);
+            return str != null ? str.length() : -1;
+        }
+
+        @Override
+        public CharSequence getStrB(int col) {
+            return getStr(col);
+        }
+
+        @Override
+        public int getStrLenB(int col) {
+            return getStrLen(col);
+        }
+
+        @Override
+        public long getTimestamp(int col) {
+            return switch (col) {
+                case 5 -> connectionInfo.connectionStartTime; // backend_start
+                case 6 -> connectionInfo.queryStartTime > 0 ? connectionInfo.queryStartTime : -1; // query_start
+                default -> Long.MIN_VALUE;
+            };
+        }
+
+        @Override
+        public CharSequence getVarchar(int col) {
+            return getStr(col);
+        }
+
+        @Override
+        public int getVarcharLen(int col) {
+            return getStrLen(col);
+        }
+    }
+
+    static {
+        final GenericRecordMetadata metadata = new GenericRecordMetadata();
+        metadata.add(0, new TableColumnMetadata("pid", ColumnType.LONG));
+        metadata.add(1, new TableColumnMetadata("datname", ColumnType.STRING));
+        metadata.add(2, new TableColumnMetadata("usename", ColumnType.STRING));
+        metadata.add(3, new TableColumnMetadata("client_addr", ColumnType.STRING));
+        metadata.add(4, new TableColumnMetadata("state", ColumnType.STRING));
+        metadata.add(5, new TableColumnMetadata("backend_start", ColumnType.TIMESTAMP));
+        metadata.add(6, new TableColumnMetadata("query_start", ColumnType.TIMESTAMP));
+        metadata.add(7, new TableColumnMetadata("query", ColumnType.STRING));
+        METADATA = metadata;
+    }
+}

--- a/core/src/main/java/io/questdb/metrics/DatabaseActivityRegistry.java
+++ b/core/src/main/java/io/questdb/metrics/DatabaseActivityRegistry.java
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.metrics;
+
+import io.questdb.std.IntHashSet;
+import io.questdb.std.IntObjHashMap;
+import io.questdb.std.Os;
+import io.questdb.std.Unsafe;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class DatabaseActivityRegistry {
+    private static final DatabaseActivityRegistry INSTANCE = new DatabaseActivityRegistry();
+    private final AtomicLong serverStartTime = new AtomicLong(Os.currentTimeMicros());
+    private final AtomicInteger nextConnectionId = new AtomicInteger(1);
+    private final IntObjHashMap<ConnectionInfo> connections = new IntObjHashMap<>();
+    private final AtomicLong totalConnections = new AtomicLong(0);
+    private final AtomicLong totalQueries = new AtomicLong(0);
+    private final AtomicLong totalTransactionCommits = new AtomicLong(0);
+    private final AtomicLong totalTransactionRollbacks = new AtomicLong(0);
+
+    private DatabaseActivityRegistry() {
+    }
+
+    public static DatabaseActivityRegistry getInstance() {
+        return INSTANCE;
+    }
+
+    public int registerConnection(String remoteAddress, String username, String database) {
+        int connectionId = nextConnectionId.getAndIncrement();
+        ConnectionInfo info = new ConnectionInfo(connectionId, remoteAddress, username, database, Os.currentTimeMicros());
+        synchronized (connections) {
+            connections.put(connectionId, info);
+        }
+        totalConnections.incrementAndGet();
+        return connectionId;
+    }
+
+    public void unregisterConnection(int connectionId) {
+        synchronized (connections) {
+            connections.remove(connectionId);
+        }
+    }
+
+    public void updateQuery(int connectionId, String query, long queryStartTime) {
+        synchronized (connections) {
+            ConnectionInfo info = connections.get(connectionId);
+            if (info != null) {
+                info.currentQuery = query;
+                info.queryStartTime = queryStartTime;
+                info.state = "active";
+            }
+        }
+        totalQueries.incrementAndGet();
+    }
+
+    public void clearQuery(int connectionId) {
+        synchronized (connections) {
+            ConnectionInfo info = connections.get(connectionId);
+            if (info != null) {
+                info.currentQuery = null;
+                info.queryStartTime = 0;
+                info.state = "idle";
+            }
+        }
+    }
+
+    public void incrementCommits() {
+        totalTransactionCommits.incrementAndGet();
+    }
+
+    public void incrementRollbacks() {
+        totalTransactionRollbacks.incrementAndGet();
+    }
+
+    public ConnectionInfo[] getActiveConnections() {
+        synchronized (connections) {
+            ConnectionInfo[] result = new ConnectionInfo[connections.size()];
+            int i = 0;
+            for (int j = 0, n = connections.capacity(); j < n; j++) {
+                if (connections.keyAt(j) != IntHashSet.NO_ENTRY_KEY) {
+                    result[i++] = connections.valueAt(j);
+                }
+            }
+            return result;
+        }
+    }
+
+    public long getServerStartTime() {
+        return serverStartTime.get();
+    }
+
+    public int getConnectionCount() {
+        synchronized (connections) {
+            return connections.size();
+        }
+    }
+
+    public long getTotalConnections() {
+        return totalConnections.get();
+    }
+
+    public long getTotalQueries() {
+        return totalQueries.get();
+    }
+
+    public long getTotalCommits() {
+        return totalTransactionCommits.get();
+    }
+
+    public long getTotalRollbacks() {
+        return totalTransactionRollbacks.get();
+    }
+
+    public static class ConnectionInfo {
+        public final int connectionId;
+        public final String remoteAddress;
+        public final String username;
+        public final String database;
+        public final long connectionStartTime;
+        public volatile String currentQuery;
+        public volatile long queryStartTime;
+        public volatile String state = "idle";
+
+        public ConnectionInfo(int connectionId, String remoteAddress, String username, String database, long connectionStartTime) {
+            this.connectionId = connectionId;
+            this.remoteAddress = remoteAddress;
+            this.username = username;
+            this.database = database;
+            this.connectionStartTime = connectionStartTime;
+        }
+    }
+}

--- a/core/src/main/resources/function_list.txt
+++ b/core/src/main/resources/function_list.txt
@@ -786,6 +786,8 @@ io.questdb.griffin.engine.functions.table.ReaderPoolFunctionFactory
 io.questdb.griffin.engine.functions.table.WriterPoolFunctionFactory
 io.questdb.griffin.engine.functions.table.TableWriterMetricsFunctionFactory
 io.questdb.griffin.engine.functions.table.MemoryMetricsFunctionFactory
+io.questdb.griffin.engine.functions.table.PgStatActivityFunctionFactory
+io.questdb.griffin.engine.functions.table.PgStatDatabaseFunctionFactory
 io.questdb.griffin.engine.functions.table.ReadParquetFunctionFactory
 io.questdb.griffin.engine.functions.table.ParquetScanFunctionFactory
 io.questdb.griffin.engine.functions.table.HydrateTableMetadataFunctionFactory


### PR DESCRIPTION
Description
Implement database activity tracking for QuestDB to provide insights into connection and query metrics.

Changes
Added DatabaseActivityRegistry to track:
Connection details
Query execution
Transaction metrics
Implemented pg_stat_activity() and pg_stat_database() functions
Updated PGConnectionContext to integrate with activity tracking
Added new tracking methods for connections, queries, commits, and rollbacks