### PR TITLE
chore(core): polymorphic AsOfJoinIndexedRecordCursorFactory

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -2711,6 +2711,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                         boolean created = false;
                                         if (!asOfAvoidBinarySearch) {
                                             if (slave.supportsTimeFrameCursor() && fastAsOfJoins) {
+                                                SymbolShortCircuit symbolShortCircuit = createSymbolShortCircuit(masterMetadata, slaveMetadata, selfJoin);
                                                 if (isSingleSymbolJoinWithIndex(slaveMetadata)) {
                                                     int masterSymbolColumnIndex = listColumnFilterB.getColumnIndexFactored(0);
                                                     int slaveSymbolColumnIndex = listColumnFilterA.getColumnIndexFactored(0);
@@ -2722,11 +2723,11 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                                             masterMetadata.getColumnCount(),
                                                             masterSymbolColumnIndex,
                                                             slaveSymbolColumnIndex,
+                                                            symbolShortCircuit,
                                                             slaveModel.getContext(),
                                                             asOfToleranceInterval
                                                     );
                                                 } else {
-                                                    SymbolShortCircuit symbolShortCircuit = createSymbolShortCircuit(masterMetadata, slaveMetadata, selfJoin);
                                                     master = new AsOfJoinFastRecordCursorFactory(
                                                             configuration,
                                                             createJoinMetadata(masterAlias, masterMetadata, slaveModel.getName(), slaveMetadata),

--- a/core/src/main/java/io/questdb/griffin/engine/join/ChainedSymbolShortCircuit.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/ChainedSymbolShortCircuit.java
@@ -25,7 +25,9 @@
 package io.questdb.griffin.engine.join;
 
 import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.StaticSymbolTable;
 import io.questdb.cairo.sql.TimeFrameRecordCursor;
+import org.jetbrains.annotations.NotNull;
 
 public final class ChainedSymbolShortCircuit implements SymbolShortCircuit {
 
@@ -33,6 +35,16 @@ public final class ChainedSymbolShortCircuit implements SymbolShortCircuit {
 
     public ChainedSymbolShortCircuit(SymbolShortCircuit[] shortCircuits) {
         this.shortCircuits = shortCircuits;
+    }
+
+    @Override
+    public CharSequence getMasterValue(Record masterRecord) {
+        throw new UnsupportedOperationException("ChainedSymbolShortCircuit can't be used to return the master value");
+    }
+
+    @Override
+    public @NotNull StaticSymbolTable getSlaveSymbolTable() {
+        throw new UnsupportedOperationException("ChainedSymbolShortCircuit doesn't have a symbol table");
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/join/DisabledSymbolShortCircuit.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/DisabledSymbolShortCircuit.java
@@ -25,10 +25,22 @@
 package io.questdb.griffin.engine.join;
 
 import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.StaticSymbolTable;
 import io.questdb.cairo.sql.TimeFrameRecordCursor;
+import org.jetbrains.annotations.NotNull;
 
 public class DisabledSymbolShortCircuit implements SymbolShortCircuit {
     public static final DisabledSymbolShortCircuit INSTANCE = new DisabledSymbolShortCircuit();
+
+    @Override
+    public CharSequence getMasterValue(Record masterRecord) {
+        throw new UnsupportedOperationException("DisabledSymbolShortCircuit can't return the master value");
+    }
+
+    @Override
+    public @NotNull StaticSymbolTable getSlaveSymbolTable() {
+        throw new UnsupportedOperationException("DisabledSymbolShortCircuit doesn't have a symbol table");
+    }
 
     @Override
     public boolean isShortCircuit(Record masterRecord) {

--- a/core/src/main/java/io/questdb/griffin/engine/join/SingleStringSymbolShortCircuit.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/SingleStringSymbolShortCircuit.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.join;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.StaticSymbolTable;
 import io.questdb.cairo.sql.TimeFrameRecordCursor;
+import org.jetbrains.annotations.NotNull;
 
 public final class SingleStringSymbolShortCircuit implements SymbolShortCircuit {
     private final int masterStringIndex;
@@ -36,6 +37,16 @@ public final class SingleStringSymbolShortCircuit implements SymbolShortCircuit 
     public SingleStringSymbolShortCircuit(int masterStringIndex, int slaveSymbolIndex) {
         this.masterStringIndex = masterStringIndex;
         this.slaveSymbolIndex = slaveSymbolIndex;
+    }
+
+    @Override
+    public CharSequence getMasterValue(Record masterRecord) {
+        return masterRecord.getStrA(masterStringIndex);
+    }
+
+    @Override
+    public @NotNull StaticSymbolTable getSlaveSymbolTable() {
+        return slaveSymbolTable;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/join/SingleSymbolSymbolShortCircuit.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/SingleSymbolSymbolShortCircuit.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.sql.StaticSymbolTable;
 import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.cairo.sql.TimeFrameRecordCursor;
 import io.questdb.std.CompactIntHashSet;
+import org.jetbrains.annotations.NotNull;
 
 public final class SingleSymbolSymbolShortCircuit implements SymbolShortCircuit {
     private final CairoConfiguration config;
@@ -43,6 +44,16 @@ public final class SingleSymbolSymbolShortCircuit implements SymbolShortCircuit 
         this.masterSymbolIndex = masterSymbolIndex;
         this.slaveSymbolIndex = slaveSymbolIndex;
         this.config = config;
+    }
+
+    @Override
+    public CharSequence getMasterValue(Record masterRecord) {
+        return masterRecord.getSymA(masterSymbolIndex);
+    }
+
+    @Override
+    public @NotNull StaticSymbolTable getSlaveSymbolTable() {
+        return slaveSymbolTable;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/join/SingleVarcharSymbolShortCircuit.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/SingleVarcharSymbolShortCircuit.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.sql.StaticSymbolTable;
 import io.questdb.cairo.sql.TimeFrameRecordCursor;
 import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8Sequence;
+import org.jetbrains.annotations.NotNull;
 
 public final class SingleVarcharSymbolShortCircuit implements SymbolShortCircuit {
     private final int masterVarcharIndex;
@@ -39,6 +40,25 @@ public final class SingleVarcharSymbolShortCircuit implements SymbolShortCircuit
     public SingleVarcharSymbolShortCircuit(int masterVarcharIndex, int slaveSymbolIndex) {
         this.masterVarcharIndex = masterVarcharIndex;
         this.slaveSymbolIndex = slaveSymbolIndex;
+    }
+
+    @Override
+    public CharSequence getMasterValue(Record masterRecord) {
+        Utf8Sequence masterVarchar = masterRecord.getVarcharA(masterVarcharIndex);
+        if (masterVarchar == null) {
+            return null;
+        }
+        if (masterVarchar.isAscii()) {
+            return masterVarchar.asAsciiCharSequence();
+        }
+        utf16Sink.clear();
+        utf16Sink.put(masterVarchar);
+        return utf16Sink;
+    }
+
+    @Override
+    public @NotNull StaticSymbolTable getSlaveSymbolTable() {
+        return slaveSymbolTable;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/join/SymbolShortCircuit.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/SymbolShortCircuit.java
@@ -25,14 +25,23 @@
 package io.questdb.griffin.engine.join;
 
 import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.StaticSymbolTable;
 import io.questdb.cairo.sql.TimeFrameRecordCursor;
+import io.questdb.std.Transient;
+import org.jetbrains.annotations.NotNull;
 
-/**
- * When joining on a single symbol column, detects when the slave column doesn't have
- * the symbol at all (by inspecting its int-to-symbol mapping), avoiding linear search
- * in that case.
- */
 public interface SymbolShortCircuit {
+    @Transient
+    CharSequence getMasterValue(Record masterRecord);
+
+    @NotNull
+    StaticSymbolTable getSlaveSymbolTable();
+
+    /**
+     * When joining on a single symbol column, detects when the slave column doesn't have
+     * the symbol at all (by inspecting its int-to-symbol mapping), avoiding linear search
+     * in that case.
+     */
     boolean isShortCircuit(Record masterRecord);
 
     void of(TimeFrameRecordCursor slaveCursor);

--- a/core/src/test/java/io/questdb/test/griffin/AsOfJoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AsOfJoinTest.java
@@ -1618,9 +1618,21 @@ public class AsOfJoinTest extends AbstractCairoTest {
             String leftSuffix = getTimestampSuffix(leftTableTimestampType.getTypeName());
             String rightSuffix = getTimestampSuffix(rightTableTimestampType.getTypeName());
 
-            // ASOF JOIN
-            String query = "SELECT * FROM x ASOF JOIN y ON(sym)";
+            // LT JOIN
+            String query = "SELECT * FROM x LT JOIN y ON(sym)";
             String expected = "sym\tts\tsym1\tts1\n" +
+                    "1\t2000-01-01T00:00:00.000000" + leftSuffix + "\t\t\n" +
+                    "3\t2000-01-01T00:00:01.000000" + leftSuffix + "\t\t\n" +
+                    "1\t2000-01-01T00:00:02.000000" + leftSuffix + "\t\t\n" +
+                    "\t2000-01-01T00:00:03.000000" + leftSuffix + "\t\t\n" +
+                    "не-ASCII\t2000-01-01T00:00:03.000000" + leftSuffix + "\t\t\n" +
+                    "2\t2000-01-01T00:00:03.000000" + leftSuffix + "\t2\t2000-01-01T00:00:00.000000" + rightSuffix + "\n" +
+                    "4\t2000-01-01T00:00:04.000000" + leftSuffix + "\t4\t2000-01-01T00:00:01.000000" + rightSuffix + "\n";
+            assertQueryNoLeakCheck(expected, query, "ts", false, true);
+
+            // ASOF JOIN
+            query = "SELECT * FROM x ASOF JOIN y ON(sym)";
+            expected = "sym\tts\tsym1\tts1\n" +
                     "1\t2000-01-01T00:00:00.000000" + leftSuffix + "\t\t\n" +
                     "3\t2000-01-01T00:00:01.000000" + leftSuffix + "\t\t\n" +
                     "1\t2000-01-01T00:00:02.000000" + leftSuffix + "\t1\t2000-01-01T00:00:02.000000" + rightSuffix + "\n" +
@@ -1629,17 +1641,7 @@ public class AsOfJoinTest extends AbstractCairoTest {
                     "2\t2000-01-01T00:00:03.000000" + leftSuffix + "\t2\t2000-01-01T00:00:03.000000" + rightSuffix + "\n" +
                     "4\t2000-01-01T00:00:04.000000" + leftSuffix + "\t4\t2000-01-01T00:00:01.000000" + rightSuffix + "\n";
             assertQueryNoLeakCheck(expected, query, "ts", false, true);
-
-            // LT JOIN
-            query = "SELECT * FROM x LT JOIN y ON(sym)";
-            expected = "sym\tts\tsym1\tts1\n" +
-                    "1\t2000-01-01T00:00:00.000000" + leftSuffix + "\t\t\n" +
-                    "3\t2000-01-01T00:00:01.000000" + leftSuffix + "\t\t\n" +
-                    "1\t2000-01-01T00:00:02.000000" + leftSuffix + "\t\t\n" +
-                    "\t2000-01-01T00:00:03.000000" + leftSuffix + "\t\t\n" +
-                    "не-ASCII\t2000-01-01T00:00:03.000000" + leftSuffix + "\t\t\n" +
-                    "2\t2000-01-01T00:00:03.000000" + leftSuffix + "\t2\t2000-01-01T00:00:00.000000" + rightSuffix + "\n" +
-                    "4\t2000-01-01T00:00:04.000000" + leftSuffix + "\t4\t2000-01-01T00:00:01.000000" + rightSuffix + "\n";
+            execute("ALTER TABLE y ALTER COLUMN sym ADD INDEX");
             assertQueryNoLeakCheck(expected, query, "ts", false, true);
         });
     }
@@ -1672,9 +1674,21 @@ public class AsOfJoinTest extends AbstractCairoTest {
             String leftSuffix = getTimestampSuffix(leftTableTimestampType.getTypeName());
             String rightSuffix = getTimestampSuffix(rightTableTimestampType.getTypeName());
 
-            // ASOF JOIN
-            String query = "SELECT * FROM x ASOF JOIN y ON(sym)";
+            // LT JOIN
+            String query = "SELECT * FROM x LT JOIN y ON(sym)";
             String expected = "sym\tts\tsym1\tts1\n" +
+                    "😊\t2000-01-01T00:00:00.000000" + leftSuffix + "\t\t\n" +
+                    "3\t2000-01-01T00:00:01.000000" + leftSuffix + "\t\t\n" +
+                    "😊\t2000-01-01T00:00:02.000000" + leftSuffix + "\t\t\n" +
+                    "\t2000-01-01T00:00:03.000000" + leftSuffix + "\t\t\n" +
+                    "не-ASCII\t2000-01-01T00:00:03.000000" + leftSuffix + "\t\t\n" +
+                    "2\t2000-01-01T00:00:03.000000" + leftSuffix + "\t2\t2000-01-01T00:00:00.000000" + rightSuffix + "\n" +
+                    "4\t2000-01-01T00:00:04.000000" + leftSuffix + "\t4\t2000-01-01T00:00:01.000000" + rightSuffix + "\n";
+            assertQueryNoLeakCheck(expected, query, "ts", false, true);
+
+            // ASOF JOIN
+            query = "SELECT * FROM x ASOF JOIN y ON(sym)";
+            expected = "sym\tts\tsym1\tts1\n" +
                     "😊\t2000-01-01T00:00:00.000000" + leftSuffix + "\t\t\n" +
                     "3\t2000-01-01T00:00:01.000000" + leftSuffix + "\t\t\n" +
                     "😊\t2000-01-01T00:00:02.000000" + leftSuffix + "\t😊\t2000-01-01T00:00:02.000000" + rightSuffix + "\n" +
@@ -1683,17 +1697,7 @@ public class AsOfJoinTest extends AbstractCairoTest {
                     "2\t2000-01-01T00:00:03.000000" + leftSuffix + "\t2\t2000-01-01T00:00:03.000000" + rightSuffix + "\n" +
                     "4\t2000-01-01T00:00:04.000000" + leftSuffix + "\t4\t2000-01-01T00:00:01.000000" + rightSuffix + "\n";
             assertQueryNoLeakCheck(expected, query, "ts", false, true);
-
-            // LT JOIN
-            query = "SELECT * FROM x LT JOIN y ON(sym)";
-            expected = "sym\tts\tsym1\tts1\n" +
-                    "😊\t2000-01-01T00:00:00.000000" + leftSuffix + "\t\t\n" +
-                    "3\t2000-01-01T00:00:01.000000" + leftSuffix + "\t\t\n" +
-                    "😊\t2000-01-01T00:00:02.000000" + leftSuffix + "\t\t\n" +
-                    "\t2000-01-01T00:00:03.000000" + leftSuffix + "\t\t\n" +
-                    "не-ASCII\t2000-01-01T00:00:03.000000" + leftSuffix + "\t\t\n" +
-                    "2\t2000-01-01T00:00:03.000000" + leftSuffix + "\t2\t2000-01-01T00:00:00.000000" + rightSuffix + "\n" +
-                    "4\t2000-01-01T00:00:04.000000" + leftSuffix + "\t4\t2000-01-01T00:00:01.000000" + rightSuffix + "\n";
+            execute("ALTER TABLE y ALTER COLUMN sym ADD INDEX");
             assertQueryNoLeakCheck(expected, query, "ts", false, true);
         });
     }


### PR DESCRIPTION
`AsOfJoinIndexedRecordCursorFactory` currently has a bug and fails when the LHS column is not SYMBOL, but STRING or VARCHAR.

This PR broadens the scope of `SymbolShortCircuit`, which already polymorphic in the LHS column type, to let the record factory access the master value in all cases.