### PR TITLE
fix(ilp): backwards incompatible way of writing null arrays

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/LineTcpSenderV2.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineTcpSenderV2.java
@@ -46,6 +46,7 @@ import java.time.temporal.ChronoUnit;
 
 @SuppressWarnings("resource")
 public class LineTcpSenderV2 extends AbstractLineTcpSender implements ArrayBufferAppender {
+
     public LineTcpSenderV2(LineChannel channel, int bufferCapacity, int maxNameLength) {
         super(channel, bufferCapacity, maxNameLength);
     }
@@ -110,7 +111,7 @@ public class LineTcpSenderV2 extends AbstractLineTcpSender implements ArrayBuffe
 
     @Override
     public Sender doubleArray(CharSequence name, DoubleArray array) {
-        if (processNullArray(name, array)) {
+        if (array == null) {
             return this;
         }
         writeFieldName(name)
@@ -157,7 +158,7 @@ public class LineTcpSenderV2 extends AbstractLineTcpSender implements ArrayBuffe
 
     @Override
     public Sender longArray(@NotNull CharSequence name, LongArray values) {
-        if (processNullArray(name, values)) {
+        if (values == null) {
             return this;
         }
         writeFieldName(name)
@@ -235,10 +236,9 @@ public class LineTcpSenderV2 extends AbstractLineTcpSender implements ArrayBuffe
             ArrayShapeAppender<T> shapeAppender,
             ArrayDataAppender<T> dataAppender
     ) {
-        if (processNullArray(name, array)) {
+        if (array == null) {
             return this;
         }
-
         writeFieldName(name)
                 .putAsciiInternal('=')
                 .put(LineTcpParser.ENTITY_TYPE_ARRAY)
@@ -247,17 +247,6 @@ public class LineTcpSenderV2 extends AbstractLineTcpSender implements ArrayBuffe
         shapeAppender.append(this, array);
         dataAppender.append(this, array);
         return this;
-    }
-
-    private boolean processNullArray(CharSequence name, Object value) {
-        if (value == null) {
-            writeFieldName(name)
-                    .putAsciiInternal('=') // binary format flag
-                    .put(LineTcpParser.ENTITY_TYPE_ARRAY) // ARRAY binary format
-                    .put((byte) ColumnType.NULL); // element type
-            return true;
-        }
-        return false;
     }
 
     private void putTimestamp(long timestamp, ChronoUnit unit) {

--- a/core/src/main/java/io/questdb/cutlass/line/LineTcpSenderV3.java
+++ b/core/src/main/java/io/questdb/cutlass/line/LineTcpSenderV3.java
@@ -66,7 +66,7 @@ public class LineTcpSenderV3 extends LineTcpSenderV2 implements ArrayBufferAppen
 
     @Override
     public Sender decimalColumn(CharSequence name, Decimal256 value) {
-        if (value.isNull()) {
+        if (value == null || value.isNull()) {
             return this;
         }
         writeFieldName(name)
@@ -83,7 +83,7 @@ public class LineTcpSenderV3 extends LineTcpSenderV2 implements ArrayBufferAppen
 
     @Override
     public Sender decimalColumn(CharSequence name, Decimal128 value) {
-        if (value.isNull()) {
+        if (value == null || value.isNull()) {
             return this;
         }
         writeFieldName(name)
@@ -98,7 +98,7 @@ public class LineTcpSenderV3 extends LineTcpSenderV2 implements ArrayBufferAppen
 
     @Override
     public Sender decimalColumn(CharSequence name, Decimal64 value) {
-        if (value.isNull()) {
+        if (value == null || value.isNull()) {
             return this;
         }
         writeFieldName(name)

--- a/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSenderV2.java
+++ b/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSenderV2.java
@@ -50,20 +50,23 @@ import java.time.temporal.ChronoUnit;
 
 public class LineHttpSenderV2 extends AbstractLineHttpSender {
 
-    public LineHttpSenderV2(String host,
-                            int port,
-                            HttpClientConfiguration clientConfiguration,
-                            ClientTlsConfiguration tlsConfig,
-                            int autoFlushRows,
-                            String authToken,
-                            String username,
-                            String password,
-                            int maxNameLength,
-                            long maxRetriesNanos,
-                            int maxBackoffMillis,
-                            long minRequestThroughput,
-                            long flushIntervalNanos) {
-        super(host,
+    public LineHttpSenderV2(
+            String host,
+            int port,
+            HttpClientConfiguration clientConfiguration,
+            ClientTlsConfiguration tlsConfig,
+            int autoFlushRows,
+            String authToken,
+            String username,
+            String password,
+            int maxNameLength,
+            long maxRetriesNanos,
+            int maxBackoffMillis,
+            long minRequestThroughput,
+            long flushIntervalNanos
+    ) {
+        super(
+                host,
                 port,
                 clientConfiguration,
                 tlsConfig,
@@ -76,27 +79,31 @@ public class LineHttpSenderV2 extends AbstractLineHttpSender {
                 maxBackoffMillis,
                 minRequestThroughput,
                 flushIntervalNanos,
-                new Rnd(NanosecondClockImpl.INSTANCE.getTicks(), MicrosecondClockImpl.INSTANCE.getTicks()));
+                new Rnd(NanosecondClockImpl.INSTANCE.getTicks(), MicrosecondClockImpl.INSTANCE.getTicks())
+        );
     }
 
-    public LineHttpSenderV2(ObjList<String> hosts,
-                            IntList ports,
-                            String path,
-                            HttpClientConfiguration clientConfiguration,
-                            ClientTlsConfiguration tlsConfig,
-                            @Nullable HttpClient client,
-                            int autoFlushRows,
-                            String authToken,
-                            String username,
-                            String password,
-                            int maxNameLength,
-                            long maxRetriesNanos,
-                            int maxBackoffMillis,
-                            long minRequestThroughput,
-                            long flushIntervalNanos,
-                            int currentAddressIndex,
-                            Rnd rnd) {
-        super(hosts,
+    public LineHttpSenderV2(
+            ObjList<String> hosts,
+            IntList ports,
+            String path,
+            HttpClientConfiguration clientConfiguration,
+            ClientTlsConfiguration tlsConfig,
+            @Nullable HttpClient client,
+            int autoFlushRows,
+            String authToken,
+            String username,
+            String password,
+            int maxNameLength,
+            long maxRetriesNanos,
+            int maxBackoffMillis,
+            long minRequestThroughput,
+            long flushIntervalNanos,
+            int currentAddressIndex,
+            Rnd rnd
+    ) {
+        super(
+                hosts,
                 ports,
                 path,
                 clientConfiguration,
@@ -112,27 +119,31 @@ public class LineHttpSenderV2 extends AbstractLineHttpSender {
                 minRequestThroughput,
                 flushIntervalNanos,
                 currentAddressIndex,
-                rnd);
+                rnd
+        );
     }
 
     @SuppressWarnings("unused")
-    protected LineHttpSenderV2(String host,
-                               int port,
-                               String path,
-                               HttpClientConfiguration clientConfiguration,
-                               ClientTlsConfiguration tlsConfig,
-                               HttpClient client,
-                               int autoFlushRows,
-                               String authToken,
-                               String username,
-                               String password,
-                               int maxNameLength,
-                               long maxRetriesNanos,
-                               int maxBackoffMillis,
-                               long minRequestThroughput,
-                               long flushIntervalNanos,
-                               Rnd rnd) {
-        super(host,
+    protected LineHttpSenderV2(
+            String host,
+            int port,
+            String path,
+            HttpClientConfiguration clientConfiguration,
+            ClientTlsConfiguration tlsConfig,
+            HttpClient client,
+            int autoFlushRows,
+            String authToken,
+            String username,
+            String password,
+            int maxNameLength,
+            long maxRetriesNanos,
+            int maxBackoffMillis,
+            long minRequestThroughput,
+            long flushIntervalNanos,
+            Rnd rnd
+    ) {
+        super(
+                host,
                 port,
                 path,
                 clientConfiguration,
@@ -147,7 +158,8 @@ public class LineHttpSenderV2 extends AbstractLineHttpSender {
                 maxBackoffMillis,
                 minRequestThroughput,
                 flushIntervalNanos,
-                rnd);
+                rnd
+        );
     }
 
     @Override
@@ -187,7 +199,7 @@ public class LineHttpSenderV2 extends AbstractLineHttpSender {
 
     @Override
     public Sender doubleArray(CharSequence name, DoubleArray array) {
-        if (processNullArray(name, array)) {
+        if (array == null) {
             return this;
         }
         writeFieldName(name)
@@ -230,7 +242,7 @@ public class LineHttpSenderV2 extends AbstractLineHttpSender {
 
     @Override
     public Sender longArray(@NotNull CharSequence name, LongArray values) {
-        if (processNullArray(name, values)) {
+        if (values == null) {
             return this;
         }
         writeFieldName(name)
@@ -263,7 +275,7 @@ public class LineHttpSenderV2 extends AbstractLineHttpSender {
             ArrayShapeAppender<T> shapeAppender,
             ArrayDataAppender<T> dataAppender
     ) {
-        if (processNullArray(name, array)) {
+        if (array == null) {
             return this;
         }
         writeFieldName(name)
@@ -274,17 +286,6 @@ public class LineHttpSenderV2 extends AbstractLineHttpSender {
         shapeAppender.append(request, array);
         dataAppender.append(request, array);
         return this;
-    }
-
-    private boolean processNullArray(CharSequence name, Object value) {
-        if (value == null) {
-            writeFieldName(name)
-                    .putAscii('=') // binary format flag
-                    .put(LineTcpParser.ENTITY_TYPE_ARRAY) // ND_ARRAY binary format
-                    .put((byte) ColumnType.NULL); // element type
-            return true;
-        }
-        return false;
     }
 
     private void putTimestamp(long timestamp, ChronoUnit unit) {

--- a/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSenderV3.java
+++ b/core/src/main/java/io/questdb/cutlass/line/http/LineHttpSenderV3.java
@@ -42,24 +42,27 @@ import org.jetbrains.annotations.Nullable;
 
 public class LineHttpSenderV3 extends LineHttpSenderV2 {
 
-    public LineHttpSenderV3(ObjList<String> hosts,
-                            IntList ports,
-                            String path,
-                            HttpClientConfiguration clientConfiguration,
-                            ClientTlsConfiguration tlsConfig,
-                            @Nullable HttpClient client,
-                            int autoFlushRows,
-                            String authToken,
-                            String username,
-                            String password,
-                            int maxNameLength,
-                            long maxRetriesNanos,
-                            int maxBackoffMillis,
-                            long minRequestThroughput,
-                            long flushIntervalNanos,
-                            int currentAddressIndex,
-                            Rnd rnd) {
-        super(hosts,
+    public LineHttpSenderV3(
+            ObjList<String> hosts,
+            IntList ports,
+            String path,
+            HttpClientConfiguration clientConfiguration,
+            ClientTlsConfiguration tlsConfig,
+            @Nullable HttpClient client,
+            int autoFlushRows,
+            String authToken,
+            String username,
+            String password,
+            int maxNameLength,
+            long maxRetriesNanos,
+            int maxBackoffMillis,
+            long minRequestThroughput,
+            long flushIntervalNanos,
+            int currentAddressIndex,
+            Rnd rnd
+    ) {
+        super(
+                hosts,
                 ports,
                 path,
                 clientConfiguration,
@@ -75,27 +78,31 @@ public class LineHttpSenderV3 extends LineHttpSenderV2 {
                 minRequestThroughput,
                 flushIntervalNanos,
                 currentAddressIndex,
-                rnd);
+                rnd
+        );
     }
 
     @SuppressWarnings("unused")
-    protected LineHttpSenderV3(String host,
-                               int port,
-                               String path,
-                               HttpClientConfiguration clientConfiguration,
-                               ClientTlsConfiguration tlsConfig,
-                               HttpClient client,
-                               int autoFlushRows,
-                               String authToken,
-                               String username,
-                               String password,
-                               int maxNameLength,
-                               long maxRetriesNanos,
-                               int maxBackoffMillis,
-                               long minRequestThroughput,
-                               long flushIntervalNanos,
-                               Rnd rnd) {
-        super(host,
+    protected LineHttpSenderV3(
+            String host,
+            int port,
+            String path,
+            HttpClientConfiguration clientConfiguration,
+            ClientTlsConfiguration tlsConfig,
+            HttpClient client,
+            int autoFlushRows,
+            String authToken,
+            String username,
+            String password,
+            int maxNameLength,
+            long maxRetriesNanos,
+            int maxBackoffMillis,
+            long minRequestThroughput,
+            long flushIntervalNanos,
+            Rnd rnd
+    ) {
+        super(
+                host,
                 port,
                 path,
                 clientConfiguration,
@@ -110,7 +117,8 @@ public class LineHttpSenderV3 extends LineHttpSenderV2 {
                 maxBackoffMillis,
                 minRequestThroughput,
                 flushIntervalNanos,
-                rnd);
+                rnd
+        );
     }
 
     @Override
@@ -128,10 +136,9 @@ public class LineHttpSenderV3 extends LineHttpSenderV2 {
 
     @Override
     public Sender decimalColumn(CharSequence name, Decimal256 value) {
-        if (value.isNull()) {
+        if (value == null || value.isNull()) {
             return this;
         }
-
         var request = writeFieldName(name)
                 .putAscii('=')
                 .put(LineTcpParser.ENTITY_TYPE_DECIMAL)
@@ -146,10 +153,9 @@ public class LineHttpSenderV3 extends LineHttpSenderV2 {
 
     @Override
     public Sender decimalColumn(CharSequence name, Decimal128 value) {
-        if (value.isNull()) {
+        if (value == null || value.isNull()) {
             return this;
         }
-
         var request = writeFieldName(name)
                 .putAscii('=')
                 .put(LineTcpParser.ENTITY_TYPE_DECIMAL)
@@ -162,10 +168,9 @@ public class LineHttpSenderV3 extends LineHttpSenderV2 {
 
     @Override
     public Sender decimalColumn(CharSequence name, Decimal64 value) {
-        if (value.isNull()) {
+        if (value == null || value.isNull()) {
             return this;
         }
-
         var request = writeFieldName(name)
                 .putAscii('=')
                 .put(LineTcpParser.ENTITY_TYPE_DECIMAL)

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/ArrayBinaryFormatParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/ArrayBinaryFormatParser.java
@@ -74,6 +74,9 @@ public class ArrayBinaryFormatParser implements QuietCloseable {
         switch (state) {
             case ELEMENT_TYPE:
                 elemType = Unsafe.getUnsafe().getByte(addr);
+                // TODO(puzpuzpuz): remove this check completely once we update all clients to skip fields
+                //  for null arrays instead of sending this code; this code is unreliable as it changes
+                //  each time we add a new column type
                 if (elemType == ColumnType.NULL) {
                     array.ofNull();
                     state = ParserState.FINISH;

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderTest.java
@@ -2151,7 +2151,7 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
             )) {
                 String tableName = "arr_nullable_test";
                 serverMain.execute("CREATE TABLE " + tableName + " (x SYMBOL, l1 LONG, a1 DOUBLE[], " +
-                        "a2 DOUBLE[][], ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                        "a2 DOUBLE[][], a3 DOUBLE[][][], ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
                 serverMain.awaitTxn(tableName, 0);
 
                 int port = serverMain.getHttpServerPort();
@@ -2167,6 +2167,7 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
                             .longColumn("l1", 123098948)
                             .doubleArray("a1", (double[]) null)
                             .doubleArray("a2", (double[][]) null)
+                            .doubleArray("a3", (double[][][]) null)
                             .at(100000000000L, ChronoUnit.MICROS);
                     sender.flush();
                 }
@@ -2175,8 +2176,8 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
 
                 serverMain.assertSql("select * from " + tableName,
                         """
-                                x\tl1\ta1\ta2\tts
-                                42i\t123098948\tnull\tnull\t1970-01-02T03:46:40.000000Z
+                                x\tl1\ta1\ta2\ta3\tts
+                                42i\t123098948\tnull\tnull\tnull\t1970-01-02T03:46:40.000000Z
                                 """);
             }
         });


### PR DESCRIPTION
`Sender` implementations were encoding `ColumnType.NULL` when sending `null` array values to the server. This is problematic from the compatibility perspective since `ColumnType.NULL` changes each time we add a new column type, e.g. this code changed to 40 recently in v9.2.  To fix this, senders now omit the field values for `null` arrays, so that the column is not included into the ILP message, like it works for other column types.