### PR TITLE
fix(core): prevent rounding overflow from being ignored during decimal divisions

### DIFF
--- a/core/src/main/java/io/questdb/std/DecimalKnuthDivider.java
+++ b/core/src/main/java/io/questdb/std/DecimalKnuthDivider.java
@@ -414,7 +414,7 @@ public class DecimalKnuthDivider {
         }
 
         if (increment) {
-            for (int i = 0; i < n; i++) {
+            for (int i = 0, s = q.length; i < s; i++) {
                 if (++q[i] != 0) {
                     break;
                 }

--- a/core/src/test/java/io/questdb/test/std/Decimal128Test.java
+++ b/core/src/test/java/io/questdb/test/std/Decimal128Test.java
@@ -328,6 +328,16 @@ public class Decimal128Test {
         Assert.assertEquals(bdResult, result.toBigDecimal());
     }
 
+    @Test
+    public void testDivideIncrementOverflow() {
+        Decimal128 a = new Decimal128(0, -1, 19);
+        Decimal128 b = new Decimal128(0, 256, 14);
+
+        a.divide(b, 6, RoundingMode.HALF_UP);
+
+        Assert.assertEquals("720575940379.279360", a.toString());
+    }
+
     @Test(expected = NumericException.class)
     public void testDivideInvalidScale() {
         Decimal128 a = new Decimal128(0, 1, 0);


### PR DESCRIPTION
This pull request addresses an overflow issue when incrementing quotient digits during decimal division and adds a corresponding unit test to ensure correct behavior. The main changes are focused on improving the reliability and correctness of the decimal division logic.

**Bug fix in decimal division logic:**

* Updated the increment loop in `DecimalKnuthDivider.java` to use the actual length of the `q` array, preventing possible misses when incrementing quotient digits during rounding.

**Testing improvements:**

* Added a new unit test `testDivideIncrementOverflow` in `Decimal128Test.java` to verify correct handling of increment overflow during division and rounding.