### PR TITLE
chore(core): fix SettingsProcessor

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/HttpResponseSink.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpResponseSink.java
@@ -59,9 +59,11 @@ import static io.questdb.std.Chars.isBlank;
 import static java.net.HttpURLConnection.*;
 
 public class HttpResponseSink implements Closeable, Mutable {
+    private static final Utf8String EMPTY_JSON = new Utf8String("{}");
     private static final int HTTP_RANGE_NOT_SATISFIABLE = 416;
     private static final int HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
     private static final Log LOG = LogFactory.getLog(HttpResponseSink.class);
+    private static final IntObjHashMap<Utf8Sequence> httpJsonStatusMap = new IntObjHashMap<>();
     private static final IntObjHashMap<Utf8Sequence> httpStatusMap = new IntObjHashMap<>();
     private final ChunkUtf8Sink buffer;
     private final ChunkedResponseImpl chunkedResponse = new ChunkedResponseImpl();
@@ -691,38 +693,28 @@ public class HttpResponseSink implements Closeable, Mutable {
             headerSent = false;
         }
 
-        @SuppressWarnings("unused")
         public void sendStatusJsonContent(
                 int code
         ) throws PeerDisconnectedException, PeerIsSlowToReadException {
-            sendStatusJsonContent(code, null, null, null, null, -1L, true);
+            final Utf8Sequence message = httpJsonStatusMap.get(code);
+            sendStatusJsonContent(code, message != null ? message : EMPTY_JSON, true);
         }
 
         public void sendStatusJsonContent(
                 int code,
-                @Nullable Utf8Sequence message
+                @NotNull Utf8Sequence message
         ) throws PeerDisconnectedException, PeerIsSlowToReadException {
             sendStatusJsonContent(code, message, true);
         }
 
         public void sendStatusJsonContent(
                 int code,
-                @Nullable Utf8Sequence message,
+                @NotNull Utf8Sequence message,
                 boolean appendEOL
         ) throws PeerDisconnectedException, PeerIsSlowToReadException {
-            sendStatusJsonContent(code, message, null, null, null, message != null ? message.size() : -1L, appendEOL);
-        }
-
-        public void sendStatusJsonContent(
-                int code,
-                @Nullable Utf8Sequence message,
-                @Nullable CharSequence header,
-                @Nullable CharSequence cookieName,
-                @Nullable CharSequence cookieValue,
-                long contentLength,
-                boolean appendEOL
-        ) throws PeerDisconnectedException, PeerIsSlowToReadException {
-            sendStatusWithContent(CONTENT_TYPE_JSON, code, message, header, cookieName, cookieValue, contentLength, appendEOL);
+            final long contentLength = message.size();
+            assert contentLength > 0 : "json content is missing";
+            sendStatusWithContent(CONTENT_TYPE_JSON, code, message, null, null, null, contentLength, appendEOL);
         }
 
         public void sendStatusNoContent(int code, @Nullable CharSequence header) throws PeerDisconnectedException, PeerIsSlowToReadException {
@@ -863,5 +855,11 @@ public class HttpResponseSink implements Closeable, Mutable {
         httpStatusMap.put(HTTP_RANGE_NOT_SATISFIABLE, new Utf8String("Request range not satisfiable"));
         httpStatusMap.put(HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE, new Utf8String("Headers too large"));
         httpStatusMap.put(HTTP_INTERNAL_ERROR, new Utf8String("Internal server error"));
+    }
+
+    static {
+        httpJsonStatusMap.put(HTTP_OK, new Utf8String("{\"status\":\"OK\"}"));
+        httpJsonStatusMap.put(HTTP_UNAUTHORIZED, new Utf8String("{\"status\":\"Unauthorized\"}"));
+        httpJsonStatusMap.put(HTTP_FORBIDDEN, new Utf8String("{\"status\":\"Forbidden\"}"));
     }
 }

--- a/core/src/test/java/io/questdb/test/cutlass/http/SettingsEndpointTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/SettingsEndpointTest.java
@@ -748,7 +748,7 @@ public class SettingsEndpointTest extends AbstractBootstrapTest {
     }
 
     private static void savePreferences(HttpClient httpClient, String preferences, SettingsStore.Mode mode, long version) {
-        assertPreferencesRequest(httpClient, preferences, mode, version, HTTP_OK, "");
+        assertPreferencesRequest(httpClient, preferences, mode, version, HTTP_OK, "{\"status\":\"OK\"}\r\n");
     }
 
     private void assertPreferencesStore(SettingsStore settingsStore, int expectedVersion, String expectedPreferences) {


### PR DESCRIPTION
Fix for intermittent test failures experienced in `SettingsEndpointTest`.
The problem was that `SettingsProcessor` sent an empty non-chunked response back to the client with HTTP OK and ContentLength=0, when preferences (instance name, type and description) were saved successfully.
HttpClient then received the header, parsed it, and when it time to read the response body, it checked the content length which was 0, and simply returned since there was nothing to receive.
This meant that the client considered the request finished before it was actually done by the server.
Solution is to always return a response body.
Considering that the content type of the response is JSON, this is actually required.

Fixing the above problem uncovered another issue.
Because there was no response body, fragmented response was not an issue.
However, after adding a response body, fragmentation tests started failing which are also fixed in this PR.

In practice these issues could have resulted in a visible problem in the web console only, if the user loaded the UI on a very slow connection, and received an error while updating preferences.
In this case the HTTP response would have had a body with the error message, and could have been got fragmented because of the slow connection.