### PR TITLE
fix(sql): preserve shifted timestamps for ASOF/LT joins

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -7968,11 +7968,27 @@ public class SqlCodeGenerator implements Mutable, Closeable {
     ) throws SqlException {
         final ObjList<QueryColumn> columns = model.getColumns();
         final int columnCount = columns.size();
-        final ObjList<Function> functions = new ObjList<>(columnCount);
+        // Timestamp offset detection stores an index into bottom-up columns. Top-down pruning
+        // can remove or shift that column in the final projection, making the index stale.
+        // The alias is stable across pruning: resolve it in the final columns, or restore it
+        // as a hidden timestamp column below when it is no longer visible.
+        int modelTimestampIndex = model.getTimestampColumnIndex();
+        final CharSequence timestampOffsetAlias = model.getTimestampOffsetAlias();
+        if (timestampOffsetAlias != null) {
+            modelTimestampIndex = -1;
+            for (int i = 0; i < columnCount; i++) {
+                if (Chars.equalsIgnoreCase(timestampOffsetAlias, columns.getQuick(i).getAlias())) {
+                    modelTimestampIndex = i;
+                    break;
+                }
+            }
+        }
+        // +1 accounts for an internal timestamp column, which can be added conditionally later.
+        final int virtualColumnReservedSlots = columnCount + 1;
+        final ObjList<Function> functions = new ObjList<>(virtualColumnReservedSlots);
         final RecordMetadata baseMetadata = factory.getMetadata();
         // Lookup metadata will resolve column references, prioritising references to the projection
-        // over the references to the base table. +1 accounts for timestamp, which can be added conditionally later.
-        final int virtualColumnReservedSlots = columnCount + 1;
+        // over the references to the base table.
         final PriorityMetadata priorityMetadata = new PriorityMetadata(virtualColumnReservedSlots, baseMetadata);
         final GenericRecordMetadata virtualMetadata = new GenericRecordMetadata();
         try {
@@ -7985,17 +8001,19 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 timestampColumn = null;
             }
 
-            // Check if the model has a detected timestamp offset - if so, use that column as timestamp
-            int modelTimestampIndex = model.getTimestampColumnIndex();
-
             for (int i = 0; i < columnCount; i++) {
                 final QueryColumn column = columns.getQuick(i);
                 final ExpressionNode node = column.getAst();
                 if (modelTimestampIndex == i) {
                     // Model explicitly indicates this column should be the timestamp
                     virtualMetadata.setTimestampIndex(i);
-                } else if (modelTimestampIndex < 0 && node.type == LITERAL && Chars.equalsNc(node.token, timestampColumn)) {
-                    // Only use literal match if model hasn't specified a timestamp index
+                } else if (
+                        timestampOffsetAlias == null
+                                && modelTimestampIndex < 0
+                                && node.type == LITERAL
+                                && Chars.equalsNc(node.token, timestampColumn)
+                ) {
+                    // Only use literal match when there is no derived timestamp selected by alias.
                     virtualMetadata.setTimestampIndex(i);
                 }
 
@@ -8023,9 +8041,13 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
                 int columnType = function.getType();
                 if (columnType == CURSOR) {
+                    Misc.free(function);
                     throw SqlException.$(node.position, "cursor function cannot be used as a column [column=").put(column.getAlias()).put(']');
                 }
-
+                if (modelTimestampIndex == i && !isTimestamp(columnType)) {
+                    Misc.free(function);
+                    throw SqlException.$(node.position, "TIMESTAMP column is required but not provided");
+                }
                 if (targetColumnType != -1 && targetColumnType != columnType) {
                     // This is an update and the target column does not match with column the update is trying to perform
                     if (isBuiltInWideningCast(function.getType(), targetColumnType)) {
@@ -8086,10 +8108,50 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 priorityMetadata.add(m);
             }
 
+            // Restore a pruned timestamp-offset projection needed by a downstream operator.
+            if (
+                    executionContext.isTimestampRequired()
+                            && timestampOffsetAlias != null
+                            && virtualMetadata.getTimestampIndex() == -1
+            ) {
+                final ObjList<QueryColumn> bottomUpColumns = model.getBottomUpColumns();
+                boolean isTimestampRestored = false;
+                for (int i = 0, n = bottomUpColumns.size(); i < n; i++) {
+                    final QueryColumn qc = bottomUpColumns.getQuick(i);
+                    if (Chars.equalsIgnoreCase(timestampOffsetAlias, qc.getAlias())) {
+                        final Function timestampFunction = functionParser.parseFunction(
+                                qc.getAst(),
+                                priorityMetadata,
+                                executionContext
+                        );
+                        final int timestampType = timestampFunction.getType();
+                        if (!isTimestamp(timestampType)) {
+                            Misc.free(timestampFunction);
+                            throw SqlException.$(qc.getAst().position, "TIMESTAMP column is required but not provided");
+                        }
+                        functions.add(timestampFunction);
+                        virtualMetadata.setTimestampIndex(virtualMetadata.getColumnCount());
+                        final TableColumnMetadata m = new TableColumnMetadata(
+                                Chars.toString(qc.getAlias()),
+                                timestampType,
+                                timestampFunction.getMetadata()
+                        );
+                        virtualMetadata.add(m);
+                        priorityMetadata.add(m);
+                        isTimestampRestored = true;
+                        break;
+                    }
+                }
+                if (!isTimestampRestored) {
+                    throw SqlException.$(model.getModelPosition(), "TIMESTAMP column is required but not provided");
+                }
+            }
+
             // if timestamp was required and present in the base model but
             // not selected, we will need to add it
             if (
                     executionContext.isTimestampRequired()
+                            && timestampOffsetAlias == null
                             && timestampColumn != null
                             && virtualMetadata.getTimestampIndex() == -1
             ) {

--- a/core/src/test/java/io/questdb/test/griffin/engine/SqlCodeGeneratorTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/SqlCodeGeneratorTest.java
@@ -40,6 +40,8 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.test.TestMatchFunctionFactory;
 import io.questdb.griffin.engine.groupby.vect.GroupByVectorAggregateJob;
+import io.questdb.griffin.model.ExecutionModel;
+import io.questdb.griffin.model.IQueryModel;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.Misc;
@@ -9174,6 +9176,31 @@ public class SqlCodeGeneratorTest extends AbstractCairoTest {
                 Assert.assertTrue(cursor.hasNext());
                 // First row: 2022-01-15T12:00:00 - 1h = 2022-01-15T11:00:00 = 1642244400000000 microseconds
                 Assert.assertEquals(100.0, record.getDouble(1), 0.001);
+            }
+        });
+    }
+
+    @Test
+    public void testVirtualColumnRejectsNonTimestampModelTimestampIndex() throws Exception {
+        assertMemoryLeak(() -> {
+            try (SqlCompiler compiler = engine.getSqlCompiler()) {
+                final String query = "SELECT x + 1 AS ts FROM long_sequence(1)";
+                final ExecutionModel executionModel = compiler.generateExecutionModel(query, sqlExecutionContext);
+                Assert.assertEquals(ExecutionModel.QUERY, executionModel.getModelType());
+
+                final IQueryModel model = (IQueryModel) executionModel;
+                model.setTimestampColumnIndex(0);
+
+                RecordCursorFactory factory = null;
+                try {
+                    factory = compiler.generateSelectWithRetries(model, null, sqlExecutionContext, false);
+                    Assert.fail("expected timestamp validation to reject non-TIMESTAMP column");
+                } catch (SqlException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "TIMESTAMP column is required but not provided");
+                    Assert.assertEquals(9, e.getPosition());
+                } finally {
+                    Misc.free(factory);
+                }
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/SqlCompilerImplTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/SqlCompilerImplTest.java
@@ -3956,6 +3956,16 @@ public class SqlCompilerImplTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCursorFunctionCannotBeUsedAsColumnFreesParsedFunction() throws Exception {
+        assertException(
+                "SELECT pg_attrdef() AS c FROM long_sequence(1)",
+                7,
+                "cursor function cannot be used as a column [column=c]",
+                sqlExecutionContext
+        );
+    }
+
+    @Test
     public void testDeallocateMissingStatementName() throws Exception {
         assertMemoryLeak(() -> {
             try {

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/AsOfJoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/AsOfJoinTest.java
@@ -2775,6 +2775,128 @@ public class AsOfJoinTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAsOfJoinWithTopDownFilteredDateaddTimestampProjection() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("""
+                            CREATE TABLE fx_trades (
+                                timestamp #TIMESTAMP,
+                                trade_id INT,
+                                symbol SYMBOL
+                            ) TIMESTAMP(timestamp) PARTITION BY DAY
+                            """,
+                    leftTableTimestampType.getTypeName()
+            );
+            execute("""
+                    INSERT INTO fx_trades VALUES
+                        ('2026-04-14T00:00:10.000000Z', 1, 'EURUSD'),
+                        ('2026-04-14T00:01:10.000000Z', 2, 'EURUSD')
+                    """);
+
+            executeWithRewriteTimestamp("""
+                            CREATE TABLE market_data (
+                                timestamp #TIMESTAMP,
+                                symbol SYMBOL,
+                                best_bid DOUBLE,
+                                best_ask DOUBLE
+                            ) TIMESTAMP(timestamp) PARTITION BY DAY
+                            """,
+                    rightTableTimestampType.getTypeName()
+            );
+            execute("""
+                    INSERT INTO market_data VALUES
+                        ('2026-04-14T00:00:30.000000Z', 'EURUSD', 1.09, 1.11),
+                        ('2026-04-14T00:01:30.000000Z', 'EURUSD', 1.19, 1.21)
+                    """);
+
+            assertQueryNoLeakCheck(
+                    replaceTimestampSuffix("""
+                                    trade_id\ttimestamp\tbest_bid\tbest_ask
+                                    1\t2026-04-14T00:00:10.000000Z\t1.09\t1.11
+                                    2\t2026-04-14T00:01:10.000000Z\t1.19\t1.21
+                                    """,
+                            leftTableTimestampType.getTypeName()),
+                    """
+                            WITH trades_yday AS (
+                                SELECT timestamp, trade_id, symbol
+                                FROM fx_trades
+                                WHERE symbol = 'EURUSD'
+                                    AND timestamp >= '2026-04-14T00:00:00Z'
+                                    AND timestamp < '2026-04-15T00:00:00Z'
+                                LIMIT 2
+                            ),
+                            market_data_p30 AS (
+                                SELECT dateadd('s', -30, timestamp) AS timestamp, symbol, best_bid, best_ask
+                                FROM market_data
+                                WHERE symbol = 'EURUSD'
+                            )
+                            SELECT t.trade_id, t.timestamp, md.best_bid, md.best_ask
+                            FROM trades_yday t
+                            ASOF JOIN market_data_p30 md ON (symbol)
+                            """,
+                    "timestamp",
+                    false,
+                    false
+            );
+        });
+    }
+
+    @Test
+    public void testAsOfJoinWithTopDownFilteredDateaddTimestampProjectionOnMaster() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("""
+                            CREATE TABLE fx_trades (
+                                timestamp #TIMESTAMP,
+                                trade_id INT,
+                                symbol SYMBOL
+                            ) TIMESTAMP(timestamp) PARTITION BY DAY
+                            """,
+                    leftTableTimestampType.getTypeName()
+            );
+            execute("""
+                    INSERT INTO fx_trades VALUES
+                        ('2026-04-14T00:00:40.000000Z', 1, 'EURUSD'),
+                        ('2026-04-14T00:01:40.000000Z', 2, 'EURUSD')
+                    """);
+
+            executeWithRewriteTimestamp("""
+                            CREATE TABLE market_data (
+                                timestamp #TIMESTAMP,
+                                symbol SYMBOL,
+                                best_bid DOUBLE
+                            ) TIMESTAMP(timestamp) PARTITION BY DAY
+                            """,
+                    rightTableTimestampType.getTypeName()
+            );
+            execute("""
+                    INSERT INTO market_data VALUES
+                        ('2026-04-14T00:00:20.000000Z', 'EURUSD', 1.09),
+                        ('2026-04-14T00:01:20.000000Z', 'EURUSD', 1.19)
+                    """);
+
+            assertQueryNoLeakCheck(
+                    """
+                            trade_id\tbest_bid
+                            1\tnull
+                            2\t1.09
+                            """,
+                    """
+                                    WITH trades_p30 AS (
+                                        SELECT dateadd('s', -30, timestamp) AS timestamp, trade_id, symbol
+                                        FROM fx_trades
+                                        WHERE symbol = 'EURUSD'
+                                    )
+                                    SELECT t.trade_id, md.best_bid
+                                    FROM trades_p30 t
+                                    ASOF JOIN market_data md ON (symbol)
+                            """,
+                    null,
+                    false,
+                    false
+            );
+        });
+    }
+
+    @Test
     public void testCursorToTop() throws Exception {
         assertMemoryLeak(() -> {
             // Verifies that toTop() properly clears the memoization state in AsOfJoinMemoizedRecordCursor.
@@ -4444,6 +4566,64 @@ public class AsOfJoinTest extends AbstractCairoTest {
             // Execute and verify results
             printSql(query);
             Assert.assertFalse(sink.isEmpty());
+        });
+    }
+
+    @Test
+    public void testLtJoinWithTopDownFilteredDateaddTimestampProjectionOnSlave() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("""
+                            CREATE TABLE fx_trades (
+                                timestamp #TIMESTAMP,
+                                trade_id INT,
+                                symbol SYMBOL
+                            ) TIMESTAMP(timestamp) PARTITION BY DAY
+                            """,
+                    leftTableTimestampType.getTypeName()
+            );
+            execute("""
+                    INSERT INTO fx_trades VALUES
+                        ('2026-04-14T00:00:10.000000Z', 1, 'EURUSD'),
+                        ('2026-04-14T00:01:10.000000Z', 2, 'EURUSD')
+                    """);
+
+            executeWithRewriteTimestamp("""
+                            CREATE TABLE market_data (
+                                timestamp #TIMESTAMP,
+                                symbol SYMBOL,
+                                best_bid DOUBLE,
+                                best_ask DOUBLE
+                            ) TIMESTAMP(timestamp) PARTITION BY DAY
+                            """,
+                    rightTableTimestampType.getTypeName()
+            );
+            execute("""
+                    INSERT INTO market_data VALUES
+                        ('2026-04-14T00:00:30.000000Z', 'EURUSD', 1.09, 1.11),
+                        ('2026-04-14T00:01:30.000000Z', 'EURUSD', 1.19, 1.21)
+                    """);
+
+            assertQueryNoLeakCheck(
+                    replaceTimestampSuffix("""
+                                    trade_id\ttimestamp\tbest_bid\tbest_ask
+                                    1\t2026-04-14T00:00:10.000000Z\t1.09\t1.11
+                                    2\t2026-04-14T00:01:10.000000Z\t1.19\t1.21
+                                    """,
+                            leftTableTimestampType.getTypeName()),
+                    """
+                                    WITH market_data_p30 AS (
+                                        SELECT dateadd('s', -30, timestamp) AS timestamp, symbol, best_bid, best_ask
+                                        FROM market_data
+                                        WHERE symbol = 'EURUSD'
+                                    )
+                                    SELECT t.trade_id, t.timestamp, md.best_bid, md.best_ask
+                                    FROM fx_trades t
+                                    LT JOIN market_data_p30 md ON (symbol)
+                            """,
+                    "timestamp",
+                    false,
+                    true
+            );
         });
     }
 


### PR DESCRIPTION
Fixes an internal error in ASOF/LT joins when a subquery shifts the designated timestamp with `dateadd()` and that timestamp is later pruned from the visible projection.

Example affected shape:

  ```sql
  SELECT ...
  FROM trades t
  ASOF JOIN (
      SELECT dateadd('s', -30, timestamp) AS timestamp, symbol, bid
      FROM market_data
  ) md ON (symbol);
```

The optimizer could remove the shifted timestamp from the output while join planning still required it, causing timestamp metadata to be lost and query compilation to fail with an AssertionError.

This change preserves/restores the hidden derived timestamp needed by the join, resolves timestamp aliases case-insensitively after pruning, and validates restored timestamp expressions.