### PR TITLE
fix(sql): fix order by position resolution with window functions over CTEs

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -6905,7 +6905,8 @@ public class SqlOptimiser implements Mutable {
                 case SELECT_MODEL_VIRTUAL:
                 case SELECT_MODEL_CHOOSE:
                     QueryModel nested = base.getNestedModel();
-                    if (nested != null && nested.getSelectModelType() == SELECT_MODEL_GROUP_BY) {
+                    if (nested != null && (nested.getSelectModelType() == SELECT_MODEL_GROUP_BY
+                            || nested.getSelectModelType() == SELECT_MODEL_WINDOW)) {
                         baseOuter = base;
                     }
                     break;


### PR DESCRIPTION
## Summary

- Fixed a bug where `ORDER BY <position>` failed with "Invalid column" error when used with a CTE containing aggregation and a window function expression

## Problem

The following query failed with `SqlException: [176] Invalid column: rank`:

```sql
with d as (select symbol, price, count() from trades)
select *
      , 100 * (rank() over(partition by symbol order by price)) as rank1
from d
where symbol = 'EURUSD'
order by 4;
```

## Root Cause

In `SqlOptimiser.rewriteOrderByPosition()`, when resolving positional ORDER BY (e.g., `order by 4`), the code determines which model's columns to use for position-to-name resolution. The condition at line 6908 only set `baseOuter` when a VIRTUAL model's direct nested model was GROUP_BY:

```java
if (nested != null && nested.getSelectModelType() == SELECT_MODEL_GROUP_BY) {
    baseOuter = base;
}
```

With window functions, the model structure is:
```
outerVirtualModel (VIRTUAL) - columns: [symbol, price, count, rank1]
    └── windowModel (WINDOW) - columns: [symbol, price, count, rank]
            └── groupByModel (GROUP_BY)
```

Since VIRTUAL's nested is WINDOW (not GROUP_BY), `baseOuter` was not set, causing the wrong model's columns (windowModel with `rank`) to be used instead of the correct model (outerVirtualModel with `rank1`).

## Fix

Extended the condition to also check for `SELECT_MODEL_WINDOW`:

```java
if (nested != null && (nested.getSelectModelType() == SELECT_MODEL_GROUP_BY
        || nested.getSelectModelType() == SELECT_MODEL_WINDOW)) {
    baseOuter = base;
}
```

## Test plan

- [x] Added `testWithWindowFunctionRankAndOrderByAlias` - tests ORDER BY with explicit alias
- [x] Added `testWithWindowFunctionRankAndOrderByPosition` - tests ORDER BY with position (the original failing case)

🤖 Generated with [Claude Code](https://claude.ai/code)