### PR TITLE
chore(core): TableReaderMetadata.clear() and ColumnVersionReader.clear() to clear all fields

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnVersionReader.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnVersionReader.java
@@ -72,6 +72,8 @@ public class ColumnVersionReader implements Closeable, Mutable {
         if (ownMem) {
             mem.close();
         }
+        cachedColumnVersionList.clear();
+        version = -1;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
@@ -121,6 +121,14 @@ public class TableReaderMetadata extends AbstractRecordMetadata implements Table
         Misc.free(metaCopyMem);
         Misc.free(transitionMeta);
         isCopy = false;
+        partitionBy = 0;
+        walEnabled = false;
+        metadataVersion = 0;
+        tableId = 0;
+        maxUncommittedRows = 0;
+        o3MaxLag = 0;
+        ttlHoursOrMonths = 0;
+        writerColumnCount = 0;
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/cairo/ColumnVersionWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/ColumnVersionWriterTest.java
@@ -96,6 +96,42 @@ public class ColumnVersionWriterTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testClearResetsAllFields() throws Exception {
+        assertMemoryLeak(() -> {
+            try (
+                    Path path = new Path();
+                    ColumnVersionWriter w = createColumnVersionWriter(path);
+                    ColumnVersionReader r = createColumnVersionReader(path)
+            ) {
+                // Write some data
+                w.upsert(0, 0, 1, 100);
+                w.upsert(0, 1, 2, 200);
+                w.upsertDefaultTxnName(0, 1, 0);
+                w.upsertDefaultTxnName(1, 2, 0);
+                w.commit();
+
+                // Read and verify data is populated
+                r.readUnsafe();
+                Assert.assertTrue("cachedColumnVersionList should not be empty", r.getCachedColumnVersionList().size() > 0);
+                Assert.assertEquals(100, r.getColumnTopQuick(0, 0));
+                Assert.assertEquals(200, r.getColumnTopQuick(0, 1));
+                Assert.assertEquals(1, r.getDefaultColumnNameTxn(0));
+                Assert.assertEquals(2, r.getDefaultColumnNameTxn(1));
+
+                // Now clear
+                r.clear();
+
+                // Verify all fields are reset
+                Assert.assertEquals("cachedColumnVersionList should be empty after clear", 0, r.getCachedColumnVersionList().size());
+                Assert.assertEquals("version should be -1 after clear", -1, r.getVersion());
+                // Lookups on cleared reader should return defaults
+                Assert.assertEquals(0, r.getColumnTopQuick(0, 0));
+                Assert.assertEquals(-1, r.getDefaultColumnNameTxn(0));
+            }
+        });
+    }
+
+    @Test
     public void testColumnTop() throws Exception {
         assertMemoryLeak(() -> {
             try (

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderMetadataTest.java
@@ -317,6 +317,40 @@ public class TableReaderMetadataTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testClearResetsAllFields() throws Exception {
+        assertMemoryLeak(() -> {
+            String tableName = "all";
+            TableToken tableToken = engine.verifyTableName(tableName);
+            try (
+                    Path path = new Path();
+                    TableReaderMetadata metadata = new TableReaderMetadata(configuration)
+            ) {
+                metadata.loadMetadata(path.of(root).concat(tableToken).concat(TableUtils.META_FILE_NAME).$());
+
+                // Verify fields are populated after load
+                Assert.assertTrue("partitionBy should be set", metadata.getPartitionBy() != 0 || metadata.getColumnCount() > 0);
+                Assert.assertTrue("columnCount should be > 0", metadata.getColumnCount() > 0);
+                Assert.assertNotEquals("tableId should be set", 0, metadata.getTableId());
+
+                // Now clear
+                metadata.clear();
+
+                // Verify all fields are reset
+                Assert.assertEquals("columnCount should be 0 after clear", 0, metadata.getColumnCount());
+                Assert.assertEquals("timestampIndex should be -1 after clear", -1, metadata.getTimestampIndex());
+                Assert.assertEquals("partitionBy should be 0 after clear", 0, metadata.getPartitionBy());
+                Assert.assertFalse("walEnabled should be false after clear", metadata.isWalEnabled());
+                Assert.assertEquals("metadataVersion should be 0 after clear", 0, metadata.getMetadataVersion());
+                Assert.assertEquals("tableId should be 0 after clear", 0, metadata.getTableId());
+                Assert.assertEquals("maxUncommittedRows should be 0 after clear", 0, metadata.getMaxUncommittedRows());
+                Assert.assertEquals("o3MaxLag should be 0 after clear", 0, metadata.getO3MaxLag());
+                Assert.assertEquals("ttlHoursOrMonths should be 0 after clear", 0, metadata.getTtlHoursOrMonths());
+                Assert.assertEquals("writerColumnCount should be 0 after clear", 0, metadata.getWriterColumnCount());
+            }
+        });
+    }
+
+    @Test
     public void testRemoveAllColumns() throws Exception {
         final String expected = "timestamp:" + ColumnType.nameOf(timestampType) + "\n";
         assertThat(expected, (w) -> {


### PR DESCRIPTION
TableReaderMetadata.clear() and ColumnVersionReader.clear() to clear all fields