### PR TITLE
fix(sql): fix `EXPLAIN UPDATE` resulting in error

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -25,7 +25,6 @@
 package io.questdb.griffin;
 
 import io.questdb.cairo.AbstractPartitionFrameCursorFactory;
-import io.questdb.cairo.AbstractRecordCursorFactory;
 import io.questdb.cairo.ArrayColumnTypes;
 import io.questdb.cairo.BitmapIndexReader;
 import io.questdb.cairo.CairoConfiguration;
@@ -6804,17 +6803,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         if (reader == null) {
             // This is WAL serialisation compilation. We don't need to read data from table
             // and don't need optimisation for query validation.
-            return new AbstractRecordCursorFactory(queryMeta) {
-                @Override
-                public boolean recordCursorSupportsRandomAccess() {
-                    return false;
-                }
-
-                @Override
-                public boolean supportsUpdateRowId(TableToken tableToken) {
-                    return metadata.getTableToken() == tableToken;
-                }
-            };
+            return new EmptyTableRecordCursorFactory(queryMeta, metadata.getTableToken());
         }
 
         GenericRecordMetadata dfcFactoryMeta = GenericRecordMetadata.deepCopyOf(metadata);

--- a/core/src/main/java/io/questdb/griffin/engine/EmptyTableRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/EmptyTableRecordCursorFactory.java
@@ -33,9 +33,15 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.Misc;
 
 public class EmptyTableRecordCursorFactory extends AbstractRecordCursorFactory {
+    private final TableToken tableToken;
 
     public EmptyTableRecordCursorFactory(RecordMetadata metadata) {
+        this(metadata, null);
+    }
+
+    public EmptyTableRecordCursorFactory(RecordMetadata metadata, TableToken tableToken) {
         super(metadata);
+        this.tableToken = tableToken;
     }
 
     @Override
@@ -50,12 +56,16 @@ public class EmptyTableRecordCursorFactory extends AbstractRecordCursorFactory {
 
     @Override
     public boolean supportsUpdateRowId(TableToken tableToken) {
-        return true;
+        return this.tableToken == null || this.tableToken == tableToken;
     }
 
     @Override
     public void toPlan(PlanSink sink) {
-        sink.type("Empty table");
+        if (tableToken != null) {
+            sink.type("on").val(": ").val(tableToken.getTableName());
+        } else {
+            sink.type("Empty table");
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes #6194

`EXPLAIN UPDATE` on WAL tables was throwing `UnsupportedOperationException` because the anonymous `RecordCursorFactory` created during WAL serialization phase did not implement `getCursor()`.

## Changes

- Modified `EmptyTableRecordCursorFactory` to accept an optional `TableToken` for proper `supportsUpdateRowId()` checks
- Replaced the anonymous factory in `SqlCodeGenerator.generateTableQuery0()` with `EmptyTableRecordCursorFactory`
- Updated `toPlan()` to show the table name when available (e.g., `on: trades`)
- Added regression test `testExplainUpdateWalTable`

## Test plan

- [x] `ExplainPlanTest#testExplainUpdateWalTable` - reproduces the issue from #6194
- [x] All `ExplainPlanTest` tests pass (515 tests)
- [x] `SqlCodeGeneratorTest` and `UpdateTest` pass