### PR TITLE
perf(sql): speed up simple single column GROUP BY queries

### DIFF
--- a/core/src/main/java/io/questdb/cairo/map/Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Map.java
@@ -25,6 +25,7 @@
 package io.questdb.cairo.map;
 
 import io.questdb.cairo.Reopenable;
+import io.questdb.griffin.engine.table.GroupByMapFragment;
 import io.questdb.std.Mutable;
 import org.jetbrains.annotations.TestOnly;
 
@@ -34,6 +35,46 @@ public interface Map extends Mutable, Closeable, Reopenable {
 
     @Override
     void close();
+
+    /**
+     * Fast path for {@code count(*)} aggregation over a single fixed-size
+     * column key. Reads {@code rowCount} keys from the column data at
+     * {@code dataAddr}, hashes and probes the map for each key, and
+     * increments a LONG count slot at {@code countByteOffset} within each
+     * entry. Bypasses the MapKey/MapValue/RecordSink/FunctionUpdater layers.
+     * <p>
+     * Throws {@link UnsupportedOperationException} if the map type does not
+     * support this fast path.
+     */
+    default void countByFixedSizeColumn(long dataAddr, long rowCount, int countByteOffset) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Filtered variant of {@link #countByFixedSizeColumn}. Reads keys at row
+     * indices listed in {@code rowsAddr} (an array of {@code rowCount} 8-byte
+     * row indices into the column).
+     */
+    default void countByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount, int countByteOffset) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Fast path for {@code SELECT key FROM ... GROUP BY key} (no aggregates)
+     * over a single fixed-size column key. Inserts each key from the column
+     * into the map without any value updates. See {@link #countByFixedSizeColumn}
+     * for parameter semantics.
+     */
+    default void distinctByFixedSizeColumn(long dataAddr, long rowCount) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Filtered variant of {@link #distinctByFixedSizeColumn}.
+     */
+    default void distinctByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount) {
+        throw new UnsupportedOperationException();
+    }
 
     MapRecordCursor getCursor();
 
@@ -71,6 +112,36 @@ public interface Map extends Mutable, Closeable, Reopenable {
     void restoreInitialCapacity();
 
     void setKeyCapacity(int keyCapacity);
+
+    /**
+     * Sharded variant of {@link #countByFixedSizeColumn}. Hashes each key
+     * upfront and dispatches it to the right shard map via
+     * {@link GroupByMapFragment#getShardMap(long)}.
+     */
+    default void shardedCountByFixedSizeColumn(long dataAddr, long rowCount, int countByteOffset, GroupByMapFragment fragment) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Sharded + filtered variant of {@link #countByFixedSizeColumn}.
+     */
+    default void shardedCountByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount, int countByteOffset, GroupByMapFragment fragment) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Sharded variant of {@link #distinctByFixedSizeColumn}.
+     */
+    default void shardedDistinctByFixedSizeColumn(long dataAddr, long rowCount, GroupByMapFragment fragment) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Sharded + filtered variant of {@link #distinctByFixedSizeColumn}.
+     */
+    default void shardedDistinctByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount, GroupByMapFragment fragment) {
+        throw new UnsupportedOperationException();
+    }
 
     long size();
 

--- a/core/src/main/java/io/questdb/cairo/map/OrderedMap.java
+++ b/core/src/main/java/io/questdb/cairo/map/OrderedMap.java
@@ -36,6 +36,7 @@ import io.questdb.cairo.arr.ArrayView;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.griffin.engine.LimitOverflowException;
+import io.questdb.griffin.engine.table.GroupByMapFragment;
 import io.questdb.std.BinarySequence;
 import io.questdb.std.Decimal128;
 import io.questdb.std.Decimal256;
@@ -287,6 +288,44 @@ public class OrderedMap implements Map, Reopenable {
         }
     }
 
+    @Override
+    public void countByFixedSizeColumn(long dataAddr, long rowCount, int countByteOffset) {
+        assert keySize > 0;
+        for (long p = 0; p < rowCount; p++) {
+            final long keyAddr = dataAddr + p * keySize;
+            insertOrIncrementFixedSizeKeyWithHash(keyAddr, Hash.hashMem64(keyAddr, keySize), countByteOffset);
+        }
+    }
+
+    @Override
+    public void countByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount, int countByteOffset) {
+        assert keySize > 0;
+        for (long p = 0; p < rowCount; p++) {
+            final long rowId = Unsafe.getUnsafe().getLong(rowsAddr + (p << 3));
+            final long keyAddr = dataAddr + rowId * keySize;
+            insertOrIncrementFixedSizeKeyWithHash(keyAddr, Hash.hashMem64(keyAddr, keySize), countByteOffset);
+        }
+    }
+
+    @Override
+    public void distinctByFixedSizeColumn(long dataAddr, long rowCount) {
+        assert keySize > 0;
+        for (long p = 0; p < rowCount; p++) {
+            final long keyAddr = dataAddr + p * keySize;
+            insertDistinctFixedSizeKeyWithHash(keyAddr, Hash.hashMem64(keyAddr, keySize));
+        }
+    }
+
+    @Override
+    public void distinctByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount) {
+        assert keySize > 0;
+        for (long p = 0; p < rowCount; p++) {
+            final long rowId = Unsafe.getUnsafe().getLong(rowsAddr + (p << 3));
+            final long keyAddr = dataAddr + rowId * keySize;
+            insertDistinctFixedSizeKeyWithHash(keyAddr, Hash.hashMem64(keyAddr, keySize));
+        }
+    }
+
     public long getAppendOffset() {
         return kPos;
     }
@@ -376,6 +415,52 @@ public class OrderedMap implements Map, Reopenable {
             throw CairoException.nonCritical().put("map capacity overflow");
         }
         rehash(Numbers.ceilPow2((int) requiredCapacity));
+    }
+
+    @Override
+    public void shardedCountByFixedSizeColumn(long dataAddr, long rowCount, int countByteOffset, GroupByMapFragment fragment) {
+        assert keySize > 0;
+        for (long p = 0; p < rowCount; p++) {
+            final long keyAddr = dataAddr + p * keySize;
+            final long hash = Hash.hashMem64(keyAddr, keySize);
+            final OrderedMap shard = (OrderedMap) fragment.getShardMap(hash);
+            shard.insertOrIncrementFixedSizeKeyWithHash(keyAddr, hash, countByteOffset);
+        }
+    }
+
+    @Override
+    public void shardedCountByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount, int countByteOffset, GroupByMapFragment fragment) {
+        assert keySize > 0;
+        for (long p = 0; p < rowCount; p++) {
+            final long rowId = Unsafe.getUnsafe().getLong(rowsAddr + (p << 3));
+            final long keyAddr = dataAddr + rowId * keySize;
+            final long hash = Hash.hashMem64(keyAddr, keySize);
+            final OrderedMap shard = (OrderedMap) fragment.getShardMap(hash);
+            shard.insertOrIncrementFixedSizeKeyWithHash(keyAddr, hash, countByteOffset);
+        }
+    }
+
+    @Override
+    public void shardedDistinctByFixedSizeColumn(long dataAddr, long rowCount, GroupByMapFragment fragment) {
+        assert keySize > 0;
+        for (long p = 0; p < rowCount; p++) {
+            final long keyAddr = dataAddr + p * keySize;
+            final long hash = Hash.hashMem64(keyAddr, keySize);
+            final OrderedMap shard = (OrderedMap) fragment.getShardMap(hash);
+            shard.insertDistinctFixedSizeKeyWithHash(keyAddr, hash);
+        }
+    }
+
+    @Override
+    public void shardedDistinctByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount, GroupByMapFragment fragment) {
+        assert keySize > 0;
+        for (long p = 0; p < rowCount; p++) {
+            final long rowId = Unsafe.getUnsafe().getLong(rowsAddr + (p << 3));
+            final long keyAddr = dataAddr + rowId * keySize;
+            final long hash = Hash.hashMem64(keyAddr, keySize);
+            final OrderedMap shard = (OrderedMap) fragment.getShardMap(hash);
+            shard.insertDistinctFixedSizeKeyWithHash(keyAddr, hash);
+        }
     }
 
     @Override
@@ -649,6 +734,96 @@ public class OrderedMap implements Map, Reopenable {
 
     private OrderedMapValue valueOf(long startAddr, long valueAddr, boolean newValue, OrderedMapValue value) {
         return value.of(startAddr, valueAddr, heapLimit, newValue);
+    }
+
+    /**
+     * Inserts the key bytes at {@code keyAddr} (with precomputed {@code hashCode})
+     * if not already present. Used by the no-aggregate (distinct) fast paths.
+     * Caller must ensure the map has a single fixed-size key column.
+     */
+    void insertDistinctFixedSizeKeyWithHash(long keyAddr, long hashCode) {
+        int hashCodeLo = Numbers.decodeLowInt(hashCode);
+        int index = hashCodeLo & mask;
+        long offsetAddr = offsetsAddr + ((long) index << 3);
+        long slotValue = Unsafe.getUnsafe().getLong(offsetAddr);
+        int rawOffset = Numbers.decodeLowInt(slotValue);
+        while (rawOffset > 0) {
+            if (hashCodeLo == Numbers.decodeHighInt(slotValue)) {
+                long offset = decompressOffset(rawOffset);
+                if (Vect.memeq(heapAddr + offset, keyAddr, keySize)) {
+                    return;
+                }
+            }
+            index = (index + 1) & mask;
+            offsetAddr = offsetsAddr + ((long) index << 3);
+            slotValue = Unsafe.getUnsafe().getLong(offsetAddr);
+            rawOffset = Numbers.decodeLowInt(slotValue);
+        }
+        final long entrySize = keySize + valueSize;
+        if (kPos + entrySize > heapLimit) {
+            resize(entrySize, kPos);
+        }
+        Vect.memcpy(kPos, keyAddr, keySize);
+        Unsafe.getUnsafe().putInt(offsetAddr, compressOffset(kPos - heapAddr));
+        Unsafe.getUnsafe().putInt(offsetAddr + 4, hashCodeLo);
+        kPos = Bytes.align8b(kPos + entrySize);
+        size++;
+        if (--free == 0) {
+            try {
+                rehash();
+            } catch (CairoException e) {
+                free = 1;
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Inserts the key bytes at {@code keyAddr} (with precomputed {@code hashCode})
+     * if not already present, or increments the LONG count slot at
+     * {@code countByteOffset} within the entry. Used by the {@code count(*)}
+     * fast paths. Caller must ensure the map has a single fixed-size key column
+     * and a LONG value column at {@code countByteOffset}.
+     */
+    void insertOrIncrementFixedSizeKeyWithHash(long keyAddr, long hashCode, int countByteOffset) {
+        int hashCodeLo = Numbers.decodeLowInt(hashCode);
+        int index = hashCodeLo & mask;
+        long offsetAddr = offsetsAddr + ((long) index << 3);
+        long slotValue = Unsafe.getUnsafe().getLong(offsetAddr);
+        int rawOffset = Numbers.decodeLowInt(slotValue);
+        while (rawOffset > 0) {
+            if (hashCodeLo == Numbers.decodeHighInt(slotValue)) {
+                long offset = decompressOffset(rawOffset);
+                long entryAddr = heapAddr + offset;
+                if (Vect.memeq(entryAddr, keyAddr, keySize)) {
+                    final long countAddr = entryAddr + countByteOffset;
+                    Unsafe.getUnsafe().putLong(countAddr, Unsafe.getUnsafe().getLong(countAddr) + 1L);
+                    return;
+                }
+            }
+            index = (index + 1) & mask;
+            offsetAddr = offsetsAddr + ((long) index << 3);
+            slotValue = Unsafe.getUnsafe().getLong(offsetAddr);
+            rawOffset = Numbers.decodeLowInt(slotValue);
+        }
+        final long entrySize = keySize + valueSize;
+        if (kPos + entrySize > heapLimit) {
+            resize(entrySize, kPos);
+        }
+        Vect.memcpy(kPos, keyAddr, keySize);
+        Unsafe.getUnsafe().putLong(kPos + countByteOffset, 1L);
+        Unsafe.getUnsafe().putInt(offsetAddr, compressOffset(kPos - heapAddr));
+        Unsafe.getUnsafe().putInt(offsetAddr + 4, hashCodeLo);
+        kPos = Bytes.align8b(kPos + entrySize);
+        size++;
+        if (--free == 0) {
+            try {
+                rehash();
+            } catch (CairoException e) {
+                free = 1;
+                throw e;
+            }
+        }
     }
 
     long keySize() {

--- a/core/src/main/java/io/questdb/cairo/map/Unordered4Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered4Map.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.arr.ArrayView;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.griffin.engine.LimitOverflowException;
+import io.questdb.griffin.engine.table.GroupByMapFragment;
 import io.questdb.std.BinarySequence;
 import io.questdb.std.Decimal128;
 import io.questdb.std.Decimal256;
@@ -207,6 +208,40 @@ public class Unordered4Map implements Map, Reopenable {
     }
 
     @Override
+    public void countByFixedSizeColumn(long dataAddr, long rowCount, int countByteOffset) {
+        for (long p = 0; p < rowCount; p++) {
+            final int k = Unsafe.getUnsafe().getInt(dataAddr + (p << 2));
+            insertOrIncrementWithHash(k, Hash.hashInt64(k), countByteOffset);
+        }
+    }
+
+    @Override
+    public void countByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount, int countByteOffset) {
+        for (long p = 0; p < rowCount; p++) {
+            final long rowId = Unsafe.getUnsafe().getLong(rowsAddr + (p << 3));
+            final int k = Unsafe.getUnsafe().getInt(dataAddr + (rowId << 2));
+            insertOrIncrementWithHash(k, Hash.hashInt64(k), countByteOffset);
+        }
+    }
+
+    @Override
+    public void distinctByFixedSizeColumn(long dataAddr, long rowCount) {
+        for (long p = 0; p < rowCount; p++) {
+            final int k = Unsafe.getUnsafe().getInt(dataAddr + (p << 2));
+            insertDistinctWithHash(k, Hash.hashInt64(k));
+        }
+    }
+
+    @Override
+    public void distinctByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount) {
+        for (long p = 0; p < rowCount; p++) {
+            final long rowId = Unsafe.getUnsafe().getLong(rowsAddr + (p << 3));
+            final int k = Unsafe.getUnsafe().getInt(dataAddr + (rowId << 2));
+            insertDistinctWithHash(k, Hash.hashInt64(k));
+        }
+    }
+
+    @Override
     public MapRecordCursor getCursor() {
         if (hasZero) {
             return cursor.init(memStart, memLimit, zeroMemStart, size + 1);
@@ -341,6 +376,48 @@ public class Unordered4Map implements Map, Reopenable {
     }
 
     @Override
+    public void shardedCountByFixedSizeColumn(long dataAddr, long rowCount, int countByteOffset, GroupByMapFragment fragment) {
+        for (long p = 0; p < rowCount; p++) {
+            final int k = Unsafe.getUnsafe().getInt(dataAddr + (p << 2));
+            final long hash = Hash.hashInt64(k);
+            final Unordered4Map shard = (Unordered4Map) fragment.getShardMap(hash);
+            shard.insertOrIncrementWithHash(k, hash, countByteOffset);
+        }
+    }
+
+    @Override
+    public void shardedCountByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount, int countByteOffset, GroupByMapFragment fragment) {
+        for (long p = 0; p < rowCount; p++) {
+            final long rowId = Unsafe.getUnsafe().getLong(rowsAddr + (p << 3));
+            final int k = Unsafe.getUnsafe().getInt(dataAddr + (rowId << 2));
+            final long hash = Hash.hashInt64(k);
+            final Unordered4Map shard = (Unordered4Map) fragment.getShardMap(hash);
+            shard.insertOrIncrementWithHash(k, hash, countByteOffset);
+        }
+    }
+
+    @Override
+    public void shardedDistinctByFixedSizeColumn(long dataAddr, long rowCount, GroupByMapFragment fragment) {
+        for (long p = 0; p < rowCount; p++) {
+            final int k = Unsafe.getUnsafe().getInt(dataAddr + (p << 2));
+            final long hash = Hash.hashInt64(k);
+            final Unordered4Map shard = (Unordered4Map) fragment.getShardMap(hash);
+            shard.insertDistinctWithHash(k, hash);
+        }
+    }
+
+    @Override
+    public void shardedDistinctByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount, GroupByMapFragment fragment) {
+        for (long p = 0; p < rowCount; p++) {
+            final long rowId = Unsafe.getUnsafe().getLong(rowsAddr + (p << 3));
+            final int k = Unsafe.getUnsafe().getInt(dataAddr + (rowId << 2));
+            final long hash = Hash.hashInt64(k);
+            final Unordered4Map shard = (Unordered4Map) fragment.getShardMap(hash);
+            shard.insertDistinctWithHash(k, hash);
+        }
+    }
+
+    @Override
     public long size() {
         return hasZero ? size + 1 : size;
     }
@@ -449,6 +526,83 @@ public class Unordered4Map implements Map, Reopenable {
 
     long entrySize() {
         return entrySize;
+    }
+
+    /**
+     * Inserts {@code k} (with precomputed {@code hash}) if not already
+     * present. Used by the no-aggregate (distinct) fast paths.
+     */
+    void insertDistinctWithHash(int k, long hash) {
+        if (k == 0) {
+            hasZero = true;
+            return;
+        }
+        long startAddress = memStart + (hash & mask) * entrySize;
+        for (; ; ) {
+            int existing = Unsafe.getUnsafe().getInt(startAddress);
+            if (existing == 0) {
+                Unsafe.getUnsafe().putInt(startAddress, k);
+                size++;
+                if (--free == 0) {
+                    try {
+                        rehash();
+                    } catch (CairoException e) {
+                        free = 1;
+                        throw e;
+                    }
+                }
+                return;
+            } else if (existing == k) {
+                return;
+            }
+            startAddress += entrySize;
+            if (startAddress >= memLimit) {
+                startAddress = memStart;
+            }
+        }
+    }
+
+    /**
+     * Inserts {@code k} (with precomputed {@code hash}) or increments its
+     * count slot by 1. Used by the {@code count(*)} fast paths.
+     */
+    void insertOrIncrementWithHash(int k, long hash, int countByteOffset) {
+        if (k == 0) {
+            final long zeroCountAddr = zeroMemStart + countByteOffset;
+            if (hasZero) {
+                Unsafe.getUnsafe().putLong(zeroCountAddr, Unsafe.getUnsafe().getLong(zeroCountAddr) + 1);
+            } else {
+                hasZero = true;
+                Unsafe.getUnsafe().putLong(zeroCountAddr, 1L);
+            }
+            return;
+        }
+        long startAddress = memStart + (hash & mask) * entrySize;
+        for (; ; ) {
+            int existing = Unsafe.getUnsafe().getInt(startAddress);
+            if (existing == 0) {
+                Unsafe.getUnsafe().putInt(startAddress, k);
+                Unsafe.getUnsafe().putLong(startAddress + countByteOffset, 1L);
+                size++;
+                if (--free == 0) {
+                    try {
+                        rehash();
+                    } catch (CairoException e) {
+                        free = 1;
+                        throw e;
+                    }
+                }
+                return;
+            } else if (existing == k) {
+                final long countAddr = startAddress + countByteOffset;
+                Unsafe.getUnsafe().putLong(countAddr, Unsafe.getUnsafe().getLong(countAddr) + 1);
+                return;
+            }
+            startAddress += entrySize;
+            if (startAddress >= memLimit) {
+                startAddress = memStart;
+            }
+        }
     }
 
     boolean isZeroKey(long startAddress) {

--- a/core/src/main/java/io/questdb/cairo/map/Unordered8Map.java
+++ b/core/src/main/java/io/questdb/cairo/map/Unordered8Map.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.arr.ArrayView;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.griffin.engine.LimitOverflowException;
+import io.questdb.griffin.engine.table.GroupByMapFragment;
 import io.questdb.std.BinarySequence;
 import io.questdb.std.Decimal128;
 import io.questdb.std.Decimal256;
@@ -208,6 +209,40 @@ public class Unordered8Map implements Map, Reopenable {
     }
 
     @Override
+    public void countByFixedSizeColumn(long dataAddr, long rowCount, int countByteOffset) {
+        for (long p = 0; p < rowCount; p++) {
+            final long k = Unsafe.getUnsafe().getLong(dataAddr + (p << 3));
+            insertOrIncrementWithHash(k, Hash.hashLong64(k), countByteOffset);
+        }
+    }
+
+    @Override
+    public void countByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount, int countByteOffset) {
+        for (long p = 0; p < rowCount; p++) {
+            final long rowId = Unsafe.getUnsafe().getLong(rowsAddr + (p << 3));
+            final long k = Unsafe.getUnsafe().getLong(dataAddr + (rowId << 3));
+            insertOrIncrementWithHash(k, Hash.hashLong64(k), countByteOffset);
+        }
+    }
+
+    @Override
+    public void distinctByFixedSizeColumn(long dataAddr, long rowCount) {
+        for (long p = 0; p < rowCount; p++) {
+            final long k = Unsafe.getUnsafe().getLong(dataAddr + (p << 3));
+            insertDistinctWithHash(k, Hash.hashLong64(k));
+        }
+    }
+
+    @Override
+    public void distinctByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount) {
+        for (long p = 0; p < rowCount; p++) {
+            final long rowId = Unsafe.getUnsafe().getLong(rowsAddr + (p << 3));
+            final long k = Unsafe.getUnsafe().getLong(dataAddr + (rowId << 3));
+            insertDistinctWithHash(k, Hash.hashLong64(k));
+        }
+    }
+
+    @Override
     public MapRecordCursor getCursor() {
         if (hasZero) {
             return cursor.init(memStart, memLimit, zeroMemStart, size + 1);
@@ -341,6 +376,48 @@ public class Unordered8Map implements Map, Reopenable {
     }
 
     @Override
+    public void shardedCountByFixedSizeColumn(long dataAddr, long rowCount, int countByteOffset, GroupByMapFragment fragment) {
+        for (long p = 0; p < rowCount; p++) {
+            final long k = Unsafe.getUnsafe().getLong(dataAddr + (p << 3));
+            final long hash = Hash.hashLong64(k);
+            final Unordered8Map shard = (Unordered8Map) fragment.getShardMap(hash);
+            shard.insertOrIncrementWithHash(k, hash, countByteOffset);
+        }
+    }
+
+    @Override
+    public void shardedCountByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount, int countByteOffset, GroupByMapFragment fragment) {
+        for (long p = 0; p < rowCount; p++) {
+            final long rowId = Unsafe.getUnsafe().getLong(rowsAddr + (p << 3));
+            final long k = Unsafe.getUnsafe().getLong(dataAddr + (rowId << 3));
+            final long hash = Hash.hashLong64(k);
+            final Unordered8Map shard = (Unordered8Map) fragment.getShardMap(hash);
+            shard.insertOrIncrementWithHash(k, hash, countByteOffset);
+        }
+    }
+
+    @Override
+    public void shardedDistinctByFixedSizeColumn(long dataAddr, long rowCount, GroupByMapFragment fragment) {
+        for (long p = 0; p < rowCount; p++) {
+            final long k = Unsafe.getUnsafe().getLong(dataAddr + (p << 3));
+            final long hash = Hash.hashLong64(k);
+            final Unordered8Map shard = (Unordered8Map) fragment.getShardMap(hash);
+            shard.insertDistinctWithHash(k, hash);
+        }
+    }
+
+    @Override
+    public void shardedDistinctByFixedSizeColumnFiltered(long dataAddr, long rowsAddr, long rowCount, GroupByMapFragment fragment) {
+        for (long p = 0; p < rowCount; p++) {
+            final long rowId = Unsafe.getUnsafe().getLong(rowsAddr + (p << 3));
+            final long k = Unsafe.getUnsafe().getLong(dataAddr + (rowId << 3));
+            final long hash = Hash.hashLong64(k);
+            final Unordered8Map shard = (Unordered8Map) fragment.getShardMap(hash);
+            shard.insertDistinctWithHash(k, hash);
+        }
+    }
+
+    @Override
     public long size() {
         return hasZero ? size + 1 : size;
     }
@@ -449,6 +526,83 @@ public class Unordered8Map implements Map, Reopenable {
 
     long entrySize() {
         return entrySize;
+    }
+
+    /**
+     * Inserts {@code k} (with precomputed {@code hash}) if not already
+     * present. Used by the no-aggregate (distinct) fast paths.
+     */
+    void insertDistinctWithHash(long k, long hash) {
+        if (k == 0) {
+            hasZero = true;
+            return;
+        }
+        long startAddress = memStart + (hash & mask) * entrySize;
+        for (; ; ) {
+            long existing = Unsafe.getUnsafe().getLong(startAddress);
+            if (existing == 0) {
+                Unsafe.getUnsafe().putLong(startAddress, k);
+                size++;
+                if (--free == 0) {
+                    try {
+                        rehash();
+                    } catch (CairoException e) {
+                        free = 1;
+                        throw e;
+                    }
+                }
+                return;
+            } else if (existing == k) {
+                return;
+            }
+            startAddress += entrySize;
+            if (startAddress >= memLimit) {
+                startAddress = memStart;
+            }
+        }
+    }
+
+    /**
+     * Inserts {@code k} (with precomputed {@code hash}) or increments its
+     * count slot by 1. Used by the {@code count(*)} fast paths.
+     */
+    void insertOrIncrementWithHash(long k, long hash, int countByteOffset) {
+        if (k == 0) {
+            final long zeroCountAddr = zeroMemStart + countByteOffset;
+            if (hasZero) {
+                Unsafe.getUnsafe().putLong(zeroCountAddr, Unsafe.getUnsafe().getLong(zeroCountAddr) + 1);
+            } else {
+                hasZero = true;
+                Unsafe.getUnsafe().putLong(zeroCountAddr, 1L);
+            }
+            return;
+        }
+        long startAddress = memStart + (hash & mask) * entrySize;
+        for (; ; ) {
+            long existing = Unsafe.getUnsafe().getLong(startAddress);
+            if (existing == 0) {
+                Unsafe.getUnsafe().putLong(startAddress, k);
+                Unsafe.getUnsafe().putLong(startAddress + countByteOffset, 1L);
+                size++;
+                if (--free == 0) {
+                    try {
+                        rehash();
+                    } catch (CairoException e) {
+                        free = 1;
+                        throw e;
+                    }
+                }
+                return;
+            } else if (existing == k) {
+                final long countAddr = startAddress + countByteOffset;
+                Unsafe.getUnsafe().putLong(countAddr, Unsafe.getUnsafe().getLong(countAddr) + 1);
+                return;
+            }
+            startAddress += entrySize;
+            if (startAddress >= memLimit) {
+                startAddress = memStart;
+            }
+        }
     }
 
     boolean isZeroKey(long startAddress) {

--- a/core/src/main/java/io/questdb/cairo/map/UnorderedVarcharMap.java
+++ b/core/src/main/java/io/questdb/cairo/map/UnorderedVarcharMap.java
@@ -401,6 +401,13 @@ public class UnorderedVarcharMap implements Map, Reopenable {
         return key.init();
     }
 
+    /**
+     * When comparing hash and size for equality, we want to ignore ascii vs non-ascii flag, since it doesn't affect hash collisions or key equality checks.
+     */
+    private static long makePackComparable(long packedHashSizeFlags) {
+        return packedHashSizeFlags & 0x7fffffffffffffffL;
+    }
+
     private UnorderedVarcharMapValue asNew(
             long startAddress,
             long hash,
@@ -486,13 +493,6 @@ public class UnorderedVarcharMap implements Map, Reopenable {
                 }
             }
         }
-    }
-
-    /**
-     * When comparing hash and size for equality, we want to ignore ascii vs non-ascii flag, since it doesn't affect hash collisions or key equality checks.
-     */
-    private static long makePackComparable(long packedHashSizeFlags) {
-        return packedHashSizeFlags & 0x7fffffffffffffffL;
     }
 
     private UnorderedVarcharMapValue probeReadOnly(long startAddress, long ptr, long size, long packedHashSizeFlagsToFind, UnorderedVarcharMapValue value) {

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -7472,8 +7472,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 if (columnExpr.type == FUNCTION && columnExpr.paramCount == 0 && isCountKeyword(columnExpr.token)) {
                     // check if count() was not aliased, if it was, we need to generate new baseMetadata, bummer
                     final RecordMetadata metadata = isCountKeyword(columnName)
-                            ? CountRecordCursorFactory.DEFAULT_COUNT_METADATA :
-                            new GenericRecordMetadata().add(new TableColumnMetadata(Chars.toString(columnName), LONG));
+                            ? CountRecordCursorFactory.DEFAULT_COUNT_METADATA
+                            : new GenericRecordMetadata().add(new TableColumnMetadata(Chars.toString(columnName), LONG));
                     return new CountRecordCursorFactory(metadata, generateSubQuery(model, executionContext));
                 }
             }

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByAtom.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.ArrayColumnTypes;
 import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.ColumnTypes;
 import io.questdb.cairo.ListColumnFilter;
 import io.questdb.cairo.RecordSink;
@@ -43,6 +44,7 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.PerWorkerLocks;
 import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.groupby.CountLongConstGroupByFunction;
 import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.griffin.engine.groupby.GroupByAllocatorFactory;
 import io.questdb.griffin.engine.groupby.GroupByFunctionsUpdater;
@@ -63,6 +65,24 @@ import java.io.Closeable;
 
 
 public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Plannable {
+    /**
+     * {@code count(*)} over a single fixed-size column key.
+     */
+    public static final int FAST_PATH_COUNT = 1;
+    /**
+     * No-aggregate {@code SELECT key FROM ... GROUP BY key} over a single fixed-size column key.
+     */
+    public static final int FAST_PATH_DISTINCT = 2;
+    /**
+     * No fast path applies.
+     */
+    public static final int FAST_PATH_NONE = 0;
+    // When fastPathMode != FAST_PATH_NONE, the base record column index of
+    // the single-column key. -1 otherwise.
+    private final int fastPathColumnIndex;
+    // Byte offset of the count value within an entry (used by FAST_PATH_COUNT).
+    private final int fastPathCountByteOffset;
+    private final int fastPathMode;
     private final AsyncFilterContext filterCtx;
     private final GroupByAllocator ownerAllocator;
     private final ObjList<GroupByFunction> ownerGroupByFunctions;
@@ -107,6 +127,41 @@ public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Pl
             this.perWorkerKeyFunctions = perWorkerKeyFunctions;
             this.ownerGroupByFunctions = ownerGroupByFunctions;
             this.perWorkerGroupByFunctions = perWorkerGroupByFunctions;
+
+            // Detect fast-path eligibility: single fixed-size column key from
+            // the base record (no computed key) with either no aggregates
+            // (distinct) or only count(*). Fixed-size keys (INT, LONG, IPv4,
+            // SYMBOL, TIMESTAMP, DATE, LONG128, LONG256, etc.) end up in
+            // Unordered4Map, Unordered8Map, or OrderedMap, all of which
+            // implement the fast-path Map methods. The detection only matches
+            // count() / count(*) — other count() forms map to different
+            // GroupByFunction subclasses and stay on the slow path.
+            int fpMode = FAST_PATH_NONE;
+            int fpColumnIndex = -1;
+            int fpCountByteOffset = 0;
+            if (ownerKeyFunctions.size() == 0
+                    && listColumnFilter.size() == 1
+                    && keyTypes.getColumnCount() == 1
+                    && ColumnType.sizeOf(keyTypes.getColumnType(0)) > 0) {
+                final int keyType = keyTypes.getColumnType(0);
+                final int aggCount = ownerGroupByFunctions.size();
+                if (aggCount == 0) {
+                    fpMode = FAST_PATH_DISTINCT;
+                } else if (aggCount == 1 && ownerGroupByFunctions.getQuick(0) instanceof CountLongConstGroupByFunction) {
+                    fpMode = FAST_PATH_COUNT;
+                    // count(*) value lives at byte offset = key size within
+                    // each entry, since the key column comes first and there
+                    // are no other value columns.
+                    fpCountByteOffset = ColumnType.sizeOf(keyType);
+                }
+                if (fpMode != FAST_PATH_NONE) {
+                    // ListColumnFilter encodes 1-based column index with sign bit for sort order.
+                    fpColumnIndex = Math.abs(listColumnFilter.getQuick(0)) - 1;
+                }
+            }
+            this.fastPathMode = fpMode;
+            this.fastPathColumnIndex = fpColumnIndex;
+            this.fastPathCountByteOffset = fpCountByteOffset;
 
             this.filterCtx = new AsyncFilterContext(
                     configuration,
@@ -249,6 +304,18 @@ public class AsyncGroupByAtom implements StatefulAtom, Closeable, Reopenable, Pl
 
     public ObjList<Map> getDestShards() {
         return shardingCtx.getDestShards();
+    }
+
+    public int getFastPathColumnIndex() {
+        return fastPathColumnIndex;
+    }
+
+    public int getFastPathCountByteOffset() {
+        return fastPathCountByteOffset;
+    }
+
+    public int getFastPathMode() {
+        return fastPathMode;
     }
 
     public AsyncFilterContext getFilterContext() {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursorFactory.java
@@ -226,8 +226,30 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
             record.setRowIndex(0);
             long baseRowId = record.getRowId();
 
+            final int fastPathMode = atom.getFastPathMode();
+            final boolean fastPathEligible = fastPathMode != AsyncGroupByAtom.FAST_PATH_NONE && !frameMemory.hasColumnTops();
             if (fragment.isNotSharded()) {
-                aggregateNonSharded(record, frameRowCount, baseRowId, functionUpdater, fragment, mapSink);
+                if (fastPathEligible) {
+                    final Map map = fragment.reopenMap();
+                    final long dataAddr = frameMemory.getPageAddress(atom.getFastPathColumnIndex());
+                    if (fastPathMode == AsyncGroupByAtom.FAST_PATH_COUNT) {
+                        map.countByFixedSizeColumn(dataAddr, frameRowCount, atom.getFastPathCountByteOffset());
+                    } else {
+                        map.distinctByFixedSizeColumn(dataAddr, frameRowCount);
+                    }
+                } else {
+                    aggregateNonSharded(record, frameRowCount, baseRowId, functionUpdater, fragment, mapSink);
+                }
+            } else if (fastPathEligible) {
+                // The first shard's map provides the polymorphic dispatch — its
+                // sharded fast-path method routes each row to the right shard.
+                final Map dispatcher = fragment.getShards().getQuick(0);
+                final long dataAddr = frameMemory.getPageAddress(atom.getFastPathColumnIndex());
+                if (fastPathMode == AsyncGroupByAtom.FAST_PATH_COUNT) {
+                    dispatcher.shardedCountByFixedSizeColumn(dataAddr, frameRowCount, atom.getFastPathCountByteOffset(), fragment);
+                } else {
+                    dispatcher.shardedDistinctByFixedSizeColumn(dataAddr, frameRowCount, fragment);
+                }
             } else {
                 aggregateSharded(record, frameRowCount, baseRowId, functionUpdater, fragment, mapSink);
             }
@@ -430,8 +452,32 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
             record.setRowIndex(0);
             long baseRowId = record.getRowId();
 
+            final int fastPathMode = atom.getFastPathMode();
+            final boolean fastPathEligible = fastPathMode != AsyncGroupByAtom.FAST_PATH_NONE && !frameMemory.hasColumnTops();
             if (fragment.isNotSharded()) {
-                aggregateFilteredNonSharded(record, rows, baseRowId, functionUpdater, fragment, mapSink);
+                if (fastPathEligible) {
+                    final Map map = fragment.reopenMap();
+                    final long dataAddr = frameMemory.getPageAddress(atom.getFastPathColumnIndex());
+                    final long rowsAddr = rows.getAddress();
+                    final long rowCount = rows.size();
+                    if (fastPathMode == AsyncGroupByAtom.FAST_PATH_COUNT) {
+                        map.countByFixedSizeColumnFiltered(dataAddr, rowsAddr, rowCount, atom.getFastPathCountByteOffset());
+                    } else {
+                        map.distinctByFixedSizeColumnFiltered(dataAddr, rowsAddr, rowCount);
+                    }
+                } else {
+                    aggregateFilteredNonSharded(record, rows, baseRowId, functionUpdater, fragment, mapSink);
+                }
+            } else if (fastPathEligible) {
+                final Map dispatcher = fragment.getShards().getQuick(0);
+                final long dataAddr = frameMemory.getPageAddress(atom.getFastPathColumnIndex());
+                final long rowsAddr = rows.getAddress();
+                final long rowCount = rows.size();
+                if (fastPathMode == AsyncGroupByAtom.FAST_PATH_COUNT) {
+                    dispatcher.shardedCountByFixedSizeColumnFiltered(dataAddr, rowsAddr, rowCount, atom.getFastPathCountByteOffset(), fragment);
+                } else {
+                    dispatcher.shardedDistinctByFixedSizeColumnFiltered(dataAddr, rowsAddr, rowCount, fragment);
+                }
             } else {
                 aggregateFilteredSharded(record, rows, baseRowId, functionUpdater, fragment, mapSink);
             }


### PR DESCRIPTION
WIP (evening experiment)

```sql
-- Rosti 27ms
-- master's Java path 32ms
-- patch's Java path 16ms
SELECT RegionID FROM hits GROUP BY RegionID;

-- Rosti 27ms
-- master's Java path 48ms
-- patch's Java path 18ms
SELECT RegionID, count() FROM hits GROUP BY RegionID;

-- master 317ms
-- patch 276ms (268ms with faster hash function)
SELECT count_distinct(UserID) FROM hits;

-- master 446ms
-- patch 313ms (307ms with faster hash function)
SELECT UserID, COUNT(*) AS c FROM hits GROUP BY UserID ORDER BY c DESC LIMIT 10;

-- master 290ms
-- patch 220ms
SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c FROM hits GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3 ORDER BY c DESC LIMIT 10;
```