### PR TITLE
chore(core): fix switch partition to parquet format async flow

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -170,6 +170,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int cairoGroupByTopKQueueCapacity;
     private final long cairoGroupByTopKThreshold;
     private final int cairoMaxCrashFiles;
+    private final boolean cairoMetadataCacheSnapshotOrdered;
     private final int cairoPageFrameReduceColumnListCapacity;
     private final int cairoPageFrameReduceQueueCapacity;
     private final int cairoPageFrameReduceRowIdListCapacity;
@@ -184,7 +185,6 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final String cairoSqlCopyRoot;
     private final String cairoSqlCopyWorkRoot;
     private final boolean cairoSqlLegacyOperatorPrecedence;
-    private final boolean cairoMetadataCacheSnapshotOrdered;
     private final long cairoTableRegistryAutoReloadFrequency;
     private final int cairoTableRegistryCompactionThreshold;
     private final int cairoUnorderedPageFrameReduceQueueCapacity;
@@ -360,6 +360,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int o3LagCalculationWindowsSize;
     private final int o3LastPartitionMaxSplits;
     private final long o3MaxLagUs;
+    private final int o3MidPartitionMaxSplits;
     private final long o3MinLagUs;
     private final int o3OpenColumnQueueCapacity;
     private final boolean o3PartitionOverwriteControlEnabled;
@@ -407,9 +408,9 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int qwpMaxSchemasPerConnection;
     private final int qwpMaxTablesPerConnection;
     private final long qwpUdpCommitInterval;
-    private final int qwpUdpMaxUncommittedDatagrams;
     private final boolean qwpUdpEnabled;
     private final int qwpUdpGroupIPv4Address;
+    private final int qwpUdpMaxUncommittedDatagrams;
     private final int qwpUdpMsgBufferSize;
     private final int qwpUdpMsgCount;
     private final boolean qwpUdpOwnThread;
@@ -1737,6 +1738,7 @@ public class PropServerConfiguration implements ServerConfiguration {
             this.ioURingEnabled = getBoolean(properties, env, PropertyKey.CAIRO_IO_URING_ENABLED, true);
             this.cairoMaxCrashFiles = getInt(properties, env, PropertyKey.CAIRO_MAX_CRASH_FILES, 100);
             this.o3LastPartitionMaxSplits = Math.max(1, getInt(properties, env, PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 20));
+            this.o3MidPartitionMaxSplits = Math.max(1, getInt(properties, env, PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 1));
             this.o3PartitionSplitMinSize = getLongSize(properties, env, PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 50 * Numbers.SIZE_1MB);
             this.o3PartitionOverwriteControlEnabled = getBoolean(properties, env, PropertyKey.CAIRO_O3_PARTITION_OVERWRITE_CONTROL_ENABLED, false);
 
@@ -3910,6 +3912,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
+        public int getO3MidPartitionMaxSplits() {
+            return o3MidPartitionMaxSplits;
+        }
+
+        @Override
         public long getO3MinLag() {
             return o3MinLagUs;
         }
@@ -4550,11 +4557,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public boolean isCairoMetadataCacheSnapshotOrdered() {
-            return cairoMetadataCacheSnapshotOrdered;
-        }
-
-        @Override
         public long getTableRegistryAutoReloadFrequency() {
             return cairoTableRegistryAutoReloadFrequency;
         }
@@ -4742,6 +4744,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getWriterTickRowsCountMod() {
             return writerTickRowsCountMod;
+        }
+
+        @Override
+        public boolean isCairoMetadataCacheSnapshotOrdered() {
+            return cairoMetadataCacheSnapshotOrdered;
         }
 
         @Override
@@ -6510,11 +6517,6 @@ public class PropServerConfiguration implements ServerConfiguration {
         }
 
         @Override
-        public int getMaxUncommittedDatagrams() {
-            return qwpUdpMaxUncommittedDatagrams;
-        }
-
-        @Override
         public int getDefaultPartitionBy() {
             return PartitionBy.DAY;
         }
@@ -6532,6 +6534,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getMaxTablesPerConnection() {
             return qwpMaxTablesPerConnection;
+        }
+
+        @Override
+        public int getMaxUncommittedDatagrams() {
+            return qwpUdpMaxUncommittedDatagrams;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -572,6 +572,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     CAIRO_TABLE_REGISTRY_COMPACTION_THRESHOLD("cairo.table.registry.compaction.threshold"),
     CAIRO_REPEAT_MIGRATION_FROM_VERSION("cairo.repeat.migration.from.version"),
     CAIRO_O3_LAST_PARTITION_MAX_SPLITS("cairo.o3.last.partition.max.splits"),
+    CAIRO_O3_MID_PARTITION_MAX_SPLITS("cairo.o3.mid.partition.max.splits"),
     CAIRO_O3_PARTITION_SPLIT_MIN_SIZE("cairo.o3.partition.split.min.size"),
     CAIRO_O3_PARTITION_OVERWRITE_CONTROL_ENABLED("cairo.o3.partition.overwrite.control.enabled"),
     CAIRO_WRITE_BACK_OFF_TIMEOUT_ON_MEM_PRESSURE("cairo.write.back.off.timeout.on.mem.pressure"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -420,6 +420,8 @@ public interface CairoConfiguration {
 
     int getO3MemMaxPages();
 
+    int getO3MidPartitionMaxSplits();
+
     long getO3MinLag();
 
     int getO3OpenColumnQueueCapacity();
@@ -464,13 +466,13 @@ public interface CairoConfiguration {
 
     double getPartitionEncoderParquetBloomFilterFpp();
 
-    double getPartitionEncoderParquetMinCompressionRatio();
-
     int getPartitionEncoderParquetCompressionCodec();
 
     int getPartitionEncoderParquetCompressionLevel();
 
     int getPartitionEncoderParquetDataPageSize();
+
+    double getPartitionEncoderParquetMinCompressionRatio();
 
     long getPartitionEncoderParquetO3RewriteUnusedMaxBytes();
 
@@ -725,8 +727,6 @@ public interface CairoConfiguration {
 
     long getSystemWalEventAppendPageSize();
 
-    boolean isCairoMetadataCacheSnapshotOrdered();
-
     long getTableRegistryAutoReloadFrequency();
 
     int getTableRegistryCompactionThreshold();
@@ -819,6 +819,8 @@ public interface CairoConfiguration {
     int getWriterFileOpenOpts();
 
     int getWriterTickRowsCountMod();
+
+    boolean isCairoMetadataCacheSnapshotOrdered();
 
     /**
      * A flag to enable/disable checkpoint recovery mechanism. Defaults to {@code true}.

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -632,6 +632,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public int getO3MidPartitionMaxSplits() {
+        return getDelegate().getO3MidPartitionMaxSplits();
+    }
+
+    @Override
     public long getO3MinLag() {
         return getDelegate().getO3MinLag();
     }
@@ -737,13 +742,13 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
-    public double getPartitionEncoderParquetMinCompressionRatio() {
-        return getDelegate().getPartitionEncoderParquetMinCompressionRatio();
+    public int getPartitionEncoderParquetDataPageSize() {
+        return getDelegate().getPartitionEncoderParquetDataPageSize();
     }
 
     @Override
-    public int getPartitionEncoderParquetDataPageSize() {
-        return getDelegate().getPartitionEncoderParquetDataPageSize();
+    public double getPartitionEncoderParquetMinCompressionRatio() {
+        return getDelegate().getPartitionEncoderParquetMinCompressionRatio();
     }
 
     @Override
@@ -1272,11 +1277,6 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
-    public boolean isCairoMetadataCacheSnapshotOrdered() {
-        return getDelegate().isCairoMetadataCacheSnapshotOrdered();
-    }
-
-    @Override
     public long getTableRegistryAutoReloadFrequency() {
         return getDelegate().getTableRegistryAutoReloadFrequency();
     }
@@ -1464,6 +1464,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     @Override
     public int getWriterTickRowsCountMod() {
         return getDelegate().getWriterTickRowsCountMod();
+    }
+
+    @Override
+    public boolean isCairoMetadataCacheSnapshotOrdered() {
+        return getDelegate().isCairoMetadataCacheSnapshotOrdered();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -647,6 +647,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public int getO3MidPartitionMaxSplits() {
+        return 1;
+    }
+
+    @Override
     public long getO3MinLag() {
         return 1_000_000;
     }
@@ -755,13 +760,13 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
-    public double getPartitionEncoderParquetMinCompressionRatio() {
-        return 0.0;
+    public int getPartitionEncoderParquetDataPageSize() {
+        return 0; // use default (1024*1024) bytes
     }
 
     @Override
-    public int getPartitionEncoderParquetDataPageSize() {
-        return 0; // use default (1024*1024) bytes
+    public double getPartitionEncoderParquetMinCompressionRatio() {
+        return 0.0;
     }
 
     @Override
@@ -1292,11 +1297,6 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
-    public boolean isCairoMetadataCacheSnapshotOrdered() {
-        return false;
-    }
-
-    @Override
     public long getTableRegistryAutoReloadFrequency() {
         return 500;
     }
@@ -1483,6 +1483,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     @Override
     public int getWriterTickRowsCountMod() {
         return 1024 - 1;
+    }
+
+    @Override
+    public boolean isCairoMetadataCacheSnapshotOrdered() {
+        return false;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -140,9 +140,9 @@ import java.util.function.LongConsumer;
 
 import static io.questdb.cairo.BitmapIndexUtils.keyFileName;
 import static io.questdb.cairo.BitmapIndexUtils.valueFileName;
+import static io.questdb.cairo.TableUtils.*;
 import static io.questdb.cairo.TableUtils.openAppend;
 import static io.questdb.cairo.TableUtils.openRO;
-import static io.questdb.cairo.TableUtils.*;
 import static io.questdb.cairo.sql.AsyncWriterCommand.Error.*;
 import static io.questdb.std.Files.*;
 import static io.questdb.std.datetime.DateLocaleFactory.EN_LOCALE;
@@ -174,9 +174,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     private static final Log LOG = LogFactory.getLog(TableWriter.class);
     /*
         The most recent logical partition is allowed to have up to cairo.o3.last.partition.max.splits (20 by default) splits.
-        Any other partition is allowed to have 0 splits (1 partition in total).
+        Any other partition is allowed to have cairo.o3.mid.partition.max.splits (1 by default) splits.
      */
-    private static final int MAX_MID_SUB_PARTITION_COUNT = 1;
     private static final Runnable NOOP = () -> {
     };
     private static final Row NOOP_ROW = new NoOpRow();
@@ -3012,7 +3011,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             return SWITCH_NO_PARQUET;
         }
 
+        int partitionCount = txWriter.getPartitionCount();
         squashPartitionForce(partitionIndex);
+        if (partitionCount != txWriter.getPartitionCount()) {
+            // If the partition was squashed, the parquet file may not reflect the current native data. Do not switch to parquet in this case.
+            return SWITCH_NO_PARQUET;
+        }
 
         long partitionNameTxn = txWriter.getPartitionNameTxn(partitionIndex);
 
@@ -10369,7 +10373,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     private void squashPartitionRange(int maxLastSubPartitionCount, int partitionIndexLo, int partitionIndexHi) {
         if (partitionIndexHi > partitionIndexLo) {
             int subpartitions = partitionIndexHi - partitionIndexLo;
-            int optimalPartitionCount = partitionIndexHi == txWriter.getPartitionCount() ? maxLastSubPartitionCount : MAX_MID_SUB_PARTITION_COUNT;
+            int optimalPartitionCount = partitionIndexHi == txWriter.getPartitionCount() ? maxLastSubPartitionCount : configuration.getO3MidPartitionMaxSplits();
             if (subpartitions > Math.max(1, optimalPartitionCount)) {
                 squashSplitPartitions(partitionIndexLo, partitionIndexHi, optimalPartitionCount, false);
             } else if (subpartitions == 1) {

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3013,8 +3013,15 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
         int partitionCount = txWriter.getPartitionCount();
         squashPartitionForce(partitionIndex);
-        if (partitionCount != txWriter.getPartitionCount()) {
-            // If the partition was squashed, the parquet file may not reflect the current native data. Do not switch to parquet in this case.
+        int newPartitionCount = txWriter.getPartitionCount();
+        if (partitionCount != newPartitionCount) {
+            // The force-squash merged one or more split sub-partitions into this logical partition.
+            // The existing parquet file was produced before the squash, so it is now stale relative
+            // to the grown native partition.
+            LOG.info()
+                    .$("skipping switch to parquet, due to partition squash [table=").$(tableToken)
+                    .$(", partition=").$ts(timestampDriver, partitionTimestamp)
+                    .I$();
             return SWITCH_NO_PARQUET;
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/BwdTableReaderPageFrameCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/BwdTableReaderPageFrameCursor.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.BitmapIndexReader;
+import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.ColumnTypeDriver;
 import io.questdb.cairo.TableReader;
@@ -345,8 +346,13 @@ public class BwdTableReaderPageFrameCursor implements TablePageFrameCursor {
         final PartitionDecoder.Metadata metadata = reenterParquetDecoder.metadata();
         final int rowGroupCount = metadata.getRowGroupCount();
 
-        // Check partitionHi to be below actual parquet row count
-        assert partitionHi <= metadata.getRowCount();
+        if (partitionHi > metadata.getRowCount()) {
+            throw CairoException.critical(0)
+                    .put("parquet partition row count mismatch [partitionHi=").put(partitionHi)
+                    .put(", parquetRowCount=").put(metadata.getRowCount())
+                    .put(", partitionIndex=").put(reenterPartitionIndex)
+                    .put(']');
+        }
 
         int targetGroup = -1;
         long targetGroupStart = 0;

--- a/core/src/main/java/io/questdb/griffin/engine/table/FwdTableReaderPageFrameCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/FwdTableReaderPageFrameCursor.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.BitmapIndexReader;
+import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.ColumnTypeDriver;
 import io.questdb.cairo.ColumnVersionReader;
@@ -350,7 +351,13 @@ public class FwdTableReaderPageFrameCursor implements TablePageFrameCursor {
         final PartitionDecoder.Metadata metadata = reenterParquetDecoder.metadata();
         final int rowGroupCount = metadata.getRowGroupCount();
 
-        assert partitionHi <= metadata.getRowCount();
+        if (partitionHi > metadata.getRowCount()) {
+            throw CairoException.critical(0)
+                    .put("parquet partition row count mismatch [partitionHi=").put(partitionHi)
+                    .put(", parquetRowCount=").put(metadata.getRowCount())
+                    .put(", partitionIndex=").put(reenterPartitionIndex)
+                    .put(']');
+        }
 
         long rowGroupStartRow = cachedRowGroupStartRow;
         for (int i = cachedRowGroupIndex; i < rowGroupCount; i++) {

--- a/core/src/main/resources/io/questdb/site/conf/server.conf
+++ b/core/src/main/resources/io/questdb/site/conf/server.conf
@@ -764,6 +764,9 @@ cairo.sql.copy.root=import
 # The number of O3 partition splits allowed for the last partitions. If the number of splits grows above this value, the splits will be squashed
 #cairo.o3.last.partition.max.splits=20
 
+# The number of O3 partition splits allowed for non-last (mid) partitions. Above this value the splits are squashed back.
+#cairo.o3.mid.partition.max.splits=1
+
 ################ Parallel SQL execution ################
 
 # Sets flag to enable parallel SQL filter execution. JIT compilation takes place only when this setting is enabled.

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -739,6 +739,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.writer.data.index.value.append.page.size\tQDB_CAIRO_WRITER_DATA_INDEX_VALUE_APPEND_PAGE_SIZE\t16777216\tdefault\tfalse\tfalse\n" +
                                     "cairo.writer.fo_opts\tQDB_CAIRO_WRITER_FO_OPTS\to_none\tdefault\tfalse\tfalse\n" +
                                     "cairo.writer.tick.rows.count\tQDB_CAIRO_WRITER_TICK_ROWS_COUNT\t1024\tdefault\tfalse\tfalse\n" +
+                                    "cairo.o3.mid.partition.max.splits\tQDB_CAIRO_O3_MID_PARTITION_MAX_SPLITS\t1\tdefault\tfalse\tfalse\n" +
                                     "circuit.breaker.buffer.size\tQDB_CIRCUIT_BREAKER_BUFFER_SIZE\t64\tdefault\tfalse\tfalse\n" +
                                     "circuit.breaker.throttle\tQDB_CIRCUIT_BREAKER_THROTTLE\t2000000\tdefault\tfalse\tfalse\n" +
                                     "config.reload.enabled\tQDB_CONFIG_RELOAD_ENABLED\ttrue\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3SquashPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3SquashPartitionTest.java
@@ -794,6 +794,96 @@ public class O3SquashPartitionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSplitMidPartitionMaxSplitsConfigured() throws Exception {
+        // cairo.o3.mid.partition.max.splits controls how many splits a non-last
+        // (mid) logical partition is allowed to keep after commit. Raising the
+        // limit above the number of splits must leave them in place instead of
+        // squashing them back into a single partition.
+        assertMemoryLeak(() -> {
+            Overrides overrides = node1.getConfigurationOverrides();
+            overrides.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
+            overrides.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 3);
+
+            // 60*36 minute ticks span 2020-02-04 (1440 rows) and 2020-02-05 (720 rows),
+            // so 2020-02-04 is a mid partition (another logical partition follows it).
+            executeWithRewriteTimestamp(
+                    "CREATE TABLE x AS (" +
+                            "SELECT" +
+                            " cast(x AS int) i," +
+                            " -x j," +
+                            " rnd_str(5,16,2) AS str," +
+                            " timestamp_sequence('2020-02-04T00', 60 * 1000000L)::#TIMESTAMP ts" +
+                            " FROM long_sequence(60 * 36)" +
+                            ") TIMESTAMP(ts) PARTITION BY DAY",
+                    timestampType.getTypeName()
+            );
+
+            // O3 insert at 2020-02-04T20:01 creates a split inside the mid partition.
+            // With max.splits=3 (> 2 actual splits) the split must survive.
+            execute(
+                    "INSERT INTO x " +
+                            "SELECT" +
+                            " cast(x AS int) * 1000000 i," +
+                            " -x - 1000000L AS j," +
+                            " rnd_str(5,16,2) AS str," +
+                            " timestamp_sequence('2020-02-04T20:01', 1000000L)::" + timestampType.getTypeName() + " ts" +
+                            " FROM long_sequence(200)"
+            );
+
+            String partitionsSql = "SELECT minTimestamp, numRows, name FROM table_partitions('x') ORDER BY minTimestamp";
+            assertSql(replaceTimestampSuffix1("""
+                    minTimestamp\tnumRows\tname
+                    2020-02-04T00:00:00.000000Z\t1201\t2020-02-04
+                    2020-02-04T20:01:00.000000Z\t439\t2020-02-04T200000-000001
+                    2020-02-05T00:00:00.000000Z\t720\t2020-02-05
+                    """, timestampType.getTypeName()), partitionsSql);
+        });
+    }
+
+    @Test
+    public void testSplitMidPartitionMaxSplitsDefault() throws Exception {
+        // Default cairo.o3.mid.partition.max.splits=1 must squash O3 splits in a
+        // non-last (mid) logical partition back into a single partition on commit.
+        assertMemoryLeak(() -> {
+            Overrides overrides = node1.getConfigurationOverrides();
+            overrides.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
+
+            // 60*36 minute ticks span 2020-02-04 (1440 rows) and 2020-02-05 (720 rows),
+            // so 2020-02-04 is a mid partition (another logical partition follows it).
+            executeWithRewriteTimestamp(
+                    "CREATE TABLE x AS (" +
+                            "SELECT" +
+                            " cast(x AS int) i," +
+                            " -x j," +
+                            " rnd_str(5,16,2) AS str," +
+                            " timestamp_sequence('2020-02-04T00', 60 * 1000000L)::#TIMESTAMP ts" +
+                            " FROM long_sequence(60 * 36)" +
+                            ") TIMESTAMP(ts) PARTITION BY DAY",
+                    timestampType.getTypeName()
+            );
+
+            // O3 insert at 2020-02-04T20:01 would split the mid partition, but the
+            // commit squashes it back because mid.partition.max.splits defaults to 1.
+            execute(
+                    "INSERT INTO x " +
+                            "SELECT" +
+                            " cast(x AS int) * 1000000 i," +
+                            " -x - 1000000L AS j," +
+                            " rnd_str(5,16,2) AS str," +
+                            " timestamp_sequence('2020-02-04T20:01', 1000000L)::" + timestampType.getTypeName() + " ts" +
+                            " FROM long_sequence(200)"
+            );
+
+            String partitionsSql = "SELECT minTimestamp, numRows, name FROM table_partitions('x') ORDER BY minTimestamp";
+            assertSql(replaceTimestampSuffix1("""
+                    minTimestamp\tnumRows\tname
+                    2020-02-04T00:00:00.000000Z\t1640\t2020-02-04
+                    2020-02-05T00:00:00.000000Z\t720\t2020-02-05
+                    """, timestampType.getTypeName()), partitionsSql);
+        });
+    }
+
+    @Test
     public void testSplitMidPartitionOpenReader() throws Exception {
         assertMemoryLeak(() -> {
             execute(


### PR DESCRIPTION
## Summary

- Fix `switchNativePartitionWithParquet`: bail out when squash changes the partition count. Otherwise the stale parquet file (from before the squash) gets linked into the grown native partition, silently dropping the O3 rows that were added after the parquet was produced.

Tandem PR https://github.com/questdb/questdb-enterprise/pull/986
