### PR TITLE
test(core): stabilize flaky testCheckpointListenerOnReleased()

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -329,7 +329,7 @@ public class CheckpointTest extends AbstractCairoTest {
             // Path B (first refresh after wal_table1 INSERT is applied):
             //   1) fromTxn=-1,toTxn=1 -> single data refresh writes commitMatView() => seqTxn=1
             // Not a TOCTOU in this test: after lastRefreshBaseTxn reaches 1 we do not perform any new base-table
-            // commits, and this immediate non-period view has no additional incremental work (fromTxn==toTxn).
+            // commits, and this immediate view has no additional incremental work (fromTxn==toTxn).
             // So reading mat_view seqTxn once here and comparing it to checkpoint callback value is stable.
             long matViewSeqTxn = server.getEngine().getTableSequencerAPI().getTxnTracker(matViewToken).getSeqTxn();
             Assert.assertTrue("mat_view seqTxn should be either 1 or 3, was " + matViewSeqTxn, matViewSeqTxn == 1L || matViewSeqTxn == 3L);


### PR DESCRIPTION
mat_view sequencer txn is scheduling-dependent in this test and can validly be 1 or 3. 

Path A (first refresh runs before wal_table1 INSERT is applied):
  1. fromTxn=-1,toTxn=0 -> refreshSuccessNoRows() writes resetMatViewState() -> seqTxn=1
  2. follow-up refresh caches intervals via resetMatViewState() -> seqTxn=2
  3. data refresh writes commitMatView() -> seqTxn=3

Path B (first refresh runs after wal_table1 INSERT is applied):
  1. fromTxn=-1,toTxn=1 -> single data refresh writes commitMatView() -> seqTxn=1

The failure can be reproduced by sprinking a bit of sleep to MatViewRefreshJob.refreshIncremental0() - just before the [TableReader acquisition](https://github.com/questdb/questdb/blob/5c082d45834cfd2efcf6354685b7b675a421b8f9/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java#L1279).