### PR TITLE
fix(core): fix checkpoint timeout caused by slow sync() system call

### DIFF
--- a/core/src/main/java/io/questdb/cairo/DatabaseCheckpointAgent.java
+++ b/core/src/main/java/io/questdb/cairo/DatabaseCheckpointAgent.java
@@ -527,12 +527,12 @@ public class DatabaseCheckpointAgent implements DatabaseCheckpointStatus, QuietC
                             LOG.info().$("_preferences~store included in the checkpoint").$();
                         }
 
+                        circuitBreaker.statefulThrowExceptionIfTrippedNoThrottle();
+
                         // Flush dirty pages and filesystem metadata to disk
                         if (!isIncrementalBackup && ff.sync() != 0) {
                             throw CairoException.critical(ff.errno()).put("Could not sync");
                         }
-
-                        circuitBreaker.statefulThrowExceptionIfTrippedNoThrottle();
                         LOG.info().$("checkpoint created").$();
                     }
                 } catch (Throwable e) {


### PR DESCRIPTION
## Summary

- Move the circuit breaker check in `DatabaseCheckpointAgent.checkpointCreate()` from after `ff.sync()` to before it

The POSIX `sync()` system call flushes all dirty filesystem buffers system-wide, not just QuestDB's files. On busy CI machines (or production hosts with heavy I/O from other processes), `sync()` can block for well over the 60-second query timeout. The circuit breaker was only checked after `sync()` returned, so a completed checkpoint was discarded when the timeout had been exceeded during the blocking `sync()` call.

Moving the check before `sync()` means:
1. If the timeout is already exceeded (from the table loop or lock acquisition), we fail fast without entering a potentially long-blocking `sync()`
2. If the timeout has not been exceeded, `sync()` runs to completion and the checkpoint succeeds regardless of how long `sync()` takes — no more discarding completed work

## Test plan

- Verified with CI failure logs from `ReplicationAclTest.testAclModelOnEmptyReplica` (3 collected failures) that the root cause was `sync()` blocking for 67–266 seconds while the query timeout is 60 seconds
- All table checkpoints completed in <10ms in every failure — no writer contention involved