### PR TITLE
test(sql): add tests for parenthesis handling mode flags

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -12330,6 +12330,27 @@ public class SqlParserTest extends AbstractSqlParserTest {
                         " a5.col3 DESC NULLS FIRST, 3 DESC LIMIT 194", 222,
                 "unexpected token [)]"
         );
+
+        // Verify ) in CREATE TABLE AS SELECT context is treated as closing the outer paren,
+        // not as an unbalanced paren - this confirms the createTableMode flag works correctly
+        assertSyntaxError("CREATE TABLE t2 AS (SELECT a,b+c) FROM t1)", 34,
+                "unexpected token [FROM]"
+        );
+
+        // Same test with nested parentheses inside expression
+        assertSyntaxError("CREATE TABLE t2 AS (SELECT a, (b+c)) FROM t1)", 37,
+                "unexpected token [FROM]"
+        );
+
+        // Verify ) in CREATE VIEW context is treated correctly - confirms createViewMode flag works
+        assertSyntaxError("CREATE VIEW v1 AS (SELECT a,b+c) FROM t1)", 33,
+                "unexpected token [FROM]"
+        );
+
+        // Verify ) in subquery context is treated correctly - confirms subQueryMode flag works
+        assertSyntaxError("SELECT * FROM (SELECT a,b+c) WHERE 1=1)", 38,
+                "unexpected token [)]"
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add test cases to verify that the mode flags (`createTableMode`, `createViewMode`, `subQueryMode`) correctly distinguish between balanced closing parentheses and unbalanced parentheses in different SQL parsing contexts

## Context
This is a follow-up to PR #6644 which fixed NPE issues with invalid SQL containing unbalanced parentheses. During code review, it was identified that additional test coverage would be beneficial to ensure the mode flags work correctly in all contexts.

## Test Plan
- All 923 tests in SqlParserTest pass
- New tests verify:
  - `)` in CREATE TABLE AS SELECT is treated as closing the outer paren (createTableMode)
  - `)` in CREATE VIEW is treated correctly (createViewMode)
  - `)` in subquery context is treated correctly (subQueryMode)

🤖 Generated with [Claude Code](https://claude.ai/code)