### PR TITLE
fix(core): reject CSV rows containing null bytes in text lexer

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/text/AbstractTextLexer.java
+++ b/core/src/main/java/io/questdb/cutlass/text/AbstractTextLexer.java
@@ -303,7 +303,8 @@ public abstract class AbstractTextLexer implements Closeable, Mutable {
             while (ptr < hi) {
                 if (!eol && !rollBufferUnusable && !useLineRollBuf && !delayedOutQuote && ptr < hi - 7) {
                     long word = Unsafe.getUnsafe().getLong(ptr);
-                    long zeroBytesWord = SwarUtils.markZeroBytes(word ^ MASK_NEW_LINE)
+                    long zeroBytesWord = SwarUtils.markZeroBytes(word)
+                            | SwarUtils.markZeroBytes(word ^ MASK_NEW_LINE)
                             | SwarUtils.markZeroBytes(word ^ MASK_CR)
                             | SwarUtils.markZeroBytes(word ^ MASK_QUOTE)
                             | SwarUtils.markZeroBytes(word ^ getDelimiterMask());
@@ -328,6 +329,15 @@ public abstract class AbstractTextLexer implements Closeable, Mutable {
                 }
 
                 final byte b = Unsafe.getUnsafe().getByte(ptr++);
+                if (b == 0) {
+                    if (!ignoreEolOnce) {
+                        LOG.error().$("invalid byte 0x00 [table=").$safe(tableName).$(", line=").$(lineCount).$(']')
+                                .$();
+                        errorCount++;
+                        ignoreEolOnce = true;
+                        this.fieldIndex = 0;
+                    }
+                }
                 this.ascii &= b > 0;
 
                 if (checkState(ptr, b)) {

--- a/core/src/test/java/io/questdb/test/cutlass/text/CsvTextLexerNullByteTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/CsvTextLexerNullByteTest.java
@@ -1,0 +1,47 @@
+package io.questdb.test.cutlass.text;
+
+import io.questdb.cutlass.text.CsvTextLexer;
+import io.questdb.cutlass.text.DefaultTextConfiguration;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.ObjList;
+import io.questdb.std.Unsafe;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+public class CsvTextLexerNullByteTest extends AbstractCairoTest {
+
+    @Test
+    public void testNullByteContaminationInCsv() throws Exception {
+        String csv = "id,name,value\n" +
+                "1,test\0data,100\n";
+
+        byte[] bytes = csv.getBytes(StandardCharsets.UTF_8);
+        long len = bytes.length;
+        long ptr = Unsafe.malloc(len, MemoryTag.NATIVE_DEFAULT);
+
+        try {
+            for (int i = 0; i < len; i++) {
+                Unsafe.getUnsafe().putByte(ptr + i, bytes[i]);
+            }
+
+            try (CsvTextLexer lexer = new CsvTextLexer(new DefaultTextConfiguration())) {
+                ObjList<String> parsedNames = new ObjList<>();
+
+                lexer.setupBeforeExactLines((line, fields, hi) -> {
+                    if (line == 1) {
+                        parsedNames.add(fields.getQuick(1).toString());
+                    }
+                });
+                lexer.parse(ptr, ptr + len);
+
+                Assert.assertEquals("Row containing null byte should be dropped", 0, parsedNames.size());
+                Assert.assertEquals("Lexer error count should increment by 1", 1, lexer.getErrorCount());
+            }
+        } finally {
+            Unsafe.free(ptr, len, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+}


### PR DESCRIPTION
### Summary
CSV files containing null bytes (`0x00`) can bypass the text lexer and reach native layers, potentially causing crashes or memory corruption in downstream components.

### Changes
- Added `SwarUtils.markZeroBytes(word)` to the high-performance SWAR loop in `AbstractTextLexer.parse0()`.
- Implemented a fast-fail mechanism: when a null byte is detected, the affected row is dropped via `ignoreEolOnce` and an error is logged.
- Ensures zero overhead for normal datasets by leveraging existing SIMD-style bitmasking.

### Testing
- Added `CsvTextLexerNullByteTest.java` to verify that rows with null bytes are correctly rejected and `errorCount` is incremented.
- Confirmed no regression in existing text import tests.