### PR TITLE
chore(core): reload sequencer files when structure change is not found in Apply Wal job 

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -331,6 +331,15 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                                     // Re-read the sequencer files to get the metadata change cursor.
                                     structuralChangeCursor = tableSequencerAPI.getMetadataChangeLogSlow(tableToken, newStructureVersion - 1);
                                     hasNext = structuralChangeCursor.hasNext();
+                                    if (!hasNext) {
+                                        // In very rare cases, when sequencer files are changed externally, we need to reload them here
+                                        // to re-read max structure version.
+                                        // We cannot do it in the previous call because we need to have sequencer writer lock to reload it.
+                                        Misc.free(structuralChangeCursor);
+                                        tableSequencerAPI.reload(tableToken);
+                                        structuralChangeCursor = tableSequencerAPI.getMetadataChangeLogSlow(tableToken, newStructureVersion - 1);
+                                        hasNext = structuralChangeCursor.hasNext();
+                                    }
                                 }
 
                                 if (hasNext) {


### PR DESCRIPTION
Same as #6186 into `master-ent-next`