### PR TITLE
fix(sql): avoid critical level logs on vectorized group by query cancellation

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/engine/QueryExecutionTimeoutTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/QueryExecutionTimeoutTest.java
@@ -496,11 +496,11 @@ public class QueryExecutionTimeoutTest extends AbstractCairoTest {
 
     @Test
     public void testTimeoutInVectorizedNonKeyedGroupBy() throws Exception {
-        assertMemoryLeak(() -> {
-            try (SqlCompiler compiler = engine.getSqlCompiler()) {
-                testTimeoutInVectorizedNonKeyedGroupBy(compiler, sqlExecutionContext);
-            }
-        });
+        executeWithPool(
+                4,
+                16,
+                (engine, compiler, sqlExecutionContext) -> testTimeoutInVectorizedNonKeyedGroupBy(compiler, sqlExecutionContext)
+        );
     }
 
     @Test // triggers timeout when processing task in main thread because queue is too small


### PR DESCRIPTION
When a query is cancelled, `GroupByVectorAggregateJob` would log the error with critical level since it wasn't handling errors properly.