### PR TITLE
perf(wal): add cairo.wal.writer.madvise.mode configuration option

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -566,6 +566,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int walTxnNotificationQueueCapacity;
     private final long walWriterDataAppendPageSize;
     private final long walWriterEventAppendPageSize;
+    private final int walWriterMadviseMode;
     private final int walWriterPoolMaxSegments;
     private final long workStealTimeoutNanos;
     private final long writerAsyncCommandBusyWaitTimeout;
@@ -1471,6 +1472,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.parallelIndexThreshold = getInt(properties, env, PropertyKey.CAIRO_PARALLEL_INDEX_THRESHOLD, 100000);
             this.readerPoolMaxSegments = getInt(properties, env, PropertyKey.CAIRO_READER_POOL_MAX_SEGMENTS, 10);
             this.poolSegmentSize = getIntSize(properties, env, PropertyKey.DEBUG_CAIRO_POOL_SEGMENT_SIZE, 32);
+            this.walWriterMadviseMode = getWalWriterMadviseMode(properties, env, PropertyKey.CAIRO_WAL_WRITER_MADVISE_MODE);
             this.walWriterPoolMaxSegments = getInt(properties, env, PropertyKey.CAIRO_WAL_WRITER_POOL_MAX_SEGMENTS, 10);
             this.viewWalWriterPoolMaxSegments = getInt(properties, env, PropertyKey.CAIRO_VIEW_WAL_WRITER_POOL_MAX_SEGMENTS, 4);
             this.spinLockTimeout = getMillis(properties, env, PropertyKey.CAIRO_SPIN_LOCK_TIMEOUT, 1_000);
@@ -2253,6 +2255,27 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         return SqlJitMode.JIT_MODE_ENABLED;
+    }
+
+    private int getWalWriterMadviseMode(Properties properties, @Nullable Map<String, String> env, ConfigPropertyKey key) throws ServerConfigurationException {
+        final String mode = getString(properties, env, key, "none");
+
+        // must not be null because we provided non-null default value
+        assert mode != null;
+
+        if (Chars.equalsLowerCaseAscii(mode, "none")) {
+            return -1;
+        }
+
+        if (Chars.equalsLowerCaseAscii(mode, "sequential")) {
+            return Files.POSIX_MADV_SEQUENTIAL;
+        }
+
+        if (Chars.equalsLowerCaseAscii(mode, "random")) {
+            return Files.POSIX_MADV_RANDOM;
+        }
+
+        throw ServerConfigurationException.forInvalidKey(key.getPropertyPath(), mode);
     }
 
     // The enterprise version needs to add tcps and https
@@ -4466,6 +4489,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getWalTxnNotificationQueueCapacity() {
             return walTxnNotificationQueueCapacity;
+        }
+
+        @Override
+        public int getWalWriterMadviseMode() {
+            return walWriterMadviseMode;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -529,6 +529,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     CAIRO_WAL_SEGMENT_ROLLOVER_SIZE("cairo.wal.segment.rollover.size"),
     CAIRO_WAL_WRITER_DATA_APPEND_PAGE_SIZE("cairo.wal.writer.data.append.page.size"),
     CAIRO_WAL_WRITER_EVENT_APPEND_PAGE_SIZE("cairo.wal.writer.event.append.page.size"),
+    CAIRO_WAL_WRITER_MADVISE_MODE("cairo.wal.writer.madvise.mode"),
     CAIRO_WAL_SEQUENCER_CHECK_INTERVAL("cairo.wal.sequencer.check.interval"),
     CAIRO_SYSTEM_WAL_WRITER_DATA_APPEND_PAGE_SIZE("cairo.system.wal.writer.data.append.page.size"),
     CAIRO_SYSTEM_WAL_WRITER_EVENT_APPEND_PAGE_SIZE("cairo.system.wal.writer.event.append.page.size"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -776,6 +776,8 @@ public interface CairoConfiguration {
 
     int getWalTxnNotificationQueueCapacity();
 
+    int getWalWriterMadviseMode();
+
     int getWalWriterPoolMaxSegments();
 
     int getWindowColumnPoolCapacity();

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -1357,6 +1357,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public int getWalWriterMadviseMode() {
+        return getDelegate().getWalWriterMadviseMode();
+    }
+
+    @Override
     public int getWalWriterPoolMaxSegments() {
         return getDelegate().getWalWriterPoolMaxSegments();
     }

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -1371,6 +1371,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public int getWalWriterMadviseMode() {
+        return -1;
+    }
+
+    @Override
     public int getWalWriterPoolMaxSegments() {
         return 5;
     }

--- a/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalWriter.java
@@ -116,6 +116,7 @@ public class WalWriter extends WalWriterBase implements TableWriterAPI {
 
     private final AlterOperation alterOp = new AlterOperation();
     private final ObjList<MemoryMA> columns;
+    private final int columnsMadviseMode;
     private final DdlListener ddlListener;
     private final AtomicIntList initialSymbolCounts;
     private final IntList localSymbolIds;
@@ -174,6 +175,7 @@ public class WalWriter extends WalWriterBase implements TableWriterAPI {
         super(configuration, tableToken, tableSequencerAPI, walDirectoryPolicy, walLocker);
 
         LOG.info().$("open [table=").$(tableToken).I$();
+        this.columnsMadviseMode = configuration.getWalWriterMadviseMode();
         this.ddlListener = ddlListener;
         this.recentWriteTracker = recentWriteTracker;
         this.telemetryWal = telemetryWal;
@@ -1308,7 +1310,7 @@ public class WalWriter extends WalWriterBase implements TableWriterAPI {
                     -1,
                     MemoryTag.MMAP_TABLE_WAL_WRITER,
                     configuration.getWriterFileOpenOpts(),
-                    Files.POSIX_MADV_RANDOM
+                    columnsMadviseMode
             );
 
             final MemoryMA auxMem = getAuxColumn(columnIndex);
@@ -1323,7 +1325,7 @@ public class WalWriter extends WalWriterBase implements TableWriterAPI {
                         getDataAppendPageSize(),
                         MemoryTag.MMAP_TABLE_WAL_WRITER,
                         configuration.getWriterFileOpenOpts(),
-                        Files.POSIX_MADV_RANDOM
+                        columnsMadviseMode
                 );
             }
         } finally {

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -1066,6 +1066,9 @@ cairo.sql.copy.root=import
 # this page size can be reduced. The optimal value should be established via ingestion benchmark.
 #cairo.wal.writer.event.append.page.size=128k
 
+# madvise mode for WalWriter memory-mapped files. Valid values: none, sequential, random.
+#cairo.wal.writer.madvise.mode=none
+
 # Multiplier to cairo.max.uncommitted.rows to calculate the limit of rows that can kept invisible when writing
 # to WAL table under heavy load, when multiple transactions are to be applied.
 # It is used to reduce the number Out Of Order commits when Out Of Order commits are unavoidable by squashing multiple commits together.

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -500,6 +500,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(1048576, configuration.getCairoConfiguration().getWalDataAppendPageSize());
         Assert.assertEquals(262144, configuration.getCairoConfiguration().getSystemWalDataAppendPageSize());
         Assert.assertTrue(configuration.getCairoConfiguration().isTableTypeConversionEnabled());
+        Assert.assertEquals(-1, configuration.getCairoConfiguration().getWalWriterMadviseMode());
         Assert.assertEquals(10, configuration.getCairoConfiguration().getWalWriterPoolMaxSegments());
         Assert.assertTrue(configuration.getCairoConfiguration().isWalApplyParallelSqlEnabled());
 
@@ -2098,6 +2099,7 @@ public class PropServerConfigurationTest {
         Assert.assertFalse(configuration.isWalApplyEnabled());
         Assert.assertEquals(23, configuration.getWalApplyLookAheadTransactionCount());
         Assert.assertFalse(configuration.isTableTypeConversionEnabled());
+        Assert.assertEquals(Files.POSIX_MADV_RANDOM, configuration.getWalWriterMadviseMode());
         Assert.assertEquals(100, configuration.getWalWriterPoolMaxSegments());
         Assert.assertEquals(50, configuration.getViewWalWriterPoolMaxSegments());
         Assert.assertEquals(120, configuration.getO3LagCalculationWindowsSize());

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -723,6 +723,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.view.wal.writer.pool.max.segments\tQDB_CAIRO_VIEW_WAL_WRITER_POOL_MAX_SEGMENTS\t4\tdefault\tfalse\tfalse\n" +
                                     "cairo.wal.sequencer.check.interval\tQDB_CAIRO_WAL_SEQUENCER_CHECK_INTERVAL\t10000\tdefault\tfalse\tfalse\n" +
                                     "cairo.wal.writer.event.append.page.size\tQDB_CAIRO_WAL_WRITER_EVENT_APPEND_PAGE_SIZE\t131072\tdefault\tfalse\tfalse\n" +
+                                    "cairo.wal.writer.madvise.mode\tQDB_CAIRO_WAL_WRITER_MADVISE_MODE\tnone\tdefault\tfalse\tfalse\n" +
                                     "cairo.work.steal.timeout.nanos\tQDB_CAIRO_WORK_STEAL_TIMEOUT_NANOS\t10000\tdefault\tfalse\tfalse\n" +
                                     "cairo.writer.alter.busy.wait.timeout\tQDB_CAIRO_WRITER_ALTER_BUSY_WAIT_TIMEOUT\t500\tdefault\tfalse\tfalse\n" +
                                     "cairo.writer.alter.max.wait.timeout\tQDB_CAIRO_WRITER_ALTER_MAX_WAIT_TIMEOUT\t30000\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -340,6 +340,7 @@ cairo.wal.enabled.default=true
 cairo.wal.purge.interval=333
 cairo.wal.segment.rollover.row.count=100
 cairo.wal.writer.data.append.page.size=256k
+cairo.wal.writer.madvise.mode=random
 cairo.system.wal.writer.data.append.page.size=512k
 cairo.wal.apply.parallel.sql.enabled=false
 

--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -843,6 +843,9 @@ pg.user=admin
 # mmap sliding page size that WalWriter uses to append data for each column
 #cairo.wal.writer.data.append.page.size=1M
 
+# madvise mode for WalWriter memory-mapped files. Valid values: none, sequential, random.
+#cairo.wal.writer.madvise.mode=none
+
 # Multiplier to cairo.max.uncommitted.rows to calculate the limit of rows that can kept invisible when writing
 # to WAL table under heavy load, when multiple transactions are to be applied.
 # It is used to reduce the number Out Of Order commits when Out Of Order commits are unavoidable by squashing multiple commits together.


### PR DESCRIPTION
WalWriter previously hardcoded `POSIX_MADV_RANDOM` for memory-mapped column files. This hurts most workloads, but some benefit from it. Make the madvise hint opt-in via a new config property with valid values: none (default, no hint), sequential and random.

RANDOM is beneficial when ingesting into many tables with many columns, as it prevents the OS from speculatively reading adjacent pages under memory pressure.

Example configuration:
```
cairo.wal.writer.madvise.mode=random
```