### PR TITLE
fix(sql): fix alias hiding original column name in CASE with window function

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -6217,7 +6217,17 @@ public class SqlOptimiser implements Mutable {
         if (n != node) {
             return n;
         }
-        return replaceLiteral(node, translatingModel, innerVirtualModel, true, baseModel, false);
+        n = replaceLiteral(node, translatingModel, innerVirtualModel, true, baseModel, false);
+        if (n != node) {
+            // The node was a column literal. replaceLiteral added it to
+            // translatingModel and innerVirtualModel, but windowModel also
+            // needs a passthrough so the outer virtual model can see it.
+            CharSequence alias = n.token;
+            if (windowModel.getAliasToColumnMap().excludes(alias)) {
+                windowModel.addBottomUpColumnIfNotExists(nextColumn(alias));
+            }
+        }
+        return n;
     }
 
     private void resolveJoinColumns(QueryModel model) throws SqlException {


### PR DESCRIPTION
Fixes #6769

## Summary

- When a `CASE`/`WHEN` expression contains a window function (e.g., `lag() OVER (...)`), column references outside the window function (in `THEN`/`ELSE` branches) were not emitted to the translating model. This caused "invalid column" errors when using the original column name alongside a SELECT alias (e.g., `price AS p` then `THEN price`).
- Introduce `replaceWindowFunctionOrLiteral()` that chains window function replacement with literal emission in a single tree traversal pass, so all column references are propagated through the model chain.

## Test plan

- New test `testAliasedColumnVisibleByRealNameInCaseThen` reproduces the exact scenario from the issue: `SELECT ts, price AS p, CASE WHEN price > lag(price) OVER (...) THEN price END FROM trades`
- Existing `WindowFunctionTest` suite passes (CASE with window functions, lag/lead, partitioned windows, etc.)
- `SqlParserTest` suite passes (model tree structure unchanged for existing queries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)