### PR TITLE
ci(build): delete dangling files in /tmp on Hetzner

### DIFF
--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -3,6 +3,10 @@ steps:
     fetchDepth: 1
     lfs: false
     submodules: false
+  - bash: |
+      rm -rf /tmp/junit* /tmp/surefire-agent /tmp/libquestdbr* /tmp/libqdbsqllogic*
+    displayName: "Cleanup dangling test artifacts from /tmp"
+    condition: startsWith(variables['poolName'], 'hetzner-')
   - bash: sudo sysctl -w fs.file-max=500000
     displayName: "Increase file count on Linux"
     condition: |


### PR DESCRIPTION
It looks like tests occasionally keep dangling files in /tmp. It is likely caused when a test is cancelled. This is invisible on Azure-hosted runners since they always start with a clean table.

Dangling files/dirs accumulate on self-hosted runners. This change removes artifacts known to accumulate before starting tests.