### PR TITLE
fix(sql): handle quoted column names with dots in JOIN metadata

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/join/JoinRecordMetadata.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/JoinRecordMetadata.java
@@ -160,7 +160,7 @@ public class JoinRecordMetadata extends AbstractRecordMetadata implements Closea
     }
 
     private int addAlias(CharSequence tableAlias, CharSequence columnName) {
-        int dot = Chars.indexOf(columnName, '.');
+        int dot = Chars.indexOfLastUnquoted(columnName, '.');
         // add column with its own alias
         MapKey key = map.withKey();
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/JoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/JoinTest.java
@@ -3561,6 +3561,28 @@ public class JoinTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testJoiningSubqueryWithDotInColumnName() throws Exception {
+        assertMemoryLeak(() -> {
+            assertQueryNoLeakCheck(
+                    """
+                            "foo.bar"	1
+                            1	1
+                            2	1
+                            3	1
+                            4	1
+                            5	1
+                            """,
+                    """
+                            SELECT * FROM (SELECT x as "foo.bar" FROM long_sequence(5))
+                            LEFT JOIN (select 1) ON true;
+                            """,
+                    null,
+                    false
+            );
+        });
+    }
+
+    @Test
     public void testLeftHashJoinOnFunctionCondition1() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table t1 (i int)");


### PR DESCRIPTION
fixes #6407