### PR TITLE
ci(build): restore master snapshot build broken by stale GraalVM path

### DIFF
--- a/ci/snapshot-pipeline.yml
+++ b/ci/snapshot-pipeline.yml
@@ -17,8 +17,8 @@ stages:
         displayName: "Build on Linux"
         pool: hetzner-incus
         variables:
-          JAVA_HOME_25_X64: "/opt/graalvm"
-          JAVA_HOME: "/opt/graalvm"
+          JAVA_HOME_25_X64: "/opt/graalvm-25"
+          JAVA_HOME: "/opt/graalvm-25"
         steps:
           - checkout: self
             fetchDepth: 1

--- a/ci/templates/aux-job.yml
+++ b/ci/templates/aux-job.yml
@@ -3,7 +3,7 @@ jobs:
     displayName: "on"
     strategy:
       matrix:
-        linux-jdk17:
+        linux-jdk25:
           imageName: "ubuntu-latest"
           poolName: "Azure Pipelines"
           os: Linux


### PR DESCRIPTION
## Summary

The `Build and upload snapshot (Linux)` Azure pipeline has been failing on every push to master since the JDK 25 bump (b700076). The job declares:

```yaml
JAVA_HOME_25_X64: "/opt/graalvm"
JAVA_HOME: "/opt/graalvm"
```

but on the `hetzner-incus` agent pool `/opt/graalvm` still points at a GraalVM 17 install. The Maven task therefore runs under Java 17.0.9, and the `enforce-versions` rule (which now requires Java 25) aborts the build before any code is compiled:

```
Java version: 17.0.9, vendor: GraalVM Community, runtime: /opt/graalvm
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M3:enforce (enforce-versions)
```

This PR points both env vars at `/opt/graalvm-25`, which is the path the rest of the self-hosted pipelines (`ci/templates/self-hosted-jobs.yml`, `ci/templates/steps.yml`) already use.

It also renames the stale `linux-jdk17` matrix key in `ci/templates/aux-job.yml` to `linux-jdk25`. The `jdk: "1.25"` value was already correct, so the underlying job was building under JDK 25; only the matrix label was wrong and was showing a misleading `RunOn linux-jdk17` row in the Azure UI.

## Scope and limits

- This restores the snapshot job. It does not address the unrelated `paths`-filter skips on `GLIBC Smoke Test` and `rebuild_native_libs` for the JDK 25 commit.
- `.github/workflows/parquet_compat.yml` still installs JDK 17 for the PySpark step. PySpark 3.5.x does not run on JDK 25, and `requirements_parquet_pyspark.txt` is pinned at `pyspark>=3.5.0`. Removing the JDK 17 install would require also pinning to `pyspark>=4.0.0`; left as a separate change.

## Test plan

- After merge, confirm `Build and upload snapshot (Linux)` succeeds on the next master push.
- Confirm the `JavaAndRustLint` stage's `RunOn` job now appears as `linux-jdk25` in the Azure DevOps UI.