### PR TITLE
fix(sql): overflow in materialized view refresh interval estimate calculation

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -59,6 +59,7 @@ import io.questdb.std.datetime.DateLocaleFactory;
 import io.questdb.std.datetime.TimeZoneRules;
 import io.questdb.std.datetime.microtime.Micros;
 import io.questdb.std.datetime.microtime.MicrosFormatUtils;
+import io.questdb.std.datetime.nanotime.Nanos;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8s;
@@ -107,7 +108,6 @@ public class MatViewTest extends AbstractCairoTest {
     public static Collection<Object[]> testParams() {
         // only run a single combination per CI run
         final Rnd rnd = generateRandom(LOG);
-
         if (rnd.nextInt(100) > 50) {
             return Arrays.asList(new Object[][]{{-1, TestTimestampType.MICRO}, {-1, TestTimestampType.NANO}});
         }
@@ -2463,6 +2463,66 @@ public class MatViewTest extends AbstractCairoTest {
     @Test
     public void testEnableDedupWithSameKeysDoesNotInvalidateMatViews() throws Exception {
         testEnableDedupWithSubsetKeys("alter table base_price dedup enable upsert keys(ts, sym);");
+    }
+
+    @Test
+    public void testEstimateRowsPerBucket() {
+        Assume.assumeTrue(timestampType == TestTimestampType.MICRO);
+
+        // Basic case: 1 billion rows, hourly bucket, daily partitions, 30 partitions
+        // Expected: (1B * 1hour) / (24hours * 30 partitions) = 1B / 720 ≈ 1,388,888
+        testEstimateRowsPerBucket(1_000_000_000L, Micros.HOUR_MICROS, Micros.DAY_MICROS, 30, 1_000_000, 2_000_000);
+
+        // Small table: 1000 rows
+        testEstimateRowsPerBucket(1_000L, Micros.HOUR_MICROS, Micros.DAY_MICROS, 30, 1, 100);
+
+        // Large table: 5 billion rows
+        // Expected: (5B * 1hour) / (24hours * 30 partitions) ≈ 6,944,444
+        testEstimateRowsPerBucket(5_000_000_000L, Micros.HOUR_MICROS, Micros.DAY_MICROS, 30, 5_000_000, 10_000_000);
+
+        // Daily bucket
+        // Expected: (1B * 24hours) / (24hours * 30 partitions) = 1B / 30 ≈ 33,333,333
+        testEstimateRowsPerBucket(1_000_000_000L, Micros.DAY_MICROS, Micros.DAY_MICROS, 30, 30_000_000, 40_000_000);
+
+        // Weekly bucket
+        // Expected: (1B * 168hours) / (24hours * 30 partitions) = 1B * 7 / 30 ≈ 233,333,333
+        testEstimateRowsPerBucket(1_000_000_000L, Micros.WEEK_MICROS, Micros.DAY_MICROS, 30, 200_000_000, 300_000_000);
+
+        // Monthly bucket (30 days)
+        // Expected: (1B * 720hours) / (24hours * 30 partitions) = 1B * 30 / 30 = 1B
+        testEstimateRowsPerBucket(1_000_000_000L, Micros.MONTH_MICROS_APPROX, Micros.DAY_MICROS, 30, 900_000_000, 1_100_000_000);
+
+        // Edge case: Weekly partitions with hourly bucket
+        // Expected: (1B * 1hour) / (168hours * 4 partitions) ≈ 1,488,095
+        testEstimateRowsPerBucket(1_000_000_000L, Micros.HOUR_MICROS, Micros.WEEK_MICROS, 4, 1_000_000, 2_000_000);
+
+        // Edge case: Single partition
+        // Expected: (1B * 1hour) / (720hours * 1 partition) ≈ 1,388,888
+        testEstimateRowsPerBucket(1_000_000_000L, Micros.HOUR_MICROS, Micros.MONTH_MICROS_APPROX, 1, 1_000_000, 2_000_000);
+
+        // Edge case: Many partitions (1000)
+        // Expected: (1B * 1hour) / (24hours * 1000 partitions) ≈ 41,666
+        testEstimateRowsPerBucket(1_000_000_000L, Micros.HOUR_MICROS, Micros.DAY_MICROS, 1000, 30_000, 50_000);
+
+        // Edge case: Zero partition count (should return 1)
+        final long result = MatViewRefreshJob.estimateRowsPerBucket(1_000_000_000L, Micros.HOUR_MICROS, Micros.HOUR_MICROS, 0);
+        Assert.assertEquals("expected 1 for zero partitions", 1, result);
+
+        // Overflow prevention test: Very large rows and bucket that would overflow with naive multiplication
+        // Should not overflow, should return a reasonable positive value
+        testEstimateRowsPerBucket(Long.MAX_VALUE / 2, Micros.HOUR_MICROS, Micros.DAY_MICROS, 1, 1, Long.MAX_VALUE / 2);
+
+        // Test with nanoseconds (1000x microseconds)
+        // Expected: same ratio as microseconds ≈ 1,388,888
+        testEstimateRowsPerBucket(1_000_000_000L, Nanos.HOUR_NANOS, Nanos.DAY_NANOS, 30, 1_000_000, 2_000_000);
+
+        // Very small bucket compared to partition
+        // Expected: very small number, but at least 1
+        testEstimateRowsPerBucket(1_000_000_000L, Micros.MILLI_MICROS, Micros.DAY_MICROS, 30, 1, 1000);
+
+        // Bucket larger than partition duration (unusual but possible)
+        // Expected: (1B * 168hours) / (24hours * 1) = 1B * 7 = 7B
+        testEstimateRowsPerBucket(1_000_000_000L, Micros.WEEK_MICROS, Micros.DAY_MICROS, 1, 6_000_000_000L, 8_000_000_000L);
     }
 
     @Test
@@ -6565,6 +6625,11 @@ public class MatViewTest extends AbstractCairoTest {
                     false
             );
         });
+    }
+
+    private void testEstimateRowsPerBucket(long rows, long bucket, long partitionDuration, int partitionCount, long expectedLo, long expectedHi) {
+        long result = MatViewRefreshJob.estimateRowsPerBucket(rows, bucket, partitionDuration, partitionCount);
+        Assert.assertTrue("Expected from " + expectedLo + " to " + expectedHi + ", got " + result, result >= expectedLo && result < expectedHi);
     }
 
     private void testIncrementalRefreshTransactionLogV2(String viewSql) throws Exception {


### PR DESCRIPTION
In case of ~1B row table and daily sampling `estimateRowsPerBucket()` could overflow and return a very small estimate leading to too large interval size chosen for the materialized view refresh.