### PR TITLE
ci(build): fix fs package install failure in R test workflow

### DIFF
--- a/.github/workflows/r_test.yml
+++ b/.github/workflows/r_test.yml
@@ -32,6 +32,8 @@ jobs:
           use-public-rspm: true
 
       - name: Run R Script
+        env:
+          USE_BUNDLED_LIBUV: "1"
         run: Rscript compat/src/test/R/test_sequence.R
 
       - name: Stop QuestDB


### PR DESCRIPTION
## Summary

- The `PGWire - R test` CI job started failing for every PR after CRAN published `fs` 2.1.0, which now requires `libuv` as a system dependency to build from source.
- `ubuntu-latest` doesn't ship `libuv1-dev`, so `fs` fails with `fatal error: uv.h: No such file or directory`. The failure cascades to `pkgload` and `testthat`, and the test script halts on `library(testthat)`.
- Setting `USE_BUNDLED_LIBUV=1` for the `Run R Script` step tells `fs` to compile a static copy of `libuv` at install time, so the workflow no longer depends on the runner image.

The alternative — installing `libuv1-dev` via `apt-get` in a new step — would also work but adds a runner-image dependency. Bundling trades a small amount of install time for self-containment.

## Test plan

- Re-run the R test workflow on this PR and confirm the `fs`, `pkgload`, and `testthat` packages install cleanly.
- Verify the R test script actually executes against QuestDB (not just that the installs pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)