### PR TITLE
ci(build): update azure devops container registry

### DIFF
--- a/ci/docker-release-pipeline.yml
+++ b/ci/docker-release-pipeline.yml
@@ -51,7 +51,7 @@ jobs:
       - task: Docker@2
         inputs:
           command: 'login'
-          containerRegistry: quest_docker_hub
+          containerRegistry: serviceaccountquestdb
 
       - task: CmdLine@2
         displayName: Setup docker buildx


### PR DESCRIPTION
Credentials expired for the old one. This should fix docker builds.

Build for this branch is here: https://dev.azure.com/questdb/questdb/_build/results?buildId=201921&view=results