### PR TITLE
fix(sql): fix AssertionError on multi-column JOIN with table-qualified key names

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -7864,7 +7864,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     columnIndex = metadata.getColumnIndexQuiet(columnName, dot + 1, columnName.length());
                     if (columnIndex > -1) {
                         filter.add(columnIndex + 1);
-                        return;
+                        continue;
                     }
                 }
                 throw SqlException.invalidColumn(columnNames.getQuick(i).position, columnName);


### PR DESCRIPTION
Fixes #6761

## Summary

- `SqlCodeGenerator.lookupColumnIndexes()` had a premature `return` inside the loop that resolves master-side join column names via dot-qualified lookup (e.g. `T3.event`). After successfully finding and adding the first column, the method returned early, leaving all subsequent join columns unprocessed.
- This caused `listColumnFilterB` to have fewer entries than `listColumnFilterA`, which then crashed in `processJoinContext()` with `AssertionError: index 1 out of bounds for list size 1` when iterating the column comparison loop.
- Fix changes `return` to `continue` so all join key columns are resolved before the method returns.

## Test plan

- Added `testCrossJoinWithMultiColumnQualifiedJoinKeys` to `JoinTest` reproducing the exact pattern from the issue: two CROSS JOINs followed by a JOIN with a two-column ON clause using table-qualified names
- Verified the test fails on master and passes with the fix
- Ran the original query from the issue against a local server; confirmed it no longer returns an internal `AssertionError` and instead processes the query correctly