### PR TITLE
Fix null safety in PreferencesParser EVT_VALUE

### DIFF
--- a/core/src/main/java/io/questdb/preferences/PreferencesParser.java
+++ b/core/src/main/java/io/questdb/preferences/PreferencesParser.java
@@ -47,7 +47,14 @@ public final class PreferencesParser extends AbstractJsonParser {
                 }
                 break;
             case JsonLexer.EVT_VALUE:
+                if (key == null) {
+                throw CairoException.critical(0)
+                    .put("Missing key for value [value=").put(tag)
+                    .put(", state=").put(state).put(']');
+                }
                 parserMap.put(key, copy(tag));
+                key = null;
+                break;
         }
     }
 }


### PR DESCRIPTION
### What this PR does
Adds a null-safety check in PreferencesParser for EVT_VALUE. Throws a clear CairoException if a JSON value is encountered without a preceding key.

### Why this matters
- Prevents potential NullPointerException on malformed preferences JSON.
- Improves robustness of preferences parsing.
- Lets the developer know exact reason of failure.