### PR TITLE
chore(build): bump gosu version in Dockerfile for CVE-2023-28642

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm AS builder
 ARG tag_name
 
-ENV GOSU_VERSION=1.14
+ENV GOSU_VERSION=1.19
 ENV JDK_VERSION=17.0.11.9-1
 
 RUN apt-get update \


### PR DESCRIPTION
Addresses https://nvd.nist.gov/vuln/detail/CVE-2023-28642 which was fixed in [gosu 1.17](https://github.com/tianon/gosu/releases/tag/1.17)

Docker build output:
```
➜  core git:(steve/bump-gosu) docker build .
[+] Building 172.4s (27/27) FINISHED                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                 0.0s
 => => transferring dockerfile: 4.48kB                                                                               0.0s
 => [internal] load metadata for docker.io/library/debian:bookworm                                                   0.6s
 => [internal] load metadata for docker.io/library/debian:bookworm-slim                                              0.6s
 => [auth] library/debian:pull token for registry-1.docker.io                                                        0.0s
 => [internal] load .dockerignore                                                                                    0.0s
 => => transferring context: 2B                                                                                      0.0s
 => [questdb 1/8] FROM docker.io/library/debian:bookworm-slim@sha256:7e490910eea2861b9664577a96b54ce68ea3e02ce7f51d  1.9s
 => => resolve docker.io/library/debian:bookworm-slim@sha256:7e490910eea2861b9664577a96b54ce68ea3e02ce7f51d89cb0103  0.1s
 => => sha256:7e490910eea2861b9664577a96b54ce68ea3e02ce7f51d89cb0103a6f9c386e0 8.56kB / 8.56kB                       0.0s
 => => sha256:48fa1e32d5ad897f7748b4b67d1ffb9e2ec46f4129f037afa3456a99f937203a 1.02kB / 1.02kB                       0.0s
 => => sha256:74a962b7e6e57f8638b2d5ce2868f01d45733f1c6820973cf7d63b667ac6dfa0 453B / 453B                           0.0s
 => => sha256:5c32499ab806884c5725c705c2bf528662d034ed99de13d3205309e0d9ef0375 28.23MB / 28.23MB                     1.1s
 => => extracting sha256:5c32499ab806884c5725c705c2bf528662d034ed99de13d3205309e0d9ef0375                            0.6s
 => [builder  1/12] FROM docker.io/library/debian:bookworm@sha256:93492d1405a072c9d3b89110490e330e0b7eb37754cafc952  2.4s
 => => resolve docker.io/library/debian:bookworm@sha256:93492d1405a072c9d3b89110490e330e0b7eb37754cafc9520908b7fe68  0.0s
 => => sha256:93492d1405a072c9d3b89110490e330e0b7eb37754cafc9520908b7fe6873f5f 8.52kB / 8.52kB                       0.0s
 => => sha256:ba3344ad4f96732518a96c041b464360e68fd04e8a53087c2627392abe3fbb30 1.02kB / 1.02kB                       0.0s
 => => sha256:4ffc839c7aa5821ee11804d75c6fa61019cfe9323e458d721739d20e5aaa7953 453B / 453B                           0.0s
 => => sha256:c6b11972fd12973831818babf60f1ffc1c4047507943d132dffc612884022858 48.48MB / 48.48MB                     1.2s
 => => extracting sha256:c6b11972fd12973831818babf60f1ffc1c4047507943d132dffc612884022858                            1.0s
 => [internal] load build context                                                                                    0.1s
 => => transferring context: 7.02kB                                                                                  0.0s
 => [questdb 2/8] WORKDIR /app                                                                                       0.1s
 => [builder  2/12] RUN apt-get update     && apt-get install --no-install-recommends git curl wget gnupg2 ca-cert  23.1s
 => [builder  3/12] RUN wget -O - https://apt.corretto.aws/corretto.key | gpg --dearmor -o /usr/share/keyrings/corr  9.9s 
 => [builder  4/12] WORKDIR /build                                                                                   0.1s 
 => [builder  5/12] RUN echo tag_name ${tag_name:-master}                                                            0.2s
 => [builder  6/12] RUN git clone --depth=1 --progress --branch "${tag_name:-master}" --verbose https://github.com/  8.9s
 => [builder  7/12] WORKDIR /build/questdb                                                                           0.1s
 => [builder  8/12] RUN mvn clean package -Djdk.lang.Process.launchMechanism=vfork -Dmaven.resolver.transport=wag  121.8s
 => [builder  9/12] WORKDIR /build/questdb/core/target                                                               0.1s
 => [builder 10/12] RUN tar xvfz questdb-*-rt-*.tar.gz                                                               0.6s
 => [builder 11/12] RUN rm questdb-*-rt-*.tar.gz                                                                     0.2s
 => [builder 12/12] RUN dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')";     wget -O gosu "https:  2.0s
 => [questdb 3/8] COPY --from=builder /build/questdb/core/target/questdb-*-rt-* .                                    0.2s
 => [questdb 4/8] COPY --from=builder /build/questdb/core/target/gosu /usr/local/bin/gosu                            0.1s
 => [questdb 5/8] COPY docker-entrypoint.sh /docker-entrypoint.sh                                                    0.1s
 => [questdb 6/8] RUN chmod +x /docker-entrypoint.sh                                                                 0.2s
 => [questdb 7/8] RUN groupadd -g 10001 questdb &&     useradd -u 10001 -g 10001 -d /var/lib/questdb -M -s /sbin/no  0.3s
 => [questdb 8/8] WORKDIR /var/lib/questdb                                                                           0.1s
 => exporting to image                                                                                               0.8s
 => => exporting layers                                                                                              0.8s
 => => writing image sha256:4b9a1c8f9b4ff457de7a70f08702f2c3c8160b73daa727ce3642f4c63fa01497                         0.0s
```

Docker run output:
```

➜  core git:(steve/bump-gosu) docker run 4b9a1c8f9b4f
No arguments found in the configuration, start with default arguments
Checking data directory ownership
Running as questdb user
Log configuration loaded from: /var/lib/questdb/conf/log.conf
2025-10-09T13:16:32.379081Z I server-main extracted [path=/var/lib/questdb/import/readme.txt]
2025-10-09T13:16:32.479349Z I server-main extracted [path=/var/lib/questdb/import/trades.parquet]
2025-10-09T13:16:32.479424Z A server-main QuestDB 9.1.1-SNAPSHOT. Copyright (C) 2014-2025, all rights reserved.
....
....
....
2025-10-09T13:16:33.342784Z I server-main os scheduled worker started [name=wal-apply_2]
2025-10-09T13:16:33.376134Z I server-main 
     ___                  _   ____  ____
    / _ \ _   _  ___  ___| |_|  _ \| __ )
   | | | | | | |/ _ \/ __| __| | | |  _ \
   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
    \__\_\\__,_|\___||___/\__|____/|____/
                        www.questdb.io

    Web Console URL                 ILP Client Connection String

    http://172.17.0.2:9000          http::addr=172.17.0.2:9000;
    http://127.0.0.1:9000           http::addr=127.0.0.1:9000;

QuestDB configuration files are in /var/lib/questdb/conf


2025-10-09T13:16:33.396776Z A server-main enjoy
``
