### PR TITLE
ci(build): add alerts on failed docker builds

### DIFF
--- a/ci/docker-release-pipeline.yml
+++ b/ci/docker-release-pipeline.yml
@@ -111,7 +111,7 @@ jobs:
         inputs:
           script: |
             curl -X POST -H 'Content-type: application/json' \
-              --data '{"text":"🚨 *Docker Build Failed*\n\nBranch: `$(Build.SourceBranchName)`\nBuild: <$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)|#$(Build.BuildId)>\nCommit: `$(Build.SourceVersion)`"}' \
+              --data '{"text":"🚨 *Docker Build Failed (OSS)*\n\nBranch: `$(Build.SourceBranchName)`\nBuild: <$(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)|#$(Build.BuildId)>\nCommit: `$(Build.SourceVersion)`"}' \
               "$(BUILDS_SLACK_HOOK_URL)"
         condition: failed()
         env:


### PR DESCRIPTION
Adds a slack webhook call to notify on build failures.

Evidence that it works:
<img width="566" height="148" alt="image" src="https://github.com/user-attachments/assets/63777df6-4236-4197-b8f4-39e26096fab5" />


