### PR TITLE
feat(sql): add GROUPING SETS, ROLLUP, CUBE support

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -489,6 +489,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int sqlMapMaxPages;
     private final int sqlMapMaxResizes;
     private final int sqlMaxArrayElementCount;
+    private final int sqlMaxGroupingSets;
     private final int sqlMaxNegativeLimit;
     private final int sqlMaxSymbolNotEqualsCount;
     private final int sqlModelPoolCapacity;
@@ -1526,6 +1527,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.sqlViewLexerPoolCapacity = getInt(properties, env, PropertyKey.CAIRO_SQL_VIEW_LEXER_POOL_CAPACITY, 8);
             this.sqlExplainModelPoolCapacity = getInt(properties, env, PropertyKey.CAIRO_SQL_EXPLAIN_MODEL_POOL_CAPACITY, 32);
             this.sqlModelPoolCapacity = getInt(properties, env, PropertyKey.CAIRO_MODEL_POOL_CAPACITY, 1024);
+            this.sqlMaxGroupingSets = getInt(properties, env, PropertyKey.CAIRO_SQL_MAX_GROUPING_SETS, 4096);
             this.sqlMaxNegativeLimit = getInt(properties, env, PropertyKey.CAIRO_SQL_MAX_NEGATIVE_LIMIT, 10_000);
             this.sqlSortKeyPageSize = getLongSize(properties, env, PropertyKey.CAIRO_SQL_SORT_KEY_PAGE_SIZE, 128 * 1024);
             this.sqlSortKeyMaxPages = getIntSize(properties, env, PropertyKey.CAIRO_SQL_SORT_KEY_MAX_PAGES, Integer.MAX_VALUE);
@@ -4394,6 +4396,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getSqlMapMaxResizes() {
             return sqlMapMaxResizes;
+        }
+
+        @Override
+        public int getSqlMaxGroupingSets() {
+            return sqlMaxGroupingSets;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -80,6 +80,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     CAIRO_SQL_UNORDERED_MAP_MAX_ENTRY_SIZE("cairo.sql.unordered.map.max.entry.size"),
     CAIRO_MODEL_POOL_CAPACITY("cairo.model.pool.capacity"),
     CAIRO_SQL_MAX_NEGATIVE_LIMIT("cairo.sql.max.negative.limit"),
+    CAIRO_SQL_MAX_GROUPING_SETS("cairo.sql.max.grouping.sets"),
     CAIRO_SQL_SORT_KEY_PAGE_SIZE("cairo.sql.sort.key.page.size"),
     CAIRO_SQL_SORT_KEY_MAX_PAGES("cairo.sql.sort.key.max.pages"),
     CAIRO_SQL_SORT_KEY_MATERIALIZATION_THRESHOLD("cairo.sql.sort.key.materialization.threshold"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -650,6 +650,8 @@ public interface CairoConfiguration {
 
     int getSqlMapMaxResizes();
 
+    int getSqlMaxGroupingSets();
+
     int getSqlMaxNegativeLimit();
 
     int getSqlModelPoolCapacity();

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -1087,6 +1087,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public int getSqlMaxGroupingSets() {
+        return getDelegate().getSqlMaxGroupingSets();
+    }
+
+    @Override
     public int getSqlMaxNegativeLimit() {
         return getDelegate().getSqlMaxNegativeLimit();
     }

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -1107,6 +1107,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public int getSqlMaxGroupingSets() {
+        return 4096;
+    }
+
+    @Override
     public int getSqlMaxNegativeLimit() {
         return 10_000;
     }

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -74,6 +74,7 @@ import io.questdb.griffin.engine.LimitRecordCursorFactory;
 import io.questdb.griffin.engine.RecordComparator;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.SymbolFunction;
+import io.questdb.griffin.engine.functions.groupby.GroupingFunction;
 import io.questdb.griffin.engine.functions.cast.CastByteToCharFunctionFactory;
 import io.questdb.griffin.engine.functions.cast.CastByteToDecimalFunctionFactory;
 import io.questdb.griffin.engine.functions.cast.CastByteToStrFunctionFactory;
@@ -171,6 +172,7 @@ import io.questdb.griffin.engine.groupby.DistinctTimeSeriesRecordCursorFactory;
 import io.questdb.griffin.engine.groupby.FillRangeRecordCursorFactory;
 import io.questdb.griffin.engine.groupby.GroupByNotKeyedRecordCursorFactory;
 import io.questdb.griffin.engine.groupby.GroupByUtils;
+import io.questdb.griffin.engine.groupby.GroupingSetsRecordCursorFactory;
 import io.questdb.griffin.engine.groupby.SampleByFillNoneNotKeyedRecordCursorFactory;
 import io.questdb.griffin.engine.groupby.SampleByFillNoneRecordCursorFactory;
 import io.questdb.griffin.engine.groupby.SampleByFillNullNotKeyedRecordCursorFactory;
@@ -3232,6 +3234,10 @@ public class SqlCodeGenerator implements Mutable, Closeable {
     }
 
     private RecordCursorFactory generateFill(IQueryModel model, RecordCursorFactory groupByFactory, SqlExecutionContext executionContext) throws SqlException {
+        return generateFill(model, groupByFactory, executionContext, null);
+    }
+
+    private RecordCursorFactory generateFill(IQueryModel model, RecordCursorFactory groupByFactory, SqlExecutionContext executionContext, IntList fillKeyColumnPositions) throws SqlException {
         // locate fill
         IQueryModel curr = model;
 
@@ -3264,6 +3270,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 if (isNoneKeyword(expr.token)) {
                     Misc.freeObjList(fillValues);
                     return groupByFactory;
+                }
+                if (isPrevKeyword(expr.token) || isLinearKeyword(expr.token)) {
+                    throw SqlException.$(expr.position, "FILL(PREV) and FILL(LINEAR) are not supported with ROLLUP, CUBE, or GROUPING SETS");
                 }
                 final Function fillValueFunc = functionParser.parseFunction(expr, EmptyRecordMetadata.INSTANCE, executionContext);
                 fillValues.add(fillValueFunc);
@@ -3324,6 +3333,22 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             char samplingIntervalUnit = fillStride.token.charAt(samplingIntervalEnd);
             TimestampSampler timestampSampler = TimestampSamplerFactory.getInstance(driver, samplingInterval, samplingIntervalUnit, fillStride.position);
 
+            if (fillKeyColumnPositions != null && fillKeyColumnPositions.size() > 0) {
+                return new FillRangeRecordCursorFactory(
+                        groupByFactory.getMetadata(),
+                        groupByFactory,
+                        fillFromFunc,
+                        fillToFunc,
+                        samplingInterval,
+                        samplingIntervalUnit,
+                        timestampSampler,
+                        fillValues,
+                        timestampIndex,
+                        timestampType,
+                        configuration,
+                        fillKeyColumnPositions
+                );
+            }
             return new FillRangeRecordCursorFactory(
                     groupByFactory.getMetadata(),
                     groupByFactory,
@@ -3335,7 +3360,6 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     fillValues,
                     timestampIndex,
                     timestampType
-
             );
         } catch (Throwable e) {
             Misc.freeObjList(fillValues);
@@ -7610,6 +7634,11 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             RecordMetadata baseMetadata = factory.getMetadata();
 
             boolean enableParallelGroupBy = executionContext.isParallelGroupByEnabled();
+            // GROUPING SETS always uses the single-threaded GroupingSetsRecordCursorFactory.
+            // Rosti and async parallel paths do not support multiple key configurations.
+            if (model.hasGroupingSets()) {
+                enableParallelGroupBy = false;
+            }
             // Inspect model for possibility of vector aggregate intrinsics.
             if (enableParallelGroupBy && pageFramingSupported && assembleKeysAndFunctionReferences(columns, baseMetadata, hourIndex)) {
                 // Create baseMetadata from everything we've gathered.
@@ -7786,6 +7815,10 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     sharedOuterProjectionFunctions
             );
 
+            if (!model.hasGroupingSets()) {
+                guardAgainstGroupingFunctionWithoutGroupingSets(groupByFunctions);
+            }
+
             // Check if we have a non-keyed query with all early exit aggregate functions (e.g. count_distinct(symbol))
             // and no filter. In such a case, use single-threaded factories instead of the multithreaded ones.
             if (
@@ -7942,7 +7975,54 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 );
             }
 
-            guardAgainstFillWithKeyedGroupBy(model, keyTypes);
+            if (!model.hasGroupingSets()) {
+                guardAgainstFillWithKeyedGroupBy(model, keyTypes);
+            }
+
+            if (model.hasGroupingSets()) {
+                // Build the mapping from GROUP BY column index to base column index
+                IntList keyColumnIndices = new IntList();
+                for (int i = 0, n = listColumnFilterA.getColumnCount(); i < n; i++) {
+                    keyColumnIndices.add(listColumnFilterA.getColumnIndexFactored(i));
+                }
+
+                // Build output column positions that should be preserved in fill
+                // rows. This includes GROUP BY key columns (SYMBOL) and
+                // GROUPING() columns (which are metadata, not aggregates).
+                // FillRangeRecordCursorFactory stores these values in a key map
+                // during the base scan and reads them back during gap filling.
+                IntList fillKeyColumnPositions = new IntList();
+                int tsIdx = outerProjectionMetadata.getTimestampIndex();
+                for (int i = 0, n = projectionFunctionFlags.size(); i < n; i++) {
+                    if (projectionFunctionFlags.getQuick(i) == GroupByUtils.PROJECTION_FUNCTION_FLAG_COLUMN
+                            && i != tsIdx) {
+                        fillKeyColumnPositions.add(i);
+                    } else if (projectionFunctionFlags.getQuick(i) == GroupByUtils.PROJECTION_FUNCTION_FLAG_GROUP_BY
+                            && tempOuterProjectionFunctions.getQuick(i) instanceof GroupingFunction) {
+                        fillKeyColumnPositions.add(i);
+                    }
+                }
+
+                return generateFill(
+                        model,
+                        new GroupingSetsRecordCursorFactory(
+                                asm,
+                                configuration,
+                                factory,
+                                listColumnFilterA,
+                                keyTypes,
+                                valueTypes,
+                                outerProjectionMetadata,
+                                groupByFunctions,
+                                keyFunctions,
+                                new ObjList<>(tempOuterProjectionFunctions),
+                                model.getGroupingSets(),
+                                keyColumnIndices
+                        ),
+                        executionContext,
+                        fillKeyColumnPositions
+                );
+            }
 
             return generateFill(
                     model,
@@ -9964,6 +10044,14 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         }
 
         throw SqlException.$(0, "cannot use FILL with a keyed GROUP BY");
+    }
+
+    private static void guardAgainstGroupingFunctionWithoutGroupingSets(ObjList<GroupByFunction> groupByFunctions) throws SqlException {
+        for (int i = 0, n = groupByFunctions.size(); i < n; i++) {
+            if (groupByFunctions.getQuick(i) instanceof GroupingFunction) {
+                throw SqlException.$(0, "GROUPING() / GROUPING_ID() can only be used with GROUPING SETS, ROLLUP, or CUBE");
+            }
+        }
     }
 
     private void guardAgainstFromToWithKeyedSampleBy(boolean isFromTo) throws SqlException {

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -3346,7 +3346,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                         timestampIndex,
                         timestampType,
                         configuration,
-                        fillKeyColumnPositions
+                        fillKeyColumnPositions,
+                        model.getModelPosition()
                 );
             }
             return new FillRangeRecordCursorFactory(
@@ -8017,7 +8018,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                 keyFunctions,
                                 new ObjList<>(tempOuterProjectionFunctions),
                                 model.getGroupingSets(),
-                                keyColumnIndices
+                                keyColumnIndices,
+                                model.getModelPosition()
                         ),
                         executionContext,
                         fillKeyColumnPositions

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -74,7 +74,6 @@ import io.questdb.griffin.engine.LimitRecordCursorFactory;
 import io.questdb.griffin.engine.RecordComparator;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.SymbolFunction;
-import io.questdb.griffin.engine.functions.groupby.GroupingFunction;
 import io.questdb.griffin.engine.functions.cast.CastByteToCharFunctionFactory;
 import io.questdb.griffin.engine.functions.cast.CastByteToDecimalFunctionFactory;
 import io.questdb.griffin.engine.functions.cast.CastByteToStrFunctionFactory;
@@ -149,6 +148,7 @@ import io.questdb.griffin.engine.functions.constants.StrConstant;
 import io.questdb.griffin.engine.functions.constants.SymbolConstant;
 import io.questdb.griffin.engine.functions.constants.TimestampConstant;
 import io.questdb.griffin.engine.functions.decimal.Decimal64LoaderFunctionFactory;
+import io.questdb.griffin.engine.functions.groupby.GroupingFunction;
 import io.questdb.griffin.engine.functions.memoization.ArrayFunctionMemoizer;
 import io.questdb.griffin.engine.functions.memoization.BooleanFunctionMemoizer;
 import io.questdb.griffin.engine.functions.memoization.ByteFunctionMemoizer;
@@ -10051,7 +10051,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
     private static void guardAgainstGroupingFunctionWithoutGroupingSets(ObjList<GroupByFunction> groupByFunctions) throws SqlException {
         for (int i = 0, n = groupByFunctions.size(); i < n; i++) {
             if (groupByFunctions.getQuick(i) instanceof GroupingFunction) {
-                throw SqlException.$(0, "GROUPING() / GROUPING_ID() can only be used with GROUPING SETS, ROLLUP, or CUBE");
+                throw SqlException.$(((GroupingFunction) groupByFunctions.getQuick(i)).getPosition(),
+                        "GROUPING() / GROUPING_ID() can only be used with GROUPING SETS, ROLLUP, or CUBE");
             }
         }
     }

--- a/core/src/main/java/io/questdb/griffin/SqlKeywords.java
+++ b/core/src/main/java/io/questdb/griffin/SqlKeywords.java
@@ -399,6 +399,14 @@ public class SqlKeywords {
                 && (tok.charAt(2) | 32) == 'v';
     }
 
+    public static boolean isCubeKeyword(CharSequence tok) {
+        return tok.length() == 4
+                && (tok.charAt(0) | 32) == 'c'
+                && (tok.charAt(1) | 32) == 'u'
+                && (tok.charAt(2) | 32) == 'b'
+                && (tok.charAt(3) | 32) == 'e';
+    }
+
     public static boolean isCumulativeKeyword(CharSequence tok) {
         return tok.length() == 10
                 && (tok.charAt(0) | 32) == 'c'
@@ -930,6 +938,18 @@ public class SqlKeywords {
                 && (tok.charAt(2) | 32) == 'o'
                 && (tok.charAt(3) | 32) == 'u'
                 && (tok.charAt(4) | 32) == 'p';
+    }
+
+    public static boolean isGroupingKeyword(CharSequence tok) {
+        return tok.length() == 8
+                && (tok.charAt(0) | 32) == 'g'
+                && (tok.charAt(1) | 32) == 'r'
+                && (tok.charAt(2) | 32) == 'o'
+                && (tok.charAt(3) | 32) == 'u'
+                && (tok.charAt(4) | 32) == 'p'
+                && (tok.charAt(5) | 32) == 'i'
+                && (tok.charAt(6) | 32) == 'n'
+                && (tok.charAt(7) | 32) == 'g';
     }
 
     public static boolean isGroupsKeyword(CharSequence tok) {
@@ -1966,6 +1986,16 @@ public class SqlKeywords {
         return tok.length() == 1 && tok.charAt(0) == ')';
     }
 
+    public static boolean isRollupKeyword(CharSequence tok) {
+        return tok.length() == 6
+                && (tok.charAt(0) | 32) == 'r'
+                && (tok.charAt(1) | 32) == 'o'
+                && (tok.charAt(2) | 32) == 'l'
+                && (tok.charAt(3) | 32) == 'l'
+                && (tok.charAt(4) | 32) == 'u'
+                && (tok.charAt(5) | 32) == 'p';
+    }
+
     public static boolean isRowKeyword(CharSequence tok) {
         return tok.length() == 3
                 && (tok.charAt(0) | 32) == 'r'
@@ -2087,6 +2117,14 @@ public class SqlKeywords {
                 && (tok.charAt(0) | 32) == 's'
                 && (tok.charAt(1) | 32) == 'e'
                 && (tok.charAt(2) | 32) == 't';
+    }
+
+    public static boolean isSetsKeyword(CharSequence tok) {
+        return tok.length() == 4
+                && (tok.charAt(0) | 32) == 's'
+                && (tok.charAt(1) | 32) == 'e'
+                && (tok.charAt(2) | 32) == 't'
+                && (tok.charAt(3) | 32) == 's';
     }
 
     public static boolean isShowKeyword(CharSequence tok) {

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -8031,7 +8031,7 @@ public class SqlOptimiser implements Mutable {
             final ExpressionNode sampleByTo = nested.getSampleByTo();
 
             final ObjList<ExpressionNode> groupBy = nested.getGroupBy();
-            if (sampleBy != null && groupBy != null && groupBy.size() > 0) {
+            if (sampleBy != null && groupBy != null && groupBy.size() > 0 && !nested.hasGroupingSets()) {
                 throw SqlException.$(groupBy.getQuick(0).position, "SELECT query must not contain both GROUP BY and SAMPLE BY");
             }
 
@@ -8048,7 +8048,12 @@ public class SqlOptimiser implements Mutable {
                             && timestamp != null
                             // null offset means ALIGN TO FIRST OBSERVATION, and we only support ALIGN TO CALENDAR
                             && sampleByOffset != null
-                            && (sampleByFillSize == 0 || (sampleByFillSize == 1 && !isPrevKeyword(sampleByFill.getQuick(0).token) && !isLinearKeyword(sampleByFill.getQuick(0).token)))
+                            // FILL(PREV/LINEAR) and multi-value fills normally go through the dedicated
+                            // SampleBy cursor path. GROUPING SETS always need the GROUP BY rewrite since
+                            // there is no dedicated SampleBy cursor for grouping sets.
+                            && (sampleByFillSize == 0
+                            || nested.hasGroupingSets()
+                            || (sampleByFillSize == 1 && !isPrevKeyword(sampleByFill.getQuick(0).token) && !isLinearKeyword(sampleByFill.getQuick(0).token)))
                             && sampleByUnit == null
                             && (sampleByFrom == null || ((sampleByFrom.type != BIND_VARIABLE) && (sampleByFrom.type != FUNCTION) && (sampleByFrom.type != OPERATION)))
             ) {
@@ -8140,7 +8145,7 @@ public class SqlOptimiser implements Mutable {
                     timestampColumn = e.toImmutable();
                 }
 
-                if (maybeKeyed.size() > 0 &&
+                if (maybeKeyed.size() > 0 && !nested.hasGroupingSets() &&
                         ((sampleByFrom != null || sampleByTo != null) || (sampleByFillSize > 0 && !isNoneKeyword(sampleByFill.getQuick(0).token)))) {
                     boolean isKeyed = false;
 
@@ -8334,6 +8339,17 @@ public class SqlOptimiser implements Mutable {
 
                 if (timestampOnly || nested.getGroupBy().size() > 0) {
                     nested.addGroupBy(tsFloorFunc);
+                }
+
+                // For SAMPLE BY with GROUPING SETS, add the timestamp column index
+                // to every grouping set. The timestamp is always an active key -
+                // it is never rolled up, since each time bucket must be preserved.
+                if (nested.hasGroupingSets()) {
+                    int tsGroupByIndex = nested.getGroupBy().size() - 1;
+                    ObjList<IntList> sets = nested.getGroupingSets();
+                    for (int s = 0, n = sets.size(); s < n; s++) {
+                        sets.getQuick(s).add(tsGroupByIndex);
+                    }
                 }
 
                 nested.setFillFrom(sampleByFrom);

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -94,6 +94,7 @@ import static io.questdb.std.GenericLexer.assertNoDotsAndSlashes;
 import static io.questdb.std.GenericLexer.unquote;
 
 public class SqlParser {
+    public static final int MAX_GROUPING_SETS = 4096;
     public static final int MAX_ORDER_BY_COLUMNS = 1560;
     public static final ExpressionNode ZERO_OFFSET = ExpressionNode.FACTORY.newInstance().of(ExpressionNode.CONSTANT, "'00:00'", 0, 0);
     private static final ExpressionNode ONE = ExpressionNode.FACTORY.newInstance().of(ExpressionNode.CONSTANT, "1", 0, 0);
@@ -3402,24 +3403,26 @@ public class SqlParser {
         LowerCaseCharSequenceIntHashMap columnIndex = new LowerCaseCharSequenceIntHashMap();
 
         do {
-            CharSequence tok = tok(lexer, "'(' or ')'");
+            // Use tokIncludingLocalBrace to avoid subQueryMode swallowing ')'
+            CharSequence tok = tokIncludingLocalBrace(lexer, "'(' or ')'");
             if (Chars.equals(tok, ')')) {
                 break;
             }
             expectTok(tok, lexer.lastTokenPosition(), '(');
 
             IntList setIndices = new IntList();
-            tok = tok(lexer, "column or ')'");
+            // Use tokIncludingLocalBrace to avoid subQueryMode swallowing ')'
+            tok = tokIncludingLocalBrace(lexer, "column or ')'");
             if (!Chars.equals(tok, ')')) {
                 // Non-empty set
                 lexer.unparseLast();
                 do {
                     ExpressionNode n = expr(lexer, model, sqlParserCallback, model.getDecls());
-                    if (n == null || (n.type != ExpressionNode.LITERAL && n.type != ExpressionNode.CONSTANT && n.type != ExpressionNode.FUNCTION && n.type != ExpressionNode.OPERATION)) {
-                        throw SqlException.$(n == null ? lexer.lastTokenPosition() : n.position, "literal expected");
+                    if (n == null || n.type != ExpressionNode.LITERAL) {
+                        throw SqlException.$(n == null ? lexer.lastTokenPosition() : n.position, "column reference expected");
                     }
 
-                    // Find or add column in groupBy
+                    // Find or add column in groupBy (dedup by column name)
                     CharSequence colName = n.token;
                     int idx = columnIndex.keyIndex(colName);
                     if (idx >= 0) {
@@ -3431,7 +3434,8 @@ public class SqlParser {
                         setIndices.add(columnIndex.valueAt(idx));
                     }
 
-                    tok = tok(lexer, "',' or ')'");
+                    // Use tokIncludingLocalBrace to avoid subQueryMode swallowing ')'
+                    tok = tokIncludingLocalBrace(lexer, "',' or ')'");
                     if (Chars.equals(tok, ')')) {
                         break;
                     }
@@ -3439,8 +3443,12 @@ public class SqlParser {
                 } while (true);
             }
             model.addGroupingSet(setIndices);
+            if (model.getGroupingSets().size() > MAX_GROUPING_SETS) {
+                throw SqlException.$(lexer.lastTokenPosition(), "too many grouping sets (maximum " + MAX_GROUPING_SETS + ")");
+            }
 
-            tok = optTok(lexer);
+            // Use SqlUtil.fetchNext to avoid subQueryMode swallowing ')'
+            tok = SqlUtil.fetchNext(lexer);
             if (tok == null || Chars.equals(tok, ')')) {
                 break;
             }
@@ -3964,6 +3972,39 @@ public class SqlParser {
         if (tok != null) {
             lexer.unparseLast();
         }
+    }
+
+    /**
+     * Parses a parenthesized comma-separated list of column expressions: (a, b, c).
+     * Used by ROLLUP and CUBE parsing.
+     */
+    private ObjList<ExpressionNode> parseParenthesizedColumnList(
+            GenericLexer lexer,
+            QueryModel model,
+            SqlParserCallback sqlParserCallback
+    ) throws SqlException {
+        expectTok(lexer, '(');
+        ObjList<ExpressionNode> columns = new ObjList<>();
+        // Use tokIncludingLocalBrace to avoid subQueryMode swallowing ')'
+        CharSequence tok = tokIncludingLocalBrace(lexer, "column or ')'");
+        if (Chars.equals(tok, ')')) {
+            return columns;
+        }
+        lexer.unparseLast();
+        do {
+            ExpressionNode n = expr(lexer, model, sqlParserCallback, model.getDecls());
+            if (n == null || (n.type != ExpressionNode.LITERAL && n.type != ExpressionNode.CONSTANT && n.type != ExpressionNode.FUNCTION && n.type != ExpressionNode.OPERATION)) {
+                throw SqlException.$(n == null ? lexer.lastTokenPosition() : n.position, "literal expected");
+            }
+            columns.add(n);
+            // Use tokIncludingLocalBrace to avoid subQueryMode swallowing ')'
+            tok = tokIncludingLocalBrace(lexer, "',' or ')'");
+            if (Chars.equals(tok, ')')) {
+                break;
+            }
+            expectTok(tok, lexer.lastTokenPosition(), ',');
+        } while (true);
+        return columns;
     }
 
     /**

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -906,7 +906,12 @@ public class SqlParser {
      * @param startIdx          index of the first ROLLUP column in model.groupBy
      * @param rollupColumnCount number of ROLLUP columns
      */
-    private static void expandRollup(QueryModel model, int startIdx, int rollupColumnCount) {
+    private static void expandRollup(QueryModel model, int startIdx, int rollupColumnCount, int position) throws SqlException {
+        int totalSets = rollupColumnCount + 1;
+        if (totalSets > MAX_GROUPING_SETS) {
+            throw SqlException.$(position, "ROLLUP produces too many grouping sets (")
+                    .put(totalSets).put(", maximum ").put(MAX_GROUPING_SETS).put(')');
+        }
         // N+1 sets: from all columns down to empty set
         for (int setSize = rollupColumnCount; setSize >= 0; setSize--) {
             IntList set = new IntList();
@@ -921,7 +926,12 @@ public class SqlParser {
      * Expands ROLLUP with composite plain columns prepended to every set.
      * GROUP BY a, ROLLUP(b, c) -> sets: (a,b,c), (a,b), (a).
      */
-    private static void expandRollupComposite(QueryModel model, int plainCount, int rollupStart, int rollupColumnCount) {
+    private static void expandRollupComposite(QueryModel model, int plainCount, int rollupStart, int rollupColumnCount, int position) throws SqlException {
+        int totalSets = rollupColumnCount + 1;
+        if (totalSets > MAX_GROUPING_SETS) {
+            throw SqlException.$(position, "ROLLUP produces too many grouping sets (")
+                    .put(totalSets).put(", maximum ").put(MAX_GROUPING_SETS).put(')');
+        }
         for (int setSize = rollupColumnCount; setSize >= 0; setSize--) {
             IntList set = new IntList();
             // Add all plain columns first
@@ -2961,7 +2971,7 @@ public class SqlParser {
                     model.addGroupBy(columnList.getQuick(i));
                 }
                 if (isRollup) {
-                    expandRollup(model, startIdx, columnList.size());
+                    expandRollup(model, startIdx, columnList.size(), kwPos);
                 } else {
                     expandCube(model, startIdx, columnList.size(), kwPos);
                 }
@@ -3331,7 +3341,7 @@ public class SqlParser {
                 model.addGroupBy(columns.getQuick(i));
             }
             if (isRollup) {
-                expandRollup(model, 0, columns.size());
+                expandRollup(model, 0, columns.size(), kwPos);
             } else {
                 expandCube(model, 0, columns.size(), kwPos);
             }
@@ -3373,7 +3383,7 @@ public class SqlParser {
                     model.addGroupBy(rollupCols.getQuick(i));
                 }
                 if (isRollup) {
-                    expandRollupComposite(model, plainCount, rollupStart, rollupCols.size());
+                    expandRollupComposite(model, plainCount, rollupStart, rollupCols.size(), kwPos);
                 } else {
                     expandCubeComposite(model, plainCount, rollupStart, rollupCols.size(), kwPos);
                 }

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -848,13 +848,49 @@ public class SqlParser {
     }
 
     /**
-     * Expands CUBE into grouping sets. CUBE(a, b) generates all 2^N subsets:
-     * (a,b), (a), (b), ().
-     *
-     * @param model           query model to add grouping sets to
-     * @param startIdx        index of the first CUBE column in model.groupBy
-     * @param cubeColumnCount number of CUBE columns
+     * Checks that all columns in the combined GROUP BY list do not mix
+     * qualified (t.a) and unqualified (a) references to the same column.
+     * The grouping set machinery deduplicates by raw token text, so
+     * mixed forms would create separate entries and incorrect sets.
      */
+    private static void checkMixedQualification(ObjList<ExpressionNode> groupByColumns) throws SqlException {
+        for (int i = 0, n = groupByColumns.size(); i < n; i++) {
+            ExpressionNode a = groupByColumns.getQuick(i);
+            for (int j = i + 1; j < n; j++) {
+                ExpressionNode b = groupByColumns.getQuick(j);
+                if (isSameColumnMixedQualification(a.token, b.token)) {
+                    throw SqlException.$(b.position, "mixing qualified and unqualified references to the same column in GROUPING SETS");
+                }
+            }
+        }
+    }
+
+    private static void ensureColumnReferences(ObjList<ExpressionNode> columns, int kwPos) throws SqlException {
+        for (int i = 0, n = columns.size(); i < n; i++) {
+            ExpressionNode node = columns.getQuick(i);
+            if (node.type != ExpressionNode.LITERAL) {
+                throw SqlException.$(node.position, "column reference expected");
+            }
+        }
+    }
+
+    /**
+     * Returns true if two column tokens refer to the same column but one
+     * is qualified (t.col) and the other is not (col).
+     */
+    private static boolean isSameColumnMixedQualification(CharSequence a, CharSequence b) {
+        int aDot = Chars.indexOf(a, '.');
+        int bDot = Chars.indexOf(b, '.');
+        if ((aDot < 0) == (bDot < 0)) {
+            // Both qualified or both unqualified - no mixed issue
+            return false;
+        }
+        // One is qualified, the other is not. Compare the column name parts.
+        CharSequence aCol = aDot >= 0 ? a.subSequence(aDot + 1, a.length()) : a;
+        CharSequence bCol = bDot >= 0 ? b.subSequence(bDot + 1, b.length()) : b;
+        return Chars.equalsIgnoreCase(aCol, bCol);
+    }
+
     private static void expandCube(QueryModel model, int startIdx, int cubeColumnCount, int position) throws SqlException {
         // 2^N subsets, from the full set (all bits set) down to empty set (0)
         int totalSets = 1 << cubeColumnCount;
@@ -2963,6 +2999,8 @@ public class SqlParser {
                 if (columnList.size() == 0) {
                     throw SqlException.$(kwPos, (isRollup ? "ROLLUP" : "CUBE") + " requires at least one column");
                 }
+                ensureColumnReferences(columnList, kwPos);
+                checkMixedQualification(columnList);
                 if (!isRollup && columnList.size() > 15) {
                     throw SqlException.$(kwPos, "CUBE supports at most 15 columns");
                 }
@@ -3334,6 +3372,8 @@ public class SqlParser {
             if (columns.size() == 0) {
                 throw SqlException.$(kwPos, isRollup ? "ROLLUP requires at least one column" : "CUBE requires at least one column");
             }
+            ensureColumnReferences(columns, kwPos);
+            checkMixedQualification(columns);
             if (!isRollup && columns.size() > 15) {
                 throw SqlException.$(kwPos, "CUBE supports at most 15 columns");
             }
@@ -3375,6 +3415,7 @@ public class SqlParser {
                 if (rollupCols.size() == 0) {
                     throw SqlException.$(kwPos, isRollup ? "ROLLUP requires at least one column" : "CUBE requires at least one column");
                 }
+                ensureColumnReferences(rollupCols, kwPos);
                 if (!isRollup && rollupCols.size() > 15) {
                     throw SqlException.$(kwPos, "CUBE supports at most 15 columns");
                 }
@@ -3382,6 +3423,8 @@ public class SqlParser {
                 for (int i = 0, n = rollupCols.size(); i < n; i++) {
                     model.addGroupBy(rollupCols.getQuick(i));
                 }
+                // Check all columns (plain + rollup) for mixed qualification
+                checkMixedQualification(model.getGroupBy());
                 if (isRollup) {
                     expandRollupComposite(model, plainCount, rollupStart, rollupCols.size(), kwPos);
                 } else {
@@ -3412,11 +3455,9 @@ public class SqlParser {
      * Parses explicit GROUPING SETS ((a, b), (a), ()).
      * The outer parentheses and inner sets with their parentheses.
      * <p>
-     * Unlike ROLLUP/CUBE (which accept expressions via
-     * {@link #parseParenthesizedColumnList}), explicit GROUPING SETS
-     * only accept column references. This is intentional: expressions
-     * in explicit sets create ambiguity in set membership resolution
-     * because the same expression can appear in different forms.
+     * Like ROLLUP/CUBE, explicit GROUPING SETS only accept column
+     * references - expressions are rejected to avoid ambiguity in
+     * set membership resolution.
      */
     private void parseExplicitGroupingSets(
             GenericLexer lexer,
@@ -3424,7 +3465,9 @@ public class SqlParser {
             SqlParserCallback sqlParserCallback
     ) throws SqlException {
         expectTok(lexer, '(');
-        // Track column name to index mapping for deduplication
+        // Track column name to index mapping for deduplication.
+        // Dedup uses raw token text; mixing qualified (t.a) and unqualified
+        // (a) references to the same column is rejected below.
         LowerCaseCharSequenceIntHashMap columnIndex = new LowerCaseCharSequenceIntHashMap();
 
         do {
@@ -3447,13 +3490,21 @@ public class SqlParser {
                         throw SqlException.$(n == null ? lexer.lastTokenPosition() : n.position, "column reference expected");
                     }
 
-                    // Find or add column in groupBy (dedup by column name)
-                    CharSequence colName = n.token;
-                    int idx = columnIndex.keyIndex(colName);
+                    // Detect mixed qualified/unqualified references to the
+                    // same column (e.g., both "a" and "t.a"). The dedup map
+                    // uses raw token text, so these would create separate
+                    // entries and produce incorrect grouping sets.
+                    for (int ci = 0, cn = columnIndex.size(); ci < cn; ci++) {
+                        CharSequence existing = columnIndex.keys().getQuick(ci);
+                        if (existing != null && isSameColumnMixedQualification(n.token, existing)) {
+                            throw SqlException.$(n.position, "mixing qualified and unqualified references to the same column in GROUPING SETS");
+                        }
+                    }
+                    int idx = columnIndex.keyIndex(n.token);
                     if (idx >= 0) {
                         int pos = model.getGroupBy().size();
                         model.addGroupBy(n);
-                        columnIndex.putAt(idx, colName, pos);
+                        columnIndex.putAt(idx, n.token, pos);
                         setIndices.add(pos);
                     } else {
                         setIndices.add(columnIndex.valueAt(idx));

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -3008,10 +3008,11 @@ public class SqlParser {
 
             // support SAMPLE BY 1h ROLLUP(symbol, side)
             if (tok != null && (isRollupKeyword(tok) || isCubeKeyword(tok))) {
+                QueryModel qm = (QueryModel) model;
                 int kwPos = lexer.lastTokenPosition();
-                guardAgainstLatestOnWithGroupingSets(model, kwPos);
+                guardAgainstLatestOnWithGroupingSets(qm, kwPos);
                 boolean isRollup = isRollupKeyword(tok);
-                ObjList<ExpressionNode> columnList = parseParenthesizedColumnList(lexer, model, sqlParserCallback);
+                ObjList<ExpressionNode> columnList = parseParenthesizedColumnList(lexer, qm, sqlParserCallback);
                 if (columnList.size() == 0) {
                     throw SqlException.$(kwPos, (isRollup ? "ROLLUP" : "CUBE") + " requires at least one column");
                 }
@@ -3026,18 +3027,18 @@ public class SqlParser {
                 }
                 int maxSets = configuration.getSqlMaxGroupingSets();
                 if (isRollup) {
-                    expandRollup(model, startIdx, columnList.size(), kwPos, maxSets);
+                    expandRollup(qm, startIdx, columnList.size(), kwPos, maxSets);
                 } else {
-                    expandCube(model, startIdx, columnList.size(), kwPos, maxSets);
+                    expandCube(qm, startIdx, columnList.size(), kwPos, maxSets);
                 }
                 tok = optTok(lexer);
             } else if (tok != null && isGroupingKeyword(tok)) {
-                guardAgainstLatestOnWithGroupingSets(model, lexer.lastTokenPosition());
+                guardAgainstLatestOnWithGroupingSets((QueryModel) model, lexer.lastTokenPosition());
                 CharSequence next = tok(lexer, "'SETS'");
                 if (!isSetsKeyword(next)) {
                     throw SqlException.$(lexer.lastTokenPosition(), "expected SETS after GROUPING");
                 }
-                parseExplicitGroupingSets(lexer, model, sqlParserCallback);
+                parseExplicitGroupingSets(lexer, (QueryModel) model, sqlParserCallback);
                 tok = optTok(lexer);
             }
 
@@ -3136,7 +3137,7 @@ public class SqlParser {
                 model = parentModel;
             }
             expectBy(lexer);
-            tok = parseGroupByColumns(lexer, model, sqlParserCallback);
+            tok = parseGroupByColumns(lexer, (QueryModel) model, sqlParserCallback);
         }
 
         // expect [window]
@@ -4123,37 +4124,6 @@ public class SqlParser {
      * significantly impact performance. This aligns with mainstream databases which also
      * do not support ELSE in PIVOT. For such requirements, user can use subqueries instead.
      */
-    /**
-     * Parses a parenthesized comma-separated list of column expressions: (a, b, c).
-     * Used by ROLLUP and CUBE parsing.
-     */
-    private ObjList<ExpressionNode> parseParenthesizedColumnList(
-            GenericLexer lexer,
-            QueryModel model,
-            SqlParserCallback sqlParserCallback
-    ) throws SqlException {
-        expectTok(lexer, '(');
-        ObjList<ExpressionNode> columns = new ObjList<>();
-        CharSequence tok = tok(lexer, "column or ')'");
-        if (Chars.equals(tok, ')')) {
-            return columns;
-        }
-        lexer.unparseLast();
-        do {
-            ExpressionNode n = expr(lexer, model, sqlParserCallback, model.getDecls());
-            if (n == null || (n.type != ExpressionNode.LITERAL && n.type != ExpressionNode.CONSTANT && n.type != ExpressionNode.FUNCTION && n.type != ExpressionNode.OPERATION)) {
-                throw SqlException.$(n == null ? lexer.lastTokenPosition() : n.position, "literal expected");
-            }
-            columns.add(n);
-            tok = tok(lexer, "',' or ')'");
-            if (Chars.equals(tok, ')')) {
-                break;
-            }
-            expectTok(tok, lexer.lastTokenPosition(), ',');
-        } while (true);
-        return columns;
-    }
-
     private CharSequence parsePivot(GenericLexer lexer, IQueryModel model, SqlParserCallback sqlParserCallback) throws SqlException {
         CharSequence tok;
         expectTok(lexer, '(');

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -871,7 +871,7 @@ public class SqlParser {
      * Rejects expressions in ROLLUP/CUBE/GROUPING SETS to avoid ambiguity
      * in set membership resolution.
      */
-    private static void ensureColumnReferences(ObjList<ExpressionNode> columns, int kwPos) throws SqlException {
+    private static void ensureColumnReferences(ObjList<ExpressionNode> columns) throws SqlException {
         for (int i = 0, n = columns.size(); i < n; i++) {
             ExpressionNode node = columns.getQuick(i);
             if (node.type != ExpressionNode.LITERAL) {
@@ -3015,7 +3015,7 @@ public class SqlParser {
                 if (columnList.size() == 0) {
                     throw SqlException.$(kwPos, (isRollup ? "ROLLUP" : "CUBE") + " requires at least one column");
                 }
-                ensureColumnReferences(columnList, kwPos);
+                ensureColumnReferences(columnList);
                 checkMixedQualification(columnList);
                 if (!isRollup && columnList.size() > 15) {
                     throw SqlException.$(kwPos, "CUBE supports at most 15 columns");
@@ -3391,7 +3391,7 @@ public class SqlParser {
             if (columns.size() == 0) {
                 throw SqlException.$(kwPos, isRollup ? "ROLLUP requires at least one column" : "CUBE requires at least one column");
             }
-            ensureColumnReferences(columns, kwPos);
+            ensureColumnReferences(columns);
             checkMixedQualification(columns);
             if (!isRollup && columns.size() > 15) {
                 throw SqlException.$(kwPos, "CUBE supports at most 15 columns");
@@ -3437,7 +3437,7 @@ public class SqlParser {
                 if (rollupCols.size() == 0) {
                     throw SqlException.$(kwPos, isRollup ? "ROLLUP requires at least one column" : "CUBE requires at least one column");
                 }
-                ensureColumnReferences(rollupCols, kwPos);
+                ensureColumnReferences(rollupCols);
                 if (!isRollup && rollupCols.size() > 15) {
                     throw SqlException.$(kwPos, "CUBE supports at most 15 columns");
                 }

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -859,12 +859,17 @@ public class SqlParser {
             for (int j = i + 1; j < n; j++) {
                 ExpressionNode b = groupByColumns.getQuick(j);
                 if (isSameColumnMixedQualification(a.token, b.token)) {
-                    throw SqlException.$(b.position, "mixing qualified and unqualified references to the same column in GROUPING SETS");
+                    throw SqlException.$(b.position, "mixing qualified and unqualified references to the same column");
                 }
             }
         }
     }
 
+    /**
+     * Validates that all nodes in the list are column references (LITERAL).
+     * Rejects expressions in ROLLUP/CUBE/GROUPING SETS to avoid ambiguity
+     * in set membership resolution.
+     */
     private static void ensureColumnReferences(ObjList<ExpressionNode> columns, int kwPos) throws SqlException {
         for (int i = 0, n = columns.size(); i < n; i++) {
             ExpressionNode node = columns.getQuick(i);
@@ -885,10 +890,13 @@ public class SqlParser {
             // Both qualified or both unqualified - no mixed issue
             return false;
         }
-        // One is qualified, the other is not. Compare the column name parts.
-        CharSequence aCol = aDot >= 0 ? a.subSequence(aDot + 1, a.length()) : a;
-        CharSequence bCol = bDot >= 0 ? b.subSequence(bDot + 1, b.length()) : b;
-        return Chars.equalsIgnoreCase(aCol, bCol);
+        // One is qualified, the other is not. Compare the column name
+        // part of the qualified token with the full unqualified token.
+        if (aDot >= 0) {
+            return Chars.equalsIgnoreCase(b, a, aDot + 1, a.length());
+        } else {
+            return Chars.equalsIgnoreCase(a, b, bDot + 1, b.length());
+        }
     }
 
     private static void expandCube(QueryModel model, int startIdx, int cubeColumnCount, int position) throws SqlException {
@@ -3497,7 +3505,7 @@ public class SqlParser {
                     for (int ci = 0, cn = columnIndex.size(); ci < cn; ci++) {
                         CharSequence existing = columnIndex.keys().getQuick(ci);
                         if (existing != null && isSameColumnMixedQualification(n.token, existing)) {
-                            throw SqlException.$(n.position, "mixing qualified and unqualified references to the same column in GROUPING SETS");
+                            throw SqlException.$(n.position, "mixing qualified and unqualified references to the same column");
                         }
                     }
                     int idx = columnIndex.keyIndex(n.token);

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -846,6 +846,86 @@ public class SqlParser {
         throw SqlException.$((lexer.lastTokenPosition()), "'zone' expected");
     }
 
+    /**
+     * Expands CUBE into grouping sets. CUBE(a, b) generates all 2^N subsets:
+     * (a,b), (a), (b), ().
+     *
+     * @param model           query model to add grouping sets to
+     * @param startIdx        index of the first CUBE column in model.groupBy
+     * @param cubeColumnCount number of CUBE columns
+     */
+    private static void expandCube(QueryModel model, int startIdx, int cubeColumnCount) {
+        // 2^N subsets, from the full set (all bits set) down to empty set (0)
+        int totalSets = 1 << cubeColumnCount;
+        for (int mask = totalSets - 1; mask >= 0; mask--) {
+            IntList set = new IntList();
+            for (int bit = 0; bit < cubeColumnCount; bit++) {
+                if ((mask & (1 << (cubeColumnCount - 1 - bit))) != 0) {
+                    set.add(startIdx + bit);
+                }
+            }
+            model.addGroupingSet(set);
+        }
+    }
+
+    /**
+     * Expands CUBE with composite plain columns prepended to every set.
+     * GROUP BY a, CUBE(b, c) -> sets: (a,b,c), (a,b), (a,c), (a).
+     */
+    private static void expandCubeComposite(QueryModel model, int plainCount, int rollupStart, int cubeColumnCount) {
+        int totalSets = 1 << cubeColumnCount;
+        for (int mask = totalSets - 1; mask >= 0; mask--) {
+            IntList set = new IntList();
+            // Add all plain columns first
+            for (int i = 0; i < plainCount; i++) {
+                set.add(i);
+            }
+            for (int bit = 0; bit < cubeColumnCount; bit++) {
+                if ((mask & (1 << (cubeColumnCount - 1 - bit))) != 0) {
+                    set.add(rollupStart + bit);
+                }
+            }
+            model.addGroupingSet(set);
+        }
+    }
+
+    /**
+     * Expands ROLLUP into grouping sets. ROLLUP(a, b, c) generates:
+     * (a,b,c), (a,b), (a), ().
+     *
+     * @param model             query model to add grouping sets to
+     * @param startIdx          index of the first ROLLUP column in model.groupBy
+     * @param rollupColumnCount number of ROLLUP columns
+     */
+    private static void expandRollup(QueryModel model, int startIdx, int rollupColumnCount) {
+        // N+1 sets: from all columns down to empty set
+        for (int setSize = rollupColumnCount; setSize >= 0; setSize--) {
+            IntList set = new IntList();
+            for (int j = 0; j < setSize; j++) {
+                set.add(startIdx + j);
+            }
+            model.addGroupingSet(set);
+        }
+    }
+
+    /**
+     * Expands ROLLUP with composite plain columns prepended to every set.
+     * GROUP BY a, ROLLUP(b, c) -> sets: (a,b,c), (a,b), (a).
+     */
+    private static void expandRollupComposite(QueryModel model, int plainCount, int rollupStart, int rollupColumnCount) {
+        for (int setSize = rollupColumnCount; setSize >= 0; setSize--) {
+            IntList set = new IntList();
+            // Add all plain columns first
+            for (int i = 0; i < plainCount; i++) {
+                set.add(i);
+            }
+            for (int j = 0; j < setSize; j++) {
+                set.add(rollupStart + j);
+            }
+            model.addGroupingSet(set);
+        }
+    }
+
     private void generateColumnAlias(GenericLexer lexer, QueryColumn qc, boolean hasFrom) throws SqlException {
         CharSequence token = qc.getAst().token;
         if (qc.getAst().isWildcard() && !hasFrom) {
@@ -2856,6 +2936,35 @@ public class SqlParser {
             expectSample(lexer, model, sqlParserCallback);
             tok = optTok(lexer);
 
+            // support SAMPLE BY 1h ROLLUP(symbol, side)
+            if (tok != null && (isRollupKeyword(tok) || isCubeKeyword(tok))) {
+                boolean isRollup = isRollupKeyword(tok);
+                ObjList<ExpressionNode> columnList = parseParenthesizedColumnList(lexer, model, sqlParserCallback);
+                if (columnList.size() == 0) {
+                    throw SqlException.$(lexer.lastTokenPosition(), (isRollup ? "ROLLUP" : "CUBE") + " requires at least one column");
+                }
+                if (!isRollup && columnList.size() > 15) {
+                    throw SqlException.$(lexer.lastTokenPosition(), "CUBE supports at most 15 columns");
+                }
+                int startIdx = model.getGroupBy().size();
+                for (int i = 0, n = columnList.size(); i < n; i++) {
+                    model.addGroupBy(columnList.getQuick(i));
+                }
+                if (isRollup) {
+                    expandRollup(model, startIdx, columnList.size());
+                } else {
+                    expandCube(model, startIdx, columnList.size());
+                }
+                tok = optTok(lexer);
+            } else if (tok != null && isGroupingKeyword(tok)) {
+                CharSequence next = tok(lexer, "'SETS'");
+                if (!isSetsKeyword(next)) {
+                    throw SqlException.$(lexer.lastTokenPosition(), "expected SETS after GROUPING");
+                }
+                parseExplicitGroupingSets(lexer, model, sqlParserCallback);
+                tok = optTok(lexer);
+            }
+
             ExpressionNode fromNode = null, toNode = null;
             // support `SAMPLE BY 5m FROM foo TO bah`
             if (tok != null && isFromKeyword(tok)) {
@@ -2951,18 +3060,7 @@ public class SqlParser {
                 model = parentModel;
             }
             expectBy(lexer);
-            do {
-                tokIncludingLocalBrace(lexer, "literal");
-                lexer.unparseLast();
-                ExpressionNode n = expr(lexer, model, sqlParserCallback, model.getDecls());
-                if (n == null || (n.type != ExpressionNode.LITERAL && n.type != ExpressionNode.CONSTANT && n.type != ExpressionNode.FUNCTION && n.type != ExpressionNode.OPERATION)) {
-                    throw SqlException.$(n == null ? lexer.lastTokenPosition() : n.position, "literal expected");
-                }
-
-                model.addGroupBy(n);
-
-                tok = optTok(lexer);
-            } while (tok != null && Chars.equals(tok, ','));
+            tok = parseGroupByColumns(lexer, model, sqlParserCallback);
         }
 
         // expect [window]
@@ -3186,6 +3284,168 @@ public class SqlParser {
             throw SqlException.position(volumeKwPos).put("'in volume' is not supported on Windows");
         }
         tableOpBuilder.setVolumeAlias(GenericLexer.unquote(tok), lexer.lastTokenPosition());
+    }
+
+    /**
+     * Parses GROUP BY columns, handling ROLLUP, CUBE, and GROUPING SETS syntax.
+     * Returns the next unconsumed token (or null).
+     *
+     * <p>Supported forms:
+     * <ul>
+     *   <li>{@code GROUP BY a, b} - plain GROUP BY (no grouping sets)</li>
+     *   <li>{@code GROUP BY ROLLUP(a, b)} - desugared to GROUPING SETS ((a,b), (a), ())</li>
+     *   <li>{@code GROUP BY CUBE(a, b)} - desugared to GROUPING SETS ((a,b), (a), (b), ())</li>
+     *   <li>{@code GROUP BY GROUPING SETS ((a,b), (a), ())} - explicit grouping sets</li>
+     *   <li>{@code GROUP BY a, ROLLUP(b, c)} - composite: plain cols added to every set</li>
+     * </ul>
+     */
+    private CharSequence parseGroupByColumns(
+            GenericLexer lexer,
+            QueryModel model,
+            SqlParserCallback sqlParserCallback
+    ) throws SqlException {
+        CharSequence tok = tokIncludingLocalBrace(lexer, "literal");
+
+        // Check for ROLLUP/CUBE/GROUPING SETS as the first token
+        if (isRollupKeyword(tok) || isCubeKeyword(tok)) {
+            int kwPos = lexer.lastTokenPosition();
+            boolean isRollup = isRollupKeyword(tok);
+            ObjList<ExpressionNode> columns = parseParenthesizedColumnList(lexer, model, sqlParserCallback);
+            if (columns.size() == 0) {
+                throw SqlException.$(kwPos, isRollup ? "ROLLUP requires at least one column" : "CUBE requires at least one column");
+            }
+            if (!isRollup && columns.size() > 15) {
+                throw SqlException.$(kwPos, "CUBE supports at most 15 columns");
+            }
+            for (int i = 0, n = columns.size(); i < n; i++) {
+                model.addGroupBy(columns.getQuick(i));
+            }
+            if (isRollup) {
+                expandRollup(model, 0, columns.size());
+            } else {
+                expandCube(model, 0, columns.size());
+            }
+            return optTok(lexer);
+        }
+
+        if (isGroupingKeyword(tok)) {
+            int kwPos = lexer.lastTokenPosition();
+            tok = optTok(lexer);
+            if (tok == null || !isSetsKeyword(tok)) {
+                throw SqlException.$(kwPos, "expected SETS after GROUPING");
+            }
+            parseExplicitGroupingSets(lexer, model, sqlParserCallback);
+            return optTok(lexer);
+        }
+
+        // Plain GROUP BY parsing - may contain ROLLUP/CUBE after plain columns (composite)
+        lexer.unparseLast();
+        ObjList<ExpressionNode> plainColumns = new ObjList<>();
+        do {
+            tok = tokIncludingLocalBrace(lexer, "literal");
+            // Check if the current token is ROLLUP/CUBE (composite syntax)
+            if (isRollupKeyword(tok) || isCubeKeyword(tok)) {
+                int kwPos = lexer.lastTokenPosition();
+                boolean isRollup = isRollupKeyword(tok);
+                int plainCount = plainColumns.size();
+                for (int i = 0; i < plainCount; i++) {
+                    model.addGroupBy(plainColumns.getQuick(i));
+                }
+                ObjList<ExpressionNode> rollupCols = parseParenthesizedColumnList(lexer, model, sqlParserCallback);
+                if (rollupCols.size() == 0) {
+                    throw SqlException.$(kwPos, isRollup ? "ROLLUP requires at least one column" : "CUBE requires at least one column");
+                }
+                if (!isRollup && rollupCols.size() > 15) {
+                    throw SqlException.$(kwPos, "CUBE supports at most 15 columns");
+                }
+                int rollupStart = plainCount;
+                for (int i = 0, n = rollupCols.size(); i < n; i++) {
+                    model.addGroupBy(rollupCols.getQuick(i));
+                }
+                if (isRollup) {
+                    expandRollupComposite(model, plainCount, rollupStart, rollupCols.size());
+                } else {
+                    expandCubeComposite(model, plainCount, rollupStart, rollupCols.size());
+                }
+                return optTok(lexer);
+            }
+
+            // Regular expression
+            lexer.unparseLast();
+            ExpressionNode n = expr(lexer, model, sqlParserCallback, model.getDecls());
+            if (n == null || (n.type != ExpressionNode.LITERAL && n.type != ExpressionNode.CONSTANT && n.type != ExpressionNode.FUNCTION && n.type != ExpressionNode.OPERATION)) {
+                throw SqlException.$(n == null ? lexer.lastTokenPosition() : n.position, "literal expected");
+            }
+            plainColumns.add(n);
+
+            tok = optTok(lexer);
+        } while (tok != null && Chars.equals(tok, ','));
+
+        // Plain GROUP BY - no ROLLUP/CUBE/GROUPING SETS
+        for (int i = 0, n = plainColumns.size(); i < n; i++) {
+            model.addGroupBy(plainColumns.getQuick(i));
+        }
+        return tok;
+    }
+
+    /**
+     * Parses explicit GROUPING SETS ((a, b), (a), ()).
+     * The outer parentheses and inner sets with their parentheses.
+     */
+    private void parseExplicitGroupingSets(
+            GenericLexer lexer,
+            QueryModel model,
+            SqlParserCallback sqlParserCallback
+    ) throws SqlException {
+        expectTok(lexer, '(');
+        // Track column name to index mapping for deduplication
+        LowerCaseCharSequenceIntHashMap columnIndex = new LowerCaseCharSequenceIntHashMap();
+
+        do {
+            CharSequence tok = tok(lexer, "'(' or ')'");
+            if (Chars.equals(tok, ')')) {
+                break;
+            }
+            expectTok(tok, lexer.lastTokenPosition(), '(');
+
+            IntList setIndices = new IntList();
+            tok = tok(lexer, "column or ')'");
+            if (!Chars.equals(tok, ')')) {
+                // Non-empty set
+                lexer.unparseLast();
+                do {
+                    ExpressionNode n = expr(lexer, model, sqlParserCallback, model.getDecls());
+                    if (n == null || (n.type != ExpressionNode.LITERAL && n.type != ExpressionNode.CONSTANT && n.type != ExpressionNode.FUNCTION && n.type != ExpressionNode.OPERATION)) {
+                        throw SqlException.$(n == null ? lexer.lastTokenPosition() : n.position, "literal expected");
+                    }
+
+                    // Find or add column in groupBy
+                    CharSequence colName = n.token;
+                    int idx = columnIndex.keyIndex(colName);
+                    if (idx >= 0) {
+                        int pos = model.getGroupBy().size();
+                        model.addGroupBy(n);
+                        columnIndex.putAt(idx, colName, pos);
+                        setIndices.add(pos);
+                    } else {
+                        setIndices.add(columnIndex.valueAt(idx));
+                    }
+
+                    tok = tok(lexer, "',' or ')'");
+                    if (Chars.equals(tok, ')')) {
+                        break;
+                    }
+                    expectTok(tok, lexer.lastTokenPosition(), ',');
+                } while (true);
+            }
+            model.addGroupingSet(setIndices);
+
+            tok = optTok(lexer);
+            if (tok == null || Chars.equals(tok, ')')) {
+                break;
+            }
+            expectTok(tok, lexer.lastTokenPosition(), ',');
+        } while (true);
     }
 
     private ExecutionModel parseInsert(
@@ -3722,6 +3982,37 @@ public class SqlParser {
      * significantly impact performance. This aligns with mainstream databases which also
      * do not support ELSE in PIVOT. For such requirements, user can use subqueries instead.
      */
+    /**
+     * Parses a parenthesized comma-separated list of column expressions: (a, b, c).
+     * Used by ROLLUP and CUBE parsing.
+     */
+    private ObjList<ExpressionNode> parseParenthesizedColumnList(
+            GenericLexer lexer,
+            QueryModel model,
+            SqlParserCallback sqlParserCallback
+    ) throws SqlException {
+        expectTok(lexer, '(');
+        ObjList<ExpressionNode> columns = new ObjList<>();
+        CharSequence tok = tok(lexer, "column or ')'");
+        if (Chars.equals(tok, ')')) {
+            return columns;
+        }
+        lexer.unparseLast();
+        do {
+            ExpressionNode n = expr(lexer, model, sqlParserCallback, model.getDecls());
+            if (n == null || (n.type != ExpressionNode.LITERAL && n.type != ExpressionNode.CONSTANT && n.type != ExpressionNode.FUNCTION && n.type != ExpressionNode.OPERATION)) {
+                throw SqlException.$(n == null ? lexer.lastTokenPosition() : n.position, "literal expected");
+            }
+            columns.add(n);
+            tok = tok(lexer, "',' or ')'");
+            if (Chars.equals(tok, ')')) {
+                break;
+            }
+            expectTok(tok, lexer.lastTokenPosition(), ',');
+        } while (true);
+        return columns;
+    }
+
     private CharSequence parsePivot(GenericLexer lexer, IQueryModel model, SqlParserCallback sqlParserCallback) throws SqlException {
         CharSequence tok;
         expectTok(lexer, '(');

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -855,9 +855,13 @@ public class SqlParser {
      * @param startIdx        index of the first CUBE column in model.groupBy
      * @param cubeColumnCount number of CUBE columns
      */
-    private static void expandCube(QueryModel model, int startIdx, int cubeColumnCount) {
+    private static void expandCube(QueryModel model, int startIdx, int cubeColumnCount, int position) throws SqlException {
         // 2^N subsets, from the full set (all bits set) down to empty set (0)
         int totalSets = 1 << cubeColumnCount;
+        if (totalSets > MAX_GROUPING_SETS) {
+            throw SqlException.$(position, "CUBE produces too many grouping sets (")
+                    .put(totalSets).put(", maximum ").put(MAX_GROUPING_SETS).put(')');
+        }
         for (int mask = totalSets - 1; mask >= 0; mask--) {
             IntList set = new IntList();
             for (int bit = 0; bit < cubeColumnCount; bit++) {
@@ -873,8 +877,12 @@ public class SqlParser {
      * Expands CUBE with composite plain columns prepended to every set.
      * GROUP BY a, CUBE(b, c) -> sets: (a,b,c), (a,b), (a,c), (a).
      */
-    private static void expandCubeComposite(QueryModel model, int plainCount, int rollupStart, int cubeColumnCount) {
+    private static void expandCubeComposite(QueryModel model, int plainCount, int rollupStart, int cubeColumnCount, int position) throws SqlException {
         int totalSets = 1 << cubeColumnCount;
+        if (totalSets > MAX_GROUPING_SETS) {
+            throw SqlException.$(position, "CUBE produces too many grouping sets (")
+                    .put(totalSets).put(", maximum ").put(MAX_GROUPING_SETS).put(')');
+        }
         for (int mask = totalSets - 1; mask >= 0; mask--) {
             IntList set = new IntList();
             // Add all plain columns first
@@ -2939,13 +2947,14 @@ public class SqlParser {
 
             // support SAMPLE BY 1h ROLLUP(symbol, side)
             if (tok != null && (isRollupKeyword(tok) || isCubeKeyword(tok))) {
+                int kwPos = lexer.lastTokenPosition();
                 boolean isRollup = isRollupKeyword(tok);
                 ObjList<ExpressionNode> columnList = parseParenthesizedColumnList(lexer, model, sqlParserCallback);
                 if (columnList.size() == 0) {
-                    throw SqlException.$(lexer.lastTokenPosition(), (isRollup ? "ROLLUP" : "CUBE") + " requires at least one column");
+                    throw SqlException.$(kwPos, (isRollup ? "ROLLUP" : "CUBE") + " requires at least one column");
                 }
                 if (!isRollup && columnList.size() > 15) {
-                    throw SqlException.$(lexer.lastTokenPosition(), "CUBE supports at most 15 columns");
+                    throw SqlException.$(kwPos, "CUBE supports at most 15 columns");
                 }
                 int startIdx = model.getGroupBy().size();
                 for (int i = 0, n = columnList.size(); i < n; i++) {
@@ -2954,7 +2963,7 @@ public class SqlParser {
                 if (isRollup) {
                     expandRollup(model, startIdx, columnList.size());
                 } else {
-                    expandCube(model, startIdx, columnList.size());
+                    expandCube(model, startIdx, columnList.size(), kwPos);
                 }
                 tok = optTok(lexer);
             } else if (tok != null && isGroupingKeyword(tok)) {
@@ -3324,7 +3333,7 @@ public class SqlParser {
             if (isRollup) {
                 expandRollup(model, 0, columns.size());
             } else {
-                expandCube(model, 0, columns.size());
+                expandCube(model, 0, columns.size(), kwPos);
             }
             return optTok(lexer);
         }
@@ -3366,7 +3375,7 @@ public class SqlParser {
                 if (isRollup) {
                     expandRollupComposite(model, plainCount, rollupStart, rollupCols.size());
                 } else {
-                    expandCubeComposite(model, plainCount, rollupStart, rollupCols.size());
+                    expandCubeComposite(model, plainCount, rollupStart, rollupCols.size(), kwPos);
                 }
                 return optTok(lexer);
             }
@@ -3392,6 +3401,12 @@ public class SqlParser {
     /**
      * Parses explicit GROUPING SETS ((a, b), (a), ()).
      * The outer parentheses and inner sets with their parentheses.
+     * <p>
+     * Unlike ROLLUP/CUBE (which accept expressions via
+     * {@link #parseParenthesizedColumnList}), explicit GROUPING SETS
+     * only accept column references. This is intentional: expressions
+     * in explicit sets create ambiguity in set membership resolution
+     * because the same expression can appear in different forms.
      */
     private void parseExplicitGroupingSets(
             GenericLexer lexer,

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -94,7 +94,6 @@ import static io.questdb.std.GenericLexer.assertNoDotsAndSlashes;
 import static io.questdb.std.GenericLexer.unquote;
 
 public class SqlParser {
-    public static final int MAX_GROUPING_SETS = 4096;
     public static final int MAX_ORDER_BY_COLUMNS = 1560;
     public static final ExpressionNode ZERO_OFFSET = ExpressionNode.FACTORY.newInstance().of(ExpressionNode.CONSTANT, "'00:00'", 0, 0);
     private static final ExpressionNode ONE = ExpressionNode.FACTORY.newInstance().of(ExpressionNode.CONSTANT, "1", 0, 0);
@@ -854,6 +853,8 @@ public class SqlParser {
      * mixed forms would create separate entries and incorrect sets.
      */
     private static void checkMixedQualification(ObjList<ExpressionNode> groupByColumns) throws SqlException {
+        // O(N²) but N is the number of GROUP BY columns, bounded at ~31 by the
+        // GROUPING_ID bitmask width. Not worth a HashSet for such small N.
         for (int i = 0, n = groupByColumns.size(); i < n; i++) {
             ExpressionNode a = groupByColumns.getQuick(i);
             for (int j = i + 1; j < n; j++) {
@@ -879,6 +880,12 @@ public class SqlParser {
         }
     }
 
+    private static void guardAgainstLatestOnWithGroupingSets(QueryModel model, int kwPos) throws SqlException {
+        if (model.getLatestBy().size() > 0) {
+            throw SqlException.$(kwPos, "LATEST ON is not supported with GROUPING SETS, ROLLUP, or CUBE");
+        }
+    }
+
     /**
      * Returns true if two column tokens refer to the same column but one
      * is qualified (t.col) and the other is not (col).
@@ -899,12 +906,12 @@ public class SqlParser {
         }
     }
 
-    private static void expandCube(QueryModel model, int startIdx, int cubeColumnCount, int position) throws SqlException {
+    private static void expandCube(QueryModel model, int startIdx, int cubeColumnCount, int position, int maxGroupingSets) throws SqlException {
         // 2^N subsets, from the full set (all bits set) down to empty set (0)
         int totalSets = 1 << cubeColumnCount;
-        if (totalSets > MAX_GROUPING_SETS) {
+        if (totalSets > maxGroupingSets) {
             throw SqlException.$(position, "CUBE produces too many grouping sets (")
-                    .put(totalSets).put(", maximum ").put(MAX_GROUPING_SETS).put(')');
+                    .put(totalSets).put(", maximum ").put(maxGroupingSets).put(')');
         }
         for (int mask = totalSets - 1; mask >= 0; mask--) {
             IntList set = new IntList();
@@ -921,11 +928,11 @@ public class SqlParser {
      * Expands CUBE with composite plain columns prepended to every set.
      * GROUP BY a, CUBE(b, c) -> sets: (a,b,c), (a,b), (a,c), (a).
      */
-    private static void expandCubeComposite(QueryModel model, int plainCount, int rollupStart, int cubeColumnCount, int position) throws SqlException {
+    private static void expandCubeComposite(QueryModel model, int plainCount, int rollupStart, int cubeColumnCount, int position, int maxGroupingSets) throws SqlException {
         int totalSets = 1 << cubeColumnCount;
-        if (totalSets > MAX_GROUPING_SETS) {
+        if (totalSets > maxGroupingSets) {
             throw SqlException.$(position, "CUBE produces too many grouping sets (")
-                    .put(totalSets).put(", maximum ").put(MAX_GROUPING_SETS).put(')');
+                    .put(totalSets).put(", maximum ").put(maxGroupingSets).put(')');
         }
         for (int mask = totalSets - 1; mask >= 0; mask--) {
             IntList set = new IntList();
@@ -950,11 +957,11 @@ public class SqlParser {
      * @param startIdx          index of the first ROLLUP column in model.groupBy
      * @param rollupColumnCount number of ROLLUP columns
      */
-    private static void expandRollup(QueryModel model, int startIdx, int rollupColumnCount, int position) throws SqlException {
+    private static void expandRollup(QueryModel model, int startIdx, int rollupColumnCount, int position, int maxGroupingSets) throws SqlException {
         int totalSets = rollupColumnCount + 1;
-        if (totalSets > MAX_GROUPING_SETS) {
+        if (totalSets > maxGroupingSets) {
             throw SqlException.$(position, "ROLLUP produces too many grouping sets (")
-                    .put(totalSets).put(", maximum ").put(MAX_GROUPING_SETS).put(')');
+                    .put(totalSets).put(", maximum ").put(maxGroupingSets).put(')');
         }
         // N+1 sets: from all columns down to empty set
         for (int setSize = rollupColumnCount; setSize >= 0; setSize--) {
@@ -970,11 +977,11 @@ public class SqlParser {
      * Expands ROLLUP with composite plain columns prepended to every set.
      * GROUP BY a, ROLLUP(b, c) -> sets: (a,b,c), (a,b), (a).
      */
-    private static void expandRollupComposite(QueryModel model, int plainCount, int rollupStart, int rollupColumnCount, int position) throws SqlException {
+    private static void expandRollupComposite(QueryModel model, int plainCount, int rollupStart, int rollupColumnCount, int position, int maxGroupingSets) throws SqlException {
         int totalSets = rollupColumnCount + 1;
-        if (totalSets > MAX_GROUPING_SETS) {
+        if (totalSets > maxGroupingSets) {
             throw SqlException.$(position, "ROLLUP produces too many grouping sets (")
-                    .put(totalSets).put(", maximum ").put(MAX_GROUPING_SETS).put(')');
+                    .put(totalSets).put(", maximum ").put(maxGroupingSets).put(')');
         }
         for (int setSize = rollupColumnCount; setSize >= 0; setSize--) {
             IntList set = new IntList();
@@ -3002,6 +3009,7 @@ public class SqlParser {
             // support SAMPLE BY 1h ROLLUP(symbol, side)
             if (tok != null && (isRollupKeyword(tok) || isCubeKeyword(tok))) {
                 int kwPos = lexer.lastTokenPosition();
+                guardAgainstLatestOnWithGroupingSets(model, kwPos);
                 boolean isRollup = isRollupKeyword(tok);
                 ObjList<ExpressionNode> columnList = parseParenthesizedColumnList(lexer, model, sqlParserCallback);
                 if (columnList.size() == 0) {
@@ -3016,13 +3024,15 @@ public class SqlParser {
                 for (int i = 0, n = columnList.size(); i < n; i++) {
                     model.addGroupBy(columnList.getQuick(i));
                 }
+                int maxSets = configuration.getSqlMaxGroupingSets();
                 if (isRollup) {
-                    expandRollup(model, startIdx, columnList.size(), kwPos);
+                    expandRollup(model, startIdx, columnList.size(), kwPos, maxSets);
                 } else {
-                    expandCube(model, startIdx, columnList.size(), kwPos);
+                    expandCube(model, startIdx, columnList.size(), kwPos, maxSets);
                 }
                 tok = optTok(lexer);
             } else if (tok != null && isGroupingKeyword(tok)) {
+                guardAgainstLatestOnWithGroupingSets(model, lexer.lastTokenPosition());
                 CharSequence next = tok(lexer, "'SETS'");
                 if (!isSetsKeyword(next)) {
                     throw SqlException.$(lexer.lastTokenPosition(), "expected SETS after GROUPING");
@@ -3375,6 +3385,7 @@ public class SqlParser {
         // Check for ROLLUP/CUBE/GROUPING SETS as the first token
         if (isRollupKeyword(tok) || isCubeKeyword(tok)) {
             int kwPos = lexer.lastTokenPosition();
+            guardAgainstLatestOnWithGroupingSets(model, kwPos);
             boolean isRollup = isRollupKeyword(tok);
             ObjList<ExpressionNode> columns = parseParenthesizedColumnList(lexer, model, sqlParserCallback);
             if (columns.size() == 0) {
@@ -3388,16 +3399,18 @@ public class SqlParser {
             for (int i = 0, n = columns.size(); i < n; i++) {
                 model.addGroupBy(columns.getQuick(i));
             }
+            int maxSets = configuration.getSqlMaxGroupingSets();
             if (isRollup) {
-                expandRollup(model, 0, columns.size(), kwPos);
+                expandRollup(model, 0, columns.size(), kwPos, maxSets);
             } else {
-                expandCube(model, 0, columns.size(), kwPos);
+                expandCube(model, 0, columns.size(), kwPos, maxSets);
             }
             return optTok(lexer);
         }
 
         if (isGroupingKeyword(tok)) {
             int kwPos = lexer.lastTokenPosition();
+            guardAgainstLatestOnWithGroupingSets(model, kwPos);
             tok = optTok(lexer);
             if (tok == null || !isSetsKeyword(tok)) {
                 throw SqlException.$(kwPos, "expected SETS after GROUPING");
@@ -3414,6 +3427,7 @@ public class SqlParser {
             // Check if the current token is ROLLUP/CUBE (composite syntax)
             if (isRollupKeyword(tok) || isCubeKeyword(tok)) {
                 int kwPos = lexer.lastTokenPosition();
+                guardAgainstLatestOnWithGroupingSets(model, kwPos);
                 boolean isRollup = isRollupKeyword(tok);
                 int plainCount = plainColumns.size();
                 for (int i = 0; i < plainCount; i++) {
@@ -3433,10 +3447,11 @@ public class SqlParser {
                 }
                 // Check all columns (plain + rollup) for mixed qualification
                 checkMixedQualification(model.getGroupBy());
+                int maxSets = configuration.getSqlMaxGroupingSets();
                 if (isRollup) {
-                    expandRollupComposite(model, plainCount, rollupStart, rollupCols.size(), kwPos);
+                    expandRollupComposite(model, plainCount, rollupStart, rollupCols.size(), kwPos, maxSets);
                 } else {
-                    expandCubeComposite(model, plainCount, rollupStart, rollupCols.size(), kwPos);
+                    expandCubeComposite(model, plainCount, rollupStart, rollupCols.size(), kwPos, maxSets);
                 }
                 return optTok(lexer);
             }
@@ -3527,8 +3542,9 @@ public class SqlParser {
                 } while (true);
             }
             model.addGroupingSet(setIndices);
-            if (model.getGroupingSets().size() > MAX_GROUPING_SETS) {
-                throw SqlException.$(lexer.lastTokenPosition(), "too many grouping sets (maximum " + MAX_GROUPING_SETS + ")");
+            int maxSets = configuration.getSqlMaxGroupingSets();
+            if (model.getGroupingSets().size() > maxSets) {
+                throw SqlException.$(lexer.lastTokenPosition(), "too many grouping sets (maximum " + maxSets + ")");
             }
 
             // Use SqlUtil.fetchNext to avoid subQueryMode swallowing ')'

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunction.java
@@ -40,7 +40,7 @@ import io.questdb.std.Numbers;
  * bit 1 means the column is rolled up (not actively grouped) in the current
  * grouping set, bit 0 means the column is actively grouped.
  *
- * <p>Implements {@link GroupByFunction} so that the optimizer keeps it in the
+ * <p>Implements {@link io.questdb.griffin.engine.functions.GroupByFunction} so that the optimizer keeps it in the
  * GROUP BY model's projection. The bitmask value is stored in the map value
  * column: during the data scan, {@link #setCurrentSet(int)} is called per
  * grouping set before the updater runs, and {@link #computeFirst} stores
@@ -68,6 +68,10 @@ public class GroupingFunction extends IntFunction implements GroupByFunction {
     public void computeNext(MapValue mapValue, Record record, long rowId) {
         // All rows in a given grouping set produce the same bitmask,
         // so no update is needed after the first row.
+    }
+
+    public int getPosition() {
+        return position;
     }
 
     public IntList getArgColumnIndices() {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunction.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Record;
 import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.IntFunction;
 import io.questdb.std.IntList;
@@ -89,7 +90,7 @@ public class GroupingFunction extends IntFunction implements GroupByFunction {
      * @param groupingIds      per-set bitmask indicating which keys are rolled up
      * @param keyColumnIndices maps key position to base column index
      */
-    public void init(IntList groupingIds, IntList keyColumnIndices) {
+    public void init(IntList groupingIds, IntList keyColumnIndices) throws SqlException {
         int setCount = groupingIds.size();
         int keyCount = keyColumnIndices.size();
         perSetValues = new int[setCount];
@@ -107,13 +108,14 @@ public class GroupingFunction extends IntFunction implements GroupByFunction {
                         break;
                     }
                 }
-                if (keyPos >= 0) {
-                    // Extract the bit for this key position from the full bitmask.
-                    // Bit (keyCount - 1 - keyPos) in the full mask tells whether
-                    // this key is rolled up (1) or active (0).
-                    int bit = (fullMask >> (keyCount - 1 - keyPos)) & 1;
-                    result |= (bit << (argColumnIndices.size() - 1 - a));
+                if (keyPos < 0) {
+                    throw SqlException.$(0, "GROUPING()/GROUPING_ID() argument must be a grouping key column");
                 }
+                // Extract the bit for this key position from the full bitmask.
+                // Bit (keyCount - 1 - keyPos) in the full mask tells whether
+                // this key is rolled up (1) or active (0).
+                int bit = (fullMask >> (keyCount - 1 - keyPos)) & 1;
+                result |= (bit << (argColumnIndices.size() - 1 - a));
             }
             perSetValues[s] = result;
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunction.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.IntFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.Numbers;
+
+/**
+ * Returns the GROUPING bitmask for its argument columns. For each argument,
+ * bit 1 means the column is rolled up (not actively grouped) in the current
+ * grouping set, bit 0 means the column is actively grouped.
+ *
+ * <p>Implements {@link GroupByFunction} so that the optimizer keeps it in the
+ * GROUP BY model's projection. The bitmask value is stored in the map value
+ * column: during the data scan, {@link #setCurrentSet(int)} is called per
+ * grouping set before the updater runs, and {@link #computeFirst} stores
+ * the pre-computed bitmask. During iteration, {@link #getInt(Record)} reads
+ * the stored value from the map record.</p>
+ */
+public class GroupingFunction extends IntFunction implements GroupByFunction {
+    private final IntList argColumnIndices;
+    private int currentValue;
+    private int[] perSetValues;
+    private int valueIndex;
+
+    public GroupingFunction(IntList argColumnIndices) {
+        this.argColumnIndices = argColumnIndices;
+    }
+
+    @Override
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        mapValue.putInt(valueIndex, currentValue);
+    }
+
+    @Override
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        // All rows in a given grouping set produce the same bitmask,
+        // so no update is needed after the first row.
+    }
+
+    public IntList getArgColumnIndices() {
+        return argColumnIndices;
+    }
+
+    @Override
+    public int getInt(Record rec) {
+        return rec.getInt(valueIndex);
+    }
+
+    @Override
+    public int getValueIndex() {
+        return valueIndex;
+    }
+
+    /**
+     * Pre-computes the per-set bitmask values. Called by
+     * {@link io.questdb.griffin.engine.groupby.GroupingSetsRecordCursorFactory}
+     * after construction, once the grouping set layout is known.
+     *
+     * @param groupingIds      per-set bitmask indicating which keys are rolled up
+     * @param keyColumnIndices maps key position to base column index
+     */
+    public void init(IntList groupingIds, IntList keyColumnIndices) {
+        int setCount = groupingIds.size();
+        int keyCount = keyColumnIndices.size();
+        perSetValues = new int[setCount];
+
+        for (int s = 0; s < setCount; s++) {
+            int fullMask = groupingIds.getQuick(s);
+            int result = 0;
+            for (int a = 0, nArgs = argColumnIndices.size(); a < nArgs; a++) {
+                int argBaseIdx = argColumnIndices.getQuick(a);
+                // Find this arg's position in the key column list
+                int keyPos = -1;
+                for (int k = 0; k < keyCount; k++) {
+                    if (keyColumnIndices.getQuick(k) == argBaseIdx) {
+                        keyPos = k;
+                        break;
+                    }
+                }
+                if (keyPos >= 0) {
+                    // Extract the bit for this key position from the full bitmask.
+                    // Bit (keyCount - 1 - keyPos) in the full mask tells whether
+                    // this key is rolled up (1) or active (0).
+                    int bit = (fullMask >> (keyCount - 1 - keyPos)) & 1;
+                    result |= (bit << (argColumnIndices.size() - 1 - a));
+                }
+            }
+            perSetValues[s] = result;
+        }
+    }
+
+    @Override
+    public void initValueIndex(int valueIndex) {
+        this.valueIndex = valueIndex;
+    }
+
+    @Override
+    public void initValueTypes(ArrayColumnTypes columnTypes) {
+        this.valueIndex = columnTypes.getColumnCount();
+        columnTypes.add(ColumnType.INT);
+    }
+
+    public void setCurrentSet(int setIndex) {
+        currentValue = perSetValues[setIndex];
+    }
+
+    @Override
+    public void setNull(MapValue mapValue) {
+        mapValue.putInt(valueIndex, Numbers.INT_NULL);
+    }
+
+    @Override
+    public void toPlan(PlanSink sink) {
+        sink.val("grouping(").val(argColumnIndices).val(')');
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunction.java
@@ -70,12 +70,12 @@ public class GroupingFunction extends IntFunction implements GroupByFunction {
         // so no update is needed after the first row.
     }
 
-    public int getPosition() {
-        return position;
-    }
-
     public IntList getArgColumnIndices() {
         return argColumnIndices;
+    }
+
+    public int getPosition() {
+        return position;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunction.java
@@ -49,12 +49,14 @@ import io.questdb.std.Numbers;
  */
 public class GroupingFunction extends IntFunction implements GroupByFunction {
     private final IntList argColumnIndices;
+    private final int position;
     private int currentValue;
     private int[] perSetValues;
     private int valueIndex;
 
-    public GroupingFunction(IntList argColumnIndices) {
+    public GroupingFunction(IntList argColumnIndices, int position) {
         this.argColumnIndices = argColumnIndices;
+        this.position = position;
     }
 
     @Override
@@ -109,7 +111,7 @@ public class GroupingFunction extends IntFunction implements GroupByFunction {
                     }
                 }
                 if (keyPos < 0) {
-                    throw SqlException.$(0, "GROUPING()/GROUPING_ID() argument must be a grouping key column");
+                    throw SqlException.$(position, "GROUPING()/GROUPING_ID() argument must be a grouping key column");
                 }
                 // Extract the bit for this key position from the full bitmask.
                 // Bit (keyCount - 1 - keyPos) in the full mask tells whether

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunction.java
@@ -145,6 +145,13 @@ public class GroupingFunction extends IntFunction implements GroupByFunction {
 
     @Override
     public void toPlan(PlanSink sink) {
-        sink.val("grouping(").val(argColumnIndices).val(')');
+        sink.val("grouping(");
+        for (int i = 0, n = argColumnIndices.size(); i < n; i++) {
+            if (i > 0) {
+                sink.val(',');
+            }
+            sink.putColumnName(argColumnIndices.getQuick(i));
+        }
+        sink.val(')');
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunctionFactory.java
@@ -39,7 +39,7 @@ import io.questdb.std.ObjList;
  * grouping set. For multi-column bitmasks, use GROUPING_ID(col1, col2, ...).
  *
  * <p>This function is only valid in queries that use GROUPING SETS, ROLLUP,
- * or CUBE. The {@link GroupingSetsRecordCursorFactory} wires up the function
+ * or CUBE. The {@link io.questdb.griffin.engine.groupby.GroupingSetsRecordCursorFactory} wires up the function
  * at construction time with the actual grouping set layout.</p>
  */
 public class GroupingFunctionFactory implements FunctionFactory {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunctionFactory.java
@@ -76,6 +76,6 @@ public class GroupingFunctionFactory implements FunctionFactory {
 
         IntList columnIndices = new IntList(1);
         columnIndices.add(((ColumnFunction) arg).getColumnIndex());
-        return new GroupingFunction(columnIndices);
+        return new GroupingFunction(columnIndices, position);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunctionFactory.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.columns.ColumnFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+/**
+ * Factory for the GROUPING(col1, col2, ...) function. Returns an integer
+ * bitmask indicating which columns are rolled up in the current grouping set.
+ * For a single argument, returns 0 (actively grouped) or 1 (rolled up).
+ * For multiple arguments, returns a multi-bit integer.
+ *
+ * <p>This function is only valid in queries that use GROUPING SETS, ROLLUP,
+ * or CUBE. The {@link GroupingSetsRecordCursorFactory} wires up the function
+ * at construction time with the actual grouping set layout.</p>
+ */
+public class GroupingFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "grouping(V)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        if (args == null || args.size() == 0) {
+            throw SqlException.$(position, "GROUPING() requires at least one argument");
+        }
+
+        IntList columnIndices = new IntList(args.size());
+        for (int i = 0, n = args.size(); i < n; i++) {
+            Function arg = args.getQuick(i);
+            if (!(arg instanceof ColumnFunction)) {
+                throw SqlException.$(argPositions.getQuick(i), "GROUPING() arguments must be column references");
+            }
+            columnIndices.add(((ColumnFunction) arg).getColumnIndex());
+        }
+
+        return new GroupingFunction(columnIndices);
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingFunctionFactory.java
@@ -34,10 +34,9 @@ import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 
 /**
- * Factory for the GROUPING(col1, col2, ...) function. Returns an integer
- * bitmask indicating which columns are rolled up in the current grouping set.
- * For a single argument, returns 0 (actively grouped) or 1 (rolled up).
- * For multiple arguments, returns a multi-bit integer.
+ * Factory for the GROUPING(col) function. Accepts a single column argument
+ * and returns 0 (actively grouped) or 1 (rolled up) for the current
+ * grouping set. For multi-column bitmasks, use GROUPING_ID(col1, col2, ...).
  *
  * <p>This function is only valid in queries that use GROUPING SETS, ROLLUP,
  * or CUBE. The {@link GroupingSetsRecordCursorFactory} wires up the function
@@ -64,18 +63,19 @@ public class GroupingFunctionFactory implements FunctionFactory {
             SqlExecutionContext sqlExecutionContext
     ) throws SqlException {
         if (args == null || args.size() == 0) {
-            throw SqlException.$(position, "GROUPING() requires at least one argument");
+            throw SqlException.$(position, "GROUPING() requires exactly one column argument");
+        }
+        if (args.size() > 1) {
+            throw SqlException.$(position, "GROUPING() accepts a single column; use GROUPING_ID() for multiple columns");
         }
 
-        IntList columnIndices = new IntList(args.size());
-        for (int i = 0, n = args.size(); i < n; i++) {
-            Function arg = args.getQuick(i);
-            if (!(arg instanceof ColumnFunction)) {
-                throw SqlException.$(argPositions.getQuick(i), "GROUPING() arguments must be column references");
-            }
-            columnIndices.add(((ColumnFunction) arg).getColumnIndex());
+        Function arg = args.getQuick(0);
+        if (!(arg instanceof ColumnFunction)) {
+            throw SqlException.$(argPositions.getQuick(0), "GROUPING() argument must be a column reference");
         }
 
+        IntList columnIndices = new IntList(1);
+        columnIndices.add(((ColumnFunction) arg).getColumnIndex());
         return new GroupingFunction(columnIndices);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingIdFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingIdFunctionFactory.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.columns.ColumnFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+/**
+ * Factory for the GROUPING_ID(col1, col2, ...) function. Returns the same
+ * bitmask as multi-argument GROUPING() - provided for Oracle/SQL Server
+ * compatibility. Requires at least one argument.
+ */
+public class GroupingIdFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "grouping_id(V)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        if (args == null || args.size() == 0) {
+            throw SqlException.$(position, "GROUPING_ID() requires at least one argument");
+        }
+
+        IntList columnIndices = new IntList(args.size());
+        for (int i = 0, n = args.size(); i < n; i++) {
+            Function arg = args.getQuick(i);
+            if (!(arg instanceof ColumnFunction)) {
+                throw SqlException.$(argPositions.getQuick(i), "GROUPING_ID() arguments must be column references");
+            }
+            columnIndices.add(((ColumnFunction) arg).getColumnIndex());
+        }
+
+        return new GroupingFunction(columnIndices);
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingIdFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/GroupingIdFunctionFactory.java
@@ -61,6 +61,9 @@ public class GroupingIdFunctionFactory implements FunctionFactory {
         if (args == null || args.size() == 0) {
             throw SqlException.$(position, "GROUPING_ID() requires at least one argument");
         }
+        if (args.size() > 31) {
+            throw SqlException.$(position, "GROUPING_ID() supports at most 31 arguments");
+        }
 
         IntList columnIndices = new IntList(args.size());
         for (int i = 0, n = args.size(); i < n; i++) {
@@ -71,6 +74,6 @@ public class GroupingIdFunctionFactory implements FunctionFactory {
             columnIndices.add(((ColumnFunction) arg).getColumnIndex());
         }
 
-        return new GroupingFunction(columnIndices);
+        return new GroupingFunction(columnIndices, position);
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
@@ -96,9 +96,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             ObjList<Function> fillValues,
             int timestampIndex,
             int timestampType
-    ) {
+    ) throws SqlException {
         this(metadata, base, fromFunc, toFunc, samplingInterval, samplingIntervalUnit,
-                timestampSampler, fillValues, timestampIndex, timestampType, null, null);
+                timestampSampler, fillValues, timestampIndex, timestampType, null, null, 0);
     }
 
     public FillRangeRecordCursorFactory(
@@ -113,8 +113,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             int timestampIndex,
             int timestampType,
             @Nullable CairoConfiguration configuration,
-            @Nullable IntList keyColumnPositions
-    ) {
+            @Nullable IntList keyColumnPositions,
+            int position
+    ) throws SqlException {
         super(metadata);
         this.base = base;
         this.fromFunc = fromFunc;
@@ -128,7 +129,7 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         this.timestampType = timestampType;
         this.cursor = new FillRangeRecordCursor(
                 timestampSampler, fromFunc, toFunc, fillValues, timestampIndex, timestampType,
-                configuration, metadata, keyColumnPositions
+                configuration, metadata, keyColumnPositions, position
         );
     }
 
@@ -277,8 +278,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                 int timestampType,
                 @Nullable CairoConfiguration configuration,
                 RecordMetadata metadata,
-                @Nullable IntList keyColumnPositions
-        ) {
+                @Nullable IntList keyColumnPositions,
+                int position
+        ) throws SqlException {
             this.timestampSampler = timestampSampler;
             this.fromFunc = fromFunc;
             this.toFunc = toFunc;
@@ -300,6 +302,7 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                     int colType = metadata.getColumnType(colPos);
                     // SYMBOL columns are stored as INT (symbol table index)
                     int mapType = ColumnType.isSymbol(colType) ? ColumnType.INT : colType;
+                    validateKeyColumnType(mapType, position);
                     keyMapColTypes[i] = mapType;
                     keyMapTypes.add(mapType);
                 }
@@ -528,8 +531,29 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                 int mapCol = outputColToKeyMapCol[i];
                 if (mapCol >= 0) {
                     switch (ColumnType.tagOf(keyMapColTypes[mapCol])) {
+                        case ColumnType.BOOLEAN:
+                            key.putBool(baseRecord.getBool(i));
+                            break;
+                        case ColumnType.BYTE:
+                            key.putByte(baseRecord.getByte(i));
+                            break;
+                        case ColumnType.CHAR:
+                            key.putChar(baseRecord.getChar(i));
+                            break;
+                        case ColumnType.DATE:
+                            key.putDate(baseRecord.getDate(i));
+                            break;
+                        case ColumnType.DOUBLE:
+                            key.putDouble(baseRecord.getDouble(i));
+                            break;
+                        case ColumnType.FLOAT:
+                            key.putFloat(baseRecord.getFloat(i));
+                            break;
                         case ColumnType.INT:
                             key.putInt(baseRecord.getInt(i));
+                            break;
+                        case ColumnType.IPv4:
+                            key.putIPv4(baseRecord.getIPv4(i));
                             break;
                         case ColumnType.LONG:
                             key.putLong(baseRecord.getLong(i));
@@ -537,11 +561,11 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                         case ColumnType.SHORT:
                             key.putShort(baseRecord.getShort(i));
                             break;
-                        case ColumnType.BYTE:
-                            key.putByte(baseRecord.getByte(i));
-                            break;
                         case ColumnType.STRING:
                             key.putStr(baseRecord.getStrA(i));
+                            break;
+                        case ColumnType.TIMESTAMP:
+                            key.putTimestamp(baseRecord.getTimestamp(i));
                             break;
                         case ColumnType.VARCHAR:
                             key.putVarchar(baseRecord.getVarcharA(i));
@@ -554,6 +578,28 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                 }
             }
             key.createValue();
+        }
+
+        private static void validateKeyColumnType(int mapType, int position) throws SqlException {
+            switch (ColumnType.tagOf(mapType)) {
+                case ColumnType.BOOLEAN:
+                case ColumnType.BYTE:
+                case ColumnType.CHAR:
+                case ColumnType.DATE:
+                case ColumnType.DOUBLE:
+                case ColumnType.FLOAT:
+                case ColumnType.INT:
+                case ColumnType.IPv4:
+                case ColumnType.LONG:
+                case ColumnType.SHORT:
+                case ColumnType.STRING:
+                case ColumnType.TIMESTAMP:
+                case ColumnType.VARCHAR:
+                    break;
+                default:
+                    throw SqlException.$(position, "unsupported key column type for FILL: ")
+                            .put(ColumnType.nameOf(mapType));
+            }
         }
 
         private class FillRangeRecord implements Record {
@@ -588,6 +634,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public boolean getBool(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getBool(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getBool(null);
                 } else {
                     return baseRecord.getBool(col);
@@ -609,9 +658,24 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public char getChar(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getChar(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getChar(null);
                 } else {
                     return baseRecord.getChar(col);
+                }
+            }
+
+            @Override
+            public long getDate(int col) {
+                if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getDate(outputColToKeyMapCol[col]);
+                    }
+                    return getFillFunction(col).getDate(null);
+                } else {
+                    return baseRecord.getDate(col);
                 }
             }
 
@@ -672,6 +736,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public double getDouble(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getDouble(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getDouble(null);
                 } else {
                     return baseRecord.getDouble(col);
@@ -681,6 +748,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public float getFloat(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getFloat(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getFloat(null);
                 } else {
                     return baseRecord.getFloat(col);
@@ -726,6 +796,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public int getIPv4(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getIPv4(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getIPv4(null);
                 } else {
                     return baseRecord.getIPv4(col);
@@ -887,9 +960,11 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                 if (gapFilling) {
                     if (col == timestampIndex) {
                         return nextBucketTimestamp;
-                    } else {
-                        return getFillFunction(col).getLong(null);
                     }
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getTimestamp(outputColToKeyMapCol[col]);
+                    }
+                    return getFillFunction(col).getLong(null);
                 } else {
                     return baseRecord.getTimestamp(col);
                 }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
@@ -141,18 +141,15 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
     @Override
     public RecordCursor getCursor(SqlExecutionContext executionContext) throws SqlException {
         if (getMetadata().getColumnCount() > fillValues.size() + 1) {
-            if (fillValues.size() == 1) {
-                // Auto-expand a single fill value to cover all non-timestamp
-                // columns. SYMBOL columns represent GROUP BY keys (never
-                // aggregates), so they get NULL in fill rows. Other columns
-                // get the user-specified fill value.
+            if (fillValues.size() == 1 && cursor.hasKeyColumns) {
+                // Grouping sets path: auto-expand a single fill value to cover
+                // all non-timestamp columns. SYMBOL columns are GROUP BY keys
+                // (never aggregates), so they get NULL in fill rows. Other
+                // columns get the user-specified fill value.
                 final Function singleFill = fillValues.getQuick(0);
                 final Function fillFunc = singleFill.isNullConstant() ? NullConstant.NULL : singleFill;
                 final RecordMetadata metadata = getMetadata();
                 final int columnCount = metadata.getColumnCount();
-                // Clear and rebuild. Each entry maps to a non-timestamp column
-                // in column order. SYMBOL columns are GROUP BY keys (never
-                // aggregates), so they get NULL in fill rows.
                 fillValues.clear();
                 for (int col = 0; col < columnCount; col++) {
                     if (col == timestampIndex) {
@@ -163,6 +160,12 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                     } else {
                         fillValues.add(fillFunc);
                     }
+                }
+            } else if (fillValues.size() == 1 && fillValues.getQuick(0).isNullConstant()) {
+                // Non-grouping-sets path: only auto-expand FILL(NULL)
+                final int diff = getMetadata().getColumnCount() - 1;
+                for (int i = 1; i < diff; i++) {
+                    fillValues.add(NullConstant.NULL);
                 }
             } else {
                 throw SqlException.$(-1, "not enough fill values");
@@ -257,6 +260,7 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         private Map keyMap;
         private RecordCursor keyMapCursor;
         private Record keyMapRecord;
+        private boolean isValueFuncsInitialized;
         private long lastTimestamp = Long.MIN_VALUE;
         private long maxTimestamp;
         private long minTimestamp;
@@ -454,6 +458,11 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         }
 
         private void initValueFuncs(ObjList<Function> valueFuncs) {
+            if (isValueFuncsInitialized) {
+                return;
+            }
+            isValueFuncsInitialized = true;
+
             // can't just check null, as we use this as the placeholder value
             if (valueFuncs.size() - 1 < timestampIndex) {
                 // timestamp is the last column, so we add it

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
@@ -304,7 +304,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         public void close() {
             baseCursor = Misc.free(baseCursor);
             presentTimestamps = Misc.free(presentTimestamps);
-            keyMap = Misc.free(keyMap);
+            if (keyMap != null) {
+                keyMap.close();
+            }
         }
 
         @Override
@@ -481,6 +483,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                 isValueFuncsInitialized = true;
             }
             assert fillValues.size() <= columnCount : "fillValues.size()=" + fillValues.size() + " exceeds columnCount=" + columnCount;
+            if (hasKeyColumns) {
+                keyMap.reopen();
+            }
             baseRecord = baseCursor.getRecord();
             toTop();
         }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
@@ -237,6 +237,10 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         // Maps output column position to key map column index (-1 = not a key column).
         // Only allocated when hasKeyColumns is true.
         private final int[] outputColToKeyMapCol;
+        // Column types for each key column in the key map (indexed by map column index).
+        // SYMBOL columns are stored as INT (symbol table index). Only allocated
+        // when hasKeyColumns is true.
+        private final int[] keyMapColTypes;
         private final TimestampDriver timestampDriver;
         private final int timestampIndex;
         private final TimestampSampler timestampSampler;
@@ -246,8 +250,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         private boolean gapFilling;
         private boolean hasNegative;
         // Map storing distinct key combinations seen during the base scan.
-        // Key columns are stored as INT values (symbol table indices for
-        // SYMBOL columns). Only allocated when hasKeyColumns is true.
+        // Key columns are stored with their actual types (SYMBOL columns
+        // are stored as INT via their symbol table index).
+        // Only allocated when hasKeyColumns is true.
         private Map keyMap;
         private RecordCursor keyMapCursor;
         private Record keyMapRecord;
@@ -287,16 +292,22 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             if (hasKeyColumns) {
                 this.outputColToKeyMapCol = new int[metadata.getColumnCount()];
                 java.util.Arrays.fill(outputColToKeyMapCol, -1);
+                this.keyMapColTypes = new int[keyColumnPositions.size()];
                 ArrayColumnTypes keyMapTypes = new ArrayColumnTypes();
                 for (int i = 0, n = keyColumnPositions.size(); i < n; i++) {
                     int colPos = keyColumnPositions.getQuick(i);
                     outputColToKeyMapCol[colPos] = i;
-                    keyMapTypes.add(ColumnType.INT);
+                    int colType = metadata.getColumnType(colPos);
+                    // SYMBOL columns are stored as INT (symbol table index)
+                    int mapType = ColumnType.isSymbol(colType) ? ColumnType.INT : colType;
+                    keyMapColTypes[i] = mapType;
+                    keyMapTypes.add(mapType);
                 }
                 ArrayColumnTypes emptyValueTypes = new ArrayColumnTypes();
                 this.keyMap = MapFactory.createUnorderedMap(configuration, keyMapTypes, emptyValueTypes);
             } else {
                 this.outputColToKeyMapCol = null;
+                this.keyMapColTypes = null;
             }
         }
 
@@ -516,7 +527,30 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             for (int i = 0, n = outputColToKeyMapCol.length; i < n; i++) {
                 int mapCol = outputColToKeyMapCol[i];
                 if (mapCol >= 0) {
-                    key.putInt(baseRecord.getInt(i));
+                    switch (ColumnType.tagOf(keyMapColTypes[mapCol])) {
+                        case ColumnType.INT:
+                            key.putInt(baseRecord.getInt(i));
+                            break;
+                        case ColumnType.LONG:
+                            key.putLong(baseRecord.getLong(i));
+                            break;
+                        case ColumnType.SHORT:
+                            key.putShort(baseRecord.getShort(i));
+                            break;
+                        case ColumnType.BYTE:
+                            key.putByte(baseRecord.getByte(i));
+                            break;
+                        case ColumnType.STRING:
+                            key.putStr(baseRecord.getStrA(i));
+                            break;
+                        case ColumnType.VARCHAR:
+                            key.putVarchar(baseRecord.getVarcharA(i));
+                            break;
+                        default:
+                            throw CairoException.nonCritical()
+                                    .put("unsupported key column type for FILL: ")
+                                    .put(ColumnType.nameOf(keyMapColTypes[mapCol]));
+                    }
                 }
             }
             key.createValue();
@@ -563,6 +597,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public byte getByte(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getByte(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getByte(null);
                 } else {
                     return baseRecord.getByte(col);
@@ -710,6 +747,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public long getLong(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getLong(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getLong(null);
                 } else {
                     return baseRecord.getLong(col);
@@ -764,6 +804,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public short getShort(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getShort(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getShort(null);
                 } else {
                     return baseRecord.getShort(col);
@@ -774,6 +817,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public @Nullable CharSequence getStrA(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getStrA(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getStrA(null);
                 } else {
                     return baseRecord.getStrA(col);
@@ -783,6 +829,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public CharSequence getStrB(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getStrB(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getStrB(null);
                 } else {
                     return baseRecord.getStrB(col);
@@ -792,6 +841,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public int getStrLen(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getStrLen(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getStrLen(null);
                 } else {
                     return baseRecord.getStrLen(col);
@@ -846,6 +898,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public @Nullable Utf8Sequence getVarcharA(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getVarcharA(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getVarcharA(null);
                 } else {
                     return baseRecord.getVarcharA(col);
@@ -855,6 +910,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public @Nullable Utf8Sequence getVarcharB(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getVarcharB(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getVarcharB(null);
                 } else {
                     return baseRecord.getVarcharB(col);
@@ -864,6 +922,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public int getVarcharSize(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getVarcharSize(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getVarcharSize(null);
                 } else {
                     return baseRecord.getVarcharSize(col);

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
@@ -234,7 +234,6 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         Misc.free(fromFunc);
         Misc.free(toFunc);
         Misc.freeObjList(fillValues);
-        Misc.free(cursor);
     }
 
     private static class FillRangeRecordCursor implements NoRandomAccessRecordCursor {
@@ -276,7 +275,6 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         private long presentTimestampsSize;
 
         private final int columnCount;
-        private boolean isValueFuncsInitialized;
 
         private FillRangeRecordCursor(
                 TimestampSampler timestampSampler,
@@ -302,7 +300,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
 
             if (hasKeyColumns) {
                 this.outputColToKeyMapCol = new int[metadata.getColumnCount()];
-                java.util.Arrays.fill(outputColToKeyMapCol, -1);
+                for (int j = 0, m = outputColToKeyMapCol.length; j < m; j++) {
+                    outputColToKeyMapCol[j] = -1;
+                }
                 this.keyMapColTypes = new int[keyColumnPositions.size()];
                 ArrayColumnTypes keyMapTypes = new ArrayColumnTypes();
                 for (int i = 0, n = keyColumnPositions.size(); i < n; i++) {
@@ -327,9 +327,7 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         public void close() {
             baseCursor = Misc.free(baseCursor);
             presentTimestamps = Misc.free(presentTimestamps);
-            if (keyMap != null) {
-                keyMap.close();
-            }
+            keyMap = Misc.free(keyMap);
         }
 
         @Override
@@ -506,10 +504,7 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                 }
                 presentTimestamps = new DirectLongList(capacity, MemoryTag.NATIVE_GROUP_BY_FUNCTION);
             }
-            if (!isValueFuncsInitialized) {
-                initValueFuncs(fillValues);
-                isValueFuncsInitialized = true;
-            }
+            initValueFuncs(fillValues);
             assert fillValues.size() <= columnCount : "fillValues.size()=" + fillValues.size() + " exceeds columnCount=" + columnCount;
             if (hasKeyColumns) {
                 keyMap.reopen();
@@ -545,49 +540,22 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                 int mapCol = outputColToKeyMapCol[i];
                 if (mapCol >= 0) {
                     switch (ColumnType.tagOf(keyMapColTypes[mapCol])) {
-                        case ColumnType.BOOLEAN:
-                            key.putBool(baseRecord.getBool(i));
-                            break;
-                        case ColumnType.BYTE:
-                            key.putByte(baseRecord.getByte(i));
-                            break;
-                        case ColumnType.CHAR:
-                            key.putChar(baseRecord.getChar(i));
-                            break;
-                        case ColumnType.DATE:
-                            key.putDate(baseRecord.getDate(i));
-                            break;
-                        case ColumnType.DOUBLE:
-                            key.putDouble(baseRecord.getDouble(i));
-                            break;
-                        case ColumnType.FLOAT:
-                            key.putFloat(baseRecord.getFloat(i));
-                            break;
-                        case ColumnType.INT:
-                            key.putInt(baseRecord.getInt(i));
-                            break;
-                        case ColumnType.IPv4:
-                            key.putIPv4(baseRecord.getIPv4(i));
-                            break;
-                        case ColumnType.LONG:
-                            key.putLong(baseRecord.getLong(i));
-                            break;
-                        case ColumnType.SHORT:
-                            key.putShort(baseRecord.getShort(i));
-                            break;
-                        case ColumnType.STRING:
-                            key.putStr(baseRecord.getStrA(i));
-                            break;
-                        case ColumnType.TIMESTAMP:
-                            key.putTimestamp(baseRecord.getTimestamp(i));
-                            break;
-                        case ColumnType.VARCHAR:
-                            key.putVarchar(baseRecord.getVarcharA(i));
-                            break;
-                        default:
-                            throw CairoException.nonCritical()
-                                    .put("unsupported key column type for FILL: ")
-                                    .put(ColumnType.nameOf(keyMapColTypes[mapCol]));
+                        case ColumnType.BOOLEAN -> key.putBool(baseRecord.getBool(i));
+                        case ColumnType.BYTE -> key.putByte(baseRecord.getByte(i));
+                        case ColumnType.CHAR -> key.putChar(baseRecord.getChar(i));
+                        case ColumnType.DATE -> key.putDate(baseRecord.getDate(i));
+                        case ColumnType.DOUBLE -> key.putDouble(baseRecord.getDouble(i));
+                        case ColumnType.FLOAT -> key.putFloat(baseRecord.getFloat(i));
+                        case ColumnType.INT -> key.putInt(baseRecord.getInt(i));
+                        case ColumnType.IPv4 -> key.putIPv4(baseRecord.getIPv4(i));
+                        case ColumnType.LONG -> key.putLong(baseRecord.getLong(i));
+                        case ColumnType.SHORT -> key.putShort(baseRecord.getShort(i));
+                        case ColumnType.STRING -> key.putStr(baseRecord.getStrA(i));
+                        case ColumnType.TIMESTAMP -> key.putTimestamp(baseRecord.getTimestamp(i));
+                        case ColumnType.VARCHAR -> key.putVarchar(baseRecord.getVarcharA(i));
+                        default -> throw CairoException.nonCritical()
+                                .put("unsupported key column type for FILL: ")
+                                .put(ColumnType.nameOf(keyMapColTypes[mapCol]));
                     }
                 }
             }
@@ -596,23 +564,14 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
 
         private static void validateKeyColumnType(int mapType, int position) throws SqlException {
             switch (ColumnType.tagOf(mapType)) {
-                case ColumnType.BOOLEAN:
-                case ColumnType.BYTE:
-                case ColumnType.CHAR:
-                case ColumnType.DATE:
-                case ColumnType.DOUBLE:
-                case ColumnType.FLOAT:
-                case ColumnType.INT:
-                case ColumnType.IPv4:
-                case ColumnType.LONG:
-                case ColumnType.SHORT:
-                case ColumnType.STRING:
-                case ColumnType.TIMESTAMP:
-                case ColumnType.VARCHAR:
-                    break;
-                default:
-                    throw SqlException.$(position, "unsupported key column type for FILL: ")
-                            .put(ColumnType.nameOf(mapType));
+                case ColumnType.BOOLEAN, ColumnType.BYTE, ColumnType.CHAR,
+                     ColumnType.DATE, ColumnType.DOUBLE, ColumnType.FLOAT,
+                     ColumnType.INT, ColumnType.IPv4, ColumnType.LONG,
+                     ColumnType.SHORT, ColumnType.STRING, ColumnType.TIMESTAMP,
+                     ColumnType.VARCHAR -> {
+                }
+                default -> throw SqlException.$(position, "unsupported key column type for FILL: ")
+                        .put(ColumnType.nameOf(mapType));
             }
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
@@ -146,6 +146,11 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                 // all non-timestamp columns. SYMBOL columns are GROUP BY keys
                 // (never aggregates), so they get NULL in fill rows. Other
                 // columns get the user-specified fill value.
+                //
+                // Note: fill values assigned to key columns (including GROUPING()
+                // / GROUPING_ID() columns) are never read at runtime because
+                // isKeyColumn() intercepts all reads and returns the actual key
+                // value from the key map instead.
                 final Function singleFill = fillValues.getQuick(0);
                 final Function fillFunc = singleFill.isNullConstant() ? NullConstant.NULL : singleFill;
                 final RecordMetadata metadata = getMetadata();

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/FillRangeRecordCursorFactory.java
@@ -25,10 +25,15 @@
 package io.questdb.griffin.engine.groupby;
 
 import io.questdb.cairo.AbstractRecordCursorFactory;
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.TimestampDriver;
 import io.questdb.cairo.arr.ArrayView;
+import io.questdb.cairo.map.Map;
+import io.questdb.cairo.map.MapFactory;
+import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.NoRandomAccessRecordCursor;
 import io.questdb.cairo.sql.Record;
@@ -46,6 +51,7 @@ import io.questdb.std.BinarySequence;
 import io.questdb.std.Decimal128;
 import io.questdb.std.Decimal256;
 import io.questdb.std.DirectLongList;
+import io.questdb.std.IntList;
 import io.questdb.std.Long256;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
@@ -62,6 +68,11 @@ import org.jetbrains.annotations.Nullable;
  * Intended to support FILL(VALUE), FILL(NULL).
  * Cannot be generated standalone (there's no syntax just to generate this, it is only generated
  * via the above optimisation).
+ *
+ * <p>When key columns are present (GROUPING SETS), the factory tracks all distinct
+ * key combinations seen during the base scan. For each missing timestamp bucket,
+ * it emits one fill row per key combination, with key columns set to their stored
+ * values and aggregate columns set to the fill value.</p>
  */
 public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
     private final RecordCursorFactory base;
@@ -86,6 +97,24 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             int timestampIndex,
             int timestampType
     ) {
+        this(metadata, base, fromFunc, toFunc, samplingInterval, samplingIntervalUnit,
+                timestampSampler, fillValues, timestampIndex, timestampType, null, null);
+    }
+
+    public FillRangeRecordCursorFactory(
+            RecordMetadata metadata,
+            RecordCursorFactory base,
+            Function fromFunc,
+            Function toFunc,
+            long samplingInterval,
+            char samplingIntervalUnit,
+            TimestampSampler timestampSampler,
+            ObjList<Function> fillValues,
+            int timestampIndex,
+            int timestampType,
+            @Nullable CairoConfiguration configuration,
+            @Nullable IntList keyColumnPositions
+    ) {
         super(metadata);
         this.base = base;
         this.fromFunc = fromFunc;
@@ -97,7 +126,10 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         this.timestampIndex = timestampIndex;
         this.fillValues = fillValues;
         this.timestampType = timestampType;
-        this.cursor = new FillRangeRecordCursor(timestampSampler, fromFunc, toFunc, fillValues, timestampIndex, timestampType, metadata.getColumnCount());
+        this.cursor = new FillRangeRecordCursor(
+                timestampSampler, fromFunc, toFunc, fillValues, timestampIndex, timestampType,
+                configuration, metadata, keyColumnPositions
+        );
     }
 
     @Override
@@ -108,11 +140,28 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
     @Override
     public RecordCursor getCursor(SqlExecutionContext executionContext) throws SqlException {
         if (getMetadata().getColumnCount() > fillValues.size() + 1) {
-            if (fillValues.size() == 1 && fillValues.getQuick(0).isNullConstant()) {
-                final int diff = (getMetadata().getColumnCount() - 1);
-                // skip one entry as it should be the designated timestamp
-                for (int i = 1; i < diff; i++) {
-                    fillValues.add(NullConstant.NULL);
+            if (fillValues.size() == 1) {
+                // Auto-expand a single fill value to cover all non-timestamp
+                // columns. SYMBOL columns represent GROUP BY keys (never
+                // aggregates), so they get NULL in fill rows. Other columns
+                // get the user-specified fill value.
+                final Function singleFill = fillValues.getQuick(0);
+                final Function fillFunc = singleFill.isNullConstant() ? NullConstant.NULL : singleFill;
+                final RecordMetadata metadata = getMetadata();
+                final int columnCount = metadata.getColumnCount();
+                // Clear and rebuild. Each entry maps to a non-timestamp column
+                // in column order. SYMBOL columns are GROUP BY keys (never
+                // aggregates), so they get NULL in fill rows.
+                fillValues.clear();
+                for (int col = 0; col < columnCount; col++) {
+                    if (col == timestampIndex) {
+                        continue;
+                    }
+                    if (ColumnType.isSymbol(metadata.getColumnType(col))) {
+                        fillValues.add(NullConstant.NULL);
+                    } else {
+                        fillValues.add(fillFunc);
+                    }
                 }
             } else {
                 throw SqlException.$(-1, "not enough fill values");
@@ -176,6 +225,7 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         Misc.free(fromFunc);
         Misc.free(toFunc);
         Misc.freeObjList(fillValues);
+        Misc.free(cursor);
     }
 
     private static class FillRangeRecordCursor implements NoRandomAccessRecordCursor {
@@ -183,6 +233,10 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         private final FillRangeRecord fillingRecord = new FillRangeRecord();
         private final FillRangeTimestampConstant fillingTimestampFunc;
         private final Function fromFunc;
+        private final boolean hasKeyColumns;
+        // Maps output column position to key map column index (-1 = not a key column).
+        // Only allocated when hasKeyColumns is true.
+        private final int[] outputColToKeyMapCol;
         private final TimestampDriver timestampDriver;
         private final int timestampIndex;
         private final TimestampSampler timestampSampler;
@@ -191,6 +245,12 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         private Record baseRecord;
         private boolean gapFilling;
         private boolean hasNegative;
+        // Map storing distinct key combinations seen during the base scan.
+        // Key columns are stored as INT values (symbol table indices for
+        // SYMBOL columns). Only allocated when hasKeyColumns is true.
+        private Map keyMap;
+        private RecordCursor keyMapCursor;
+        private Record keyMapRecord;
         private long lastTimestamp = Long.MIN_VALUE;
         private long maxTimestamp;
         private long minTimestamp;
@@ -210,7 +270,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                 ObjList<Function> fillValues,
                 int timestampIndex,
                 int timestampType,
-                int columnCount
+                @Nullable CairoConfiguration configuration,
+                RecordMetadata metadata,
+                @Nullable IntList keyColumnPositions
         ) {
             this.timestampSampler = timestampSampler;
             this.fromFunc = fromFunc;
@@ -219,13 +281,30 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             this.timestampIndex = timestampIndex;
             this.fillingTimestampFunc = new FillRangeTimestampConstant(timestampType);
             this.timestampDriver = ColumnType.getTimestampDriver(timestampType);
-            this.columnCount = columnCount;
+            this.columnCount = metadata.getColumnCount();
+            this.hasKeyColumns = keyColumnPositions != null && keyColumnPositions.size() > 0;
+
+            if (hasKeyColumns) {
+                this.outputColToKeyMapCol = new int[metadata.getColumnCount()];
+                java.util.Arrays.fill(outputColToKeyMapCol, -1);
+                ArrayColumnTypes keyMapTypes = new ArrayColumnTypes();
+                for (int i = 0, n = keyColumnPositions.size(); i < n; i++) {
+                    int colPos = keyColumnPositions.getQuick(i);
+                    outputColToKeyMapCol[colPos] = i;
+                    keyMapTypes.add(ColumnType.INT);
+                }
+                ArrayColumnTypes emptyValueTypes = new ArrayColumnTypes();
+                this.keyMap = MapFactory.createUnorderedMap(configuration, keyMapTypes, emptyValueTypes);
+            } else {
+                this.outputColToKeyMapCol = null;
+            }
         }
 
         @Override
         public void close() {
             baseCursor = Misc.free(baseCursor);
             presentTimestamps = Misc.free(presentTimestamps);
+            keyMap = Misc.free(keyMap);
         }
 
         @Override
@@ -240,13 +319,25 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
 
         @Override
         public boolean hasNext() {
-            // We rely on the fact this cursor is allowed to return result set
-            // that is not ordered on time. For that reason all the filling is done at the end
             if (gapFilling) {
+                if (hasKeyColumns) {
+                    // Try next key combination for the current gap timestamp.
+                    if (keyMapCursor.hasNext()) {
+                        return true;
+                    }
+                    // All key combinations emitted. Advance to next gap.
+                    nextBucketTimestamp = timestampSampler.nextTimestamp(nextBucketTimestamp);
+                    if (foundGapToFill()) {
+                        keyMapCursor.toTop();
+                        return keyMapCursor.hasNext();
+                    }
+                    return false;
+                }
+                // Non-keyed: one fill row per gap.
                 nextBucketTimestamp = timestampSampler.nextTimestamp(nextBucketTimestamp);
                 return foundGapToFill();
             } else if (baseCursor.hasNext()) {
-                // Scan base cursor and return all the records
+                // Scan base cursor and return all the records.
                 // Also save all the timestamps already returned by the base cursor
                 // to determine the gaps later.
                 long timestamp = baseRecord.getTimestamp(timestampIndex);
@@ -257,11 +348,23 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                 }
                 // Start saving timestamps to determine the gaps
                 presentTimestamps.add(lastTimestamp = timestamp);
+                // Record key combination for per-key gap filling
+                if (hasKeyColumns) {
+                    recordKeyValues();
+                }
                 return true;
             }
             gapFilling = true;
             prepareGapFilling();
-            return foundGapToFill();
+            if (foundGapToFill()) {
+                if (hasKeyColumns) {
+                    keyMapCursor = keyMap.getCursor();
+                    keyMapRecord = keyMapCursor.getRecord();
+                    return keyMapCursor.hasNext();
+                }
+                return true;
+            }
+            return false;
         }
 
         @Override
@@ -279,9 +382,27 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
         public void toTop() {
             baseCursor.toTop();
             presentTimestamps.clear();
+            if (hasKeyColumns) {
+                keyMap.clear();
+            }
             gapFilling = false;
             needsSorting = false;
             lastTimestamp = Long.MIN_VALUE;
+        }
+
+        private void deduplicateTimestamps() {
+            // GROUPING SETS produces multiple rows per timestamp (one per
+            // grouping set × key combination). The gap-finding logic expects
+            // unique timestamps, so we deduplicate after sorting.
+            if (presentTimestampsSize > 1) {
+                long writeIdx = 1;
+                for (long readIdx = 1; readIdx < presentTimestampsSize; readIdx++) {
+                    if (presentTimestamps.get(readIdx) != presentTimestamps.get(readIdx - 1)) {
+                        presentTimestamps.set(writeIdx++, presentTimestamps.get(readIdx));
+                    }
+                }
+                presentTimestampsSize = writeIdx;
+            }
         }
 
         private boolean foundGapToFill() {
@@ -334,6 +455,10 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             }
         }
 
+        private boolean isKeyColumn(int col) {
+            return hasKeyColumns && outputColToKeyMapCol[col] >= 0;
+        }
+
         private void of(
                 RecordCursor baseCursor,
                 SqlExecutionContext executionContext
@@ -368,6 +493,10 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
                 presentTimestamps.sortAsUnsigned();
             }
 
+            if (hasKeyColumns) {
+                deduplicateTimestamps();
+            }
+
             if (presentTimestampsSize > 0) {
                 minTimestamp = Math.min(minTimestamp, presentTimestamps.get(0));
                 maxTimestamp = Math.max(maxTimestamp, presentTimestamps.get(presentTimestampsSize - 1));
@@ -375,6 +504,17 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             timestampSampler.setStart(minTimestamp);
             nextBucketTimestamp = minTimestamp;
             presentTimestampsIndex = 0;
+        }
+
+        private void recordKeyValues() {
+            MapKey key = keyMap.withKey();
+            for (int i = 0, n = outputColToKeyMapCol.length; i < n; i++) {
+                int mapCol = outputColToKeyMapCol[i];
+                if (mapCol >= 0) {
+                    key.putInt(baseRecord.getInt(i));
+                }
+            }
+            key.createValue();
         }
 
         private class FillRangeRecord implements Record {
@@ -553,6 +693,9 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public int getInt(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        return keyMapRecord.getInt(outputColToKeyMapCol[col]);
+                    }
                     return getFillFunction(col).getInt(null);
                 } else {
                     return baseRecord.getInt(col);
@@ -653,6 +796,13 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public CharSequence getSymA(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        int symIdx = keyMapRecord.getInt(outputColToKeyMapCol[col]);
+                        if (symIdx == SymbolTable.VALUE_IS_NULL) {
+                            return null;
+                        }
+                        return baseCursor.getSymbolTable(col).valueOf(symIdx);
+                    }
                     return getFillFunction(col).getSymbol(null);
                 } else {
                     return baseRecord.getSymA(col);
@@ -662,6 +812,13 @@ public class FillRangeRecordCursorFactory extends AbstractRecordCursorFactory {
             @Override
             public CharSequence getSymB(int col) {
                 if (gapFilling) {
+                    if (isKeyColumn(col)) {
+                        int symIdx = keyMapRecord.getInt(outputColToKeyMapCol[col]);
+                        if (symIdx == SymbolTable.VALUE_IS_NULL) {
+                            return null;
+                        }
+                        return baseCursor.getSymbolTable(col).valueBOf(symIdx);
+                    }
                     return getFillFunction(col).getSymbolB(null);
                 } else {
                     return baseRecord.getSymB(col);

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
@@ -1,0 +1,412 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.groupby;
+
+import io.questdb.cairo.AbstractRecordCursorFactory;
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.ListColumnFilter;
+import io.questdb.cairo.RecordSink;
+import io.questdb.cairo.RecordSinkFactory;
+import io.questdb.cairo.map.Map;
+import io.questdb.cairo.map.MapFactory;
+import io.questdb.cairo.map.MapKey;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.groupby.GroupingFunction;
+import io.questdb.std.BytecodeAssembler;
+import io.questdb.std.IntList;
+import io.questdb.std.Misc;
+import io.questdb.std.ObjList;
+import io.questdb.std.Transient;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Executes GROUP BY with GROUPING SETS using a single-pass, N-map approach.
+ * Scans the source data once and updates N aggregation maps (one per grouping
+ * set) with different key projections.
+ *
+ * <p>All maps share the same key layout (union of all GROUP BY columns) and
+ * the same value layout. For each grouping set, a {@link NullingRecord} wraps
+ * the source record and returns NULL for columns not active in that set.
+ * The standard {@link RecordSink} copies from this wrapped record, so the
+ * map key has NULLs for inactive columns. Rows with different values for
+ * inactive columns then hash to the same map entry, achieving correct
+ * aggregation per grouping set.</p>
+ */
+public class GroupingSetsRecordCursorFactory extends AbstractRecordCursorFactory {
+    private final RecordCursorFactory base;
+    private final GroupingSetsRecordCursor cursor;
+    private final ObjList<GroupByFunction> groupByFunctions;
+    private final ObjList<Function> keyFunctions;
+    private final ObjList<Function> recordFunctions;
+
+    public GroupingSetsRecordCursorFactory(
+            @Transient @NotNull BytecodeAssembler asm,
+            CairoConfiguration configuration,
+            RecordCursorFactory base,
+            @Transient @NotNull ListColumnFilter listColumnFilter,
+            @Transient @NotNull ArrayColumnTypes keyTypes,
+            @Transient @NotNull ArrayColumnTypes valueTypes,
+            RecordMetadata groupByMetadata,
+            ObjList<GroupByFunction> groupByFunctions,
+            ObjList<Function> keyFunctions,
+            ObjList<Function> recordFunctions,
+            ObjList<IntList> groupingSets,
+            IntList keyColumnIndices
+    ) {
+        super(groupByMetadata);
+        try {
+            this.base = base;
+            this.groupByFunctions = groupByFunctions;
+            this.keyFunctions = keyFunctions;
+            this.recordFunctions = recordFunctions;
+
+            int setCount = groupingSets.size();
+            int totalKeyColumns = keyColumnIndices.size();
+
+            // Build the single RecordSink that copies all key columns.
+            RecordSink mapSink = RecordSinkFactory.getInstance(
+                    configuration, asm, base.getMetadata(), listColumnFilter, keyFunctions, null
+            );
+
+            // Build per-set lists of base column indices to null out. For each
+            // grouping set, columns NOT in its active list must return NULL.
+            ObjList<IntList> nulledColumnsPerSet = new ObjList<>(setCount);
+            for (int s = 0; s < setCount; s++) {
+                IntList activeIndices = groupingSets.getQuick(s);
+                IntList nulled = new IntList();
+                for (int k = 0; k < totalKeyColumns; k++) {
+                    if (!containsValue(activeIndices, k)) {
+                        nulled.add(keyColumnIndices.getQuick(k));
+                    }
+                }
+                nulledColumnsPerSet.add(nulled);
+            }
+
+            // Compute the GROUPING_ID bitmask for each grouping set. Bit positions
+            // are assigned right-to-left per the SQL standard: the rightmost GROUP BY
+            // column occupies bit 0.
+            IntList groupingIds = new IntList(setCount);
+            for (int s = 0; s < setCount; s++) {
+                IntList activeIndices = groupingSets.getQuick(s);
+                int mask = 0;
+                for (int k = 0; k < totalKeyColumns; k++) {
+                    if (!containsValue(activeIndices, k)) {
+                        mask |= (1 << (totalKeyColumns - 1 - k));
+                    }
+                }
+                groupingIds.add(mask);
+            }
+
+            // Find GROUPING() functions among the group-by functions and
+            // initialize them with the grouping set layout. Each GroupingFunction
+            // stores its bitmask in the map value (it implements GroupByFunction),
+            // and setCurrentSet() is called before each set's map is populated
+            // so computeFirst() stores the correct bitmask.
+            ObjList<GroupingFunction> groupingFunctions = new ObjList<>();
+            for (int i = 0, n = groupByFunctions.size(); i < n; i++) {
+                GroupByFunction f = groupByFunctions.getQuick(i);
+                if (f instanceof GroupingFunction gf) {
+                    gf.init(groupingIds, keyColumnIndices);
+                    groupingFunctions.add(gf);
+                }
+            }
+
+            GroupByFunctionsUpdater updater = GroupByFunctionsUpdaterFactory.getInstance(asm, groupByFunctions);
+            this.cursor = new GroupingSetsRecordCursor(
+                    configuration,
+                    recordFunctions,
+                    groupByFunctions,
+                    updater,
+                    keyTypes,
+                    valueTypes,
+                    mapSink,
+                    nulledColumnsPerSet,
+                    groupingFunctions,
+                    setCount
+            );
+        } catch (Throwable e) {
+            close();
+            throw e;
+        }
+    }
+
+    @Override
+    public RecordCursorFactory getBaseFactory() {
+        return base;
+    }
+
+    @Override
+    public RecordCursor getCursor(SqlExecutionContext executionContext) throws SqlException {
+        final RecordCursor baseCursor = base.getCursor(executionContext);
+        try {
+            Function.init(recordFunctions, baseCursor, executionContext, null);
+        } catch (Throwable th) {
+            baseCursor.close();
+            throw th;
+        }
+
+        try {
+            cursor.of(baseCursor, executionContext);
+            return cursor;
+        } catch (Throwable th) {
+            cursor.close();
+            throw th;
+        }
+    }
+
+    @Override
+    public boolean recordCursorSupportsRandomAccess() {
+        return false;
+    }
+
+    @Override
+    public void toPlan(PlanSink sink) {
+        sink.type("GroupBy");
+        sink.meta("vectorized").val(false);
+        sink.attr("groupingSets").val(true);
+        sink.optAttr("keys", GroupByRecordCursorFactory.getKeys(recordFunctions, getMetadata()));
+        sink.optAttr("values", groupByFunctions, true);
+        sink.child(base);
+    }
+
+    @Override
+    public boolean usesCompiledFilter() {
+        return base.usesCompiledFilter();
+    }
+
+    @Override
+    public boolean usesIndex() {
+        return base.usesIndex();
+    }
+
+    @Override
+    protected void _close() {
+        Misc.freeObjList(recordFunctions);
+        Misc.freeObjList(keyFunctions);
+        Misc.free(base);
+        Misc.free(cursor);
+    }
+
+    private static boolean containsValue(IntList list, int value) {
+        for (int i = 0, n = list.size(); i < n; i++) {
+            if (list.getQuick(i) == value) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Cursor that iterates N aggregation maps sequentially. Each map corresponds
+     * to one grouping set. Within each map, rows are iterated normally. When
+     * one map is exhausted, the cursor advances to the next map.
+     */
+    private class GroupingSetsRecordCursor extends VirtualFunctionSkewedSymbolRecordCursor {
+        private final GroupByAllocator allocator;
+        private final ObjList<Map> dataMaps;
+        private final GroupByFunctionsUpdater groupByFunctionsUpdater;
+        private final ObjList<GroupingFunction> groupingFunctions;
+        private final RecordSink mapSink;
+        private final ObjList<IntList> nulledColumnsPerSet;
+        private final ObjList<NullingRecord> nullingRecords;
+        private final int setCount;
+        private SqlExecutionCircuitBreaker circuitBreaker;
+        private int currentSetIndex;
+        private boolean isDataMapBuilt;
+        private boolean isOpen;
+        private long rowId;
+
+        public GroupingSetsRecordCursor(
+                CairoConfiguration configuration,
+                ObjList<Function> functions,
+                ObjList<GroupByFunction> groupByFunctions,
+                GroupByFunctionsUpdater groupByFunctionsUpdater,
+                @Transient @NotNull ArrayColumnTypes keyTypes,
+                @Transient @NotNull ArrayColumnTypes valueTypes,
+                RecordSink mapSink,
+                ObjList<IntList> nulledColumnsPerSet,
+                ObjList<GroupingFunction> groupingFunctions,
+                int setCount
+        ) {
+            super(functions);
+            try {
+                this.isOpen = true;
+                this.groupByFunctionsUpdater = groupByFunctionsUpdater;
+                this.groupingFunctions = groupingFunctions;
+                this.mapSink = mapSink;
+                this.nulledColumnsPerSet = nulledColumnsPerSet;
+                this.setCount = setCount;
+
+                this.dataMaps = new ObjList<>(setCount);
+                for (int i = 0; i < setCount; i++) {
+                    dataMaps.add(MapFactory.createUnorderedMap(configuration, keyTypes, valueTypes));
+                }
+
+                // Pre-allocate NullingRecord wrappers (one per set)
+                this.nullingRecords = new ObjList<>(setCount);
+                for (int i = 0; i < setCount; i++) {
+                    nullingRecords.add(new NullingRecord());
+                }
+
+                this.allocator = GroupByAllocatorFactory.createAllocator(configuration);
+                GroupByUtils.setAllocator(groupByFunctions, allocator);
+            } catch (Throwable th) {
+                close();
+                throw th;
+            }
+        }
+
+        @Override
+        public void calculateSize(SqlExecutionCircuitBreaker circuitBreaker, Counter counter) {
+            buildMapConditionally();
+            long total = 0;
+            for (int i = 0; i < setCount; i++) {
+                total += dataMaps.getQuick(i).size();
+            }
+            counter.add(total);
+        }
+
+        @Override
+        public void close() {
+            if (isOpen) {
+                isOpen = false;
+                for (int i = 0, n = dataMaps.size(); i < n; i++) {
+                    Misc.free(dataMaps.getQuick(i));
+                }
+                Misc.free(allocator);
+                Misc.clearObjList(groupByFunctions);
+                super.close();
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            buildMapConditionally();
+            if (baseCursor != null && baseCursor.hasNext()) {
+                return true;
+            }
+            // Advance to next map
+            while (++currentSetIndex < setCount) {
+                of(dataMaps.getQuick(currentSetIndex).getCursor());
+                if (baseCursor.hasNext()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public void of(RecordCursor managedCursor, SqlExecutionContext executionContext) throws SqlException {
+            this.managedCursor = managedCursor;
+            if (!isOpen) {
+                isOpen = true;
+                for (int i = 0; i < setCount; i++) {
+                    dataMaps.getQuick(i).reopen();
+                }
+                allocator.reopen();
+            }
+            this.circuitBreaker = executionContext.getCircuitBreaker();
+            Function.init(keyFunctions, managedCursor, executionContext, null);
+            isDataMapBuilt = false;
+            currentSetIndex = -1;
+            rowId = 0;
+        }
+
+        @Override
+        public long preComputedStateSize() {
+            return isDataMapBuilt ? 1 : 0;
+        }
+
+        @Override
+        public void toTop() {
+            currentSetIndex = 0;
+            of(dataMaps.getQuick(0).getCursor());
+            rowId = 0;
+        }
+
+        /**
+         * Scans the source data once and populates all N maps. For each input
+         * row, wraps it in a NullingRecord per grouping set and updates the
+         * corresponding map. This is the single-pass core of GROUPING SETS.
+         *
+         * <p>Before updating each set's map, setCurrentSet(s) is called on all
+         * GROUPING() functions so that computeFirst() stores the correct
+         * bitmask in the map value for that set.</p>
+         */
+        private void buildDataMaps() {
+            final Record baseRecord = managedCursor.getRecord();
+            // Initialize NullingRecords with the base record
+            for (int s = 0; s < setCount; s++) {
+                nullingRecords.getQuick(s).of(baseRecord, nulledColumnsPerSet.getQuick(s));
+            }
+
+            while (managedCursor.hasNext()) {
+                circuitBreaker.statefulThrowExceptionIfTripped();
+                for (int s = 0; s < setCount; s++) {
+                    // Set the current grouping set index so GROUPING() functions
+                    // store the correct bitmask when computeFirst() is called.
+                    updateGroupingFunctions(s);
+                    final MapKey key = dataMaps.getQuick(s).withKey();
+                    // The NullingRecord returns NULL for inactive columns,
+                    // so the map key has NULLs for non-grouped columns.
+                    mapSink.copy(nullingRecords.getQuick(s), key);
+                    MapValue value = key.createValue();
+                    if (value.isNew()) {
+                        groupByFunctionsUpdater.updateNew(value, baseRecord, rowId);
+                    } else {
+                        groupByFunctionsUpdater.updateExisting(value, baseRecord, rowId);
+                    }
+                }
+                rowId++;
+            }
+            // Start iteration from first map
+            currentSetIndex = 0;
+            of(dataMaps.getQuick(0).getCursor());
+            isDataMapBuilt = true;
+        }
+
+        private void buildMapConditionally() {
+            if (!isDataMapBuilt) {
+                buildDataMaps();
+            }
+        }
+
+        private void updateGroupingFunctions(int setIndex) {
+            for (int i = 0, n = groupingFunctions.size(); i < n; i++) {
+                groupingFunctions.getQuick(i).setCurrentSet(setIndex);
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
@@ -96,6 +96,11 @@ public class GroupingSetsRecordCursorFactory extends AbstractRecordCursorFactory
             int setCount = groupingSets.size();
             int totalKeyColumns = keyColumnIndices.size();
 
+            // GROUPING_ID bitmask is int-based (31 usable bits).
+            if (totalKeyColumns > 31) {
+                throw SqlException.$(0, "GROUPING SETS supports at most 31 key columns");
+            }
+
             // Build the single RecordSink that copies all key columns.
             RecordSink mapSink = RecordSinkFactory.getInstance(
                     configuration, asm, base.getMetadata(), listColumnFilter, keyFunctions, null

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
@@ -231,6 +231,8 @@ public class GroupingSetsRecordCursorFactory extends AbstractRecordCursorFactory
         Misc.free(cursor);
     }
 
+    // O(N) linear scan, called only during construction (not on the data path).
+    // N is the number of active key columns per set (small in practice).
     private static boolean containsValue(IntList list, int value) {
         for (int i = 0, n = list.size(); i < n; i++) {
             if (list.getQuick(i) == value) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
@@ -84,7 +84,8 @@ public class GroupingSetsRecordCursorFactory extends AbstractRecordCursorFactory
             ObjList<Function> keyFunctions,
             ObjList<Function> recordFunctions,
             ObjList<IntList> groupingSets,
-            IntList keyColumnIndices
+            IntList keyColumnIndices,
+            int position
     ) throws SqlException {
         super(groupByMetadata);
         try {
@@ -95,11 +96,6 @@ public class GroupingSetsRecordCursorFactory extends AbstractRecordCursorFactory
 
             int setCount = groupingSets.size();
             int totalKeyColumns = keyColumnIndices.size();
-
-            // GROUPING_ID bitmask is int-based (31 usable bits).
-            if (totalKeyColumns > 31) {
-                throw SqlException.$(0, "GROUPING SETS supports at most 31 key columns");
-            }
 
             // Build the single RecordSink that copies all key columns.
             RecordSink mapSink = RecordSinkFactory.getInstance(
@@ -120,32 +116,42 @@ public class GroupingSetsRecordCursorFactory extends AbstractRecordCursorFactory
                 nulledColumnsPerSet.add(nulled);
             }
 
-            // Compute the GROUPING_ID bitmask for each grouping set. Bit positions
-            // are assigned right-to-left per the SQL standard: the rightmost GROUP BY
-            // column occupies bit 0.
-            IntList groupingIds = new IntList(setCount);
-            for (int s = 0; s < setCount; s++) {
-                IntList activeIndices = groupingSets.getQuick(s);
-                int mask = 0;
-                for (int k = 0; k < totalKeyColumns; k++) {
-                    if (!containsValue(activeIndices, k)) {
-                        mask |= (1 << (totalKeyColumns - 1 - k));
-                    }
-                }
-                groupingIds.add(mask);
-            }
-
-            // Find GROUPING() functions among the group-by functions and
-            // initialize them with the grouping set layout. Each GroupingFunction
-            // stores its bitmask in the map value (it implements GroupByFunction),
-            // and setCurrentSet() is called before each set's map is populated
-            // so computeFirst() stores the correct bitmask.
+            // Find GROUPING() functions among the group-by functions.
             ObjList<GroupingFunction> groupingFunctions = new ObjList<>();
             for (int i = 0, n = groupByFunctions.size(); i < n; i++) {
                 GroupByFunction f = groupByFunctions.getQuick(i);
                 if (f instanceof GroupingFunction gf) {
-                    gf.init(groupingIds, keyColumnIndices);
                     groupingFunctions.add(gf);
+                }
+            }
+
+            boolean hasGroupingFunctions = groupingFunctions.size() > 0;
+
+            // GROUPING_ID bitmask is int-based (31 usable bits). Guard only
+            // when GROUPING()/GROUPING_ID() functions are present, since
+            // the bitmask is only consumed by those functions.
+            if (hasGroupingFunctions && totalKeyColumns > 31) {
+                throw SqlException.$(position, "GROUPING SETS with GROUPING()/GROUPING_ID() supports at most 31 key columns");
+            }
+
+            // Compute GROUPING_ID bitmasks and initialize GROUPING() functions
+            // only when such functions are present. The bitmask is only consumed
+            // by GroupingFunction, so skip the O(setCount * keyCount) work when
+            // no GROUPING()/GROUPING_ID() calls exist.
+            if (hasGroupingFunctions) {
+                IntList groupingIds = new IntList(setCount);
+                for (int s = 0; s < setCount; s++) {
+                    IntList activeIndices = groupingSets.getQuick(s);
+                    int mask = 0;
+                    for (int k = 0; k < totalKeyColumns; k++) {
+                        if (!containsValue(activeIndices, k)) {
+                            mask |= (1 << (totalKeyColumns - 1 - k));
+                        }
+                    }
+                    groupingIds.add(mask);
+                }
+                for (int i = 0, n = groupingFunctions.size(); i < n; i++) {
+                    groupingFunctions.getQuick(i).init(groupingIds, keyColumnIndices);
                 }
             }
 

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
@@ -85,7 +85,7 @@ public class GroupingSetsRecordCursorFactory extends AbstractRecordCursorFactory
             ObjList<Function> recordFunctions,
             ObjList<IntList> groupingSets,
             IntList keyColumnIndices
-    ) {
+    ) throws SqlException {
         super(groupByMetadata);
         try {
             this.base = base;

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
@@ -281,6 +281,9 @@ public class GroupingSetsRecordCursorFactory extends AbstractRecordCursorFactory
                 this.nulledColumnsPerSet = nulledColumnsPerSet;
                 this.setCount = setCount;
 
+                // One map per grouping set. Maps start with a small initial
+                // capacity and grow lazily during the scan, so the upfront
+                // allocation cost is modest for typical set counts (< 20).
                 this.dataMaps = new ObjList<>(setCount);
                 for (int i = 0; i < setCount; i++) {
                     dataMaps.add(MapFactory.createUnorderedMap(configuration, keyTypes, valueTypes));

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupingSetsRecordCursorFactory.java
@@ -346,6 +346,10 @@ public class GroupingSetsRecordCursorFactory extends AbstractRecordCursorFactory
 
         public void of(RecordCursor managedCursor, SqlExecutionContext executionContext) throws SqlException {
             this.managedCursor = managedCursor;
+            // Clear baseCursor to prevent stale state if buildDataMaps() throws
+            // (e.g. circuit breaker). Without this, close() could see a baseCursor
+            // from a previous execution cycle.
+            this.baseCursor = null;
             if (!isOpen) {
                 isOpen = true;
                 for (int i = 0; i < setCount; i++) {

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/NullingRecord.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/NullingRecord.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.groupby;
+
+import io.questdb.cairo.sql.Record;
+import io.questdb.std.BinarySequence;
+import io.questdb.std.IntList;
+import io.questdb.std.Long256;
+import io.questdb.std.Long256Impl;
+import io.questdb.std.Numbers;
+import io.questdb.std.str.CharSink;
+import io.questdb.std.str.Utf8Sequence;
+
+/**
+ * Wraps a source Record and returns NULL values for "nulled" columns.
+ * Used by GROUPING SETS to mask out columns that are not part of the
+ * current grouping set, so the map key treats them as identical NULLs.
+ */
+public class NullingRecord implements Record {
+    private Record base;
+    // Columns for which this record returns NULL instead of the base value.
+    // Contains base record column indices (0-based).
+    private IntList nulledColumns;
+
+    @Override
+    public BinarySequence getBin(int col) {
+        return isNulled(col) ? null : base.getBin(col);
+    }
+
+    @Override
+    public long getBinLen(int col) {
+        return isNulled(col) ? -1 : base.getBinLen(col);
+    }
+
+    @Override
+    public boolean getBool(int col) {
+        return !isNulled(col) && base.getBool(col);
+    }
+
+    @Override
+    public byte getByte(int col) {
+        return isNulled(col) ? 0 : base.getByte(col);
+    }
+
+    @Override
+    public char getChar(int col) {
+        return isNulled(col) ? 0 : base.getChar(col);
+    }
+
+    @Override
+    public long getDate(int col) {
+        return isNulled(col) ? Numbers.LONG_NULL : base.getDate(col);
+    }
+
+    @Override
+    public double getDouble(int col) {
+        return isNulled(col) ? Double.NaN : base.getDouble(col);
+    }
+
+    @Override
+    public float getFloat(int col) {
+        return isNulled(col) ? Float.NaN : base.getFloat(col);
+    }
+
+    @Override
+    public byte getGeoByte(int col) {
+        return isNulled(col) ? 0 : base.getGeoByte(col);
+    }
+
+    @Override
+    public int getGeoInt(int col) {
+        return isNulled(col) ? Numbers.INT_NULL : base.getGeoInt(col);
+    }
+
+    @Override
+    public long getGeoLong(int col) {
+        return isNulled(col) ? Numbers.LONG_NULL : base.getGeoLong(col);
+    }
+
+    @Override
+    public short getGeoShort(int col) {
+        return isNulled(col) ? 0 : base.getGeoShort(col);
+    }
+
+    @Override
+    public int getIPv4(int col) {
+        return isNulled(col) ? Numbers.IPv4_NULL : base.getIPv4(col);
+    }
+
+    @Override
+    public int getInt(int col) {
+        return isNulled(col) ? Numbers.INT_NULL : base.getInt(col);
+    }
+
+    @Override
+    public long getLong(int col) {
+        return isNulled(col) ? Numbers.LONG_NULL : base.getLong(col);
+    }
+
+    @Override
+    public void getLong256(int col, CharSink<?> sink) {
+        if (!isNulled(col)) {
+            base.getLong256(col, sink);
+        }
+    }
+
+    @Override
+    public Long256 getLong256A(int col) {
+        return isNulled(col) ? Long256Impl.NULL_LONG256 : base.getLong256A(col);
+    }
+
+    @Override
+    public Long256 getLong256B(int col) {
+        return isNulled(col) ? Long256Impl.NULL_LONG256 : base.getLong256B(col);
+    }
+
+    @Override
+    public long getRowId() {
+        return base.getRowId();
+    }
+
+    @Override
+    public short getShort(int col) {
+        return isNulled(col) ? 0 : base.getShort(col);
+    }
+
+    @Override
+    public CharSequence getStrA(int col) {
+        return isNulled(col) ? null : base.getStrA(col);
+    }
+
+    @Override
+    public CharSequence getStrB(int col) {
+        return isNulled(col) ? null : base.getStrB(col);
+    }
+
+    @Override
+    public int getStrLen(int col) {
+        return isNulled(col) ? -1 : base.getStrLen(col);
+    }
+
+    @Override
+    public CharSequence getSymA(int col) {
+        return isNulled(col) ? null : base.getSymA(col);
+    }
+
+    @Override
+    public CharSequence getSymB(int col) {
+        return isNulled(col) ? null : base.getSymB(col);
+    }
+
+    @Override
+    public long getTimestamp(int col) {
+        return isNulled(col) ? Numbers.LONG_NULL : base.getTimestamp(col);
+    }
+
+    @Override
+    public Utf8Sequence getVarcharA(int col) {
+        return isNulled(col) ? null : base.getVarcharA(col);
+    }
+
+    @Override
+    public Utf8Sequence getVarcharB(int col) {
+        return isNulled(col) ? null : base.getVarcharB(col);
+    }
+
+    @Override
+    public int getVarcharSize(int col) {
+        return isNulled(col) ? -1 : base.getVarcharSize(col);
+    }
+
+    public void of(Record base, IntList nulledColumns) {
+        this.base = base;
+        this.nulledColumns = nulledColumns;
+    }
+
+    private boolean isNulled(int col) {
+        if (nulledColumns == null) {
+            return false;
+        }
+        for (int i = 0, n = nulledColumns.size(); i < n; i++) {
+            if (nulledColumns.getQuick(i) == col) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/NullingRecord.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/NullingRecord.java
@@ -263,7 +263,14 @@ public class NullingRecord implements Record {
             for (int i = 0, n = nulledColumns.size(); i < n; i++) {
                 maxCol = Math.max(maxCol, nulledColumns.getQuick(i));
             }
-            this.isColumnNulled = new boolean[maxCol + 1];
+            int requiredLength = maxCol + 1;
+            if (this.isColumnNulled == null || this.isColumnNulled.length < requiredLength) {
+                this.isColumnNulled = new boolean[requiredLength];
+            } else {
+                for (int i = 0, n = this.isColumnNulled.length; i < n; i++) {
+                    this.isColumnNulled[i] = false;
+                }
+            }
             for (int i = 0, n = nulledColumns.size(); i < n; i++) {
                 isColumnNulled[nulledColumns.getQuick(i)] = true;
             }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/NullingRecord.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/NullingRecord.java
@@ -24,6 +24,7 @@
 
 package io.questdb.griffin.engine.groupby;
 
+import io.questdb.cairo.GeoHashes;
 import io.questdb.cairo.arr.ArrayView;
 import io.questdb.griffin.engine.functions.constants.ArrayConstant;
 import io.questdb.cairo.sql.Record;
@@ -134,22 +135,22 @@ public class NullingRecord implements Record {
 
     @Override
     public byte getGeoByte(int col) {
-        return isNulled(col) ? 0 : base.getGeoByte(col);
+        return isNulled(col) ? GeoHashes.BYTE_NULL : base.getGeoByte(col);
     }
 
     @Override
     public int getGeoInt(int col) {
-        return isNulled(col) ? Numbers.INT_NULL : base.getGeoInt(col);
+        return isNulled(col) ? GeoHashes.INT_NULL : base.getGeoInt(col);
     }
 
     @Override
     public long getGeoLong(int col) {
-        return isNulled(col) ? Numbers.LONG_NULL : base.getGeoLong(col);
+        return isNulled(col) ? GeoHashes.NULL : base.getGeoLong(col);
     }
 
     @Override
     public short getGeoShort(int col) {
-        return isNulled(col) ? 0 : base.getGeoShort(col);
+        return isNulled(col) ? GeoHashes.SHORT_NULL : base.getGeoShort(col);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/NullingRecord.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/NullingRecord.java
@@ -24,9 +24,15 @@
 
 package io.questdb.griffin.engine.groupby;
 
+import io.questdb.cairo.arr.ArrayView;
+import io.questdb.griffin.engine.functions.constants.ArrayConstant;
 import io.questdb.cairo.sql.Record;
 import io.questdb.std.BinarySequence;
+import io.questdb.std.Decimal128;
+import io.questdb.std.Decimal256;
+import io.questdb.std.Decimals;
 import io.questdb.std.IntList;
+import io.questdb.std.Interval;
 import io.questdb.std.Long256;
 import io.questdb.std.Long256Impl;
 import io.questdb.std.Numbers;
@@ -42,6 +48,11 @@ public class NullingRecord implements Record {
     private Record base;
     // O(1) lookup: true at index i means column i is nulled.
     private boolean[] isColumnNulled;
+
+    @Override
+    public ArrayView getArray(int col, int columnType) {
+        return isNulled(col) ? ArrayConstant.NULL : base.getArray(col, columnType);
+    }
 
     @Override
     public BinarySequence getBin(int col) {
@@ -71,6 +82,44 @@ public class NullingRecord implements Record {
     @Override
     public long getDate(int col) {
         return isNulled(col) ? Numbers.LONG_NULL : base.getDate(col);
+    }
+
+    @Override
+    public void getDecimal128(int col, Decimal128 sink) {
+        if (isNulled(col)) {
+            sink.ofRawNull();
+        } else {
+            base.getDecimal128(col, sink);
+        }
+    }
+
+    @Override
+    public short getDecimal16(int col) {
+        return isNulled(col) ? Decimals.DECIMAL16_NULL : base.getDecimal16(col);
+    }
+
+    @Override
+    public void getDecimal256(int col, Decimal256 sink) {
+        if (isNulled(col)) {
+            sink.ofRawNull();
+        } else {
+            base.getDecimal256(col, sink);
+        }
+    }
+
+    @Override
+    public int getDecimal32(int col) {
+        return isNulled(col) ? Decimals.DECIMAL32_NULL : base.getDecimal32(col);
+    }
+
+    @Override
+    public long getDecimal64(int col) {
+        return isNulled(col) ? Decimals.DECIMAL64_NULL : base.getDecimal64(col);
+    }
+
+    @Override
+    public byte getDecimal8(int col) {
+        return isNulled(col) ? Decimals.DECIMAL8_NULL : base.getDecimal8(col);
     }
 
     @Override
@@ -114,8 +163,23 @@ public class NullingRecord implements Record {
     }
 
     @Override
+    public Interval getInterval(int col) {
+        return isNulled(col) ? Interval.NULL : base.getInterval(col);
+    }
+
+    @Override
     public long getLong(int col) {
         return isNulled(col) ? Numbers.LONG_NULL : base.getLong(col);
+    }
+
+    @Override
+    public long getLong128Hi(int col) {
+        return isNulled(col) ? Numbers.LONG_NULL : base.getLong128Hi(col);
+    }
+
+    @Override
+    public long getLong128Lo(int col) {
+        return isNulled(col) ? Numbers.LONG_NULL : base.getLong128Lo(col);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/NullingRecord.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/NullingRecord.java
@@ -40,9 +40,8 @@ import io.questdb.std.str.Utf8Sequence;
  */
 public class NullingRecord implements Record {
     private Record base;
-    // Columns for which this record returns NULL instead of the base value.
-    // Contains base record column indices (0-based).
-    private IntList nulledColumns;
+    // O(1) lookup: true at index i means column i is nulled.
+    private boolean[] isColumnNulled;
 
     @Override
     public BinarySequence getBin(int col) {
@@ -193,18 +192,21 @@ public class NullingRecord implements Record {
 
     public void of(Record base, IntList nulledColumns) {
         this.base = base;
-        this.nulledColumns = nulledColumns;
+        if (nulledColumns == null || nulledColumns.size() == 0) {
+            this.isColumnNulled = null;
+        } else {
+            int maxCol = 0;
+            for (int i = 0, n = nulledColumns.size(); i < n; i++) {
+                maxCol = Math.max(maxCol, nulledColumns.getQuick(i));
+            }
+            this.isColumnNulled = new boolean[maxCol + 1];
+            for (int i = 0, n = nulledColumns.size(); i < n; i++) {
+                isColumnNulled[nulledColumns.getQuick(i)] = true;
+            }
+        }
     }
 
     private boolean isNulled(int col) {
-        if (nulledColumns == null) {
-            return false;
-        }
-        for (int i = 0, n = nulledColumns.size(); i < n; i++) {
-            if (nulledColumns.getQuick(i) == col) {
-                return true;
-            }
-        }
-        return false;
+        return isColumnNulled != null && col < isColumnNulled.length && isColumnNulled[col];
     }
 }

--- a/core/src/main/java/io/questdb/griffin/model/IQueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/IQueryModel.java
@@ -292,6 +292,8 @@ public interface IQueryModel extends Mutable, ExecutionModel, AliasTranslator, S
 
     ObjList<ExpressionNode> getGroupBy();
 
+    ObjList<IntList> getGroupingSets();
+
     LowerCaseCharSequenceObjHashMap<CharSequence> getHints();
 
     HorizonJoinContext getHorizonJoinContext();
@@ -453,6 +455,8 @@ public interface IQueryModel extends Mutable, ExecutionModel, AliasTranslator, S
     LowerCaseCharSequenceObjHashMap<WithClauseModel> getWithClauses();
 
     boolean hasExplicitTimestamp();
+
+    boolean hasGroupingSets();
 
     boolean hasSharedRefs();
 

--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -776,6 +776,7 @@ public class QueryModel implements IQueryModel {
         return groupBy;
     }
 
+    @Override
     public ObjList<IntList> getGroupingSets() {
         return groupingSets;
     }
@@ -1092,6 +1093,7 @@ public class QueryModel implements IQueryModel {
         return timestamp;
     }
 
+    @Override
     public boolean hasGroupingSets() {
         return groupingSets != null && groupingSets.size() > 0;
     }

--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -74,6 +74,9 @@ public class QueryModel implements IQueryModel {
     private final IntHashSet dependencies = new IntHashSet();
     private final ObjList<ExpressionNode> expressionModels = new ObjList<>();
     private final ObjList<ExpressionNode> groupBy = new ObjList<>();
+    // Each IntList contains indices into groupBy for columns active in that grouping set.
+    // Empty IntList = empty set () = grand total. Null means no GROUPING SETS syntax.
+    private ObjList<IntList> groupingSets;
     private final LowerCaseCharSequenceObjHashMap<CharSequence> hintsMap = new LowerCaseCharSequenceObjHashMap<>();
     private final HorizonJoinContext horizonJoinContext = new HorizonJoinContext();
     private final ObjList<ExpressionNode> joinColumns = new ObjList<>(4);
@@ -274,6 +277,13 @@ public class QueryModel implements IQueryModel {
         groupBy.add(node);
     }
 
+    public void addGroupingSet(IntList columnIndices) {
+        if (groupingSets == null) {
+            groupingSets = new ObjList<>();
+        }
+        groupingSets.add(columnIndices);
+    }
+
     @Override
     public void addHint(CharSequence key, CharSequence value) {
         hintsMap.put(key, value);
@@ -387,6 +397,7 @@ public class QueryModel implements IQueryModel {
         orderByAdviceMnemonic = OrderByMnemonic.ORDER_BY_UNKNOWN;
         isSelectTranslation = false;
         groupBy.clear();
+        groupingSets = null;
         dependencies.clear();
         parsedWhere.clear();
         whereClause = null;
@@ -765,6 +776,10 @@ public class QueryModel implements IQueryModel {
         return groupBy;
     }
 
+    public ObjList<IntList> getGroupingSets() {
+        return groupingSets;
+    }
+
     @NotNull
     @Override
     public LowerCaseCharSequenceObjHashMap<CharSequence> getHints() {
@@ -1075,6 +1090,10 @@ public class QueryModel implements IQueryModel {
     @Override
     public ExpressionNode getTimestamp() {
         return timestamp;
+    }
+
+    public boolean hasGroupingSets() {
+        return groupingSets != null && groupingSets.size() > 0;
     }
 
     @Override
@@ -1432,6 +1451,10 @@ public class QueryModel implements IQueryModel {
     public void moveGroupByFrom(IQueryModel model) {
         ObjList<ExpressionNode> thatGroupBy = model.getGroupBy();
         groupBy.addAll(thatGroupBy);
+        if (model instanceof QueryModel that) {
+            groupingSets = that.groupingSets;
+            that.groupingSets = null;
+        }
         // clear the source
         thatGroupBy.clear();
     }

--- a/core/src/main/java/io/questdb/griffin/model/QueryModelWrapper.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModelWrapper.java
@@ -363,6 +363,11 @@ public class QueryModelWrapper implements IQueryModel {
     }
 
     @Override
+    public ObjList<IntList> getGroupingSets() {
+        return delegate.getGroupingSets();
+    }
+
+    @Override
     public LowerCaseCharSequenceObjHashMap<CharSequence> getHints() {
         return delegate.getHints();
     }
@@ -774,6 +779,11 @@ public class QueryModelWrapper implements IQueryModel {
     @Override
     public boolean hasExplicitTimestamp() {
         return delegate.hasExplicitTimestamp();
+    }
+
+    @Override
+    public boolean hasGroupingSets() {
+        return delegate.hasGroupingSets();
     }
 
     @Override

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -632,6 +632,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.sql.map.max.pages\tQDB_CAIRO_SQL_MAP_MAX_PAGES\t2147483647\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.map.max.resizes\tQDB_CAIRO_SQL_MAP_MAX_RESIZES\t2147483647\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.unordered.map.max.entry.size\tQDB_CAIRO_SQL_UNORDERED_MAP_MAX_ENTRY_SIZE\t32\tdefault\tfalse\tfalse\n" +
+                                    "cairo.sql.max.grouping.sets\tQDB_CAIRO_SQL_MAX_GROUPING_SETS\t4096\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.max.negative.limit\tQDB_CAIRO_SQL_MAX_NEGATIVE_LIMIT\t10000\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.max.recompile.attempts\tQDB_CAIRO_SQL_MAX_RECOMPILE_ATTEMPTS\t10\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.max.symbol.not.equals.count\tQDB_CAIRO_SQL_MAX_SYMBOL_NOT_EQUALS_COUNT\t100\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/java/io/questdb/test/griffin/GroupingSetsFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupingSetsFuzzTest.java
@@ -335,11 +335,22 @@ public class GroupingSetsFuzzTest extends AbstractCairoTest {
             if (r > 0) {
                 sb.append(',');
             }
-            sb.append("('");
-            sb.append(SYMBOLS[rnd.nextInt(SYMBOLS.length)]);
-            sb.append("', '");
-            sb.append(SIDES[rnd.nextInt(SIDES.length)]);
-            sb.append("', ");
+            // ~10% chance of NULL symbol or side to test data NULLs vs rollup NULLs
+            boolean nullSymbol = rnd.nextInt(10) == 0;
+            boolean nullSide = rnd.nextInt(10) == 0;
+            sb.append('(');
+            if (nullSymbol) {
+                sb.append("NULL");
+            } else {
+                sb.append('\'').append(SYMBOLS[rnd.nextInt(SYMBOLS.length)]).append('\'');
+            }
+            sb.append(", ");
+            if (nullSide) {
+                sb.append("NULL");
+            } else {
+                sb.append('\'').append(SIDES[rnd.nextInt(SIDES.length)]).append('\'');
+            }
+            sb.append(", ");
             sb.append(1 + rnd.nextInt(1000));
             sb.append(')');
         }

--- a/core/src/test/java/io/questdb/test/griffin/GroupingSetsFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupingSetsFuzzTest.java
@@ -1,0 +1,401 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin;
+
+import io.questdb.std.Rnd;
+import io.questdb.std.str.StringSink;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Fuzz tests for GROUPING SETS, ROLLUP, and CUBE. Verifies that:
+ * <ul>
+ *   <li>ROLLUP and CUBE produce identical results to their explicit GROUPING SETS expansions</li>
+ *   <li>Each ROLLUP level matches an independent GROUP BY query</li>
+ *   <li>SAMPLE BY + ROLLUP matches SAMPLE BY + GROUPING SETS</li>
+ *   <li>Random aggregate functions produce consistent results across equivalent forms</li>
+ * </ul>
+ */
+public class GroupingSetsFuzzTest extends AbstractCairoTest {
+
+    private static final String[] AGGREGATES = {"SUM", "COUNT", "AVG", "MIN", "MAX"};
+    private static final int ITERATIONS = 100;
+    private static final String[] SIDES = {"buy", "sell"};
+    private static final String[] SYMBOLS = {"BTC", "ETH", "SOL", "ADA", "DOT"};
+    private Rnd rnd;
+
+    @Override
+    @Before
+    public void setUp() {
+        rnd = TestUtils.generateRandom(LOG);
+        super.setUp();
+    }
+
+    @Test
+    public void testCubeEquivalentToGroupingSets() throws Exception {
+        // CUBE(symbol, side) must produce the same rows as
+        // GROUPING SETS ((symbol, side), (symbol), (side), ())
+        assertMemoryLeak(() -> {
+            for (int i = 0; i < ITERATIONS; i++) {
+                execute("DROP TABLE IF EXISTS t");
+                createRandomTable();
+
+                String cubeQuery = "SELECT * FROM (" +
+                        "SELECT symbol, side, SUM(quantity) AS s, GROUPING_ID(symbol, side) AS grp " +
+                        "FROM t GROUP BY CUBE(symbol, side)" +
+                        ") ORDER BY grp, symbol, side";
+
+                String gsQuery = "SELECT * FROM (" +
+                        "SELECT symbol, side, SUM(quantity) AS s, GROUPING_ID(symbol, side) AS grp " +
+                        "FROM t GROUP BY GROUPING SETS ((symbol, side), (symbol), (side), ())" +
+                        ") ORDER BY grp, symbol, side";
+
+                assertEquivalent(cubeQuery, gsQuery, i);
+            }
+        });
+    }
+
+    @Test
+    public void testRollupEquivalentToGroupingSets() throws Exception {
+        // ROLLUP(symbol, side) must produce the same rows as
+        // GROUPING SETS ((symbol, side), (symbol), ())
+        assertMemoryLeak(() -> {
+            for (int i = 0; i < ITERATIONS; i++) {
+                execute("DROP TABLE IF EXISTS t");
+                createRandomTable();
+
+                String rollupQuery = "SELECT * FROM (" +
+                        "SELECT symbol, side, SUM(quantity) AS s, GROUPING_ID(symbol, side) AS grp " +
+                        "FROM t GROUP BY ROLLUP(symbol, side)" +
+                        ") ORDER BY grp, symbol, side";
+
+                String gsQuery = "SELECT * FROM (" +
+                        "SELECT symbol, side, SUM(quantity) AS s, GROUPING_ID(symbol, side) AS grp " +
+                        "FROM t GROUP BY GROUPING SETS ((symbol, side), (symbol), ())" +
+                        ") ORDER BY grp, symbol, side";
+
+                assertEquivalent(rollupQuery, gsQuery, i);
+            }
+        });
+    }
+
+    @Test
+    public void testRollupGrandTotalMatchesUngrouped() throws Exception {
+        // The grand total row from ROLLUP(symbol) must match SELECT AGG(x) FROM t
+        assertMemoryLeak(() -> {
+            for (int i = 0; i < ITERATIONS; i++) {
+                execute("DROP TABLE IF EXISTS t");
+                createRandomTable();
+
+                String agg = randomAggregate("quantity");
+
+                // Grand total from ROLLUP: filter to the rolled-up level
+                String rollupGrand = "SELECT v FROM (" +
+                        "SELECT " + agg + " AS v, GROUPING(symbol) AS g " +
+                        "FROM t GROUP BY ROLLUP(symbol)" +
+                        ") WHERE g = 1";
+
+                // Standalone grand total: no GROUP BY
+                String standalone = "SELECT " + agg + " AS v FROM t";
+
+                assertEquivalent(rollupGrand, standalone, i, agg);
+            }
+        });
+    }
+
+    @Test
+    public void testRollupDetailMatchesGroupBy() throws Exception {
+        // Detail rows from ROLLUP(symbol) must match GROUP BY symbol
+        assertMemoryLeak(() -> {
+            for (int i = 0; i < ITERATIONS; i++) {
+                execute("DROP TABLE IF EXISTS t");
+                createRandomTable();
+
+                String agg = randomAggregate("quantity");
+
+                // Detail rows from ROLLUP: filter to grouped level
+                String rollupDetail = "SELECT symbol, v FROM (" +
+                        "SELECT symbol, " + agg + " AS v, GROUPING(symbol) AS g " +
+                        "FROM t GROUP BY ROLLUP(symbol)" +
+                        ") WHERE g = 0 ORDER BY symbol";
+
+                // Standalone GROUP BY
+                String groupBy = "SELECT symbol, " + agg + " AS v " +
+                        "FROM t GROUP BY symbol ORDER BY symbol";
+
+                assertEquivalent(rollupDetail, groupBy, i, agg);
+            }
+        });
+    }
+
+    @Test
+    public void testRollupTwoColumnsMiddleLevelMatchesGroupBy() throws Exception {
+        // For ROLLUP(symbol, side), level grp=1 (side rolled up) must match
+        // GROUP BY symbol alone
+        assertMemoryLeak(() -> {
+            for (int i = 0; i < ITERATIONS; i++) {
+                execute("DROP TABLE IF EXISTS t");
+                createRandomTable();
+
+                String agg = randomAggregate("quantity");
+
+                // Level 1 from ROLLUP(symbol, side): side is rolled up
+                String rollupLevel1 = "SELECT symbol, v FROM (" +
+                        "SELECT symbol, side, " + agg + " AS v, GROUPING_ID(symbol, side) AS grp " +
+                        "FROM t GROUP BY ROLLUP(symbol, side)" +
+                        ") WHERE grp = 1 ORDER BY symbol";
+
+                // Standalone GROUP BY symbol
+                String groupBy = "SELECT symbol, " + agg + " AS v " +
+                        "FROM t GROUP BY symbol ORDER BY symbol";
+
+                assertEquivalent(rollupLevel1, groupBy, i, agg + " level 1");
+            }
+        });
+    }
+
+    @Test
+    public void testRollupWithRandomAggregates() throws Exception {
+        // Multiple random aggregates: ROLLUP must match GROUPING SETS
+        assertMemoryLeak(() -> {
+            for (int i = 0; i < ITERATIONS; i++) {
+                execute("DROP TABLE IF EXISTS t");
+                createRandomTable();
+
+                String agg1 = randomAggregate("quantity");
+                String agg2 = randomAggregate("quantity");
+
+                String rollupQuery = "SELECT * FROM (" +
+                        "SELECT symbol, " + agg1 + " AS v1, " + agg2 + " AS v2, " +
+                        "GROUPING(symbol) AS g " +
+                        "FROM t GROUP BY ROLLUP(symbol)" +
+                        ") ORDER BY g, symbol";
+
+                String gsQuery = "SELECT * FROM (" +
+                        "SELECT symbol, " + agg1 + " AS v1, " + agg2 + " AS v2, " +
+                        "GROUPING(symbol) AS g " +
+                        "FROM t GROUP BY GROUPING SETS ((symbol), ())" +
+                        ") ORDER BY g, symbol";
+
+                assertEquivalent(rollupQuery, gsQuery, i, agg1 + " + " + agg2);
+            }
+        });
+    }
+
+    @Test
+    public void testRollupWithWhereClause() throws Exception {
+        // ROLLUP with a WHERE filter must produce the same results as
+        // GROUPING SETS with the same WHERE filter
+        assertMemoryLeak(() -> {
+            for (int i = 0; i < ITERATIONS; i++) {
+                execute("DROP TABLE IF EXISTS t");
+                createRandomTable();
+
+                // Random threshold between 100 and 800
+                int threshold = 100 + rnd.nextInt(700);
+
+                String rollupQuery = "SELECT * FROM (" +
+                        "SELECT symbol, SUM(quantity) AS s, GROUPING(symbol) AS g " +
+                        "FROM t WHERE quantity > " + threshold + " " +
+                        "GROUP BY ROLLUP(symbol)" +
+                        ") ORDER BY g, symbol";
+
+                String gsQuery = "SELECT * FROM (" +
+                        "SELECT symbol, SUM(quantity) AS s, GROUPING(symbol) AS g " +
+                        "FROM t WHERE quantity > " + threshold + " " +
+                        "GROUP BY GROUPING SETS ((symbol), ())" +
+                        ") ORDER BY g, symbol";
+
+                assertEquivalent(rollupQuery, gsQuery, i, "threshold=" + threshold);
+            }
+        });
+    }
+
+    @Test
+    public void testSampleByRollupEquivalentToGroupingSets() throws Exception {
+        // SAMPLE BY 1h ROLLUP(symbol) must match
+        // SAMPLE BY 1h GROUPING SETS ((symbol), ())
+        assertMemoryLeak(() -> {
+            for (int i = 0; i < ITERATIONS; i++) {
+                execute("DROP TABLE IF EXISTS t");
+                createRandomTimestampTable();
+
+                String rollupQuery = "SELECT * FROM (" +
+                        "SELECT ts, symbol, SUM(quantity) AS s, GROUPING(symbol) AS g " +
+                        "FROM t SAMPLE BY 1h ROLLUP(symbol)" +
+                        ") ORDER BY ts, g, symbol";
+
+                String gsQuery = "SELECT * FROM (" +
+                        "SELECT ts, symbol, SUM(quantity) AS s, GROUPING(symbol) AS g " +
+                        "FROM t SAMPLE BY 1h GROUPING SETS ((symbol), ())" +
+                        ") ORDER BY ts, g, symbol";
+
+                assertEquivalent(rollupQuery, gsQuery, i);
+            }
+        });
+    }
+
+    @Test
+    public void testSampleByCubeEquivalentToGroupingSets() throws Exception {
+        // SAMPLE BY 1h CUBE(symbol, side) must match the explicit expansion
+        assertMemoryLeak(() -> {
+            for (int i = 0; i < ITERATIONS; i++) {
+                execute("DROP TABLE IF EXISTS t");
+                createRandomTimestampTableTwoKeys();
+
+                String cubeQuery = "SELECT * FROM (" +
+                        "SELECT ts, symbol, side, SUM(quantity) AS s, GROUPING_ID(symbol, side) AS grp " +
+                        "FROM t SAMPLE BY 1h CUBE(symbol, side)" +
+                        ") ORDER BY ts, grp, symbol, side";
+
+                String gsQuery = "SELECT * FROM (" +
+                        "SELECT ts, symbol, side, SUM(quantity) AS s, GROUPING_ID(symbol, side) AS grp " +
+                        "FROM t SAMPLE BY 1h GROUPING SETS ((symbol, side), (symbol), (side), ())" +
+                        ") ORDER BY ts, grp, symbol, side";
+
+                assertEquivalent(cubeQuery, gsQuery, i);
+            }
+        });
+    }
+
+    @Test
+    public void testSampleByRollupFillConstantEquivalence() throws Exception {
+        // SAMPLE BY ROLLUP with FILL(0) must match GROUPING SETS with FILL(0)
+        assertMemoryLeak(() -> {
+            for (int i = 0; i < ITERATIONS; i++) {
+                execute("DROP TABLE IF EXISTS t");
+                createRandomTimestampTable();
+
+                String rollupQuery = "SELECT * FROM (" +
+                        "SELECT ts, symbol, SUM(quantity) AS s, GROUPING(symbol) AS g " +
+                        "FROM t SAMPLE BY 1h ROLLUP(symbol) FILL(0)" +
+                        ") ORDER BY ts, g, symbol";
+
+                String gsQuery = "SELECT * FROM (" +
+                        "SELECT ts, symbol, SUM(quantity) AS s, GROUPING(symbol) AS g " +
+                        "FROM t SAMPLE BY 1h GROUPING SETS ((symbol), ()) FILL(0)" +
+                        ") ORDER BY ts, g, symbol";
+
+                assertEquivalent(rollupQuery, gsQuery, i);
+            }
+        });
+    }
+
+    private void assertEquivalent(String query1, String query2, int iteration) {
+        assertEquivalent(query1, query2, iteration, null);
+    }
+
+    private void assertEquivalent(String query1, String query2, int iteration, String context) {
+        try {
+            StringSink result1 = new StringSink();
+            printSql(query1, result1);
+
+            StringSink result2 = new StringSink();
+            printSql(query2, result2);
+
+            TestUtils.assertEquals(result1, result2);
+        } catch (Exception e) {
+            String msg = "Iteration " + iteration +
+                    (context != null ? " (" + context + ")" : "") +
+                    " failed.\nQuery 1: " + query1 +
+                    "\nQuery 2: " + query2;
+            throw new AssertionError(msg, e);
+        }
+    }
+
+    private void createRandomTable() throws Exception {
+        execute("CREATE TABLE t (symbol SYMBOL, side SYMBOL, quantity DOUBLE)");
+        int rows = 5 + rnd.nextInt(46); // 5-50 rows
+        StringBuilder sb = new StringBuilder("INSERT INTO t VALUES ");
+        for (int r = 0; r < rows; r++) {
+            if (r > 0) {
+                sb.append(',');
+            }
+            sb.append("('");
+            sb.append(SYMBOLS[rnd.nextInt(SYMBOLS.length)]);
+            sb.append("', '");
+            sb.append(SIDES[rnd.nextInt(SIDES.length)]);
+            sb.append("', ");
+            sb.append(1 + rnd.nextInt(1000));
+            sb.append(')');
+        }
+        execute(sb.toString());
+    }
+
+    private void createRandomTimestampTable() throws Exception {
+        execute("CREATE TABLE t (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+        int rows = 10 + rnd.nextInt(41); // 10-50 rows
+        StringBuilder sb = new StringBuilder("INSERT INTO t VALUES ");
+        long ts = 1_704_067_200_000_000L; // 2024-01-01T00:00:00.000000Z in micros
+        for (int r = 0; r < rows; r++) {
+            if (r > 0) {
+                sb.append(',');
+            }
+            sb.append("('");
+            sb.append(SYMBOLS[rnd.nextInt(3)]); // BTC, ETH, SOL only
+            sb.append("', ");
+            sb.append(1 + rnd.nextInt(1000));
+            sb.append(", ");
+            sb.append(ts);
+            sb.append(')');
+            // Advance 1-3600 seconds to spread across multiple hours
+            ts += (1 + rnd.nextInt(3600)) * 1_000_000L;
+        }
+        execute(sb.toString());
+    }
+
+    private void createRandomTimestampTableTwoKeys() throws Exception {
+        execute("CREATE TABLE t (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+        int rows = 10 + rnd.nextInt(41); // 10-50 rows
+        StringBuilder sb = new StringBuilder("INSERT INTO t VALUES ");
+        long ts = 1_704_067_200_000_000L; // 2024-01-01T00:00:00.000000Z in micros
+        for (int r = 0; r < rows; r++) {
+            if (r > 0) {
+                sb.append(',');
+            }
+            sb.append("('");
+            sb.append(SYMBOLS[rnd.nextInt(3)]); // BTC, ETH, SOL
+            sb.append("', '");
+            sb.append(SIDES[rnd.nextInt(SIDES.length)]);
+            sb.append("', ");
+            sb.append(1 + rnd.nextInt(1000));
+            sb.append(", ");
+            sb.append(ts);
+            sb.append(')');
+            ts += (1 + rnd.nextInt(3600)) * 1_000_000L;
+        }
+        execute(sb.toString());
+    }
+
+    private String randomAggregate(String col) {
+        String agg = AGGREGATES[rnd.nextInt(AGGREGATES.length)];
+        if ("COUNT".equals(agg)) {
+            return "COUNT()";
+        }
+        return agg + "(" + col + ")";
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
@@ -24,7 +24,6 @@
 
 package io.questdb.test.griffin;
 
-import io.questdb.PropertyKey;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Test;
 
@@ -1432,15 +1431,17 @@ public class GroupingSetsTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testCube15ColumnsAccepted() throws Exception {
-        // CUBE(15 columns) = 2^15 = 32768 sets. Within the hard parser cap of 15.
-        // Use 12 columns (2^12 = 4096) to stay at default config limit.
+    public void testCube12ColumnsAtDefaultLimit() throws Exception {
+        // CUBE(12 columns) = 2^12 = 4096 sets, exactly at the default config
+        // limit. Tests the boundary where the set count cap is not exceeded.
+        // Note: CUBE(15) = 32768 would exceed the default 4096 limit but is
+        // within the hard parser cap of 15 columns. CUBE(16+) is rejected by
+        // the parser regardless of the set count limit.
         assertMemoryLeak(() -> {
             execute("CREATE TABLE cube12 (" +
                     "c1 INT, c2 INT, c3 INT, c4 INT, c5 INT, " +
                     "c6 INT, c7 INT, c8 INT, c9 INT, c10 INT, " +
                     "c11 INT, c12 INT, v INT)");
-            // 12 columns = 4096 sets, exactly at default limit; must not error
             assertSql(
                     "c1\tSUM\n",
                     "SELECT c1, SUM(v) FROM cube12" +
@@ -1561,6 +1562,85 @@ public class GroupingSetsTest extends AbstractCairoTest {
                     "SELECT * FROM t GROUP BY CUBE(c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13)",
                     25,
                     "CUBE produces too many grouping sets"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByRollupFillLinearNotSupported() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+
+            assertException(
+                    "SELECT ts, symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "SAMPLE BY 1h ROLLUP(symbol) FILL(LINEAR)",
+                    78,
+                    "FILL(PREV) and FILL(LINEAR) are not supported with ROLLUP, CUBE, or GROUPING SETS"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingIdWithCube() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('ETH', 'sell', 20, '2024-01-01T00:01:00.000000Z')"
+            );
+
+            // CUBE(symbol, side) produces sets: (symbol,side), (symbol), (side), ()
+            // GROUPING_ID bitmasks: 0, 1, 2, 3
+            assertSql(
+                    "symbol\tside\tSUM\tgrp\n" +
+                            "BTC\tbuy\t10.0\t0\n" +
+                            "ETH\tsell\t20.0\t0\n" +
+                            "BTC\t\t10.0\t1\n" +
+                            "ETH\t\t20.0\t1\n" +
+                            "\tbuy\t10.0\t2\n" +
+                            "\tsell\t20.0\t2\n" +
+                            "\t\t30.0\t3\n",
+                    "SELECT symbol, side, SUM(quantity), GROUPING_ID(symbol, side) AS grp " +
+                            "FROM trades " +
+                            "GROUP BY CUBE(symbol, side) " +
+                            "ORDER BY grp, symbol, side"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupWithNullAggregateInputs() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', NaN, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 30, '2024-01-01T00:02:00.000000Z')," +
+                            "('ETH', NaN, '2024-01-01T00:03:00.000000Z')"
+            );
+
+            // SUM should skip NaN values; count should count non-NaN only
+            assertSql(
+                    "symbol\tSUM\tcount\n" +
+                            "BTC\t10.0\t1\n" +
+                            "ETH\t30.0\t1\n" +
+                            "\t40.0\t2\n",
+                    "SELECT symbol, SUM(quantity), COUNT(quantity) AS count " +
+                            "FROM trades " +
+                            "GROUP BY ROLLUP(symbol) " +
+                            "ORDER BY GROUPING(symbol), symbol"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
@@ -659,34 +659,20 @@ public class GroupingSetsTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testGroupingFunctionMultiArg() throws Exception {
+    public void testGroupingFunctionMultiArgRejected() throws Exception {
         assertMemoryLeak(() -> {
             execute(
                     "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
                             " TIMESTAMP(ts) PARTITION BY DAY"
             );
-            execute(
-                    "INSERT INTO trades VALUES " +
-                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
-                            "('BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
-                            "('ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')"
-            );
 
-            // GROUPING(symbol, side) returns a 2-bit bitmask:
-            // 0b00 = 0: both grouped
-            // 0b01 = 1: side rolled up
-            // 0b11 = 3: both rolled up
-            assertSql(
-                    "symbol\tside\tSUM\tgrp\n" +
-                            "BTC\tbuy\t10.0\t0\n" +
-                            "BTC\tsell\t20.0\t0\n" +
-                            "ETH\tbuy\t30.0\t0\n" +
-                            "BTC\t\t30.0\t1\n" +
-                            "ETH\t\t30.0\t1\n" +
-                            "\t\t60.0\t3\n",
+            // GROUPING() only accepts a single column; use GROUPING_ID() for multiple
+            assertException(
                     "SELECT symbol, side, SUM(quantity), GROUPING(symbol, side) AS grp " +
                             "FROM trades " +
-                            "GROUP BY ROLLUP(symbol, side)"
+                            "GROUP BY ROLLUP(symbol, side)",
+                    36,
+                    "GROUPING() accepts a single column; use GROUPING_ID() for multiple columns"
             );
         });
     }
@@ -1121,7 +1107,7 @@ public class GroupingSetsTest extends AbstractCairoTest {
                             "FROM trades " +
                             "GROUP BY ROLLUP(symbol)",
                     7,
-                    "GROUPING() requires at least one argument"
+                    "GROUPING() requires exactly one column argument"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
@@ -1182,6 +1182,21 @@ public class GroupingSetsTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testLatestOnWithGroupingSetsRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE t (sym SYMBOL, v DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            assertException(
+                    "SELECT sym, SUM(v) FROM t LATEST ON ts PARTITION BY sym GROUP BY ROLLUP(sym)",
+                    65,
+                    "LATEST ON is not supported with GROUPING SETS, ROLLUP, or CUBE"
+            );
+        });
+    }
+
+    @Test
     public void testGroupByExpressionNotAffected() throws Exception {
         assertMemoryLeak(() -> {
             execute("CREATE TABLE t (a INT, b INT, v DOUBLE)");
@@ -1288,6 +1303,160 @@ public class GroupingSetsTest extends AbstractCairoTest {
                             "1\t300.0\n" +
                             "2\t300.0\n",
                     "SELECT t.a, SUM(v) FROM t GROUP BY ROLLUP(t.a) ORDER BY t.a"
+            );
+        });
+    }
+
+    @Test
+    public void testDataNullsVsRollupNulls() throws Exception {
+        // Data NULLs and rollup NULLs both produce NULL in the output,
+        // but GROUPING() returns 0 for data NULLs and 1 for rollup NULLs.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a SYMBOL, v DOUBLE)");
+            execute("INSERT INTO t VALUES ('x', 10.0), (NULL, 20.0), ('x', 30.0)");
+            assertSql(
+                    "a\tSUM\tGROUPING\n" +
+                            "\t20.0\t0\n" +
+                            "x\t40.0\t0\n" +
+                            "\t60.0\t1\n",
+                    "SELECT a, SUM(v), GROUPING(a) FROM t GROUP BY ROLLUP(a) ORDER BY GROUPING(a), a"
+            );
+        });
+    }
+
+    @Test
+    public void testEmptyTableRollup() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, v DOUBLE)");
+            // Empty table produces no rows (map is empty, no data to aggregate)
+            assertSql(
+                    "a\tSUM\n",
+                    "SELECT a, SUM(v) FROM t GROUP BY ROLLUP(a)"
+            );
+        });
+    }
+
+    @Test
+    public void testEmptyTableCube() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, v DOUBLE)");
+            assertSql(
+                    "a\tb\tSUM\n",
+                    "SELECT a, b, SUM(v) FROM t GROUP BY CUBE(a, b)"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupWithJoin() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE orders (product_id INT, qty INT)");
+            execute("CREATE TABLE products (id INT, name SYMBOL)");
+            execute("INSERT INTO products VALUES (1, 'A'), (2, 'B')");
+            execute("INSERT INTO orders VALUES (1, 10), (1, 20), (2, 30)");
+            assertSql(
+                    "name\tSUM\n" +
+                            "\t60\n" +
+                            "A\t30\n" +
+                            "B\t30\n",
+                    "SELECT p.name, SUM(o.qty) FROM orders o" +
+                            " JOIN products p ON o.product_id = p.id" +
+                            " GROUP BY ROLLUP(p.name) ORDER BY p.name"
+            );
+        });
+    }
+
+    @Test
+    public void testLatestOnWithCubeRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE t (sym SYMBOL, v DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            assertException(
+                    "SELECT sym, SUM(v) FROM t LATEST ON ts PARTITION BY sym GROUP BY CUBE(sym)",
+                    65,
+                    "LATEST ON is not supported with GROUPING SETS, ROLLUP, or CUBE"
+            );
+        });
+    }
+
+    @Test
+    public void testLatestOnWithExplicitGroupingSetsRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE t (sym SYMBOL, v DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            assertException(
+                    "SELECT sym, SUM(v) FROM t LATEST ON ts PARTITION BY sym GROUP BY GROUPING SETS ((sym), ())",
+                    65,
+                    "LATEST ON is not supported with GROUPING SETS, ROLLUP, or CUBE"
+            );
+        });
+    }
+
+    @Test
+    public void testCursorReuse() throws Exception {
+        // Test that the cursor works correctly on repeated execution
+        // (toTop after partial iteration)
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a SYMBOL, v DOUBLE)");
+            execute("INSERT INTO t VALUES ('x', 10.0), ('y', 20.0)");
+            String expected =
+                    "a\tSUM\n" +
+                            "\t30.0\n" +
+                            "x\t10.0\n" +
+                            "y\t20.0\n";
+            String query = "SELECT a, SUM(v) FROM t GROUP BY ROLLUP(a) ORDER BY a";
+            // Execute twice to trigger toTop/reuse
+            assertSql(expected, query);
+            assertSql(expected, query);
+        });
+    }
+
+    @Test
+    public void testGroupingSetsWithMultipleAggregates() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a SYMBOL, v DOUBLE)");
+            execute("INSERT INTO t VALUES ('x', 10.0), ('x', 20.0), ('y', 30.0)");
+            assertSql(
+                    "a\tSUM\tCOUNT\tAVG\n" +
+                            "\t60.0\t3\t20.0\n" +
+                            "x\t30.0\t2\t15.0\n" +
+                            "y\t30.0\t1\t30.0\n",
+                    "SELECT a, SUM(v), COUNT(v), AVG(v) FROM t GROUP BY ROLLUP(a) ORDER BY a"
+            );
+        });
+    }
+
+    @Test
+    public void testCubeSetCountCapApplied() throws Exception {
+        // CUBE(16 columns) would produce 2^16 = 65536 sets, exceeding the default 4096
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (c1 INT, c2 INT, c3 INT, c4 INT, c5 INT," +
+                    " c6 INT, c7 INT, c8 INT, c9 INT, c10 INT," +
+                    " c11 INT, c12 INT, c13 INT, c14 INT, c15 INT, c16 INT, v INT)");
+            // CUBE supports at most 15 columns
+            assertException(
+                    "SELECT * FROM t GROUP BY CUBE(c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16)",
+                    25,
+                    "CUBE supports at most 15 columns"
+            );
+        });
+    }
+
+    @Test
+    public void testCubeTooManySets() throws Exception {
+        // CUBE(13 columns) produces 2^13 = 8192 sets, exceeding default 4096
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (c1 INT, c2 INT, c3 INT, c4 INT, c5 INT," +
+                    " c6 INT, c7 INT, c8 INT, c9 INT, c10 INT," +
+                    " c11 INT, c12 INT, c13 INT, v INT)");
+            assertException(
+                    "SELECT * FROM t GROUP BY CUBE(c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13)",
+                    25,
+                    "CUBE produces too many grouping sets"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin;
 
+import io.questdb.PropertyKey;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Test;
 
@@ -1426,6 +1427,50 @@ public class GroupingSetsTest extends AbstractCairoTest {
                             "x\t30.0\t2\t15.0\n" +
                             "y\t30.0\t1\t30.0\n",
                     "SELECT a, SUM(v), COUNT(v), AVG(v) FROM t GROUP BY ROLLUP(a) ORDER BY a"
+            );
+        });
+    }
+
+    @Test
+    public void testCube15ColumnsAccepted() throws Exception {
+        // CUBE(15 columns) = 2^15 = 32768 sets. Within the hard parser cap of 15.
+        // Use 12 columns (2^12 = 4096) to stay at default config limit.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE cube12 (" +
+                    "c1 INT, c2 INT, c3 INT, c4 INT, c5 INT, " +
+                    "c6 INT, c7 INT, c8 INT, c9 INT, c10 INT, " +
+                    "c11 INT, c12 INT, v INT)");
+            // 12 columns = 4096 sets, exactly at default limit; must not error
+            assertSql(
+                    "c1\tSUM\n",
+                    "SELECT c1, SUM(v) FROM cube12" +
+                            " GROUP BY CUBE(c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12)"
+            );
+        });
+    }
+
+    @Test
+    public void testCteWithRollup() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')"
+            );
+
+            assertSql(
+                    "symbol\tSUM\n" +
+                            "BTC\t30.0\n" +
+                            "ETH\t30.0\n" +
+                            "\t60.0\n",
+                    "WITH base AS (SELECT symbol, quantity FROM trades)" +
+                            " SELECT symbol, SUM(quantity) FROM base GROUP BY ROLLUP(symbol)" +
+                            " ORDER BY GROUPING(symbol), symbol"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
@@ -1054,7 +1054,7 @@ public class GroupingSetsTest extends AbstractCairoTest {
                     "SELECT symbol, SUM(quantity), GROUPING(symbol) " +
                             "FROM trades " +
                             "GROUP BY symbol",
-                    0,
+                    30,
                     "GROUPING() / GROUPING_ID() can only be used with GROUPING SETS, ROLLUP, or CUBE"
             );
         });
@@ -1071,7 +1071,7 @@ public class GroupingSetsTest extends AbstractCairoTest {
             assertException(
                     "SELECT SUM(quantity), GROUPING(symbol) " +
                             "FROM trades",
-                    0,
+                    22,
                     "GROUPING() / GROUPING_ID() can only be used with GROUPING SETS, ROLLUP, or CUBE"
             );
         });
@@ -1089,7 +1089,7 @@ public class GroupingSetsTest extends AbstractCairoTest {
                     "SELECT symbol, SUM(quantity), GROUPING_ID(symbol) " +
                             "FROM trades " +
                             "GROUP BY symbol",
-                    0,
+                    30,
                     "GROUPING() / GROUPING_ID() can only be used with GROUPING SETS, ROLLUP, or CUBE"
             );
         });
@@ -1487,6 +1487,65 @@ public class GroupingSetsTest extends AbstractCairoTest {
                     "SELECT * FROM t GROUP BY CUBE(c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14,c15,c16)",
                     25,
                     "CUBE supports at most 15 columns"
+            );
+        });
+    }
+
+    @Test
+    public void testFilterByGroupingViaSubquery() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (sym SYMBOL, val DOUBLE)");
+            execute("""
+                    INSERT INTO t VALUES
+                    ('A', 10.0),
+                    ('A', 20.0),
+                    ('B', 30.0)
+                    """);
+            // QuestDB has no HAVING, so filter subtotal/grand total rows via subquery
+            assertSql(
+                    "sym\ts\tgs\n" +
+                            "A\t30.0\t0\n" +
+                            "B\t30.0\t0\n",
+                    "SELECT * FROM (SELECT sym, SUM(val) s, GROUPING(sym) gs FROM t GROUP BY ROLLUP(sym)) WHERE gs = 0 ORDER BY sym"
+            );
+        });
+    }
+
+    @Test
+    public void testDuplicateGroupingSets() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (sym SYMBOL, val DOUBLE)");
+            execute("""
+                    INSERT INTO t VALUES
+                    ('A', 10.0),
+                    ('B', 20.0)
+                    """);
+            // Duplicate sets should produce duplicate output rows per SQL standard
+            assertSql(
+                    "sym\ts\n" +
+                            "A\t10.0\n" +
+                            "A\t10.0\n" +
+                            "B\t20.0\n" +
+                            "B\t20.0\n",
+                    "SELECT sym, SUM(val) s FROM t GROUP BY GROUPING SETS ((sym), (sym)) ORDER BY sym, s"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingIdThreeColumns() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a SYMBOL, b SYMBOL, c SYMBOL, val DOUBLE)");
+            execute("INSERT INTO t VALUES ('x', 'y', 'z', 1.0)");
+            // GROUPING_ID(a, b, c) with ROLLUP(a, b, c) produces:
+            // (a,b,c) -> 0b000=0, (a,b) -> 0b001=1, (a) -> 0b011=3, () -> 0b111=7
+            assertSql(
+                    "a\tb\tc\ts\tgid\n" +
+                            "\t\t\t1.0\t7\n" +
+                            "x\t\t\t1.0\t3\n" +
+                            "x\ty\t\t1.0\t1\n" +
+                            "x\ty\tz\t1.0\t0\n",
+                    "SELECT a, b, c, SUM(val) s, GROUPING_ID(a, b, c) gid FROM t GROUP BY ROLLUP(a, b, c) ORDER BY gid DESC"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
@@ -1182,6 +1182,22 @@ public class GroupingSetsTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testGroupByExpressionNotAffected() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, v DOUBLE)");
+            execute("INSERT INTO t VALUES (1, 2, 100.0), (1, 2, 200.0), (3, 4, 300.0)");
+            // Plain GROUP BY with expressions must still work (no
+            // column-reference restriction outside ROLLUP/CUBE/GROUPING SETS).
+            assertSql(
+                    "column\tSUM\n" +
+                            "3\t300.0\n" +
+                            "7\t300.0\n",
+                    "SELECT a + b, SUM(v) FROM t GROUP BY a + b ORDER BY 1"
+            );
+        });
+    }
+
+    @Test
     public void testGroupingFillPreservesValue() throws Exception {
         assertMemoryLeak(() -> {
             execute(

--- a/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
@@ -1,0 +1,1177 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class GroupingSetsTest extends AbstractCairoTest {
+
+    @Test
+    public void testCompositeGroupByCube() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (region SYMBOL, symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('US', 'BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('US', 'BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('EU', 'ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')," +
+                            "('EU', 'ETH', 'sell', 40, '2024-01-01T00:03:00.000000Z')"
+            );
+
+            // GROUP BY region, CUBE(symbol) -> sets: (region, symbol), (region)
+            // same as ROLLUP for single cube column
+            assertSql(
+                    "region\tsymbol\tSUM\n" +
+                            "US\tBTC\t30.0\n" +
+                            "EU\tETH\t70.0\n" +
+                            "US\t\t30.0\n" +
+                            "EU\t\t70.0\n",
+                    "SELECT region, symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "GROUP BY region, CUBE(symbol)"
+            );
+        });
+    }
+
+    @Test
+    public void testCompositeGroupByRollup() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (region SYMBOL, symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('US', 'BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('US', 'BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('EU', 'ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')," +
+                            "('EU', 'ETH', 'sell', 40, '2024-01-01T00:03:00.000000Z')"
+            );
+
+            // GROUP BY region, ROLLUP(symbol) -> sets: (region, symbol), (region)
+            assertSql(
+                    "region\tsymbol\tSUM\n" +
+                            "US\tBTC\t30.0\n" +
+                            "EU\tETH\t70.0\n" +
+                            "US\t\t30.0\n" +
+                            "EU\t\t70.0\n",
+                    "SELECT region, symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "GROUP BY region, ROLLUP(symbol)"
+            );
+        });
+    }
+
+    @Test
+    public void testCubeBasic() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')," +
+                            "('ETH', 'sell', 40, '2024-01-01T00:03:00.000000Z')"
+            );
+
+            assertSql(
+                    "symbol\tside\tSUM\n" +
+                            "BTC\tbuy\t10.0\n" +
+                            "BTC\tsell\t20.0\n" +
+                            "ETH\tbuy\t30.0\n" +
+                            "ETH\tsell\t40.0\n" +
+                            "BTC\t\t30.0\n" +
+                            "ETH\t\t70.0\n" +
+                            "\tbuy\t40.0\n" +
+                            "\tsell\t60.0\n" +
+                            "\t\t100.0\n",
+                    "SELECT symbol, side, SUM(quantity) " +
+                            "FROM trades " +
+                            "GROUP BY CUBE(symbol, side)"
+            );
+        });
+    }
+
+    @Test
+    public void testCubeParserError() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (x INT, y DOUBLE)");
+            assertException(
+                    "SELECT x, SUM(y) FROM t GROUP BY CUBE()",
+                    33,
+                    "CUBE requires at least one column"
+            );
+        });
+    }
+
+    @Test
+    public void testCubeThreeColumns() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, c INT, v DOUBLE)");
+            execute(
+                    "INSERT INTO t VALUES " +
+                            "(1, 10, 100, 1000), " +
+                            "(2, 20, 200, 2000)"
+            );
+
+            // CUBE(a, b, c) -> 2^3 = 8 grouping sets, ordered by mask iteration:
+            // (a,b,c), (a,b), (a,c), (a), (b,c), (b), (c), ()
+            assertSql(
+                    "a\tb\tc\tSUM\n" +
+                            "1\t10\t100\t1000.0\n" +
+                            "2\t20\t200\t2000.0\n" +
+                            "1\t10\tnull\t1000.0\n" +
+                            "2\t20\tnull\t2000.0\n" +
+                            "1\tnull\t100\t1000.0\n" +
+                            "2\tnull\t200\t2000.0\n" +
+                            "1\tnull\tnull\t1000.0\n" +
+                            "2\tnull\tnull\t2000.0\n" +
+                            "null\t10\t100\t1000.0\n" +
+                            "null\t20\t200\t2000.0\n" +
+                            "null\t10\tnull\t1000.0\n" +
+                            "null\t20\tnull\t2000.0\n" +
+                            "null\tnull\t100\t1000.0\n" +
+                            "null\tnull\t200\t2000.0\n" +
+                            "null\tnull\tnull\t3000.0\n",
+                    "SELECT a, b, c, SUM(v) FROM t GROUP BY CUBE(a, b, c)"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingSetsExplicit() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')," +
+                            "('ETH', 'sell', 40, '2024-01-01T00:03:00.000000Z')"
+            );
+
+            assertSql(
+                    "symbol\tside\tSUM\n" +
+                            "BTC\tbuy\t10.0\n" +
+                            "BTC\tsell\t20.0\n" +
+                            "ETH\tbuy\t30.0\n" +
+                            "ETH\tsell\t40.0\n" +
+                            "\t\t100.0\n",
+                    "SELECT symbol, side, SUM(quantity) " +
+                            "FROM trades " +
+                            "GROUP BY GROUPING SETS ((symbol, side), ())"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingSetsNonOverlapping() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')," +
+                            "('ETH', 'sell', 40, '2024-01-01T00:03:00.000000Z')"
+            );
+
+            // Non-overlapping sets: group by symbol only, then by side only
+            assertSql(
+                    "symbol\tside\tSUM\n" +
+                            "BTC\t\t30.0\n" +
+                            "ETH\t\t70.0\n" +
+                            "\tbuy\t40.0\n" +
+                            "\tsell\t60.0\n",
+                    "SELECT symbol, side, SUM(quantity) " +
+                            "FROM trades " +
+                            "GROUP BY GROUPING SETS ((symbol), (side))"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingSetsParserError() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (x INT, y DOUBLE)");
+            assertException(
+                    "SELECT x, SUM(y) FROM t GROUP BY GROUPING x",
+                    33,
+                    "expected SETS after GROUPING"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupBasic() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')," +
+                            "('ETH', 'sell', 40, '2024-01-01T00:03:00.000000Z')"
+            );
+
+            assertSql(
+                    "symbol\tside\tSUM\n" +
+                            "BTC\tbuy\t10.0\n" +
+                            "BTC\tsell\t20.0\n" +
+                            "ETH\tbuy\t30.0\n" +
+                            "ETH\tsell\t40.0\n" +
+                            "BTC\t\t30.0\n" +
+                            "ETH\t\t70.0\n" +
+                            "\t\t100.0\n",
+                    "SELECT symbol, side, SUM(quantity) " +
+                            "FROM trades " +
+                            "GROUP BY ROLLUP(symbol, side)"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupMultipleAggregates() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, price DOUBLE, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 100, 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 200, 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 300, 30, '2024-01-01T00:02:00.000000Z')," +
+                            "('ETH', 400, 40, '2024-01-01T00:03:00.000000Z')"
+            );
+
+            assertSql(
+                    "symbol\tSUM\tCOUNT\tMIN\tMAX\n" +
+                            "\t100.0\t4\t100.0\t400.0\n" +
+                            "BTC\t30.0\t2\t100.0\t200.0\n" +
+                            "ETH\t70.0\t2\t300.0\t400.0\n",
+                    "SELECT symbol, SUM(quantity), COUNT(), MIN(price), MAX(price) " +
+                            "FROM trades " +
+                            "GROUP BY ROLLUP(symbol) " +
+                            "ORDER BY symbol"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupParserError() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (x INT, y DOUBLE)");
+            assertException(
+                    "SELECT x, SUM(y) FROM t GROUP BY ROLLUP()",
+                    33,
+                    "ROLLUP requires at least one column"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupSingleColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (x INT, y DOUBLE)");
+            execute("INSERT INTO t VALUES (1, 10), (1, 20), (2, 30)");
+
+            assertSql(
+                    "x\tSUM\n" +
+                            "1\t30.0\n" +
+                            "2\t30.0\n" +
+                            "null\t60.0\n",
+                    "SELECT x, SUM(y) FROM t GROUP BY ROLLUP(x)"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupThreeColumns() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, c INT, v DOUBLE)");
+            execute(
+                    "INSERT INTO t VALUES " +
+                            "(1, 10, 100, 1000), " +
+                            "(2, 20, 200, 2000)"
+            );
+
+            // ROLLUP(a, b, c) -> (a,b,c), (a,b), (a), ()
+            assertSql(
+                    "a\tb\tc\tSUM\n" +
+                            "1\t10\t100\t1000.0\n" +
+                            "2\t20\t200\t2000.0\n" +
+                            "1\t10\tnull\t1000.0\n" +
+                            "2\t20\tnull\t2000.0\n" +
+                            "1\tnull\tnull\t1000.0\n" +
+                            "2\tnull\tnull\t2000.0\n" +
+                            "null\tnull\tnull\t3000.0\n",
+                    "SELECT a, b, c, SUM(v) FROM t GROUP BY ROLLUP(a, b, c)"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupWithAvg() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (category SYMBOL, val DOUBLE)");
+            execute(
+                    "INSERT INTO t VALUES " +
+                            "('A', 10), ('A', 20), ('A', 30), " +
+                            "('B', 40), ('B', 50)"
+            );
+
+            assertSql(
+                    "category\tAVG\n" +
+                            "\t30.0\n" +
+                            "A\t20.0\n" +
+                            "B\t45.0\n",
+                    "SELECT category, AVG(val) " +
+                            "FROM t " +
+                            "GROUP BY ROLLUP(category) " +
+                            "ORDER BY category"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupWithCount() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')," +
+                            "('ETH', 'sell', 40, '2024-01-01T00:03:00.000000Z')"
+            );
+
+            assertSql(
+                    "symbol\tCOUNT\tSUM\n" +
+                            "\t4\t100.0\n" +
+                            "BTC\t2\t30.0\n" +
+                            "ETH\t2\t70.0\n",
+                    "SELECT symbol, COUNT(), SUM(quantity) " +
+                            "FROM trades " +
+                            "GROUP BY ROLLUP(symbol) " +
+                            "ORDER BY symbol"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupWithIntKey() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (grp INT, val DOUBLE)");
+            execute(
+                    "INSERT INTO t VALUES " +
+                            "(1, 10), (1, 20), " +
+                            "(2, 30), (2, 40)"
+            );
+
+            assertSql(
+                    "grp\tSUM\n" +
+                            "null\t100.0\n" +
+                            "1\t30.0\n" +
+                            "2\t70.0\n",
+                    "SELECT grp, SUM(val) " +
+                            "FROM t " +
+                            "GROUP BY ROLLUP(grp) " +
+                            "ORDER BY grp"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupWithOrderBy() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')," +
+                            "('ETH', 'sell', 40, '2024-01-01T00:03:00.000000Z')"
+            );
+
+            assertSql(
+                    "symbol\tSUM\n" +
+                            "\t100.0\n" +
+                            "BTC\t30.0\n" +
+                            "ETH\t70.0\n",
+                    "SELECT symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "GROUP BY ROLLUP(symbol) " +
+                            "ORDER BY symbol"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupWithStringKey() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (name STRING, val DOUBLE)");
+            execute(
+                    "INSERT INTO t VALUES " +
+                            "('Alice', 10), ('Alice', 20), " +
+                            "('Bob', 30)"
+            );
+
+            assertSql(
+                    "name\tSUM\n" +
+                            "\t60.0\n" +
+                            "Alice\t30.0\n" +
+                            "Bob\t30.0\n",
+                    "SELECT name, SUM(val) " +
+                            "FROM t " +
+                            "GROUP BY ROLLUP(name) " +
+                            "ORDER BY name"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupWithVarcharKey() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (label VARCHAR, val DOUBLE)");
+            execute(
+                    "INSERT INTO t VALUES " +
+                            "('foo', 10), ('foo', 20), " +
+                            "('bar', 30)"
+            );
+
+            assertSql(
+                    "label\tSUM\n" +
+                            "\t60.0\n" +
+                            "bar\t30.0\n" +
+                            "foo\t30.0\n",
+                    "SELECT label, SUM(val) " +
+                            "FROM t " +
+                            "GROUP BY ROLLUP(label) " +
+                            "ORDER BY label"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupWithWhereClause() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 30, '2024-01-01T00:02:00.000000Z')," +
+                            "('ETH', 40, '2024-01-01T00:03:00.000000Z')"
+            );
+
+            assertSql(
+                    "symbol\tSUM\n" +
+                            "\t90.0\n" +
+                            "BTC\t20.0\n" +
+                            "ETH\t70.0\n",
+                    "SELECT symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "WHERE quantity > 10 " +
+                            "GROUP BY ROLLUP(symbol) " +
+                            "ORDER BY symbol"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupEquivalentToGroupingSets() throws Exception {
+        // ROLLUP(a, b) should produce the same results as
+        // GROUPING SETS ((a, b), (a), ())
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, v DOUBLE)");
+            execute(
+                    "INSERT INTO t VALUES " +
+                            "(1, 10, 100), (1, 20, 200), " +
+                            "(2, 10, 300), (2, 20, 400)"
+            );
+
+            String rollupResult = "a\tb\tSUM\n" +
+                    "1\t10\t100.0\n" +
+                    "1\t20\t200.0\n" +
+                    "2\t10\t300.0\n" +
+                    "2\t20\t400.0\n" +
+                    "1\tnull\t300.0\n" +
+                    "2\tnull\t700.0\n" +
+                    "null\tnull\t1000.0\n";
+
+            assertSql(rollupResult,
+                    "SELECT a, b, SUM(v) FROM t GROUP BY ROLLUP(a, b)"
+            );
+
+            assertSql(rollupResult,
+                    "SELECT a, b, SUM(v) FROM t GROUP BY GROUPING SETS ((a, b), (a), ())"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupWithNullData() throws Exception {
+        // Verify behavior when input data contains actual NULLs
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (category SYMBOL, val DOUBLE)");
+            execute(
+                    "INSERT INTO t VALUES " +
+                            "('A', 10), (NULL, 20), ('A', 30)"
+            );
+
+            // NULL category rows should aggregate with other NULL category rows
+            // The grand total row also has NULL category
+            assertSql(
+                    "category\tSUM\n" +
+                            "\t20.0\n" +
+                            "A\t40.0\n" +
+                            "\t60.0\n",
+                    "SELECT category, SUM(val) FROM t GROUP BY ROLLUP(category)"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupCaseInsensitive() throws Exception {
+        // ROLLUP keyword should be case-insensitive
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (x INT, y DOUBLE)");
+            execute("INSERT INTO t VALUES (1, 10), (2, 20)");
+
+            assertSql(
+                    "x\tSUM\n" +
+                            "1\t10.0\n" +
+                            "2\t20.0\n" +
+                            "null\t30.0\n",
+                    "SELECT x, SUM(y) FROM t GROUP BY rollup(x)"
+            );
+        });
+    }
+
+    @Test
+    public void testCubeCaseInsensitive() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (x INT, y DOUBLE)");
+            execute("INSERT INTO t VALUES (1, 10), (2, 20)");
+
+            assertSql(
+                    "x\tSUM\n" +
+                            "1\t10.0\n" +
+                            "2\t20.0\n" +
+                            "null\t30.0\n",
+                    "SELECT x, SUM(y) FROM t GROUP BY cube(x)"
+            );
+        });
+    }
+
+    @Test
+    public void testRollupEmptyTable() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (x INT, y DOUBLE)");
+
+            // Empty table should produce no rows, even for the grand total
+            assertSql(
+                    "x\tSUM\n",
+                    "SELECT x, SUM(y) FROM t GROUP BY ROLLUP(x)"
+            );
+        });
+    }
+
+    // ==================== GROUPING() function tests ====================
+
+    @Test
+    public void testGroupingFunctionRollup() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')"
+            );
+
+            // GROUPING(col) returns 0 when column is actively grouped,
+            // 1 when the column is rolled up (NULL)
+            assertSql(
+                    "symbol\tside\tSUM\tgs\tgsd\n" +
+                            "BTC\tbuy\t10.0\t0\t0\n" +
+                            "BTC\tsell\t20.0\t0\t0\n" +
+                            "ETH\tbuy\t30.0\t0\t0\n" +
+                            "BTC\t\t30.0\t0\t1\n" +
+                            "ETH\t\t30.0\t0\t1\n" +
+                            "\t\t60.0\t1\t1\n",
+                    "SELECT symbol, side, SUM(quantity), GROUPING(symbol) AS gs, GROUPING(side) AS gsd " +
+                            "FROM trades " +
+                            "GROUP BY ROLLUP(symbol, side)"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingFunctionMultiArg() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')"
+            );
+
+            // GROUPING(symbol, side) returns a 2-bit bitmask:
+            // 0b00 = 0: both grouped
+            // 0b01 = 1: side rolled up
+            // 0b11 = 3: both rolled up
+            assertSql(
+                    "symbol\tside\tSUM\tgrp\n" +
+                            "BTC\tbuy\t10.0\t0\n" +
+                            "BTC\tsell\t20.0\t0\n" +
+                            "ETH\tbuy\t30.0\t0\n" +
+                            "BTC\t\t30.0\t1\n" +
+                            "ETH\t\t30.0\t1\n" +
+                            "\t\t60.0\t3\n",
+                    "SELECT symbol, side, SUM(quantity), GROUPING(symbol, side) AS grp " +
+                            "FROM trades " +
+                            "GROUP BY ROLLUP(symbol, side)"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingIdFunction() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')"
+            );
+
+            // GROUPING_ID(symbol, side) is equivalent to multi-arg GROUPING()
+            assertSql(
+                    "symbol\tside\tSUM\tgrp\n" +
+                            "BTC\tbuy\t10.0\t0\n" +
+                            "BTC\tsell\t20.0\t0\n" +
+                            "ETH\tbuy\t30.0\t0\n" +
+                            "BTC\t\t30.0\t1\n" +
+                            "ETH\t\t30.0\t1\n" +
+                            "\t\t60.0\t3\n",
+                    "SELECT symbol, side, SUM(quantity), GROUPING_ID(symbol, side) AS grp " +
+                            "FROM trades " +
+                            "GROUP BY ROLLUP(symbol, side)"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingIdSingleArg() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:01:00.000000Z')," +
+                            "('ETH', 'buy', 30, '2024-01-01T00:02:00.000000Z')"
+            );
+
+            // Single-arg GROUPING_ID works like GROUPING
+            assertSql(
+                    "symbol\tside\tSUM\tgs\n" +
+                            "BTC\tbuy\t10.0\t0\n" +
+                            "BTC\tsell\t20.0\t0\n" +
+                            "ETH\tbuy\t30.0\t0\n" +
+                            "BTC\t\t30.0\t0\n" +
+                            "ETH\t\t30.0\t0\n" +
+                            "\t\t60.0\t1\n",
+                    "SELECT symbol, side, SUM(quantity), GROUPING_ID(symbol) AS gs " +
+                            "FROM trades " +
+                            "GROUP BY ROLLUP(symbol, side)"
+            );
+        });
+    }
+
+    // ==================== SAMPLE BY + GROUPING SETS tests ====================
+
+    @Test
+    public void testSampleByRollupBasic() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 20, '2024-01-01T00:30:00.000000Z')," +
+                            "('ETH', 30, '2024-01-01T00:45:00.000000Z')," +
+                            "('BTC', 40, '2024-01-01T01:00:00.000000Z')," +
+                            "('ETH', 50, '2024-01-01T01:15:00.000000Z')"
+            );
+
+            // SAMPLE BY 1h ROLLUP(symbol): for each hour, compute per-symbol and grand total
+            assertSql(
+                    "ts\tsymbol\tSUM\n" +
+                            "2024-01-01T00:00:00.000000Z\t\t60.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\t30.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tETH\t30.0\n" +
+                            "2024-01-01T01:00:00.000000Z\t\t90.0\n" +
+                            "2024-01-01T01:00:00.000000Z\tBTC\t40.0\n" +
+                            "2024-01-01T01:00:00.000000Z\tETH\t50.0\n",
+                    "SELECT ts, symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "SAMPLE BY 1h ROLLUP(symbol) " +
+                            "ORDER BY ts, symbol"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByRollupTwoColumns() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:30:00.000000Z')," +
+                            "('ETH', 'buy', 30, '2024-01-01T00:45:00.000000Z')"
+            );
+
+            // SAMPLE BY 1h ROLLUP(symbol, side): detail, by-symbol subtotals, grand total per hour
+            assertSql(
+                    "ts\tsymbol\tside\tSUM\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\tbuy\t10.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\tsell\t20.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tETH\tbuy\t30.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\t\t30.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tETH\t\t30.0\n" +
+                            "2024-01-01T00:00:00.000000Z\t\t\t60.0\n",
+                    "SELECT ts, symbol, side, SUM(quantity) " +
+                            "FROM trades " +
+                            "SAMPLE BY 1h ROLLUP(symbol, side)"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByCubeBasic() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, side SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 'buy', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 'sell', 20, '2024-01-01T00:30:00.000000Z')"
+            );
+
+            // SAMPLE BY 1h CUBE(symbol, side): all combinations per hour
+            assertSql(
+                    "ts\tsymbol\tside\tSUM\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\tbuy\t10.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\tsell\t20.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\t\t30.0\n" +
+                            "2024-01-01T00:00:00.000000Z\t\tbuy\t10.0\n" +
+                            "2024-01-01T00:00:00.000000Z\t\tsell\t20.0\n" +
+                            "2024-01-01T00:00:00.000000Z\t\t\t30.0\n",
+                    "SELECT ts, symbol, side, SUM(quantity) " +
+                            "FROM trades " +
+                            "SAMPLE BY 1h CUBE(symbol, side)"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByRollupMultipleBuckets() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('ETH', 20, '2024-01-01T00:30:00.000000Z')," +
+                            "('BTC', 30, '2024-01-01T01:00:00.000000Z')," +
+                            "('ETH', 40, '2024-01-01T01:30:00.000000Z')," +
+                            "('BTC', 50, '2024-01-01T02:00:00.000000Z')"
+            );
+
+            // 3 time buckets, each with per-symbol detail + grand total
+            assertSql(
+                    "ts\tsymbol\tSUM\n" +
+                            "2024-01-01T00:00:00.000000Z\t\t30.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\t10.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tETH\t20.0\n" +
+                            "2024-01-01T01:00:00.000000Z\t\t70.0\n" +
+                            "2024-01-01T01:00:00.000000Z\tBTC\t30.0\n" +
+                            "2024-01-01T01:00:00.000000Z\tETH\t40.0\n" +
+                            "2024-01-01T02:00:00.000000Z\t\t50.0\n" +
+                            "2024-01-01T02:00:00.000000Z\tBTC\t50.0\n",
+                    "SELECT ts, symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "SAMPLE BY 1h ROLLUP(symbol) " +
+                            "ORDER BY ts, symbol"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByRollupFillNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('ETH', 20, '2024-01-01T00:30:00.000000Z')," +
+                            "('BTC', 30, '2024-01-01T01:00:00.000000Z')"
+            );
+
+            // SAMPLE BY 1h ROLLUP(symbol) FILL(NULL) should work
+            assertSql(
+                    "ts\tsymbol\tSUM\n" +
+                            "2024-01-01T00:00:00.000000Z\t\t30.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\t10.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tETH\t20.0\n" +
+                            "2024-01-01T01:00:00.000000Z\t\t30.0\n" +
+                            "2024-01-01T01:00:00.000000Z\tBTC\t30.0\n",
+                    "SELECT ts, symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "SAMPLE BY 1h ROLLUP(symbol) FILL(NULL) " +
+                            "ORDER BY ts, symbol"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByRollupFillNone() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('ETH', 20, '2024-01-01T00:30:00.000000Z')," +
+                            "('BTC', 30, '2024-01-01T01:00:00.000000Z')"
+            );
+
+            // SAMPLE BY 1h ROLLUP(symbol) FILL(NONE) should work
+            assertSql(
+                    "ts\tsymbol\tSUM\n" +
+                            "2024-01-01T00:00:00.000000Z\t\t30.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\t10.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tETH\t20.0\n" +
+                            "2024-01-01T01:00:00.000000Z\t\t30.0\n" +
+                            "2024-01-01T01:00:00.000000Z\tBTC\t30.0\n",
+                    "SELECT ts, symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "SAMPLE BY 1h ROLLUP(symbol) FILL(NONE) " +
+                            "ORDER BY ts, symbol"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByRollupFillPrevNotSupported() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+
+            assertException(
+                    "SELECT ts, symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "SAMPLE BY 1h ROLLUP(symbol) FILL(PREV)",
+                    78,
+                    "FILL(PREV) and FILL(LINEAR) are not supported with ROLLUP, CUBE, or GROUPING SETS"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByRollupFillConstant() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 30, '2024-01-01T02:00:00.000000Z')"
+            );
+
+            // FILL(0) emits one fill row per key combination per missing
+            // timestamp bucket. Key columns retain their actual values,
+            // aggregate columns get the fill value.
+            assertSql(
+                    "ts\tsymbol\tSUM\n" +
+                            "2024-01-01T00:00:00.000000Z\t\t10.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\t10.0\n" +
+                            "2024-01-01T01:00:00.000000Z\t\t0.0\n" +
+                            "2024-01-01T01:00:00.000000Z\tBTC\t0.0\n" +
+                            "2024-01-01T02:00:00.000000Z\t\t30.0\n" +
+                            "2024-01-01T02:00:00.000000Z\tBTC\t30.0\n",
+                    "SELECT ts, symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "SAMPLE BY 1h ROLLUP(symbol) FILL(0) " +
+                            "ORDER BY ts, symbol"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByRollupFillNullWithGap() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 30, '2024-01-01T02:00:00.000000Z')"
+            );
+
+            // FILL(NULL) emits one fill row per key combination per missing
+            // timestamp bucket. Key columns retain their actual values,
+            // aggregate columns get NULL.
+            assertSql(
+                    "ts\tsymbol\tSUM\n" +
+                            "2024-01-01T00:00:00.000000Z\t\t10.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\t10.0\n" +
+                            "2024-01-01T01:00:00.000000Z\t\tnull\n" +
+                            "2024-01-01T01:00:00.000000Z\tBTC\tnull\n" +
+                            "2024-01-01T02:00:00.000000Z\t\t30.0\n" +
+                            "2024-01-01T02:00:00.000000Z\tBTC\t30.0\n",
+                    "SELECT ts, symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "SAMPLE BY 1h ROLLUP(symbol) FILL(NULL) " +
+                            "ORDER BY ts, symbol"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByRollupWithFrom() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('ETH', 20, '2024-01-01T00:30:00.000000Z')," +
+                            "('BTC', 30, '2024-01-01T01:00:00.000000Z')"
+            );
+
+            // SAMPLE BY 1h ROLLUP(symbol) FROM '...' should work
+            assertSql(
+                    "ts\tsymbol\tSUM\n" +
+                            "2024-01-01T00:00:00.000000Z\t\t30.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tBTC\t10.0\n" +
+                            "2024-01-01T00:00:00.000000Z\tETH\t20.0\n" +
+                            "2024-01-01T01:00:00.000000Z\t\t30.0\n" +
+                            "2024-01-01T01:00:00.000000Z\tBTC\t30.0\n",
+                    "SELECT ts, symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "SAMPLE BY 1h ROLLUP(symbol) " +
+                            "FROM '2024-01-01' " +
+                            "ORDER BY ts, symbol"
+            );
+        });
+    }
+
+    // ==================== Error / validation tests ====================
+
+    @Test
+    public void testGroupingFunctionOutsideGroupingSetsKeyed() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+
+            assertException(
+                    "SELECT symbol, SUM(quantity), GROUPING(symbol) " +
+                            "FROM trades " +
+                            "GROUP BY symbol",
+                    0,
+                    "GROUPING() / GROUPING_ID() can only be used with GROUPING SETS, ROLLUP, or CUBE"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingFunctionOutsideGroupingSetsNoKey() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+
+            assertException(
+                    "SELECT SUM(quantity), GROUPING(symbol) " +
+                            "FROM trades",
+                    0,
+                    "GROUPING() / GROUPING_ID() can only be used with GROUPING SETS, ROLLUP, or CUBE"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingIdOutsideGroupingSets() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+
+            assertException(
+                    "SELECT symbol, SUM(quantity), GROUPING_ID(symbol) " +
+                            "FROM trades " +
+                            "GROUP BY symbol",
+                    0,
+                    "GROUPING() / GROUPING_ID() can only be used with GROUPING SETS, ROLLUP, or CUBE"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingNoArgs() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+
+            assertException(
+                    "SELECT GROUPING(), SUM(quantity) " +
+                            "FROM trades " +
+                            "GROUP BY ROLLUP(symbol)",
+                    7,
+                    "GROUPING() requires at least one argument"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingIdNoArgs() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+
+            assertException(
+                    "SELECT GROUPING_ID(), SUM(quantity) " +
+                            "FROM trades " +
+                            "GROUP BY ROLLUP(symbol)",
+                    7,
+                    "GROUPING_ID() requires at least one argument"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingFillPreservesValue() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE trades (symbol SYMBOL, quantity DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            execute(
+                    "INSERT INTO trades VALUES " +
+                            "('BTC', 10, '2024-01-01T00:00:00.000000Z')," +
+                            "('BTC', 30, '2024-01-01T02:00:00.000000Z')"
+            );
+
+            // GROUPING() in fill rows should show the correct bitmask,
+            // not the fill value (NULL or 0).
+            assertSql(
+                    "grp\tts\tsymbol\tSUM\n" +
+                            "0\t2024-01-01T00:00:00.000000Z\tBTC\t10.0\n" +
+                            "1\t2024-01-01T00:00:00.000000Z\t\t10.0\n" +
+                            "0\t2024-01-01T01:00:00.000000Z\tBTC\tnull\n" +
+                            "1\t2024-01-01T01:00:00.000000Z\t\tnull\n" +
+                            "0\t2024-01-01T02:00:00.000000Z\tBTC\t30.0\n" +
+                            "1\t2024-01-01T02:00:00.000000Z\t\t30.0\n",
+                    "SELECT GROUPING(symbol) AS grp, ts, symbol, SUM(quantity) " +
+                            "FROM trades " +
+                            "SAMPLE BY 1h ROLLUP(symbol) FILL(NULL) " +
+                            "ORDER BY ts, grp, symbol"
+            );
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/GroupingSetsTest.java
@@ -1131,6 +1131,57 @@ public class GroupingSetsTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testGroupingSetsExpressionRejectedInCube() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, v DOUBLE)");
+            assertException(
+                    "SELECT SUM(v) FROM t GROUP BY CUBE(a + b)",
+                    37,
+                    "column reference expected"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingSetsExpressionRejectedInExplicit() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, v DOUBLE)");
+            assertException(
+                    "SELECT SUM(v) FROM t GROUP BY GROUPING SETS ((a + b))",
+                    48,
+                    "column reference expected"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingSetsExpressionRejectedInRollup() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, v DOUBLE)");
+            assertException(
+                    "SELECT SUM(v) FROM t GROUP BY ROLLUP(a + b)",
+                    39,
+                    "column reference expected"
+            );
+        });
+    }
+
+    @Test
+    public void testGroupingSetsExpressionRejectedInSampleByRollup() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(
+                    "CREATE TABLE t (a INT, b INT, v DOUBLE, ts TIMESTAMP)" +
+                            " TIMESTAMP(ts) PARTITION BY DAY"
+            );
+            assertException(
+                    "SELECT SUM(v) FROM t SAMPLE BY 1h ROLLUP(a + b)",
+                    43,
+                    "column reference expected"
+            );
+        });
+    }
+
+    @Test
     public void testGroupingFillPreservesValue() throws Exception {
         assertMemoryLeak(() -> {
             execute(
@@ -1157,6 +1208,70 @@ public class GroupingSetsTest extends AbstractCairoTest {
                             "FROM trades " +
                             "SAMPLE BY 1h ROLLUP(symbol) FILL(NULL) " +
                             "ORDER BY ts, grp, symbol"
+            );
+        });
+    }
+
+    @Test
+    public void testMixedQualificationRejectedInCompositeRollup() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, v DOUBLE)");
+            assertException(
+                    "SELECT SUM(v) FROM t GROUP BY a, ROLLUP(t.a)",
+                    40,
+                    "mixing qualified and unqualified references to the same column"
+            );
+        });
+    }
+
+    @Test
+    public void testMixedQualificationRejectedInCube() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, v DOUBLE)");
+            assertException(
+                    "SELECT SUM(v) FROM t GROUP BY CUBE(a, t.a)",
+                    38,
+                    "mixing qualified and unqualified references to the same column"
+            );
+        });
+    }
+
+    @Test
+    public void testMixedQualificationRejectedInExplicitGroupingSets() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, v DOUBLE)");
+            assertException(
+                    "SELECT SUM(v) FROM t GROUP BY GROUPING SETS ((a), (t.a))",
+                    51,
+                    "mixing qualified and unqualified references to the same column"
+            );
+        });
+    }
+
+    @Test
+    public void testMixedQualificationRejectedInRollup() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, v DOUBLE)");
+            assertException(
+                    "SELECT SUM(v) FROM t GROUP BY ROLLUP(a, t.a)",
+                    40,
+                    "mixing qualified and unqualified references to the same column"
+            );
+        });
+    }
+
+    @Test
+    public void testQualifiedReferencesAccepted() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (a INT, b INT, v DOUBLE)");
+            execute("INSERT INTO t VALUES (1, 10, 100.0), (1, 20, 200.0), (2, 10, 300.0)");
+            // All qualified - no mixed qualification error
+            assertSql(
+                    "a\tSUM\n" +
+                            "null\t600.0\n" +
+                            "1\t300.0\n" +
+                            "2\t300.0\n",
+                    "SELECT t.a, SUM(v) FROM t GROUP BY ROLLUP(t.a) ORDER BY t.a"
             );
         });
     }


### PR DESCRIPTION
This PR adds SQL:1999 GROUPING SETS support for both GROUP BY and SAMPLE BY, including the companion functions GROUPING() and GROUPING_ID().

Draft docs at:
* https://github.com/questdb/documentation/pull/385
* https://preview-385--questdb-documentation.netlify.app/docs/query/sql/grouping-sets/

## How it works

### Single-pass, N-map approach

The engine scans the data **once** and updates N aggregation maps (one per grouping set) with different key projections. This avoids N full scans (unlike a UNION ALL rewrite).

All maps share the same key layout (union of all GROUP BY columns). For each grouping set, a `NullingRecord` wraps the source record and returns NULL for columns not active in that set. The standard `RecordSink` copies from this wrapped record, so the map key has NULLs for inactive columns. Rows with different values for inactive columns then hash to the same map entry, achieving correct aggregation per grouping set.

### Desugaring

ROLLUP/CUBE are desugared to GROUPING SETS in the parser:
- `ROLLUP(a, b)` -> `GROUPING SETS ((a, b), (a), ())`
- `CUBE(a, b)` -> `GROUPING SETS ((a, b), (a), (b), ())`

Composite syntax is supported: `GROUP BY a, ROLLUP(b, c)` -> `GROUPING SETS ((a, b, c), (a, b), (a))`.

### GROUPING() and GROUPING_ID()

Two companion functions distinguish real NULLs from rollup NULLs:

- **`GROUPING(col)`** - single column only. Returns 0 (actively grouped) or 1 (rolled up). Follows the Oracle/SQL Server convention.
- **`GROUPING_ID(col1, col2, ...)`** - one or more columns. Returns a bitmask where each bit indicates whether the corresponding column is rolled up. Bit positions are assigned right-to-left per the SQL standard: the rightmost argument occupies bit 0.

Example with `CUBE(symbol, side)`:

| Set | GROUPING(symbol) | GROUPING(side) | GROUPING_ID(symbol, side) |
|-----|-------------------|----------------|---------------------------|
| symbol, side | 0 | 0 | 0 (0b00) |
| symbol only | 0 | 1 | 1 (0b01) |
| side only | 1 | 0 | 2 (0b10) |
| grand total | 1 | 1 | 3 (0b11) |

Both functions error when used outside a GROUPING SETS / ROLLUP / CUBE context.

### FILL support

`FillRangeRecordCursorFactory` tracks all distinct key combinations seen during the base scan. For each missing timestamp bucket, it emits one fill row per key combination (matching regular keyed SAMPLE BY behavior). GROUPING() and GROUPING_ID() values are preserved in fill rows (not nullified).

**Not supported with GROUPING SETS:**
- `FILL(PREV)` - would require per-grouping-set carry-forward state, which the current `FillRangeRecordCursorFactory` architecture does not support
- `FILL(LINEAR)` - would require per-grouping-set interpolation state, same limitation

Both produce a clear SQL error when attempted.

**Supported with GROUPING SETS:**
- `FILL(NULL)` - fills missing buckets with NULL aggregates, key columns preserved
- `FILL(value)` - fills missing buckets with constant value, key columns preserved
- `FILL(NONE)` - no fill rows emitted (default behavior)

## Examples using fx_trades

Schema: `fx_trades (ts TIMESTAMP, symbol SYMBOL, side SYMBOL, price DOUBLE, quantity DOUBLE)`

### GROUP BY ROLLUP

Compute per-symbol-side totals, per-symbol subtotals, and a grand total:

```sql
SELECT symbol, side, SUM(quantity), AVG(price),
       GROUPING(symbol) AS gs, GROUPING(side) AS gsd
FROM fx_trades
GROUP BY ROLLUP(symbol, side)
ORDER BY symbol, side;
```

Output includes three levels:
- Detail rows (gs=0, gsd=0): both `symbol` and `side` are actively grouped
- Subtotal rows (gs=0, gsd=1): `side` is rolled up (NULL), `symbol` is grouped
- Grand total (gs=1, gsd=1): both rolled up (both NULL)

### GROUP BY CUBE

All possible combinations of `symbol` and `side`:

```sql
SELECT symbol, side, SUM(quantity), COUNT(*),
       GROUPING_ID(symbol, side) AS grp
FROM fx_trades
GROUP BY CUBE(symbol, side)
ORDER BY symbol, side;
```

Produces 4 levels: detail (grp=0), per-symbol (grp=1), per-side (grp=2), grand total (grp=3).

### GROUP BY GROUPING SETS

Explicit control over which grouping sets to compute:

```sql
SELECT symbol, side, SUM(quantity)
FROM fx_trades
GROUP BY GROUPING SETS ((symbol, side), (symbol), ());
```

### SAMPLE BY with ROLLUP

Per-hour aggregation with per-symbol breakdown and hourly grand totals:

```sql
SELECT ts, symbol, SUM(quantity), AVG(price)
FROM fx_trades
SAMPLE BY 1h ROLLUP(symbol)
ORDER BY ts, symbol;
```

Each 1h bucket has: one row per symbol + one grand total row (symbol=NULL).

### SAMPLE BY with ROLLUP and FILL

Missing time buckets are filled per key combination:

```sql
SELECT GROUPING(symbol) AS gs, ts, symbol, SUM(quantity)
FROM fx_trades
SAMPLE BY 1h ROLLUP(symbol) FILL(NULL)
ORDER BY ts, gs, symbol;
```

Fill rows preserve key column values, GROUPING() values, and set aggregates to NULL.

## New files

- `GroupingSetsRecordCursorFactory.java` - single-pass GROUP BY execution with N maps
- `NullingRecord.java` - record wrapper that returns NULL for inactive columns
- `GroupingFunction.java` / `GroupingFunctionFactory.java` - GROUPING(col) function (single column, returns 0/1)
- `GroupingIdFunctionFactory.java` - GROUPING_ID(col1, col2, ...) function (multi-column bitmask)
- `GroupingSetsTest.java` - 55 tests
- `GroupingSetsFuzzTest.java` - 10 randomized tests

## Modified files

- `SqlParser.java` - GROUP BY and SAMPLE BY clause parsing for ROLLUP/CUBE/GROUPING SETS
- `SqlKeywords.java` - new keyword recognizers
- `QueryModel.java` - groupingSets storage
- `SqlOptimiser.java` - SAMPLE BY rewrite propagation, validation
- `SqlCodeGenerator.java` - dispatch to GroupingSetsRecordCursorFactory, FILL wiring
- `FillRangeRecordCursorFactory.java` - key-aware fill for per-key gap filling

## Validation

- GROUPING SETS + LATEST ON: rejected
- GROUPING(col1, col2): rejected (use GROUPING_ID for multi-column)
- GROUPING() / GROUPING_ID() outside GROUPING SETS: rejected
- Expressions in ROLLUP/CUBE/GROUPING SETS: rejected (column references only)
- Mixed qualified/unqualified references to the same column: rejected
- CUBE limited to 15 columns
- GROUPING_ID() limited to 31 arguments
- GROUPING()/GROUPING_ID() with more than 31 key columns: rejected
- FILL(PREV) / FILL(LINEAR) with GROUPING SETS: rejected with clear error
- Unsupported key column types for FILL: rejected at compile time

## Test plan

- ROLLUP, CUBE, GROUPING SETS parsing and execution
- Composite syntax (GROUP BY a, ROLLUP(b, c))
- GROUPING(col) returns 0/1
- GROUPING_ID(col1, col2) returns correct bitmask
- GROUPING() multi-arg rejection with helpful message
- SAMPLE BY with ROLLUP/CUBE/GROUPING SETS
- FILL(NULL), FILL(0), FILL(NONE) with GROUPING SETS
- FILL preserves GROUPING() / GROUPING_ID() values in fill rows
- FILL(PREV) / FILL(LINEAR) rejection
- GROUPING() outside GROUPING SETS context rejection
- No-arg GROUPING() / GROUPING_ID() error
- Expression rejection in ROLLUP/CUBE/GROUPING SETS
- Mixed qualified/unqualified column reference rejection
- Plain GROUP BY with expressions unaffected
- Qualified-only column references accepted
- Cursor reuse (no NPE on second execution)
- Fuzz tests with randomized schemas and data
- No regressions in SampleByTest, SqlCodeGeneratorTest, SqlParserTest (21,930 tests)