### PR TITLE
fix(core): rare assertion error in SQL after metadata change

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -263,16 +263,12 @@ public class TableReader implements Closeable, SymbolTableSource {
         final long partitionTimestamp = txFile.getPartitionTimestampByIndex(partitionIndex);
         final long columnNameTxn = columnVersionReader.getColumnNameTxn(partitionTimestamp, metadata.getWriterIndex(columnIndex));
         final long partitionTxn = txFile.getPartitionNameTxn(partitionIndex);
-        BitmapIndexReader reader = getBitmapIndexReaderIfExists(partitionIndex, columnIndex, direction);
-        if (reader != null) {
-            if (reader.isOpen()) {
-                assert reader.getPartitionTxn() == partitionTxn;
-                assert reader.getColumnTxn() == columnNameTxn;
-                reader.reloadConditionally();
-            } else {
+        BitmapIndexReader indexReader = getBitmapIndexReaderIfExists(partitionIndex, columnIndex, direction);
+        if (indexReader != null) {
+            if (!indexReader.isOpen() || indexReader.getColumnTxn() != columnNameTxn) {
                 int plen = path.size();
                 try {
-                    reader.of(
+                    indexReader.of(
                             configuration,
                             pathGenNativePartition(partitionIndex, partitionTxn),
                             metadata.getColumnName(columnIndex),
@@ -283,8 +279,11 @@ public class TableReader implements Closeable, SymbolTableSource {
                 } finally {
                     path.trimTo(plen);
                 }
+            } else {
+                assert indexReader.getPartitionTxn() == partitionTxn;
+                indexReader.reloadConditionally();
             }
-            return reader;
+            return indexReader;
         }
         return createBitmapIndexReaderAt(index, columnBase, columnIndex, columnNameTxn, direction, partitionTxn);
     }

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -265,7 +265,11 @@ public class TableReader implements Closeable, SymbolTableSource {
         final long partitionTxn = txFile.getPartitionNameTxn(partitionIndex);
         BitmapIndexReader indexReader = getBitmapIndexReaderIfExists(partitionIndex, columnIndex, direction);
         if (indexReader != null) {
-            if (!indexReader.isOpen() || indexReader.getColumnTxn() != columnNameTxn) {
+            if (
+                    !indexReader.isOpen()
+                            || indexReader.getColumnTxn() != columnNameTxn
+                            || indexReader.getPartitionTxn() != partitionTxn
+            ) {
                 int plen = path.size();
                 try {
                     indexReader.of(
@@ -280,7 +284,6 @@ public class TableReader implements Closeable, SymbolTableSource {
                     path.trimTo(plen);
                 }
             } else {
-                assert indexReader.getPartitionTxn() == partitionTxn;
                 indexReader.reloadConditionally();
             }
             return indexReader;


### PR DESCRIPTION
Fixes assertion error found by fuzz tests:

```
java.lang.AssertionError
	at io.questdb@9.0.4-SNAPSHOT/io.questdb.cairo.TableReader.getBitmapIndexReader(TableReader.java:261)
	at io.questdb@9.0.4-SNAPSHOT/io.questdb.griffin.engine.table.FwdTableReaderPageFrameCursor$TableReaderPageFrame.getBitmapIndexReader(FwdTableReaderPageFrameCursor.java:332)
	at io.questdb@9.0.4-SNAPSHOT/io.questdb.griffin.engine.table.SymbolIndexRowCursorFactory.getCursor(SymbolIndexRowCursorFactory.java:60)
	at io.questdb@9.0.4-SNAPSHOT/io.questdb.griffin.engine.table.PageFrameRecordCursorImpl.hasNext(PageFrameRecordCursorImpl.java:107)
	at io.questdb@9.0.4-SNAPSHOT/io.questdb.griffin.engine.groupby.GroupByRecordCursorFactory$GroupByRecordCursor.buildDataMap(GroupByRecordCursorFactory.java:251)
	at io.questdb@9.0.4-SNAPSHOT/io.questdb.griffin.engine.groupby.GroupByRecordCursorFactory$GroupByRecordCursor.buildMapConditionally(GroupByRecordCursorFactory.java:268)
	at io.questdb@9.0.4-SNAPSHOT/io.questdb.griffin.engine.groupby.GroupByRecordCursorFactory$GroupByRecordCursor.hasNext(GroupByRecordCursorFactory.java:216)
	at io.questdb@9.0.4-SNAPSHOT/io.questdb.griffin.engine.QueryProgress$RegisteredRecordCursor.hasNext(QueryProgress.java:419)
	at io.questdb.test/io.questdb.test.fuzz.FuzzValidateSymbolFilterOperation.validateSymbolIndex(FuzzValidateSymbolFilterOperation.java:87)
	at io.questdb.test/io.questdb.test.fuzz.FuzzValidateSymbolFilterOperation.apply(FuzzValidateSymbolFilterOperation.java:60)
	at io.questdb.test/io.questdb.test.cairo.fuzz.FuzzRunner.applyNonWal(FuzzRunner.java:269)
	at io.questdb.test/io.questdb.test.cairo.fuzz.FuzzRunner.createTransactions(FuzzRunner.java:825)
	at io.questdb.test/io.questdb.test.cairo.fuzz.FuzzRunner.runFuzz(FuzzRunner.java:1236)
	at io.questdb.test/io.questdb.test.cairo.fuzz.AbstractFuzzTest.lambda$fullRandomFuzz$1(AbstractFuzzTest.java:147)
	at io.questdb.test/io.questdb.test.AbstractCairoTest.lambda$assertMemoryLeak$8(AbstractCairoTest.java:1208)
	at io.questdb.test/io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:740)
	at io.questdb.test/io.questdb.test.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:1205)
	at io.questdb.test/io.questdb.test.cairo.fuzz.AbstractFuzzTest.fullRandomFuzz(AbstractFuzzTest.java:147)
	at io.questdb.test/io.questdb.test.cairo.fuzz.WalWriterFuzzTest.testWalWriteFullRandomMultipleTables(WalWriterFuzzTest.java:450)
```

```
>>>>= io.questdb.test.cairo.fuzz.WalWriterFuzzTest.testWalWriteFullRandomMultipleTables
random seeds: 840694641921L, 1758809832819L
```