### PR TITLE
test(core): fix test failure with nd_array memory leak

### DIFF
--- a/core/src/test/java/io/questdb/test/tools/TestUtils.java
+++ b/core/src/test/java/io/questdb/test/tools/TestUtils.java
@@ -140,6 +140,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.questdb.cairo.TableUtils.*;
+import static io.questdb.test.AbstractTest.CLOSEABLE;
 import static org.junit.Assert.assertNotNull;
 
 public final class TestUtils {
@@ -2473,6 +2474,7 @@ public final class TestUtils {
 
         public LeakCheck() {
             Path.clearThreadLocals();
+            CLOSEABLE.forEach(Misc::free);
             mem = Unsafe.getMemUsed();
             for (int i = MemoryTag.MMAP_DEFAULT; i < MemoryTag.SIZE; i++) {
                 memoryUsageByTag[i] = Unsafe.getMemUsedByTag(i);
@@ -2498,6 +2500,7 @@ public final class TestUtils {
             }
 
             Path.clearThreadLocals();
+            CLOSEABLE.forEach(Misc::free);
             if (cachedFileCount != Files.getOpenCachedFileCount() || fileCount != Files.getOpenFileCount()) {
                 Assert.fail(
                         "expected: cached file descriptors: " + cachedFileCount +


### PR DESCRIPTION
Fixes:

```
2025-10-22T06:25:20.7617842Z java.lang.AssertionError: Memory usage by tag: NATIVE_ND_ARRAY, difference: 630 expected:<0> but was:<630>
2025-10-22T06:25:20.7618692Z 	at org.junit.Assert.fail(Assert.java:89)
2025-10-22T06:25:20.7619252Z 	at org.junit.Assert.failNotEquals(Assert.java:835)
2025-10-22T06:25:20.7619793Z 	at org.junit.Assert.assertEquals(Assert.java:647)
2025-10-22T06:25:20.7620358Z 	at io.questdb.test.tools.TestUtils$LeakCheck.close(TestUtils.java:2521)
2025-10-22T06:25:20.7620988Z 	at io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:778)
2025-10-22T06:25:20.7621610Z 	at io.questdb.test.cairo.o3.AbstractO3Test.assertMemoryLeak(AbstractO3Test.java:218)
2025-10-22T06:25:20.7622463Z 	at io.questdb.test.cairo.o3.AbstractO3Test.executeVanilla(AbstractO3Test.java:320)
2025-10-22T06:25:20.7623103Z 	at io.questdb.test.cairo.o3.AbstractO3Test.executeWithPool(AbstractO3Test.java:363)
2025-10-22T06:25:20.7623871Z 	at io.questdb.test.cairo.o3.AbstractO3Test.executeWithPool(AbstractO3Test.java:351)
2025-10-22T06:25:20.7628048Z 	at io.questdb.test.cairo.fuzz.O3MaxLagFuzzTest.testFuzzParallel(O3MaxLagFuzzTest.java:73)

```