### PR TITLE
chore(core): only track resources that supports supervisors

### DIFF
--- a/core/src/main/java/io/questdb/cairo/pool/AbstractMultiTenantPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/AbstractMultiTenantPool.java
@@ -265,6 +265,7 @@ public abstract class AbstractMultiTenantPool<T extends PoolTenant<T>> extends A
                         tenant.goodbye();
                         LOG.info().$("born free [table=").$(tableToken).I$();
                         tenant.updateTableToken(tableToken);
+                        supervisor = tenant.getSupervisor();
                         if (supervisor != null) {
                             supervisor.onResourceBorrowed(tenant);
                         }
@@ -275,6 +276,7 @@ public abstract class AbstractMultiTenantPool<T extends PoolTenant<T>> extends A
                             .$(", thread=").$(thread)
                             .I$();
                     tenant.updateTableToken(tableToken);
+                    supervisor = tenant.getSupervisor();
                     if (supervisor != null) {
                         supervisor.onResourceBorrowed(tenant);
                     }


### PR DESCRIPTION
As per the title, this PR fixes a leak that occurs whenever a supervisor (`QueryProgress`/`TracingResourcePoolSupervisor`) borrows a resource but the resource doesn't support supervisors. This causes the resource to never release itself from the supervisor before being returned to the pool.

The fix is quite self-explanatory: a resource that supports supervisors **MUST** return the one that is attached when the `getSupervisor` method is called. Based on this assumption, before borrowing the resource, we check if a supervisor is indeed attached to it instead of retrieving the local one.

Thanks to @jerrinot for detecting and reporting this issue!