### PR TITLE
test(sql): fix flaky ParallelLatestByTest

### DIFF
--- a/core/src/test/java/io/questdb/test/AbstractCairoTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractCairoTest.java
@@ -639,7 +639,6 @@ public abstract class AbstractCairoTest extends AbstractTest {
         ParanoiaState.FD_PARANOIA_MODE = new Rnd(System.nanoTime(), System.currentTimeMillis()).nextInt(100) > 70;
         engine.getMetrics().clear();
         engine.getMatViewStateStore().clear();
-        SqlCodeGenerator.ALLOW_FUNCTION_MEMOIZATION = false;
     }
 
     public void tearDown(boolean removeDir) {
@@ -665,7 +664,6 @@ public abstract class AbstractCairoTest extends AbstractTest {
         tearDown(true);
         super.tearDown();
         spinLockTimeout = DEFAULT_SPIN_LOCK_TIMEOUT;
-        SqlCodeGenerator.ALLOW_FUNCTION_MEMOIZATION = false;
     }
 
     private static void assertCalculateSize(RecordCursorFactory factory) throws SqlException {

--- a/core/src/test/java/io/questdb/test/AbstractTest.java
+++ b/core/src/test/java/io/questdb/test/AbstractTest.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.mv.MatViewRefreshJob;
 import io.questdb.cairo.mv.MatViewTimerJob;
 import io.questdb.cairo.wal.ApplyWal2TableJob;
 import io.questdb.cairo.wal.CheckWalTransactionsJob;
+import io.questdb.griffin.SqlCodeGenerator;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.QuietCloseable;
@@ -90,6 +91,7 @@ public class AbstractTest {
         LOG.info().$("Starting test ").$safe(getClass().getSimpleName()).$('#').$safe(testName.getMethodName()).$();
         TestUtils.createTestPath(root);
         Metrics.ENABLED.clear();
+        SqlCodeGenerator.ALLOW_FUNCTION_MEMOIZATION = false;
     }
 
     @After
@@ -97,6 +99,7 @@ public class AbstractTest {
         LOG.info().$("Finished test ").$safe(getClass().getSimpleName()).$('#').$safe(testName.getMethodName()).$();
         TestUtils.removeTestPath(root);
         OFF_POOL_READER_ID.set(0);
+        SqlCodeGenerator.ALLOW_FUNCTION_MEMOIZATION = false;
     }
 
     protected static MatViewRefreshJob createMatViewRefreshJob(CairoEngine engine) {

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -66,7 +66,6 @@ import io.questdb.cutlass.http.processors.StaticContentProcessorFactory;
 import io.questdb.cutlass.http.processors.TextImportProcessor;
 import io.questdb.griffin.DefaultSqlExecutionCircuitBreakerConfiguration;
 import io.questdb.griffin.QueryRegistry;
-import io.questdb.griffin.SqlCodeGenerator;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
@@ -233,7 +232,6 @@ public class IODispatcherTest extends AbstractTest {
     @Before
     public void setUp() {
         super.setUp();
-        SqlCodeGenerator.ALLOW_FUNCTION_MEMOIZATION = false;
         SharedRandom.RANDOM.set(new Rnd());
         testHttpClient.setKeepConnection(false);
         Metrics.ENABLED.clear();


### PR DESCRIPTION
`ParallelLatestByTest#testLatestByWithin*()` led to different table data generated depending on whether you run the test on its own or along with any other tests. That's due to `SqlCodeGenerator.ALLOW_FUNCTION_MEMOIZATION` being set to `false` in `setUp()`/`tearDown()` methods of `AbstractCairoTest`. But `ParallelLatestByTest` itself only extends `AbstractTest`, not `AbstractCairoTest`. The fix simply moves the `SqlCodeGenerator.ALLOW_FUNCTION_MEMOIZATION` flag initialization from `AbstractCairoTest` to `AbstractTest`.