### PR TITLE
feat(core): client to send nanos as nanos, and everything else as micros

### DIFF
--- a/core/src/test/resources/io/questdb/test/cutlass/line/interop/client-protocol-version-2-test.json
+++ b/core/src/test/resources/io/questdb/test/cutlass/line/interop/client-protocol-version-2-test.json
@@ -95,7 +95,7 @@
     ],
     "buffer": {
       "status": "SUCCESS",
-      "base64Content": "ZW1wdHlfdGVzdCBhMD09DgoDAgAAAAMAAAAAAAAAIDEwMDAwMDAwMDAwMDAwMAo="
+      "base64Content": "ZW1wdHlfdGVzdCBhMD09DgoDAgAAAAMAAAAAAAAAIDEwMDAwMDAwMDAwMHQK"
     },
     "querys": [
       {
@@ -139,7 +139,7 @@
     ],
     "buffer": {
       "status": "SUCCESS",
-      "base64Content": "YXJyYXlfMWQgYTE9PQ4KAQYAAAAAAACgmZnxPwAAAKCZmQFAAAAAYGZmCkAAAACgmZkRQAAAAAAAABZAAAAAYGZmGkAgMTAwMDAwMDAwMDAwMDAwCg=="
+      "base64Content": "YXJyYXlfMWQgYTE9PQ4KAQYAAAAAAACgmZnxPwAAAKCZmQFAAAAAYGZmCkAAAACgmZkRQAAAAAAAABZAAAAAYGZmGkAgMTAwMDAwMDAwMDAwdAo"
     },
     "querys": [
       {


### PR DESCRIPTION
If the timestamp passed to the client in nanos, it should send it as nanos on the wire, otherwise we will send timestamps in micros.
This increases the time range we can cover with the client without forcing the user to use `Instant`.
When `Instant` is used, we will always try to send it as nanos first, but if the value does not fit in a long we fallback to micros.
