### PR TITLE
ci(build): clean up log dirs for ARM jobs

### DIFF
--- a/ci/templates/self-hosted-jobs.yml
+++ b/ci/templates/self-hosted-jobs.yml
@@ -1,5 +1,7 @@
 jobs:
   - job: linux_arm64_jdk17
+    workspace:
+      clean: all
     displayName: "on linux-arm64"
     pool:
       name: "hetzner-docker-arm"


### PR DESCRIPTION
Azure CI job runners aren't cleaning up log files from previous runs, filling up the disk.

```
root@arm-vmss-testing:/var/azp-agents/agent-1/1/b# ls -lah .
total 104G
drwxr-xr-x 2 1001 1001 4.0K Nov  4 21:10 .
drwxr-xr-x 6 1001 1001 4.0K Nov  5 14:28 ..
-rw-r--r-- 1 1001 1001 104G Nov  5 14:49 tests.log
```