### PR TITLE
feat(sql): `rnd_symbol_zipf()` function for generating skewed symbol distributions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ compat/src/test/nodejs-postgres/node_modules
 compat/src/test/php/vendor/
 compat/src/test/php/composer.lock
 compat/src/test/golang/gorunner
-
+compat/src/test/rust/scenarios/target/

--- a/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndSymbolWeightedFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndSymbolWeightedFunctionFactory.java
@@ -1,0 +1,212 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.rnd;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.SymbolTable;
+import io.questdb.cairo.sql.SymbolTableSource;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.SymbolFunction;
+import io.questdb.std.Chars;
+import io.questdb.std.DoubleList;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.std.Rnd;
+import io.questdb.std.Transient;
+
+import static io.questdb.std.Vect.BIN_SEARCH_SCAN_UP;
+
+public class RndSymbolWeightedFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "rnd_symbol_weighted(V)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            @Transient ObjList<Function> args,
+            @Transient IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        if (args == null || args.size() < 2) {
+            throw SqlException.$(position, "expected at least one symbol-weight pair");
+        }
+
+        if (args.size() % 2 != 0) {
+            throw SqlException.$(position, "expected even number of arguments (symbol-weight pairs)");
+        }
+
+        final int pairCount = args.size() / 2;
+        final ObjList<String> symbols = new ObjList<>(pairCount);
+        final DoubleList weights = new DoubleList(pairCount);
+
+        // Extract symbol-weight pairs
+        for (int i = 0; i < pairCount; i++) {
+            int symbolIdx = i * 2;
+            int weightIdx = i * 2 + 1;
+
+            // Extract symbol
+            Function symbolFunc = args.getQuick(symbolIdx);
+            if (!symbolFunc.isConstant()) {
+                throw SqlException.$(argPositions.getQuick(symbolIdx), "constant expected");
+            }
+            CharSequence symbolValue = symbolFunc.getStrA(null);
+            if (symbolValue == null) {
+                throw SqlException.$(argPositions.getQuick(symbolIdx), "STRING constant expected");
+            }
+            symbols.add(Chars.toString(symbolValue));
+
+            // Extract weight
+            Function weightFunc = args.getQuick(weightIdx);
+            if (!weightFunc.isConstant()) {
+                throw SqlException.$(argPositions.getQuick(weightIdx), "constant weight expected");
+            }
+            double weight = weightFunc.getDouble(null);
+
+            if (weight < 0 || Double.isNaN(weight)) {
+                throw SqlException.$(argPositions.getQuick(weightIdx), "weight must be non-negative");
+            }
+            weights.add(weight);
+        }
+
+        return new Func(symbols, weights);
+    }
+
+    private static final class Func extends SymbolFunction implements Function {
+        private final int count;
+        private final DoubleList cumulativeProbabilities;
+        private final ObjList<String> symbols;
+        private final DoubleList weights;
+        private Rnd rnd;
+
+        public Func(ObjList<String> symbols, DoubleList weights) {
+            this.symbols = symbols;
+            this.weights = weights;
+            this.count = symbols.size();
+            this.cumulativeProbabilities = new DoubleList(count);
+            this.cumulativeProbabilities.setPos(count);
+
+            // Calculate total weight
+            double totalWeight = 0.0;
+            for (int i = 0; i < count; i++) {
+                totalWeight += weights.getQuick(i);
+            }
+
+            if (totalWeight == 0) {
+                throw new IllegalArgumentException("total weight must be positive");
+            }
+
+            // Build cumulative probability distribution
+            double cumulative = 0.0;
+            for (int i = 0; i < count; i++) {
+                double probability = weights.getQuick(i) / totalWeight;
+                cumulative += probability;
+                cumulativeProbabilities.setQuick(i, cumulative);
+            }
+        }
+
+        @Override
+        public int getInt(Record rec) {
+            return next();
+        }
+
+        @Override
+        public CharSequence getSymbol(Record rec) {
+            return symbols.getQuick(next());
+        }
+
+        @Override
+        public CharSequence getSymbolB(Record rec) {
+            return getSymbol(rec);
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) {
+            this.rnd = executionContext.getRandom();
+        }
+
+        @Override
+        public boolean isNonDeterministic() {
+            return true;
+        }
+
+        @Override
+        public boolean isRandom() {
+            return true;
+        }
+
+        @Override
+        public boolean isSymbolTableStatic() {
+            return false;
+        }
+
+        @Override
+        public SymbolTable newSymbolTable() {
+            Func func = new Func(symbols, weights);
+            func.rnd = new Rnd(this.rnd.getSeed0(), this.rnd.getSeed1());
+            return func;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val("rnd_symbol_weighted(");
+            for (int i = 0; i < count; i++) {
+                if (i > 0) {
+                    sink.val(',');
+                }
+                sink.val(symbols.getQuick(i)).val(',').val(weights.getQuick(i));
+            }
+            sink.val(')');
+        }
+
+        @Override
+        public CharSequence valueBOf(int key) {
+            return valueOf(key);
+        }
+
+        @Override
+        public CharSequence valueOf(int symbolKey) {
+            return symbolKey != -1 ? symbols.getQuick(symbolKey) : null;
+        }
+
+        private int next() {
+            // Generate random value between 0 and 1
+            double u = rnd.nextDouble();
+            int idx = cumulativeProbabilities.binarySearch(u, BIN_SEARCH_SCAN_UP);
+            if (idx >= 0) {
+                return idx;
+            }
+            idx = -idx - 1;
+            return idx < count ? idx : count - 1;
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndSymbolZipfFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/rnd/RndSymbolZipfFunctionFactory.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.rnd;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.SymbolTable;
+import io.questdb.cairo.sql.SymbolTableSource;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.SymbolFunction;
+import io.questdb.std.Chars;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.std.Rnd;
+import io.questdb.std.Transient;
+import io.questdb.std.str.Sinkable;
+
+public class RndSymbolZipfFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "rnd_symbol_zipf(V)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            @Transient ObjList<Function> args,
+            @Transient IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        if (args == null || args.size() < 2) {
+            throw SqlException.$(position, "expected at least 2 arguments: symbol list and alpha parameter");
+        }
+
+        // Last argument is alpha (double), rest are symbols
+        final int symbolCount = args.size() - 1;
+        final ObjList<String> symbols = new ObjList<>(symbolCount);
+
+        // Extract symbols from all arguments except the last one
+        for (int i = 0; i < symbolCount; i++) {
+            Function arg = args.getQuick(i);
+            if (!arg.isConstant()) {
+                throw SqlException.$(argPositions.getQuick(i), "constant expected");
+            }
+            CharSequence value = arg.getStrA(null);
+            if (value == null) {
+                throw SqlException.$(argPositions.getQuick(i), "STRING constant expected");
+            }
+            symbols.add(Chars.toString(value));
+        }
+
+        // Extract alpha parameter
+        Function alphaFunc = args.getQuick(symbolCount);
+        if (!alphaFunc.isConstant()) {
+            throw SqlException.$(argPositions.getQuick(symbolCount), "constant alpha expected");
+        }
+        double alpha = alphaFunc.getDouble(null);
+
+        if (alpha <= 0 || Double.isNaN(alpha)) {
+            throw SqlException.$(argPositions.getQuick(symbolCount), "alpha must be positive");
+        }
+
+        return new Func(symbols, alpha);
+    }
+
+    private static final class Func extends SymbolFunction implements Function {
+        private final double alpha;
+        private final double[] cumulativeProbabilities;
+        private final int count;
+        private final ObjList<String> symbols;
+        private Rnd rnd;
+
+        public Func(ObjList<String> symbols, double alpha) {
+            this.symbols = symbols;
+            this.count = symbols.size();
+            this.alpha = alpha;
+            this.cumulativeProbabilities = new double[count];
+
+            // Calculate Zipf distribution
+            // p(k) = (1/k^alpha) / sum(1/i^alpha for i=1..n)
+            double sum = 0.0;
+            for (int i = 1; i <= count; i++) {
+                sum += 1.0 / Math.pow(i, alpha);
+            }
+
+            // Build cumulative probability distribution
+            double cumulative = 0.0;
+            for (int i = 0; i < count; i++) {
+                double probability = (1.0 / Math.pow(i + 1, alpha)) / sum;
+                cumulative += probability;
+                cumulativeProbabilities[i] = cumulative;
+            }
+        }
+
+        @Override
+        public int getInt(Record rec) {
+            return next();
+        }
+
+        @Override
+        public CharSequence getSymbol(Record rec) {
+            return symbols.getQuick(next());
+        }
+
+        @Override
+        public CharSequence getSymbolB(Record rec) {
+            return getSymbol(rec);
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) {
+            this.rnd = executionContext.getRandom();
+        }
+
+        @Override
+        public boolean isNonDeterministic() {
+            return true;
+        }
+
+        @Override
+        public boolean isRandom() {
+            return true;
+        }
+
+        @Override
+        public boolean isSymbolTableStatic() {
+            return false;
+        }
+
+        @Override
+        public SymbolTable newSymbolTable() {
+            Func func = new Func(symbols, alpha);
+            func.rnd = new Rnd(this.rnd.getSeed0(), this.rnd.getSeed1());
+            return func;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val("rnd_symbol_zipf(").val((Sinkable) symbols).val(',').val(alpha).val(')');
+        }
+
+        @Override
+        public CharSequence valueBOf(int key) {
+            return valueOf(key);
+        }
+
+        @Override
+        public CharSequence valueOf(int symbolKey) {
+            return symbolKey != -1 ? symbols.getQuick(symbolKey) : null;
+        }
+
+        private int next() {
+            // Generate random value between 0 and 1
+            double u = rnd.nextDouble();
+
+            // Binary search to find the index where u falls in cumulative distribution
+            for (int i = 0; i < count; i++) {
+                if (u <= cumulativeProbabilities[i]) {
+                    return i;
+                }
+            }
+
+            // Fallback to last element (should not happen due to cumulative[count-1] == 1.0)
+            return count - 1;
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/rnd/RndSymbolWeightedFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/rnd/RndSymbolWeightedFunctionFactoryTest.java
@@ -1,0 +1,258 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.rnd;
+
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.engine.functions.rnd.RndSymbolWeightedFunctionFactory;
+import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
+import org.junit.Test;
+
+public class RndSymbolWeightedFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void testBasicFunction() throws Exception {
+        execute("""
+                create table abc as (
+                  select rnd_symbol_weighted('AAPL', 50, 'MSFT', 30, 'GOOGL', 15, 'TSLA', 5) as testCol
+                  from long_sequence(100)
+                )
+                """);
+
+        // Weights: AAPL=50, MSFT=30, GOOGL=15, TSLA=5 (total=100)
+        // Expected distribution: AAPL=50%, MSFT=30%, GOOGL=15%, TSLA=5%
+        assertSql("""
+                        testCol\tcnt
+                        AAPL\t46
+                        GOOGL\t19
+                        MSFT\t29
+                        TSLA\t6
+                        """,
+                "select testCol, count() as cnt from abc order by 1"
+        );
+    }
+
+    @Test
+    public void testDecimalWeights() throws Exception {
+        execute("""
+                create table abc as (
+                  select rnd_symbol_weighted('A', 2.5, 'B', 1.5, 'C', 1.0) as testCol
+                  from long_sequence(100)
+                )
+                """);
+
+        // Weights sum to 5.0: A=50%, B=30%, C=20%
+        assertSql("""
+                        testCol	cnt
+                        A	46
+                        B	29
+                        C	25
+                        """,
+                "select testCol, count() as cnt from abc order by 1"
+        );
+    }
+
+    @Test
+    public void testEqualWeights() throws Exception {
+        execute("""
+                create table abc as (
+                  select rnd_symbol_weighted('A', 1, 'B', 1, 'C', 1) as testCol
+                  from long_sequence(99)
+                )
+                """);
+
+        // Equal weights should produce roughly equal distribution
+        assertSql("""
+                        testCol	cnt
+                        A	27
+                        B	35
+                        C	37
+                        """,
+                "select testCol, count() as cnt from abc order by 1"
+        );
+    }
+
+    @Test
+    public void testHighlySkewedWeights() throws Exception {
+        execute("""
+                create table abc as (
+                  select rnd_symbol_weighted('A', 95, 'B', 3, 'C', 2) as testCol
+                  from long_sequence(100)
+                )
+                """);
+
+        // A should dominate with 95% probability
+        assertSql("""
+                        testCol	cnt
+                        A	94
+                        B	5
+                        C	1
+                        """,
+                "select testCol, count() as cnt from abc order by 1"
+        );
+    }
+
+    @Test
+    public void testInsufficientArgs() {
+        assertFailure("[7] expected at least one symbol-weight pair",
+                "select rnd_symbol_weighted('AAPL') as testCol from long_sequence(10)");
+    }
+
+    @Test
+    public void testMixedZeroAndNonZeroWeights() throws Exception {
+        execute("""
+                create table abc as (
+                  select rnd_symbol_weighted('A', 100, 'B', 0, 'C', 0) as testCol
+                  from long_sequence(50)
+                )
+                """);
+
+        // Only A should appear (weight=100, others=0)
+        assertSql("""
+                        testCol\tcnt
+                        A\t50
+                        """,
+                "select testCol, count() as cnt from abc order by 1"
+        );
+    }
+
+    @Test
+    public void testNegativeWeight() {
+        assertFailure("[47] weight must be non-negative",
+                "select rnd_symbol_weighted('AAPL', 50, 'MSFT', -10) as testCol from long_sequence(10)");
+    }
+
+    @Test
+    public void testOddNumberOfArgs() {
+        assertFailure("[7] expected even number of arguments (symbol-weight pairs)",
+                "select rnd_symbol_weighted('AAPL', 50, 'MSFT') as testCol from long_sequence(10)");
+    }
+
+    @Test
+    public void testTwoSymbols() throws Exception {
+        execute("""
+                create table abc as (
+                  select rnd_symbol_weighted('A', 70, 'B', 30) as testCol
+                  from long_sequence(100)
+                )
+                """);
+
+        assertSql("""
+                        testCol\tcnt
+                        A\t68
+                        B\t32
+                        """,
+                "select testCol, count() as cnt from abc order by 1"
+        );
+    }
+
+    @Test
+    public void testZeroWeights() throws Exception {
+        // All zero weights should fail at runtime when constructing the function
+        assertException(
+                "select rnd_symbol_weighted('A', 0, 'B', 0) as testCol from long_sequence(10)",
+                7,
+                "total weight must be positive"
+        );
+    }
+
+    @Test
+    public void testNonConstantSymbol() {
+        // Symbol must be constant
+        assertFailure("[27] constant expected",
+                "select rnd_symbol_weighted(cast(x as string), 50) as testCol from long_sequence(10)");
+    }
+
+    @Test
+    public void testNullSymbol() {
+        // Symbol must not be null
+        assertFailure("[27] STRING constant expected",
+                "select rnd_symbol_weighted(cast(null as string), 50) as testCol from long_sequence(10)");
+    }
+
+    @Test
+    public void testNonConstantWeight() {
+        // Weight must be constant
+        assertFailure("[35] constant weight expected",
+                "select rnd_symbol_weighted('AAPL', x) as testCol from long_sequence(10)");
+    }
+
+    @Test
+    public void testNonConstantSecondSymbol() {
+        // Second symbol must also be constant
+        assertFailure("[39] constant expected",
+                "select rnd_symbol_weighted('AAPL', 50, cast(x as string), 30) as testCol from long_sequence(10)");
+    }
+
+    @Test
+    public void testNonConstantSecondWeight() {
+        // Second weight must also be constant
+        assertFailure("[47] constant weight expected",
+                "select rnd_symbol_weighted('AAPL', 50, 'MSFT', x) as testCol from long_sequence(10)");
+    }
+
+    @Test
+    public void testExplainPlan() throws Exception {
+        assertSql(
+                """
+                        QUERY PLAN
+                        VirtualRecord
+                          functions: [rnd_symbol_weighted(AAPL,50.0,MSFT,30.0,GOOGL,20.0)]
+                            long_sequence count: 10
+                        """,
+                "explain select rnd_symbol_weighted('AAPL', 50, 'MSFT', 30, 'GOOGL', 20) from long_sequence(10)"
+        );
+    }
+
+    @Test
+    public void testExplainPlanTwoSymbols() throws Exception {
+        assertSql(
+                """
+                        QUERY PLAN
+                        VirtualRecord
+                          functions: [rnd_symbol_weighted(A,70.0,B,30.0)]
+                            long_sequence count: 5
+                        """,
+                "explain select rnd_symbol_weighted('A', 70, 'B', 30) from long_sequence(5)"
+        );
+    }
+
+    @Test
+    public void testExplainPlanWithDecimalWeights() throws Exception {
+        assertSql(
+                """
+                        QUERY PLAN
+                        VirtualRecord
+                          functions: [rnd_symbol_weighted(X,2.5,Y,1.5)]
+                            long_sequence count: 3
+                        """,
+                "explain select rnd_symbol_weighted('X', 2.5, 'Y', 1.5) from long_sequence(3)"
+        );
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new RndSymbolWeightedFunctionFactory();
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/rnd/RndSymbolZipfFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/rnd/RndSymbolZipfFunctionFactoryTest.java
@@ -67,13 +67,13 @@ public class RndSymbolZipfFunctionFactoryTest extends AbstractFunctionFactoryTes
 
         // The first symbol should have significantly more occurrences
         assertSql("""
-                testCol\tcnt
-                A\t666
-                B\t185
-                C\t76
-                D\t49
-                E\t24
-                """,
+                        testCol\tcnt
+                        A\t666
+                        B\t185
+                        C\t76
+                        D\t49
+                        E\t24
+                        """,
                 "select testCol, count() as cnt from abc order by 1"
         );
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/rnd/RndSymbolZipfFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/rnd/RndSymbolZipfFunctionFactoryTest.java
@@ -152,6 +152,45 @@ public class RndSymbolZipfFunctionFactoryTest extends AbstractFunctionFactoryTes
         );
     }
 
+    @Test
+    public void testExplainPlan() throws Exception {
+        assertSql(
+                """
+                        QUERY PLAN
+                        VirtualRecord
+                          functions: [rnd_symbol_zipf([AAPL,MSFT,GOOGL],1.5)]
+                            long_sequence count: 10
+                        """,
+                "explain select rnd_symbol_zipf('AAPL', 'MSFT', 'GOOGL', 1.5) from long_sequence(10)"
+        );
+    }
+
+    @Test
+    public void testExplainPlanTwoSymbols() throws Exception {
+        assertSql(
+                """
+                        QUERY PLAN
+                        VirtualRecord
+                          functions: [rnd_symbol_zipf([A,B],2.0)]
+                            long_sequence count: 5
+                        """,
+                "explain select rnd_symbol_zipf('A', 'B', 2.0) from long_sequence(5)"
+        );
+    }
+
+    @Test
+    public void testExplainPlanLowAlpha() throws Exception {
+        assertSql(
+                """
+                        QUERY PLAN
+                        VirtualRecord
+                          functions: [rnd_symbol_zipf([X,Y,Z],0.5)]
+                            long_sequence count: 3
+                        """,
+                "explain select rnd_symbol_zipf('X', 'Y', 'Z', 0.5) from long_sequence(3)"
+        );
+    }
+
     @Override
     protected FunctionFactory getFunctionFactory() {
         return new RndSymbolZipfFunctionFactory();

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/rnd/RndSymbolZipfFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/rnd/RndSymbolZipfFunctionFactoryTest.java
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.rnd;
+
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.engine.functions.rnd.RndSymbolZipfFunctionFactory;
+import io.questdb.test.griffin.engine.AbstractFunctionFactoryTest;
+import org.junit.Test;
+
+public class RndSymbolZipfFunctionFactoryTest extends AbstractFunctionFactoryTest {
+
+    @Test
+    public void testBasicFunction() throws Exception {
+        execute("""
+                create table abc as (
+                  select rnd_symbol_zipf('1AAPL', '2MSFT', '2GOOGL', '4TSLA', '5AMZN', 1.5) as testCol
+                  from long_sequence(100)
+                )
+                """);
+
+        // Should return all 5 symbols, but with different frequencies (AAPL most common)
+        assertSql(
+                """
+                        testCol	cnt
+                        1AAPL	53
+                        2GOOGL	12
+                        2MSFT	20
+                        4TSLA	9
+                        5AMZN	6
+                        """,
+                """
+                        select testCol, count() as cnt from abc order by 1
+                        """
+        );
+    }
+
+    @Test
+    public void testCountsSkewedToFirstSymbol() throws Exception {
+        execute("""
+                create table abc as (
+                  select rnd_symbol_zipf('A', 'B', 'C', 'D', 'E', 2.0) as testCol
+                  from long_sequence(1000)
+                )
+                """);
+
+        // The first symbol should have significantly more occurrences
+        assertSql("""
+                testCol\tcnt
+                A\t666
+                B\t185
+                C\t76
+                D\t49
+                E\t24
+                """,
+                "select testCol, count() as cnt from abc order by 1"
+        );
+    }
+
+    @Test
+    public void testHighAlphaConcentration() throws Exception {
+        execute("""
+                create table abc as (
+                  select rnd_symbol_zipf('1AAPL', '2MSFT', '3GOOGL', '4TSLA', '5AMZN', 5.0) as testCol
+                  from long_sequence(100)
+                )
+                """);
+
+        // With alpha=5.0, AAPL should dominate
+        assertSql("""
+                testCol\tcnt
+                1AAPL\t98
+                2MSFT\t2
+                """, "select testCol, count() as cnt from abc order by 1");
+    }
+
+    @Test
+    public void testInsufficientArgs() {
+        // Need at least 2 arguments: one symbol and alpha
+        assertFailure("[7] expected at least 2 arguments: symbol list and alpha parameter",
+                "select rnd_symbol_zipf('AAPL') as testCol from long_sequence(10)");
+    }
+
+    @Test
+    public void testLowAlphaModerateDist() throws Exception {
+        execute("""
+                create table abc as (
+                  select rnd_symbol_zipf('1AAPL', '2MSFT', '3GOOGL', '4TSLA', '5AMZN', 0.5) as testCol
+                  from long_sequence(100)
+                )
+                """);
+
+        // With alpha=0.5, distribution should be more even
+        assertSql("""
+                testCol\tcnt
+                1AAPL\t26
+                2MSFT\t22
+                3GOOGL\t20
+                4TSLA\t14
+                5AMZN\t18
+                """, "select testCol, count() as cnt from abc order by 1");
+    }
+
+    @Test
+    public void testNegativeAlpha() {
+        assertFailure("[39] alpha must be positive",
+                "select rnd_symbol_zipf('AAPL', 'MSFT', -1.0) as testCol from long_sequence(10)");
+    }
+
+    @Test
+    public void testTwoSymbols() throws Exception {
+        execute("""
+                create table abc as (
+                  select rnd_symbol_zipf('A', 'B', 1.0) as testCol
+                  from long_sequence(100)
+                )
+                """);
+
+        assertSql("""
+                testCol\tcnt
+                A\t63
+                B\t37
+                """, "select testCol, count() as cnt from abc order by 1");
+    }
+
+    @Test
+    public void testZeroAlpha() {
+        assertFailure(
+                "[39] alpha must be positive",
+                "select rnd_symbol_zipf('AAPL', 'MSFT', 0.0) as testCol from long_sequence(10)"
+        );
+    }
+
+    @Override
+    protected FunctionFactory getFunctionFactory() {
+        return new RndSymbolZipfFunctionFactory();
+    }
+}


### PR DESCRIPTION
Generates Zipf/Power Law Distribution of symbols from the list. The probability of symbol decays from left to right with given 'alpha' velocity.

Usage:

```sql
select rnd_symbol_zipf('AAPL', 'MSFT', 'GOOGL', 'TSLA', 'AMZN', 5.3) from long_sequence(100_000);
```

Also added weighted, but more verbose function:

```sql
select rnd_symbol_weighted('AAPL', 50, 'MSFT', 30, 'GOOGL', 15, 'TSLA', 5) from long_sequence(100_000);
```