### PR TITLE
fix(ui): remove line ending declarations from web console assembly descriptor

### DIFF
--- a/core/src/main/assembly/web-console.xml
+++ b/core/src/main/assembly/web-console.xml
@@ -34,21 +34,6 @@
             <includes>
                 <include>**/*</include>
             </includes>
-            <excludes>
-                <exclude>**/*.woff</exclude>
-                <exclude>**/*.ttf</exclude>
-            </excludes>
-            <outputDirectory>.</outputDirectory>
-            <fileMode>755</fileMode>
-            <lineEnding>unix</lineEnding>
-        </fileSet>
-        <!-- font files are included separately to avoid corrupting them due to lineEnding -->
-        <fileSet>
-            <directory>${project.build.directory}/site/package/dist/</directory>
-            <includes>
-                <include>**/*.woff</include>
-                <include>**/*.ttf</include>
-            </includes>
             <outputDirectory>.</outputDirectory>
             <fileMode>755</fileMode>
         </fileSet>


### PR DESCRIPTION
We were changing all byte sequences `0D 0A` (that is `\r\n` in ASCII) in web console package that we download from NPM.
This PR removes the unix line-ending configuration from the web console assembly descriptor to fix the broken assets due to removing this sequence. Exclusion workaround is also not needed anymore.