### PR TITLE
test(ilp): less aggressive column conversion in QWiP fuzz test

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFuzzTest.java
@@ -268,7 +268,7 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
     @Test
     public void testReorderingColumnsNoSymbols() throws Exception {
         initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
-        initFuzzParameters(4, -1, -1, -1, true, false, false, 0.1);
+        initFuzzParameters(4, -1, -1, -1, true, false, false, 0.05);
         runTest();
     }
 


### PR DESCRIPTION
There was a QWiP client ACK timeout while `WalWriter` kept still rolling WAL due to conversions. It appears it's just a too aggressive test config. 

This change decreases probability of column conversions to align it with an equivalent ILP@HTTP test: https://github.com/questdb/questdb/blob/7e782564e7d6bb883b5715da51c5e2bb00148734/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpReceiverFuzzTest.java#L107

From the test failure CI log:
```
[...]
2026-04-22T09:41:27.3623274Z 2026-04-22T09:41:27.361817Z I i.q.c.w.WalWriter rolling uncommitted rows to new segment with type conversion [wal=C:\Users\VSSADM~1\AppData\Local\Temp\junit17273984315994468814\dbRoot\weather0~5\wal3\4, lastSegmentTxn=0, newSegmentId=5, skipRows=0, rowCount=3, existingType=STRING, newType=SYMBOL]
2026-04-22T09:41:27.7662637Z 2026-04-22T09:41:27.765739Z I i.q.c.w.WalWriter rolling uncommitted rows to new segment with type conversion [wal=C:\Users\VSSADM~1\AppData\Local\Temp\junit17273984315994468814\dbRoot\WEATHER1~6\wal4\0, lastSegmentTxn=1, newSegmentId=1, skipRows=3, rowCount=2, existingType=DOUBLE, newType=FLOAT]
2026-04-22T09:41:28.0046792Z 2026-04-22T09:41:28.004120Z I i.q.c.w.WalWriter rolling uncommitted rows to new segment with type conversion [wal=C:\Users\VSSADM~1\AppData\Local\Temp\junit17273984315994468814\dbRoot\WEATHER1~6\wal4\1, lastSegmentTxn=0, newSegmentId=2, skipRows=0, rowCount=2, existingType=VARCHAR, newType=SYMBOL]
2026-04-22T09:41:28.3163222Z 2026-04-22T09:41:28.315776Z I i.q.c.w.WalWriter rolling uncommitted rows to new segment with type conversion [wal=C:\Users\VSSADM~1\AppData\Local\Temp\junit17273984315994468814\dbRoot\WEATHER1~6\wal4\2, lastSegmentTxn=0, newSegmentId=3, skipRows=0, rowCount=2, existingType=SYMBOL, newType=STRING]
2026-04-22T09:41:28.6254332Z 2026-04-22T09:41:28.624946Z I i.q.c.w.WalWriter rolling uncommitted rows to new segment with type conversion [wal=C:\Users\VSSADM~1\AppData\Local\Temp\junit17273984315994468814\dbRoot\WEATHER1~6\wal4\3, lastSegmentTxn=0, newSegmentId=4, skipRows=0, rowCount=2, existingType=STRING, newType=SYMBOL]
2026-04-22T09:41:28.8732426Z 2026-04-22T09:41:28.872639Z I i.q.c.w.WalWriter rolling uncommitted rows to new segment with type conversion [wal=C:\Users\VSSADM~1\AppData\Local\Temp\junit17273984315994468814\dbRoot\WEATHER1~6\wal4\4, lastSegmentTxn=0, newSegmentId=5, skipRows=0, rowCount=2, existingType=SYMBOL, newType=STRING]
2026-04-22T09:41:29.1143626Z 2026-04-22T09:41:29.113811Z I i.q.c.w.WalWriter rolling uncommitted rows to new segment with type conversion [wal=C:\Users\VSSADM~1\AppData\Local\Temp\junit17273984315994468814\dbRoot\WEATHER1~6\wal4\5, lastSegmentTxn=0, newSegmentId=6, skipRows=0, rowCount=2, existingType=STRING, newType=SYMBOL]
2026-04-22T09:41:29.4074169Z 2026-04-22T09:41:29.406868Z I i.q.c.w.WalWriter rolling uncommitted rows to new segment with type conversion [wal=C:\Users\VSSADM~1\AppData\Local\Temp\junit17273984315994468814\dbRoot\WEATHER1~6\wal4\6, lastSegmentTxn=0, newSegmentId=7, skipRows=0, rowCount=2, existingType=VARCHAR, newType=STRING]
2026-04-22T09:41:29.7018693Z 2026-04-22T09:41:29.701338Z I i.q.c.w.WalWriter rolling uncommitted rows to new segment with type conversion [wal=C:\Users\VSSADM~1\AppData\Local\Temp\junit17273984315994468814\dbRoot\WEATHER4~2\wal4\0, lastSegmentTxn=1, newSegmentId=1, skipRows=1, rowCount=2, existingType=DOUBLE, newType=FLOAT]
2026-04-22T09:41:29.9729077Z 2026-04-22T09:41:29.972368Z I i.q.c.w.WalWriter rolling uncommitted rows to new segment with type conversion [wal=C:\Users\VSSADM~1\AppData\Local\Temp\junit17273984315994468814\dbRoot\WEATHER4~2\wal4\1, lastSegmentTxn=0, newSegmentId=2, skipRows=0, rowCount=2, existingType=STRING, newType=SYMBOL]
2026-04-22T09:41:30.3724447Z 2026-04-22T09:41:30.371913Z I i.q.c.w.WalWriter rolling uncommitted rows to new segment with type conversion [wal=C:\Users\VSSADM~1\AppData\Local\Temp\junit17273984315994468814\dbRoot\WEATHER4~2\wal4\2, lastSegmentTxn=0, newSegmentId=3, skipRows=0, rowCount=2, existingType=SYMBOL, newType=STRING]
2026-04-22T09:41:30.5810155Z 2026-04-22T09:41:30.579467Z E i.q.t.c.q.e.QwpSenderFuzzTest Data sending failed [e=io.questdb.client.cutlass.line.LineSenderException: Timeout waiting for batch acknowledgments, 1 batches still in flight
2026-04-22T09:41:30.5813684Z 	at io.questdb.client.cutlass.qwp.client.InFlightWindow.awaitEmpty(InFlightWindow.java:275)
2026-04-22T09:41:30.5815283Z 	at io.questdb.client.cutlass.qwp.client.WebSocketSendQueue.awaitPendingAcks(WebSocketSendQueue.java:323)
2026-04-22T09:41:30.5819063Z 	at io.questdb.client.cutlass.qwp.client.QwpWebSocketSender.flush(QwpWebSocketSender.java:750)
2026-04-22T09:41:30.5820859Z 	at io.questdb.test.cutlass.qwp.e2e.QwpSenderFuzzTest.lambda$startThread$2(QwpSenderFuzzTest.java:710)
2026-04-22T09:41:30.5822288Z 	at java.lang.Thread.run(Thread.java:840)
2026-04-22T09:41:30.5823558Z ]
```

Notice WalWriter is still rolling rows to new segments (conversions) when the timeout expires.