### PR TITLE
feat(core): hints for handling histogram out of bounds error for approx_percentile()/approx_median()

### DIFF
--- a/core/src/main/java/io/questdb/std/histogram/org/HdrHistogram/DoubleHistogram.java
+++ b/core/src/main/java/io/questdb/std/histogram/org/HdrHistogram/DoubleHistogram.java
@@ -1268,7 +1268,6 @@ public class DoubleHistogram extends EncodableHistogram implements DoubleValueRe
                 while (value >= currentHighestValueLimitInAutoRange);
             }
         } catch (CairoException ex) {
-            throw CairoException.nonCritical().put("The value ").put(value)
             // Build the base error message first
             CairoException err = CairoException.nonCritical().put("The value ").put(value)
                     .put(" is out of bounds for histogram, current covered range [")


### PR DESCRIPTION
This PR provides the user with hints to resolve the Histogram out of Bounds error which occurs during the approx_median(d) query,when the inserted values exceed the allowed range for the Histogram.In this case the default precision value for median is set to be 1.

- This error can often be resolved by using a lower precision value with the query approx_median(d,0).
- Or normalizing the values to fit into the allowed range.
- This PR is in reference to the issue #6442 
