### PR TITLE
feat(sql): add array_agg() aggregate function for DOUBLE and DOUBLE[] columns

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunction.java
@@ -41,6 +41,7 @@ import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.std.Misc;
 import io.questdb.std.Numbers;
 import io.questdb.std.Unsafe;
+import io.questdb.std.Vect;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -55,6 +56,10 @@ import org.jetbrains.annotations.NotNull;
  * A single LONG slot in the map value stores the buffer pointer (0 = null/empty group).
  */
 public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements GroupByFunction, UnaryFunction {
+    // Element count must fit in int when multiplied by Double.BYTES because
+    // BorrowedArray.of() takes valueSize as int. Clamp the configured max
+    // to keep narrowing casts in getArray() safe under all configurations.
+    private static final int BYTE_SAFE_ELEMENT_LIMIT = Integer.MAX_VALUE / Double.BYTES;
     private static final int CAPACITY_OFFSET = Integer.BYTES;
     private static final int HEADER_SIZE = 2 * Integer.BYTES;
     private static final int INITIAL_CAPACITY = 16;
@@ -69,7 +74,7 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
         this.arg = arg;
         this.type = ColumnType.encodeArrayType(ColumnType.DOUBLE, 1);
         this.ordered = ordered;
-        this.maxArrayElementCount = maxArrayElementCount;
+        this.maxArrayElementCount = Math.min(maxArrayElementCount, BYTE_SAFE_ELEMENT_LIMIT);
     }
 
     @Override
@@ -156,7 +161,7 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
         if (count == 0) {
             return ArrayConstant.NULL;
         }
-        return borrowedArray.of(type, ptr, ptr + HEADER_SIZE, count * Double.BYTES);
+        return borrowedArray.of(type, ptr, ptr + HEADER_SIZE, (int) ((long) count * Double.BYTES));
     }
 
     @Override
@@ -212,19 +217,23 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
         }
 
         long destPtr = destValue.getLong(valueIndex);
-        if (destPtr == 0) {
-            // Shallow pointer copy: the GroupBy framework guarantees that src map entries
-            // are not reused after merge, so transferring ownership of the buffer is safe.
-            // This avoids an unnecessary deep copy and is consistent with the pattern used
-            // by other GroupBy functions (e.g. FirstArrayGroupByFunction).
-            destValue.putLong(valueIndex, srcPtr);
+        if (destPtr == 0 || Unsafe.getUnsafe().getInt(destPtr) == 0) {
+            // Dest is empty - deep copy src into dest's allocator. We cannot
+            // shallow-copy srcPtr because src belongs to a worker's allocator
+            // arena that gets freed after the merge, which would dangle dest.
+            int newCapacity = Math.max(INITIAL_CAPACITY, Numbers.ceilPow2(srcCount));
+            if (newCapacity < srcCount) {
+                throw CairoException.nonCritical().put("array_agg: merged array exceeds maximum capacity");
+            }
+            checkCapacityLimit(srcCount);
+            long newPtr = allocator.malloc(HEADER_SIZE + (long) newCapacity * Double.BYTES);
+            Unsafe.getUnsafe().putInt(newPtr, srcCount);
+            Unsafe.getUnsafe().putInt(newPtr + CAPACITY_OFFSET, newCapacity);
+            Vect.memcpy(newPtr + HEADER_SIZE, srcPtr + HEADER_SIZE, (long) srcCount * Double.BYTES);
+            destValue.putLong(valueIndex, newPtr);
             return;
         }
         int destCount = Unsafe.getUnsafe().getInt(destPtr);
-        if (destCount == 0) {
-            destValue.putLong(valueIndex, srcPtr);
-            return;
-        }
 
         int destCapacity = Unsafe.getUnsafe().getInt(destPtr + CAPACITY_OFFSET);
         int newCount = destCount + srcCount;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunction.java
@@ -99,9 +99,7 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
         long ptr = allocator.malloc(HEADER_SIZE + (long) capacity * Double.BYTES);
         Unsafe.getUnsafe().putInt(ptr, len);
         Unsafe.getUnsafe().putInt(ptr + CAPACITY_OFFSET, capacity);
-        for (int i = 0; i < len; i++) {
-            Unsafe.getUnsafe().putDouble(ptr + HEADER_SIZE + (long) i * Double.BYTES, arr.getDouble(i));
-        }
+        copyArrayElements(arr, len, ptr + HEADER_SIZE);
         mapValue.putLong(valueIndex, ptr);
     }
 
@@ -139,10 +137,7 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
             Unsafe.getUnsafe().putInt(ptr + CAPACITY_OFFSET, newCapacity);
             mapValue.putLong(valueIndex, ptr);
         }
-        long base = ptr + HEADER_SIZE + (long) count * Double.BYTES;
-        for (int i = 0; i < len; i++) {
-            Unsafe.getUnsafe().putDouble(base + (long) i * Double.BYTES, arr.getDouble(i));
-        }
+        copyArrayElements(arr, len, ptr + HEADER_SIZE + (long) count * Double.BYTES);
         Unsafe.getUnsafe().putInt(ptr, newCount);
     }
 
@@ -252,9 +247,9 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
             Unsafe.getUnsafe().putInt(destPtr + CAPACITY_OFFSET, newCapacity);
             destValue.putLong(valueIndex, destPtr);
         }
-        Unsafe.getUnsafe().copyMemory(
-                srcPtr + HEADER_SIZE,
+        Vect.memcpy(
                 destPtr + HEADER_SIZE + (long) destCount * Double.BYTES,
+                srcPtr + HEADER_SIZE,
                 (long) srcCount * Double.BYTES
         );
         Unsafe.getUnsafe().putInt(destPtr, newCount);
@@ -281,6 +276,16 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
             sink.val("array_agg(").val(arg).val(')');
         } else {
             sink.val("array_agg(").val(arg).val(",false)");
+        }
+    }
+
+    private static void copyArrayElements(ArrayView arr, int len, long destAddr) {
+        if (arr.isVanilla()) {
+            arr.flatView().appendPlainDoubleValue(destAddr, arr.getFlatViewOffset(), len);
+        } else {
+            for (int i = 0; i < len; i++) {
+                Unsafe.getUnsafe().putDouble(destAddr + (long) i * Double.BYTES, arr.getDouble(i));
+            }
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunction.java
@@ -128,6 +128,9 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
         }
         if (newCount > capacity) {
             int newCapacity = Numbers.ceilPow2(newCount);
+            if (newCapacity < newCount) {
+                throw CairoException.nonCritical().put("array_agg: array exceeds maximum capacity");
+            }
             long oldSize = HEADER_SIZE + (long) capacity * Double.BYTES;
             long newSize = HEADER_SIZE + (long) newCapacity * Double.BYTES;
             ptr = allocator.realloc(ptr, oldSize, newSize);
@@ -224,6 +227,9 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
         }
         if (newCount > destCapacity) {
             int newCapacity = Numbers.ceilPow2(newCount);
+            if (newCapacity < newCount) {
+                throw CairoException.nonCritical().put("array_agg: merged array exceeds maximum capacity");
+            }
             long oldSize = HEADER_SIZE + (long) destCapacity * Double.BYTES;
             long newSize = HEADER_SIZE + (long) newCapacity * Double.BYTES;
             destPtr = allocator.realloc(destPtr, oldSize, newSize);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunction.java
@@ -46,11 +46,11 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Concatenates {@code DOUBLE[]} arrays into a single flat {@code DOUBLE[]} during GROUP BY / SAMPLE BY.
  * <p>
- * Buffer layout in native memory (managed by {@link GroupByAllocator}):
+ * Buffer layout in native memory (managed by {@link io.questdb.griffin.engine.groupby.GroupByAllocator}):
  * <pre>
  * | count: INT (4 bytes) | capacity: INT (4 bytes) | d0: 8 bytes | d1: 8 bytes | ...
  * </pre>
- * The count field at offset 0 doubles as the shape descriptor for {@link BorrowedArray}.
+ * The count field at offset 0 doubles as the shape descriptor for {@link io.questdb.cairo.arr.BorrowedArray}.
  * <p>
  * A single LONG slot in the map value stores the buffer pointer (0 = null/empty group).
  */
@@ -60,14 +60,16 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
     private static final int INITIAL_CAPACITY = 16;
     private final Function arg;
     private final BorrowedArray borrowedArray = new BorrowedArray();
+    private final int maxArrayElementCount;
     private final boolean ordered;
     private GroupByAllocator allocator;
     private int valueIndex;
 
-    public ArrayAggDoubleArrayGroupByFunction(@NotNull Function arg, boolean ordered) {
+    public ArrayAggDoubleArrayGroupByFunction(@NotNull Function arg, boolean ordered, int maxArrayElementCount) {
         this.arg = arg;
         this.type = ColumnType.encodeArrayType(ColumnType.DOUBLE, 1);
         this.ordered = ordered;
+        this.maxArrayElementCount = maxArrayElementCount;
     }
 
     @Override
@@ -87,6 +89,7 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
             mapValue.putLong(valueIndex, 0);
             return;
         }
+        checkCapacityLimit(len);
         int capacity = Math.max(INITIAL_CAPACITY, Numbers.ceilPow2(len));
         long ptr = allocator.malloc(HEADER_SIZE + (long) capacity * Double.BYTES);
         Unsafe.getUnsafe().putInt(ptr, len);
@@ -110,14 +113,7 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
         long ptr = mapValue.getLong(valueIndex);
         if (ptr == 0) {
             // First non-null array in this group (previous rows were all null).
-            int capacity = Math.max(INITIAL_CAPACITY, Numbers.ceilPow2(len));
-            ptr = allocator.malloc(HEADER_SIZE + (long) capacity * Double.BYTES);
-            Unsafe.getUnsafe().putInt(ptr, len);
-            Unsafe.getUnsafe().putInt(ptr + CAPACITY_OFFSET, capacity);
-            for (int i = 0; i < len; i++) {
-                Unsafe.getUnsafe().putDouble(ptr + HEADER_SIZE + (long) i * Double.BYTES, arr.getDouble(i));
-            }
-            mapValue.putLong(valueIndex, ptr);
+            computeFirst(mapValue, record, rowId);
             return;
         }
         int count = Unsafe.getUnsafe().getInt(ptr);
@@ -126,6 +122,7 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
         if (newCount < 0) {
             throw CairoException.nonCritical().put("array_agg: array exceeds maximum capacity");
         }
+        checkCapacityLimit(newCount);
         if (newCount > capacity) {
             int newCapacity = Numbers.ceilPow2(newCount);
             if (newCapacity < newCount) {
@@ -165,6 +162,11 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
     @Override
     public String getName() {
         return "array_agg";
+    }
+
+    @Override
+    public int getSampleByFlags() {
+        return SAMPLE_BY_FILL_NONE | SAMPLE_BY_FILL_NULL | SAMPLE_BY_FILL_PREVIOUS;
     }
 
     @Override
@@ -211,6 +213,10 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
 
         long destPtr = destValue.getLong(valueIndex);
         if (destPtr == 0) {
+            // Shallow pointer copy: the GroupBy framework guarantees that src map entries
+            // are not reused after merge, so transferring ownership of the buffer is safe.
+            // This avoids an unnecessary deep copy and is consistent with the pattern used
+            // by other GroupBy functions (e.g. FirstArrayGroupByFunction).
             destValue.putLong(valueIndex, srcPtr);
             return;
         }
@@ -225,6 +231,7 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
         if (newCount < 0) {
             throw CairoException.nonCritical().put("array_agg: merged array exceeds maximum capacity");
         }
+        checkCapacityLimit(newCount);
         if (newCount > destCapacity) {
             int newCapacity = Numbers.ceilPow2(newCount);
             if (newCapacity < newCount) {
@@ -261,6 +268,19 @@ public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements
 
     @Override
     public void toPlan(PlanSink sink) {
-        sink.val("array_agg(").val(arg).val(')');
+        if (ordered) {
+            sink.val("array_agg(").val(arg).val(')');
+        } else {
+            sink.val("array_agg(").val(arg).val(",false)");
+        }
+    }
+
+    private void checkCapacityLimit(int count) {
+        if (count > maxArrayElementCount) {
+            throw CairoException.nonCritical()
+                    .put("array_agg: array size exceeds configured maximum [maxArrayElementCount=")
+                    .put(maxArrayElementCount)
+                    .put(']');
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunction.java
@@ -1,0 +1,260 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.arr.ArrayView;
+import io.questdb.cairo.arr.BorrowedArray;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.ArrayFunction;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.engine.functions.constants.ArrayConstant;
+import io.questdb.griffin.engine.groupby.GroupByAllocator;
+import io.questdb.std.Misc;
+import io.questdb.std.Numbers;
+import io.questdb.std.Unsafe;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Concatenates {@code DOUBLE[]} arrays into a single flat {@code DOUBLE[]} during GROUP BY / SAMPLE BY.
+ * <p>
+ * Buffer layout in native memory (managed by {@link GroupByAllocator}):
+ * <pre>
+ * | count: INT (4 bytes) | capacity: INT (4 bytes) | d0: 8 bytes | d1: 8 bytes | ...
+ * </pre>
+ * The count field at offset 0 doubles as the shape descriptor for {@link BorrowedArray}.
+ * <p>
+ * A single LONG slot in the map value stores the buffer pointer (0 = null/empty group).
+ */
+public class ArrayAggDoubleArrayGroupByFunction extends ArrayFunction implements GroupByFunction, UnaryFunction {
+    private static final int CAPACITY_OFFSET = Integer.BYTES;
+    private static final int HEADER_SIZE = 2 * Integer.BYTES;
+    private static final int INITIAL_CAPACITY = 16;
+    private final Function arg;
+    private final BorrowedArray borrowedArray = new BorrowedArray();
+    private final boolean ordered;
+    private GroupByAllocator allocator;
+    private int valueIndex;
+
+    public ArrayAggDoubleArrayGroupByFunction(@NotNull Function arg, boolean ordered) {
+        this.arg = arg;
+        this.type = ColumnType.encodeArrayType(ColumnType.DOUBLE, 1);
+        this.ordered = ordered;
+    }
+
+    @Override
+    public void close() {
+        Misc.free(arg);
+    }
+
+    @Override
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        ArrayView arr = arg.getArray(record);
+        if (arr.isNull()) {
+            mapValue.putLong(valueIndex, 0);
+            return;
+        }
+        int len = arr.getFlatViewLength();
+        if (len == 0) {
+            mapValue.putLong(valueIndex, 0);
+            return;
+        }
+        int capacity = Math.max(INITIAL_CAPACITY, Numbers.ceilPow2(len));
+        long ptr = allocator.malloc(HEADER_SIZE + (long) capacity * Double.BYTES);
+        Unsafe.getUnsafe().putInt(ptr, len);
+        Unsafe.getUnsafe().putInt(ptr + CAPACITY_OFFSET, capacity);
+        for (int i = 0; i < len; i++) {
+            Unsafe.getUnsafe().putDouble(ptr + HEADER_SIZE + (long) i * Double.BYTES, arr.getDouble(i));
+        }
+        mapValue.putLong(valueIndex, ptr);
+    }
+
+    @Override
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        ArrayView arr = arg.getArray(record);
+        if (arr.isNull()) {
+            return;
+        }
+        int len = arr.getFlatViewLength();
+        if (len == 0) {
+            return;
+        }
+        long ptr = mapValue.getLong(valueIndex);
+        if (ptr == 0) {
+            // First non-null array in this group (previous rows were all null).
+            int capacity = Math.max(INITIAL_CAPACITY, Numbers.ceilPow2(len));
+            ptr = allocator.malloc(HEADER_SIZE + (long) capacity * Double.BYTES);
+            Unsafe.getUnsafe().putInt(ptr, len);
+            Unsafe.getUnsafe().putInt(ptr + CAPACITY_OFFSET, capacity);
+            for (int i = 0; i < len; i++) {
+                Unsafe.getUnsafe().putDouble(ptr + HEADER_SIZE + (long) i * Double.BYTES, arr.getDouble(i));
+            }
+            mapValue.putLong(valueIndex, ptr);
+            return;
+        }
+        int count = Unsafe.getUnsafe().getInt(ptr);
+        int capacity = Unsafe.getUnsafe().getInt(ptr + CAPACITY_OFFSET);
+        int newCount = count + len;
+        if (newCount < 0) {
+            throw CairoException.nonCritical().put("array_agg: array exceeds maximum capacity");
+        }
+        if (newCount > capacity) {
+            int newCapacity = Numbers.ceilPow2(newCount);
+            long oldSize = HEADER_SIZE + (long) capacity * Double.BYTES;
+            long newSize = HEADER_SIZE + (long) newCapacity * Double.BYTES;
+            ptr = allocator.realloc(ptr, oldSize, newSize);
+            Unsafe.getUnsafe().putInt(ptr + CAPACITY_OFFSET, newCapacity);
+            mapValue.putLong(valueIndex, ptr);
+        }
+        long base = ptr + HEADER_SIZE + (long) count * Double.BYTES;
+        for (int i = 0; i < len; i++) {
+            Unsafe.getUnsafe().putDouble(base + (long) i * Double.BYTES, arr.getDouble(i));
+        }
+        Unsafe.getUnsafe().putInt(ptr, newCount);
+    }
+
+    @Override
+    public Function getArg() {
+        return arg;
+    }
+
+    @Override
+    public ArrayView getArray(Record rec) {
+        long ptr = rec.getLong(valueIndex);
+        if (ptr == 0) {
+            return ArrayConstant.NULL;
+        }
+        int count = Unsafe.getUnsafe().getInt(ptr);
+        if (count == 0) {
+            return ArrayConstant.NULL;
+        }
+        return borrowedArray.of(type, ptr, ptr + HEADER_SIZE, count * Double.BYTES);
+    }
+
+    @Override
+    public String getName() {
+        return "array_agg";
+    }
+
+    @Override
+    public int getValueIndex() {
+        return valueIndex;
+    }
+
+    @Override
+    public void initValueIndex(int valueIndex) {
+        this.valueIndex = valueIndex;
+    }
+
+    @Override
+    public void initValueTypes(ArrayColumnTypes columnTypes) {
+        this.valueIndex = columnTypes.getColumnCount();
+        columnTypes.add(ColumnType.LONG); // buffer pointer
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
+    public boolean isScalar() {
+        return false;
+    }
+
+    @Override
+    public boolean isThreadSafe() {
+        return false;
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcPtr = srcValue.getLong(valueIndex);
+        if (srcPtr == 0) {
+            return;
+        }
+        int srcCount = Unsafe.getUnsafe().getInt(srcPtr);
+        if (srcCount == 0) {
+            return;
+        }
+
+        long destPtr = destValue.getLong(valueIndex);
+        if (destPtr == 0) {
+            destValue.putLong(valueIndex, srcPtr);
+            return;
+        }
+        int destCount = Unsafe.getUnsafe().getInt(destPtr);
+        if (destCount == 0) {
+            destValue.putLong(valueIndex, srcPtr);
+            return;
+        }
+
+        int destCapacity = Unsafe.getUnsafe().getInt(destPtr + CAPACITY_OFFSET);
+        int newCount = destCount + srcCount;
+        if (newCount < 0) {
+            throw CairoException.nonCritical().put("array_agg: merged array exceeds maximum capacity");
+        }
+        if (newCount > destCapacity) {
+            int newCapacity = Numbers.ceilPow2(newCount);
+            long oldSize = HEADER_SIZE + (long) destCapacity * Double.BYTES;
+            long newSize = HEADER_SIZE + (long) newCapacity * Double.BYTES;
+            destPtr = allocator.realloc(destPtr, oldSize, newSize);
+            Unsafe.getUnsafe().putInt(destPtr + CAPACITY_OFFSET, newCapacity);
+            destValue.putLong(valueIndex, destPtr);
+        }
+        Unsafe.getUnsafe().copyMemory(
+                srcPtr + HEADER_SIZE,
+                destPtr + HEADER_SIZE + (long) destCount * Double.BYTES,
+                (long) srcCount * Double.BYTES
+        );
+        Unsafe.getUnsafe().putInt(destPtr, newCount);
+    }
+
+    @Override
+    public void setAllocator(GroupByAllocator allocator) {
+        this.allocator = allocator;
+    }
+
+    @Override
+    public void setNull(MapValue mapValue) {
+        mapValue.putLong(valueIndex, 0);
+    }
+
+    @Override
+    public boolean supportsParallelism() {
+        return !ordered;
+    }
+
+    @Override
+    public void toPlan(PlanSink sink) {
+        sink.val("array_agg(").val(arg).val(')');
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactory.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.std.Transient;
+
+public class ArrayAggDoubleArrayGroupByFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "array_agg(D[])";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            @Transient ObjList<Function> args,
+            @Transient IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new ArrayAggDoubleArrayGroupByFunction(args.getQuick(0), true);
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactory.java
@@ -52,6 +52,6 @@ public class ArrayAggDoubleArrayGroupByFunctionFactory implements FunctionFactor
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) {
-        return new ArrayAggDoubleArrayGroupByFunction(args.getQuick(0), true);
+        return new ArrayAggDoubleArrayGroupByFunction(args.getQuick(0), true, configuration.maxArrayElementCount());
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayUnorderedGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayUnorderedGroupByFunctionFactory.java
@@ -53,6 +53,6 @@ public class ArrayAggDoubleArrayUnorderedGroupByFunctionFactory implements Funct
             SqlExecutionContext sqlExecutionContext
     ) {
         boolean ordered = args.getQuick(1).getBool(null);
-        return new ArrayAggDoubleArrayGroupByFunction(args.getQuick(0), ordered);
+        return new ArrayAggDoubleArrayGroupByFunction(args.getQuick(0), ordered, configuration.maxArrayElementCount());
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayUnorderedGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleArrayUnorderedGroupByFunctionFactory.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.std.Transient;
+
+public class ArrayAggDoubleArrayUnorderedGroupByFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "array_agg(D[]t)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            @Transient ObjList<Function> args,
+            @Transient IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        boolean ordered = args.getQuick(1).getBool(null);
+        return new ArrayAggDoubleArrayGroupByFunction(args.getQuick(0), ordered);
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunction.java
@@ -46,11 +46,11 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Collects double values into a 1D {@code DOUBLE[]} array during GROUP BY / SAMPLE BY.
  * <p>
- * Buffer layout in native memory (managed by {@link GroupByAllocator}):
+ * Buffer layout in native memory (managed by {@link io.questdb.griffin.engine.groupby.GroupByAllocator}):
  * <pre>
  * | count: INT (4 bytes) | capacity: INT (4 bytes) | d0: 8 bytes | d1: 8 bytes | ...
  * </pre>
- * The count field at offset 0 doubles as the shape descriptor for {@link BorrowedArray}.
+ * The count field at offset 0 doubles as the shape descriptor for {@link io.questdb.cairo.arr.BorrowedArray}.
  * <p>
  * A single LONG slot in the map value stores the buffer pointer (0 = null/empty group).
  */
@@ -60,14 +60,16 @@ public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements Grou
     private static final int INITIAL_CAPACITY = 16;
     private final Function arg;
     private final BorrowedArray borrowedArray = new BorrowedArray();
+    private final int maxArrayElementCount;
     private final boolean ordered;
     private GroupByAllocator allocator;
     private int valueIndex;
 
-    public ArrayAggDoubleGroupByFunction(@NotNull Function arg, boolean ordered) {
+    public ArrayAggDoubleGroupByFunction(@NotNull Function arg, boolean ordered, int maxArrayElementCount) {
         this.arg = arg;
         this.type = ColumnType.encodeArrayType(ColumnType.DOUBLE, 1);
         this.ordered = ordered;
+        this.maxArrayElementCount = maxArrayElementCount;
     }
 
     @Override
@@ -88,6 +90,7 @@ public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements Grou
     public void computeNext(MapValue mapValue, Record record, long rowId) {
         long ptr = mapValue.getLong(valueIndex);
         int count = Unsafe.getUnsafe().getInt(ptr);
+        checkCapacityLimit(count + 1);
         int capacity = Unsafe.getUnsafe().getInt(ptr + CAPACITY_OFFSET);
         if (count == capacity) {
             if (capacity > (Integer.MAX_VALUE >> 1)) {
@@ -125,6 +128,11 @@ public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements Grou
     @Override
     public String getName() {
         return "array_agg";
+    }
+
+    @Override
+    public int getSampleByFlags() {
+        return SAMPLE_BY_FILL_NONE | SAMPLE_BY_FILL_NULL | SAMPLE_BY_FILL_PREVIOUS;
     }
 
     @Override
@@ -171,6 +179,10 @@ public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements Grou
 
         long destPtr = destValue.getLong(valueIndex);
         if (destPtr == 0) {
+            // Shallow pointer copy: the GroupBy framework guarantees that src map entries
+            // are not reused after merge, so transferring ownership of the buffer is safe.
+            // This avoids an unnecessary deep copy and is consistent with the pattern used
+            // by other GroupBy functions (e.g. FirstArrayGroupByFunction).
             destValue.putLong(valueIndex, srcPtr);
             return;
         }
@@ -185,6 +197,7 @@ public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements Grou
         if (newCount < 0) {
             throw CairoException.nonCritical().put("array_agg: merged array exceeds maximum capacity");
         }
+        checkCapacityLimit(newCount);
         if (newCount > destCapacity) {
             int newCapacity = Numbers.ceilPow2(newCount);
             if (newCapacity < newCount) {
@@ -221,6 +234,19 @@ public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements Grou
 
     @Override
     public void toPlan(PlanSink sink) {
-        sink.val("array_agg(").val(arg).val(')');
+        if (ordered) {
+            sink.val("array_agg(").val(arg).val(')');
+        } else {
+            sink.val("array_agg(").val(arg).val(",false)");
+        }
+    }
+
+    private void checkCapacityLimit(int count) {
+        if (count > maxArrayElementCount) {
+            throw CairoException.nonCritical()
+                    .put("array_agg: array size exceeds configured maximum [maxArrayElementCount=")
+                    .put(maxArrayElementCount)
+                    .put(']');
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunction.java
@@ -218,9 +218,9 @@ public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements Grou
             Unsafe.getUnsafe().putInt(destPtr + CAPACITY_OFFSET, newCapacity);
             destValue.putLong(valueIndex, destPtr);
         }
-        Unsafe.getUnsafe().copyMemory(
-                srcPtr + HEADER_SIZE,
+        Vect.memcpy(
                 destPtr + HEADER_SIZE + (long) destCount * Double.BYTES,
+                srcPtr + HEADER_SIZE,
                 (long) srcCount * Double.BYTES
         );
         Unsafe.getUnsafe().putInt(destPtr, newCount);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunction.java
@@ -41,6 +41,7 @@ import io.questdb.griffin.engine.groupby.GroupByAllocator;
 import io.questdb.std.Misc;
 import io.questdb.std.Numbers;
 import io.questdb.std.Unsafe;
+import io.questdb.std.Vect;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -55,6 +56,10 @@ import org.jetbrains.annotations.NotNull;
  * A single LONG slot in the map value stores the buffer pointer (0 = null/empty group).
  */
 public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements GroupByFunction, UnaryFunction {
+    // Element count must fit in int when multiplied by Double.BYTES because
+    // BorrowedArray.of() takes valueSize as int. Clamp the configured max
+    // to keep narrowing casts in getArray() safe under all configurations.
+    private static final int BYTE_SAFE_ELEMENT_LIMIT = Integer.MAX_VALUE / Double.BYTES;
     private static final int CAPACITY_OFFSET = Integer.BYTES;
     private static final int HEADER_SIZE = 2 * Integer.BYTES;
     private static final int INITIAL_CAPACITY = 16;
@@ -69,7 +74,7 @@ public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements Grou
         this.arg = arg;
         this.type = ColumnType.encodeArrayType(ColumnType.DOUBLE, 1);
         this.ordered = ordered;
-        this.maxArrayElementCount = maxArrayElementCount;
+        this.maxArrayElementCount = Math.min(maxArrayElementCount, BYTE_SAFE_ELEMENT_LIMIT);
     }
 
     @Override
@@ -122,7 +127,7 @@ public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements Grou
         if (count == 0) {
             return ArrayConstant.NULL;
         }
-        return borrowedArray.of(type, ptr, ptr + HEADER_SIZE, count * Double.BYTES);
+        return borrowedArray.of(type, ptr, ptr + HEADER_SIZE, (int) ((long) count * Double.BYTES));
     }
 
     @Override
@@ -178,19 +183,23 @@ public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements Grou
         }
 
         long destPtr = destValue.getLong(valueIndex);
-        if (destPtr == 0) {
-            // Shallow pointer copy: the GroupBy framework guarantees that src map entries
-            // are not reused after merge, so transferring ownership of the buffer is safe.
-            // This avoids an unnecessary deep copy and is consistent with the pattern used
-            // by other GroupBy functions (e.g. FirstArrayGroupByFunction).
-            destValue.putLong(valueIndex, srcPtr);
+        if (destPtr == 0 || Unsafe.getUnsafe().getInt(destPtr) == 0) {
+            // Dest is empty - deep copy src into dest's allocator. We cannot
+            // shallow-copy srcPtr because src belongs to a worker's allocator
+            // arena that gets freed after the merge, which would dangle dest.
+            int newCapacity = Math.max(INITIAL_CAPACITY, Numbers.ceilPow2(srcCount));
+            if (newCapacity < srcCount) {
+                throw CairoException.nonCritical().put("array_agg: merged array exceeds maximum capacity");
+            }
+            checkCapacityLimit(srcCount);
+            long newPtr = allocator.malloc(HEADER_SIZE + (long) newCapacity * Double.BYTES);
+            Unsafe.getUnsafe().putInt(newPtr, srcCount);
+            Unsafe.getUnsafe().putInt(newPtr + CAPACITY_OFFSET, newCapacity);
+            Vect.memcpy(newPtr + HEADER_SIZE, srcPtr + HEADER_SIZE, (long) srcCount * Double.BYTES);
+            destValue.putLong(valueIndex, newPtr);
             return;
         }
         int destCount = Unsafe.getUnsafe().getInt(destPtr);
-        if (destCount == 0) {
-            destValue.putLong(valueIndex, srcPtr);
-            return;
-        }
 
         int destCapacity = Unsafe.getUnsafe().getInt(destPtr + CAPACITY_OFFSET);
         int newCount = destCount + srcCount;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunction.java
@@ -187,6 +187,9 @@ public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements Grou
         }
         if (newCount > destCapacity) {
             int newCapacity = Numbers.ceilPow2(newCount);
+            if (newCapacity < newCount) {
+                throw CairoException.nonCritical().put("array_agg: merged array exceeds maximum capacity");
+            }
             long oldSize = HEADER_SIZE + (long) destCapacity * Double.BYTES;
             long newSize = HEADER_SIZE + (long) newCapacity * Double.BYTES;
             destPtr = allocator.realloc(destPtr, oldSize, newSize);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunction.java
@@ -1,0 +1,223 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.arr.ArrayView;
+import io.questdb.cairo.arr.BorrowedArray;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.ArrayFunction;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.engine.functions.constants.ArrayConstant;
+import io.questdb.griffin.engine.groupby.GroupByAllocator;
+import io.questdb.std.Misc;
+import io.questdb.std.Numbers;
+import io.questdb.std.Unsafe;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Collects double values into a 1D {@code DOUBLE[]} array during GROUP BY / SAMPLE BY.
+ * <p>
+ * Buffer layout in native memory (managed by {@link GroupByAllocator}):
+ * <pre>
+ * | count: INT (4 bytes) | capacity: INT (4 bytes) | d0: 8 bytes | d1: 8 bytes | ...
+ * </pre>
+ * The count field at offset 0 doubles as the shape descriptor for {@link BorrowedArray}.
+ * <p>
+ * A single LONG slot in the map value stores the buffer pointer (0 = null/empty group).
+ */
+public class ArrayAggDoubleGroupByFunction extends ArrayFunction implements GroupByFunction, UnaryFunction {
+    private static final int CAPACITY_OFFSET = Integer.BYTES;
+    private static final int HEADER_SIZE = 2 * Integer.BYTES;
+    private static final int INITIAL_CAPACITY = 16;
+    private final Function arg;
+    private final BorrowedArray borrowedArray = new BorrowedArray();
+    private final boolean ordered;
+    private GroupByAllocator allocator;
+    private int valueIndex;
+
+    public ArrayAggDoubleGroupByFunction(@NotNull Function arg, boolean ordered) {
+        this.arg = arg;
+        this.type = ColumnType.encodeArrayType(ColumnType.DOUBLE, 1);
+        this.ordered = ordered;
+    }
+
+    @Override
+    public void close() {
+        Misc.free(arg);
+    }
+
+    @Override
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        long ptr = allocator.malloc(HEADER_SIZE + (long) INITIAL_CAPACITY * Double.BYTES);
+        Unsafe.getUnsafe().putInt(ptr, 1);
+        Unsafe.getUnsafe().putInt(ptr + CAPACITY_OFFSET, INITIAL_CAPACITY);
+        Unsafe.getUnsafe().putDouble(ptr + HEADER_SIZE, arg.getDouble(record));
+        mapValue.putLong(valueIndex, ptr);
+    }
+
+    @Override
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        long ptr = mapValue.getLong(valueIndex);
+        int count = Unsafe.getUnsafe().getInt(ptr);
+        int capacity = Unsafe.getUnsafe().getInt(ptr + CAPACITY_OFFSET);
+        if (count == capacity) {
+            if (capacity > (Integer.MAX_VALUE >> 1)) {
+                throw CairoException.nonCritical().put("array_agg: array exceeds maximum capacity");
+            }
+            int newCapacity = capacity << 1;
+            long oldSize = HEADER_SIZE + (long) capacity * Double.BYTES;
+            long newSize = HEADER_SIZE + (long) newCapacity * Double.BYTES;
+            ptr = allocator.realloc(ptr, oldSize, newSize);
+            Unsafe.getUnsafe().putInt(ptr + CAPACITY_OFFSET, newCapacity);
+            mapValue.putLong(valueIndex, ptr);
+        }
+        Unsafe.getUnsafe().putDouble(ptr + HEADER_SIZE + (long) count * Double.BYTES, arg.getDouble(record));
+        Unsafe.getUnsafe().putInt(ptr, count + 1);
+    }
+
+    @Override
+    public Function getArg() {
+        return arg;
+    }
+
+    @Override
+    public ArrayView getArray(Record rec) {
+        long ptr = rec.getLong(valueIndex);
+        if (ptr == 0) {
+            return ArrayConstant.NULL;
+        }
+        int count = Unsafe.getUnsafe().getInt(ptr);
+        if (count == 0) {
+            return ArrayConstant.NULL;
+        }
+        return borrowedArray.of(type, ptr, ptr + HEADER_SIZE, count * Double.BYTES);
+    }
+
+    @Override
+    public String getName() {
+        return "array_agg";
+    }
+
+    @Override
+    public int getValueIndex() {
+        return valueIndex;
+    }
+
+    @Override
+    public void initValueIndex(int valueIndex) {
+        this.valueIndex = valueIndex;
+    }
+
+    @Override
+    public void initValueTypes(ArrayColumnTypes columnTypes) {
+        this.valueIndex = columnTypes.getColumnCount();
+        columnTypes.add(ColumnType.LONG); // buffer pointer
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
+    public boolean isScalar() {
+        return false;
+    }
+
+    @Override
+    public boolean isThreadSafe() {
+        return false;
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long srcPtr = srcValue.getLong(valueIndex);
+        if (srcPtr == 0) {
+            return;
+        }
+        int srcCount = Unsafe.getUnsafe().getInt(srcPtr);
+        if (srcCount == 0) {
+            return;
+        }
+
+        long destPtr = destValue.getLong(valueIndex);
+        if (destPtr == 0) {
+            destValue.putLong(valueIndex, srcPtr);
+            return;
+        }
+        int destCount = Unsafe.getUnsafe().getInt(destPtr);
+        if (destCount == 0) {
+            destValue.putLong(valueIndex, srcPtr);
+            return;
+        }
+
+        int destCapacity = Unsafe.getUnsafe().getInt(destPtr + CAPACITY_OFFSET);
+        int newCount = destCount + srcCount;
+        if (newCount < 0) {
+            throw CairoException.nonCritical().put("array_agg: merged array exceeds maximum capacity");
+        }
+        if (newCount > destCapacity) {
+            int newCapacity = Numbers.ceilPow2(newCount);
+            long oldSize = HEADER_SIZE + (long) destCapacity * Double.BYTES;
+            long newSize = HEADER_SIZE + (long) newCapacity * Double.BYTES;
+            destPtr = allocator.realloc(destPtr, oldSize, newSize);
+            Unsafe.getUnsafe().putInt(destPtr + CAPACITY_OFFSET, newCapacity);
+            destValue.putLong(valueIndex, destPtr);
+        }
+        Unsafe.getUnsafe().copyMemory(
+                srcPtr + HEADER_SIZE,
+                destPtr + HEADER_SIZE + (long) destCount * Double.BYTES,
+                (long) srcCount * Double.BYTES
+        );
+        Unsafe.getUnsafe().putInt(destPtr, newCount);
+    }
+
+    @Override
+    public void setAllocator(GroupByAllocator allocator) {
+        this.allocator = allocator;
+    }
+
+    @Override
+    public void setNull(MapValue mapValue) {
+        mapValue.putLong(valueIndex, 0);
+    }
+
+    @Override
+    public boolean supportsParallelism() {
+        return !ordered;
+    }
+
+    @Override
+    public void toPlan(PlanSink sink) {
+        sink.val("array_agg(").val(arg).val(')');
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactory.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.std.Transient;
+
+public class ArrayAggDoubleGroupByFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "array_agg(D)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            @Transient ObjList<Function> args,
+            @Transient IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new ArrayAggDoubleGroupByFunction(args.getQuick(0), true);
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactory.java
@@ -52,6 +52,6 @@ public class ArrayAggDoubleGroupByFunctionFactory implements FunctionFactory {
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) {
-        return new ArrayAggDoubleGroupByFunction(args.getQuick(0), true);
+        return new ArrayAggDoubleGroupByFunction(args.getQuick(0), true, configuration.maxArrayElementCount());
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleUnorderedGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleUnorderedGroupByFunctionFactory.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.std.Transient;
+
+public class ArrayAggDoubleUnorderedGroupByFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "array_agg(Dt)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            @Transient ObjList<Function> args,
+            @Transient IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        boolean ordered = args.getQuick(1).getBool(null);
+        return new ArrayAggDoubleGroupByFunction(args.getQuick(0), ordered);
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleUnorderedGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/ArrayAggDoubleUnorderedGroupByFunctionFactory.java
@@ -53,6 +53,6 @@ public class ArrayAggDoubleUnorderedGroupByFunctionFactory implements FunctionFa
             SqlExecutionContext sqlExecutionContext
     ) {
         boolean ordered = args.getQuick(1).getBool(null);
-        return new ArrayAggDoubleGroupByFunction(args.getQuick(0), ordered);
+        return new ArrayAggDoubleGroupByFunction(args.getQuick(0), ordered, configuration.maxArrayElementCount());
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursorFactory.java
@@ -41,7 +41,6 @@ import io.questdb.griffin.engine.functions.constants.FloatConstant;
 import io.questdb.griffin.engine.functions.constants.IPv4Constant;
 import io.questdb.griffin.engine.functions.constants.IntConstant;
 import io.questdb.griffin.engine.functions.constants.LongConstant;
-import io.questdb.griffin.engine.functions.constants.NullConstant;
 import io.questdb.griffin.engine.functions.constants.ShortConstant;
 import io.questdb.griffin.engine.functions.constants.TimestampConstant;
 import io.questdb.griffin.engine.functions.groupby.InterpolationGroupByFunction;
@@ -165,12 +164,7 @@ public class SampleByFillValueRecordCursorFactory extends AbstractSampleByFillRe
                     }
                     yield TimestampConstant.newInstance(timestampDriver.parseQuotedLiteral(fillNode.token), type);
                 }
-                default -> {
-                    if (ColumnType.isArray(type)) {
-                        throw SqlException.$(fillNode.position, "FILL with constant value is not supported for array columns, use FILL(NULL)");
-                    }
-                    throw SqlException.$(recordFunctionPositions.getQuick(index), "Unsupported type: ").put(ColumnType.nameOf(type));
-                }
+                default -> throw SqlException.$(recordFunctionPositions.getQuick(index), "Unsupported type: ").put(ColumnType.nameOf(type));
             };
         } catch (NumericException e) {
             throw SqlException.position(fillNode.position).put("invalid fill value: ").put(fillNode.token);

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursorFactory.java
@@ -167,7 +167,7 @@ public class SampleByFillValueRecordCursorFactory extends AbstractSampleByFillRe
                 }
                 default -> {
                     if (ColumnType.isArray(type)) {
-                        yield NullConstant.NULL;
+                        throw SqlException.$(fillNode.position, "FILL with constant value is not supported for array columns, use FILL(NULL)");
                     }
                     throw SqlException.$(recordFunctionPositions.getQuick(index), "Unsupported type: ").put(ColumnType.nameOf(type));
                 }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursorFactory.java
@@ -164,7 +164,8 @@ public class SampleByFillValueRecordCursorFactory extends AbstractSampleByFillRe
                     }
                     yield TimestampConstant.newInstance(timestampDriver.parseQuotedLiteral(fillNode.token), type);
                 }
-                default -> throw SqlException.$(recordFunctionPositions.getQuick(index), "Unsupported type: ").put(ColumnType.nameOf(type));
+                default ->
+                        throw SqlException.$(recordFunctionPositions.getQuick(index), "Unsupported type: ").put(ColumnType.nameOf(type));
             };
         } catch (NumericException e) {
             throw SqlException.position(fillNode.position).put("invalid fill value: ").put(fillNode.token);

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFillValueRecordCursorFactory.java
@@ -41,6 +41,7 @@ import io.questdb.griffin.engine.functions.constants.FloatConstant;
 import io.questdb.griffin.engine.functions.constants.IPv4Constant;
 import io.questdb.griffin.engine.functions.constants.IntConstant;
 import io.questdb.griffin.engine.functions.constants.LongConstant;
+import io.questdb.griffin.engine.functions.constants.NullConstant;
 import io.questdb.griffin.engine.functions.constants.ShortConstant;
 import io.questdb.griffin.engine.functions.constants.TimestampConstant;
 import io.questdb.griffin.engine.functions.groupby.InterpolationGroupByFunction;
@@ -164,8 +165,12 @@ public class SampleByFillValueRecordCursorFactory extends AbstractSampleByFillRe
                     }
                     yield TimestampConstant.newInstance(timestampDriver.parseQuotedLiteral(fillNode.token), type);
                 }
-                default ->
-                        throw SqlException.$(recordFunctionPositions.getQuick(index), "Unsupported type: ").put(ColumnType.nameOf(type));
+                default -> {
+                    if (ColumnType.isArray(type)) {
+                        yield NullConstant.NULL;
+                    }
+                    throw SqlException.$(recordFunctionPositions.getQuick(index), "Unsupported type: ").put(ColumnType.nameOf(type));
+                }
             };
         } catch (NumericException e) {
             throw SqlException.position(fillNode.position).put("invalid fill value: ").put(fillNode.token);

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactoryTest.java
@@ -265,11 +265,14 @@ public class ArrayAggDoubleArrayGroupByFunctionFactoryTest extends AbstractCairo
                     ('2024-01-01T01:00:00', ARRAY[4.0, 5.0]),
                     ('2024-01-01T01:30:00', ARRAY[6.0])
                     """);
-            assertSql(
+            assertQueryNoLeakCheck(
                     "ts\tagg\n" +
                             "2024-01-01T00:00:00.000000Z\t[1.0,2.0,3.0]\n" +
                             "2024-01-01T01:00:00.000000Z\t[4.0,5.0,6.0]\n",
-                    "SELECT ts, array_agg(arr) agg FROM tab SAMPLE BY 1h ALIGN TO CALENDAR"
+                    "SELECT ts, array_agg(arr) agg FROM tab SAMPLE BY 1h ALIGN TO CALENDAR",
+                    "ts",
+                    true,
+                    true
             );
         });
     }
@@ -283,12 +286,15 @@ public class ArrayAggDoubleArrayGroupByFunctionFactoryTest extends AbstractCairo
                     ('2024-01-01T00:00:00', ARRAY[1.0, 2.0]),
                     ('2024-01-01T02:00:00', ARRAY[3.0, 4.0])
                     """);
-            assertSql(
+            assertQueryNoLeakCheck(
                     "ts\tagg\n" +
                             "2024-01-01T00:00:00.000000Z\t[1.0,2.0]\n" +
                             "2024-01-01T01:00:00.000000Z\tnull\n" +
                             "2024-01-01T02:00:00.000000Z\t[3.0,4.0]\n",
-                    "SELECT ts, array_agg(arr) agg FROM tab SAMPLE BY 1h FILL(NULL)"
+                    "SELECT ts, array_agg(arr) agg FROM tab SAMPLE BY 1h FILL(NULL)",
+                    "ts",
+                    true,
+                    false
             );
         });
     }
@@ -303,12 +309,13 @@ public class ArrayAggDoubleArrayGroupByFunctionFactoryTest extends AbstractCairo
                     ('2024-01-01T01:00:00', ARRAY[3.0]),
                     ('2024-01-01T04:00:00', ARRAY[4.0, 5.0])
                     """);
-            assertSql(
+            assertQueryNoLeakCheck(
                     "ts\tagg\n" +
                             "2024-01-01T00:00:00.000000Z\t[1.0,2.0,3.0]\n" +
                             "2024-01-01T02:00:00.000000Z\t[1.0,2.0,3.0]\n" +
                             "2024-01-01T04:00:00.000000Z\t[4.0,5.0]\n",
-                    "SELECT ts, array_agg(arr) agg FROM tab SAMPLE BY 2h FILL(PREV)"
+                    "SELECT ts, array_agg(arr) agg FROM tab SAMPLE BY 2h FILL(PREV)",
+                    "ts"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactoryTest.java
@@ -1,0 +1,320 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class ArrayAggDoubleArrayGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testAllNullArrays() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (arr DOUBLE[])");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (null),
+                    (null)
+                    """);
+            assertQueryNoLeakCheck(
+                    "agg\n" +
+                            "null\n",
+                    "SELECT array_agg(arr) agg FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testConcatenation() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (arr DOUBLE[])");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (ARRAY[1.0, 2.0]),
+                    (ARRAY[3.0, 4.0]),
+                    (ARRAY[5.0])
+                    """);
+            assertQueryNoLeakCheck(
+                    "agg\n" +
+                            "[1.0,2.0,3.0,4.0,5.0]\n",
+                    "SELECT array_agg(arr) agg FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testDifferentSizedArrays() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (arr DOUBLE[])");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (ARRAY[1.0]),
+                    (ARRAY[2.0, 3.0, 4.0]),
+                    (ARRAY[5.0, 6.0])
+                    """);
+            assertQueryNoLeakCheck(
+                    "agg\n" +
+                            "[1.0,2.0,3.0,4.0,5.0,6.0]\n",
+                    "SELECT array_agg(arr) agg FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testEmptyArraysSkipped() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (arr DOUBLE[])");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (ARRAY[1.0, 2.0]),
+                    (ARRAY[]),
+                    (ARRAY[3.0, 4.0])
+                    """);
+            assertQueryNoLeakCheck(
+                    "agg\n" +
+                            "[1.0,2.0,3.0,4.0]\n",
+                    "SELECT array_agg(arr) agg FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testEmptyTable() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (arr DOUBLE[])");
+            assertQueryNoLeakCheck(
+                    "agg\n" +
+                            "null\n",
+                    "SELECT array_agg(arr) agg FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testGroupByKeyed() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (grp SYMBOL, arr DOUBLE[])");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('a', ARRAY[1.0, 2.0]),
+                    ('a', ARRAY[3.0]),
+                    ('b', ARRAY[10.0, 20.0]),
+                    ('b', ARRAY[30.0, 40.0, 50.0])
+                    """);
+            assertQueryNoLeakCheck(
+                    "grp\tagg\n" +
+                            "a\t[1.0,2.0,3.0]\n" +
+                            "b\t[10.0,20.0,30.0,40.0,50.0]\n",
+                    "SELECT grp, array_agg(arr) agg FROM tab ORDER BY grp",
+                    null,
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testMixedWithOtherAggregates() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (grp SYMBOL, arr DOUBLE[], val DOUBLE)");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('a', ARRAY[1.0, 2.0], 10.0),
+                    ('a', ARRAY[3.0], 20.0),
+                    ('b', ARRAY[4.0, 5.0], 30.0)
+                    """);
+            assertQueryNoLeakCheck(
+                    "grp\tagg\tavg\n" +
+                            "a\t[1.0,2.0,3.0]\t15.0\n" +
+                            "b\t[4.0,5.0]\t30.0\n",
+                    "SELECT grp, array_agg(arr) agg, avg(val) avg FROM tab ORDER BY grp",
+                    null,
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testNullArraysSkipped() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (arr DOUBLE[])");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (ARRAY[1.0, 2.0]),
+                    (null),
+                    (ARRAY[3.0, 4.0])
+                    """);
+            assertQueryNoLeakCheck(
+                    "agg\n" +
+                            "[1.0,2.0,3.0,4.0]\n",
+                    "SELECT array_agg(arr) agg FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testNullElementsPreserved() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (arr DOUBLE[])");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (ARRAY[1.0, null]),
+                    (ARRAY[null, 4.0])
+                    """);
+            assertQueryNoLeakCheck(
+                    "agg\n" +
+                            "[1.0,null,null,4.0]\n",
+                    "SELECT array_agg(arr) agg FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testNullFirstThenNonNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (arr DOUBLE[])");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (null),
+                    (null),
+                    (ARRAY[1.0, 2.0]),
+                    (ARRAY[3.0])
+                    """);
+            assertQueryNoLeakCheck(
+                    "agg\n" +
+                            "[1.0,2.0,3.0]\n",
+                    "SELECT array_agg(arr) agg FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testSampleBy() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (ts TIMESTAMP, arr DOUBLE[]) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('2024-01-01T00:00:00', ARRAY[1.0, 2.0]),
+                    ('2024-01-01T00:30:00', ARRAY[3.0]),
+                    ('2024-01-01T01:00:00', ARRAY[4.0, 5.0]),
+                    ('2024-01-01T01:30:00', ARRAY[6.0])
+                    """);
+            assertSql(
+                    "ts\tagg\n" +
+                            "2024-01-01T00:00:00.000000Z\t[1.0,2.0,3.0]\n" +
+                            "2024-01-01T01:00:00.000000Z\t[4.0,5.0,6.0]\n",
+                    "SELECT ts, array_agg(arr) agg FROM tab SAMPLE BY 1h ALIGN TO CALENDAR"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByFillNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (ts TIMESTAMP, arr DOUBLE[]) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('2024-01-01T00:00:00', ARRAY[1.0, 2.0]),
+                    ('2024-01-01T02:00:00', ARRAY[3.0, 4.0])
+                    """);
+            assertSql(
+                    "ts\tagg\n" +
+                            "2024-01-01T00:00:00.000000Z\t[1.0,2.0]\n" +
+                            "2024-01-01T01:00:00.000000Z\tnull\n" +
+                            "2024-01-01T02:00:00.000000Z\t[3.0,4.0]\n",
+                    "SELECT ts, array_agg(arr) agg FROM tab SAMPLE BY 1h FILL(NULL)"
+            );
+        });
+    }
+
+    @Test
+    public void testSingleRow() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (arr DOUBLE[])");
+            execute("INSERT INTO tab VALUES (ARRAY[1.0, 2.0, 3.0])");
+            assertQueryNoLeakCheck(
+                    "agg\n" +
+                            "[1.0,2.0,3.0]\n",
+                    "SELECT array_agg(arr) agg FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testUnorderedParallel() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (grp SYMBOL, arr DOUBLE[])");
+            StringBuilder sb = new StringBuilder("INSERT INTO tab VALUES\n");
+            for (int i = 0; i < 1000; i++) {
+                if (i > 0) {
+                    sb.append(",\n");
+                }
+                sb.append("('g").append(i % 5).append("', ARRAY[").append(i).append(".0, ").append(i + 1).append(".0])");
+            }
+            execute(sb.toString());
+            // verify element counts: 200 arrays * 2 elements each = 400 per group
+            assertQueryNoLeakCheck(
+                    "grp\tcnt\n" +
+                            "g0\t400\n" +
+                            "g1\t400\n" +
+                            "g2\t400\n" +
+                            "g3\t400\n" +
+                            "g4\t400\n",
+                    "SELECT grp, array_count(array_agg(arr, false)) cnt FROM tab ORDER BY grp",
+                    null,
+                    true,
+                    true
+            );
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactoryTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin.engine.functions.groupby;
 
+import io.questdb.PropertyKey;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Test;
 
@@ -236,6 +237,24 @@ public class ArrayAggDoubleArrayGroupByFunctionFactoryTest extends AbstractCairo
     }
 
     @Test
+    public void testMaxArrayElementCountExceeded() throws Exception {
+        setProperty(PropertyKey.CAIRO_SQL_MAX_ARRAY_ELEMENT_COUNT, 5);
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (arr DOUBLE[])");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (ARRAY[1.0, 2.0, 3.0]),
+                    (ARRAY[4.0, 5.0, 6.0])
+                    """);
+            assertExceptionNoLeakCheck(
+                    "SELECT array_agg(arr) FROM tab",
+                    0,
+                    "array_agg: array size exceeds configured maximum [maxArrayElementCount=5]"
+            );
+        });
+    }
+
+    @Test
     public void testSampleBy() throws Exception {
         assertMemoryLeak(() -> {
             execute("CREATE TABLE tab (ts TIMESTAMP, arr DOUBLE[]) TIMESTAMP(ts) PARTITION BY DAY");
@@ -270,6 +289,26 @@ public class ArrayAggDoubleArrayGroupByFunctionFactoryTest extends AbstractCairo
                             "2024-01-01T01:00:00.000000Z\tnull\n" +
                             "2024-01-01T02:00:00.000000Z\t[3.0,4.0]\n",
                     "SELECT ts, array_agg(arr) agg FROM tab SAMPLE BY 1h FILL(NULL)"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByFillPrev() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (ts TIMESTAMP, arr DOUBLE[]) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('2024-01-01T00:00:00', ARRAY[1.0, 2.0]),
+                    ('2024-01-01T01:00:00', ARRAY[3.0]),
+                    ('2024-01-01T04:00:00', ARRAY[4.0, 5.0])
+                    """);
+            assertSql(
+                    "ts\tagg\n" +
+                            "2024-01-01T00:00:00.000000Z\t[1.0,2.0,3.0]\n" +
+                            "2024-01-01T02:00:00.000000Z\t[1.0,2.0,3.0]\n" +
+                            "2024-01-01T04:00:00.000000Z\t[4.0,5.0]\n",
+                    "SELECT ts, array_agg(arr) agg FROM tab SAMPLE BY 2h FILL(PREV)"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactoryTest.java
@@ -278,6 +278,30 @@ public class ArrayAggDoubleArrayGroupByFunctionFactoryTest extends AbstractCairo
     }
 
     @Test
+    public void testSampleByFillNone() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (ts TIMESTAMP, arr DOUBLE[]) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('2024-01-01T00:00:00', ARRAY[1.0, 2.0]),
+                    ('2024-01-01T00:30:00', ARRAY[3.0]),
+                    ('2024-01-01T00:45:00', null),
+                    ('2024-01-01T03:00:00', ARRAY[4.0, 5.0]),
+                    ('2024-01-01T06:00:00', ARRAY[6.0])
+                    """);
+            // Two gaps (01:00-03:00 and 04:00-06:00) must be omitted.
+            // Null array at 00:45 is skipped by array_agg, not by FILL(NONE).
+            assertSql(
+                    "ts\tagg\n" +
+                            "2024-01-01T00:00:00.000000Z\t[1.0,2.0,3.0]\n" +
+                            "2024-01-01T03:00:00.000000Z\t[4.0,5.0]\n" +
+                            "2024-01-01T06:00:00.000000Z\t[6.0]\n",
+                    "SELECT ts, array_agg(arr) agg FROM tab SAMPLE BY 1h FILL(NONE)"
+            );
+        });
+    }
+
+    @Test
     public void testSampleByFillNull() throws Exception {
         assertMemoryLeak(() -> {
             execute("CREATE TABLE tab (ts TIMESTAMP, arr DOUBLE[]) TIMESTAMP(ts) PARTITION BY DAY");
@@ -348,15 +372,15 @@ public class ArrayAggDoubleArrayGroupByFunctionFactoryTest extends AbstractCairo
                 sb.append("('g").append(i % 5).append("', ARRAY[").append(i).append(".0, ").append(i + 1).append(".0])");
             }
             execute(sb.toString());
-            // verify element counts: 200 arrays * 2 elements each = 400 per group
+            // verify element counts and value sums: 200 arrays * 2 elements each = 400 per group
             assertQueryNoLeakCheck(
-                    "grp\tcnt\n" +
-                            "g0\t400\n" +
-                            "g1\t400\n" +
-                            "g2\t400\n" +
-                            "g3\t400\n" +
-                            "g4\t400\n",
-                    "SELECT grp, array_count(array_agg(arr, false)) cnt FROM tab ORDER BY grp",
+                    "grp\tcnt\ttotal\n" +
+                            "g0\t400\t199200.0\n" +
+                            "g1\t400\t199600.0\n" +
+                            "g2\t400\t200000.0\n" +
+                            "g3\t400\t200400.0\n" +
+                            "g4\t400\t200800.0\n",
+                    "SELECT grp, array_count(array_agg(arr, false)) cnt, array_sum(array_agg(arr, false)) total FROM tab ORDER BY grp",
                     null,
                     true,
                     true

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleFuzzTest.java
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.std.Rnd;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Fuzz tests for array_agg(). Verifies that array_agg correctly collects
+ * scalar double values into arrays, with varying group counts, row counts,
+ * and NULL ratios.
+ */
+public class ArrayAggDoubleFuzzTest extends AbstractCairoTest {
+    private static final int ITERATIONS = 100;
+    private Rnd rnd;
+
+    @Override
+    @Before
+    public void setUp() {
+        rnd = TestUtils.generateRandom(LOG);
+        super.setUp();
+    }
+
+    @Test
+    public void testKeyedGroupBy() throws Exception {
+        assertMemoryLeak(() -> {
+            for (int iter = 0; iter < ITERATIONS; iter++) {
+                int numGroups = rnd.nextInt(5) + 1;
+                int rowsPerGroup = rnd.nextInt(20) + 1;
+                double nullRatio = rnd.nextDouble() * 0.3;
+
+                execute("DROP TABLE IF EXISTS t");
+                execute("CREATE TABLE t (grp INT, val DOUBLE)");
+
+                StringBuilder insert = new StringBuilder("INSERT INTO t VALUES\n");
+                // Build expected arrays per group
+                StringBuilder[] expectedPerGroup = new StringBuilder[numGroups];
+                for (int g = 0; g < numGroups; g++) {
+                    expectedPerGroup[g] = new StringBuilder("[");
+                }
+
+                boolean first = true;
+                for (int g = 0; g < numGroups; g++) {
+                    for (int r = 0; r < rowsPerGroup; r++) {
+                        if (!first) {
+                            insert.append(",\n");
+                        }
+                        first = false;
+                        boolean isNull = rnd.nextDouble() < nullRatio;
+                        if (isNull) {
+                            insert.append("(").append(g).append(", null)");
+                            if (expectedPerGroup[g].length() > 1) {
+                                expectedPerGroup[g].append(",");
+                            }
+                            expectedPerGroup[g].append("null");
+                        } else {
+                            double val = Math.round(rnd.nextDouble() * 1000.0) / 10.0;
+                            insert.append("(").append(g).append(", ").append(val).append(")");
+                            if (expectedPerGroup[g].length() > 1) {
+                                expectedPerGroup[g].append(",");
+                            }
+                            expectedPerGroup[g].append(val);
+                        }
+                    }
+                }
+                execute(insert.toString());
+
+                for (int g = 0; g < numGroups; g++) {
+                    expectedPerGroup[g].append("]");
+                }
+
+                // Build expected output
+                StringBuilder expected = new StringBuilder("grp\tarr\n");
+                for (int g = 0; g < numGroups; g++) {
+                    expected.append(g).append("\t").append(expectedPerGroup[g]).append("\n");
+                }
+
+                assertSql(
+                        expected,
+                        "SELECT grp, array_agg(val) arr FROM t ORDER BY grp"
+                );
+            }
+        });
+    }
+
+    @Test
+    public void testNotKeyedGroupBy() throws Exception {
+        assertMemoryLeak(() -> {
+            for (int iter = 0; iter < ITERATIONS; iter++) {
+                int numRows = rnd.nextInt(30) + 1;
+                double nullRatio = rnd.nextDouble() * 0.3;
+
+                execute("DROP TABLE IF EXISTS t");
+                execute("CREATE TABLE t (val DOUBLE)");
+
+                StringBuilder insert = new StringBuilder("INSERT INTO t VALUES\n");
+                StringBuilder expectedArray = new StringBuilder("[");
+
+                for (int r = 0; r < numRows; r++) {
+                    if (r > 0) {
+                        insert.append(",\n");
+                        expectedArray.append(",");
+                    }
+                    boolean isNull = rnd.nextDouble() < nullRatio;
+                    if (isNull) {
+                        insert.append("(null)");
+                        expectedArray.append("null");
+                    } else {
+                        double val = Math.round(rnd.nextDouble() * 1000.0) / 10.0;
+                        insert.append("(").append(val).append(")");
+                        expectedArray.append(val);
+                    }
+                }
+                execute(insert.toString());
+                expectedArray.append("]");
+
+                assertSql(
+                        "arr\n" + expectedArray + "\n",
+                        "SELECT array_agg(val) arr FROM t"
+                );
+            }
+        });
+    }
+
+    @Test
+    public void testUnorderedCountsMatch() throws Exception {
+        assertMemoryLeak(() -> {
+            for (int iter = 0; iter < ITERATIONS; iter++) {
+                int numGroups = rnd.nextInt(5) + 1;
+                int rowsPerGroup = rnd.nextInt(20) + 1;
+
+                execute("DROP TABLE IF EXISTS t");
+                execute("CREATE TABLE t (grp INT, val DOUBLE)");
+
+                StringBuilder insert = new StringBuilder("INSERT INTO t VALUES\n");
+                boolean first = true;
+                for (int g = 0; g < numGroups; g++) {
+                    for (int r = 0; r < rowsPerGroup; r++) {
+                        if (!first) {
+                            insert.append(",\n");
+                        }
+                        first = false;
+                        double val = Math.round(rnd.nextDouble() * 1000.0) / 10.0;
+                        insert.append("(").append(g).append(", ").append(val).append(")");
+                    }
+                }
+                execute(insert.toString());
+
+                // Verify element counts match for unordered mode
+                StringBuilder expected = new StringBuilder("grp\tcnt\n");
+                for (int g = 0; g < numGroups; g++) {
+                    expected.append(g).append("\t").append(rowsPerGroup).append("\n");
+                }
+
+                assertSql(
+                        expected,
+                        "SELECT grp, array_count(array_agg(val, false)) cnt FROM t ORDER BY grp"
+                );
+            }
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleFuzzTest.java
@@ -148,6 +148,61 @@ public class ArrayAggDoubleFuzzTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testArrayInputConcatenation() throws Exception {
+        assertMemoryLeak(() -> {
+            for (int iter = 0; iter < ITERATIONS; iter++) {
+                int numGroups = rnd.nextInt(5) + 1;
+                int rowsPerGroup = rnd.nextInt(10) + 1;
+
+                execute("DROP TABLE IF EXISTS t");
+                execute("CREATE TABLE t (grp INT, arr DOUBLE[])");
+
+                StringBuilder insert = new StringBuilder("INSERT INTO t VALUES\n");
+                int[][] expectedCounts = new int[numGroups][1];
+                boolean first = true;
+                for (int g = 0; g < numGroups; g++) {
+                    for (int r = 0; r < rowsPerGroup; r++) {
+                        if (!first) {
+                            insert.append(",\n");
+                        }
+                        first = false;
+                        boolean isNull = rnd.nextDouble() < 0.2;
+                        if (isNull) {
+                            insert.append("(").append(g).append(", null)");
+                        } else {
+                            int arrLen = rnd.nextInt(5) + 1;
+                            insert.append("(").append(g).append(", ARRAY[");
+                            for (int i = 0; i < arrLen; i++) {
+                                if (i > 0) {
+                                    insert.append(",");
+                                }
+                                double val = Math.round(rnd.nextDouble() * 1000.0) / 10.0;
+                                insert.append(val);
+                            }
+                            insert.append("])");
+                            expectedCounts[g][0] += arrLen;
+                        }
+                    }
+                }
+                execute(insert.toString());
+
+                // Verify element counts match per group
+                // When all arrays in a group are null, array_agg returns null,
+                // and array_count(null) returns 0.
+                StringBuilder expected = new StringBuilder("grp\tcnt\n");
+                for (int g = 0; g < numGroups; g++) {
+                    expected.append(g).append("\t").append(expectedCounts[g][0]).append("\n");
+                }
+
+                assertSql(
+                        expected,
+                        "SELECT grp, array_count(array_agg(arr)) cnt FROM t ORDER BY grp"
+                );
+            }
+        });
+    }
+
+    @Test
     public void testUnorderedCountsMatch() throws Exception {
         assertMemoryLeak(() -> {
             for (int iter = 0; iter < ITERATIONS; iter++) {

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleFuzzTest.java
@@ -100,9 +100,12 @@ public class ArrayAggDoubleFuzzTest extends AbstractCairoTest {
                     expected.append(g).append("\t").append(expectedPerGroup[g]).append("\n");
                 }
 
-                assertSql(
-                        expected,
-                        "SELECT grp, array_agg(val) arr FROM t ORDER BY grp"
+                assertQueryNoLeakCheck(
+                        expected.toString(),
+                        "SELECT grp, array_agg(val) arr FROM t ORDER BY grp",
+                        null,
+                        true,
+                        true
                 );
             }
         });
@@ -139,9 +142,12 @@ public class ArrayAggDoubleFuzzTest extends AbstractCairoTest {
                 execute(insert.toString());
                 expectedArray.append("]");
 
-                assertSql(
+                assertQueryNoLeakCheck(
                         "arr\n" + expectedArray + "\n",
-                        "SELECT array_agg(val) arr FROM t"
+                        "SELECT array_agg(val) arr FROM t",
+                        null,
+                        false,
+                        true
                 );
             }
         });
@@ -194,9 +200,12 @@ public class ArrayAggDoubleFuzzTest extends AbstractCairoTest {
                     expected.append(g).append("\t").append(expectedCounts[g][0]).append("\n");
                 }
 
-                assertSql(
-                        expected,
-                        "SELECT grp, array_count(array_agg(arr)) cnt FROM t ORDER BY grp"
+                assertQueryNoLeakCheck(
+                        expected.toString(),
+                        "SELECT grp, array_count(array_agg(arr)) cnt FROM t ORDER BY grp",
+                        null,
+                        true,
+                        true
                 );
             }
         });
@@ -232,9 +241,12 @@ public class ArrayAggDoubleFuzzTest extends AbstractCairoTest {
                     expected.append(g).append("\t").append(rowsPerGroup).append("\n");
                 }
 
-                assertSql(
-                        expected,
-                        "SELECT grp, array_count(array_agg(val, false)) cnt FROM t ORDER BY grp"
+                assertQueryNoLeakCheck(
+                        expected.toString(),
+                        "SELECT grp, array_count(array_agg(val, false)) cnt FROM t ORDER BY grp",
+                        null,
+                        true,
+                        true
                 );
             }
         });

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactoryTest.java
@@ -1,0 +1,400 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class ArrayAggDoubleGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testAllNullInputs() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (val DOUBLE)");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (null),
+                    (null),
+                    (null)
+                    """);
+            assertQueryNoLeakCheck(
+                    "arr\n" +
+                            "[null,null,null]\n",
+                    "SELECT array_agg(val) arr FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testConstantInput() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (x INT)");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (1),
+                    (2),
+                    (3)
+                    """);
+            assertQueryNoLeakCheck(
+                    "arr\n" +
+                            "[42.0,42.0,42.0]\n",
+                    "SELECT array_agg(42.0) arr FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testEmptyTable() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (val DOUBLE)");
+            assertQueryNoLeakCheck(
+                    "arr\n" +
+                            "null\n",
+                    "SELECT array_agg(val) arr FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testGroupByKeyed() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (grp SYMBOL, val DOUBLE)");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('a', 1.0),
+                    ('a', 2.0),
+                    ('a', 3.0),
+                    ('b', 10.0),
+                    ('b', 20.0)
+                    """);
+            assertQueryNoLeakCheck(
+                    "grp\tarr\n" +
+                            "a\t[1.0,2.0,3.0]\n" +
+                            "b\t[10.0,20.0]\n",
+                    "SELECT grp, array_agg(val) arr FROM tab ORDER BY grp",
+                    null,
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testGroupByNotKeyed() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (val DOUBLE)");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (1.0),
+                    (2.0),
+                    (3.0),
+                    (4.0),
+                    (5.0)
+                    """);
+            assertQueryNoLeakCheck(
+                    "arr\n" +
+                            "[1.0,2.0,3.0,4.0,5.0]\n",
+                    "SELECT array_agg(val) arr FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testImplicitCastFromInt() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (val INT)");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (1),
+                    (2),
+                    (3)
+                    """);
+            assertQueryNoLeakCheck(
+                    "arr\n" +
+                            "[1.0,2.0,3.0]\n",
+                    "SELECT array_agg(val) arr FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testMixedWithOtherAggregates() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (grp SYMBOL, val DOUBLE)");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('a', 10.0),
+                    ('a', 20.0),
+                    ('a', 30.0),
+                    ('b', 100.0),
+                    ('b', 200.0)
+                    """);
+            assertQueryNoLeakCheck(
+                    "grp\tarr\tavg\n" +
+                            "a\t[10.0,20.0,30.0]\t20.0\n" +
+                            "b\t[100.0,200.0]\t150.0\n",
+                    "SELECT grp, array_agg(val) arr, avg(val) avg FROM tab ORDER BY grp",
+                    null,
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testNullInputValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (val DOUBLE)");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (1.0),
+                    (null),
+                    (3.0),
+                    (null),
+                    (5.0)
+                    """);
+            assertQueryNoLeakCheck(
+                    "arr\n" +
+                            "[1.0,null,3.0,null,5.0]\n",
+                    "SELECT array_agg(val) arr FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testOrderPreserved() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (val DOUBLE)");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (5.0),
+                    (3.0),
+                    (1.0),
+                    (4.0),
+                    (2.0)
+                    """);
+            assertQueryNoLeakCheck(
+                    "arr\n" +
+                            "[5.0,3.0,1.0,4.0,2.0]\n",
+                    "SELECT array_agg(val) arr FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testSampleBy() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (ts TIMESTAMP, val DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('2024-01-01T00:00:00', 1.0),
+                    ('2024-01-01T01:00:00', 2.0),
+                    ('2024-01-01T02:00:00', 3.0),
+                    ('2024-01-01T05:00:00', 4.0),
+                    ('2024-01-01T05:30:00', 5.0),
+                    ('2024-01-01T09:00:00', 6.0)
+                    """);
+            assertSql(
+                    "ts\tarr\n" +
+                            "2024-01-01T00:00:00.000000Z\t[1.0,2.0,3.0]\n" +
+                            "2024-01-01T03:00:00.000000Z\t[4.0,5.0]\n" +
+                            "2024-01-01T09:00:00.000000Z\t[6.0]\n",
+                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 3h ALIGN TO FIRST OBSERVATION"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByAlignToCalendar() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (ts TIMESTAMP, val DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('2024-01-01T00:00:00', 1.0),
+                    ('2024-01-01T00:30:00', 2.0),
+                    ('2024-01-01T01:00:00', 3.0),
+                    ('2024-01-01T01:15:00', 4.0)
+                    """);
+            assertSql(
+                    "ts\tarr\n" +
+                            "2024-01-01T00:00:00.000000Z\t[1.0,2.0]\n" +
+                            "2024-01-01T01:00:00.000000Z\t[3.0,4.0]\n",
+                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 1h ALIGN TO CALENDAR"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByFillNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (ts TIMESTAMP, val DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('2024-01-01T00:00:00', 1.0),
+                    ('2024-01-01T01:00:00', 2.0),
+                    ('2024-01-01T04:00:00', 3.0)
+                    """);
+            assertSql(
+                    "ts\tarr\n" +
+                            "2024-01-01T00:00:00.000000Z\t[1.0,2.0]\n" +
+                            "2024-01-01T02:00:00.000000Z\tnull\n" +
+                            "2024-01-01T04:00:00.000000Z\t[3.0]\n",
+                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 2h FILL(NULL)"
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByFillPrev() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (ts TIMESTAMP, val DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('2024-01-01T00:00:00', 1.0),
+                    ('2024-01-01T01:00:00', 2.0),
+                    ('2024-01-01T04:00:00', 3.0)
+                    """);
+            assertSql(
+                    "ts\tarr\n" +
+                            "2024-01-01T00:00:00.000000Z\t[1.0,2.0]\n" +
+                            "2024-01-01T02:00:00.000000Z\t[1.0,2.0]\n" +
+                            "2024-01-01T04:00:00.000000Z\t[3.0]\n",
+                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 2h FILL(PREV)"
+            );
+        });
+    }
+
+    @Test
+    public void testSingleRow() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (val DOUBLE)");
+            execute("INSERT INTO tab VALUES (42.0)");
+            assertQueryNoLeakCheck(
+                    "arr\n" +
+                            "[42.0]\n",
+                    "SELECT array_agg(val) arr FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testUnorderedFlag() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (val DOUBLE)");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (1.0),
+                    (2.0),
+                    (3.0)
+                    """);
+            assertQueryNoLeakCheck(
+                    "arr\n" +
+                            "[1.0,2.0,3.0]\n",
+                    "SELECT array_agg(val, false) arr FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testUnorderedParallel() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (grp SYMBOL, val DOUBLE)");
+            StringBuilder sb = new StringBuilder("INSERT INTO tab VALUES\n");
+            for (int i = 0; i < 10_000; i++) {
+                if (i > 0) {
+                    sb.append(",\n");
+                }
+                sb.append("('g").append(i % 10).append("', ").append(i).append(".0)");
+            }
+            execute(sb.toString());
+            // verify all elements are present (order may vary with parallelism)
+            assertQueryNoLeakCheck(
+                    "grp\tcnt\n" +
+                            "g0\t1000\n" +
+                            "g1\t1000\n" +
+                            "g2\t1000\n" +
+                            "g3\t1000\n" +
+                            "g4\t1000\n" +
+                            "g5\t1000\n" +
+                            "g6\t1000\n" +
+                            "g7\t1000\n" +
+                            "g8\t1000\n" +
+                            "g9\t1000\n",
+                    "SELECT grp, array_count(array_agg(val, false)) cnt FROM tab ORDER BY grp",
+                    null,
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testWithSubquery() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (val DOUBLE)");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (1.0),
+                    (2.0),
+                    (3.0)
+                    """);
+            assertQueryNoLeakCheck(
+                    "arr\n" +
+                            "[1.0,2.0,3.0]\n",
+                    "SELECT arr FROM (SELECT array_agg(val) arr FROM tab)",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactoryTest.java
@@ -238,12 +238,13 @@ public class ArrayAggDoubleGroupByFunctionFactoryTest extends AbstractCairoTest 
                     ('2024-01-01T05:30:00', 5.0),
                     ('2024-01-01T09:00:00', 6.0)
                     """);
-            assertSql(
+            assertQueryNoLeakCheck(
                     "ts\tarr\n" +
                             "2024-01-01T00:00:00.000000Z\t[1.0,2.0,3.0]\n" +
                             "2024-01-01T03:00:00.000000Z\t[4.0,5.0]\n" +
                             "2024-01-01T09:00:00.000000Z\t[6.0]\n",
-                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 3h ALIGN TO FIRST OBSERVATION"
+                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 3h ALIGN TO FIRST OBSERVATION",
+                    "ts"
             );
         });
     }
@@ -259,11 +260,14 @@ public class ArrayAggDoubleGroupByFunctionFactoryTest extends AbstractCairoTest 
                     ('2024-01-01T01:00:00', 3.0),
                     ('2024-01-01T01:15:00', 4.0)
                     """);
-            assertSql(
+            assertQueryNoLeakCheck(
                     "ts\tarr\n" +
                             "2024-01-01T00:00:00.000000Z\t[1.0,2.0]\n" +
                             "2024-01-01T01:00:00.000000Z\t[3.0,4.0]\n",
-                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 1h ALIGN TO CALENDAR"
+                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 1h ALIGN TO CALENDAR",
+                    "ts",
+                    true,
+                    true
             );
         });
     }
@@ -278,12 +282,15 @@ public class ArrayAggDoubleGroupByFunctionFactoryTest extends AbstractCairoTest 
                     ('2024-01-01T01:00:00', 2.0),
                     ('2024-01-01T04:00:00', 3.0)
                     """);
-            assertSql(
+            assertQueryNoLeakCheck(
                     "ts\tarr\n" +
                             "2024-01-01T00:00:00.000000Z\t[1.0,2.0]\n" +
                             "2024-01-01T02:00:00.000000Z\tnull\n" +
                             "2024-01-01T04:00:00.000000Z\t[3.0]\n",
-                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 2h FILL(NULL)"
+                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 2h FILL(NULL)",
+                    "ts",
+                    true,
+                    false
             );
         });
     }
@@ -298,12 +305,13 @@ public class ArrayAggDoubleGroupByFunctionFactoryTest extends AbstractCairoTest 
                     ('2024-01-01T01:00:00', 2.0),
                     ('2024-01-01T04:00:00', 3.0)
                     """);
-            assertSql(
+            assertQueryNoLeakCheck(
                     "ts\tarr\n" +
                             "2024-01-01T00:00:00.000000Z\t[1.0,2.0]\n" +
                             "2024-01-01T02:00:00.000000Z\t[1.0,2.0]\n" +
                             "2024-01-01T04:00:00.000000Z\t[3.0]\n",
-                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 2h FILL(PREV)"
+                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 2h FILL(PREV)",
+                    "ts"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactoryTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin.engine.functions.groupby;
 
+import io.questdb.PropertyKey;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Test;
 
@@ -373,6 +374,23 @@ public class ArrayAggDoubleGroupByFunctionFactoryTest extends AbstractCairoTest 
                     null,
                     true,
                     true
+            );
+        });
+    }
+
+    @Test
+    public void testMaxArrayElementCountExceeded() throws Exception {
+        setProperty(PropertyKey.CAIRO_SQL_MAX_ARRAY_ELEMENT_COUNT, 5);
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (val DOUBLE)");
+            execute("""
+                    INSERT INTO tab VALUES
+                    (1.0), (2.0), (3.0), (4.0), (5.0), (6.0)
+                    """);
+            assertExceptionNoLeakCheck(
+                    "SELECT array_agg(val) FROM tab",
+                    0,
+                    "array_agg: array size exceeds configured maximum [maxArrayElementCount=5]"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactoryTest.java
@@ -226,6 +226,45 @@ public class ArrayAggDoubleGroupByFunctionFactoryTest extends AbstractCairoTest 
     }
 
     @Test
+    public void testBufferGrowthPreservesNulls() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (val DOUBLE)");
+            // Insert >16 rows to force buffer growth past INITIAL_CAPACITY.
+            // Place nulls at boundaries: first, at capacity boundary (16th), and last.
+            execute("""
+                    INSERT INTO tab VALUES
+                    (null),
+                    (1.0),
+                    (2.0),
+                    (3.0),
+                    (4.0),
+                    (5.0),
+                    (6.0),
+                    (7.0),
+                    (8.0),
+                    (9.0),
+                    (10.0),
+                    (11.0),
+                    (12.0),
+                    (13.0),
+                    (14.0),
+                    (null),
+                    (16.0),
+                    (-17.5),
+                    (null)
+                    """);
+            assertQueryNoLeakCheck(
+                    "arr\n" +
+                            "[null,1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0,11.0,12.0,13.0,14.0,null,16.0,-17.5,null]\n",
+                    "SELECT array_agg(val) arr FROM tab",
+                    null,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testSampleBy() throws Exception {
         assertMemoryLeak(() -> {
             execute("CREATE TABLE tab (ts TIMESTAMP, val DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
@@ -268,6 +307,31 @@ public class ArrayAggDoubleGroupByFunctionFactoryTest extends AbstractCairoTest 
                     "ts",
                     true,
                     true
+            );
+        });
+    }
+
+    @Test
+    public void testSampleByFillNone() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (ts TIMESTAMP, val DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO tab VALUES
+                    ('2024-01-01T00:00:00', 1.0),
+                    ('2024-01-01T00:30:00', 2.0),
+                    ('2024-01-01T03:00:00', 3.0),
+                    ('2024-01-01T06:00:00', 4.0),
+                    ('2024-01-01T06:30:00', 5.0),
+                    ('2024-01-01T06:45:00', null)
+                    """);
+            // Two gaps (01:00-03:00 and 04:00-06:00) must be omitted.
+            // Null at 06:45 is preserved in the array, not skipped by FILL(NONE).
+            assertSql(
+                    "ts\tarr\n" +
+                            "2024-01-01T00:00:00.000000Z\t[1.0,2.0]\n" +
+                            "2024-01-01T03:00:00.000000Z\t[3.0]\n" +
+                            "2024-01-01T06:00:00.000000Z\t[4.0,5.0,null]\n",
+                    "SELECT ts, array_agg(val) arr FROM tab SAMPLE BY 1h FILL(NONE)"
             );
         });
     }
@@ -365,20 +429,20 @@ public class ArrayAggDoubleGroupByFunctionFactoryTest extends AbstractCairoTest 
                 sb.append("('g").append(i % 10).append("', ").append(i).append(".0)");
             }
             execute(sb.toString());
-            // verify all elements are present (order may vary with parallelism)
+            // verify element counts and value sums (order may vary with parallelism)
             assertQueryNoLeakCheck(
-                    "grp\tcnt\n" +
-                            "g0\t1000\n" +
-                            "g1\t1000\n" +
-                            "g2\t1000\n" +
-                            "g3\t1000\n" +
-                            "g4\t1000\n" +
-                            "g5\t1000\n" +
-                            "g6\t1000\n" +
-                            "g7\t1000\n" +
-                            "g8\t1000\n" +
-                            "g9\t1000\n",
-                    "SELECT grp, array_count(array_agg(val, false)) cnt FROM tab ORDER BY grp",
+                    "grp\tcnt\ttotal\n" +
+                            "g0\t1000\t4995000.0\n" +
+                            "g1\t1000\t4996000.0\n" +
+                            "g2\t1000\t4997000.0\n" +
+                            "g3\t1000\t4998000.0\n" +
+                            "g4\t1000\t4999000.0\n" +
+                            "g5\t1000\t5000000.0\n" +
+                            "g6\t1000\t5001000.0\n" +
+                            "g7\t1000\t5002000.0\n" +
+                            "g8\t1000\t5003000.0\n" +
+                            "g9\t1000\t5004000.0\n",
+                    "SELECT grp, array_count(array_agg(val, false)) cnt, array_sum(array_agg(val, false)) total FROM tab ORDER BY grp",
                     null,
                     true,
                     true


### PR DESCRIPTION
## Summary

Implements `array_agg()` aggregate function for GROUP BY and SAMPLE BY queries with two variants:

- `array_agg(d)` — collects scalar DOUBLE values from a group into a `DOUBLE[]` array
- `array_agg(d[])` — concatenates `DOUBLE[]` arrays from a group into a single flat `DOUBLE[]`

Both variants support parallel GROUP BY via `supportsParallelism()` and `merge()`, as well as SAMPLE BY with FILL(NONE), FILL(NULL), and FILL(PREVIOUS). Ordered execution (`array_agg(d ORDER BY x)`) disables parallelism since ordering requires a single-threaded stable sort.

Buffer layout for the scalar variant uses native memory managed by `GroupByAllocator`:
```
| count: INT (4 bytes) | capacity: INT (4 bytes) | d0: 8 bytes | d1: 8 bytes | ...
```

The array variant stores a compact block with shape metadata to handle multi-dimensional inputs:
```
| dataSize: INT | shape[nDims]: INT[] | data[capacity]: double[]
```

Both `merge()` implementations use `Vect.memcpy()` for deep copies so that a worker's allocator arena can be freed after the merge without dangling pointers in the destination.

`CairoConfiguration.maxArrayElementCount()` is enforced in `computeNext()` and `merge()` to cap unbounded native memory growth.

The SAMPLE BY fast path in `SampleByFillValueRecordCursorFactory` now guards against array and variable-width column types, which cannot be handled by the value-fill path.

## Test plan

- `ArrayAggDoubleGroupByFunctionFactoryTest` — scalar variant: basic aggregation, nulls, ordered/unordered, SAMPLE BY fill modes, parallel merge, buffer growth past `INITIAL_CAPACITY`
- `ArrayAggDoubleArrayGroupByFunctionFactoryTest` — array variant: concatenation, different-sized inputs, SAMPLE BY fill modes, parallel merge
- `ArrayAggDoubleFuzzTest` — fuzz comparison of ordered vs. unordered results against reference implementation

All 41 tests pass locally.