### PR TITLE
feat(core): allow setting instance name via QDB_DEFAULT_INSTANCE_NAME env variable

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -210,6 +210,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final boolean devModeEnabled;
     private final Set<? extends ConfigPropertyKey> dynamicProperties;
     private final boolean enableTestFactories;
+    private final @Nullable Map<String, String> env;
     private final WorkerPoolConfiguration exportPoolConfiguration = new PropExportPoolConfiguration();
     private final int[] exportWorkerAffinity;
     private final int exportWorkerCount;
@@ -760,6 +761,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             boolean loadAdditionalConfigurations
     ) throws ServerConfigurationException, JsonException {
         this.log = log;
+        this.env = env;
         this.metricsEnabled = getBoolean(properties, env, PropertyKey.METRICS_ENABLED, false);
         this.metrics = metricsEnabled ? new Metrics(true, new MetricsRegistryImpl()) : Metrics.DISABLED;
         this.logSqlQueryProgressExe = getBoolean(properties, env, PropertyKey.LOG_SQL_QUERY_PROGRESS_EXE, true);
@@ -2938,6 +2940,11 @@ public class PropServerConfiguration implements ServerConfiguration {
                 return value.incrementAndGet();
             }
         };
+
+        @Override
+        public Map<String, String> getEnv() {
+            return env;
+        }
 
         @Override
         public boolean attachPartitionCopy() {

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -44,6 +44,7 @@ import io.questdb.std.str.CharSink;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.LongSupplier;
 
@@ -54,6 +55,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     public CairoConfigurationWrapper(Metrics metrics) {
         this.metrics = metrics;
         delegate.set(null);
+    }
+
+    @Override
+    public Map<String, String> getEnv() {
+        return getDelegate().getEnv();
     }
 
     public CairoConfigurationWrapper(@NotNull CairoConfiguration delegate) {

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -213,6 +213,7 @@ public class CairoEngine implements Closeable, WriterSource {
 
             settingsStore = new SettingsStore(configuration);
             settingsStore.init();
+            initInstanceNameFromEnv();
 
             tableIdGenerator.open();
             checkpointRecover();
@@ -1850,6 +1851,20 @@ public class CairoEngine implements Closeable, WriterSource {
             throw CairoException.tableDoesNotExist(tableName);
         }
         return token;
+    }
+
+    private void initInstanceNameFromEnv() {
+        if (configuration.isReadOnlyInstance()) {
+            return;
+        }
+        final CharSequence instanceName = settingsStore.getPreference("instance_name");
+        if (Chars.isBlank(instanceName)) {
+            final String envInstanceName = configuration.getEnv().get("QDB_DEFAULT_INSTANCE_NAME");
+            if (!Chars.isBlank(envInstanceName)) {
+                settingsStore.setPreference("instance_name", envInstanceName);
+                LOG.info().$("instance name initialized from environment [name=").$(envInstanceName).I$();
+            }
+        }
     }
 
     // used in ent

--- a/core/src/main/java/io/questdb/preferences/SettingsStore.java
+++ b/core/src/main/java/io/questdb/preferences/SettingsStore.java
@@ -81,12 +81,30 @@ public class SettingsStore implements Closeable {
         }
     }
 
+    public synchronized CharSequence getPreference(CharSequence key) {
+        return preferencesMap.get(key);
+    }
+
     public void registerListener(@NotNull PreferencesUpdateListener listener) {
         this.listener = listener;
 
         // call the listener with current state,
         // it will be called on subsequent updates too
         listener.update(preferencesMap);
+    }
+
+    /**
+     * Sets a single preference value and persists it.
+     * This method is intended for programmatic initialization of preferences,
+     * for example from environment variables during startup.
+     */
+    public synchronized void setPreference(CharSequence key, CharSequence value) {
+        preferencesMap.put(key, value);
+        persist(preferencesMap);
+
+        if (listener != null) {
+            listener.update(preferencesMap);
+        }
     }
 
     public synchronized void save(DirectUtf8Sink sink, Mode mode, long expectedVersion) {


### PR DESCRIPTION
Instance name can now be set via environment variable. When starting QuestDB, set QDB_DEFAULT_INSTANCE_NAME to automatically configure the instance name if it hasn't been set before.

This is useful for container deployments and automated provisioning where setting the name via the web console isn't practical.