### PR TITLE
perf(sql): apply scan optimization for `first/last/min/max(timestamp)` as function argument 

### DIFF
--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -1284,6 +1284,12 @@ public class QueryModel implements Mutable, ExecutionModel, AliasTranslator, Sin
         }
     }
 
+    public void replaceColumnNameMap(CharSequence alias, CharSequence oldToken, CharSequence newToken) {
+        aliasToColumnNameMap.put(alias, newToken);
+        columnNameToAliasMap.remove(oldToken);
+        columnNameToAliasMap.put(newToken, alias);
+    }
+
     public void replaceJoinModel(int pos, QueryModel model) {
         joinModels.setQuick(pos, model);
     }

--- a/core/src/test/java/io/questdb/test/griffin/SqlOptimiserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlOptimiserTest.java
@@ -479,6 +479,35 @@ public class SqlOptimiserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testFirstLastTimestampFunctionAsArgument() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table y ( x int, ts timestamp) timestamp(ts);");
+            String queryTemplate = "select dateadd('m', -15, %s(ts)) from y";
+            String[] functions = {"first", "last", "min", "max"};
+            String[] scanDirection = {"forward", "backward", "forward", "backward"};
+            String modelTemplate = "select-virtual dateadd('m', -(15), %s) dateadd from (select-choose [ts %s] ts %s from (select [ts] from y timestamp (ts))%s limit 1)";
+            String planTemplate = """
+                    VirtualRecord
+                      functions: [dateadd('m',-15,%s)]
+                        Limit value: 1 skip-rows: 0 take-rows: 0
+                            SelectedRecord
+                                PageFrame
+                                    Row %s scan
+                                    Frame %s scan on: y
+                    """;
+            for (int i = 0; i < functions.length; i++) {
+                String query = String.format(queryTemplate, functions[i]);
+                QueryModel model = compileModel(query);
+                TestUtils.assertEquals(String.format(modelTemplate, functions[i], functions[i], functions[i], i % 2 == 1 ? String.format(" order by %s desc", functions[i]) : ""), model.toString0());
+                assertPlanNoLeakCheck(
+                        query,
+                        String.format(planTemplate, functions[i], scanDirection[i], scanDirection[i])
+                );
+            }
+        });
+    }
+
+    @Test
     public void testFunctionMemoizationBasicColumnRefCount() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table x (a int, b double, c string)");
@@ -5576,6 +5605,77 @@ public class SqlOptimiserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testWindowFunctionDeduplicationWhenNestedInExpression() throws Exception {
+        // This test verifies that when a window function appears first inside an expression
+        // (e.g., abs(row_number() over(...))) and then as a top-level window column
+        // (e.g., row_number() over(...)), they are properly deduplicated.
+        // Bug: replaceIfWindowFunction() (called via emitWindowFunctions) adds window functions
+        // to windowModel but doesn't register them in windowFunctionHashMap, causing
+        // findDuplicateWindowFunction() to miss them when processing later identical windows.
+        assertMemoryLeak(() -> {
+            execute("create table t ( x int, ts timestamp) timestamp(ts);");
+            execute("insert into t select x, x::timestamp from long_sequence(3)");
+
+            // Case 1: Window function nested in expression appears BEFORE the same top-level window function
+            // If deduplication works correctly, there should be only ONE window function in the plan
+            String q1 = "select abs(row_number() over(order by x)), row_number() over(order by x) from t";
+
+            assertPlanNoLeakCheck(
+                    q1,
+                    """
+                            VirtualRecord
+                              functions: [abs(row_number),row_number]
+                                CachedWindow
+                                  orderedFunctions: [[x] => [row_number()]]
+                                    PageFrame
+                                        Row forward scan
+                                        Frame forward scan on: t
+                            """
+            );
+
+            // Verify the result is correct
+            assertSql("""
+                    abs\trow_number
+                    1\t1
+                    2\t2
+                    3\t3
+                    """, q1);
+
+            // Case 2: Same test but with partition by clause
+            String q2 = "select abs(row_number() over(partition by x order by ts)), row_number() over(partition by x order by ts) from t";
+
+            assertPlanNoLeakCheck(
+                    q2,
+                    """
+                            VirtualRecord
+                              functions: [abs(row_number),row_number]
+                                Window
+                                  functions: [row_number() over (partition by [x])]
+                                    PageFrame
+                                        Row forward scan
+                                        Frame forward scan on: t
+                            """
+            );
+
+            // Case 3: Multiple nested window functions that are the same
+            String q3 = "select abs(row_number() over(order by x)) + abs(row_number() over(order by x)), row_number() over(order by x) from t";
+
+            assertPlanNoLeakCheck(
+                    q3,
+                    """
+                            VirtualRecord
+                              functions: [abs(row_number)+abs(row_number),row_number]
+                                CachedWindow
+                                  orderedFunctions: [[x] => [row_number()]]
+                                    PageFrame
+                                        Row forward scan
+                                        Frame forward scan on: t
+                            """
+            );
+        });
+    }
+
+    @Test
     public void testWindowJoinNotSupportGroupBy() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table x (a int, b int, ts timestamp) timestamp(ts);");
@@ -5867,76 +5967,5 @@ public class SqlOptimiserTest extends AbstractSqlParserTest {
             assertEquals(ExecutionModel.QUERY, model.getModelType());
             return (QueryModel) model;
         }
-    }
-
-    @Test
-    public void testWindowFunctionDeduplicationWhenNestedInExpression() throws Exception {
-        // This test verifies that when a window function appears first inside an expression
-        // (e.g., abs(row_number() over(...))) and then as a top-level window column
-        // (e.g., row_number() over(...)), they are properly deduplicated.
-        // Bug: replaceIfWindowFunction() (called via emitWindowFunctions) adds window functions
-        // to windowModel but doesn't register them in windowFunctionHashMap, causing
-        // findDuplicateWindowFunction() to miss them when processing later identical windows.
-        assertMemoryLeak(() -> {
-            execute("create table t ( x int, ts timestamp) timestamp(ts);");
-            execute("insert into t select x, x::timestamp from long_sequence(3)");
-
-            // Case 1: Window function nested in expression appears BEFORE the same top-level window function
-            // If deduplication works correctly, there should be only ONE window function in the plan
-            String q1 = "select abs(row_number() over(order by x)), row_number() over(order by x) from t";
-
-            assertPlanNoLeakCheck(
-                    q1,
-                    """
-                            VirtualRecord
-                              functions: [abs(row_number),row_number]
-                                CachedWindow
-                                  orderedFunctions: [[x] => [row_number()]]
-                                    PageFrame
-                                        Row forward scan
-                                        Frame forward scan on: t
-                            """
-            );
-
-            // Verify the result is correct
-            assertSql("""
-                    abs\trow_number
-                    1\t1
-                    2\t2
-                    3\t3
-                    """, q1);
-
-            // Case 2: Same test but with partition by clause
-            String q2 = "select abs(row_number() over(partition by x order by ts)), row_number() over(partition by x order by ts) from t";
-
-            assertPlanNoLeakCheck(
-                    q2,
-                    """
-                            VirtualRecord
-                              functions: [abs(row_number),row_number]
-                                Window
-                                  functions: [row_number() over (partition by [x])]
-                                    PageFrame
-                                        Row forward scan
-                                        Frame forward scan on: t
-                            """
-            );
-
-            // Case 3: Multiple nested window functions that are the same
-            String q3 = "select abs(row_number() over(order by x)) + abs(row_number() over(order by x)), row_number() over(order by x) from t";
-
-            assertPlanNoLeakCheck(
-                    q3,
-                    """
-                            VirtualRecord
-                              functions: [abs(row_number)+abs(row_number),row_number]
-                                CachedWindow
-                                  orderedFunctions: [[x] => [row_number()]]
-                                    PageFrame
-                                        Row forward scan
-                                        Frame forward scan on: t
-                            """
-            );
-        });
     }
 }


### PR DESCRIPTION
Fixes #6633

Move `rewriteSingleFirstLastGroupBy` after `rewriteSelectClause` to optimise                                                                                                                                                                 queries like `SELECT dateadd('m', -15, max(ts)) FROM t` where `max` aggregate function as function argument