### PR TITLE
test(core): unfreeze accidentally const rnd seeds

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/fuzz/O3MaxLagFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/O3MaxLagFuzzTest.java
@@ -247,7 +247,7 @@ public class O3MaxLagFuzzTest extends AbstractO3Test {
             SqlExecutionContext sqlExecutionContext,
             String timestampTypeName
     ) throws SqlException, NumericException {
-        testFuzz00(engine, compiler, sqlExecutionContext, timestampTypeName, TestUtils.generateRandom(LOG, 970596704993L, 1744736957813L));
+        testFuzz00(engine, compiler, sqlExecutionContext, timestampTypeName, TestUtils.generateRandom(LOG));
     }
 
     private void testRollbackFuzz(CairoEngine engine, SqlCompiler compiler, SqlExecutionContext sqlExecutionContext, String timestampTypeName) throws SqlException {


### PR DESCRIPTION
The seeds were accidentally frozen in https://github.com/questdb/questdb/pull/5590 
Unfreezing.