### PR TITLE
fix(sql): fix LIKE exact match falling back to table scan instead of using index

### DIFF
--- a/core/src/main/java/io/questdb/griffin/WhereClauseParser.java
+++ b/core/src/main/java/io/questdb/griffin/WhereClauseParser.java
@@ -2522,7 +2522,6 @@ public final class WhereClauseParser implements Mutable {
             boolean latestByMultiColumn,
             TableReader reader
     ) throws SqlException {
-        // here
         return switch (intrinsicOps.get(node.token)) {
             case INTRINSIC_OP_IN ->
                     analyzeIn(timestampDriver, translator, model, node, m, functionParser, executionContext, latestByMultiColumn, reader);

--- a/core/src/main/java/io/questdb/griffin/WhereClauseParser.java
+++ b/core/src/main/java/io/questdb/griffin/WhereClauseParser.java
@@ -78,6 +78,7 @@ public final class WhereClauseParser implements Mutable {
     private static final int INTRINSIC_OP_LESS_EQ = 5;
     private static final int INTRINSIC_OP_NOT = 8;
     private static final int INTRINSIC_OP_NOT_EQ = 7;
+    private static final int MAYBE_INTRINSIC_OP_LIKE = 11;
     private static final CharSequenceIntHashMap intrinsicOps = new CharSequenceIntHashMap();
     // TODO: configure size
     private final ObjectPool<FlyweightCharSequence> csPool = new ObjectPool<>(FlyweightCharSequence.FACTORY, 64);
@@ -2521,6 +2522,7 @@ public final class WhereClauseParser implements Mutable {
             boolean latestByMultiColumn,
             TableReader reader
     ) throws SqlException {
+        // here
         return switch (intrinsicOps.get(node.token)) {
             case INTRINSIC_OP_IN ->
                     analyzeIn(timestampDriver, translator, model, node, m, functionParser, executionContext, latestByMultiColumn, reader);
@@ -2567,8 +2569,32 @@ public final class WhereClauseParser implements Mutable {
                     analyzeBetween(timestampDriver, translator, model, node, m, functionParser, metadata, executionContext);
             case INTRINSIC_OP_AND_OFFSET ->
                     analyzeAndOffset(timestampDriver, translator, model, node, m, functionParser, metadata, executionContext, latestByMultiColumn, reader);
+            case MAYBE_INTRINSIC_OP_LIKE -> {
+                if (node.rhs != null && node.rhs.type == ExpressionNode.CONSTANT) {
+                    CharSequence pattern = unquote(node.rhs.token);
+                    if (!hasWildcard(pattern)) {
+                        yield analyzeEquals(timestampDriver, translator, model, node, m,
+                                functionParser, executionContext, latestByMultiColumn, reader);
+                    }
+                }
+                yield false;
+            }
             default -> false;
         };
+    }
+
+    private boolean hasWildcard(CharSequence pattern) {
+        for (int i = 0, n = pattern.length(); i < n; i++) {
+            char c = pattern.charAt(i);
+            if (c == '\\') {
+                i++;
+                continue;
+            }
+            if (c == '%' || c == '_') {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void removeNodes(ExpressionNode b, ObjList<ExpressionNode> nodes) {
@@ -2879,5 +2905,6 @@ public final class WhereClauseParser implements Mutable {
         intrinsicOps.put("not", INTRINSIC_OP_NOT);
         intrinsicOps.put("between", INTRINSIC_OP_BETWEEN);
         intrinsicOps.put("and_offset", INTRINSIC_OP_AND_OFFSET);
+        intrinsicOps.put("like", MAYBE_INTRINSIC_OP_LIKE);
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
@@ -1860,6 +1860,20 @@ public class WhereClauseParserTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testLikeWithConst() throws Exception {
+        IntrinsicModel m = modelOf("sym like 'X'");                                             
+        Assert.assertEquals("[X]", keyValueFuncsToString(m.keyValueFuncs));
+        assertFilter(m, null);
+    }
+
+    @Test
+    public void testLikeWithWildCards() throws Exception {
+        IntrinsicModel m = modelOf("sym like 'X%'");
+        Assert.assertEquals("[]", keyValueFuncsToString(m.keyValueFuncs));
+        assertFilter(m, "'X%' sym like");
+    }
+
+    @Test
     public void testEqualsIndexedSearchWithFunction2() throws Exception {
         IntrinsicModel m = modelOf("sym = case when 1 = 0 then 'A' else 'B' end ");
         TestUtils.assertEquals("sym", m.keyColumn);

--- a/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
@@ -1861,7 +1861,7 @@ public class WhereClauseParserTest extends AbstractCairoTest {
 
     @Test
     public void testLikeWithConst() throws Exception {
-        IntrinsicModel m = modelOf("sym like 'X'");                                             
+        IntrinsicModel m = modelOf("sym like 'X'");
         Assert.assertEquals("[X]", keyValueFuncsToString(m.keyValueFuncs));
         assertFilter(m, null);
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/regex/LikeSymbolFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/regex/LikeSymbolFunctionFactoryTest.java
@@ -552,6 +552,35 @@ public class LikeSymbolFunctionFactoryTest extends AbstractCairoTest {
         });
     }
 
+    @Test
+    public void testExactLikeOnIndexedSymbolUsesIndexScan() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE x (s SYMBOL INDEX, ts TIMESTAMP) TIMESTAMP(ts)");
+            execute("INSERT INTO x VALUES ('v', 0::TIMESTAMP), ('vv', 1::TIMESTAMP), (NULL, 2::TIMESTAMP)");
+
+            // exact LIKE without wildcards should return same result as =
+            assertSql("s\tts\n" +
+                    "v\t1970-01-01T00:00:00.000000Z\n", "SELECT * FROM x WHERE s LIKE 'v'");
+
+            // verify the plan uses index scan, not table scan
+            assertSql("QUERY PLAN\n" +
+                            "DeferredSingleSymbolFilterPageFrame\n" +
+                            "    Index forward scan on: s\n" +
+                            "      filter: s=1\n" +
+                            "    Frame forward scan on: x\n",
+                    "EXPLAIN SELECT * FROM x WHERE s LIKE 'v'");
+
+            // wildcard LIKE should still use table scan
+            assertSql("QUERY PLAN\n" +
+                            "Async Filter workers: 1\n" +
+                            "  filter: s like v% [state-shared]\n" +
+                            "    PageFrame\n" +
+                            "        Row forward scan\n" +
+                            "        Frame forward scan on: x\n",
+                    "EXPLAIN SELECT * FROM x WHERE s LIKE 'v%'");
+        });
+    }
+
     private void assertLike(String expected, String query) throws Exception {
         assertQueryNoLeakCheck(expected, query, null, true, false);
         assertQueryNoLeakCheck(expected, query.replace("like", "ilike"), null, true, false);


### PR DESCRIPTION
Fixes #6279

## Summary

- `WhereClauseParser.extract()` now recognizes `LIKE` as a conditionally intrinsic operator
- When the LIKE pattern contains no wildcards (`%`, `_`), the predicate delegates to `analyzeEquals`, enabling symbol index scans

## Test plan

- `WhereClauseParserTest#testLikeWithConst` verifies exact LIKE pattern extracts into `keyValueFuncs`
- `WhereClauseParserTest#testLikeWithWildCards` verifies wildcard LIKE pattern stays as a filter
-  `testExactLikeOnIndexedSymbolUsesIndexScan` verify query plan for constant and wildcard