### PR TITLE
fix(core): fix assertion exception in writer, which is triggered by OS error

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -5456,6 +5456,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
     private void handleHousekeepingException(Throwable e) {
         // Log the exception stack.
+        distressed = true;
         LOG.error().$("data has been persisted, but we could not perform housekeeping [table=").$(tableToken)
                 .$(", error=").$(e)
                 .I$();


### PR DESCRIPTION
found by fuzz test:

```
public void testWalWriteFullRandomMultipleTables() throws Exception {
        Rnd rnd = generateRandom(LOG,631396799652L, 1759158542588L);
```