### PR TITLE
ci(build): reverts move snapshot builds to hetzner (#6489)

### DIFF
--- a/ci/snapshot-pipeline.yml
+++ b/ci/snapshot-pipeline.yml
@@ -8,8 +8,6 @@ pr: none
 variables:
   MVN_VERSION: "3.6.3"
   MVN: "apache-maven-$(MVN_VERSION)"
-  JAVA_HOME_17_X64: "/usr/lib/jvm/java-17-openjdk-amd64"
-  JAVA_HOME: "/usr/lib/jvm/java-17-openjdk-amd64"
 
 stages:
   - stage: BuildSnapshotMaster
@@ -17,7 +15,8 @@ stages:
     jobs:
       - job: BuildOnLinux
         displayName: "Build on Linux"
-        pool: hetzner-docker
+        pool:
+          vmImage: "ubuntu-latest"
         steps:
           - checkout: self
             fetchDepth: 1
@@ -30,8 +29,7 @@ stages:
               goals: "package"
               options:
                 "--batch-mode --quiet -DskipTests -P build-web-console,build-binaries -Dhttp.keepAlive=false -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)"
-              javaHomeOption: 'Path'
-              jdkDirectory: '$(JAVA_HOME)'
+              jdkVersionOption: 1.17
           - bash: |
               cd "$(Build.SourcesDirectory)"/core
               find target \( -name "*rt-linux*.tar.gz" -o -name "*no-jre*.tar.gz" \) -exec mv '{}' "$(Build.BinariesDirectory)"/ \;
@@ -47,7 +45,8 @@ stages:
         condition: succeeded()
         displayName: "Upload snapshot to S3"
         container: pypy:3.7-slim-buster
-        pool: hetzner-docker
+        pool:
+          vmImage: "ubuntu-latest"
         steps:
           - checkout: none
           - task: DownloadBuildArtifacts@0


### PR DESCRIPTION
This reverts commit 21716541fbb8b47ad06f2f1e3c2f64f94575fe8f until we have better docker support in our self-hosted hetzner runners