### PR TITLE
fix(sql): Handling of unexpected dot after the left parenthesis (#6535)

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -1618,7 +1618,7 @@ public class ExpressionParser {
                                 throw SqlException.$(lastPos, "qualifier expected");
                             }
                             if (en.type != ExpressionNode.LITERAL && en.type != ExpressionNode.CONSTANT) {
-                                throw SqlException.$(lexer.getContent().toString().lastIndexOf('.', lastPos), "unexpected dot");
+                                throw SqlException.$(lastPos, "unexpected dot");
                             }
                             // two possibilities here:
                             // 1. 'a.b'
@@ -1640,7 +1640,7 @@ public class ExpressionParser {
                                 cse.put(en.token).put(GenericLexer.unquoteIfNoDots(tok));
                                 opStack.push(expressionNodePool.next().of(
                                         ExpressionNode.LITERAL, cse.toImmutable(), Integer.MIN_VALUE, en.position));
-                            } else if (en.token instanceof GenericLexer.FloatingSequence) {
+                            } else {
                                 final GenericLexer.FloatingSequence fsA = (GenericLexer.FloatingSequence) en.token;
                                 // vanilla 'a.b', just concat tokens efficiently
                                 fsA.setHi(lexer.getTokenHi());

--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -1617,6 +1617,9 @@ public class ExpressionParser {
                             if (en == null) {
                                 throw SqlException.$(lastPos, "qualifier expected");
                             }
+                            if (en.type != ExpressionNode.LITERAL) {
+                                throw SqlException.$(lexer.getContent().toString().lastIndexOf('.', lastPos), "unexpected dot");
+                            }
                             // two possibilities here:
                             // 1. 'a.b'
                             // 2. 'a. b'
@@ -1641,8 +1644,6 @@ public class ExpressionParser {
                                 final GenericLexer.FloatingSequence fsA = (GenericLexer.FloatingSequence) en.token;
                                 // vanilla 'a.b', just concat tokens efficiently
                                 fsA.setHi(lexer.getTokenHi());
-                            } else {
-                                throw SqlException.$(lastPos - 1, "unexpected dot");
                             }
                         } else if (prevBranch == BRANCH_DOT_DEREFERENCE) {
                             argStackDepth++;

--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -1617,7 +1617,7 @@ public class ExpressionParser {
                             if (en == null) {
                                 throw SqlException.$(lastPos, "qualifier expected");
                             }
-                            if (en.type != ExpressionNode.LITERAL) {
+                            if (en.type != ExpressionNode.LITERAL && en.type != ExpressionNode.CONSTANT) {
                                 throw SqlException.$(lexer.getContent().toString().lastIndexOf('.', lastPos), "unexpected dot");
                             }
                             // two possibilities here:

--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -1637,10 +1637,12 @@ public class ExpressionParser {
                                 cse.put(en.token).put(GenericLexer.unquoteIfNoDots(tok));
                                 opStack.push(expressionNodePool.next().of(
                                         ExpressionNode.LITERAL, cse.toImmutable(), Integer.MIN_VALUE, en.position));
-                            } else {
+                            } else if (en.token instanceof GenericLexer.FloatingSequence) {
                                 final GenericLexer.FloatingSequence fsA = (GenericLexer.FloatingSequence) en.token;
                                 // vanilla 'a.b', just concat tokens efficiently
                                 fsA.setHi(lexer.getTokenHi());
+                            } else {
+                                throw SqlException.$(lastPos - 1, "unexpected dot");
                             }
                         } else if (prevBranch == BRANCH_DOT_DEREFERENCE) {
                             argStackDepth++;

--- a/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
@@ -1526,6 +1526,11 @@ public class ExpressionParserTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testLeftParenthesisUnexpectedDot() {
+        assertFail("SELECT - sym AS a2 FROM t1 a4 WHERE (.a4.col4 = 0);", 37, "unexpected dot");
+    }
+
+    @Test
     public void testUnquotedRegexFail() {
         assertFail(
                 "s ~ '.*TDF",

--- a/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
@@ -1285,6 +1285,17 @@ public class ExpressionParserTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testLeftParenthesisUnexpectedDot() {
+        assertFail("SELECT - sym AS a2 FROM t1 a4 WHERE (. = 0);", 39, "too few arguments for '=' [found=1,expected=2]");
+        assertFail("SELECT - sym AS a2 FROM t1 a4 WHERE (.a4 = 0);", 37, "unexpected dot");
+        assertFail("SELECT - sym AS a2 FROM t1 a4 WHERE (. a4 = 0);", 37, "unexpected dot");
+        assertFail("SELECT - sym AS a2 FROM t1 a4 WHERE (.a4.col4 = 0);", 37, "unexpected dot");
+        assertFail("SELECT - sym AS a2 FROM t1 a4 WHERE (. a4.col4 = 0);", 37, "unexpected dot");
+        assertFail("SELECT - sym AS a2 FROM t1 a4 WHERE (.a4. = 0);", 37, "unexpected dot");
+        assertFail("SELECT - sym AS a2 FROM t1 a4 WHERE (. a4. = 0);", 37, "unexpected dot");
+    }
+
+    @Test
     public void testListOfValues() throws SqlException {
         x("a.b", "a.b, c");
     }
@@ -1523,11 +1534,6 @@ public class ExpressionParserTest extends AbstractCairoTest {
     @Test
     public void testUnbalancedRightBraceExit() throws Exception {
         x("a 5 x y c b +", "a+b(5,c(x,y)))");
-    }
-
-    @Test
-    public void testLeftParenthesisUnexpectedDot() {
-        assertFail("SELECT - sym AS a2 FROM t1 a4 WHERE (.a4.col4 = 0);", 37, "unexpected dot");
     }
 
     @Test


### PR DESCRIPTION
fix(sql): Handling of unexpected dot after the left parenthesis (#6535)