### PR TITLE
chore(core): reload sequencer files when structure change is not found in Apply Wal job

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
@@ -400,9 +400,15 @@ public class TableSequencerImpl implements TableSequencer {
 
     @Override
     public TableToken reload() {
+        long lastTxn = tableTransactionLog.lastTxn();
         tableTransactionLog.reload(path);
         if (tableTransactionLog.isDropped()) {
             return null;
+        }
+
+        if (lastTxn == tableTransactionLog.lastTxn()) {
+            // Nothing to do.
+            return tableToken;
         }
 
         try (TableMetadataChangeLog metaChangeCursor = tableTransactionLog.getTableMetadataChangeLog(
@@ -418,7 +424,7 @@ public class TableSequencerImpl implements TableSequencer {
                 metadata.syncToMetaFile();
             }
         }
-        long lastTxn = tableTransactionLog.lastTxn();
+        lastTxn = tableTransactionLog.lastTxn();
         LOG.info()
                 .$("reloaded table sequencer [table=").$(tableToken)
                 .$(", lastTxn=").$(lastTxn)


### PR DESCRIPTION
This fixes replica bug that suspends WAL table on processing metadata change.

```
io.questdb.cairo.CairoException: [0] could not apply structure change from WAL to table. WAL metadata change does not exist [structureVersion=6]
	at io.questdb.cairo.CairoException.instance(CairoException.java:375)
	at io.questdb.cairo.CairoException.critical(CairoException.java:78)
	at io.questdb.cairo.wal.ApplyWal2TableJob.applyOutstandingWalTransactions(ApplyWal2TableJob.java:357)
	at io.questdb.cairo.wal.ApplyWal2TableJob.applyWal(ApplyWal2TableJob.java:801)
	at io.questdb.cairo.wal.ApplyWal2TableJob.doRun(ApplyWal2TableJob.java:855)
	at io.questdb.mp.AbstractQueueConsumerJob.run(AbstractQueueConsumerJob.java:50)
	at io.questdb.mp.Worker.run(Worker.java:152)
]
```