### PR TITLE
fix(core): prevent rare exception from async jobs when table is dropped

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/CheckWalTransactionsJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/CheckWalTransactionsJob.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.TableToken;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.TxReader;
 import io.questdb.cairo.sql.TableMetadata;
+import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.cairo.wal.seq.SeqTxnTracker;
 import io.questdb.cairo.wal.seq.TableSequencerAPI;
 import io.questdb.mp.SynchronizedJob;
@@ -109,6 +110,8 @@ public class CheckWalTransactionsJob extends SynchronizedJob {
                         if (!e.isFileCannotRead()) {
                             throw e;
                         } // race, table is dropped, ApplyWal2TableJob is already deleting the files
+                    } catch (TableReferenceOutOfDateException ignore) {
+                        // ignore, table was deleted if we got this exception on a table token
                     }
                 } // else table is dropped, ApplyWal2TableJob already is deleting the files
             }


### PR DESCRIPTION
Found through concurrent tests:

```
io.questdb.cairo.sql.TableReferenceOutOfDateException: cached query plan cannot be used because table schema has changed [table=tango', expectedTableId=31, actualTableId=32, expectedMetadataVersion=32, actualMetadataVersion=-1]
	at io.questdb@9.1.2-SNAPSHOT/io.questdb.cairo.sql.TableReferenceOutOfDateException.of(TableReferenceOutOfDateException.java:74)
	at io.questdb@9.1.2-SNAPSHOT/io.questdb.cairo.CairoEngine.verifyTableToken(CairoEngine.java:1588)
	at io.questdb@9.1.2-SNAPSHOT/io.questdb.cairo.CairoEngine.getTableMetadata(CairoEngine.java:912)
	at io.questdb@9.1.2-SNAPSHOT/io.questdb.cairo.CairoEngine.getTableMetadata(CairoEngine.java:895)
	at io.questdb@9.1.2-SNAPSHOT/io.questdb.cairo.wal.CheckWalTransactionsJob.checkNotifyOutstandingTxnInWal(CheckWalTransactionsJob.java:101)
	at io.questdb@9.1.2-SNAPSHOT/io.questdb.cairo.wal.CheckWalTransactionsJob.lambda$new$0(CheckWalTransactionsJob.java:67)
	at io.questdb@9.1.2-SNAPSHOT/io.questdb.cairo.wal.seq.TableSequencerAPI.forAllWalTables(TableSequencerAPI.java:174)
	at io.questdb@9.1.2-SNAPSHOT/io.questdb.cairo.wal.CheckWalTransactionsJob.checkMissingWalTransactions(CheckWalTransactionsJob.java:74)
	at io.questdb@9.1.2-SNAPSHOT/io.questdb.cairo.wal.CheckWalTransactionsJob.runSerially(CheckWalTransactionsJob.java:130)
	at io.questdb@9.1.2-SNAPSHOT/io.questdb.mp.SynchronizedJob.run(SynchronizedJob.java:40)
	at io.questdb@9.1.2-SNAPSHOT/io.questdb.mp.SynchronizedJob.run(SynchronizedJob.java:50)
	at io.questdb.test/io.questdb.test.AbstractTest.drainWalQueue(AbstractTest.java:153)
	at io.questdb.test/io.questdb.test.AbstractTest.drainWalQueue(AbstractTest.java:145)
	at io.questdb.test/io.questdb.test.AbstractCairoTest.drainWalQueue(AbstractCairoTest.java:1573)
	at io.questdb.test/io.questdb.test.cutlass.pgwire.PreparedStatementInvalidationTest.mayDrainWalQueue(PreparedStatementInvalidationTest.java:1447)
	at io.questdb.test/io.questdb.test.cutlass.pgwire.PreparedStatementInvalidationTest.executeStatementWhileConcurrentlyChangingSchema(PreparedStatementInvalidationTest.java:1414)
	at io.questdb.test/io.questdb.test.cutlass.pgwire.PreparedStatementInvalidationTest.lambda$testUpdateWhileConcurrentlyRecreatingTable_preparedStatementReused$69(PreparedStatementInvalidationTest.java:1321)
	at io.questdb.test/io.questdb.test.cutlass.pgwire.BasePGTest.lambda$assertWithPgServer$1(BasePGTest.java:472)
	at io.questdb.test/io.questdb.test.AbstractCairoTest.lambda$assertMemoryLeak$9(AbstractCairoTest.java:1259)
	at io.questdb.test/io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:775)
	at io.questdb.test/io.questdb.test.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:1254)
	at io.questdb.test/io.questdb.test.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:1237)
	at io.questdb.test/io.questdb.test.cutlass.pgwire.BasePGTest.assertWithPgServer(BasePGTest.java:462)
	at io.questdb.test/io.questdb.test.cutlass.pgwire.BasePGTest.assertWithPgServer(BasePGTest.java:493)
	at io.questdb.test/io.questdb.test.cutlass.pgwire.BasePGTest.assertWithPgServer(BasePGTest.java:482)
	at io.questdb.test/io.questdb.test.cutlass.pgwire.PreparedStatementInvalidationTest.testUpdateWhileConcurrentlyRecreatingTable_preparedStatementReused(PreparedStatementInvalidationTest.java:1319)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at junit@4.13.2/org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at junit@4.13.2/org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at junit@4.13.2/org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at junit@4.13.2/org.junit.internal.runners.statements.InvokeMe
```