### PR TITLE
fix(sql): fix silent acceptance of excess FILL values in SAMPLE BY

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursorFactory.java
@@ -215,6 +215,14 @@ public class SampleByFillValueRecordCursorFactory extends AbstractSampleByFillRe
                 placeholderFunctions.add(function);
             }
         }
+        if (fillIndex < fillValueCount) {
+            throw SqlException.position(fillValues.getQuick(fillIndex).position)
+                    .put("too many fill values for SAMPLE BY FILL: expected ")
+                    .put(fillIndex)
+                    .put(" values but ")
+                    .put(fillValueCount)
+                    .put(" provided");
+        }
         return placeholderFunctions;
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursorFactory.java
@@ -191,7 +191,7 @@ public class SampleByFillValueRecordCursorFactory extends AbstractSampleByFillRe
                     throw SqlException.position(fillValues.getQuick(fillIndex - 1).position)
                             .put("insufficient fill values for SAMPLE BY FILL: expected ")
                             .put(groupByFunctions.size())
-                            .put(" values but only ")
+                            .put(groupByFunctions.size() == 1 ? " value but only " : " values but only ")
                             .put(fillValueCount)
                             .put(" provided");
                 }
@@ -219,7 +219,7 @@ public class SampleByFillValueRecordCursorFactory extends AbstractSampleByFillRe
             throw SqlException.position(fillValues.getQuick(fillIndex).position)
                     .put("too many fill values for SAMPLE BY FILL: expected ")
                     .put(fillIndex)
-                    .put(" values but ")
+                    .put(fillIndex == 1 ? " value but " : " values but ")
                     .put(fillValueCount)
                     .put(" provided");
         }

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByNanoTimestampTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByNanoTimestampTest.java
@@ -12846,7 +12846,7 @@ public class SampleByNanoTimestampTest extends AbstractCairoTest {
                         139.22127942393962\t2\t44.80468966861358\t94.41658975532606\t1970-01-03T13:30:00.000000000Z
                         94.55893004802432\t1\t94.55893004802432\t94.55893004802432\t1970-01-03T14:00:00.000000000Z
                         """,
-                "select sum(a), count(), min(a), max(a), k from x sample by 30m fill(20.56, null, prev, prev, linear)",
+                "select sum(a), count(), min(a), max(a), k from x sample by 30m fill(20.56, null, prev, prev)",
                 "create table x as " +
                         "(" +
                         "select" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -15381,6 +15381,23 @@ public class SampleByTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSampleFillValueTooMany() throws Exception {
+        assertException(
+                "SELECT sum(a), k FROM x SAMPLE BY 3h FILL(0, PREV)",
+                "create table x as " +
+                        "(" +
+                        "select" +
+                        " rnd_double(0)*100 a," +
+                        " timestamp_sequence(172800000000, 3600000000) k" +
+                        " from" +
+                        " long_sequence(20)" +
+                        ") timestamp(k) partition by NONE",
+                43,
+                "too many fill values for SAMPLE BY FILL"
+        );
+    }
+
+    @Test
     public void testSampleFillValueNotKeyed() throws Exception {
         Rnd rnd = TestUtils.generateRandom(LOG);
         setProperty(PropertyKey.DEBUG_CAIRO_COPIER_TYPE, rnd.nextInt(4));

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -15392,8 +15392,44 @@ public class SampleByTest extends AbstractCairoTest {
                         " from" +
                         " long_sequence(20)" +
                         ") timestamp(k) partition by NONE",
-                43,
-                "too many fill values for SAMPLE BY FILL"
+                45,
+                "too many fill values for SAMPLE BY FILL: expected 1 value but 2 provided"
+        );
+    }
+
+    @Test
+    public void testSampleFillValueTooManyMultiAggregate() throws Exception {
+        assertException(
+                "select b, sum(a), sum(c), k from x sample by 3h fill(20.56, 0, 0, 0)",
+                "create table x as " +
+                        "(" +
+                        "select" +
+                        " rnd_double(0)*100 a," +
+                        " rnd_symbol(5,4,4,1) b," +
+                        " rnd_float(0)*100 c," +
+                        " timestamp_sequence(172800000000, 3600000000) k" +
+                        " from" +
+                        " long_sequence(20)" +
+                        ") timestamp(k) partition by NONE",
+                63,
+                "too many fill values for SAMPLE BY FILL: expected 2 values but 4 provided"
+        );
+    }
+
+    @Test
+    public void testSampleFillValueTooManyNotKeyed() throws Exception {
+        assertException(
+                "SELECT sum(a), k FROM x SAMPLE BY 3h FILL(0, PREV)",
+                "create table x as " +
+                        "(" +
+                        "select" +
+                        " rnd_double(0)*100 a," +
+                        " timestamp_sequence(172800000000, 3600000000) k" +
+                        " from" +
+                        " long_sequence(20)" +
+                        ") timestamp(k) partition by NONE",
+                45,
+                "too many fill values for SAMPLE BY FILL: expected 1 value but 2 provided"
         );
     }
 


### PR DESCRIPTION
Fixes #1986

When using `SAMPLE BY` with `FILL` values, providing more fill values than the number of aggregate columns would silently succeed - the extra values were just ignored. For example:

```sql
SELECT count FROM foo SAMPLE BY 1h FILL(0, PREV)
```

This has one aggregate (`count`) but two fill values (`0, PREV`). It should error out but instead just uses the first fill and drops the rest.

The existing code already validates the case where there are *fewer* fill values than aggregates (throwing "insufficient fill values for SAMPLE BY FILL"). This adds the symmetric check: when there are *more* fill values than aggregates, throw "too many fill values for SAMPLE BY FILL".

Added a test that verifies the error is thrown.