### PR TITLE
fix(sql): WINDOW JOIN with ORDER BY ts DESC returns error

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -4322,6 +4322,7 @@ public class SqlOptimiser implements Mutable {
         if (model.getGroupBy().size() != 0
                 || model.getSampleBy() != null
                 || model.getSelectModelType() == SELECT_MODEL_DISTINCT
+                || model.getSelectModelType() == SELECT_MODEL_WINDOW_JOIN
                 || model.windowStopPropagate()) {
             jm1.setAllowPropagationOfOrderByAdvice(false);
             if (jm2 != null) {


### PR DESCRIPTION
Fixes `left side of time series join doesn't have ASC timestamp order` error when ORDER BY timestamp DESC is used in a WINDOW JOIN query.