### PR TITLE
fix(sql): report empty LIMIT in DECLARE subquery

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionTreeBuilder.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionTreeBuilder.java
@@ -26,6 +26,7 @@ package io.questdb.griffin;
 
 import io.questdb.griffin.model.ExpressionNode;
 import io.questdb.griffin.model.IQueryModel;
+import io.questdb.std.IntStack;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -33,7 +34,10 @@ import java.util.Deque;
 public final class ExpressionTreeBuilder implements ExpressionParserListener {
 
     private final Deque<ExpressionNode> argStack = new ArrayDeque<>();
+    private final IntStack argStackBottomStack = new IntStack();
     private final Deque<IQueryModel> modelStack = new ArrayDeque<>();
+    // parseExpr() is reentrant; nested parses must not consume outer operands.
+    private int argStackBottom;
     private IQueryModel model;
 
     @Override
@@ -55,15 +59,15 @@ public final class ExpressionTreeBuilder implements ExpressionParserListener {
             case 0:
                 break;
             case 1:
-                node.rhs = argStack.poll();
+                node.rhs = pollArg();
                 break;
             case 2:
-                node.rhs = argStack.poll();
-                node.lhs = argStack.poll();
+                node.rhs = pollArg();
+                node.lhs = pollArg();
                 break;
             default:
                 for (int i = 0; i < node.paramCount; i++) {
-                    node.args.add(argStack.poll());
+                    node.args.add(pollArg());
                 }
                 break;
         }
@@ -71,26 +75,35 @@ public final class ExpressionTreeBuilder implements ExpressionParserListener {
     }
 
     public ExpressionNode poll() {
-        return argStack.poll();
+        return argStack.size() > argStackBottom ? argStack.poll() : null;
     }
 
     void popModel() {
         this.model = modelStack.poll();
+        this.argStackBottom = argStackBottomStack.notEmpty() ? argStackBottomStack.pop() : 0;
     }
 
     void pushModel(IQueryModel model) {
         if (this.model != null) {
             modelStack.push(this.model);
         }
+        argStackBottomStack.push(argStackBottom);
+        argStackBottom = argStack.size();
         this.model = model;
     }
 
     void reset() {
         argStack.clear();
+        argStackBottom = 0;
+        argStackBottomStack.clear();
         modelStack.clear();
     }
 
     int size() {
-        return argStack.size();
+        return argStack.size() - argStackBottom;
+    }
+
+    private ExpressionNode pollArg() {
+        return argStack.size() > argStackBottom ? argStack.poll() : null;
     }
 }

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -934,6 +934,10 @@ public class SqlParser {
         return false;
     }
 
+    private boolean isUnexpectedRightParenInTopLevelSelect(CharSequence tok) {
+        return Chars.equals(tok, ')') && !(subQueryMode || createTableMode || copyMode || createViewMode);
+    }
+
     private ExpressionNode literal(GenericLexer lexer, CharSequence name) {
         return literal(name, lexer.lastTokenPosition());
     }
@@ -3094,6 +3098,8 @@ public class SqlParser {
             } else {
                 lexer.unparseLast();
             }
+            // questdb accepts open-ended limits like 'LIMIT 5,' and 'LIMIT ,5'.
+            // so reject only when neither side of the LIMIT clause parsed.
             if (lo == null && hi == null) {
                 throw SqlException.$(lexer.lastTokenPosition(), "limit expression expected");
             }
@@ -4037,7 +4043,7 @@ public class SqlParser {
                         throw SqlException.$(lexer.getPosition(), "reserved name");
                     }
 
-                    if (Chars.equals(tok, ')') && !(subQueryMode || createTableMode || copyMode || createViewMode)) {
+                    if (isUnexpectedRightParenInTopLevelSelect(tok)) {
                         throw SqlException.$(lexer.lastTokenPosition(), "unexpected token [)]");
                     }
 
@@ -4123,13 +4129,13 @@ public class SqlParser {
                 }
 
                 if (Chars.equals(tok, ')')) {
-                    if (subQueryMode || createTableMode || copyMode || createViewMode) {
+                    if (isUnexpectedRightParenInTopLevelSelect(tok)) {
+                        // it's an unbalanced ')' in top-level SELECT
+                        throw SqlException.$(lexer.lastTokenPosition(), "unexpected token [)]");
+                    } else {
                         // it's a balanced: ')'
                         lexer.unparseLast();
                         break;
-                    } else {
-                        // it's an unbalanced ')' in top-level SELECT
-                        throw SqlException.$(lexer.lastTokenPosition(), "unexpected token [)]");
                     }
                 }
 

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -3094,6 +3094,9 @@ public class SqlParser {
             } else {
                 lexer.unparseLast();
             }
+            if (lo == null && hi == null) {
+                throw SqlException.$(lexer.lastTokenPosition(), "limit expression expected");
+            }
             model.setLimit(lo, hi);
         } else {
             lexer.unparseLast();
@@ -4032,6 +4035,10 @@ public class SqlParser {
 
                     if (isSelectKeyword(tok)) {
                         throw SqlException.$(lexer.getPosition(), "reserved name");
+                    }
+
+                    if (Chars.equals(tok, ')') && !(subQueryMode || createTableMode || copyMode || createViewMode)) {
+                        throw SqlException.$(lexer.lastTokenPosition(), "unexpected token [)]");
                     }
 
                     lexer.unparseLast();

--- a/core/src/test/java/io/questdb/test/griffin/DeclareTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DeclareTest.java
@@ -799,6 +799,18 @@ public class DeclareTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testDeclareVariableAsSubQueryWithEmptyLimit() throws Exception {
+        assertException(
+                "declare @pair := (select symbol from fx_trades limit ), " +
+                        "with bids as (select symbol, bids[1,1] from market_data where symbol = @pair), " +
+                        "asks as (select symbol, asks[1,1] from market_data where symbol = @pair) " +
+                        "select symbol, * from bids",
+                53,
+                "limit expression expected"
+        );
+    }
+
+    @Test
     public void testDeclareVariableAsSubQueryWithNestedVariable() throws Exception {
         assertModel("select-choose y from (select-virtual [4 y] 4 y from (long_sequence(1)))",
                 "DECLARE @x := (DECLARE @y := 4 SELECT @y as y) SELECT * FROM @x", ExecutionModel.QUERY);


### PR DESCRIPTION
Malformed SQL with inner queries such as:  (notice the LIMIT has no value)
```sql
DECLARE @pair := (SELECT symbol FROM fx_trades LIMIT ) SELECT ... 
```
could trigger an internal error. This change improves error reporting for such queries. 


**Implementation details for reviewers**
The parser was allowing a nested expression parse to consume operands from the
outer declaration expression, corrupting the assignment AST before `parseDeclare()` inspected it.

The fix: 
Isolate `ExpressionTreeBuilder` operand stack frames across reentrant
`parseExpr()` calls, so nested parses cannot consume outer operands. Also
reject an empty `LIMIT` clause with a clear parser error: 'limit expression expected'