### PR TITLE
fix(core): fix bad connection state after TLS session initialization failure

### DIFF
--- a/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
+++ b/core/src/main/java/io/questdb/network/AbstractIODispatcher.java
@@ -226,7 +226,6 @@ public abstract class AbstractIODispatcher<C extends IOContext<C>> extends Synch
                 LOG.error().$("could not initialize connection context [fd=").$(connectionContext.getFd())
                         .$(", e=").$safe(e.getFlyweightMessage())
                         .I$();
-                ioContextFactory.done(connectionContext);
                 disconnect(connectionContext, DISCONNECT_REASON_TLS_SESSION_INIT_FAILED);
             }
         }


### PR DESCRIPTION
When TLS session initialization failed, then the connection context was closed twice, and it could be also pooled twice. This could lead to issues in later connections.

Joint work with @RaphDal

Note for reviewers: `disconnect()` enqueues the context in the `disconnectQueue`. The queue is later processed, and the connection is closed. 