### PR TITLE
feat(core): scale symbol capacity automatically

### DIFF
--- a/core/src/main/java/io/questdb/cairo/MapWriter.java
+++ b/core/src/main/java/io/questdb/cairo/MapWriter.java
@@ -68,6 +68,14 @@ public interface MapWriter extends SymbolCountProvider {
         }
     }
 
+    /**
+     * Column index in table writer metadata. This value is a pass-thru from table writer, and
+     * it used by table writer to look-back the column name when needed.
+     *
+     * @return column index or -1 if this is a NullWriter (noop writer)
+     */
+    int getColumnIndex();
+
     boolean getNullFlag();
 
     int getSymbolCapacity();

--- a/core/src/main/java/io/questdb/cairo/vm/NullMapWriter.java
+++ b/core/src/main/java/io/questdb/cairo/vm/NullMapWriter.java
@@ -32,6 +32,11 @@ public class NullMapWriter implements MapWriter {
     public static final MapWriter INSTANCE = new NullMapWriter();
 
     @Override
+    public int getColumnIndex() {
+        return -1;
+    }
+
+    @Override
     public boolean getNullFlag() {
         return false;
     }

--- a/core/src/test/java/io/questdb/test/cairo/FullFwdPartitionFrameCursorTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/FullFwdPartitionFrameCursorTest.java
@@ -541,7 +541,7 @@ public class FullFwdPartitionFrameCursorTest extends AbstractCairoTest {
 
     @Test
     public void testParallelIndexFailAtRuntimeByYear1v() throws Exception {
-        testParallelIndexFailureAtRuntime(PartitionBy.YEAR, 10000000L * 30 * 12, false, "1972.0" + Files.SEPARATOR + "a.v", 2);
+        testParallelIndexFailureAtRuntime(PartitionBy.YEAR, 10000000L * 30 * 12, false, "1972.3" + Files.SEPARATOR + "a.v.1", 2);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cairo/SymbolMapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/SymbolMapTest.java
@@ -103,7 +103,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     int prev = -1;
@@ -124,7 +125,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 N,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     int prev = N - 1;
@@ -186,7 +188,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                         COLUMN_NAME_TXN_NONE,
                         0,
                         -1,
-                        NOOP_COLLECTOR
+                        NOOP_COLLECTOR,
+                        -1
                 )) {
                     int prev = -1;
                     for (int i = 0; i < keys; i++) {
@@ -259,7 +262,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     Assert.assertEquals(0, writer.put("A1"));
@@ -296,7 +300,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 symbolCount,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     Assert.fail("expected corrupt exception");
@@ -319,7 +324,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 symbolCount,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     Assert.assertEquals(5, writer.put("A6"));
@@ -349,7 +355,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     Rnd rnd = new Rnd();
@@ -385,7 +392,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                             COLUMN_NAME_TXN_NONE,
                             0,
                             -1,
-                            NOOP_COLLECTOR
+                            NOOP_COLLECTOR,
+                            -1
                     );
                     Assert.fail();
                 } catch (CairoException e) {
@@ -409,7 +417,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     int prev = -1;
@@ -431,7 +440,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     int prev = -1;
@@ -453,7 +463,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     try (SymbolMapReaderImpl reader = new SymbolMapReaderImpl(configuration, path, "x", COLUMN_NAME_TXN_NONE, N)) {
@@ -498,7 +509,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     int prev = -1;
@@ -520,7 +532,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     try (SymbolMapReaderImpl reader = new SymbolMapReaderImpl(configuration, path, "x", COLUMN_NAME_TXN_NONE, N)) {
@@ -558,7 +571,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     int prev = -1;
@@ -580,7 +594,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     int prev = -1;
@@ -603,7 +618,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     try (SymbolMapReaderImpl reader = new SymbolMapReaderImpl(configuration, path, "x", COLUMN_NAME_TXN_NONE, N)) {
@@ -674,7 +690,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     int prev = -1;
@@ -729,7 +746,16 @@ public class SymbolMapTest extends AbstractCairoTest {
                 create(path, "x", 16, true);
 
                 int[] keys = new int[16];
-                try (SymbolMapWriter writer = new SymbolMapWriter(configuration, path, "x", COLUMN_NAME_TXN_NONE, 0, -1, NOOP_COLLECTOR)) {
+                try (SymbolMapWriter writer = new SymbolMapWriter(
+                        configuration,
+                        path,
+                        "x",
+                        COLUMN_NAME_TXN_NONE,
+                        0,
+                        -1,
+                        NOOP_COLLECTOR,
+                        -1
+                )) {
                     for (int i = 0; i < keys.length; i++) {
                         keys[i] = writer.put("key" + i);
                     }
@@ -791,7 +817,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     Rnd rnd = new Rnd();
@@ -833,7 +860,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     Assert.assertEquals(0, writer.put("A1"));
@@ -893,7 +921,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                         COLUMN_NAME_TXN_NONE,
                         0,
                         -1,
-                        NOOP_COLLECTOR
+                        NOOP_COLLECTOR,
+                        -1
                 );
                 int hi = rnd.nextInt(symbols);
                 hi = addRange(w, 0, hi, rnd, symbolList, indexList, prefix);
@@ -912,7 +941,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                             COLUMN_NAME_TXN_NONE,
                             resetTo,
                             -1,
-                            NOOP_COLLECTOR
+                            NOOP_COLLECTOR,
+                            -1
                     );
 
                     hi = resetTo + rnd.nextInt(symbols - resetTo);
@@ -937,7 +967,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                             COLUMN_NAME_TXN_NONE,
                             0,
                             -1,
-                            NOOP_COLLECTOR
+                            NOOP_COLLECTOR,
+                            -1
                     );
                     Assert.fail();
                 } catch (CairoException e) {
@@ -960,7 +991,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                         COLUMN_NAME_TXN_NONE,
                         0,
                         -1,
-                        NOOP_COLLECTOR
+                        NOOP_COLLECTOR,
+                        -1
                 )
                 ) {
                     Rnd rnd = new Rnd();
@@ -992,7 +1024,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     int prev = -1;
@@ -1035,7 +1068,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     int prev = -1;
@@ -1085,7 +1119,8 @@ public class SymbolMapTest extends AbstractCairoTest {
                                 COLUMN_NAME_TXN_NONE,
                                 0,
                                 -1,
-                                NOOP_COLLECTOR
+                                NOOP_COLLECTOR,
+                                -1
                         )
                 ) {
                     Rnd rnd = new Rnd();


### PR DESCRIPTION
This PR introduces automatic capacity management for symbols.

Previously, symbol capacity had to be manually tracked, which led to performance degradation when the symbol map was undersized—especially in high-cardinality cases. With this change, capacity is resized dynamically as cardinality grows, ensuring consistent system performance without manual intervention.