### PR TITLE
fix(sql): fix negative tick duration handling

### DIFF
--- a/core/src/main/java/io/questdb/griffin/model/CompiledTickExpression.java
+++ b/core/src/main/java/io/questdb/griffin/model/CompiledTickExpression.java
@@ -317,12 +317,15 @@ public class CompiledTickExpression extends UntypedFunction {
                 long offset = ir.getQuick(toOff + j * 3);
                 long width = ir.getQuick(toOff + j * 3 + 1);
                 long zoneMatch = ir.getQuick(toOff + j * 3 + 2);
-                long lo = dayStart + offset;
+                long anchor = dayStart + offset;
+                long lo = anchor;
                 long hi;
                 if (durationPartCount > 0 && !hasDurationWithExchange) {
-                    hi = applyDuration(lo) - 1;
+                    long endExclusive = applyDuration(anchor);
+                    lo = IntervalUtils.resolveDurationLo(anchor, endExclusive);
+                    hi = IntervalUtils.resolveDurationHi(anchor, endExclusive);
                 } else {
-                    hi = lo + width;
+                    hi = anchor + width;
                 }
                 if (zoneMatch != Long.MIN_VALUE) {
                     // Per-element tz: convert to UTC first
@@ -342,7 +345,11 @@ public class CompiledTickExpression extends UntypedFunction {
                 out.add(lo, hi);
             }
         } else if (durationPartCount > 0 && !hasDurationWithExchange) {
-            out.add(dayStart, applyDuration(dayStart) - 1);
+            long endExclusive = applyDuration(dayStart);
+            out.add(
+                    IntervalUtils.resolveDurationLo(dayStart, endExclusive),
+                    IntervalUtils.resolveDurationHi(dayStart, endExclusive)
+            );
         } else {
             out.add(dayStart, timestampDriver.endOfDay(dayStart));
         }

--- a/core/src/main/java/io/questdb/griffin/model/CompiledTickExpression.java
+++ b/core/src/main/java/io/questdb/griffin/model/CompiledTickExpression.java
@@ -389,7 +389,9 @@ public class CompiledTickExpression extends UntypedFunction {
         if (isDayLevel) {
             emitDayInterval(timestamp, out);
         } else if (durationPartCount > 0 && !hasDurationWithExchange) {
-            out.add(timestamp, applyDuration(timestamp) - 1);
+            long endExclusive = applyDuration(timestamp);
+            out.add(IntervalUtils.resolveDurationLo(timestamp, endExclusive),
+                    IntervalUtils.resolveDurationHi(timestamp, endExclusive));
         } else {
             out.add(timestamp, timestamp);
         }

--- a/core/src/main/java/io/questdb/griffin/model/IntervalUtils.java
+++ b/core/src/main/java/io/questdb/griffin/model/IntervalUtils.java
@@ -1451,43 +1451,53 @@ public final class IntervalUtils {
 
     private static void addMonthInterval(TimestampDriver timestampDriver, int period, int count, LongList out) {
         int k = out.size();
-        long lo = out.getQuick(k - 2);
-        long hi = out.getQuick(k - 1);
+        long baseLo = out.getQuick(k - 2);
+        long baseHi = out.getQuick(k - 1);
         int writePoint = k / 2;
         int n = count - 1;
+        int startOffset;
+        int step;
         if (period < 0) {
-            lo = timestampDriver.addMonths(lo, period * n);
-            hi = timestampDriver.addMonths(hi, period * n);
-            out.setQuick(k - 2, lo);
-            out.setQuick(k - 1, hi);
-            period = -period;
+            startOffset = period * n;
+            step = -period;
+            out.setQuick(k - 2, timestampDriver.addMonths(baseLo, startOffset));
+            out.setQuick(k - 1, timestampDriver.addMonths(baseHi, startOffset));
+        } else {
+            startOffset = 0;
+            step = period;
         }
 
-        for (int i = 0; i < n; i++) {
-            lo = timestampDriver.addMonths(lo, period);
-            hi = timestampDriver.addMonths(hi, period);
-            writePoint = append(out, writePoint, lo, hi);
+        for (int i = 1; i <= n; i++) {
+            int months = startOffset + step * i;
+            writePoint = append(out, writePoint,
+                    timestampDriver.addMonths(baseLo, months),
+                    timestampDriver.addMonths(baseHi, months));
         }
     }
 
     private static void addYearIntervals(TimestampDriver timestampDriver, int period, int count, LongList out) {
         int k = out.size();
-        long lo = out.getQuick(k - 2);
-        long hi = out.getQuick(k - 1);
+        long baseLo = out.getQuick(k - 2);
+        long baseHi = out.getQuick(k - 1);
         int writePoint = k / 2;
         int n = count - 1;
+        int startOffset;
+        int step;
         if (period < 0) {
-            lo = timestampDriver.addYears(lo, period * n);
-            hi = timestampDriver.addYears(hi, period * n);
-            out.setQuick(k - 2, lo);
-            out.setQuick(k - 1, hi);
-            period = -period;
+            startOffset = period * n;
+            step = -period;
+            out.setQuick(k - 2, timestampDriver.addYears(baseLo, startOffset));
+            out.setQuick(k - 1, timestampDriver.addYears(baseHi, startOffset));
+        } else {
+            startOffset = 0;
+            step = period;
         }
 
-        for (int i = 0; i < n; i++) {
-            lo = timestampDriver.addYears(lo, period);
-            hi = timestampDriver.addYears(hi, period);
-            writePoint = append(out, writePoint, lo, hi);
+        for (int i = 1; i <= n; i++) {
+            int years = startOffset + step * i;
+            writePoint = append(out, writePoint,
+                    timestampDriver.addYears(baseLo, years),
+                    timestampDriver.addYears(baseHi, years));
         }
     }
 
@@ -4313,6 +4323,9 @@ public final class IntervalUtils {
                     count = Numbers.parseInt(seq, pos2 + 1, lim);
                 } catch (NumericException e) {
                     throw SqlException.$(position, "Count not a number");
+                }
+                if (count < 1) {
+                    throw SqlException.$(position, "Count must be positive");
                 }
 
                 parseRange(timestampDriver, seq, lo, pos0, pos1, position, operation, out);

--- a/core/src/main/java/io/questdb/griffin/model/IntervalUtils.java
+++ b/core/src/main/java/io/questdb/griffin/model/IntervalUtils.java
@@ -1389,6 +1389,9 @@ public final class IntervalUtils {
         int numStart = lo;
         for (int i = lo; i < lim; i++) {
             char c = seq.charAt(i);
+            if ((c == '-' || c == '+') && i == numStart) {
+                continue;
+            }
             if ((c >= '0' && c <= '9') || c == '_') {
                 continue;
             }
@@ -1412,6 +1415,17 @@ public final class IntervalUtils {
             throw SqlException.$(position, "Missing unit at end of duration");
         }
         return timestamp;
+    }
+
+    static long resolveDurationLo(long anchor, long endExclusive) {
+        return endExclusive >= anchor ? anchor : endExclusive;
+    }
+
+    static long resolveDurationHi(long anchor, long endExclusive) {
+        if (endExclusive >= anchor) {
+            return endExclusive - 1;
+        }
+        return anchor - 1;
     }
 
     private static void addLinearInterval(long period, int count, LongList out) {
@@ -1870,6 +1884,9 @@ public final class IntervalUtils {
         int numStart = durationLo;
         for (int i = durationLo; i < durationHi; i++) {
             char c = seq.charAt(i);
+            if ((c == '-' || c == '+') && i == numStart) {
+                continue;
+            }
             if (Chars.isAsciiDigit(c) || c == '_') {
                 continue;
             }
@@ -4372,16 +4389,20 @@ public final class IntervalUtils {
             int index = out.size();
             timestampDriver.parseInterval(seq, lo, p, operation, out);
             long low = decodeIntervalLo(out, index);
-            long hi = addDuration(timestampDriver, low, seq, p + 1, lim, position) - 1;
-            replaceHiLoInterval(low, hi, operation, out);
+            long endExclusive = addDuration(timestampDriver, low, seq, p + 1, lim, position);
+            long intervalLo = resolveDurationLo(low, endExclusive);
+            long intervalHi = resolveDurationHi(low, endExclusive);
+            replaceHiLoInterval(intervalLo, intervalHi, operation, out);
             return;
         } catch (NumericException ignore) {
             // try date instead
         }
         try {
             long loMicros = timestampDriver.parseAnyFormat(seq, lo, p);
-            long hiMicros = addDuration(timestampDriver, loMicros, seq, p + 1, lim, position) - 1;
-            encodeInterval(loMicros, hiMicros, operation, out);
+            long endExclusive = addDuration(timestampDriver, loMicros, seq, p + 1, lim, position);
+            long intervalLo = resolveDurationLo(loMicros, endExclusive);
+            long intervalHi = resolveDurationHi(loMicros, endExclusive);
+            encodeInterval(intervalLo, intervalHi, operation, out);
         } catch (NumericException e) {
             throw SqlException.$(position, "Invalid date: ").put(seq, lo, p);
         }

--- a/core/src/main/java/io/questdb/std/datetime/microtime/Micros.java
+++ b/core/src/main/java/io/questdb/std/datetime/microtime/Micros.java
@@ -152,13 +152,17 @@ public final class Micros {
         }
 
         int y = getYear(micros);
-        int m;
         boolean leap1 = CommonUtils.isLeapYear(y);
         boolean leap2 = CommonUtils.isLeapYear(y + years);
-
+        int m = getMonthOfYear(micros, y, leap1);
+        int d = getDayOfMonth(micros, y, m, leap1);
+        int maxDay = CommonUtils.getDaysPerMonth(m, leap2);
+        if (d > maxDay) {
+            d = maxDay;
+        }
         return yearMicros(y + years, leap2)
-                + monthOfYearMicros(m = getMonthOfYear(micros, y, leap1), leap2)
-                + (getDayOfMonth(micros, y, m, leap1) - 1) * DAY_MICROS
+                + monthOfYearMicros(m, leap2)
+                + (d - 1) * DAY_MICROS
                 + getTimeMicros(micros);
     }
 

--- a/core/src/main/java/io/questdb/std/datetime/millitime/Dates.java
+++ b/core/src/main/java/io/questdb/std/datetime/millitime/Dates.java
@@ -143,13 +143,17 @@ public final class Dates {
         }
 
         int y = getYear(millis);
-        int m;
         boolean leap1 = isLeapYear(y);
         boolean leap2 = isLeapYear(y + years);
-
+        int m = getMonthOfYear(millis, y, leap1);
+        int d = getDayOfMonth(millis, y, m, leap1);
+        int maxDay = getDaysPerMonth(m, leap2);
+        if (d > maxDay) {
+            d = maxDay;
+        }
         return yearMillis(y + years, leap2)
-                + monthOfYearMillis(m = getMonthOfYear(millis, y, leap1), leap2)
-                + (getDayOfMonth(millis, y, m, leap1) - 1) * DAY_MILLIS
+                + monthOfYearMillis(m, leap2)
+                + (d - 1) * DAY_MILLIS
                 + getTime(millis)
                 + (millis < 0 ? 1 : 0);
 

--- a/core/src/main/java/io/questdb/std/datetime/nanotime/Nanos.java
+++ b/core/src/main/java/io/questdb/std/datetime/nanotime/Nanos.java
@@ -144,15 +144,18 @@ public final class Nanos {
             return nanos;
         }
 
-        // Use the nano version of getYear
         int y = getYear(nanos);
-        int m;
         boolean leap1 = isLeapYear(y);
         boolean leap2 = isLeapYear(y + years);
-
+        int m = getMonthOfYear(nanos, y, leap1);
+        int d = getDayOfMonth(nanos, y, m, leap1);
+        int maxDay = CommonUtils.getDaysPerMonth(m, leap2);
+        if (d > maxDay) {
+            d = maxDay;
+        }
         return yearNanos(y + years, leap2)
-                + monthOfYearNanos(m = getMonthOfYear(nanos, y, leap1), leap2)
-                + (getDayOfMonth(nanos, y, m, leap1) - 1) * DAY_NANOS
+                + monthOfYearNanos(m, leap2)
+                + (d - 1) * DAY_NANOS
                 + getTimeNanos(nanos);
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/model/TickCalendarTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/model/TickCalendarTest.java
@@ -441,6 +441,27 @@ public class TickCalendarTest {
     }
 
     @Test
+    public void testExchangeFilterWithNegativeDuration() throws SqlException {
+        // XNYS Jan 24: 14:30-21:00 UTC (6.5h session)
+        // ;-1h shrinks session by 1h from the end: 14:30-20:00
+        assertTickInterval(
+                "[{lo=2025-01-24T14:30:00.000000Z, hi=2025-01-24T19:59:59.999999Z}]",
+                "2025-01-24#XNYS;-1h"
+        );
+    }
+
+    @Test
+    public void testExchangeFilterWithNegativeDurationMultipleDays() throws SqlException {
+        // XNYS ;-1h over Fri-Tue (Sat/Sun filtered out)
+        assertTickInterval(
+                "[{lo=2025-01-24T14:30:00.000000Z, hi=2025-01-24T19:59:59.999999Z}," +
+                        "{lo=2025-01-27T14:30:00.000000Z, hi=2025-01-27T19:59:59.999999Z}," +
+                        "{lo=2025-01-28T14:30:00.000000Z, hi=2025-01-28T19:59:59.999999Z}]",
+                "2025-01-[24..28]#XNYS;-1h"
+        );
+    }
+
+    @Test
     public void testExchangeFilterWithDurationMultipleDays() throws SqlException {
         // Exchange filter with duration over multiple days
         // 2025-01-[24..28]#XNYS;1h

--- a/core/src/test/java/io/questdb/test/griffin/model/TickExprTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/model/TickExprTest.java
@@ -203,6 +203,16 @@ public class TickExprTest {
     }
 
     @Test
+    public void testBracketExpansionErrorCountNegative() {
+        assertBracketIntervalError("2026-01-27T15:00;-1s;-1h;-2", "Count must be positive");
+    }
+
+    @Test
+    public void testBracketExpansionErrorCountZero() {
+        assertBracketIntervalError("2026-01-27T15:00;1s;1h;0", "Count must be positive");
+    }
+
+    @Test
     public void testBracketExpansionErrorDescendingRange() {
         assertBracketIntervalError("2018-01-[15..10]", "Range must be ascending");
     }
@@ -826,8 +836,28 @@ public class TickExprTest {
     }
 
     @Test
+    public void testCompiledTickExprNegativeDurationMixedSigns() throws SqlException {
+        assertCompiledTickExpr("$today;-3d2h");
+    }
+
+    @Test
+    public void testCompiledTickExprNegativeDurationMultiNegative() throws SqlException {
+        assertCompiledTickExpr("$today;-3d-2h");
+    }
+
+    @Test
     public void testCompiledTickExprNegativeDurationWithTimeOverride() throws SqlException {
         assertCompiledTickExpr("[$today, $tomorrow]T[09:30,14:00];-5m");
+    }
+
+    @Test
+    public void testCompiledTickExprPositiveDurationExplicitSign() throws SqlException {
+        assertCompiledTickExpr("$today;+3d");
+    }
+
+    @Test
+    public void testCompiledTickExprZeroDuration() throws SqlException {
+        assertCompiledTickExpr("$today;0d");
     }
 
     @Test
@@ -863,6 +893,11 @@ public class TickExprTest {
     @Test
     public void testCompiledTickExprDynamicNowDuration() throws SqlException {
         assertCompiledTickExpr("$now;1h");
+    }
+
+    @Test
+    public void testCompiledTickExprDynamicNowNegativeDuration() throws SqlException {
+        assertCompiledTickExpr("$now;-1h");
     }
 
     @Test
@@ -2355,9 +2390,9 @@ public class TickExprTest {
 
     @Test
     public void testDateVariableArithmeticYearsLeapYear() throws SqlException {
-        // $today + 1y from Feb 29 leap year wraps to March 1 (29th day doesn't exist in non-leap Feb)
+        // $today + 1y from Feb 29 leap year clamps to Feb 28 (non-leap year)
         assertBracketIntervalWithNow(
-                "[{lo=2025-03-01T00:00:00.000000Z, hi=2025-03-01T23:59:59.999999Z}]",
+                "[{lo=2025-02-28T00:00:00.000000Z, hi=2025-02-28T23:59:59.999999Z}]",
                 "[$today + 1y]",
                 "2024-02-29T10:30:00.000000Z"
         );
@@ -4839,6 +4874,101 @@ public class TickExprTest {
         assertShortInterval(
                 "[{lo=2013-03-12T11:00:00.000000Z, hi=2013-03-12T11:04:59.999999Z},{lo=2014-03-12T11:00:00.000000Z, hi=2014-03-12T11:04:59.999999Z},{lo=2015-03-12T11:00:00.000000Z, hi=2015-03-12T11:04:59.999999Z}]",
                 "2015-03-12T11:00:00;5m;-1y;3"
+        );
+    }
+
+    @Test
+    public void testParseNegativeDurationCalendarMonth() throws Exception {
+        // -1M from Jan 27 15:00 → [Dec 27 15:00, Jan 27 14:59:59.999999]
+        assertShortInterval(
+                "[{lo=2025-12-27T15:00:00.000000Z, hi=2026-01-27T14:59:59.999999Z}]",
+                "2026-01-27T15:00;-1M"
+        );
+    }
+
+    @Test
+    public void testParseNegativeDurationCalendarMonthDayClamping() throws Exception {
+        // -1M from Mar 31 → Feb 28 (2026 is not leap), interval [Feb 28, Mar 30]
+        // Mar 31 itself is excluded (hi = anchor - 1)
+        assertShortInterval(
+                "[{lo=2026-02-28T00:00:00.000000Z, hi=2026-03-30T23:59:59.999999Z}]",
+                "2026-03-31;-1M"
+        );
+    }
+
+    @Test
+    public void testParseNegativeDurationCalendarYear() throws Exception {
+        // -1y from Feb 29 (leap 2024) → Feb 28 2023 (clamped), interval [Feb 28 2023, Feb 28 2024]
+        assertShortInterval(
+                "[{lo=2023-02-28T00:00:00.000000Z, hi=2024-02-28T23:59:59.999999Z}]",
+                "2024-02-29;-1y"
+        );
+    }
+
+    @Test
+    public void testParseNegativeDurationRepeatingCalendarMonth() throws Exception {
+        // -1s window from 12:00, repeated 3x with -1M period
+        // Each interval computed from base (Mar 31): -2M → Jan 31, -1M → Feb 28, 0 → Mar 31
+        assertShortInterval(
+                "[{lo=2026-01-31T11:59:59.000000Z, hi=2026-01-31T11:59:59.999999Z}," +
+                        "{lo=2026-02-28T11:59:59.000000Z, hi=2026-02-28T11:59:59.999999Z}," +
+                        "{lo=2026-03-31T11:59:59.000000Z, hi=2026-03-31T11:59:59.999999Z}]",
+                "2026-03-31T12:00;-1s;-1M;3"
+        );
+    }
+
+    @Test
+    public void testParseNegativeDurationRepeating() throws Exception {
+        // Negative duration with negative period: -1s window repeated 2x going back 1h
+        assertShortInterval(
+                "[{lo=2026-01-27T13:59:59.000000Z, hi=2026-01-27T13:59:59.999999Z}," +
+                        "{lo=2026-01-27T14:59:59.000000Z, hi=2026-01-27T14:59:59.999999Z}]",
+                "2026-01-27T15:00;-1s;-1h;2"
+        );
+    }
+
+    @Test
+    public void testParseNegativeDuration() throws Exception {
+        // Plain timestamp with negative duration — exercises parseRange static path directly
+        assertShortInterval(
+                "[{lo=2025-01-15T08:00:00.000000Z, hi=2025-01-15T09:59:59.999999Z}]",
+                "2025-01-15T10:00:00;-2h"
+        );
+    }
+
+    @Test
+    public void testParseNegativeDurationMixedSigns() throws Exception {
+        // -3d2h: go back 3 days then forward 2 hours
+        assertShortInterval(
+                "[{lo=2025-01-12T02:00:00.000000Z, hi=2025-01-14T23:59:59.999999Z}]",
+                "2025-01-15;-3d2h"
+        );
+    }
+
+    @Test
+    public void testParseNegativeDurationMultiNegative() throws Exception {
+        // -3d-2h: go back 3 days and 2 hours
+        assertShortInterval(
+                "[{lo=2025-01-11T22:00:00.000000Z, hi=2025-01-14T23:59:59.999999Z}]",
+                "2025-01-15;-3d-2h"
+        );
+    }
+
+    @Test
+    public void testParsePositiveDurationExplicitSign() throws Exception {
+        // +3d should behave identically to 3d
+        assertShortInterval(
+                "[{lo=2025-01-15T00:00:00.000000Z, hi=2025-01-17T23:59:59.999999Z}]",
+                "2025-01-15;+3d"
+        );
+    }
+
+    @Test
+    public void testParseZeroDuration() throws Exception {
+        // 0d produces an inverted interval (hi < lo) — effectively empty
+        assertShortInterval(
+                "[{lo=2025-01-15T10:00:00.000000Z, hi=2025-01-15T09:59:59.999999Z}]",
+                "2025-01-15T10:00:00;0d"
         );
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/model/TickExprTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/model/TickExprTest.java
@@ -248,15 +248,33 @@ public class TickExprTest {
     }
 
     @Test
-    public void testBracketExpansionErrorNegativeDuration() {
-        // Negative duration - '-' is not a valid start for a duration segment
-        assertBracketIntervalError("2018-01-[10,15]T00:00;-1h", "Expected number before unit");
+    public void testBracketExpansionNegativeDuration() throws SqlException {
+        // Negative duration should create a range that ends at the anchor time
+        assertBracketInterval(
+                "[{lo=2018-01-09T23:00:00.000000Z, hi=2018-01-09T23:59:59.999999Z}," +
+                        "{lo=2018-01-14T23:00:00.000000Z, hi=2018-01-14T23:59:59.999999Z}]",
+                "2018-01-[10,15]T00:00;-1h"
+        );
     }
 
     @Test
-    public void testBracketExpansionErrorNegativeDurationAnyFormat() {
-        // Negative duration via parseAnyFormat path - same error
-        assertBracketIntervalError("2018-01-[10,15]T00:00:00.000000Z;-1h", "Expected number before unit");
+    public void testBracketExpansionNegativeDurationAnyFormat() throws SqlException {
+        assertBracketInterval(
+                "[{lo=2018-01-09T23:00:00.000000Z, hi=2018-01-09T23:59:59.999999Z}," +
+                        "{lo=2018-01-14T23:00:00.000000Z, hi=2018-01-14T23:59:59.999999Z}]",
+                "2018-01-[10,15]T00:00:00.000000Z;-1h"
+        );
+    }
+
+    @Test
+    public void testBracketExpansionNegativeDurationSimpleMonth() throws SqlException {
+        // Bare imprecise month expands per-day; negative duration shifts each day backwards
+        // resulting in a merged window covering the previous 3 days of the first element
+        // through the tail of the month (Dec 29 2025 .. Jan 30 2026)
+        assertShortInterval(
+                "[{lo=2025-12-29T00:00:00.000000Z, hi=2026-01-30T23:59:59.999999Z}]",
+                "2026-01;-3d"
+        );
     }
 
     @Test
@@ -800,6 +818,16 @@ public class TickExprTest {
     @Test
     public void testCompiledTickExprDurationOnly() throws SqlException {
         assertCompiledTickExpr("$today;6h30m");
+    }
+
+    @Test
+    public void testCompiledTickExprNegativeDuration() throws SqlException {
+        assertCompiledTickExpr("$today;-3d");
+    }
+
+    @Test
+    public void testCompiledTickExprNegativeDurationWithTimeOverride() throws SqlException {
+        assertCompiledTickExpr("[$today, $tomorrow]T[09:30,14:00];-5m");
     }
 
     @Test
@@ -1431,9 +1459,12 @@ public class TickExprTest {
     }
 
     @Test
-    public void testDateListErrorNegativeDuration() {
-        // '[2025-01-01]T09:30;-5m' - negative duration not supported
-        assertBracketIntervalError("[2025-01-01]T09:30;-5m", "Expected number before unit");
+    public void testDateListNegativeDuration() throws SqlException {
+        // '[2025-01-01]T09:30;-5m' - goes 5 minutes backwards from 09:30
+        assertBracketInterval(
+                "[{lo=2025-01-01T09:25:00.000000Z, hi=2025-01-01T09:29:59.999999Z}]",
+                "[2025-01-01]T09:30;-5m"
+        );
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/std/datetime/microtime/MicrosTest.java
+++ b/core/src/test/java/io/questdb/test/std/datetime/microtime/MicrosTest.java
@@ -90,6 +90,22 @@ public class MicrosTest {
     }
 
     @Test
+    public void testAddYearsLeapFeb29Forward() {
+        // Feb 29 in leap year + 1y clamps to Feb 28 in non-leap year
+        long micros = MicrosFormatUtils.parseTimestamp("2024-02-29T12:30:00.000000Z");
+        MicrosFormatUtils.appendDateTimeUSec(sink, Micros.addYears(micros, 1));
+        TestUtils.assertEquals("2025-02-28T12:30:00.000000Z", sink);
+    }
+
+    @Test
+    public void testAddYearsLeapFeb29Backward() {
+        // Feb 29 in leap year - 1y clamps to Feb 28 in non-leap year
+        long micros = MicrosFormatUtils.parseTimestamp("2024-02-29T12:30:00.000000Z");
+        MicrosFormatUtils.appendDateTimeUSec(sink, Micros.addYears(micros, -1));
+        TestUtils.assertEquals("2023-02-28T12:30:00.000000Z", sink);
+    }
+
+    @Test
     public void testAddYearsNonLeapToLeap() {
         long micros = MicrosFormatUtils.parseTimestamp("2015-01-01T00:00:00.000000Z");
         MicrosFormatUtils.appendDateTimeUSec(sink, Micros.addYears(micros, 1));

--- a/core/src/test/java/io/questdb/test/std/datetime/millitime/DatesTest.java
+++ b/core/src/test/java/io/questdb/test/std/datetime/millitime/DatesTest.java
@@ -127,6 +127,22 @@ public class DatesTest {
     }
 
     @Test
+    public void testAddYearsLeapFeb29Backward() {
+        // Feb 29 in leap year - 1y clamps to Feb 28 in non-leap year
+        long millis = DateFormatUtils.parseUTCDate("2024-02-29T12:30:00.000Z");
+        DateFormatUtils.appendDateTime(sink, Dates.addYears(millis, -1));
+        TestUtils.assertEquals("2023-02-28T12:30:00.000Z", sink);
+    }
+
+    @Test
+    public void testAddYearsLeapFeb29Forward() {
+        // Feb 29 in leap year + 1y clamps to Feb 28 in non-leap year
+        long millis = DateFormatUtils.parseUTCDate("2024-02-29T12:30:00.000Z");
+        DateFormatUtils.appendDateTime(sink, Dates.addYears(millis, 1));
+        TestUtils.assertEquals("2025-02-28T12:30:00.000Z", sink);
+    }
+
+    @Test
     public void testAddYearsNonLeapToLeap() {
         long millis = DateFormatUtils.parseUTCDate("2015-01-01T00:00:00.000Z");
         DateFormatUtils.appendDateTime(sink, Dates.addYears(millis, 1));

--- a/core/src/test/java/io/questdb/test/std/datetime/nanotime/NanosTest.java
+++ b/core/src/test/java/io/questdb/test/std/datetime/nanotime/NanosTest.java
@@ -106,6 +106,24 @@ public class NanosTest {
     }
 
     @Test
+    public void testAddYearsLeapFeb29Backward() {
+        // Feb 29 in leap year - 1y clamps to Feb 28 in non-leap year
+        assertNanos(
+                "2023-02-28T12:30:00.123456789Z",
+                Nanos.addYears(parseNSecUTC("2024-02-29T12:30:00.123456789Z"), -1)
+        );
+    }
+
+    @Test
+    public void testAddYearsLeapFeb29Forward() {
+        // Feb 29 in leap year + 1y clamps to Feb 28 in non-leap year
+        assertNanos(
+                "2025-02-28T12:30:00.123456789Z",
+                Nanos.addYears(parseNSecUTC("2024-02-29T12:30:00.123456789Z"), 1)
+        );
+    }
+
+    @Test
     public void testAddYearsNonLeapToLeap() {
         assertNanos(
                 "2016-01-01T00:00:00.878901304Z",


### PR DESCRIPTION
Fixes #6950

## Summary
- Allow signed duration segments when parsing/compiling tick expressions (e.g., `timestamp in '2026-01;-3d'`)
- Normalize intervals when durations move backwards so static and compiled paths produce matching results
- Fix `emitSingleVar` compiled path that produced inverted intervals for non-day-level variables like `$now;-1h`
- Fix `addYears` day-of-month clamping in Micros, Nanos, and Dates (e.g., Feb 29 + 1y now correctly produces Feb 28 instead of Mar 1)
- Fix calendar drift in repeating month/year intervals by computing each interval from the base timestamp instead of iterating
- Reject non-positive count in repeating interval syntax with a clear error message
- Add regression coverage for negative durations across static, compiled, calendar, repeating, and exchange calendar paths

## Testing
- `mvn -pl core -Dtest=io.questdb.test.griffin.model.TickExprTest test`
- `mvn -pl core -Dtest=io.questdb.test.griffin.model.TickCalendarTest test`
- `mvn -pl core -Dtest=io.questdb.test.std.datetime.microtime.MicrosTest,io.questdb.test.std.datetime.nanotime.NanosTest,io.questdb.test.std.datetime.millitime.DatesTest test`