### PR TITLE
chore(core): speed up WalTableWriterFuzzTest.testRandomInOutOfOrderOverlappingInserts()

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/wal/WalTableWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalTableWriterFuzzTest.java
@@ -140,11 +140,16 @@ public class WalTableWriterFuzzTest extends AbstractMultiNodeTest {
                 drainWalQueue();
             }
 
-            assertSql("i\tts\n" +
-                    "2\t1970-01-01T00:00:00.000500Z\n" +
-                    "1\t1970-01-01T00:00:00.001000Z\n" +
-                    "3\t1970-01-01T00:00:00.001500Z\n" +
-                    "4\t1970-01-01T00:00:00.001500Z\n", tableName);
+            assertSql(
+                    """
+                            i\tts
+                            2\t1970-01-01T00:00:00.000500Z
+                            1\t1970-01-01T00:00:00.001000Z
+                            3\t1970-01-01T00:00:00.001500Z
+                            4\t1970-01-01T00:00:00.001500Z
+                            """,
+                    tableName
+            );
         });
     }
 
@@ -276,11 +281,11 @@ public class WalTableWriterFuzzTest extends AbstractMultiNodeTest {
                 long start = now;
                 WalWriter[] writers = new WalWriter[]{walWriter1, walWriter2, walWriter3};
 
-                for (int i = 0; i < 20; i++) {
+                for (int i = 0; i < 10; i++) {
                     boolean inOrder = rnd.nextBoolean();
                     int walIndex = rnd.nextInt(writers.length);
                     WalWriter walWriter = writers[walIndex];
-                    int rowCount = rnd.nextInt(10000) + 1;
+                    int rowCount = rnd.nextInt(2000) + 1;
                     int partitions = rnd.nextInt(3) + 1;
                     tsIncrement = partitions * Micros.HOUR_MICROS / rowCount;
                     long tsOffset = rnd.nextLong(2 * Micros.HOUR_MICROS);
@@ -462,10 +467,15 @@ public class WalTableWriterFuzzTest extends AbstractMultiNodeTest {
                 drainWalQueue();
             }
 
-            assertSql("a\tb\tts\tc\n" +
-                    "10\t10\t1970-01-01T00:00:00.000000Z\t10\n" +
-                    "11\t11\t1970-01-01T00:00:00.000000Z\t11\n" +
-                    "12\t12\t1970-01-01T00:00:00.000000Z\t12\n", tableName);
+            assertSql(
+                    """
+                            a\tb\tts\tc
+                            10\t10\t1970-01-01T00:00:00.000000Z\t10
+                            11\t11\t1970-01-01T00:00:00.000000Z\t11
+                            12\t12\t1970-01-01T00:00:00.000000Z\t12
+                            """,
+                    tableName
+            );
         });
     }
 


### PR DESCRIPTION
- Reduce iteration count (20 → 10) and max row count (10000 → 2000) in `testRandomInOutOfOrderOverlappingInserts()` to speed up the test
- Convert `assertSql` string concatenations to text blocks

----------
This test took 25-30 seconds to run locally, that usually translates to 10-15 minutes on CI.
It timed out on my PR, the test timeout is 20 minutes.
Now it finishes in 2-3 seconds locally, I expect that to be around 2 minutes on CI.