### PR TITLE
feat(core): move release to use Graal CE JDK

### DIFF
--- a/ci/github-release-pipeline.yml
+++ b/ci/github-release-pipeline.yml
@@ -47,8 +47,9 @@ stages:
               curl -L -o "${FILENAME}" "${BASE_URL}/${FILENAME}"
               curl -L -o "${FILENAME}.sha256" "${BASE_URL}/${FILENAME}.sha256"
 
-              # Verify checksum
-              sha256sum -c "${FILENAME}.sha256"
+              # .sha256 only contains the hash → wrap with filename for sha256sum -c
+              HASH="$(cut -d ' ' -f1 "${FILENAME}.sha256")"
+              echo "${HASH}  ${FILENAME}" | sha256sum -c -
 
               # Install to /usr/lib/jvm/graalvm-community-jdk-${GRAAL_VERSION}
               INSTALL_DIR="/usr/lib/jvm/graalvm-community-jdk-${GRAAL_VERSION}"
@@ -77,7 +78,7 @@ stages:
               Write-Host "Downloading $baseUrl/$fileName.sha256"
               Invoke-WebRequest "$baseUrl/$fileName.sha256" -OutFile $shaPath
 
-              # Verify checksum
+              # Verify checksum (file contains only the hash)
               $expected = (Get-Content $shaPath).Split(" ")[0].ToLower()
               $actual = (Get-FileHash $zipPath -Algorithm SHA256).Hash.ToLower()
 
@@ -109,11 +110,13 @@ stages:
               options: "-DskipTests -Dhttp.keepAlive=false -P build-web-console,build-binaries"
               javaHomeOption: 'Path'
               jdkDirectory: '$(GRAALVM_HOME)'
+
           - task: CopyFiles@2
             inputs:
               SourceFolder: '$(build.sourcesDirectory)/core/target'
               Contents: '$(build.sourcesDirectory)/core/target/questdb-*.gz'
               TargetFolder: '$(build.artifactstagingdirectory)'
+
           - task: PublishBuildArtifacts@1
             inputs:
               PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,23 +1,38 @@
 FROM debian:bookworm AS builder
+
 ARG tag_name
 ARG GRAAL_JDK_VERSION=17.0.9
 
 ENV GOSU_VERSION=1.19
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Base tools + maven (no Corretto repo anymore)
+# 1) Base tools + Maven
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
        git curl wget gnupg2 ca-certificates lsb-release software-properties-common unzip maven \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GraalVM Community JDK 17
-RUN curl -L -o /tmp/graalvm-ce.tar.gz \
-      "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAAL_JDK_VERSION}/graalvm-community-jdk-${GRAAL_JDK_VERSION}_linux-x64_bin.tar.gz" \
-    && mkdir -p /usr/lib/jvm/graalvm-community-jdk-${GRAAL_JDK_VERSION} \
-    && tar -xzf /tmp/graalvm-ce.tar.gz \
-         -C /usr/lib/jvm/graalvm-community-jdk-${GRAAL_JDK_VERSION} \
-         --strip-components=1 \
-    && rm /tmp/graalvm-ce.tar.gz
+# 2) Download GraalVM CE archive + SHA256
+RUN set -eux; \
+    TAG="jdk-${GRAAL_JDK_VERSION}"; \
+    FILENAME="graalvm-community-jdk-${GRAAL_JDK_VERSION}_linux-x64_bin.tar.gz"; \
+    BASE_URL="https://github.com/graalvm/graalvm-ce-builds/releases/download/${TAG}"; \
+    mkdir -p /tmp/graalvm; \
+    cd /tmp/graalvm; \
+    curl -L -o "${FILENAME}" "${BASE_URL}/${FILENAME}"; \
+    curl -L -o "${FILENAME}.sha256" "${BASE_URL}/${FILENAME}.sha256"
+
+# 3) Verify SHA256 and install GraalVM CE
+RUN set -eux; \
+    cd /tmp/graalvm; \
+    FILENAME="graalvm-community-jdk-${GRAAL_JDK_VERSION}_linux-x64_bin.tar.gz"; \
+    # .sha256 contains only the hash, so wrap it with filename for sha256sum -c
+    HASH="$(cut -d ' ' -f1 "${FILENAME}.sha256")"; \
+    echo "${HASH}  ${FILENAME}" | sha256sum -c -; \
+    INSTALL_DIR="/usr/lib/jvm/graalvm-community-jdk-${GRAAL_JDK_VERSION}"; \
+    mkdir -p "${INSTALL_DIR}"; \
+    tar -xzf "${FILENAME}" -C "${INSTALL_DIR}" --strip-components=1; \
+    rm -rf /tmp/graalvm
 
 ENV JAVA_HOME=/usr/lib/jvm/graalvm-community-jdk-${GRAAL_JDK_VERSION}
 ENV PATH="${JAVA_HOME}/bin:${PATH}"


### PR DESCRIPTION
Release CI works: https://dev.azure.com/questdb/questdb/_build/results?buildId=194946&view=results

Docker:
```
❯ docker build -t questdb-graal-test .

[+] Building 6.3s (5/25)                                                                                                                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                                     0.0s
 => => transferring dockerfile: 4.77kB                                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/debian:bookworm                                                                                                                                                       1.0s
 => [internal] load metadata for docker.io/library/debian:bookworm-slim                                                                                                                                                  1.1s
 => [internal] load .dockerignore                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                                                        0.0s
 => => transferring context: 7.08kB                                                                                                                                                                                      0.0s
 => [builder  1/12] FROM docker.io/library/debian:bookworm@sha256:6337ad82d5c764a8b6a16cde86b157fdce353e36d8ca06fc1b16d4f34d29960e                                                                                       5.2s
 => => resolve docker.io/library/debian:bookworm@sha256:6337ad82d5c764a8b6a16cde86b157fdce353e36d8ca06fc1b16d4f34d29960e                                                                                                 0.0s
[+] Building 233.8s (26/26) FINISHED                                                                                                                                                                         docker:default2 => [internal] load build definition from Dockerfile                                                                                                                                                                   0.0s
 => => transferring dockerfile: 4.77kB                                                                                                                                                                                 0.0s0 => [internal] load metadata for docker.io/library/debian:bookworm                                                                                                                                                     1.0s
 => [internal] load metadata for docker.io/library/debian:bookworm-slim                                                                                                                                                1.1s0 => [internal] load .dockerignore                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                        0.0s0 => [internal] load build context                                                                                                                                                                                      0.0s
 => => transferring context: 7.08kB                                                                                                                                                                                    0.0s2 => [builder  1/12] FROM docker.io/library/debian:bookworm@sha256:6337ad82d5c764a8b6a16cde86b157fdce353e36d8ca06fc1b16d4f34d29960e                                                                                     8.4s
 => => resolve docker.io/library/debian:bookworm@sha256:6337ad82d5c764a8b6a16cde86b157fdce353e36d8ca06fc1b16d4f34d29960e                                                                                               0.0s0 => => sha256:5d93aea697980315f27f81c68582d14f63dd3579c2d3a27dc495a588279eda20 48.48MB / 48.48MB                                                                                                                       6.5s
 => => sha256:6337ad82d5c764a8b6a16cde86b157fdce353e36d8ca06fc1b16d4f34d29960e 8.52kB / 8.52kB                                                                                                                         0.0s0 => => sha256:9d11a2b1e25f5c84ae3d454ed51ef64f0cf07cbbc1ec25d689b9b0de7071ea66 1.02kB / 1.02kB                                                                                                                         0.0s
 => => sha256:160279ddc32dcbc5152003a47fa174ec737fb737e916feba965fbb01f62983e7 453B / 453B                                                                                                                             0.0s0 => => extracting sha256:5d93aea697980315f27f81c68582d14f63dd3579c2d3a27dc495a588279eda20                                                                                                                              1.8s
 => [questdb 1/8] FROM docker.io/library/debian:bookworm-slim@sha256:936abff852736f951dab72d91a1b6337cf04217b2a77a5eaadc7c0f2f1ec1758                                                                                  5.7s0 => => resolve docker.io/library/debian:bookworm-slim@sha256:936abff852736f951dab72d91a1b6337cf04217b2a77a5eaadc7c0f2f1ec1758                                                                                          0.0s
 => => sha256:936abff852736f951dab72d91a1b6337cf04217b2a77a5eaadc7c0f2f1ec1758 8.56kB / 8.56kB                                                                                                                         0.0s5 => => sha256:f522a3167fb670cc4a4518fab6d8c4227fe4bc458f4c7294832383bf284d5e78 1.02kB / 1.02kB                                                                                                                         0.0s
 => => sha256:d23d86cb8a70ed255f7e4dc658df8dae7ceb9faf5c76ab0d05f9c4ab5a4bc3a4 453B / 453B                                                                                                                             0.0s7 => => sha256:1adabd6b0d6b8acfa4ad149a984df0977135a7babf423538c7284a02744a4ee8 28.23MB / 28.23MB                                                                                                                       4.5s
 => => extracting sha256:1adabd6b0d6b8acfa4ad149a984df0977135a7babf423538c7284a02744a4ee8                                                                                                                              1.1s
 => [questdb 2/8] WORKDIR /app                                                                                                                                                                                         0.2s
 => [builder  2/12] RUN apt-get update     && apt-get install --no-install-recommends -y        git curl wget gnupg2 ca-certificates lsb-release software-properties-common unzip maven     && rm -rf /var/lib/apt/l  31.6s
 => [builder  3/12] RUN curl -L -o /tmp/graalvm-ce.tar.gz       "https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-17.0.9/graalvm-community-jdk-17.0.9_linux-x64_bin.tar.gz"     && mkdir -p /usr/l  27.6s
 => [builder  4/12] WORKDIR /build                                                                                                                                                                                     0.0s
 => [builder  5/12] RUN echo tag_name ${tag_name:-master}                                                                                                                                                              0.2s
 => [builder  6/12] RUN git clone --depth=1 --progress --branch "${tag_name:-master}" --verbose https://github.com/questdb/questdb.git                                                                                11.2s
 => [builder  7/12] WORKDIR /build/questdb                                                                                                                                                                             0.0s
 => [builder  8/12] RUN mvn clean package -Djdk.lang.Process.launchMechanism=vfork -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -DskipTests -P build-web-console,build-binari  148.6s
 => [builder  9/12] WORKDIR /build/questdb/core/target                                                                                                                                                                 0.0s
 => [builder 10/12] RUN tar xvfz questdb-*-rt-*.tar.gz                                                                                                                                                                 0.9s
 => [builder 11/12] RUN rm questdb-*-rt-*.tar.gz                                                                                                                                                                       0.2s
 => [builder 12/12] RUN dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')";     wget -O gosu "https://github.com/tianon/gosu/releases/download/1.19/gosu-$dpkgArch" &&     wget -O gosu.asc "https://g  1.7s
 => [questdb 3/8] COPY --from=builder /build/questdb/core/target/questdb-*-rt-* .                                                                                                                                      0.2s
 => [questdb 4/8] COPY --from=builder /build/questdb/core/target/gosu /usr/local/bin/gosu                                                                                                                              0.0s
 => [questdb 5/8] COPY docker-entrypoint.sh /docker-entrypoint.sh                                                                                                                                                      0.0s
 => [questdb 6/8] RUN chmod +x /docker-entrypoint.sh                                                                                                                                                                   0.2s
 => [questdb 7/8] RUN groupadd -g 10001 questdb &&     useradd -u 10001 -g 10001 -d /var/lib/questdb -M -s /sbin/nologin questdb &&     mkdir -p /var/lib/questdb &&     chown -R questdb:questdb /var/lib/questdb     0.2s
 => [questdb 8/8] WORKDIR /var/lib/questdb                                                                                                                                                                             0.0s
 => exporting to image                                                                                                                                                                                                 0.4s
 => => exporting layers                                                                                                                                                                                                0.4s
 => => writing image sha256:874d9bf83d3e5af112c6848950d6a4045f8260626fbc8ee79ce004b3abbeb90e                                                                                                                           0.0s
 => => naming to docker.io/library/questdb-graal-test                                                                                                                                                                  0.0s
❯ docker run questdb-graal-test

No arguments found in the configuration, start with default arguments
Checking data directory ownership
Running as questdb user
Log configuration loaded from: /var/lib/questdb/conf/log.conf
2025-11-13T14:23:32.822377Z I server-main extracted [path=/var/lib/questdb/import/readme.txt]
2025-11-13T14:23:32.963060Z I server-main extracted [path=/var/lib/questdb/import/trades.parquet]
2025-11-13T14:23:32.963136Z A server-main QuestDB 9.1.2-SNAPSHOT. Copyright (C) 2014-2025, all rights reserved.
2025-11-13T14:23:32.963555Z A server-main linux-x86-64 [AVX2,8, 64 bits, 64 processors]
2025-11-13T14:23:32.963626Z A server-main fs.file-max checked [limit=1073741816]
2025-11-13T14:23:32.963816Z A server-main vm.max_map_count checked [limit=1048576]
2025-11-13T14:23:32.997058Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/editor/editor.main.js]
2025-11-13T14:23:32.997580Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/editor/editor.main.css]
2025-11-13T14:23:32.998121Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/editor/editor.main.nls.js]
2025-11-13T14:23:32.998241Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/editor/editor.main.js.LICENSE.txt]
2025-11-13T14:23:32.998354Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/editor/editor.main.nls.js.LICENSE.txt]
2025-11-13T14:23:32.998619Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/loader.js]
2025-11-13T14:23:32.999003Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/base/common/worker/simpleWorker.nls.de.js]
2025-11-13T14:23:32.999132Z I server-main extracted [path=/var/lib/questdb/public/assets/vs/base/common/worker/simpleWorker.nls.es.js]
```