### PR TITLE
fix(sql): parquet export erroring when writing descending ordered timestamps

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/text/CopyExportContext.java
+++ b/core/src/main/java/io/questdb/cutlass/text/CopyExportContext.java
@@ -382,7 +382,7 @@ public class CopyExportContext {
                         false
                 );
                 createOp.setTableKind(TableUtils.TABLE_KIND_TEMP_PARQUET_EXPORT);
-                createOp.validateAndUpdateMetadataFromSelect(rcf.getMetadata());
+                createOp.validateAndUpdateMetadataFromSelect(rcf.getMetadata(), rcf.getScanDirection());
             }
         } catch (SqlException ex) {
             ex.setPosition(ex.getPosition() + tableOrSelectTextPos);

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -3550,7 +3550,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                     try {
                         final RecordMetadata metadata = newFactory.getMetadata();
                         try (TableReader baseReader = engine.getReader(createMatViewOp.getBaseTableName())) {
-                            createMatViewOp.validateAndUpdateMetadataFromSelect(metadata, baseReader.getMetadata());
+                            createMatViewOp.validateAndUpdateMetadataFromSelect(metadata, baseReader.getMetadata(), newFactory.getScanDirection());
                         }
 
                         matViewDefinition = engine.createMatView(
@@ -3663,7 +3663,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                             RecordCursor cursor = newCursor
                     ) {
                         final RecordMetadata metadata = factory.getMetadata();
-                        createTableOp.validateAndUpdateMetadataFromSelect(metadata);
+                        createTableOp.validateAndUpdateMetadataFromSelect(metadata, factory.getScanDirection());
                         boolean keepLock = !createTableOp.isWalEnabled();
 
                         // todo: test create table if exists with select

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperation.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperation.java
@@ -57,5 +57,5 @@ public interface CreateMatViewOperation extends TableStructure, Operation {
 
     void validateAndUpdateMetadataFromModel(SqlExecutionContext sqlExecutionContext, FunctionFactoryCache functionFactoryCache, QueryModel queryModel) throws SqlException;
 
-    void validateAndUpdateMetadataFromSelect(RecordMetadata selectMetadata, TableReaderMetadata baseTableMetadata) throws SqlException;
+    void validateAndUpdateMetadataFromSelect(RecordMetadata selectMetadata, TableReaderMetadata baseTableMetadata, int scanDirection) throws SqlException;
 }

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationImpl.java
@@ -459,7 +459,8 @@ public class CreateMatViewOperationImpl implements CreateMatViewOperation {
     @Override
     public void validateAndUpdateMetadataFromSelect(
             @NotNull RecordMetadata selectMetadata,
-            @NotNull TableReaderMetadata baseTableMetadata
+            @NotNull TableReaderMetadata baseTableMetadata,
+            int scanDirection
     ) throws SqlException {
         final int selectTextPosition = createTableOperation.getSelectTextPosition();
         // SELECT validation
@@ -469,7 +470,7 @@ public class CreateMatViewOperationImpl implements CreateMatViewOperation {
                         .put("materialized view query is required to have designated timestamp");
             }
         }
-        createTableOperation.validateAndUpdateMetadataFromSelect(selectMetadata);
+        createTableOperation.validateAndUpdateMetadataFromSelect(selectMetadata, scanDirection);
         updateMatViewTablePartitionBy(createTableOperation.getTimestampType());
         this.baseTableTimestampType = baseTableMetadata.getTimestampType();
     }

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperation.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperation.java
@@ -74,5 +74,5 @@ public interface CreateTableOperation extends TableStructure, Operation {
 
     void updateOperationFutureTableToken(TableToken tableToken);
 
-    void validateAndUpdateMetadataFromSelect(RecordMetadata metadata) throws SqlException;
+    void validateAndUpdateMetadataFromSelect(RecordMetadata metadata, int scanDirection) throws SqlException;
 }


### PR DESCRIPTION
Fixes https://github.com/questdb/questdb/issues/6323

Checking timestamp index is insufficient to determine if the timestamp is designated or not, you must check the scan direction too.

This touches other validation users (mat views), so let's see what CI brings to the table.