### PR TITLE
Update USER to be a number

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -75,7 +75,7 @@ RUN groupadd -g 10001 questdb && \
     mkdir -p /var/lib/questdb && \
     chown -R questdb:questdb /var/lib/questdb
 
-USER questdb
+USER 10001
 
 WORKDIR /var/lib/questdb
 


### PR DESCRIPTION
This addresses a security concern on some Kubernetes managment platforms, like OpenShift, that require that the USER must be non-root (and this can only be confirmed if a numeric USER field is used).