### PR TITLE
chore(build): improve coverage report accuracy

### DIFF
--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -182,6 +182,7 @@ stages:
             fetchDepth: 1
             lfs: false
             submodules: false
+            persistCredentials: true
           - download: current
             artifact: jacoco-coverage
             condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo'))
@@ -272,8 +273,15 @@ stages:
               done
               [ -f cobertura.xml ] && COVER_ARGS="$COVER_ARGS -type cobertura --cover cobertura.xml"
 
+              # cover-checker is able to automatically retrieve the diff from the Github Rest API.
+              # Unfortunately, it happpens that the Rest API responses are missing the patch field for some files
+              # which excludes these files from being covered.
+              git fetch origin $(System.PullRequest.targetBranchName)
+              git diff origin/$(System.PullRequest.targetBranchName)..HEAD > pr.diff
+
               $JAVA_HOME_17_X64/bin/java -jar \
                 $(Build.SourcesDirectory)/ci/cover-checker-1.5.0-all.jar \
+                -dt file -d pr.diff \
                 $COVER_ARGS --repo "questdb/questdb" --pr $(System.PullRequest.PullRequestNumber) \
                 -t $(DIFF_COVER_THRESHOLD_PCT) --github-token $(GH_TOKEN)
             displayName: "Post combined report to GitHub"


### PR DESCRIPTION
This PR improves the accuracy of the coverage reports. Previously, non-binary files may have been missing from the coverage report because of inconsistencies in the Github Rest API.

## Problem statement

The motivation for this change is that the `/repos/{owner}/{repo}/pulls/{pull_number}/files` endpoint of the Github Rest API seems to be inconsistent with the `git diff` command. We observed the `patch` field to be missing in some non-binary files.

## Changes

Instead of letting cover-checker rely on the Github Rest API to retrieve the files diff, we generate the diff manually with `git diff` and feed it to cover-checker.