### PR TITLE
[DOCKER SEEDING] Add Docker config and run scripts

### DIFF
--- a/.helix/Dockerfile.helix
+++ b/.helix/Dockerfile.helix
@@ -1,0 +1,18 @@
+FROM eclipse-temurin:17-jdk
+
+RUN _jh="$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")" && ln -sfn "$_jh" /opt/helix-jdk
+ENV JAVA_HOME=/opt/helix-jdk
+
+ENV MAVEN_VERSION=3.9.9
+ENV MAVEN_HOME=/opt/maven
+ENV PATH=/opt/maven/bin:$PATH
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git curl tar && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz -o /tmp/maven.tar.gz && tar -xzf /tmp/maven.tar.gz -C /opt && ln -s /opt/apache-maven-${MAVEN_VERSION} /opt/maven && rm /tmp/maven.tar.gz
+
+WORKDIR /app
+
+COPY . .
+
+RUN mvn -B -ntp -DskipTests -pl '!benchmarks' install

--- a/.helix/metadata.json
+++ b/.helix/metadata.json
@@ -1,0 +1,22 @@
+[
+  {
+    "instance_id": "handshake",
+    "task_title": "handshake",
+    "problem_statement": "",
+    "hints": "",
+    "repo": "handshake",
+    "repo_path_or_url": "handshake",
+    "FAIL_TO_PASS": "",
+    "PASS_TO_PASS": "",
+    "language": "handshake",
+    "docker_file": "handshake",
+    "run_script": "handshake",
+    "task_type": "handshake",
+    "task_category": "handshake",
+    "repo_category": "handshake",
+    "version": "handshake",
+    "container_mem": "handshake",
+    "container_memswap": "handshake",
+    "container_network_needed": "handshake"
+  }
+]

--- a/.helix/run-tests-eval.sh
+++ b/.helix/run-tests-eval.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+path_to_classname() {
+    local f="$1"
+    f="${f#./}"
+    f="${f#core/}"
+    f="${f#compat/}"
+    f="${f#utils/}"
+    f="${f#java-questdb-client/}"
+    for prefix in src/test/java/ src/test/kotlin/ src/test/scala/ \
+                  src/main/java/ src/main/kotlin/ src/main/scala/ \
+                  src/it/java/ src/it/kotlin/ src/it/scala/; do
+        f="${f#$prefix}"
+    done
+    for ext in .java .kt .scala .groovy .kts; do
+        f="${f%$ext}"
+    done
+    echo "${f//\//.}"
+}
+
+if [[ $# -eq 0 || -z "${1:-}" ]]; then
+    mvn -B -ntp test -pl '!benchmarks' \
+        -Dspotless.check.skip=true \
+        -Dcheckstyle.skip=true \
+        -Dpmd.skip=true \
+        -Dcpd.skip=true \
+        -Denforcer.skip=true \
+        -Dlicense.skip=true \
+        -Dformatter.skip=true \
+        -Dimpsort.skip=true \
+        -Dsort.skip=true \
+        -Djacoco.skip=true
+else
+    IFS=',' read -ra TEST_FILES <<< "$1"
+    CLASSES=()
+    for file in "${TEST_FILES[@]}"; do
+        trimmed="${file#"${file%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+        [[ -z "$trimmed" ]] && continue
+        CLASSES+=("$(path_to_classname "$trimmed")")
+    done
+
+    if [[ ${#CLASSES[@]} -eq 0 ]]; then
+        echo "No valid test files were provided." >&2
+        exit 1
+    fi
+
+    TEST_SELECTOR="$(IFS=,; echo "${CLASSES[*]}")"
+    mvn -B -ntp test -pl '!benchmarks' -Dtest="$TEST_SELECTOR" \
+        -Dspotless.check.skip=true \
+        -Dcheckstyle.skip=true \
+        -Dpmd.skip=true \
+        -Dcpd.skip=true \
+        -Denforcer.skip=true \
+        -Dlicense.skip=true \
+        -Dformatter.skip=true \
+        -Dimpsort.skip=true \
+        -Dsort.skip=true \
+        -Djacoco.skip=true
+fi


### PR DESCRIPTION
@bluestreak01 Helix docs:
- https://docs.helix.ml/
- https://docs.helix.ml/helix/
- https://docs.helix.ml/helix/getting-started/architecture/

This PR adds the files expected by the Helix/Handshake evaluation flow:
- `.helix/Dockerfile.helix` defines the evaluation container
- `.helix/run-tests-eval.sh` defines how tests are executed inside that container
- `.helix/metadata.json` provides task metadata consumed by the evaluation pipeline

The `handshake` placeholder in `.helix/metadata.json` is not QuestDB application logic. It is placeholder/default metadata used by the Handshake/Helix evaluation harness so the pipeline has a metadata file to read. It is evaluation metadata, not QuestDB runtime configuration.

If preferred, I can update the placeholder values to be more explicitly QuestDB-specific so the intent is clearer.
