### PR TITLE
test(ilp): handle null writer for non-wal table

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpLegacyWriterJob.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpLegacyWriterJob.java
@@ -147,7 +147,7 @@ class LineTcpLegacyWriterJob implements Job, Closeable {
                 boolean closeWriter = false;
                 if (event.getWriterWorkerId() == workerId) {
                     try {
-                        if (tud.isWriterInError()) {
+                        if (tud.isWriterInError() || tud.getWriter() == null) {
                             closeWriter = true;
                         } else {
                             if (!tud.isAssignedToJob()) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpMeasurementScheduler.java
@@ -304,7 +304,7 @@ public class LineTcpMeasurementScheduler implements Closeable {
                 if (tud == null) {
                     tud = getTableUpdateDetailsFromSharedArea(securityContext, netIoJob, ctx, parser);
                 }
-            } else if (tud.isWriterInError()) {
+            } else if (tud.isWriterInError() || tud.getWriter() == null) {
                 TableUpdateDetails removed = ctx.removeTableUpdateDetails(measurementName);
                 assert tud == removed;
                 removed.close();
@@ -390,8 +390,8 @@ public class LineTcpMeasurementScheduler implements Closeable {
         long seq = getNextPublisherEventSequence(writerThreadId);
         if (seq > -1) {
             try {
-                if (tud.isWriterInError()) {
-                    throw CairoException.critical(0).put("writer is in error, aborting ILP pipeline");
+                if (tud.isWriterInError() || tud.getWriter() == null) {
+                    throw CairoException.critical(0).put("writer is in error or released, aborting ILP pipeline");
                 }
                 queue[writerThreadId].get(seq).createMeasurementEvent(securityContext, tud, parser, netIoJob.getWorkerId());
             } finally {


### PR DESCRIPTION
Found in https://github.com/questdb/questdb/pull/6076/checks?check_run_id=51432033257

The root cause is that `TableUpdateDetails` releases the writer when an exception occurs.
non-WAL tables lack null writer validation before use.

```
2025-09-28T14:13:19.9561634Z 2025-09-28T14:13:19.943713Z E i.q.c.l.t.LineTcpMeasurementEvent could not write line protocol measurement [tableName=weather3~, message=Cannot invoke "io.questdb.cairo.TableWriterAPI.getMetadataVersion()" because "writer" is null, trace: 
2025-09-28T14:13:19.9562638Z java.lang.NullPointerException: Cannot invoke "io.questdb.cairo.TableWriterAPI.getMetadataVersion()" because "writer" is null
2025-09-28T14:13:19.9563496Z 	at io.questdb.cutlass.line.tcp.LineTcpMeasurementEvent.append(LineTcpMeasurementEvent.java:125)
2025-09-28T14:13:19.9564373Z 	at io.questdb.cutlass.line.tcp.LineTcpLegacyWriterJob.drainQueue(LineTcpLegacyWriterJob.java:162)
2025-09-28T14:13:19.9565420Z 	at io.questdb.cutlass.line.tcp.LineTcpLegacyWriterJob.run(LineTcpLegacyWriterJob.java:87)
2025-09-28T14:13:19.9566201Z 	at io.questdb.mp.Worker.run(Worker.java:152)
2025-09-28T14:13:19.9566846Z ]
```
```
2025-09-28T14:16:26.8311244Z 2025-09-28T14:16:26.253256Z E i.q.t.c.l.t.LineTcpReceiverFuzzTest 
2025-09-28T14:16:26.8312014Z java.lang.RuntimeException: Timed out on waiting for the data, table=weather3
2025-09-28T14:16:26.8312616Z  at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverFuzzTest.waitForTable(AbstractLineTcpReceiverFuzzTest.java:620)
2025-09-28T14:16:26.8313271Z  at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverFuzzTest.waitDone(AbstractLineTcpReceiverFuzzTest.java:602)
2025-09-28T14:16:26.8313929Z  at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverFuzzTest.lambda$runTest$2(AbstractLineTcpReceiverFuzzTest.java:546)
2025-09-28T14:16:26.8314634Z  at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.lambda$runInContext$2(AbstractLineTcpReceiverTest.java:316)
2025-09-28T14:16:26.8315407Z  at io.questdb.test.AbstractCairoTest.lambda$assertMemoryLeak$9(AbstractCairoTest.java:1247)
2025-09-28T14:16:26.8315988Z  at io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:741)
2025-09-28T14:16:26.8316562Z  at io.questdb.test.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:1242)
2025-09-28T14:16:26.8317174Z  at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:308)
2025-09-28T14:16:26.8318039Z  at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverTest.runInContext(AbstractLineTcpReceiverTest.java:332)
2025-09-28T14:16:26.8318702Z  at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverFuzzTest.runTest(AbstractLineTcpReceiverFuzzTest.java:530)
2025-09-28T14:16:26.8319366Z  at io.questdb.test.cutlass.line.tcp.AbstractLineTcpReceiverFuzzTest.runTest(AbstractLineTcpReceiverFuzzTest.java:121)
2025-09-28T14:16:26.8320119Z  at io.questdb.test.cutlass.line.tcp.LineTcpReceiverFuzzTest.runTest(LineTcpReceiverFuzzTest.java:40)
2025-09-28T14:16:26.8320953Z  at io.questdb.test.cutlass.line.tcp.LineTcpReceiverFuzzTest.testLoad(LineTcpReceiverFuzzTest.java:100)
2025-09-28T14:16:26.8321532Z  at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2025-09-28T14:16:26.8322081Z  at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
2025-09-28T14:16:26.8322690Z  at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2025-09-28T14:16:26.8323237Z  at java.lang.reflect.Method.invoke(Method.java:569)
2025-09-28T14:16:26.8323779Z  at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
2025-09-28T14:16:26.8324367Z  at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
2025-09-28T14:16:26.8324938Z  at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
2025-09-28T14:16:26.8325515Z  at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
2025-09-28T14:16:26.8326076Z  at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
2025-09-28T14:16:26.8326626Z  at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
2025-09-28T14:16:26.8327320Z  at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
2025-09-28T14:16:26.8327894Z  at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
2025-09-28T14:16:26.8328519Z  at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
2025-09-28T14:16:26.8329076Z  at java.util.concurrent.FutureTask.run(FutureTask.java:264)
2025-09-28T14:16:26.8329548Z  at java.lang.Thread.run(Thread.java:840)
```