### PR TITLE
fix(sql): fix false timestamp ordering error with nested SAMPLE BY and ORDER BY

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -4669,11 +4669,17 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         // Remember the last model with non-empty ORDER BY as we descend through nested models.
         // We need the ORDER BY clause in the Markout Horizon Join optimization, but it's stored
         // several levels up from the model that holds the join clause.
+        boolean pushed = false;
         final QueryModel savedOrderByModel = lastSeenOrderByModel;
         try {
             final ObjList<ExpressionNode> orderBy = model.getOrderBy();
             if (orderBy != null && orderBy.size() > 0) {
                 lastSeenOrderByModel = model;
+
+                // when order-by specific here it would be pointless to require timestamp from the
+                // nested models
+                executionContext.pushTimestampRequiredFlag(false);
+                pushed = true;
             }
             RecordCursorFactory factory;
 
@@ -4686,6 +4692,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             return factory;
         } finally {
             lastSeenOrderByModel = savedOrderByModel;
+            if (pushed) {
+                executionContext.popTimestampRequiredFlag();
+            }
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -6903,6 +6903,73 @@ public class SampleByTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSampleByOrderBy() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE eq_equities_market_data (" +
+                    "timestamp TIMESTAMP, " +
+                    "symbol SYMBOL, " +
+                    "venue SYMBOL, " +
+                    "asks DOUBLE[][], bids DOUBLE[][]" +
+                    ") TIMESTAMP(timestamp) PARTITION BY DAY");
+            execute("INSERT INTO eq_equities_market_data VALUES " +
+                    "(0, 'HSBC', 'LSE', ARRAY[ [11.4, 12], [10.3, 15] ], ARRAY[ [21.1, 31], [20.1, 21] ]), " +
+                    "(1, 'HSBC', 'HKG', ARRAY[ [11.5, 13], [10.4, 14] ], ARRAY[ [21.2, 32], [20.2, 22] ]), " +
+                    "(2, 'BAC', 'NYSE', ARRAY[ [11.6, 17], [10.5, 15] ], ARRAY[ [21.3, 33], [20.3, 23] ]), " +
+                    "(3, 'HSBC', 'LSE', ARRAY[ [11.2, 30], [10.2, 16] ], ARRAY[ [21.4, 34], [20.4, 24] ]), " +
+                    "(4, 'BAC', 'NYSE', ARRAY[ [11.4, 20], [10.4,  7] ], ARRAY[ [21.5, 35], [20.5, 25] ]), " +
+                    "(5, 'MQG', 'ASX', ARRAY[ [16.0,  3], [15.0,  2] ], ARRAY[ [15.6, 36], [14.6, 26] ])"
+            );
+            drainWalQueue();
+
+            final String expected = """
+                    timestamp\tcount
+                    1970-01-01T00:00:00.000000Z\t1
+                    """;
+            // sample-by rewrite
+            assertQueryAndCache(
+                    expected,
+                    """
+                            select timestamp, count()
+                            from (
+                                (
+                                    select timestamp, symbol, count(bids[1][1]) as total
+                                    from eq_equities_market_data
+                                    where symbol = 'HSBC'
+                                    sample by 10s
+                                )
+                                order by timestamp
+                            )
+                            sample by 10m
+                            """,
+                    "timestamp",
+                    false,
+                    false
+            );
+
+            // sample by fill
+            assertQueryAndCache(
+                    expected,
+                    """
+                            select timestamp, count()
+                            from (
+                                (
+                                    select timestamp, symbol, count(bids[1][1]) as total
+                                    from eq_equities_market_data
+                                    where symbol = 'HSBC'
+                                    sample by 10s fill(prev)
+                                )
+                                order by timestamp
+                            )
+                            sample by 10m
+                            """,
+                    "timestamp",
+                    false,
+                    false
+            );
+        });
+    }
+
+    @Test
     public void testSampleByRewriteJoinNoTimestamp() throws Exception {
         Rnd rnd = TestUtils.generateRandom(LOG);
         setProperty(PropertyKey.DEBUG_CAIRO_COPIER_TYPE, rnd.nextInt(4));


### PR DESCRIPTION
## Problem

Nested `SAMPLE BY` queries with an `ORDER BY` clause in between incorrectly failed with:
```
ASC order over TIMESTAMP column is required but not provided
```

Example of failing query:
```sql
SELECT timestamp, count()
FROM (
    (
        SELECT timestamp, symbol, count(bids[1][1]) as total
        FROM eq_equities_market_data
        WHERE symbol = 'HSBC'
        SAMPLE BY 10s
    )
    ORDER BY timestamp
)
SAMPLE BY 10m
```

## Root Cause

When `SAMPLE BY` needs ordered timestamp data, it pushes `timestampRequired=true` onto a context stack. This flag propagates to nested models and throws an error if ASC timestamp order isn't guaranteed.

However, when there's an `ORDER BY` clause between the outer and inner `SAMPLE BY`, the inner model's ordering is irrelevant since `ORDER BY` will re-sort the data anyway.

## Fix

When an `ORDER BY` clause is present, push `timestampRequired=false` to signal that nested models don't need to maintain timestamp ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)