### PR TITLE
chore(sql): fix frame index out of bounds in WINDOW JOIN

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/join/WindowJoinTimeFrameHelper.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/WindowJoinTimeFrameHelper.java
@@ -462,9 +462,11 @@ public class WindowJoinTimeFrameHelper {
     public void restoreBookmark(int frameIndex, long rowIndex) {
         this.bookmarkedFrameIndex = frameIndex;
         this.bookmarkedRowIndex = rowIndex;
-        timeFrameCursor.jumpTo(bookmarkedFrameIndex);
-        timeFrameCursor.open();
-        timeFrameCursor.recordAt(record, frameIndex, rowIndex);
+        if (frameIndex >= 0) {
+            timeFrameCursor.jumpTo(bookmarkedFrameIndex);
+            timeFrameCursor.open();
+            timeFrameCursor.recordAt(record, frameIndex, rowIndex);
+        }
     }
 
     public void toTop() {


### PR DESCRIPTION
Fixes a bug introduced in #6822 (not yet released)

The bug was reproducible in `WindowJoinFuzzTest` with the following seeds: 2493838018984017L, 1773168993406L