### PR TITLE
chore(ui): upgrade web console to 1.1.8

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,7 +37,7 @@
         <argLine>-ea -Dfile.encoding=UTF-8 -XX:+UseParallelGC</argLine>
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
-        <web.console.version>1.1.7</web.console.version>
+        <web.console.version>1.1.8</web.console.version>
         <qdbr.path>rust/qdbr</qdbr.path>
         <qdbr.release>false</qdbr.release>
 


### PR DESCRIPTION
### Fixed
- add polyfill for crypto.randomUUID to be used in insecure contexts [#508](https://github.com/questdb/ui/pull/508)