### PR TITLE
chore(core): fix DirectByteSink.reopen() to clear the sink

### DIFF
--- a/core/src/main/java/io/questdb/std/bytes/DirectByteSink.java
+++ b/core/src/main/java/io/questdb/std/bytes/DirectByteSink.java
@@ -250,6 +250,8 @@ public class DirectByteSink implements DirectByteSequence, BorrowableAsNativeByt
     public void reopen() {
         if (impl == 0) {
             inflate();
+        } else {
+            clear();
         }
     }
 


### PR DESCRIPTION
Found during fixing [#881](https://github.com/questdb/questdb-enterprise/pull/881)