### PR TITLE
chore(core): remove orphan directory left behind when CREATE TABLE fails

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -2056,6 +2056,7 @@ public class CairoEngine implements Closeable, WriterSource {
             while (!lockTableCreate(tableToken)) {
                 Os.pause();
             }
+            boolean filesystemCreated = false;
             try {
                 String lockedReason = lockAll(tableToken, "createTable", true);
                 boolean locked = true;
@@ -2066,6 +2067,7 @@ public class CairoEngine implements Closeable, WriterSource {
                         } else {
                             createTableOrViewOrMatViewUnsafe(mem, blockFileWriter, path, struct, tableToken);
                         }
+                        filesystemCreated = true;
 
                         if (struct.isWalEnabled()) {
                             tableSequencerAPI.registerTable(tableToken.getTableId(), struct, tableToken);
@@ -2099,6 +2101,21 @@ public class CairoEngine implements Closeable, WriterSource {
                 if (struct.isWalEnabled()) {
                     // tableToken.getLoggingName() === tableName, table cannot be renamed while creation hasn't finished
                     tableSequencerAPI.dropTable(tableToken, true);
+                }
+                // If on-disk files were created before the failure (e.g. registerName threw),
+                // remove them so the table name does not stay blocked by an orphan directory.
+                if (filesystemCreated) {
+                    try {
+                        final FilesFacade ff = configuration.getFilesFacade();
+                        path.of(configuration.getDbRoot()).concat(tableToken).$();
+                        if (!ff.unlinkOrRemove(path, LOG)) {
+                            LOG.error().$("could not clean up partial table after failed create [table=").$(tableToken)
+                                    .$(", errno=").$(ff.errno()).I$();
+                        }
+                    } catch (Throwable cleanupEx) {
+                        LOG.error().$("cleanup after failed create threw [table=").$(tableToken)
+                                .$(", err=").$(cleanupEx).I$();
+                    }
                 }
                 throw th;
             } finally {

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -2101,15 +2101,23 @@ public class CairoEngine implements Closeable, WriterSource {
                 if (struct.isWalEnabled()) {
                     // tableToken.getLoggingName() === tableName, table cannot be renamed while creation hasn't finished
                     tableSequencerAPI.dropTable(tableToken, true);
-                }
-                // If on-disk files were created before the failure (e.g. registerName threw),
-                // remove them so the table name does not stay blocked by an orphan directory.
-                if (filesystemCreated) {
+                } else if (filesystemCreated) {
+                    final FilesFacade ff = configuration.getFilesFacade();
                     try {
-                        final FilesFacade ff = configuration.getFilesFacade();
                         path.of(configuration.getDbRoot()).concat(tableToken).$();
+                        Path volumeTarget = null;
+                        if (ff.isSoftLink(path.$())) {
+                            volumeTarget = Path.getThreadLocal2("");
+                            if (!ff.readLink(path, volumeTarget)) {
+                                volumeTarget = null;
+                            }
+                        }
                         if (!ff.unlinkOrRemove(path, LOG)) {
                             LOG.error().$("could not clean up partial table after failed create [table=").$(tableToken)
+                                    .$(", errno=").$(ff.errno()).I$();
+                        }
+                        if (volumeTarget != null && !ff.unlinkOrRemove(volumeTarget, LOG)) {
+                            LOG.error().$("could not clean up partial table in volume [table=").$(tableToken)
                                     .$(", errno=").$(ff.errno()).I$();
                         }
                     } catch (Throwable cleanupEx) {

--- a/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
@@ -38,6 +38,7 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.ops.CreateTableOperationFuture;
 import io.questdb.griffin.engine.ops.Operation;
+import io.questdb.log.Log;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjHashSet;
 import io.questdb.std.ObjList;
@@ -48,8 +49,10 @@ import io.questdb.std.str.Utf8s;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
+import org.junit.Assume;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -58,6 +61,200 @@ import static org.junit.Assert.*;
 
 @SuppressWarnings("SameParameterValue")
 public class CreateTableTest extends AbstractCairoTest {
+
+    @Test
+    public void testCreateCleanupFailureDoesNotMaskOriginalError() throws Exception {
+        final String tableName = "x_cleanup_fail";
+        final AtomicBoolean failNextMetaOpen = new AtomicBoolean(false);
+        final AtomicBoolean failNextUnlinkOrRemove = new AtomicBoolean(false);
+
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public long openRO(LPSZ name) {
+                if (failNextMetaOpen.get()
+                        && Utf8s.containsAscii(name, tableName)
+                        && Utf8s.endsWithAscii(name, TableUtils.META_FILE_NAME)) {
+                    failNextMetaOpen.set(false);
+                    return -1;
+                }
+                return super.openRO(name);
+            }
+
+            @Override
+            public boolean unlinkOrRemove(Path path, Log LOG) {
+                if (failNextUnlinkOrRemove.get() && Utf8s.containsAscii(path, tableName)) {
+                    failNextUnlinkOrRemove.set(false);
+                    return false;
+                }
+                return super.unlinkOrRemove(path, LOG);
+            }
+        };
+
+        assertMemoryLeak(ff, () -> {
+            failNextMetaOpen.set(true);
+            failNextUnlinkOrRemove.set(true);
+            try {
+                execute("CREATE TABLE " + tableName +
+                        " (x INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+                fail("expected CREATE to fail on injected _meta openRO failure");
+            } catch (CairoException | SqlException e) {
+                // The original openRO error must propagate even when the best-effort
+                // cleanup also fails. The cleanup error is logged and swallowed.
+                TestUtils.assertContains(e.getFlyweightMessage(), "could not open");
+            }
+        });
+    }
+
+    @Test
+    public void testCreateInVolumeCleansUpOnRegisterNameHydrateFailure() throws Exception {
+        Assume.assumeFalse(Os.isWindows());
+        final String tableName = "x_orphan_vol";
+        final AtomicBoolean failNextMetaOpen = new AtomicBoolean(false);
+
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public long openRO(LPSZ name) {
+                if (failNextMetaOpen.get()
+                        && Utf8s.containsAscii(name, tableName)
+                        && Utf8s.endsWithAscii(name, TableUtils.META_FILE_NAME)) {
+                    failNextMetaOpen.set(false);
+                    return -1;
+                }
+                return super.openRO(name);
+            }
+        };
+
+        assertMemoryLeak(ff, () -> {
+            final File volume = temp.newFolder("volume_orphan");
+            final String volumeAlias = "orphan_vol";
+            final String volumePath = volume.getAbsolutePath();
+            try (Path p = new Path()) {
+                configuration.getVolumeDefinitions().of(volumeAlias + "->" + volumePath, p, root);
+            }
+            try {
+                failNextMetaOpen.set(true);
+                try {
+                    execute("CREATE TABLE " + tableName +
+                            " (x INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL IN VOLUME '" + volumeAlias + "'");
+                    fail("expected CREATE to fail on injected _meta openRO failure");
+                } catch (CairoException | SqlException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "could not open");
+                }
+
+                execute("CREATE TABLE " + tableName +
+                        " (x INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL IN VOLUME '" + volumeAlias + "'");
+            } finally {
+                configuration.getVolumeDefinitions().clear();
+            }
+        });
+    }
+
+    @Test
+    public void testCreateInVolumeReadLinkFailureDoesNotMaskOriginalError() throws Exception {
+        Assume.assumeFalse(Os.isWindows());
+        final String tableName = "x_orphan_readlink";
+        final AtomicBoolean failNextMetaOpen = new AtomicBoolean(false);
+        final AtomicBoolean failNextReadLink = new AtomicBoolean(false);
+
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public long openRO(LPSZ name) {
+                if (failNextMetaOpen.get()
+                        && Utf8s.containsAscii(name, tableName)
+                        && Utf8s.endsWithAscii(name, TableUtils.META_FILE_NAME)) {
+                    failNextMetaOpen.set(false);
+                    return -1;
+                }
+                return super.openRO(name);
+            }
+
+            @Override
+            public boolean readLink(Path softLink, Path readTo) {
+                if (failNextReadLink.get() && Utf8s.containsAscii(softLink, tableName)) {
+                    failNextReadLink.set(false);
+                    return false;
+                }
+                return super.readLink(softLink, readTo);
+            }
+        };
+
+        assertMemoryLeak(ff, () -> {
+            final File volume = temp.newFolder("volume_readlink");
+            final String volumeAlias = "vol_readlink";
+            try (Path p = new Path()) {
+                configuration.getVolumeDefinitions().of(volumeAlias + "->" + volume.getAbsolutePath(), p, root);
+            }
+            try {
+                failNextMetaOpen.set(true);
+                failNextReadLink.set(true);
+                try {
+                    execute("CREATE TABLE " + tableName +
+                            " (x INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL IN VOLUME '" + volumeAlias + "'");
+                    fail("expected CREATE to fail on injected _meta openRO failure");
+                } catch (CairoException | SqlException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "could not open");
+                }
+            } finally {
+                configuration.getVolumeDefinitions().clear();
+            }
+        });
+    }
+
+    @Test
+    public void testCreateInVolumeTargetUnlinkFailureDoesNotMaskOriginalError() throws Exception {
+        Assume.assumeFalse(Os.isWindows());
+        final String tableName = "x_orphan_volunlink";
+        final String volumeFolder = "volume_target_unlink";
+        final AtomicBoolean failNextMetaOpen = new AtomicBoolean(false);
+        final AtomicBoolean failNextVolumeUnlink = new AtomicBoolean(false);
+
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public long openRO(LPSZ name) {
+                if (failNextMetaOpen.get()
+                        && Utf8s.containsAscii(name, tableName)
+                        && Utf8s.endsWithAscii(name, TableUtils.META_FILE_NAME)) {
+                    failNextMetaOpen.set(false);
+                    return -1;
+                }
+                return super.openRO(name);
+            }
+
+            @Override
+            public boolean unlinkOrRemove(Path path, Log LOG) {
+                // Match only the volume-side call: the dbRoot arm never contains the
+                // volume folder name, so the dbRoot unlink is left to succeed.
+                if (failNextVolumeUnlink.get()
+                        && Utf8s.containsAscii(path, volumeFolder)
+                        && Utf8s.containsAscii(path, tableName)) {
+                    failNextVolumeUnlink.set(false);
+                    return false;
+                }
+                return super.unlinkOrRemove(path, LOG);
+            }
+        };
+
+        assertMemoryLeak(ff, () -> {
+            final File volume = temp.newFolder(volumeFolder);
+            final String volumeAlias = "vol_target_unlink";
+            try (Path p = new Path()) {
+                configuration.getVolumeDefinitions().of(volumeAlias + "->" + volume.getAbsolutePath(), p, root);
+            }
+            try {
+                failNextMetaOpen.set(true);
+                failNextVolumeUnlink.set(true);
+                try {
+                    execute("CREATE TABLE " + tableName +
+                            " (x INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL IN VOLUME '" + volumeAlias + "'");
+                    fail("expected CREATE to fail on injected _meta openRO failure");
+                } catch (CairoException | SqlException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "could not open");
+                }
+            } finally {
+                configuration.getVolumeDefinitions().clear();
+            }
+        });
+    }
 
     @Test
     public void testCreateNaNColumn() throws Exception {
@@ -100,8 +297,8 @@ public class CreateTableTest extends AbstractCairoTest {
                 execute("CREATE TABLE " + tableName +
                         " (x INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
                 fail("expected CREATE to fail on injected _meta openRO failure");
-            } catch (CairoException | SqlException ignore) {
-                // expected: SqlException wraps the injected CairoException
+            } catch (CairoException | SqlException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "could not open");
             }
 
             // Once the engine rolls back the on-disk state on registerName failure,

--- a/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
@@ -24,11 +24,13 @@
 
 package io.questdb.test.cairo;
 
+import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableReaderMetadata;
 import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.OperationFuture;
 import io.questdb.griffin.CompiledQuery;
 import io.questdb.griffin.SqlCompiler;
@@ -40,12 +42,16 @@ import io.questdb.std.IntList;
 import io.questdb.std.ObjHashSet;
 import io.questdb.std.ObjList;
 import io.questdb.std.Os;
+import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
+import io.questdb.std.str.Utf8s;
 import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Test;
 
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.*;
@@ -60,6 +66,50 @@ public class CreateTableTest extends AbstractCairoTest {
                 0,
                 "cannot create NULL-type column, please use type cast, e.g. x::type"
         );
+    }
+
+    @Test
+    public void testCreateNonWalLeavesOrphanDirWhenRegisterNameHydrateFails() throws Exception {
+        final String tableName = "x_orphan";
+        final AtomicBoolean failNextMetaOpen = new AtomicBoolean(false);
+
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public long openRO(LPSZ name) {
+                if (failNextMetaOpen.get()
+                        && Utf8s.containsAscii(name, tableName)
+                        && Utf8s.endsWithAscii(name, TableUtils.META_FILE_NAME)) {
+                    failNextMetaOpen.set(false);
+                    return -1;
+                }
+                return super.openRO(name);
+            }
+        };
+
+        assertMemoryLeak(ff, () -> {
+            execute("CREATE TABLE " + tableName +
+                    " (x INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+            execute("DROP TABLE " + tableName);
+
+            // Fail the openRO(_meta) performed by
+            // TableNameRegistryRW.registerName -> MetadataCache.hydrateTableStartup,
+            // which runs after createTableOrViewOrMatViewUnsafe has already written
+            // the directory and _meta to disk.
+            failNextMetaOpen.set(true);
+            try {
+                execute("CREATE TABLE " + tableName +
+                        " (x INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+                fail("expected CREATE to fail on injected _meta openRO failure");
+            } catch (CairoException | SqlException ignore) {
+                // expected: SqlException wraps the injected CairoException
+            }
+
+            // Once the engine rolls back the on-disk state on registerName failure,
+            // retrying CREATE under the same name must succeed. Today it fails
+            // with "name is reserved" from CairoEngine.createTableOrViewOrMatViewUnsafe.
+            execute("CREATE TABLE " + tableName +
+                    " (x INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+        });
     }
 
     @Test


### PR DESCRIPTION
## Summary

`CairoEngine.createTableOrViewOrMatViewUnsecure` runs two filesystem-visible steps in sequence: `createTableOrViewOrMatViewUnsafe` (or `createTableOrMatViewInVolumeUnsafe`) writes the table directory and `_meta` to disk, then `tableNameRegistry.registerName` hydrates the metadata cache, which re-opens `_meta` via `MetadataCache.hydrateTableStartup` -> `MemoryCMRImpl.smallFile` -> `TableUtils.openRO`. If that second `openRO` fails, the exception propagates out and the existing catch at `CairoEngine.java:2098` only cleans up the sequencer side for WAL tables:

```java
} catch (Throwable th) {
    if (struct.isWalEnabled()) {
        tableSequencerAPI.dropTable(tableToken, true);
    }
    throw th;
}
```

Nothing undoes the on-disk directory. For a non-WAL table, the dirname is just `<tableName>` (or `<tableName>~` with mangle) and is stable across retries, so the next CREATE for the same name hits the `TableUtils.exists` guard at `CairoEngine.java:2004` (or `TableUtils.existsInVolume` for IN VOLUME) and throws `[-1] name is reserved [table=<name>]`. The name is effectively poisoned until an operator removes the directory manually. For a WAL table the dirname is `<tableName>~<tableId>` and the retry generates a fresh `tableId`, so the existence check returns NOT_EXISTS regardless; retry already worked on master, the orphan just accumulated as clutter under `dbRoot`.

The fuzz harness surfaced the non-WAL case on CI in `WalWriterFuzzTest.testWalApplyEjectsMultipleTables`. The CI log shows `createTableOrViewOrMatViewUnsafe` succeeding and unlocking the pool, then an injected IO failure hitting the `openRO(_meta)` inside `registerName`, then `FuzzRunner.applyNonWal`'s retry via `FuzzDropCreateTableOperation.recreateTable` failing with `name is reserved [table=testWalApplyEjectsMultipleTables_0_nonwal]`. The table is non-WAL (note the `_nonwal` suffix) even though the fuzz class is `WalWriterFuzzTest`.

This PR tracks whether the on-disk create succeeded with a local `filesystemCreated` flag and, in the existing outer catch for non-WAL tables, runs a best-effort `FilesFacade.unlinkOrRemove` on `dbRoot/<tableDir>`. For IN VOLUME tables the dbRoot entry is a soft link into the volume, so before unlinking the dbRoot entry the cleanup calls `ff.readLink()` to recover the volume-side target and removes that too — mirroring the pattern `WalPurgeJob` already uses on table drop. Removing only the dbRoot soft link would not satisfy the subsequent `existsInVolume` check, which reads the volume directly. Errors inside the cleanup are logged and swallowed so the original exception still propagates.

WAL tables are intentionally excluded from the cleanup: their retry already works on master (fresh `tableId` -> fresh dirname), so adding an unlink there would only have a cosmetic effect and is out of scope here.

## Changes

- `core/src/main/java/io/questdb/cairo/CairoEngine.java`
  - `createTableOrViewOrMatViewUnsecure`: add `boolean filesystemCreated`, set after the on-disk create call. In the outer `catch (Throwable th)`, when `filesystemCreated && !struct.isWalEnabled()`, best-effort `unlinkOrRemove(dbRoot/<tableDir>)`. If that entry is a soft link (IN VOLUME table), first resolve the target with `ff.readLink()` and then `unlinkOrRemove` it too. Cleanup errors are logged and swallowed; the original exception is rethrown.

- `core/src/test/java/io/questdb/test/cairo/CreateTableTest.java`
  - `testCreateNonWalLeavesOrphanDirWhenRegisterNameHydrateFails`: installs a `TestFilesFacadeImpl` whose `openRO` returns `-1` for the `_meta` file of the target table when a per-test flag is set. CREATE -> DROP -> arm flag -> CREATE (must fail with `could not open`) -> CREATE (must succeed). On master the final CREATE fails with `name is reserved`; after the fix it succeeds.
  - `testCreateInVolumeCleansUpOnRegisterNameHydrateFailure`: same fault injection, but the table is created `IN VOLUME '<alias>'`. Exercises the volume-side unlink — on master the retry fails with `name is reserved` because the volume target dir remains after the dbRoot symlink is gone; after the fix it succeeds.
  - `testCreateCleanupFailureDoesNotMaskOriginalError`: arms both the `openRO(_meta)` fault and an `unlinkOrRemove` fault. The original `CairoException` from the injected `openRO` failure must still propagate — the swallowed cleanup error must not replace or shadow it.

## Effects

Positive:
- Transient IO errors during `registerName`/`hydrateTable` no longer leave a non-WAL table name blocked. Callers (SQL CREATE TABLE, ILP table auto-create, REST API, DDL listeners) can retry under the same name without operator intervention. Covers both regular and IN VOLUME tables.
- The fuzz-observed failure in `WalWriterFuzzTest.testWalApplyEjectsMultipleTables` and any similar fuzz runs that inject IO during hydrate can progress past the poisoned state.

Neutral and negative:
- WAL tables are not touched by this PR. Retry was already working there on master; the dbRoot orphan directory it leaves behind on failure still lingers until an operator removes it. Addressing that cleanliness issue is a separate concern.
- The cleanup is best-effort. If `unlinkOrRemove` itself fails (for example, the filesystem error that caused the original exception is still in effect), the directory will persist and a retry will still see `name is reserved`. The error is logged as `could not clean up partial table after failed create` (and, for the volume arm, `could not clean up partial table in volume`). This is the same observable behavior as master; the fix is a strict improvement for the common case where the failure was on a specific `openRO` rather than blanket-failing.
- The cleanup changes the contents of `dbRoot` and of the volume in the error path. Callers that previously inspected the orphan directory for post-mortem diagnosis will no longer find it. The pre-create `LOG.info` lines in `TableUtils.createTableOrViewOrMatView` plus the new cleanup error logs still document what happened.
- No allocations on either path: the volume-side target is recovered through `ff.readLink()` into a thread-local `Path`, same as `WalPurgeJob` does on drop.

## Test plan

- `mvn -Dtest='CreateTableTest#testCreateNonWalLeavesOrphanDirWhenRegisterNameHydrateFails+testCreateInVolumeCleansUpOnRegisterNameHydrateFailure+testCreateCleanupFailureDoesNotMaskOriginalError' test` — passes with the fix. The first two fail on master with `name is reserved`; the third passes on master too but locks in the cleanup-error-swallowing contract.
- `mvn -Dtest='CreateTableTest,TableNameRegistryTest,CairoEngineTest' test` — 94 tests, no regression.
- `mvn -Dtest='WalWriterFuzzTest#testWalApplyEjectsMultipleTables' test` — happy-path sanity check on the fuzz test that originally surfaced the bug. Note the fuzz is stochastic: this run is not guaranteed to re-exercise the exact CI seed (`3099845320031L, 1776975582561L`), but the deterministic unit tests above cover the failure mechanism.
