### PR TITLE
test(wal): fix WalLockerFuzzTest crash on timeout

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/wal/WalLockerFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalLockerFuzzTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class WalLockerFuzzTest {
@@ -92,15 +93,17 @@ public class WalLockerFuzzTest {
         final CountDownLatch startLatch = new CountDownLatch(1);
         final CountDownLatch doneLatch = new CountDownLatch(numThreads);
         final AtomicReference<Throwable> error = new AtomicReference<>();
+        final AtomicBoolean isStopRequested = new AtomicBoolean(false);
+        final Thread[] workers = new Thread[numThreads];
 
         for (int threadIdx = 0; threadIdx < numThreads; threadIdx++) {
             final int threadId = threadIdx;
-            new Thread(() -> {
+            Thread worker = new Thread(() -> {
                 try {
                     startLatch.await();
                     Rnd threadRnd = new Rnd(threadSeeds[threadId][0], threadSeeds[threadId][1]);
 
-                    for (int op = 0; op < operationsPerThread && error.get() == null; op++) {
+                    for (int op = 0; op < operationsPerThread && error.get() == null && !isStopRequested.get(); op++) {
                         int tableIdx = threadRnd.nextInt(numTables);
                         int walId = threadRnd.nextInt(numWalsPerTable);
                         TableToken table = tables[tableIdx];
@@ -190,14 +193,25 @@ public class WalLockerFuzzTest {
                 } finally {
                     doneLatch.countDown();
                 }
-            }, "FuzzThread-" + threadIdx).start();
+            }, "FuzzThread-" + threadIdx);
+            workers[threadIdx] = worker;
+            worker.start();
         }
 
         // Start all threads
         startLatch.countDown();
 
-        // Wait for completion
-        Assert.assertTrue("Fuzz test timed out", doneLatch.await(30, TimeUnit.SECONDS));
+        // Wait for completion. On timeout, signal workers to stop and join them before
+        // tearDown() frees the native WalLock; otherwise surviving threads would make
+        // JNI calls against a freed pointer and crash the JVM.
+        final boolean isCompleted = doneLatch.await(30, TimeUnit.SECONDS);
+        if (!isCompleted) {
+            isStopRequested.set(true);
+            for (Thread worker : workers) {
+                worker.join();
+            }
+        }
+        Assert.assertTrue("Fuzz test timed out", isCompleted);
 
         if (error.get() != null) {
             error.get().printStackTrace();

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalLockerFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalLockerFuzzTest.java
@@ -306,8 +306,17 @@ public class WalLockerFuzzTest {
             writer.start();
             purge.start();
 
-            Assert.assertTrue("Iteration " + iter + " threads didn't start", ready.await(5, TimeUnit.SECONDS));
-            Assert.assertTrue("Iteration " + iter + " timed out", done.await(5, TimeUnit.SECONDS));
+            // On timeout, join the workers before tearDown() frees the native WalLock;
+            // otherwise a surviving thread would make JNI calls against a freed pointer
+            // and crash the JVM.
+            final boolean isReady = ready.await(5, TimeUnit.SECONDS);
+            final boolean isDone = isReady && done.await(5, TimeUnit.SECONDS);
+            if (!isDone) {
+                writer.join();
+                purge.join();
+            }
+            Assert.assertTrue("Iteration " + iter + " threads didn't start", isReady);
+            Assert.assertTrue("Iteration " + iter + " timed out", isDone);
 
             if (error.get() != null) {
                 error.get().printStackTrace();


### PR DESCRIPTION
## Summary

`WalLockerFuzzTest.testFuzz` runs 8 worker threads performing 200_000 operations each against a native `WalLock`. When the overall deadline of 30 seconds elapses, the current code asserts the timeout and falls into `@After tearDown()`, which calls `locker.close()` and frees the Rust `Arc<WalLock>` through `Box::from_raw`. The worker threads are never signaled to stop, so any worker still inside a JNI call (e.g. `setWalSegmentMinId0`) continues to operate on the freed pointer. Its next `DashMap` shard-lock unlock reads a recycled atomic state word and fails the `WRITE_LOCKED` sanity check in `dashmap::RawRwLock::unlock_exclusive_slow`. Because that assertion is marked no-unwind, the Rust runtime aborts the JVM with SIGABRT, and Surefire reports:

```
The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
```

This masks the real timeout and also terminates every subsequent test scheduled on the same fork (in the original failure, `TtlTest.testMonthOneMicrosBeyondTtl[WITH_WAL]` was in-flight when the panic landed).

The fix introduces an `AtomicBoolean isStopRequested` that each worker checks in its loop guard, tracks the spawned workers in an array, and, on timeout, sets the flag and joins all workers before asserting. By the time `tearDown` runs, no thread is still holding a JNI handle to the native lock.

## Changes

- `core/src/test/java/io/questdb/test/cairo/wal/WalLockerFuzzTest.java`
  - Add `AtomicBoolean isStopRequested` and include it in the worker loop guard.
  - Retain references to the spawned threads in a `Thread[] workers` array.
  - On timeout, set the stop flag and join every worker before `Assert.assertTrue(...)` fails the test.

No production code is touched.