### PR TITLE
chore(build): disable trivy in release pipelines

### DIFF
--- a/ci/docker-release-pipeline.yml
+++ b/ci/docker-release-pipeline.yml
@@ -33,22 +33,22 @@ jobs:
       - bash: |
           tag=$(Build.SourceBranchName)
           echo "Checking tag: $tag"
-          
+
           if [[ ! $tag =~ ^\d+(\.\d+)*$ ]]; then
             echo "Tag '$tag' is not a pure numeric version (x.y.z) - skipping build"
             echo "Valid tags should only contain numbers and dots (e.g., 1.2.3, 10.0.5)"
             echo "##vso[task.complete result=Succeeded;]Skipping build for non-numeric version tag"
             exit 0
           fi
-          
+
           echo "Tag '$tag' is a valid numeric version, continuing with build"
         displayName: 'Validate semantic version format'
         condition: and(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), ne(variables['SKIP_VALIDATION'], 'true'))
 
-      - task: CmdLine@2
-        displayName: Check that trivy is installed and present in PATH
-        inputs:
-          script: which trivy && trivy version
+      # - task: CmdLine@2
+      #   displayName: Check that trivy is installed and present in PATH
+      #   inputs:
+      #     script: which trivy && trivy version
 
       - task: CmdLine@2
         displayName: Download latest openshift-preflight tool
@@ -83,16 +83,16 @@ jobs:
           workingDirectory: core
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
-      - task: CmdLine@2
-        displayName: Scan nightly docker image for vulnerabilities
-        inputs:
-          script: |
-            echo "Scanning image: questdb/questdb:nightly"
-            trivy image --exit-code 1 --severity HIGH,CRITICAL questdb/questdb:nightly
-
-            echo "Scanning image: questdb/questdb:nightly-rhel"
-            trivy image --exit-code 1 --severity HIGH,CRITICAL questdb/questdb:nightly-rhel
-        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      #- task: CmdLine@2
+      #  displayName: Scan nightly docker image for vulnerabilities
+      #  inputs:
+      #    script: |
+      #      echo "Scanning image: questdb/questdb:nightly"
+      #      trivy image --exit-code 1 --severity HIGH,CRITICAL questdb/questdb:nightly
+      #
+      #      echo "Scanning image: questdb/questdb:nightly-rhel"
+      #      trivy image --exit-code 1 --severity HIGH,CRITICAL questdb/questdb:nightly-rhel
+      #  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
       - task: CmdLine@2
         displayName: Release Tag
@@ -116,18 +116,18 @@ jobs:
           workingDirectory: core
         condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
 
-      - task: CmdLine@2
-        displayName: Scan tagged docker image for vulnerabilities
-        inputs:
-          script: |
-            tag_name=$(echo "$(Build.SourceBranch)" | cut -d'/' -f '3-')
-
-            echo "Scanning image: questdb/questdb:${tag_name}"
-            trivy image --exit-code 1 --severity HIGH,CRITICAL "questdb/questdb:${tag_name}"
-
-            echo "Scanning image: questdb/questdb:${tag_name}-rhel"
-            trivy image --exit-code 1 --severity HIGH,CRITICAL "questdb/questdb:${tag_name}-rhel"
-        condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
+      #- task: CmdLine@2
+      #  displayName: Scan tagged docker image for vulnerabilities
+      #  inputs:
+      #    script: |
+      #      tag_name=$(echo "$(Build.SourceBranch)" | cut -d'/' -f '3-')
+      #
+      #      echo "Scanning image: questdb/questdb:${tag_name}"
+      #      trivy image --exit-code 1 --severity HIGH,CRITICAL "questdb/questdb:${tag_name}"
+      #
+      #      echo "Scanning image: questdb/questdb:${tag_name}-rhel"
+      #      trivy image --exit-code 1 --severity HIGH,CRITICAL "questdb/questdb:${tag_name}-rhel"
+      #  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
 
       - task: CmdLine@2
         displayName: Release Commit from Branch
@@ -147,18 +147,18 @@ jobs:
           workingDirectory: core
         condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/'), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
 
-      - task: CmdLine@2
-        displayName: Scan branch docker image for vulnerabilities
-        inputs:
-          script: |
-            docker_tag_name=patch-$(echo $(Build.SourceVersion) | cut -c 1-7)
-
-            echo "Scanning image: questdb/questdb:${docker_tag_name}"
-            trivy image --exit-code 1 --severity HIGH,CRITICAL "questdb/questdb:${docker_tag_name}"
-
-            echo "Scanning image: questdb/questdb:${docker_tag_name}-rhel"
-            trivy image --exit-code 1 --severity HIGH,CRITICAL "questdb/questdb:${docker_tag_name}-rhel"
-        condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/'), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+      #- task: CmdLine@2
+      #  displayName: Scan branch docker image for vulnerabilities
+      #  inputs:
+      #    script: |
+      #      docker_tag_name=patch-$(echo $(Build.SourceVersion) | cut -c 1-7)
+      #
+      #      echo "Scanning image: questdb/questdb:${docker_tag_name}"
+      #      trivy image --exit-code 1 --severity HIGH,CRITICAL "questdb/questdb:${docker_tag_name}"
+      #
+      #      echo "Scanning image: questdb/questdb:${docker_tag_name}-rhel"
+      #      trivy image --exit-code 1 --severity HIGH,CRITICAL "questdb/questdb:${docker_tag_name}-rhel"
+      #  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/'), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
 
       - task: CmdLine@2
         displayName: Notify Slack on Failure


### PR DESCRIPTION
Trivy is currently under attack by a sophisticated threat actor. Their docker images and github actions have already been compromised, and there are rumors that the inflitration is ongoing.

Since `trivy` commands download libraries of vulns on every run, I'm disabling these checks until this calms down. I've already rotated docker registry credentials.

- https://socket.dev/blog/trivy-under-attack-again-github-actions-compromise
- https://thehackernews.com/2026/03/trivy-security-scanner-github-actions.html
- https://www.aquasec.com/blog/trivy-supply-chain-attack-what-you-need-to-know/