### PR TITLE
chore(build): run CI tests on ent-next branch

### DIFF
--- a/ci/test-fuzz.yml
+++ b/ci/test-fuzz.yml
@@ -8,7 +8,7 @@ schedules:
     branches:
       include:
         - master
-        - ent-next
+        - master-ent-next
     always: true
 
 variables:

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -4,7 +4,7 @@ pr:
   branches:
     include:
       - master
-      - ent-next
+      - master-ent-next
   drafts: false
 
 variables:


### PR DESCRIPTION
To have a stable enterprise, release a new pair of enterprise branches introduced

main-ent-next in questdb-enterprise repo
master-ent-next in questdb repo

This is until we are comfortable releasing risky big changes like nanos in enterprise.