### PR TITLE
fix(sql): fix SAMPLE BY DST bucket timestamp after a skipped day

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractNoRecordSampleByCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractNoRecordSampleByCursor.java
@@ -251,11 +251,16 @@ public abstract class AbstractNoRecordSampleByCursor extends AbstractSampleByCur
 
     protected void nextSamplePeriod(long timestamp) {
         localEpoch = timestampSampler.round(timestamp);
-        // Sometimes rounding, especially around Days can throw localEpoch
-        // to the "before" previous DST. When this happens we need to compensate for
-        // tzOffset subtraction at the time of delivery of the timestamp to client
-        if (localEpoch - tzOffset < prevDst) {
-            localEpoch += tzOffset;
+        // After a DST transition, rounding down (common for multi-hour or day units) can place
+        // the new bucket's boundary at a local time whose UTC instant lies before the transition
+        // we just crossed. TimestampFunc emits `sampleLocalEpoch - tzOffset`, so if we leave
+        // localEpoch as-is, we'd back-convert with the post-transition offset even though the
+        // bucket start belongs to the pre-transition offset. Shift localEpoch by the delta
+        // between the current offset and the one valid at the bucket boundary so the emitted
+        // UTC timestamp lands on the correct side of the transition.
+        if (rules != null && localEpoch - tzOffset < prevDst) {
+            final long boundaryTzOffset = rules.getOffset(localEpoch - tzOffset);
+            localEpoch += (tzOffset - boundaryTzOffset);
         }
         GroupByUtils.toTop(groupByFunctions);
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -5399,6 +5399,53 @@ public class SampleByTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSampleByDayNoFromAlignToCalendarDSTNYSpringForwardGap() throws Exception {
+        // Regression for https://github.com/questdb/questdb/issues/4678
+        //
+        // America/New_York: UTC-5 (EST) -> UTC-4 (EDT)
+        // Spring forward: Mar 10, 2024 at 2:00 EST -> 3:00 EDT (= Mar 10 07:00 UTC)
+        //
+        // Day boundaries (midnight local -> UTC):
+        //   Mar  7 00:00 EST = Mar  7 05:00 UTC
+        //   Mar  8 00:00 EST = Mar  8 05:00 UTC
+        //   Mar 10 00:00 EST = Mar 10 05:00 UTC  (spring-forward day, 23h long)
+        //   Mar 11 00:00 EDT = Mar 11 04:00 UTC  (now in daylight time)
+        //
+        // The filter skips Mar 9 entirely and resumes after DST on Mar 10. Before the fix, the
+        // Mar 10 bucket was emitted as Mar 10 00:00 UTC because the cursor back-converted the
+        // bucket's local boundary with the current (post-DST, EDT) offset instead of the offset
+        // valid at the bucket start (EST, pre-DST).
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE trades (timestamp TIMESTAMP, amount DOUBLE) TIMESTAMP(timestamp) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO trades VALUES
+                        ('2024-03-08T00:00:00.000000Z', 1.0),
+                        ('2024-03-08T12:00:00.000000Z', 2.0),
+                        ('2024-03-10T08:00:00.000000Z', 8.0),
+                        ('2024-03-10T09:00:00.000000Z', 8.0),
+                        ('2024-03-10T10:00:00.000000Z', 8.0),
+                        ('2024-03-11T10:00:00.000000Z', 16.0)""");
+            assertQueryNoLeakCheck(
+                    """
+                            timestamp\tsum
+                            2024-03-07T05:00:00.000000Z\t1.0
+                            2024-03-08T05:00:00.000000Z\t2.0
+                            2024-03-10T05:00:00.000000Z\t24.0
+                            2024-03-11T04:00:00.000000Z\t16.0
+                            """,
+                    "SELECT timestamp, sum(amount) FROM (" +
+                            " SELECT timestamp, amount FROM trades" +
+                            " WHERE timestamp IN '2024-03-08'" +
+                            " OR timestamp BETWEEN('2024-03-10T08:00:00Z', '2024-03-12')" +
+                            ") SAMPLE BY 1d ALIGN TO CALENDAR TIME ZONE 'America/New_York'",
+                    "timestamp",
+                    false,
+                    false
+            );
+        });
+    }
+
+    @Test
     public void testSampleByDayFromAlignToCalendarDSTChathamFallBack() throws Exception {
         // Pacific/Chatham: UTC+12:45 (CHAST) / UTC+13:45 (CHADT)
         // Fall back: Apr 4, 2021 at 3:45am CHADT -> 2:45am CHAST (= Apr 3 14:00 UTC)


### PR DESCRIPTION
Fixes #4678

## Summary

`SAMPLE BY 1d ALIGN TO CALENDAR TIME ZONE` emitted a wrong bucket timestamp for the DST-start day when the preceding day had no data.

Reproducer (America/New_York, 2024-03-10 spring-forward):

```sql
CREATE TABLE trades (timestamp TIMESTAMP, amount DOUBLE) TIMESTAMP(timestamp) PARTITION BY DAY;
INSERT INTO trades VALUES
    ('2024-03-08T00:00:00Z', 1.0),
    ('2024-03-08T12:00:00Z', 2.0),
    ('2024-03-10T08:00:00Z', 8.0),
    ('2024-03-10T09:00:00Z', 8.0),
    ('2024-03-10T10:00:00Z', 8.0),
    ('2024-03-11T10:00:00Z', 16.0);

SELECT timestamp, sum(amount) FROM trades
WHERE timestamp IN '2024-03-08'
   OR timestamp BETWEEN('2024-03-10T08:00:00Z', '2024-03-12')
SAMPLE BY 1d ALIGN TO CALENDAR TIME ZONE 'America/New_York';
```

Before: the 2024-03-10 bucket was emitted as `2024-03-10T00:00:00Z` (midnight UTC).
After: it is emitted as `2024-03-10T05:00:00Z` (midnight NY EST), matching `timestamp_floor_utc` and the Berlin spring-forward test pattern.

Aggregation itself was correct (all three 03-10 rows summed to 24.0); only the emitted bucket timestamp was wrong.

## Root cause

In `AbstractNoRecordSampleByCursor.nextSamplePeriod`, after `adjustDst` promotes `tzOffset` to the post-transition value, rounding a fresh row down to the bucket boundary can land at a local time whose UTC instant is pre-transition. The existing compensation `localEpoch += tzOffset` subtracted the whole current offset rather than the delta between the current and the pre-transition offsets, so `TimestampFunc` back-converted the bucket with the wrong side of the transition.

## Fix

Use the offset valid at the bucket boundary (looked up via `rules.getOffset(localEpoch - tzOffset)`) and shift `localEpoch` by the delta between the cursor's current `tzOffset` and that boundary offset. This mirrors what `CommonUtils.offsetFlooredUtcResult` does for `timestamp_floor_utc`.

## Tradeoffs

- Narrow, surgical change inside the existing DST branch of `nextSamplePeriod`; only fires when the condition was already met (`localEpoch - tzOffset < prevDst`).
- The no-DST path (no `TIME ZONE` clause, or fixed-offset zones) is unaffected — `rules` is `null` in those cases and the guard short-circuits.
- No change to aggregation behavior; only the emitted bucket-start timestamp.

## Test plan

- New regression `SampleByTest.testSampleByDayNoFromAlignToCalendarDSTNYSpringForwardGap` reproduces the issue's scenario.
- Full `SampleByTest` suite: 303/303 pass.
- `SampleBy*Test` + `GroupBy*Test` + `TimestampFloor*Test`: 1020/1020 pass.
- `*MatView*Test`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)