### PR TITLE
chore(core): fix index file hard-link for columns with no data in parquet partition

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -4410,14 +4410,14 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     continue;
                 }
                 final long colTop = columnVersionWriter.getColumnTop(partitionTimestamp, columnIndex);
-                if (colTop == -1) {
-                    continue; // column does not exist in this partition
+                if (colTop == -1 || colTop >= partitionRowCount) {
+                    continue; // column does not exist or has no data in this partition
                 }
 
                 final String columnName = metadata.getColumnName(columnIndex);
                 final long columnNameTxn = getColumnNameTxn(partitionTimestamp, columnIndex);
 
-                if (colTop > 0 && colTop < partitionRowCount) {
+                if (colTop > 0) {
                     if (indexWriter == null) {
                         indexWriter = new BitmapIndexWriter(configuration);
                     }


### PR DESCRIPTION
## Summary

- `copyOrRebuildColumnIndexes()` skipped columns only when `colTop == -1` but `rebuildPartitionIndexFiles()` also skips when `colTop >= partitionRowCount` (column has no data). When a symbol column was added after a parquet partition existed, O3 merge set `colTop == partitionRowCount`. The parquet-to-native conversion correctly skipped building index files, but the subsequent native-to-parquet conversion tried to hard-link the non-existent `.k`/`.v` files, suspending the table.
- Align the skip condition in `copyOrRebuildColumnIndexes()` with `rebuildPartitionIndexFiles()` by also skipping `colTop >= partitionRowCount`.

## Test plan

- Reproducible with `WalWriterFuzzTest#testConvertPartitionToParquet` using seeds `4470041531544032L, 1775145196919L`
- Test passes after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)