### PR TITLE
feat(sql): add bool_and() and bool_or() aggregate functions

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/AndFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/AndFunctionFactory.java
@@ -76,13 +76,11 @@ public class AndFunctionFactory implements FunctionFactory {
             }
         }
 
-        if (leftFunc instanceof AndBooleanFunction) {
-            AndBooleanFunction leftAndFunc = (AndBooleanFunction) leftFunc;
+        if (leftFunc instanceof AndBooleanFunction leftAndFunc) {
             return new TernaryAndBooleanFunction(leftAndFunc.left, leftAndFunc.right, rightFunc);
         }
 
-        if (leftFunc instanceof TernaryAndBooleanFunction) {
-            TernaryAndBooleanFunction leftAndFunc = (TernaryAndBooleanFunction) leftFunc;
+        if (leftFunc instanceof TernaryAndBooleanFunction leftAndFunc) {
             return new QuaternaryAndBooleanFunction(leftAndFunc.left, leftAndFunc.center, leftAndFunc.right, rightFunc);
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/BoolAndGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/BoolAndGroupByFunction.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Boolean AND aggregate function - returns true if all values are true, false otherwise.
+ * Returns false for empty groups (SQL standard would return null, but QuestDB booleans don't support null).
+ */
+public class BoolAndGroupByFunction extends BooleanFunction implements GroupByFunction, UnaryFunction {
+    private final Function arg;
+    private int valueIndex;
+
+    public BoolAndGroupByFunction(@NotNull Function arg) {
+        this.arg = arg;
+    }
+
+    @Override
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putBool(valueIndex, arg.getBool(record));
+        mapValue.putLong(valueIndex + 1, 1L);
+    }
+
+    @Override
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        // Short-circuit: if already false, stay false
+        if (mapValue.getBool(valueIndex)) {
+            mapValue.putBool(valueIndex, arg.getBool(record));
+        }
+        mapValue.addLong(valueIndex + 1, 1L);
+    }
+
+    @Override
+    public Function getArg() {
+        return arg;
+    }
+
+    @Override
+    public boolean getBool(Record rec) {
+        // Empty group returns false (could be considered null in strict SQL)
+        if (rec.getLong(valueIndex + 1) == 0) {
+            return false;
+        }
+        return rec.getBool(valueIndex);
+    }
+
+    @Override
+    public String getName() {
+        return "bool_and";
+    }
+
+    @Override
+    public int getValueIndex() {
+        return valueIndex;
+    }
+
+    @Override
+    public void initValueIndex(int valueIndex) {
+        this.valueIndex = valueIndex;
+    }
+
+    @Override
+    public void initValueTypes(ArrayColumnTypes columnTypes) {
+        this.valueIndex = columnTypes.getColumnCount();
+        columnTypes.add(ColumnType.BOOLEAN); // aggregate result
+        columnTypes.add(ColumnType.LONG);    // count (for empty group detection)
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
+    public boolean isThreadSafe() {
+        return UnaryFunction.super.isThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcCount = srcValue.getLong(valueIndex + 1);
+        if (srcCount == 0) {
+            return; // Source has no data
+        }
+        long destCount = destValue.getLong(valueIndex + 1);
+        if (destCount == 0) {
+            // Destination empty: copy from source
+            destValue.putBool(valueIndex, srcValue.getBool(valueIndex));
+            destValue.putLong(valueIndex + 1, srcCount);
+        } else {
+            // Merge: AND the results
+            destValue.putBool(valueIndex, destValue.getBool(valueIndex) && srcValue.getBool(valueIndex));
+            destValue.putLong(valueIndex + 1, destCount + srcCount);
+        }
+    }
+
+    @Override
+    public void setNull(MapValue mapValue) {
+        mapValue.putBool(valueIndex, true); // Identity for AND
+        mapValue.putLong(valueIndex + 1, 0L);
+    }
+
+    @Override
+    public boolean supportsParallelism() {
+        return UnaryFunction.super.supportsParallelism();
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/BoolAndGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/BoolAndGroupByFunctionFactory.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.constants.BooleanConstant;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class BoolAndGroupByFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "bool_and(T)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        Function arg = args.getQuick(0);
+        if (arg.isConstant()) {
+            // bool_and(true) = true, bool_and(false) = false
+            return BooleanConstant.of(arg.getBool(null));
+        }
+        return new BoolAndGroupByFunction(arg);
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/BoolOrGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/BoolOrGroupByFunction.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Boolean OR aggregate function - returns true if any value is true, false otherwise.
+ * Returns false for empty groups (SQL standard would return null, but QuestDB booleans don't support null).
+ */
+public class BoolOrGroupByFunction extends BooleanFunction implements GroupByFunction, UnaryFunction {
+    private final Function arg;
+    private int valueIndex;
+
+    public BoolOrGroupByFunction(@NotNull Function arg) {
+        this.arg = arg;
+    }
+
+    @Override
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putBool(valueIndex, arg.getBool(record));
+        mapValue.putLong(valueIndex + 1, 1L);
+    }
+
+    @Override
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        // Short-circuit: if already true, stay true
+        if (!mapValue.getBool(valueIndex)) {
+            mapValue.putBool(valueIndex, arg.getBool(record));
+        }
+        mapValue.addLong(valueIndex + 1, 1L);
+    }
+
+    @Override
+    public Function getArg() {
+        return arg;
+    }
+
+    @Override
+    public boolean getBool(Record rec) {
+        // Empty group returns false (could be considered null in strict SQL)
+        if (rec.getLong(valueIndex + 1) == 0) {
+            return false;
+        }
+        return rec.getBool(valueIndex);
+    }
+
+    @Override
+    public String getName() {
+        return "bool_or";
+    }
+
+    @Override
+    public int getValueIndex() {
+        return valueIndex;
+    }
+
+    @Override
+    public void initValueIndex(int valueIndex) {
+        this.valueIndex = valueIndex;
+    }
+
+    @Override
+    public void initValueTypes(ArrayColumnTypes columnTypes) {
+        this.valueIndex = columnTypes.getColumnCount();
+        columnTypes.add(ColumnType.BOOLEAN); // aggregate result
+        columnTypes.add(ColumnType.LONG);    // count (for empty group detection)
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
+    public boolean isThreadSafe() {
+        return UnaryFunction.super.isThreadSafe();
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcCount = srcValue.getLong(valueIndex + 1);
+        if (srcCount == 0) {
+            return; // Source has no data
+        }
+        long destCount = destValue.getLong(valueIndex + 1);
+        if (destCount == 0) {
+            // Destination empty: copy from source
+            destValue.putBool(valueIndex, srcValue.getBool(valueIndex));
+            destValue.putLong(valueIndex + 1, srcCount);
+        } else {
+            // Merge: OR the results
+            destValue.putBool(valueIndex, destValue.getBool(valueIndex) || srcValue.getBool(valueIndex));
+            destValue.putLong(valueIndex + 1, destCount + srcCount);
+        }
+    }
+
+    @Override
+    public void setNull(MapValue mapValue) {
+        mapValue.putBool(valueIndex, false); // Identity for OR
+        mapValue.putLong(valueIndex + 1, 0L);
+    }
+
+    @Override
+    public boolean supportsParallelism() {
+        return UnaryFunction.super.supportsParallelism();
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/BoolOrGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/BoolOrGroupByFunctionFactory.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.constants.BooleanConstant;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class BoolOrGroupByFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "bool_or(T)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        Function arg = args.getQuick(0);
+        if (arg.isConstant()) {
+            // bool_or(true) = true, bool_or(false) = false
+            return BooleanConstant.of(arg.getBool(null));
+        }
+        return new BoolOrGroupByFunction(arg);
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/BoolAndGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/BoolAndGroupByFunctionFactoryTest.java
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class BoolAndGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testBoolAndAllTrue() throws Exception {
+        assertQuery(
+                """
+                        bool_and
+                        true
+                        """,
+                "select bool_and(f) from tab",
+                "create table tab as (select true as f from long_sequence(5))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolAndAllFalse() throws Exception {
+        assertQuery(
+                """
+                        bool_and
+                        false
+                        """,
+                "select bool_and(f) from tab",
+                "create table tab as (select false as f from long_sequence(5))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolAndMixed() throws Exception {
+        // One false makes the entire result false
+        assertQuery(
+                """
+                        bool_and
+                        false
+                        """,
+                "select bool_and(f) from tab",
+                "create table tab as (" +
+                        "select true as f from long_sequence(3) " +
+                        "union all " +
+                        "select false as f from long_sequence(1)" +
+                        ")",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolAndEmpty() throws Exception {
+        // Empty table returns false (identity for AND in terms of aggregation)
+        assertQuery(
+                """
+                        bool_and
+                        false
+                        """,
+                "select bool_and(f) from tab",
+                "create table tab (f boolean)",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolAndSingleTrue() throws Exception {
+        assertQuery(
+                """
+                        bool_and
+                        true
+                        """,
+                "select bool_and(f) from tab",
+                "create table tab as (select true as f from long_sequence(1))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolAndSingleFalse() throws Exception {
+        assertQuery(
+                """
+                        bool_and
+                        false
+                        """,
+                "select bool_and(f) from tab",
+                "create table tab as (select false as f from long_sequence(1))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolAndWithGroupBy() throws Exception {
+        assertQuery(
+                """
+                        g\tbool_and
+                        A\ttrue
+                        B\tfalse
+                        C\tfalse
+                        """,
+                "select g, bool_and(f) from tab order by g",
+                "create table tab as (" +
+                        "select 'A' as g, true as f from long_sequence(3) " +
+                        "union all " +
+                        "select 'B' as g, false as f from long_sequence(2) " +
+                        "union all " +
+                        "select 'B' as g, true as f from long_sequence(1) " +
+                        "union all " +
+                        "select 'C' as g, true as f from long_sequence(2) " +
+                        "union all " +
+                        "select 'C' as g, false as f from long_sequence(1)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolAndWithExpression() throws Exception {
+        // Using a boolean expression
+        assertQuery(
+                """
+                        bool_and
+                        false
+                        """,
+                "select bool_and(x > 0) from tab",
+                "create table tab as (select x - 5 as x from long_sequence(10))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolAndWithSampleBy() throws Exception {
+        assertQuery(
+                """
+                        k\tbool_and
+                        1970-01-01T00:00:00.000000Z\ttrue
+                        1970-01-01T01:00:00.000000Z\ttrue
+                        1970-01-01T02:00:00.000000Z\ttrue
+                        """,
+                "select k, bool_and(f) from tab sample by 1h",
+                "create table tab as (" +
+                        "select true as f, " +
+                        "timestamp_sequence(0, 60*60*1000000L/10) k " +
+                        "from long_sequence(30)" +
+                        ") timestamp(k) partition by HOUR",
+                "k",
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolAndWithSampleByMixed() throws Exception {
+        assertQuery(
+                """
+                        k\tbool_and
+                        1970-01-01T00:00:00.000000Z\tfalse
+                        1970-01-01T01:00:00.000000Z\tfalse
+                        1970-01-01T02:00:00.000000Z\tfalse
+                        """,
+                "select k, bool_and(f) from tab sample by 1h",
+                "create table tab as (" +
+                        "select (x % 2 = 0) as f, " +
+                        "timestamp_sequence(0, 60*60*1000000L/10) k " +
+                        "from long_sequence(30)" +
+                        ") timestamp(k) partition by HOUR",
+                "k",
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolAndConstantTrue() throws Exception {
+        // Constant folding: bool_and(true) = true
+        assertQuery(
+                """
+                        bool_and
+                        true
+                        """,
+                "select bool_and(true) from tab",
+                "create table tab as (select x from long_sequence(5))",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolAndConstantFalse() throws Exception {
+        // Constant folding: bool_and(false) = false
+        assertQuery(
+                """
+                        bool_and
+                        false
+                        """,
+                "select bool_and(false) from tab",
+                "create table tab as (select x from long_sequence(5))",
+                null,
+                true,
+                true
+        );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/BoolOrGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/BoolOrGroupByFunctionFactoryTest.java
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class BoolOrGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testBoolOrAllTrue() throws Exception {
+        assertQuery(
+                """
+                        bool_or
+                        true
+                        """,
+                "select bool_or(f) from tab",
+                "create table tab as (select true as f from long_sequence(5))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolOrAllFalse() throws Exception {
+        assertQuery(
+                """
+                        bool_or
+                        false
+                        """,
+                "select bool_or(f) from tab",
+                "create table tab as (select false as f from long_sequence(5))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolOrMixed() throws Exception {
+        // One true makes the entire result true
+        assertQuery(
+                """
+                        bool_or
+                        true
+                        """,
+                "select bool_or(f) from tab",
+                "create table tab as (" +
+                        "select false as f from long_sequence(3) " +
+                        "union all " +
+                        "select true as f from long_sequence(1)" +
+                        ")",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolOrEmpty() throws Exception {
+        // Empty table returns false (identity for OR in terms of aggregation)
+        assertQuery(
+                """
+                        bool_or
+                        false
+                        """,
+                "select bool_or(f) from tab",
+                "create table tab (f boolean)",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolOrSingleTrue() throws Exception {
+        assertQuery(
+                """
+                        bool_or
+                        true
+                        """,
+                "select bool_or(f) from tab",
+                "create table tab as (select true as f from long_sequence(1))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolOrSingleFalse() throws Exception {
+        assertQuery(
+                """
+                        bool_or
+                        false
+                        """,
+                "select bool_or(f) from tab",
+                "create table tab as (select false as f from long_sequence(1))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolOrWithGroupBy() throws Exception {
+        assertQuery(
+                """
+                        g\tbool_or
+                        A\tfalse
+                        B\ttrue
+                        C\ttrue
+                        """,
+                "select g, bool_or(f) from tab order by g",
+                "create table tab as (" +
+                        "select 'A' as g, false as f from long_sequence(3) " +
+                        "union all " +
+                        "select 'B' as g, false as f from long_sequence(2) " +
+                        "union all " +
+                        "select 'B' as g, true as f from long_sequence(1) " +
+                        "union all " +
+                        "select 'C' as g, false as f from long_sequence(2) " +
+                        "union all " +
+                        "select 'C' as g, true as f from long_sequence(1)" +
+                        ")",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolOrWithExpression() throws Exception {
+        // Using a boolean expression
+        assertQuery(
+                """
+                        bool_or
+                        true
+                        """,
+                "select bool_or(x > 5) from tab",
+                "create table tab as (select x from long_sequence(10))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolOrWithSampleBy() throws Exception {
+        assertQuery(
+                """
+                        k\tbool_or
+                        1970-01-01T00:00:00.000000Z\tfalse
+                        1970-01-01T01:00:00.000000Z\tfalse
+                        1970-01-01T02:00:00.000000Z\tfalse
+                        """,
+                "select k, bool_or(f) from tab sample by 1h",
+                "create table tab as (" +
+                        "select false as f, " +
+                        "timestamp_sequence(0, 60*60*1000000L/10) k " +
+                        "from long_sequence(30)" +
+                        ") timestamp(k) partition by HOUR",
+                "k",
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolOrWithSampleByMixed() throws Exception {
+        assertQuery(
+                """
+                        k\tbool_or
+                        1970-01-01T00:00:00.000000Z\ttrue
+                        1970-01-01T01:00:00.000000Z\ttrue
+                        1970-01-01T02:00:00.000000Z\ttrue
+                        """,
+                "select k, bool_or(f) from tab sample by 1h",
+                "create table tab as (" +
+                        "select (x % 3 = 0) as f, " +
+                        "timestamp_sequence(0, 60*60*1000000L/10) k " +
+                        "from long_sequence(30)" +
+                        ") timestamp(k) partition by HOUR",
+                "k",
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolOrConstantTrue() throws Exception {
+        // Constant folding: bool_or(true) = true
+        assertQuery(
+                """
+                        bool_or
+                        true
+                        """,
+                "select bool_or(true) from tab",
+                "create table tab as (select x from long_sequence(5))",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testBoolOrConstantFalse() throws Exception {
+        // Constant folding: bool_or(false) = false
+        assertQuery(
+                """
+                        bool_or
+                        false
+                        """,
+                "select bool_or(false) from tab",
+                "create table tab as (select x from long_sequence(5))",
+                null,
+                true,
+                true
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `bool_and(T)` aggregate function - returns true if all values are true, false otherwise
- Add `bool_or(T)` aggregate function - returns true if any value is true, false otherwise

## Features
- Support for parallel execution via `merge()` method
- Works with `GROUP BY` clauses
- Works with `SAMPLE BY` clauses  
- Accepts boolean expressions as arguments (e.g., `bool_and(x > 5)`)
- Constant folding optimization - when argument is constant, returns result directly without row-by-row computation

## Test plan
- [x] Unit tests for basic functionality (all true, all false, mixed)
- [x] Tests for empty tables
- [x] Tests with GROUP BY
- [x] Tests with SAMPLE BY
- [x] Tests with boolean expressions
- [x] Tests for constant folding optimization

🤖 Generated with [Claude Code](https://claude.ai/code)