### PR TITLE
fix(core): suppress error output in print-hello.sh during startup failure

### DIFF
--- a/core/src/main/bin/print-hello.sh
+++ b/core/src/main/bin/print-hello.sh
@@ -2,9 +2,9 @@
 
 HELLO_FILE=$1
 for a in {1..80}; do
- if [ -f $HELLO_FILE ]; then
-   cat $HELLO_FILE
-   rm $HELLO_FILE
+ if [ -f "$HELLO_FILE" ]; then
+   cat "$HELLO_FILE" 2>/dev/null
+   rm "$HELLO_FILE" 2>/dev/null
    break
  fi
  sleep 0.25


### PR DESCRIPTION
## Summary
- Suppress confusing `cat`/`rm` error messages when QuestDB fails to start due to configuration errors
- Add quotes around `$HELLO_FILE` for robustness with paths containing spaces

## Problem
When QuestDB fails to start (e.g., invalid cron expression in enterprise), there's a race condition:
1. Server starts, creates `hello.txt` with `deleteOnExit()`
2. Configuration validation fails, JVM begins shutdown
3. `deleteOnExit()` removes `hello.txt`
4. `print-hello.sh` tries to read/remove the file → error messages

```
JAVA: /opt/apps/questdb/bin/java
cat: /opt/apps/.questdb-eq1/hello.txt: No such file or directory
rm: cannot remove '/opt/apps/.questdb/hello.txt': No such file or directory
```

## Solution
Redirect stderr to `/dev/null` for `cat` and `rm` commands. The actual startup failure is logged in `stdout-*.txt`.
