### PR TITLE
ci(build): add test cleanup for fuzz tests

### DIFF
--- a/ci/test-fuzz.yml
+++ b/ci/test-fuzz.yml
@@ -27,7 +27,8 @@ stages:
 
     jobs:
       - job: RunOn
-        clean: all
+        workspace:
+          clean: all
         displayName: "on"
         strategy:
           matrix:


### PR DESCRIPTION
<img width="352" height="290" alt="image" src="https://github.com/user-attachments/assets/db66212b-c815-4ed9-89e9-e6f3102a3265" />

We got an error compressing logs on a failed fuzz test. I believe this has to do with the fact that we did not set workspace cleaning up for fuzz tests. We've done this for other tests, just haven't done it for the fuzz test yet.

https://learn.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#workspace

### Testing

Using this run https://dev.azure.com/questdb/questdb/_build/results?buildId=202127&view=logs&j=b4f20092-3671-5fdc-5d42-62b121039426&t=11585f97-ccff-44f1-9f27-ff86741d5b20

on `Docker Agent - Linux-dedi-i9-9000K-3-1`
<img width="642" height="318" alt="image" src="https://github.com/user-attachments/assets/573e38dc-7b0e-49b7-862b-120135952c0b" />

see cleanup triggered at start of the job and disk space reclaimed

