### PR TITLE
chore(sql): avoid NPE for missing expression in ORDER BY or unbalanced right parentheses in top level SELECT

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -147,6 +147,9 @@ public class SqlParser {
     private final LowerCaseCharSequenceHashSet viewsBeingCompiled = new LowerCaseCharSequenceHashSet();
     private final ObjectPool<WindowExpression> windowExpressionPool;
     private final ObjectPool<WithClauseModel> withClauseModelPool;
+    private boolean copyMode = false;
+    private boolean createTableMode = false;
+    private boolean createViewMode = false;
     private int digit;
     private boolean pivotMode = false;
     private boolean subQueryMode = false;
@@ -921,10 +924,15 @@ public class SqlParser {
 
         if (tok.length() == 1 && tok.charAt(0) == '(') {
             startOfSelect = lexer.getPosition();
-            parseDml(lexer, startOfSelect, sqlParserCallback);
-            final int endOfSelect = lexer.getPosition() - 1;
-            selectText = lexer.getContent().subSequence(startOfSelect, endOfSelect);
-            expectTok(lexer, ')');
+            copyMode = true;
+            try {
+                parseDml(lexer, startOfSelect, sqlParserCallback);
+                final int endOfSelect = lexer.getPosition() - 1;
+                selectText = lexer.getContent().subSequence(startOfSelect, endOfSelect);
+                expectTok(lexer, ')');
+            } finally {
+                copyMode = false;
+            }
         } else {
             lexer.unparseLast();
             target = expectExpr(lexer, sqlParserCallback);
@@ -1738,7 +1746,13 @@ public class SqlParser {
         final int startOfSelect = lexer.getPosition();
         // Parse SELECT for the sake of basic SQL validation.
         // It'll be compiled and optimized later, at the execution phase.
-        final QueryModel selectModel = parseDml(lexer, startOfSelect, sqlParserCallback);
+        QueryModel selectModel;
+        createTableMode = true;
+        try {
+            selectModel = parseDml(lexer, startOfSelect, sqlParserCallback);
+        } finally {
+            createTableMode = false;
+        }
         final int endOfSelect = lexer.getPosition() - 1;
         final String selectText = Chars.toString(lexer.getContent(), startOfSelect, endOfSelect);
         createTableOperationBuilder.setSelectText(selectText, startOfSelect);
@@ -2014,7 +2028,13 @@ public class SqlParser {
             expectTok(lexer, "select");
         }
         lexer.unparseLast();
-        final QueryModel queryModel = parseDml(lexer, lexer.getPosition(), sqlParserCallback);
+        final QueryModel queryModel;
+        try {
+            createViewMode = true;
+            queryModel = parseDml(lexer, lexer.getPosition(), sqlParserCallback);
+        } finally {
+            createViewMode = false;
+        }
         final int endOfQuery = enclosedInParentheses ? lexer.getPosition() - 1 : lexer.getPosition();
 
         final String viewSql = Chars.toString(lexer.getContent(), startOfQuery, endOfQuery);
@@ -2785,8 +2805,9 @@ public class SqlParser {
                     throw SqlException.$(lexer.lastTokenPosition(), "literal or expression expected");
                 }
 
+                // token can sometimes be null, like during parsing of CASE clause
                 if ((n.type == ExpressionNode.CONSTANT && Chars.equals("''", n.token))
-                        || (n.type == ExpressionNode.LITERAL && n.token.isEmpty())) {
+                        || (n.type == ExpressionNode.LITERAL && (n.token == null || n.token.isEmpty()))) {
                     throw SqlException.$(lexer.lastTokenPosition(), "non-empty literal or expression expected");
                 }
 
@@ -3719,10 +3740,20 @@ public class SqlParser {
                 accumulatedColumns.add(col);
                 accumulatedColumnPositions.add(colPosition);
 
-                if (tok == null || Chars.equals(tok, ';') || Chars.equals(tok, ')')) {
-                    //accept ending ')' in create table as
+                if (tok == null || Chars.equals(tok, ';')) {
                     lexer.unparseLast();
                     break;
+                }
+
+                if (Chars.equals(tok, ')')) {
+                    if (subQueryMode || createTableMode || copyMode || createViewMode) {
+                        // it's a balanced: ')'
+                        lexer.unparseLast();
+                        break;
+                    } else {
+                        // it's an unbalanced ')' in top-level SELECT
+                        throw SqlException.$(lexer.lastTokenPosition(), "unexpected token [)]");
+                    }
                 }
 
                 if (isFromKeyword(tok)) {
@@ -4612,6 +4643,9 @@ public class SqlParser {
         withClauseModelPool.clear();
         compileViewModelPool.clear();
         subQueryMode = false;
+        createTableMode = false;
+        copyMode = false;
+        createViewMode = false;
         characterStore.clear();
         insertModelPool.clear();
         pivotQueryColumnPool.clear();

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -7713,6 +7713,24 @@ public class SqlParserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testMissingExpressionInOrderByThrowsCorrectErrorMessage() throws Exception {
+        assertSyntaxError("SELECT a,b,c FROM t1 ORDER BY col1,,col2;", 35,
+                "literal or expression expected"
+        );
+
+        assertSyntaxError(
+                "SELECT  a,\n" +
+                        "  CASE \n" +
+                        "    WHEN col10 > '3975' THEN col7 \n" +
+                        "    WHEN col5 < '4045' FILL -3754167527262084558 \n" +
+                        "  END\n" +
+                        "FROM t1 \n" +
+                        "ORDER BY col1,,col2;", 133,
+                "literal or expression expected"
+        );
+    }
+
+    @Test
     public void testMissingTable() throws Exception {
         assertSyntaxError(
                 "select a from",
@@ -8110,70 +8128,6 @@ public class SqlParserTest extends AbstractSqlParserTest {
                         .col("a", ColumnType.INT)
                         .col("b", ColumnType.INT)
                         .col("c", ColumnType.INT)
-                        .timestamp("ts")
-        );
-    }
-
-    @Test
-    public void testWindowFunctionSimple() throws Exception {
-        // Basic window function without cast - should work
-        assertQuery(
-                "select-window row_number() row_number over (order by ts) from (select-choose [ts] ts from (select [ts] from x timestamp (ts)))",
-                "SELECT row_number() OVER (ORDER BY ts) FROM x",
-                modelOf("x")
-                        .timestamp("ts")
-        );
-    }
-
-    @Test
-    public void testWindowFunctionCastNoParen() throws Exception {
-        // Window function with cast - the window function is extracted to select-window,
-        // and the cast operation references it by alias in select-virtual
-        assertQuery(
-                "select-virtual row_number::string cast from (select-window [row_number() row_number over (order by ts)] row_number() row_number over (order by ts) from (select [ts] from x timestamp (ts)))",
-                "SELECT row_number() OVER (ORDER BY ts)::string FROM x",
-                modelOf("x")
-                        .timestamp("ts")
-        );
-    }
-
-    @Test
-    public void testWindowFunctionCastToString() throws Exception {
-        // Window function with cast AND outer parentheses - same structure as without parentheses
-        assertQuery(
-                "select-virtual row_number::string cast from (select-window [row_number() row_number over (order by ts)] row_number() row_number over (order by ts) from (select [ts] from x timestamp (ts)))",
-                "SELECT (row_number() OVER (ORDER BY ts))::string FROM x",
-                modelOf("x")
-                        .timestamp("ts")
-        );
-    }
-
-    @Test
-    public void testWindowFunctionArithmeticTwoWindows() throws Exception {
-        // Two window functions in arithmetic operation - sum() is both aggregate and window function name,
-        // but with OVER clause it should be treated as window function, not GROUP BY aggregate
-        assertQuery(
-                "select-virtual sum - lag id_diff from (select-window [lag(id) lag over (order by ts), sum(id) sum over (order by ts)] lag(id) lag over (order by ts), sum(id) sum over (order by ts) from (select [id, ts] from x timestamp (ts)))",
-                "SELECT sum(id) OVER (ORDER BY ts) - lag(id) OVER (ORDER BY ts) AS id_diff FROM x",
-                modelOf("x")
-                        .col("id", ColumnType.LONG)
-                        .timestamp("ts")
-        );
-    }
-
-    @Test
-    public void testWindowFunctionInCaseExpression() throws Exception {
-        // Window function directly inside CASE WHEN condition (two WHEN clauses with same window function)
-        // Both window functions are extracted to select-window layer with different aliases
-        assertQuery(
-                "select-virtual case when row_number = 1 then 'first' when row_number1 = 3 then 'last' else 'middle' end category from (select-window [row_number() row_number over (order by ts), row_number() row_number1 over (order by ts)] row_number() row_number over (order by ts), row_number() row_number1 over (order by ts) from (select [ts] from x timestamp (ts)))",
-                "SELECT CASE " +
-                        "  WHEN row_number() OVER (ORDER BY ts) = 1 THEN 'first' " +
-                        "  WHEN row_number() OVER (ORDER BY ts) = 3 THEN 'last' " +
-                        "  ELSE 'middle' " +
-                        "END AS category " +
-                        "FROM x",
-                modelOf("x")
                         .timestamp("ts")
         );
     }
@@ -12364,6 +12318,21 @@ public class SqlParserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testUnbalancedRightParenthesesThrowsCorrectErrorMessage() throws Exception {
+        assertSyntaxError("SELECT a,b+c) from t1;", 12,
+                "unexpected token [)]"
+        );
+        assertSyntaxError("SELECT ts, col6 AS a1, CASE WHEN col5 <> '192.168.150.217' THEN 754326 WHEN col1 = false THEN '' " +
+                        "WHEN ts <= ''''qocvwy'''' THEN col4 ELSE sym END, col4, -109639495026, '1986-05-10T21:39:17Z', '" +
+                        "2026-07-22T10:32:41.213795Z',) col2 AS a2, 'p', 0.0 AS a3 FROM t1 a4 LT JOIN t2 " +
+                        "a5 ON a4.timestamp = a5.timestamp LEFT OUTER JOIN t3 ON a4.col3 = t3.col3 LEFT col7 <= false " +
+                        "OR a4.sym <> col2 GROUP BY a5.col4, col4, a5.col7, col10 ORDER BY col7 ASC NULLS FIRST, a5.col10 DESC," +
+                        " a5.col3 DESC NULLS FIRST, 3 DESC LIMIT 194", 222,
+                "unexpected token [)]"
+        );
+    }
+
+    @Test
     public void testUndefinedBindVariables() throws SqlException {
         assertQuery(
                 "select-virtual $1 + 1 column, $2 $2, $3 $3 from (long_sequence(10))",
@@ -12710,6 +12679,19 @@ public class SqlParserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testWindowFunctionArithmeticTwoWindows() throws Exception {
+        // Two window functions in arithmetic operation - sum() is both aggregate and window function name,
+        // but with OVER clause it should be treated as window function, not GROUP BY aggregate
+        assertQuery(
+                "select-virtual sum - lag id_diff from (select-window [lag(id) lag over (order by ts), sum(id) sum over (order by ts)] lag(id) lag over (order by ts), sum(id) sum over (order by ts) from (select [id, ts] from x timestamp (ts)))",
+                "SELECT sum(id) OVER (ORDER BY ts) - lag(id) OVER (ORDER BY ts) AS id_diff FROM x",
+                modelOf("x")
+                        .col("id", ColumnType.LONG)
+                        .timestamp("ts")
+        );
+    }
+
+    @Test
     public void testWindowFunctionAsArgumentToFunctionNotSupported() throws Exception {
         assertMemoryLeak(() -> {
             // Window function as argument to cast() - not allowed
@@ -12729,6 +12711,46 @@ public class SqlParserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testWindowFunctionCastNoParen() throws Exception {
+        // Window function with cast - the window function is extracted to select-window,
+        // and the cast operation references it by alias in select-virtual
+        assertQuery(
+                "select-virtual row_number::string cast from (select-window [row_number() row_number over (order by ts)] row_number() row_number over (order by ts) from (select [ts] from x timestamp (ts)))",
+                "SELECT row_number() OVER (ORDER BY ts)::string FROM x",
+                modelOf("x")
+                        .timestamp("ts")
+        );
+    }
+
+    @Test
+    public void testWindowFunctionCastToString() throws Exception {
+        // Window function with cast AND outer parentheses - same structure as without parentheses
+        assertQuery(
+                "select-virtual row_number::string cast from (select-window [row_number() row_number over (order by ts)] row_number() row_number over (order by ts) from (select [ts] from x timestamp (ts)))",
+                "SELECT (row_number() OVER (ORDER BY ts))::string FROM x",
+                modelOf("x")
+                        .timestamp("ts")
+        );
+    }
+
+    @Test
+    public void testWindowFunctionInCaseExpression() throws Exception {
+        // Window function directly inside CASE WHEN condition (two WHEN clauses with same window function)
+        // Both window functions are extracted to select-window layer with different aliases
+        assertQuery(
+                "select-virtual case when row_number = 1 then 'first' when row_number1 = 3 then 'last' else 'middle' end category from (select-window [row_number() row_number over (order by ts), row_number() row_number1 over (order by ts)] row_number() row_number over (order by ts), row_number() row_number1 over (order by ts) from (select [ts] from x timestamp (ts)))",
+                "SELECT CASE " +
+                        "  WHEN row_number() OVER (ORDER BY ts) = 1 THEN 'first' " +
+                        "  WHEN row_number() OVER (ORDER BY ts) = 3 THEN 'last' " +
+                        "  ELSE 'middle' " +
+                        "END AS category " +
+                        "FROM x",
+                modelOf("x")
+                        .timestamp("ts")
+        );
+    }
+
+    @Test
     public void testWindowFunctionReferencesSameColumnAsVirtual() throws Exception {
         assertQuery(
                 "select-window a, b1, f(c) f over (partition by b11 order by ts) from (select-virtual [a, concat(b, 'abc') b1, c, b1 b11, ts] a, concat(b, 'abc') b1, c, b1 b11, ts from (select-choose [a, b, c, b b1, ts] a, b, c, b b1, ts from (select [a, b, c, ts] from xyz k timestamp (ts)) k) k) k",
@@ -12737,6 +12759,17 @@ public class SqlParserTest extends AbstractSqlParserTest {
                         .col("c", ColumnType.INT)
                         .col("b", ColumnType.INT)
                         .col("a", ColumnType.INT)
+                        .timestamp("ts")
+        );
+    }
+
+    @Test
+    public void testWindowFunctionSimple() throws Exception {
+        // Basic window function without cast - should work
+        assertQuery(
+                "select-window row_number() row_number over (order by ts) from (select-choose [ts] ts from (select [ts] from x timestamp (ts)))",
+                "SELECT row_number() OVER (ORDER BY ts) FROM x",
+                modelOf("x")
                         .timestamp("ts")
         );
     }


### PR DESCRIPTION
**Summary**:
1. Avoid NullPointerException when there is a missing expression in ORDER BY.
2. Avoid NullPointerException when there is a unbalanced right prentheses in top level SELECT.

**Problem**
As reported in [issue](https://github.com/questdb/questdb/issues/6536), some SQLs are invalid due to missing expression or unablanced right parentheses, but fail with NPE instead of SQL exception with appropriate message.

**Root Cause**
Though missing expression in ORDER BY clause is captured as empty token, but for some scenarios( like, CASE clause being present) it is captured as null token.
Unabalanced right parentheses not handled correctly, leading to creation of null objects during sql parsing.

**Changes**
1. **SqlParser.java::parseFromClause** : For handling NPE when there is a missing expression in ORDER BY clause, add check for null token in code block where ORER-BY clause is parsed.
2. **SqlParser.java::parseSelectClause** : Unabalanced right parentheses in top elevel SELECT clause is captured and sql exception is generated, using appropriate flags to handle subquery mode, copy mode, create tabel mode, create view mode normally.

**Test Plan**
1. Added 2 tests in SqlParserTest.java to capture the scenarios(testUnbalancedRightParenthesesThrowsCorrectErrorMessage, testMissingExpressionInOrderByThrowsCorrectErrorMessage).
2. All 918 tests in SqlParserTest.java pass.
3. Failing queries mentioned in issue now throw SQL exception with correct error message.
4. All tests in PGErrorHandlingTest, HttpErrorHandlingTest pass.


