### PR TITLE
test(core): fix too many cached query plan fuzz test failure

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/fuzz/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/WalWriterFuzzTest.java
@@ -293,7 +293,7 @@ public class WalWriterFuzzTest extends AbstractFuzzTest {
 
     @Test
     public void testWalApplyEjectsMultipleTables() throws Exception {
-        Rnd rnd = generateRandom(LOG, 2865819778738013L, 1769056535379L);
+        Rnd rnd = generateRandom(LOG);
         setTestParams(rnd);
 
         setFuzzProperties(rnd.nextLong(50), getRndO3PartitionSplit(rnd), getRndO3PartitionSplitMaxCount(rnd), getMaxWalSize(rnd), getMaxWalFdCache(rnd));


### PR DESCRIPTION
Fixes fuzz test failure when a query recompile limit is reached because of too many DDL transactions on the table.

```
java.lang.RuntimeException: io.questdb.griffin.SqlException: [0] too many cached query plan cannot be used because table schema has changed [table=testWalApplyEjectsMultipleTables_0', expectedTableId=2, actualTableId=2, expectedMetadataVersion=79, actualMetadataVersion=80]



Stack trace
java.lang.RuntimeException: java.lang.RuntimeException: io.questdb.griffin.SqlException: [0] too many cached query plan cannot be used because table schema has changed [table=testWalApplyEjectsMultipleTables_0', expectedTableId=2, actualTableId=2, expectedMetadataVersion=79, actualMetadataVersion=80]
	at io.questdb.test/io.questdb.test.cairo.fuzz.FuzzRunner.applyManyWalParallel(FuzzRunner.java:222)
	at io.questdb.test/io.questdb.test.cairo.fuzz.FuzzRunner.runFuzz(FuzzRunner.java:1330)
	at io.questdb.test/io.questdb.test.cairo.fuzz.AbstractFuzzTest.lambda$fullRandomFuzz$1(AbstractFuzzTest.java:148)
	at io.questdb.test/io.questdb.test.AbstractCairoTest.lambda$assertMemoryLeak$9(AbstractCairoTest.java:1284)
	at io.questdb.test/io.questdb.test.tools.TestUtils.assertMemoryLeak(TestUtils.java:859)
	at io.questdb.test/io.questdb.test.AbstractCairoTest.assertMemoryLeak(AbstractCairoTest.java:1279)
	at io.questdb.test/io.questdb.test.cairo.fuzz.AbstractFuzzTest.fullRandomFuzz(AbstractFuzzTest.java:148)
	at io.questdb.test/io.questdb.test.cairo.fuzz.WalWriterFuzzTest.testWalApplyEjectsMultipleTables(WalWriterFuzzTest.java:301)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at junit@4.13.2/org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at junit@4.13.2/org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at junit@4.13.2/org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at junit@4.13.2/org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at junit@4.13.2/org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at junit@4.13.2/org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at junit@4.13.2/org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at junit@4.13.2/org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
	at junit@4.13.2/org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.RuntimeException: io.questdb.griffin.SqlException: [0] too many cached query plan cannot be used because table schema has changed [table=testWalApplyEjectsMultipleTables_0', expectedTableId=2, actualTableId=2, expectedMetadataVersion=79, actualMetadataVersion=80]
	at io.questdb.test/io.questdb.test.fuzz.FuzzQueryOperation.apply(FuzzQueryOperation.java:78)
	at io.questdb.test/io.questdb.test.cairo.fuzz.FuzzRunner.lambda$createWalWriteThread$5(FuzzRunner.java:978)
	... 1 more
Caused by: io.questdb.griffin.SqlException: [0] too many cached query plan cannot be used because table schema has changed [table=testWalApplyEjectsMultipleTables_0', expectedTableId=2, actualTableId=2, expectedMetadataVersion=79, actualMetadataVersion=80]
	at io.questdb@9.3.2-SNAPSHOT/io.questdb.griffin.SqlException.position(SqlException.java:141)
	at io.questdb@9.3.2-SNAPSHOT/io.questdb.griffin.SqlCompilerImpl.generateSelectWithRetries(SqlCompilerImpl.java:548)
	at io.questdb@9.3.2-SNAPSHOT/io.questdb.griffin.SqlCompilerImpl.compileUsingModel(SqlCompilerImpl.java:3473)
	at io.questdb@9.3.2-SNAPSHOT/io.questdb.griffin.SqlCompilerImpl.compileInner(SqlCompilerImpl.java:2830)
	at io.questdb@9.3.2-SNAPSHOT/io.questdb.griffin.SqlCompilerImpl.compile(SqlCompilerImpl.java:414)
	at io.questdb@9.3.2-SNAPSHOT/io.questdb.cairo.pool.SqlCompilerPool$C.compile(SqlCompilerPool.java:145)
	at io.questdb.test/io.questdb.test.tools.TestUtils.printSql(TestUtils.java:1909)
	at io.questdb.test
```