### PR TITLE
docs: clarify NaN rate parameter in rnd_double_array()

### DIFF
--- a/docs/rnd_double_array.md
+++ b/docs/rnd_double_array.md
@@ -1,0 +1,24 @@
+# rnd_double_array
+
+Generates a random array of doubles.
+
+## Syntax
+
+rnd_double_array(nDims)
+rnd_double_array(nDims, nanRate)
+rnd_double_array(nDims, nanRate, maxDimLength)
+rnd_double_array(nDims, nanRate, 0, dim1Len, dim2Len, ...)
+
+
+## Parameters
+
+- `nDims` — number of dimensions  
+- `nanRate` — controls the probability that a generated value will be `NaN`.  
+  Example: `0.1` → about 10% of elements are `NaN`.  
+- `maxDimLength` — maximum size of each dimension  
+- additional arguments — fixed lengths for each dimension
+
+## Example
+
+```sql
+SELECT rnd_double_array(5, 0.2);


### PR DESCRIPTION
This PR improves the reference documentation for rnd_double_array() by explaining how the NaN rate parameter works and providing an example query.