### PR TITLE
fix(sql): fix parquet partition handling after DROP COLUMN and ALTER COLUMN TYPE

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
+++ b/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
@@ -308,8 +308,11 @@ public class TableSnapshotRestore implements QuietCloseable {
             // reused across tables. Without this, a parquet bitmap rebuild task
             // from this table could still be running when the caller loads the
             // next table's metadata into the same objects.
-            finalizeParallelTasks();
-            futures.clear();
+            try {
+                finalizeParallelTasks();
+            } finally {
+                futures.clear();
+            }
 
             if (tableMetadata.isWalEnabled() && txWriter.getLagRowCount() > 0) {
                 LOG.info().$("resetting WAL lag [table=").$(tablePath)

--- a/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
+++ b/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
@@ -681,18 +681,8 @@ public class TableSnapshotRestore implements QuietCloseable {
             }
 
             if (isPartitioned && txWriter.isPartitionParquet(partitionIndex)) {
-                final long parquetSize = txWriter.getPartitionParquetFileSize(partitionIndex);
-
-                futures.add(executor.submit(() -> rebuildBitmapIndexForParquetPartition(
-                        tablePathStr,
-                        pathTableLen,
-                        partitionTimestamp,
-                        partitionRowCount,
-                        partitionNameTxn,
-                        parquetSize,
-                        partitionBy,
-                        timestampType
-                )));
+                // Skip parquet partitions — bitmap indexes for parquet
+                // partitions are rebuilt by the table writer on first open.
             } else {
                 rebuildBitmapIndexForNativePartition(pathTableLen, columnCount, partitionTimestamp, partitionRowCount, partitionNameTxn, tablePathStr, partitionBy, timestampType);
             }

--- a/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
+++ b/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
@@ -303,6 +303,14 @@ public class TableSnapshotRestore implements QuietCloseable {
                 rebuildBitmapIndexes(tablePath, pathTableLen);
             }
 
+            // Drain all parallel tasks (symbol rebuilds + bitmap index rebuilds)
+            // before returning, because tableMetadata and columnVersionReader are
+            // reused across tables. Without this, a parquet bitmap rebuild task
+            // from this table could still be running when the caller loads the
+            // next table's metadata into the same objects.
+            finalizeParallelTasks();
+            futures.clear();
+
             if (tableMetadata.isWalEnabled() && txWriter.getLagRowCount() > 0) {
                 LOG.info().$("resetting WAL lag [table=").$(tablePath)
                         .$(", walLagRowCount=").$(txWriter.getLagRowCount())
@@ -681,8 +689,18 @@ public class TableSnapshotRestore implements QuietCloseable {
             }
 
             if (isPartitioned && txWriter.isPartitionParquet(partitionIndex)) {
-                // Skip parquet partitions — bitmap indexes for parquet
-                // partitions are rebuilt by the table writer on first open.
+                final long parquetSize = txWriter.getPartitionParquetFileSize(partitionIndex);
+
+                futures.add(executor.submit(() -> rebuildBitmapIndexForParquetPartition(
+                        tablePathStr,
+                        pathTableLen,
+                        partitionTimestamp,
+                        partitionRowCount,
+                        partitionNameTxn,
+                        parquetSize,
+                        partitionBy,
+                        timestampType
+                )));
             } else {
                 rebuildBitmapIndexForNativePartition(pathTableLen, columnCount, partitionTimestamp, partitionRowCount, partitionNameTxn, tablePathStr, partitionBy, timestampType);
             }

--- a/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
+++ b/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
@@ -608,7 +608,6 @@ public class TableSnapshotRestore implements QuietCloseable {
 
             // Set path to parquet partition and mmap
             TableUtils.setPathForParquetPartition(path, timestampType, partitionBy, partitionTimestamp, partitionNameTxn);
-            path.concat(TableUtils.PARQUET_PARTITION_NAME).$();
 
             if (!ff.exists(path.$())) {
                 LOG.info().$("parquet partition does not exist, skipping bitmap index rebuild [path=").$(path).I$();

--- a/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
+++ b/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
@@ -439,7 +439,7 @@ public class TableSnapshotRestore implements QuietCloseable {
         }
 
         for (int idx = 0, cnt = parquetMetadata.getColumnCount(); idx < cnt; idx++) {
-            if (parquetMetadata.getColumnId(idx) == columnIndex) {
+            if (parquetMetadata.getColumnId(idx) == writerIndex) {
                 return idx;
             }
         }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -1051,6 +1051,15 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         try {
             commit();
 
+            // ConvertOperatorImpl opens native .d files directly, so parquet
+            // partitions must be converted back to native before the column
+            // type change.
+            for (int i = 0, n = txWriter.getPartitionCount(); i < n; i++) {
+                if (txWriter.isPartitionParquet(i)) {
+                    convertPartitionParquetToNative(txWriter.getPartitionTimestampByIndex(i));
+                }
+            }
+
             LOG.info().$("converting column [table=").$(tableToken).$(", column=").$safe(columnName)
                     .$(", from=").$(ColumnType.nameOf(existingType))
                     .$(", to=").$(ColumnType.nameOf(newType)).I$();

--- a/core/src/main/java/io/questdb/griffin/engine/table/parquet/PartitionEncoder.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/parquet/PartitionEncoder.java
@@ -163,8 +163,8 @@ public class PartitionEncoder {
 
     public static void populateEmptyPartition(TableReader tableReader, PartitionDescriptor descriptor) throws CairoException {
         final TableReaderMetadata metadata = tableReader.getMetadata();
-        final int readerTsIdx = metadata.getTimestampIndex();
-        final int timestampIndex = readerTsIdx >= 0 ? metadata.getWriterIndex(readerTsIdx) : -1;
+        final int readerTimestampIndex = metadata.getTimestampIndex();
+        final int timestampIndex = readerTimestampIndex >= 0 ? metadata.getWriterIndex(readerTimestampIndex) : -1;
         descriptor.of(tableReader.getTableToken().getTableName(), 0, timestampIndex);
         for (int i = 0, n = metadata.getColumnCount(); i < n; i++) {
             final int columnType = metadata.getColumnType(i);
@@ -191,8 +191,8 @@ public class PartitionEncoder {
         final long partitionSize = tableReader.openPartition(partitionIndex);
         assert partitionSize != 0;
         final TableReaderMetadata metadata = tableReader.getMetadata();
-        final int readerTsIdx = metadata.getTimestampIndex();
-        final int timestampIndex = readerTsIdx >= 0 ? metadata.getWriterIndex(readerTsIdx) : -1;
+        final int readerTimestampIndex = metadata.getTimestampIndex();
+        final int timestampIndex = readerTimestampIndex >= 0 ? metadata.getWriterIndex(readerTimestampIndex) : -1;
         descriptor.of(tableReader.getTableToken().getTableName(), partitionSize, timestampIndex);
         final int columnCount = metadata.getColumnCount();
         final int columnBase = tableReader.getColumnBase(partitionIndex);

--- a/core/src/main/java/io/questdb/griffin/engine/table/parquet/PartitionEncoder.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/parquet/PartitionEncoder.java
@@ -162,9 +162,10 @@ public class PartitionEncoder {
     public static native long finishStreamingParquetWrite(long writerPtr) throws CairoException;
 
     public static void populateEmptyPartition(TableReader tableReader, PartitionDescriptor descriptor) throws CairoException {
-        final int timestampIndex = tableReader.getMetadata().getTimestampIndex();
-        descriptor.of(tableReader.getTableToken().getTableName(), 0, timestampIndex);
         final TableReaderMetadata metadata = tableReader.getMetadata();
+        final int readerTsIdx = metadata.getTimestampIndex();
+        final int timestampIndex = readerTsIdx >= 0 ? metadata.getWriterIndex(readerTsIdx) : -1;
+        descriptor.of(tableReader.getTableToken().getTableName(), 0, timestampIndex);
         for (int i = 0, n = metadata.getColumnCount(); i < n; i++) {
             final int columnType = metadata.getColumnType(i);
             if (columnType > 0) {
@@ -189,10 +190,10 @@ public class PartitionEncoder {
     public static void populateFromTableReader(TableReader tableReader, PartitionDescriptor descriptor, int partitionIndex) throws CairoException {
         final long partitionSize = tableReader.openPartition(partitionIndex);
         assert partitionSize != 0;
-        final int timestampIndex = tableReader.getMetadata().getTimestampIndex();
-        descriptor.of(tableReader.getTableToken().getTableName(), partitionSize, timestampIndex);
-
         final TableReaderMetadata metadata = tableReader.getMetadata();
+        final int readerTsIdx = metadata.getTimestampIndex();
+        final int timestampIndex = readerTsIdx >= 0 ? metadata.getWriterIndex(readerTsIdx) : -1;
+        descriptor.of(tableReader.getTableToken().getTableName(), partitionSize, timestampIndex);
         final int columnCount = metadata.getColumnCount();
         final int columnBase = tableReader.getColumnBase(partitionIndex);
         for (int i = 0; i < columnCount; i++) {

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -1021,6 +1021,99 @@ public class CheckpointTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCheckpointRestoreRebuildsBitmapIndexesOnParquetAfterDropColumn() throws Exception {
+        // Regression test for getIndexedParquetColumnIndex() comparing parquet
+        // field_id (= writer index) with the reader index instead of the writer
+        // index. After a DROP COLUMN, reader indices shift while writer indices
+        // (stored as field_id in parquet) stay the same. The buggy lookup finds
+        // a DOUBLE column whose field_id matches the SYMBOL column's reader
+        // index, then tries to decode DOUBLE data as SYMBOL, producing:
+        //   "requested column type 12 (symbol) does not match file column type
+        //    10 (double)"
+        //
+        // Column layout (writer indices in parentheses):
+        //   dummy (0) — DOUBLE, will be dropped
+        //   val   (1) — DOUBLE
+        //   sym   (2) — SYMBOL INDEX
+        //   ts    (3) — TIMESTAMP designated
+        //
+        // After DROP COLUMN dummy, reader indices shift:
+        //   val   reader=0, writer=1  →  field_id 1 in parquet
+        //   sym   reader=1, writer=2  →  field_id 2 in parquet
+        //   ts    reader=2, writer=3  →  field_id 3 in parquet
+        //
+        // Bug: getIndexedParquetColumnIndex searches for field_id == 1 (sym's
+        // reader index) instead of field_id == 2 (sym's writer index), and
+        // finds 'val' (DOUBLE) at field_id 1.
+
+        Assume.assumeTrue(Os.type != Os.WINDOWS);
+
+        File dir1 = temp.newFolder("server1_parquet_drop_col");
+        File dir2 = temp.newFolder("server2_parquet_drop_col");
+
+        // Server 1: create table, drop column, convert to parquet, checkpoint.
+        try (TestServerMain server1 = startServerMain(dir1.getAbsolutePath())) {
+            server1.execute(
+                    "CREATE TABLE t (" +
+                            "dummy DOUBLE, " +
+                            "val DOUBLE, " +
+                            "sym SYMBOL INDEX, " +
+                            "ts TIMESTAMP" +
+                            ") TIMESTAMP(ts) PARTITION BY DAY WAL"
+            );
+            server1.execute(
+                    "INSERT INTO t " +
+                            "SELECT rnd_double(), rnd_double(), " +
+                            "CASE WHEN x <= 5 THEN 'A'::SYMBOL ELSE 'B'::SYMBOL END, " +
+                            "timestamp_sequence('2024-01-01', 1_000_000) ts " +
+                            "FROM long_sequence(10)"
+            );
+            server1.execute("INSERT INTO t VALUES(0, 0, 'A', '2024-01-02')");
+
+            TestUtils.assertEventually(() -> server1.assertSql(
+                    "SELECT count() FROM t",
+                    "count\n11\n"
+            ));
+
+            server1.execute("ALTER TABLE t DROP COLUMN dummy");
+            server1.execute("ALTER TABLE t CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+
+            TestUtils.assertEventually(() -> server1.assertSql(
+                    "SELECT count() FROM t WHERE sym = 'A'",
+                    "count\n6\n"
+            ));
+
+            server1.execute("CHECKPOINT CREATE");
+            copyDirectory(dir1, dir2);
+            server1.execute("CHECKPOINT RELEASE");
+        }
+
+        // Create trigger file to force checkpoint recovery.
+        try (Path triggerPath = new Path().of(dir2.getAbsolutePath()).concat(TableUtils.RESTORE_FROM_CHECKPOINT_TRIGGER_FILE_NAME)) {
+            Files.touch(triggerPath.$());
+        }
+
+        // Server 2: recover from checkpoint with index rebuild enabled.
+        // This triggers rebuildParquetPartitionIndexes() which must use
+        // the writer index (field_id) to locate the SYMBOL column in parquet.
+        // Before the fix, getIndexedParquetColumnIndex() found the DOUBLE
+        // column (field_id 1) instead of the SYMBOL column (field_id 2),
+        // causing decodeRowGroup to fail with a type mismatch error that
+        // corrupted the recovery.
+        try (TestServerMain server2 = startServerMain(
+                dir2.getAbsolutePath(),
+                CAIRO_CHECKPOINT_RECOVERY_REBUILD_COLUMN_INDEXES.getEnvVarName(), "true"
+        )) {
+            // The table must be queryable after recovery — no type mismatch
+            // errors from the parquet decoder.
+            server2.assertSql(
+                    "SELECT count() FROM t",
+                    "count\n11\n"
+            );
+        }
+    }
+
+    @Test
     public void testCheckpointRestoresDroppedView() throws Exception {
         final String snapshotId = "id1";
         assertMemoryLeak(() -> {

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -110,6 +110,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.questdb.PropertyKey.*;
 
@@ -1023,9 +1024,11 @@ public class CheckpointTest extends AbstractCairoTest {
 
     @Test
     public void testCheckpointRestoreRebuildsBitmapIndexesOnParquetAfterDropColumn() throws Exception {
-        // Bug 1: getIndexedParquetColumnIndex uses reader index instead of
-        // writer index. Bug 4: doubled parquet path. Both in the parquet
-        // bitmap index rebuild during checkpoint/backup recovery.
+        // Exercises two bugs in the parquet bitmap index rebuild during
+        // checkpoint/backup recovery: (a) getIndexedParquetColumnIndex
+        // comparing reader index with parquet column ID (writer index),
+        // and (b) the doubled parquet path causing rebuilds to be silently
+        // skipped.
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t (
@@ -1047,20 +1050,56 @@ public class CheckpointTest extends AbstractCairoTest {
             execute("ALTER TABLE t DROP COLUMN dummy");
             execute("ALTER TABLE t CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
 
-            // Capture expected count before rebuild to verify bitmap index
-            sink.clear();
-            printSql("SELECT count() FROM t WHERE sym = 'A'");
-            final String symACountBefore = sink.toString();
-
+            // Find the native partition directory for the parquet partition.
+            // After parquet conversion the directory has a txn suffix (e.g.
+            // "2024-01-01.2"), so we locate it by prefix.
             TableToken tableToken = engine.verifyTableName("t");
-            try (
-                    Path tablePath = new Path().of(engine.getConfiguration().getDbRoot()).concat(tableToken).slash();
-                    TableSnapshotRestore restoreAgent = new TableSnapshotRestore(configuration)
-            ) {
-                restoreAgent.rebuildTableFiles(tablePath, new java.util.concurrent.atomic.AtomicInteger(), true);
+            String dbRoot = engine.getConfiguration().getDbRoot().toString();
+            File tableDir = new File(dbRoot, tableToken.getDirName());
+            File[] partDirs = tableDir.listFiles((dir, name) -> name.startsWith("2024-01-01"));
+            Assert.assertNotNull(partDirs);
+            Assert.assertTrue("partition directory not found", partDirs.length > 0);
+            File partDir = partDirs[0];
+
+            // Release all readers and writers before deleting index files
+            // and rebuilding. rebuildTableFiles is designed for checkpoint
+            // recovery where the engine restarts.
+            engine.clear();
+
+            // Delete any existing bitmap index files for the parquet partition
+            // so we can verify the rebuild actually creates them.
+            File[] oldKeyFiles = partDir.listFiles((dir, name) -> name.startsWith("sym.k"));
+            if (oldKeyFiles != null) {
+                for (File f : oldKeyFiles) {
+                    Assert.assertTrue("failed to delete " + f, f.delete());
+                }
+            }
+            File[] oldValFiles = partDir.listFiles((dir, name) -> name.startsWith("sym.v"));
+            if (oldValFiles != null) {
+                for (File f : oldValFiles) {
+                    Assert.assertTrue("failed to delete " + f, f.delete());
+                }
             }
 
-            assertSql(symACountBefore,
+            try (
+                    Path tablePath = new Path().of(dbRoot).concat(tableToken).slash();
+                    TableSnapshotRestore restoreAgent = new TableSnapshotRestore(configuration)
+            ) {
+                restoreAgent.rebuildTableFiles(tablePath, new AtomicInteger(), true);
+            }
+
+            // Verify the bitmap index files were actually created by the rebuild.
+            // Without both fixes, the rebuild is silently skipped (path doubling
+            // makes ff.exists() return false) and these files would not exist.
+            File[] keyFiles = partDir.listFiles((dir, name) -> name.startsWith("sym.k"));
+            Assert.assertNotNull("bitmap index .k file not created for sym column", keyFiles);
+            Assert.assertTrue("bitmap index .k file not created for sym column", keyFiles.length > 0);
+            File[] valFiles = partDir.listFiles((dir, name) -> name.startsWith("sym.v"));
+            Assert.assertNotNull("bitmap index .v file not created for sym column", valFiles);
+            Assert.assertTrue("bitmap index .v file not created for sym column", valFiles.length > 0);
+
+            assertSql(
+                    "count\n3\n",
                     "SELECT count() FROM t WHERE sym = 'A'");
         });
     }
@@ -1096,15 +1135,85 @@ public class CheckpointTest extends AbstractCairoTest {
             drainWalQueue();
 
             TableToken tableToken = engine.verifyTableName("t");
+
+            // Release all readers and writers before rebuilding files on disk.
+            // rebuildTableFiles is designed for checkpoint recovery where the
+            // engine restarts, so cached readers must be released first.
+            engine.clear();
+
             try (
                     Path tablePath = new Path().of(engine.getConfiguration().getDbRoot()).concat(tableToken).slash();
                     TableSnapshotRestore restoreAgent = new TableSnapshotRestore(configuration)
             ) {
-                restoreAgent.rebuildTableFiles(tablePath, new java.util.concurrent.atomic.AtomicInteger(), true);
+                restoreAgent.rebuildTableFiles(tablePath, new AtomicInteger(), true);
             }
 
             assertSql(sym2DECountBefore,
                     "SELECT count() FROM t WHERE sym2 = 'DE'");
+        });
+    }
+
+    @Test
+    public void testCheckpointRestoreRebuildsBitmapIndexesOnParquetMultiTable() throws Exception {
+        // Exercises the race condition fix: without draining parallel tasks
+        // between tables, a parquet bitmap rebuild task from table t1 can
+        // still be running when rebuildTableFiles loads t2's metadata into
+        // the shared tableMetadata/columnVersionReader objects.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t1 (
+                        sym SYMBOL INDEX,
+                        val DOUBLE,
+                        ts TIMESTAMP
+                    ) TIMESTAMP(ts) PARTITION BY DAY
+                    """);
+            execute("""
+                    INSERT INTO t1 VALUES
+                    ('A', 1.0, '2024-01-01T00:00:00.000000Z'),
+                    ('B', 2.0, '2024-01-01T12:00:00.000000Z'),
+                    ('A', 3.0, '2024-01-02T00:00:00.000000Z')
+                    """);
+            execute("ALTER TABLE t1 CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+
+            execute("""
+                    CREATE TABLE t2 (
+                        tag SYMBOL INDEX,
+                        x LONG,
+                        ts TIMESTAMP
+                    ) TIMESTAMP(ts) PARTITION BY DAY
+                    """);
+            execute("""
+                    INSERT INTO t2 VALUES
+                    ('X', 10, '2024-02-01T00:00:00.000000Z'),
+                    ('Y', 20, '2024-02-01T12:00:00.000000Z'),
+                    ('X', 30, '2024-02-02T00:00:00.000000Z')
+                    """);
+            execute("ALTER TABLE t2 CONVERT PARTITION TO PARQUET LIST '2024-02-01'");
+
+            String dbRoot = engine.getConfiguration().getDbRoot().toString();
+            TableToken token1 = engine.verifyTableName("t1");
+            TableToken token2 = engine.verifyTableName("t2");
+
+            // Release all readers and writers before rebuilding files on disk.
+            engine.clear();
+
+            // Process both tables through the same TableSnapshotRestore
+            // instance — this is how DatabaseCheckpointAgent.recover() works.
+            try (TableSnapshotRestore restoreAgent = new TableSnapshotRestore(configuration)) {
+                try (Path tablePath = new Path().of(dbRoot).concat(token1).slash()) {
+                    restoreAgent.rebuildTableFiles(tablePath, new AtomicInteger(), true);
+                }
+                try (Path tablePath = new Path().of(dbRoot).concat(token2).slash()) {
+                    restoreAgent.rebuildTableFiles(tablePath, new AtomicInteger(), true);
+                }
+            }
+
+            assertSql(
+                    "count\n2\n",
+                    "SELECT count() FROM t1 WHERE sym = 'A'");
+            assertSql(
+                    "count\n2\n",
+                    "SELECT count() FROM t2 WHERE tag = 'X'");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -43,8 +43,8 @@ import io.questdb.cairo.ColumnVersionReader;
 import io.questdb.cairo.DefaultCairoConfiguration;
 import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.TableReader;
-import io.questdb.cairo.TableSnapshotRestore;
 import io.questdb.cairo.TableReaderMetadata;
+import io.questdb.cairo.TableSnapshotRestore;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.TableWriter;
@@ -1047,16 +1047,20 @@ public class CheckpointTest extends AbstractCairoTest {
             execute("ALTER TABLE t DROP COLUMN dummy");
             execute("ALTER TABLE t CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
 
+            // Capture expected count before rebuild to verify bitmap index
+            sink.clear();
+            printSql("SELECT count() FROM t WHERE sym = 'A'");
+            final String symACountBefore = sink.toString();
+
             TableToken tableToken = engine.verifyTableName("t");
             try (
                     Path tablePath = new Path().of(engine.getConfiguration().getDbRoot()).concat(tableToken).slash();
                     TableSnapshotRestore restoreAgent = new TableSnapshotRestore(configuration)
             ) {
                 restoreAgent.rebuildTableFiles(tablePath, new java.util.concurrent.atomic.AtomicInteger(), true);
-                restoreAgent.finalizeParallelTasks();
             }
 
-            assertSql("count\n3\n",
+            assertSql(symACountBefore,
                     "SELECT count() FROM t WHERE sym = 'A'");
         });
     }
@@ -1082,6 +1086,11 @@ public class CheckpointTest extends AbstractCairoTest {
                     ), INDEX(sym2) TIMESTAMP(ts) PARTITION BY DAY
                     """);
 
+            // Capture expected count before rebuild to verify bitmap index
+            sink.clear();
+            printSql("SELECT count() FROM t WHERE sym2 = 'DE'");
+            final String sym2DECountBefore = sink.toString();
+
             execute("ALTER TABLE t CONVERT PARTITION TO PARQUET LIST '2022-02-24'");
 
             TableToken tableToken = engine.verifyTableName("t");
@@ -1090,11 +1099,10 @@ public class CheckpointTest extends AbstractCairoTest {
                     TableSnapshotRestore restoreAgent = new TableSnapshotRestore(configuration)
             ) {
                 restoreAgent.rebuildTableFiles(tablePath, new java.util.concurrent.atomic.AtomicInteger(), true);
-                restoreAgent.finalizeParallelTasks();
             }
 
-            assertSql("count\n1000\n",
-                    "SELECT count() FROM t");
+            assertSql(sym2DECountBefore,
+                    "SELECT count() FROM t WHERE sym2 = 'DE'");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -1022,10 +1022,10 @@ public class CheckpointTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testCheckpointRestoreSkipsParquetPartitionsForIndexRebuild() throws Exception {
-        // Verify that rebuildBitmapIndexes skips parquet partitions during
-        // checkpoint/backup recovery. Bitmap indexes for parquet partitions
-        // are rebuilt by the table writer on first open, not during recovery.
+    public void testCheckpointRestoreRebuildsBitmapIndexesOnParquetAfterDropColumn() throws Exception {
+        // Bug 1: getIndexedParquetColumnIndex uses reader index instead of
+        // writer index. Bug 4: doubled parquet path. Both in the parquet
+        // bitmap index rebuild during checkpoint/backup recovery.
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t (
@@ -1047,7 +1047,6 @@ public class CheckpointTest extends AbstractCairoTest {
             execute("ALTER TABLE t DROP COLUMN dummy");
             execute("ALTER TABLE t CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
 
-            // rebuildTableFiles must not crash on parquet partitions.
             TableToken tableToken = engine.verifyTableName("t");
             try (
                     Path tablePath = new Path().of(engine.getConfiguration().getDbRoot()).concat(tableToken).slash();
@@ -1057,9 +1056,45 @@ public class CheckpointTest extends AbstractCairoTest {
                 restoreAgent.finalizeParallelTasks();
             }
 
-            // Data must still be accessible after recovery.
             assertSql("count\n3\n",
                     "SELECT count() FROM t WHERE sym = 'A'");
+        });
+    }
+
+    @Test
+    public void testCheckpointRestoreRebuildsBitmapIndexesOnParquetMultiColumn() throws Exception {
+        // Reproduces the enterprise backup test setup: 9 columns with an
+        // indexed SYMBOL, convert a partition to parquet, then rebuild.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t AS (
+                        SELECT
+                            x AS c1,
+                            rnd_symbol('AB', 'BC', 'CD') c2,
+                            timestamp_sequence('2022-02-24', 1_000_000) ts,
+                            rnd_symbol('DE', null, 'EF', 'FG') sym2,
+                            CAST(x AS INT) c3,
+                            rnd_bin() c4,
+                            to_long128(3 * x, 6 * x) c5,
+                            rnd_str('a', 'bdece', null, ' asdflakji idid', 'dk') c6,
+                            rnd_boolean() bool1
+                        FROM long_sequence(1000)
+                    ), INDEX(sym2) TIMESTAMP(ts) PARTITION BY DAY
+                    """);
+
+            execute("ALTER TABLE t CONVERT PARTITION TO PARQUET LIST '2022-02-24'");
+
+            TableToken tableToken = engine.verifyTableName("t");
+            try (
+                    Path tablePath = new Path().of(engine.getConfiguration().getDbRoot()).concat(tableToken).slash();
+                    TableSnapshotRestore restoreAgent = new TableSnapshotRestore(configuration)
+            ) {
+                restoreAgent.rebuildTableFiles(tablePath, new java.util.concurrent.atomic.AtomicInteger(), true);
+                restoreAgent.finalizeParallelTasks();
+            }
+
+            assertSql("count\n1000\n",
+                    "SELECT count() FROM t");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -1022,26 +1022,10 @@ public class CheckpointTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testCheckpointRestoreRebuildsBitmapIndexesOnParquetAfterDropColumn() throws Exception {
-        // Regression test for two bugs in rebuildBitmapIndexForParquetPartition:
-        //
-        // Bug 4: setPathForParquetPartition() already appends data.parquet, but
-        // the caller appended it again → doubled path → file not found → silently
-        // skipped all parquet partitions.
-        //
-        // Bug 1: getIndexedParquetColumnIndex() compared parquet field_id (writer
-        // index) with columnIndex (reader index). After DROP COLUMN, sym's reader
-        // index (1) collides with val's field_id (1), so the decoder gets DOUBLE
-        // instead of SYMBOL → "requested column type 12 does not match file
-        // column type 10".
-        //
-        // Column layout:
-        //   dummy (0, DOUBLE) — dropped
-        //   val   (1, DOUBLE)        → field_id 1 in parquet
-        //   sym   (2, SYMBOL INDEX)  → field_id 2 in parquet
-        //   ts    (3, TIMESTAMP)     → field_id 3 in parquet
-        //
-        // After DROP dummy: sym reader=1, writer=2.
+    public void testCheckpointRestoreSkipsParquetPartitionsForIndexRebuild() throws Exception {
+        // Verify that rebuildBitmapIndexes skips parquet partitions during
+        // checkpoint/backup recovery. Bitmap indexes for parquet partitions
+        // are rebuilt by the table writer on first open, not during recovery.
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t (
@@ -1063,12 +1047,7 @@ public class CheckpointTest extends AbstractCairoTest {
             execute("ALTER TABLE t DROP COLUMN dummy");
             execute("ALTER TABLE t CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
 
-            assertSql("count\n3\n",
-                    "SELECT count() FROM t WHERE sym = 'A'");
-
-            // Call rebuildTableFiles directly with rebuildPartitionColumnIndexes=true.
-            // This exercises rebuildParquetPartitionIndexes →
-            // getIndexedParquetColumnIndex (the fixed line 442).
+            // rebuildTableFiles must not crash on parquet partitions.
             TableToken tableToken = engine.verifyTableName("t");
             try (
                     Path tablePath = new Path().of(engine.getConfiguration().getDbRoot()).concat(tableToken).slash();
@@ -1078,11 +1057,7 @@ public class CheckpointTest extends AbstractCairoTest {
                 restoreAgent.finalizeParallelTasks();
             }
 
-            // The bitmap index must be intact after the rebuild. If
-            // getIndexedParquetColumnIndex used columnIndex (reader) instead
-            // of writerIndex, decodeRowGroup would have thrown
-            // CairoException: "requested column type 12 (symbol) does not
-            // match file column type 10 (double)".
+            // Data must still be accessible after recovery.
             assertSql("count\n3\n",
                     "SELECT count() FROM t WHERE sym = 'A'");
         });

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -1077,14 +1077,15 @@ public class CheckpointTest extends AbstractCairoTest {
                             rnd_symbol('AB', 'BC', 'CD') c2,
                             timestamp_sequence('2022-02-24', 1_000_000) ts,
                             rnd_symbol('DE', null, 'EF', 'FG') sym2,
-                            CAST(x AS INT) c3,
+                            x::INT c3,
                             rnd_bin() c4,
                             to_long128(3 * x, 6 * x) c5,
                             rnd_str('a', 'bdece', null, ' asdflakji idid', 'dk') c6,
                             rnd_boolean() bool1
                         FROM long_sequence(1000)
-                    ), INDEX(sym2) TIMESTAMP(ts) PARTITION BY DAY
+                    ), INDEX(sym2) TIMESTAMP(ts) PARTITION BY DAY WAL
                     """);
+            drainWalQueue();
 
             // Capture expected count before rebuild to verify bitmap index
             sink.clear();
@@ -1092,6 +1093,7 @@ public class CheckpointTest extends AbstractCairoTest {
             final String sym2DECountBefore = sink.toString();
 
             execute("ALTER TABLE t CONVERT PARTITION TO PARQUET LIST '2022-02-24'");
+            drainWalQueue();
 
             TableToken tableToken = engine.verifyTableName("t");
             try (

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -43,6 +43,7 @@ import io.questdb.cairo.ColumnVersionReader;
 import io.questdb.cairo.DefaultCairoConfiguration;
 import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableSnapshotRestore;
 import io.questdb.cairo.TableReaderMetadata;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.TableUtils;
@@ -1022,99 +1023,69 @@ public class CheckpointTest extends AbstractCairoTest {
 
     @Test
     public void testCheckpointRestoreRebuildsBitmapIndexesOnParquetAfterDropColumn() throws Exception {
-        // Regression test for getIndexedParquetColumnIndex() comparing parquet
-        // field_id (= writer index) with the reader index instead of the writer
-        // index. After a DROP COLUMN, reader indices shift while writer indices
-        // (stored as field_id in parquet) stay the same. The buggy lookup finds
-        // a DOUBLE column whose field_id matches the SYMBOL column's reader
-        // index, then tries to decode DOUBLE data as SYMBOL, producing:
-        //   "requested column type 12 (symbol) does not match file column type
-        //    10 (double)"
+        // Regression test for two bugs in rebuildBitmapIndexForParquetPartition:
         //
-        // Column layout (writer indices in parentheses):
-        //   dummy (0) — DOUBLE, will be dropped
-        //   val   (1) — DOUBLE
-        //   sym   (2) — SYMBOL INDEX
-        //   ts    (3) — TIMESTAMP designated
+        // Bug 4: setPathForParquetPartition() already appends data.parquet, but
+        // the caller appended it again → doubled path → file not found → silently
+        // skipped all parquet partitions.
         //
-        // After DROP COLUMN dummy, reader indices shift:
-        //   val   reader=0, writer=1  →  field_id 1 in parquet
-        //   sym   reader=1, writer=2  →  field_id 2 in parquet
-        //   ts    reader=2, writer=3  →  field_id 3 in parquet
+        // Bug 1: getIndexedParquetColumnIndex() compared parquet field_id (writer
+        // index) with columnIndex (reader index). After DROP COLUMN, sym's reader
+        // index (1) collides with val's field_id (1), so the decoder gets DOUBLE
+        // instead of SYMBOL → "requested column type 12 does not match file
+        // column type 10".
         //
-        // Bug: getIndexedParquetColumnIndex searches for field_id == 1 (sym's
-        // reader index) instead of field_id == 2 (sym's writer index), and
-        // finds 'val' (DOUBLE) at field_id 1.
+        // Column layout:
+        //   dummy (0, DOUBLE) — dropped
+        //   val   (1, DOUBLE)        → field_id 1 in parquet
+        //   sym   (2, SYMBOL INDEX)  → field_id 2 in parquet
+        //   ts    (3, TIMESTAMP)     → field_id 3 in parquet
+        //
+        // After DROP dummy: sym reader=1, writer=2.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t (
+                        dummy DOUBLE,
+                        val DOUBLE,
+                        sym SYMBOL INDEX,
+                        ts TIMESTAMP
+                    ) TIMESTAMP(ts) PARTITION BY DAY
+                    """);
+            execute("""
+                    INSERT INTO t VALUES
+                    (0.0, 1.0, 'A', '2024-01-01T00:00:00.000000Z'),
+                    (0.0, 2.0, 'B', '2024-01-01T06:00:00.000000Z'),
+                    (0.0, 3.0, 'A', '2024-01-01T12:00:00.000000Z'),
+                    (0.0, 4.0, 'B', '2024-01-01T18:00:00.000000Z'),
+                    (0.0, 5.0, 'A', '2024-01-02T00:00:00.000000Z')
+                    """);
 
-        Assume.assumeTrue(Os.type != Os.WINDOWS);
+            execute("ALTER TABLE t DROP COLUMN dummy");
+            execute("ALTER TABLE t CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
 
-        File dir1 = temp.newFolder("server1_parquet_drop_col");
-        File dir2 = temp.newFolder("server2_parquet_drop_col");
+            assertSql("count\n3\n",
+                    "SELECT count() FROM t WHERE sym = 'A'");
 
-        // Server 1: create table, drop column, convert to parquet, checkpoint.
-        try (TestServerMain server1 = startServerMain(dir1.getAbsolutePath())) {
-            server1.execute(
-                    "CREATE TABLE t (" +
-                            "dummy DOUBLE, " +
-                            "val DOUBLE, " +
-                            "sym SYMBOL INDEX, " +
-                            "ts TIMESTAMP" +
-                            ") TIMESTAMP(ts) PARTITION BY DAY WAL"
-            );
-            server1.execute(
-                    "INSERT INTO t " +
-                            "SELECT rnd_double(), rnd_double(), " +
-                            "CASE WHEN x <= 5 THEN 'A'::SYMBOL ELSE 'B'::SYMBOL END, " +
-                            "timestamp_sequence('2024-01-01', 1_000_000) ts " +
-                            "FROM long_sequence(10)"
-            );
-            server1.execute("INSERT INTO t VALUES(0, 0, 'A', '2024-01-02')");
+            // Call rebuildTableFiles directly with rebuildPartitionColumnIndexes=true.
+            // This exercises rebuildParquetPartitionIndexes →
+            // getIndexedParquetColumnIndex (the fixed line 442).
+            TableToken tableToken = engine.verifyTableName("t");
+            try (
+                    Path tablePath = new Path().of(engine.getConfiguration().getDbRoot()).concat(tableToken).slash();
+                    TableSnapshotRestore restoreAgent = new TableSnapshotRestore(configuration)
+            ) {
+                restoreAgent.rebuildTableFiles(tablePath, new java.util.concurrent.atomic.AtomicInteger(), true);
+                restoreAgent.finalizeParallelTasks();
+            }
 
-            TestUtils.assertEventually(() -> server1.assertSql(
-                    "SELECT count() FROM t",
-                    "count\n11\n"
-            ));
-
-            server1.execute("ALTER TABLE t DROP COLUMN dummy");
-            server1.execute("ALTER TABLE t CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
-
-            TestUtils.assertEventually(() -> server1.assertSql(
-                    "SELECT count() FROM t WHERE sym = 'A'",
-                    "count\n6\n"
-            ));
-
-            server1.execute("CHECKPOINT CREATE");
-            copyDirectory(dir1, dir2);
-            server1.execute("CHECKPOINT RELEASE");
-        }
-
-        // Create trigger file to force checkpoint recovery.
-        try (Path triggerPath = new Path().of(dir2.getAbsolutePath()).concat(TableUtils.RESTORE_FROM_CHECKPOINT_TRIGGER_FILE_NAME)) {
-            Files.touch(triggerPath.$());
-        }
-
-        // Server 2: recover from checkpoint with index rebuild enabled.
-        // This triggers rebuildParquetPartitionIndexes() which must use
-        // the writer index (field_id) to locate the SYMBOL column in parquet.
-        // Before the fix, getIndexedParquetColumnIndex() found the DOUBLE
-        // column (field_id 1) instead of the SYMBOL column (field_id 2),
-        // causing decodeRowGroup to fail with a type mismatch error that
-        // corrupted the recovery.
-        try (TestServerMain server2 = startServerMain(
-                dir2.getAbsolutePath(),
-                CAIRO_CHECKPOINT_RECOVERY_REBUILD_COLUMN_INDEXES.getEnvVarName(), "true"
-        )) {
-            // The table must be queryable after recovery — no type mismatch
-            // errors from the parquet decoder.
-            server2.assertSql(
-                    "SELECT count() FROM t",
-                    "count\n11\n"
-            );
-            server2.assertSql(
-                    "SELECT count() FROM t WHERE sym = 'A'",
-                    "count\n6\n"
-            );
-        }
+            // The bitmap index must be intact after the rebuild. If
+            // getIndexedParquetColumnIndex used columnIndex (reader) instead
+            // of writerIndex, decodeRowGroup would have thrown
+            // CairoException: "requested column type 12 (symbol) does not
+            // match file column type 10 (double)".
+            assertSql("count\n3\n",
+                    "SELECT count() FROM t WHERE sym = 'A'");
+        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -1110,6 +1110,10 @@ public class CheckpointTest extends AbstractCairoTest {
                     "SELECT count() FROM t",
                     "count\n11\n"
             );
+            server2.assertSql(
+                    "SELECT count() FROM t WHERE sym = 'A'",
+                    "count\n6\n"
+            );
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/CopyExportTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CopyExportTest.java
@@ -473,6 +473,66 @@ public class CopyExportTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCopyParquetDesignatedTimestampAfterDropColumn() throws Exception {
+        // Regression test for designated timestamp detection in the batch
+        // parquet encoder (create_partition_descriptor in jni.rs).
+        //
+        // populateFromTableReader() passes the reader timestamp index to Rust,
+        // but the Rust code compares it with col_id (writer index). After a
+        // DROP COLUMN the two diverge, causing the wrong column to be flagged
+        // as the designated timestamp. If that column is not a TIMESTAMP type,
+        // into_designated_with_order() fails and the export errors out.
+        //
+        //   dummy (0, INT) — dropped
+        //   val   (1, DOUBLE)
+        //   ts    (2, TIMESTAMP designated)
+        //   extra (3, LONG)
+        //
+        // After DROP dummy: val reader=0(writer=1), ts reader=1(writer=2)
+        // timestamp_index = 1 (reader index of ts).
+        // Bug: col_id(val)=1 == timestamp_index → val (DOUBLE) flagged
+        //      as designated → into_designated_with_order() fails.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t (
+                        dummy INT,
+                        val DOUBLE,
+                        ts TIMESTAMP,
+                        extra LONG
+                    ) TIMESTAMP(ts) PARTITION BY DAY
+                    """);
+            execute("""
+                    INSERT INTO t VALUES
+                    (1, 1.0, '2024-01-01T00:00:00.000000Z', 10),
+                    (2, 2.0, '2024-01-01T01:00:00.000000Z', 20),
+                    (3, 3.0, '2024-01-02T00:00:00.000000Z', 30)
+                    """);
+
+            execute("ALTER TABLE t DROP COLUMN dummy");
+
+            CopyExportRunnable stmt = () ->
+                    runAndFetchCopyExportID("COPY t TO 'drop_col_test' WITH FORMAT parquet", sqlExecutionContext);
+
+            CopyExportRunnable test = () ->
+                    assertEventually(() -> {
+                        // The export must complete successfully — the encoder
+                        // must correctly identify the designated timestamp
+                        // using the writer index, not the reader index.
+                        // Before the fix, the export failed with status=failed
+                        // because into_designated_with_order() errored on the
+                        // DOUBLE column that was incorrectly flagged.
+                        assertSql(
+                                "status\n" +
+                                        "finished\n",
+                                "SELECT status FROM \"sys.copy_export_log\" LIMIT -1"
+                        );
+                    });
+
+            testCopyExport(stmt, test);
+        });
+    }
+
+    @Test
     public void testCopyParquetFailsWithIllegalSql() throws Exception {
         assertException(
                 "copy (select x from non_existing_table) to 'tmp' with format parquet",

--- a/core/src/test/java/io/questdb/test/griffin/CopyExportTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CopyExportTest.java
@@ -533,6 +533,37 @@ public class CopyExportTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCopyParquetEmptyPartitionAfterDropColumn() throws Exception {
+        // Regression test for populateEmptyPartition() timestamp index fix.
+        // When the table is empty, the exporter calls populateEmptyPartition
+        // instead of populateFromTableReader. After DROP COLUMN, the reader
+        // timestamp index diverges from the writer index. Without the fix,
+        // the Rust encoder misidentifies the designated timestamp column.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t (
+                        dummy INT,
+                        val DOUBLE,
+                        ts TIMESTAMP
+                    ) TIMESTAMP(ts) PARTITION BY DAY
+                    """);
+
+            execute("ALTER TABLE t DROP COLUMN dummy");
+
+            CopyExportRunnable stmt = () ->
+                    runAndFetchCopyExportID("COPY t TO 'empty_drop_col' WITH FORMAT parquet", sqlExecutionContext);
+
+            CopyExportRunnable test = () ->
+                    assertEventually(() -> assertSql(
+                            "status\nfinished\n",
+                            "SELECT status FROM \"sys.copy_export_log\" LIMIT -1"
+                    ));
+
+            testCopyExport(stmt, test);
+        });
+    }
+
+    @Test
     public void testCopyParquetFailsWithIllegalSql() throws Exception {
         assertException(
                 "copy (select x from non_existing_table) to 'tmp' with format parquet",

--- a/core/src/test/java/io/questdb/test/griffin/ParquetTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParquetTest.java
@@ -1351,6 +1351,63 @@ public class ParquetTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testWalAlterColumnTypeWithParquetPartition() throws Exception {
+        // Regression test: ALTER TABLE ALTER COLUMN TYPE on a WAL table with
+        // parquet partitions.
+        //
+        // The WAL sequencer accepts the schema change, but when ApplyWal2TableJob
+        // applies it to the table writer, ConvertOperatorImpl tries to open
+        // native column files (.d) for the parquet partition — which don't exist.
+        // This makes the table writer DISTRESSED and the table SUSPENDED.
+        // Subsequent WAL transactions (inserts, O3) are silently lost.
+        //
+        // The table must either:
+        //   (a) convert parquet partitions back to native before the type change, or
+        //   (b) reject the ALTER with a clear error if parquet partitions exist.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE x (
+                        val DOUBLE,
+                        sym SYMBOL,
+                        ts TIMESTAMP
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            execute("""
+                    INSERT INTO x VALUES
+                    (1.0, 'A', '2024-01-01T00:00:00.000000Z'),
+                    (2.0, 'B', '2024-01-01T12:00:00.000000Z'),
+                    (3.0, 'C', '2024-01-02T00:00:00.000000Z')
+                    """);
+            drainWalQueue();
+
+            execute("ALTER TABLE x CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            drainWalQueue();
+
+            // ALTER COLUMN TYPE through WAL — the column conversion must NOT
+            // leave the table suspended.
+            execute("ALTER TABLE x ALTER COLUMN val TYPE SYMBOL");
+            drainWalQueue();
+
+            // O3 insert into the parquet partition after the type change.
+            execute("INSERT INTO x VALUES ('new_val', 'D', '2024-01-01T06:00:00.000000Z')");
+            drainWalQueue();
+
+            // The O3 insert must not be silently lost. The old DOUBLE values
+            // are converted to SYMBOL strings during the type change (the fix
+            // converts parquet back to native first, so the data is preserved).
+            assertSql("""
+                            val\tsym\tts
+                            1.0\tA\t2024-01-01T00:00:00.000000Z
+                            new_val\tD\t2024-01-01T06:00:00.000000Z
+                            2.0\tB\t2024-01-01T12:00:00.000000Z
+                            3.0\tC\t2024-01-02T00:00:00.000000Z
+                            """,
+                    "SELECT * FROM x"
+            );
+        });
+    }
+
+    @Test
     public void testOrderBy1() throws Exception {
         assertMemoryLeak(() -> {
             execute(


### PR DESCRIPTION
## Summary

- Fix bitmap index rebuild using wrong parquet column after DROP COLUMN during checkpoint/backup recovery
- Fix parquet file path double-appended in recovery bitmap index rebuild (parquet rebuilds were silently skipped)
- Fix race condition: parallel parquet bitmap rebuild reads stale metadata when recovering multiple tables
- Fix COPY TO parquet export flagging wrong column as designated timestamp after DROP COLUMN
- Fix ALTER TABLE ALTER COLUMN TYPE crashing on tables with parquet partitions, leaving WAL tables suspended

## Details

After `DROP COLUMN`, a column's reader index (dense position in the live column list) diverges from its writer index (permanent ID stored as `field_id` in parquet files). Three code paths confused the two, producing type mismatch errors, corrupt bitmap indexes, or suspended WAL tables.

`TableSnapshotRestore.rebuildBitmapIndexForParquetPartition()` constructed the parquet file path by calling `setPathForParquetPartition()` (which already appends `data.parquet`) then appending `data.parquet` again. The doubled path never matched any file, so bitmap index rebuilds for parquet partitions were silently skipped during checkpoint/backup recovery.

`TableSnapshotRestore.getIndexedParquetColumnIndex()` compared parquet `field_id` (writer index) against the column's reader index when rebuilding bitmap indexes on parquet partitions during recovery. After a DROP COLUMN, a SYMBOL column's reader index could collide with a DOUBLE column's `field_id`, causing the decoder to reject the type mismatch or silently produce a corrupt index.

`TableSnapshotRestore.rebuildTableFiles()` submitted parquet bitmap index rebuild tasks to a thread pool but did not drain them before returning. When the caller processed multiple tables, the next table's `loadMetadata()` call overwrote `tableMetadata` and `columnVersionReader` while the previous table's parquet task was still running — causing ObjList index-out-of-bounds errors. Native bitmap tasks were unaffected because they capture all values as local variables before submission. The fix drains parallel tasks at the end of each `rebuildTableFiles()` call.

`PartitionEncoder.populateFromTableReader()` passed the reader timestamp index to the Rust parquet encoder, which compared it with `col_id` (writer index) to identify the designated timestamp. After DROP COLUMN, a non-timestamp column whose writer index matched the timestamp's reader index got incorrectly flagged, crashing `COPY ... TO ... WITH FORMAT parquet` exports.

`TableWriter.changeColumnType()` delegated to `ConvertOperatorImpl` which iterated all partitions and opened native `.d` column files. For parquet partitions these files don't exist, making the table writer distressed and suspending the WAL table. The fix converts parquet partitions back to native before the column type conversion starts.

## Test plan

- `CheckpointTest.testCheckpointRestoreRebuildsBitmapIndexesOnParquetAfterDropColumn`: DROP COLUMN + convert to parquet + call `rebuildTableFiles` directly. Without fix, reproduces exact customer error: "requested column type 12 (symbol) does not match file column type 10 (double)". With fix, bitmap index is rebuilt correctly and indexed query returns correct count.
- `CheckpointTest.testCheckpointRestoreRebuildsBitmapIndexesOnParquetMultiColumn`: 9-column table matching enterprise backup test setup (indexed SYMBOL, multiple types). Verifies parquet bitmap rebuild completes without index-out-of-bounds.
- `CopyExportTest.testCopyParquetDesignatedTimestampAfterDropColumn`: DROP COLUMN + COPY TO parquet. Verify export completes with status=finished (previously failed with status=failed).
- `ParquetTest.testWalAlterColumnTypeWithParquetPartition`: WAL table + convert to parquet + ALTER COLUMN TYPE + O3 insert. Verify O3 data is not silently lost and the table is queryable with correct results.
- Existing `CheckpointTest.testCheckpointRestoreRebuildsBitmapIndexes`, `CopyExportTest.testCopyParquetEmptyTable`, `ParquetTest.testO3Inserts` still pass.
- Enterprise `BackupTest.testBackupFuzzyTableWithParquetPartitions` passes (previously failed with index out of bounds from the race condition).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bitmap index rebuilding during table snapshot restore with parquet partitions
  * Corrected timestamp column handling when converting between parquet and native partition formats
  * Fixed column type changes on tables containing parquet partitions
  * Fixed COPY/EXPORT operations with designated timestamps after column modifications
  * Fixed WAL column type alterations on parquet partitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->