### PR TITLE
optimise SELECT min(timestamp), max(timestamp) queries

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -6645,13 +6645,13 @@ public class SqlOptimiser implements Mutable {
         return root;
     }
 
-    private void replaceNestedWithFirstLastUnion(
+    private void replaceNestedWithMinMaxUnion(
             QueryModel model,
             QueryModel baseNested,
             CharSequence timestampColumn
     ) {
-        final QueryModel firstRowModel = createSelectModelWithLimit(baseNested, timestampColumn, "1");
-        final QueryModel lastRowModel = createSelectModelWithLimit(baseNested, timestampColumn, "-1");
+        QueryModel firstRowModel = createSelectModelWithLimit(baseNested, timestampColumn, "1");
+        QueryModel lastRowModel = createSelectModelWithLimit(baseNested, timestampColumn, "-1");
 
         firstRowModel.setUnionModel(lastRowModel);
         firstRowModel.setSetOperationType(QueryModel.SET_OPERATION_UNION);
@@ -6659,88 +6659,88 @@ public class SqlOptimiser implements Mutable {
         model.setNestedModel(firstRowModel);
     }
 
-    private boolean canOptimizeMultipleFirstLast(
+    private boolean canOptimizeMultipleMinMax(
             ObjList<QueryColumn> queryColumns,
             CharSequence timestampColumn
     ) {
-        boolean hasMinOrFirst = false;
-        boolean hasMaxOrLast = false;
+        boolean hasMin = false;
+        boolean hasMax = false;
 
         for (int i = 0, n = queryColumns.size(); i < n; i++) {
-            final QueryColumn column = queryColumns.get(i);
-            final ExpressionNode ast = column.getAst();
+            QueryColumn column = queryColumns.get(i);
+            ExpressionNode ast = column.getAst();
             if (ast == null || ast.type != FUNCTION || ast.rhs == null) {
                 return false;
             }
-            final CharSequence token = ast.token;
-            final CharSequence rhs = ast.rhs.token;
+            CharSequence token = ast.token;
+            CharSequence rhs = ast.rhs.token;
             if (!Chars.equals(timestampColumn, rhs)) {
                 return false;
             }
-            if (Chars.equalsIgnoreCase("min", token) || Chars.equalsIgnoreCase("first", token)) {
-                hasMinOrFirst = true;
-            } else if (Chars.equalsIgnoreCase("max", token) || Chars.equalsIgnoreCase("last", token)) {
-                hasMaxOrLast = true;
+            if (Chars.equalsIgnoreCase("min", token)) {
+                hasMin = true;
+            } else if (Chars.equalsIgnoreCase("max", token)) {
+                hasMax = true;
             } else {
                 return false;
             }
         }
 
-        return hasMinOrFirst && hasMaxOrLast;
+        return hasMin && hasMax;
     }
 
     private QueryModel createSelectModelWithLimit(QueryModel baseNested, CharSequence timestampColumn, String limitValue) {
-        final QueryModel nested = queryModelPool.next();
+        QueryModel nested = queryModelPool.next();
         nested.setTableNameExpr(baseNested.getTableNameExpr());
         nested.setModelType(baseNested.getModelType());
         nested.setTimestamp(baseNested.getTimestamp());
         nested.setWhereClause(baseNested.getWhereClause());
         nested.copyColumnsFrom(baseNested, queryColumnPool, expressionNodePool);
 
-        final QueryModel selectModel = queryModelPool.next();
+        QueryModel selectModel = queryModelPool.next();
         selectModel.setSelectModelType(QueryModel.SELECT_MODEL_CHOOSE);
         selectModel.setNestedModel(nested);
 
-        final ExpressionNode tsNode = expressionNodePool.next().of(LITERAL, timestampColumn, 0, 0);
-        final QueryColumn tsCol = queryColumnPool.next().of(timestampColumn, tsNode);
+        ExpressionNode tsNode = expressionNodePool.next().of(LITERAL, timestampColumn, 0, 0);
+        QueryColumn tsCol = queryColumnPool.next().of(timestampColumn, tsNode);
         selectModel.addBottomUpColumnIfNotExists(tsCol);
 
-        final ExpressionNode limitNode = expressionNodePool.next().of(CONSTANT, limitValue, 0, 0);
+        ExpressionNode limitNode = expressionNodePool.next().of(CONSTANT, limitValue, 0, 0);
         selectModel.setLimit(limitNode, null);
 
         return selectModel;
     }
 
-    private void rewriteMultipleFirstLastGroupBy(QueryModel model) {
+    private void rewriteMultipleMinMaxGroupBy(QueryModel model) {
         if (model.getSelectModelType() != QueryModel.SELECT_MODEL_GROUP_BY) {
-            final QueryModel nested = model.getNestedModel();
+            QueryModel nested = model.getNestedModel();
             if (nested != null) {
-                rewriteMultipleFirstLastGroupBy(nested);
+                rewriteMultipleMinMaxGroupBy(nested);
             }
-            final QueryModel union = model.getUnionModel();
+            QueryModel union = model.getUnionModel();
             if (union != null) {
-                rewriteMultipleFirstLastGroupBy(union);
+                rewriteMultipleMinMaxGroupBy(union);
             }
             ObjList<QueryModel> joinModels = model.getJoinModels();
             for (int i = 1, n = joinModels.size(); i < n; i++) {
-                rewriteMultipleFirstLastGroupBy(joinModels.getQuick(i));
+                rewriteMultipleMinMaxGroupBy(joinModels.getQuick(i));
             }
             return;
         }
 
-        final QueryModel nested = model.getNestedModel();
+        QueryModel nested = model.getNestedModel();
         if (nested == null || nested.getTimestamp() == null) {
             return;
         }
 
-        final ObjList<QueryColumn> queryColumns = model.getBottomUpColumns();
+        ObjList<QueryColumn> queryColumns = model.getBottomUpColumns();
         if (queryColumns.size() <= 1) {
             return;
         }
 
-        final CharSequence timestampColumn = nested.getTimestamp().token;
-        if (canOptimizeMultipleFirstLast(queryColumns, timestampColumn)) {
-            replaceNestedWithFirstLastUnion(model, nested, timestampColumn);
+        CharSequence timestampColumn = nested.getTimestamp().token;
+        if (canOptimizeMultipleMinMax(queryColumns, timestampColumn)) {
+            replaceNestedWithMinMaxUnion(model, nested, timestampColumn);
         }
     }
 
@@ -7547,7 +7547,7 @@ public class SqlOptimiser implements Mutable {
             optimiseBooleanNot(rewrittenModel);
             rewriteSingleFirstLastGroupBy(rewrittenModel);
             rewrittenModel = rewriteSelectClause(rewrittenModel, true, sqlExecutionContext, sqlParserCallback);
-            rewriteMultipleFirstLastGroupBy(rewrittenModel);
+            rewriteMultipleMinMaxGroupBy(rewrittenModel);
             rewriteTrivialGroupByExpressions(rewrittenModel);
             optimiseJoins(rewrittenModel);
             collapseStackedChooseModels(rewrittenModel);

--- a/core/src/test/java/io/questdb/test/griffin/SqlOptimiserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlOptimiserTest.java
@@ -42,7 +42,6 @@ import java.util.List;
 import static io.questdb.griffin.SqlOptimiser.aliasAppearsInFuncArgs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class SqlOptimiserTest extends AbstractSqlParserTest {
     private static final String orderByAdviceDdl = """


### PR DESCRIPTION
Attempt at closing https://github.com/questdb/questdb/issues/6325. Approach: rewrite query to: 

```sql
SELECT min(ts), max(ts) FROM (
      SELECT ts FROM trades LIMIT 1
      UNION
      SELECT ts FROM trades LIMIT -1
  )
```