### PR TITLE
fix(griffin): allow compatible cast to VARCHAR in CTAS

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationBuilderImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationBuilderImpl.java
@@ -411,7 +411,7 @@ public class CreateTableOperationBuilderImpl implements CreateTableOperationBuil
     }
 
     static boolean isCompatibleCast(int from, int to) {
-        if (from == to || isIPv4Cast(from, to)) {
+        if (from == to || isIPv4Cast(from, to) || ColumnType.isVarchar(to)) {
             return true;
         }
         return castGroups.getQuick(ColumnType.tagOf(from)) == castGroups.getQuick(ColumnType.tagOf(to));

--- a/core/src/test/java/io/questdb/test/griffin/Issue6583Test.java
+++ b/core/src/test/java/io/questdb/test/griffin/Issue6583Test.java
@@ -1,0 +1,50 @@
+package io.questdb.test.griffin;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class Issue6583Test extends AbstractCairoTest {
+
+    @Test
+    public void testCTASTrailingVarcharCast() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t_ctas_1 as (" +
+                    "select cast('2024-01-01' as timestamp) as x from long_sequence(1) " +
+                    "union all " +
+                    "select cast('2024-01-02' as varchar) as x from long_sequence(1))");
+
+            assertSql("column\ttype\n" +
+                      "x\tVARCHAR\n", 
+                      "select \"column\", type from table_columns('t_ctas_1')");
+        });
+    }
+
+    @Test
+    public void testVarcharAndStringUnionInCTAS() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t_ctas_2 AS (" +
+                "SELECT CAST('legacy_string' AS STRING) as payload FROM long_sequence(1) " +
+                "UNION ALL " +
+                "SELECT CAST('new_varchar' AS VARCHAR) as payload FROM long_sequence(1)" +
+                "), CAST(payload AS VARCHAR)"); 
+
+            assertSql("count\n2\n", "select count() from t_ctas_2");
+            assertSql("column\ttype\n" +
+                      "payload\tVARCHAR\n", 
+                      "select \"column\", type from table_columns('t_ctas_2')");
+        });
+    }
+
+    @Test
+    public void testLongVarcharCasting() throws Exception {
+        assertMemoryLeak(() -> {
+            String longStr = "this_is_a_very_long_string_that_exceeds_inlining_limits";
+            execute("CREATE TABLE t_ctas_3 AS (" +
+                "SELECT CAST('" + longStr + "' AS VARCHAR) as x " +
+                "FROM long_sequence(1)" +
+                "), CAST(x AS VARCHAR)");
+
+            assertSql("x\n" + longStr + "\n", "select x from t_ctas_3");
+        });
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes #6583 by adding `ColumnType.isVarchar(to)` to the `isCompatibleCast` check in `CreateTableOperationBuilderImpl`. This ensures that `CREATE TABLE AS SELECT` (CTAS) operations correctly recognize `VARCHAR` as a valid destination type when casting from other types (like `TIMESTAMP`).

## Changes
- Modified `CreateTableOperationBuilderImpl.java` to support compatible casts to `VARCHAR`.
- Added `Issue6583Test.java` with comprehensive test coverage:
    - `testCTASTrailingVarcharCast`: Verifies type resolution when mixing `TIMESTAMP` and `VARCHAR`.
    - `testVarcharAndStringUnionInCTAS`: Ensures compatibility between legacy `STRING` and new `VARCHAR` types.
    - `testLongVarcharCasting`: Validates handling of long strings that exceed inlining limits.

## Verification
- Ran `mvn clean compile -pl core` to ensure no syntax errors.
- Ran `mvn test -Dtest=Issue6583Test -pl core` 
    - Result: **BUILD SUCCESS** (All 3 tests passed).

### Test Result Evidence
<img width="742" height="284" alt="Screenshot from 2026-01-11 00-11-51" src="https://github.com/user-attachments/assets/7f32ce4b-ff17-426e-abae-475fd7051339" />