### PR TITLE
ci(build): cache JDK and Maven to avoid transient issues with glibc smoke tests

### DIFF
--- a/.github/workflows/glibc_smoke_test.yml
+++ b/.github/workflows/glibc_smoke_test.yml
@@ -56,20 +56,20 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            /opt/apache-maven-3.9.6
+            /opt/apache-maven-3.9.9
             /root/.m2/repository
-          key: maven-3.9.6-repo-${{ runner.arch }}-${{ hashFiles('**/pom.xml') }}
+          key: maven-3.9.9-repo-${{ runner.arch }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            maven-3.9.6-repo-${{ runner.arch }}-
+            maven-3.9.9-repo-${{ runner.arch }}-
       - name: Install Apache Maven
         if: steps.maven-cache.outputs.cache-hit != 'true'
         # Amazon Linux 2 has too old version of Maven, so we need to install a newer one
         run: |
-          wget https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.tar.gz
-          tar xf apache-maven-3.9.6-bin.tar.gz -C /opt
+          wget https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.tar.gz
+          tar xf apache-maven-3.9.9-bin.tar.gz -C /opt
       - name: Setup Maven
         run: |
-          ln -sf /opt/apache-maven-3.9.6 /opt/maven
+          ln -sf /opt/apache-maven-3.9.9 /opt/maven
           echo "MAVEN_HOME=/opt/maven" >> $GITHUB_ENV
           echo "PATH=/opt/maven/bin:$PATH" >> $GITHUB_ENV
       - name: Build distribution
@@ -127,9 +127,8 @@ jobs:
         if: steps.maven-cache.outputs.cache-hit != 'true'
         # AlmaLinux 8 has too old version of Maven, so we need to install a newer one
         run: |
-          cd /opt
-          wget https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.zip
-          unzip -o apache-maven-3.9.9-bin.zip
+          wget https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.tar.gz
+          tar xf apache-maven-3.9.9-bin.tar.gz -C /opt
       - name: Setup Maven
         run: |
           ln -sf /opt/apache-maven-3.9.9 /opt/maven


### PR DESCRIPTION
The GLIBC smoke test has been [flaky due](https://github.com/questdb/questdb/actions/workflows/glibc_smoke_test.yml) to transient network failures when downloading the JDK and Maven:

```
Downloading Java 17.0.18+8 (Temurin-Hotspot) from https://github.com/adoptium/...
socket hang up
Waiting 14 seconds before trying again
Unexpected HTTP response: 504
Waiting 14 seconds before trying again
Error: socket hang up
```

`setup-java@v4` relies on `@actions/tool-cache` to download the JDK, which has hardcoded retry logic (3 attempts) and not all errors are retried. 

Similarly, the Maven installation download from `archive.apache.org` has no retry logic at all.

**Changes:**
- Cache the JDK tool-cache directory with `actions/cache`. On cache hit, `setup-java` finds the JDK already present and skips the download entirely.
- Cache the Maven installation and `~/.m2/repository` together. On cache hit, both the Maven binary and all dependencies are restored, skipping both the Maven download and most Maven Central fetches during the build.
- Drop `cache: 'maven'` from `setup-java` — it was broken in container jobs due to a path mismatch: Node.js `os.homedir()` resolves `HOME` (`/github/home`) while Java's `user.home` uses `getpwuid` (`/root`), so `setup-java` tried to cache a directory that didn't exist.
- Trigger the workflow on pushes to master (filtered to `pom.xml` changes) to seed the cache for PR branches, since GitHub Actions caches are scoped per-branch but feature branches can read from the default branch cache.
- Align Maven version in amd64 and aarach64 builds to 3.9.9