### PR TITLE
fix(sql): fix EMA, VWEMA and KSUM failures in combined window queries

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/EmaDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/EmaDoubleWindowFunctionFactory.java
@@ -47,6 +47,7 @@ import io.questdb.griffin.engine.window.WindowFunction;
 import io.questdb.std.IntList;
 import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
+import io.questdb.std.Unsafe;
 
 /**
  * Exponential Moving Average (EMA) window function.
@@ -326,7 +327,8 @@ public class EmaDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
 
         @Override
         public void pass1(Record record, long recordOffset, WindowSPI spi) {
-            throw new UnsupportedOperationException();
+            computeNext(record);
+            Unsafe.putDouble(spi.getAddress(recordOffset, columnIndex), ema);
         }
 
         @Override
@@ -446,7 +448,8 @@ public class EmaDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
 
         @Override
         public void pass1(Record record, long recordOffset, WindowSPI spi) {
-            throw new UnsupportedOperationException();
+            computeNext(record);
+            Unsafe.putDouble(spi.getAddress(recordOffset, columnIndex), ema);
         }
 
         @Override
@@ -510,7 +513,8 @@ public class EmaDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
 
         @Override
         public void pass1(Record record, long recordOffset, WindowSPI spi) {
-            throw new UnsupportedOperationException();
+            computeNext(record);
+            Unsafe.putDouble(spi.getAddress(recordOffset, columnIndex), ema);
         }
 
         @Override
@@ -604,7 +608,8 @@ public class EmaDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
 
         @Override
         public void pass1(Record record, long recordOffset, WindowSPI spi) {
-            throw new UnsupportedOperationException();
+            computeNext(record);
+            Unsafe.putDouble(spi.getAddress(recordOffset, columnIndex), ema);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/KSumDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/KSumDoubleWindowFunctionFactory.java
@@ -624,8 +624,8 @@ public class KSumDoubleWindowFunctionFactory extends AbstractWindowFunctionFacto
 
         @Override
         public void pass1(Record record, long recordOffset, WindowSPI spi) {
-            // pass1 is never called when getPassCount() returns ZERO_PASS
-            throw new UnsupportedOperationException();
+            computeNext(record);
+            Unsafe.putDouble(spi.getAddress(recordOffset, columnIndex), sum);
         }
 
         @Override
@@ -1016,8 +1016,8 @@ public class KSumDoubleWindowFunctionFactory extends AbstractWindowFunctionFacto
 
         @Override
         public void pass1(Record record, long recordOffset, WindowSPI spi) {
-            // pass1 is never called when getPassCount() returns ZERO_PASS
-            throw new UnsupportedOperationException();
+            computeNext(record);
+            Unsafe.putDouble(spi.getAddress(recordOffset, columnIndex), externalSum);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/VwemaDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/VwemaDoubleWindowFunctionFactory.java
@@ -47,6 +47,7 @@ import io.questdb.griffin.engine.window.WindowFunction;
 import io.questdb.std.IntList;
 import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
+import io.questdb.std.Unsafe;
 
 /**
  * Volume-Weighted Exponential Moving Average (VWEMA) window function.
@@ -361,7 +362,8 @@ public class VwemaDoubleWindowFunctionFactory extends AbstractWindowFunctionFact
 
         @Override
         public void pass1(Record record, long recordOffset, WindowSPI spi) {
-            throw new UnsupportedOperationException();
+            computeNext(record);
+            Unsafe.putDouble(spi.getAddress(recordOffset, columnIndex), vwema);
         }
 
         @Override
@@ -447,7 +449,8 @@ public class VwemaDoubleWindowFunctionFactory extends AbstractWindowFunctionFact
 
         @Override
         public void pass1(Record record, long recordOffset, WindowSPI spi) {
-            throw new UnsupportedOperationException();
+            computeNext(record);
+            Unsafe.putDouble(spi.getAddress(recordOffset, columnIndex), getDouble(record));
         }
 
         @Override
@@ -605,7 +608,8 @@ public class VwemaDoubleWindowFunctionFactory extends AbstractWindowFunctionFact
 
         @Override
         public void pass1(Record record, long recordOffset, WindowSPI spi) {
-            throw new UnsupportedOperationException();
+            computeNext(record);
+            Unsafe.putDouble(spi.getAddress(recordOffset, columnIndex), vwema);
         }
 
         @Override
@@ -705,7 +709,8 @@ public class VwemaDoubleWindowFunctionFactory extends AbstractWindowFunctionFact
 
         @Override
         public void pass1(Record record, long recordOffset, WindowSPI spi) {
-            throw new UnsupportedOperationException();
+            computeNext(record);
+            Unsafe.putDouble(spi.getAddress(recordOffset, columnIndex), getDouble(record));
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowFunction.java
@@ -203,8 +203,20 @@ public interface WindowFunction extends Function {
     }
 
     /**
-     * @return number of additional passes over base data set required to calculate this function.
-     * {@link  #ZERO_PASS} means window function can be calculated on the fly and doesn't require additional passes .
+     * Returns a pass-count-oriented optimization hint for window execution.
+     * <p>
+     * This value is also used by the planner as a streaming fast-path hint when the input cursor
+     * already satisfies the window order. In that case, {@link #ZERO_PASS} functions are evaluated
+     * row-by-row through {@link #computeNext(Record)}.
+     * <p>
+     * {@link #ZERO_PASS} is the strongest optimization hint, not a promise that cached execution
+     * will skip this function. If the query is routed through the cached executor, every window
+     * function, including {@link #ZERO_PASS}, must still implement
+     * {@link #pass1(Record, long, WindowSPI)}. For a {@link #ZERO_PASS} function, {@code pass1()}
+     * normally performs the cached equivalent of {@code computeNext(record)} and materializes the
+     * current result into the output slot identified by {@link #setColumnIndex(int)}.
+     *
+     * @return cached execution pass count: {@link #ZERO_PASS}, {@link #ONE_PASS}, or {@link #TWO_PASS}
      */
     default int getPassCount() {
         return ONE_PASS;
@@ -279,11 +291,27 @@ public interface WindowFunction extends Function {
         return false;
     }
 
+    /**
+     * Performs the primary cached traversal for this function.
+     * <p>
+     * The cached executor calls this method for every window function, including functions whose
+     * {@link #getPassCount()} returns {@link #ZERO_PASS}. Implementations must therefore not rely
+     * on {@link #ZERO_PASS} to avoid cached execution. One-pass and zero-pass functions should
+     * materialize their final result for {@code recordOffset}; two-pass functions may instead
+     * build state or store scratch values for {@link #pass2(Record, long, WindowSPI)}.
+     */
     void pass1(Record record, long recordOffset, WindowSPI spi);
 
+    /**
+     * Performs the optional secondary cached traversal. The cached executor calls this only when
+     * {@link #getPassCount()} is greater than {@link #ONE_PASS}.
+     */
     default void pass2(Record record, long recordOffset, WindowSPI spi) {
     }
 
+    /**
+     * Prepares state before the optional secondary cached traversal.
+     */
     default void preparePass2() {
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/EmaWindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/EmaWindowFunctionTest.java
@@ -545,6 +545,35 @@ public class EmaWindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testEmaPeriodCachedWindowPartitionedReorderedReplay() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sort_key long, i long, val double) timestamp(ts)", timestampType.getTypeName());
+            execute("insert into tab values (1::timestamp, 2, 0, 10.0)");
+            execute("insert into tab values (2::timestamp, 2, 1, 100.0)");
+            execute("insert into tab values (3::timestamp, 1, 0, 20.0)");
+            execute("insert into tab values (4::timestamp, 3, 1, 300.0)");
+            execute("insert into tab values (5::timestamp, 3, 0, 30.0)");
+            execute("insert into tab values (6::timestamp, 1, 1, 200.0)");
+
+            assertQueryNoLeakCheck(
+                    replaceTimestampSuffix("""
+                            ts\tsort_key\ti\tval\tavg
+                            1970-01-01T00:00:00.000001Z\t2\t0\t10.0\t15.0
+                            1970-01-01T00:00:00.000002Z\t2\t1\t100.0\t150.0
+                            1970-01-01T00:00:00.000003Z\t1\t0\t20.0\t20.0
+                            1970-01-01T00:00:00.000004Z\t3\t1\t300.0\t225.0
+                            1970-01-01T00:00:00.000005Z\t3\t0\t30.0\t22.5
+                            1970-01-01T00:00:00.000006Z\t1\t1\t200.0\t200.0
+                            """),
+                    "select ts, sort_key, i, val, avg(val, 'period', 3) over (partition by i order by sort_key) from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testEmaResetBetweenQueries() throws Exception {
         // Test that EMA state resets properly between queries
         assertMemoryLeak(() -> {

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/EmaWindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/EmaWindowFunctionTest.java
@@ -158,6 +158,46 @@ public class EmaWindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testEmaCachedWindowWithNulls() throws Exception {
+        // Forces cached execution via order-by-non-timestamp column and exercises NULL handling
+        // through pass1() for both EmaOverPartitionFunction and EmaOverUnboundedRowsFrameFunction.
+        // NULL values must keep the previous EMA; a partition that starts with NULL (lowest sort_key
+        // in the partition is NULL) must produce NULL until the first finite value.
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sort_key long, i long, val double) timestamp(ts)", timestampType.getTypeName());
+            execute("insert into tab values " +
+                    "('1970-01-01T00:00:01.000000Z'::timestamp, 3, 0, 30.0), " +
+                    "('1970-01-01T00:00:02.000000Z'::timestamp, 2, 1, 10.0), " +
+                    "('1970-01-01T00:00:03.000000Z'::timestamp, 5, 0, NULL), " +
+                    "('1970-01-01T00:00:04.000000Z'::timestamp, 1, 1, NULL), " +
+                    "('1970-01-01T00:00:05.000000Z'::timestamp, 4, 0, 100.0)");
+
+            // sort_key order, alpha = 2/(period+1) = 0.5:
+            //   no-partition stream: (sk=1,NULL) (sk=2,10) (sk=3,30) (sk=4,100) (sk=5,NULL)
+            //     -> NULL, 10, 20, 60, 60
+            //   partition i=1: (sk=1,NULL) (sk=2,10) -> NULL (first row NULL), 10 (first valid)
+            //   partition i=0: (sk=3,30)  (sk=4,100) (sk=5,NULL) -> 30, 65, 65
+            assertQueryNoLeakCheck(
+                    replaceTimestampSuffix("""
+                            ts\tsort_key\ti\tval\tema_no_part\tema_part
+                            1970-01-01T00:00:01.000000Z\t3\t0\t30.0\t20.0\t30.0
+                            1970-01-01T00:00:02.000000Z\t2\t1\t10.0\t10.0\t10.0
+                            1970-01-01T00:00:03.000000Z\t5\t0\tnull\t60.0\t65.0
+                            1970-01-01T00:00:04.000000Z\t1\t1\tnull\tnull\tnull
+                            1970-01-01T00:00:05.000000Z\t4\t0\t100.0\t60.0\t65.0
+                            """),
+                    "select ts, sort_key, i, val, " +
+                            "avg(val, 'period', 3) over (order by sort_key) ema_no_part, " +
+                            "avg(val, 'period', 3) over (partition by i order by sort_key) ema_part " +
+                            "from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testEmaEmptyTable() throws Exception {
         // Test avg() with empty table
         assertMemoryLeak(() -> {
@@ -1067,6 +1107,6 @@ public class EmaWindowFunctionTest extends AbstractCairoTest {
     }
 
     private String replaceTimestampSuffix(String expected) {
-        return timestampType == TestTimestampType.NANO ? expected.replaceAll("Z\t", "000Z\t").replaceAll("Z\n", "000Z\n") : expected;
+        return timestampType == TestTimestampType.NANO ? expected.replace("Z\t", "000Z\t").replace("Z\n", "000Z\n") : expected;
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/EmaWindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/EmaWindowFunctionTest.java
@@ -127,6 +127,37 @@ public class EmaWindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testEmaCachedWindowAllPass1Variants() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sort_key long, i long, val double) timestamp(ts)", timestampType.getTypeName());
+            execute("insert into tab values " +
+                    "('1970-01-01T00:00:01.000000Z'::timestamp, 1, 0, 10.0), " +
+                    "('1970-01-01T00:00:02.000000Z'::timestamp, 2, 1, 100.0), " +
+                    "('1970-01-01T00:00:03.000000Z'::timestamp, 3, 0, 20.0), " +
+                    "('1970-01-01T00:00:04.000000Z'::timestamp, 4, 1, 200.0)");
+
+            assertQueryNoLeakCheck(
+                    replaceTimestampSuffix("""
+                            ts\tsort_key\ti\tval\tema_period\tema_period_part\tema_second\tema_second_part
+                            1970-01-01T00:00:01.000000Z\t1\t0\t10.0\t10.0\t10.0\t10.0\t10.0
+                            1970-01-01T00:00:02.000000Z\t2\t1\t100.0\t55.0\t100.0\t66.89085029457019\t100.0
+                            1970-01-01T00:00:03.000000Z\t3\t0\t20.0\t37.5\t15.0\t37.25017980242024\t18.646647167633873
+                            1970-01-01T00:00:04.000000Z\t4\t1\t200.0\t118.75\t150.0\t140.12768709496163\t186.46647167633873
+                            """),
+                    "select ts, sort_key, i, val, " +
+                            "avg(val, 'period', 3) over (order by sort_key) ema_period, " +
+                            "avg(val, 'period', 3) over (partition by i order by sort_key) ema_period_part, " +
+                            "avg(val, 'second', 1) over (order by sort_key) ema_second, " +
+                            "avg(val, 'second', 1) over (partition by i order by sort_key) ema_second_part " +
+                            "from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testEmaEmptyTable() throws Exception {
         // Test avg() with empty table
         assertMemoryLeak(() -> {
@@ -245,16 +276,6 @@ public class EmaWindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testEmaExceptionZeroParameterValue() throws Exception {
-        assertException(
-                "select ts, val, avg(val, 'alpha', 0) over (order by ts) from tab",
-                "create table tab (ts " + timestampType.getTypeName() + ", val double) timestamp(ts)",
-                34,
-                "parameter value must be a positive number"
-        );
-    }
-
-    @Test
     public void testEmaExceptionTauTooSmall() throws Exception {
         // When value < 1, casting to long produces 0, which would make tau = 0
         assertException(
@@ -262,6 +283,16 @@ public class EmaWindowFunctionTest extends AbstractCairoTest {
                 "create table tab (ts " + timestampType.getTypeName() + ", val double) timestamp(ts)",
                 25,
                 "time constant must be at least 1 unit in native timestamp precision"
+        );
+    }
+
+    @Test
+    public void testEmaExceptionZeroParameterValue() throws Exception {
+        assertException(
+                "select ts, val, avg(val, 'alpha', 0) over (order by ts) from tab",
+                "create table tab (ts " + timestampType.getTypeName() + ", val double) timestamp(ts)",
+                34,
+                "parameter value must be a positive number"
         );
     }
 
@@ -463,37 +494,6 @@ public class EmaWindowFunctionTest extends AbstractCairoTest {
                     "select ts, i, val, avg(val, 'alpha', 0.5) over (partition by i order by ts) from tab",
                     "ts",
                     false,
-                    true
-            );
-        });
-    }
-
-    @Test
-    public void testEmaCachedWindowAllPass1Variants() throws Exception {
-        assertMemoryLeak(() -> {
-            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sort_key long, i long, val double) timestamp(ts)", timestampType.getTypeName());
-            execute("insert into tab values " +
-                    "('1970-01-01T00:00:01.000000Z'::timestamp, 1, 0, 10.0), " +
-                    "('1970-01-01T00:00:02.000000Z'::timestamp, 2, 1, 100.0), " +
-                    "('1970-01-01T00:00:03.000000Z'::timestamp, 3, 0, 20.0), " +
-                    "('1970-01-01T00:00:04.000000Z'::timestamp, 4, 1, 200.0)");
-
-            assertQueryNoLeakCheck(
-                    replaceTimestampSuffix("""
-                            ts\tsort_key\ti\tval\tema_period\tema_period_part\tema_second\tema_second_part
-                            1970-01-01T00:00:01.000000Z\t1\t0\t10.0\t10.0\t10.0\t10.0\t10.0
-                            1970-01-01T00:00:02.000000Z\t2\t1\t100.0\t55.0\t100.0\t66.89085029457019\t100.0
-                            1970-01-01T00:00:03.000000Z\t3\t0\t20.0\t37.5\t15.0\t37.25017980242024\t18.646647167633873
-                            1970-01-01T00:00:04.000000Z\t4\t1\t200.0\t118.75\t150.0\t140.12768709496163\t186.46647167633873
-                            """),
-                    "select ts, sort_key, i, val, " +
-                            "avg(val, 'period', 3) over (order by sort_key) ema_period, " +
-                            "avg(val, 'period', 3) over (partition by i order by sort_key) ema_period_part, " +
-                            "avg(val, 'second', 1) over (order by sort_key) ema_second, " +
-                            "avg(val, 'second', 1) over (partition by i order by sort_key) ema_second_part " +
-                            "from tab",
-                    "ts",
-                    true,
                     true
             );
         });

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/EmaWindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/EmaWindowFunctionTest.java
@@ -469,6 +469,67 @@ public class EmaWindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testEmaCachedWindowAllPass1Variants() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sort_key long, i long, val double) timestamp(ts)", timestampType.getTypeName());
+            execute("insert into tab values " +
+                    "('1970-01-01T00:00:01.000000Z'::timestamp, 1, 0, 10.0), " +
+                    "('1970-01-01T00:00:02.000000Z'::timestamp, 2, 1, 100.0), " +
+                    "('1970-01-01T00:00:03.000000Z'::timestamp, 3, 0, 20.0), " +
+                    "('1970-01-01T00:00:04.000000Z'::timestamp, 4, 1, 200.0)");
+
+            assertQueryNoLeakCheck(
+                    replaceTimestampSuffix("""
+                            ts\tsort_key\ti\tval\tema_period\tema_period_part\tema_second\tema_second_part
+                            1970-01-01T00:00:01.000000Z\t1\t0\t10.0\t10.0\t10.0\t10.0\t10.0
+                            1970-01-01T00:00:02.000000Z\t2\t1\t100.0\t55.0\t100.0\t66.89085029457019\t100.0
+                            1970-01-01T00:00:03.000000Z\t3\t0\t20.0\t37.5\t15.0\t37.25017980242024\t18.646647167633873
+                            1970-01-01T00:00:04.000000Z\t4\t1\t200.0\t118.75\t150.0\t140.12768709496163\t186.46647167633873
+                            """),
+                    "select ts, sort_key, i, val, " +
+                            "avg(val, 'period', 3) over (order by sort_key) ema_period, " +
+                            "avg(val, 'period', 3) over (partition by i order by sort_key) ema_period_part, " +
+                            "avg(val, 'second', 1) over (order by sort_key) ema_second, " +
+                            "avg(val, 'second', 1) over (partition by i order by sort_key) ema_second_part " +
+                            "from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testEmaPeriodCachedWindowPartitionedReorderedReplay() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sort_key long, i long, val double) timestamp(ts)", timestampType.getTypeName());
+            execute("insert into tab values " +
+                    "(1::timestamp, 2, 0, 10.0), " +
+                    "(2::timestamp, 2, 1, 100.0), " +
+                    "(3::timestamp, 1, 0, 20.0), " +
+                    "(4::timestamp, 3, 1, 300.0), " +
+                    "(5::timestamp, 3, 0, 30.0), " +
+                    "(6::timestamp, 1, 1, 200.0)");
+
+            assertQueryNoLeakCheck(
+                    replaceTimestampSuffix("""
+                            ts\tsort_key\ti\tval\tavg
+                            1970-01-01T00:00:00.000001Z\t2\t0\t10.0\t15.0
+                            1970-01-01T00:00:00.000002Z\t2\t1\t100.0\t150.0
+                            1970-01-01T00:00:00.000003Z\t1\t0\t20.0\t20.0
+                            1970-01-01T00:00:00.000004Z\t3\t1\t300.0\t225.0
+                            1970-01-01T00:00:00.000005Z\t3\t0\t30.0\t22.5
+                            1970-01-01T00:00:00.000006Z\t1\t1\t200.0\t200.0
+                            """),
+                    "select ts, sort_key, i, val, avg(val, 'period', 3) over (partition by i order by sort_key) from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testEmaPeriodMode() throws Exception {
         // Test avg() with period mode (N-period EMA where alpha = 2 / (N + 1))
         assertMemoryLeak(() -> {
@@ -539,65 +600,6 @@ public class EmaWindowFunctionTest extends AbstractCairoTest {
                     "select ts, val, avg(val, 'period', 1) over (order by ts) from tab",
                     "ts",
                     false,
-                    true
-            );
-        });
-    }
-
-    @Test
-    public void testEmaPeriodCachedWindowPartitionedReorderedReplay() throws Exception {
-        assertMemoryLeak(() -> {
-            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sort_key long, i long, val double) timestamp(ts)", timestampType.getTypeName());
-            execute("insert into tab values (1::timestamp, 2, 0, 10.0)");
-            execute("insert into tab values (2::timestamp, 2, 1, 100.0)");
-            execute("insert into tab values (3::timestamp, 1, 0, 20.0)");
-            execute("insert into tab values (4::timestamp, 3, 1, 300.0)");
-            execute("insert into tab values (5::timestamp, 3, 0, 30.0)");
-            execute("insert into tab values (6::timestamp, 1, 1, 200.0)");
-
-            assertQueryNoLeakCheck(
-                    replaceTimestampSuffix("""
-                            ts\tsort_key\ti\tval\tavg
-                            1970-01-01T00:00:00.000001Z\t2\t0\t10.0\t15.0
-                            1970-01-01T00:00:00.000002Z\t2\t1\t100.0\t150.0
-                            1970-01-01T00:00:00.000003Z\t1\t0\t20.0\t20.0
-                            1970-01-01T00:00:00.000004Z\t3\t1\t300.0\t225.0
-                            1970-01-01T00:00:00.000005Z\t3\t0\t30.0\t22.5
-                            1970-01-01T00:00:00.000006Z\t1\t1\t200.0\t200.0
-                            """),
-                    "select ts, sort_key, i, val, avg(val, 'period', 3) over (partition by i order by sort_key) from tab",
-                    "ts",
-                    true,
-                    true
-            );
-        });
-    }
-
-    @Test
-    public void testEmaCachedWindowAllPass1Variants() throws Exception {
-        assertMemoryLeak(() -> {
-            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sort_key long, i long, val double) timestamp(ts)", timestampType.getTypeName());
-            execute("insert into tab values ('1970-01-01T00:00:01.000000Z'::timestamp, 1, 0, 10.0)");
-            execute("insert into tab values ('1970-01-01T00:00:02.000000Z'::timestamp, 2, 1, 100.0)");
-            execute("insert into tab values ('1970-01-01T00:00:03.000000Z'::timestamp, 3, 0, 20.0)");
-            execute("insert into tab values ('1970-01-01T00:00:04.000000Z'::timestamp, 4, 1, 200.0)");
-
-            assertQueryNoLeakCheck(
-                    replaceTimestampSuffix("""
-                            ts\tsort_key\ti\tval\tema_period\tema_period_part\tema_second\tema_second_part
-                            1970-01-01T00:00:01.000000Z\t1\t0\t10.0\t10.0\t10.0\t10.0\t10.0
-                            1970-01-01T00:00:02.000000Z\t2\t1\t100.0\t55.0\t100.0\t66.89085029457019\t100.0
-                            1970-01-01T00:00:03.000000Z\t3\t0\t20.0\t37.5\t15.0\t37.25017980242024\t18.646647167633873
-                            1970-01-01T00:00:04.000000Z\t4\t1\t200.0\t118.75\t150.0\t140.12768709496163\t186.46647167633873
-                            """),
-                    "select ts, sort_key, i, val, " +
-                            "avg(val, 'period', 3) over (order by sort_key) ema_period, " +
-                            "avg(val, 'period', 3) over (partition by i order by sort_key) ema_period_part, " +
-                            "avg(val, 'second', 1) over (order by sort_key) ema_second, " +
-                            "avg(val, 'second', 1) over (partition by i order by sort_key) ema_second_part " +
-                            "from tab",
-                    "ts",
-                    true,
                     true
             );
         });

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/EmaWindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/EmaWindowFunctionTest.java
@@ -574,6 +574,36 @@ public class EmaWindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testEmaCachedWindowAllPass1Variants() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sort_key long, i long, val double) timestamp(ts)", timestampType.getTypeName());
+            execute("insert into tab values ('1970-01-01T00:00:01.000000Z'::timestamp, 1, 0, 10.0)");
+            execute("insert into tab values ('1970-01-01T00:00:02.000000Z'::timestamp, 2, 1, 100.0)");
+            execute("insert into tab values ('1970-01-01T00:00:03.000000Z'::timestamp, 3, 0, 20.0)");
+            execute("insert into tab values ('1970-01-01T00:00:04.000000Z'::timestamp, 4, 1, 200.0)");
+
+            assertQueryNoLeakCheck(
+                    replaceTimestampSuffix("""
+                            ts\tsort_key\ti\tval\tema_period\tema_period_part\tema_second\tema_second_part
+                            1970-01-01T00:00:01.000000Z\t1\t0\t10.0\t10.0\t10.0\t10.0\t10.0
+                            1970-01-01T00:00:02.000000Z\t2\t1\t100.0\t55.0\t100.0\t66.89085029457019\t100.0
+                            1970-01-01T00:00:03.000000Z\t3\t0\t20.0\t37.5\t15.0\t37.25017980242024\t18.646647167633873
+                            1970-01-01T00:00:04.000000Z\t4\t1\t200.0\t118.75\t150.0\t140.12768709496163\t186.46647167633873
+                            """),
+                    "select ts, sort_key, i, val, " +
+                            "avg(val, 'period', 3) over (order by sort_key) ema_period, " +
+                            "avg(val, 'period', 3) over (partition by i order by sort_key) ema_period_part, " +
+                            "avg(val, 'second', 1) over (order by sort_key) ema_second, " +
+                            "avg(val, 'second', 1) over (partition by i order by sort_key) ema_second_part " +
+                            "from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testEmaResetBetweenQueries() throws Exception {
         // Test that EMA state resets properly between queries
         assertMemoryLeak(() -> {

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/VwemaWindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/VwemaWindowFunctionTest.java
@@ -556,6 +556,35 @@ public class VwemaWindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testVwemaPeriodCachedWindowPartitionedReorderedReplay() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tab (ts timestamp, sort_key long, sym symbol, price double, volume double) timestamp(ts)");
+            execute("insert into tab values ('2024-01-01T00:00:00.000000Z'::timestamp, 2, 'A', 10.0, 3.0)");
+            execute("insert into tab values ('2024-01-01T00:00:01.000000Z'::timestamp, 2, 'B', 100.0, 1.0)");
+            execute("insert into tab values ('2024-01-01T00:00:02.000000Z'::timestamp, 1, 'A', 20.0, 1.0)");
+            execute("insert into tab values ('2024-01-01T00:00:03.000000Z'::timestamp, 3, 'B', 300.0, 4.0)");
+            execute("insert into tab values ('2024-01-01T00:00:04.000000Z'::timestamp, 3, 'A', 30.0, 1.0)");
+            execute("insert into tab values ('2024-01-01T00:00:05.000000Z'::timestamp, 1, 'B', 200.0, 2.0)");
+
+            assertQueryNoLeakCheck(
+                    """
+                            ts\tsort_key\tsym\tprice\tvolume\tvwema
+                            2024-01-01T00:00:00.000000Z\t2\tA\t10.0\t3.0\t12.5
+                            2024-01-01T00:00:01.000000Z\t2\tB\t100.0\t1.0\t166.66666666666666
+                            2024-01-01T00:00:02.000000Z\t1\tA\t20.0\t1.0\t20.0
+                            2024-01-01T00:00:03.000000Z\t3\tB\t300.0\t4.0\t263.6363636363636
+                            2024-01-01T00:00:04.000000Z\t3\tA\t30.0\t1.0\t18.333333333333332
+                            2024-01-01T00:00:05.000000Z\t1\tB\t200.0\t2.0\t200.0
+                            """,
+                    "select ts, sort_key, sym, price, volume, avg(price, 'period', 3, volume) over (partition by sym order by sort_key) as vwema from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testVwemaTimeWeightedModeHours() throws Exception {
         // Test 'hour' time unit parsing
         assertQuery(

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/VwemaWindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/VwemaWindowFunctionTest.java
@@ -447,6 +447,67 @@ public class VwemaWindowFunctionTest extends AbstractCairoTest {
     // ========================= Period and Time-Weighted Mode Tests =========================
 
     @Test
+    public void testVwemaCachedWindowAllPass1Variants() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tab (ts timestamp, sort_key long, sym symbol, price double, volume double) timestamp(ts)");
+            execute("insert into tab values " +
+                    "('2024-01-01T00:00:01.000000Z'::timestamp, 1, 'A', 10.0, 1.0), " +
+                    "('2024-01-01T00:00:02.000000Z'::timestamp, 2, 'B', 100.0, 1.0), " +
+                    "('2024-01-01T00:00:03.000000Z'::timestamp, 3, 'A', 20.0, 1.0), " +
+                    "('2024-01-01T00:00:04.000000Z'::timestamp, 4, 'B', 200.0, 1.0)");
+
+            assertQueryNoLeakCheck(
+                    """
+                            ts\tsort_key\tsym\tprice\tvolume\tvwema_period\tvwema_period_part\tvwema_second\tvwema_second_part
+                            2024-01-01T00:00:01.000000Z\t1\tA\t10.0\t1.0\t10.0\t10.0\t10.0\t10.0
+                            2024-01-01T00:00:02.000000Z\t2\tB\t100.0\t1.0\t55.0\t100.0\t66.89085029457019\t100.0
+                            2024-01-01T00:00:03.000000Z\t3\tA\t20.0\t1.0\t37.5\t15.0\t37.25017980242024\t18.646647167633873
+                            2024-01-01T00:00:04.000000Z\t4\tB\t200.0\t1.0\t118.75\t150.0\t140.12768709496163\t186.46647167633873
+                            """,
+                    "select ts, sort_key, sym, price, volume, " +
+                            "avg(price, 'period', 3, volume) over (order by sort_key) vwema_period, " +
+                            "avg(price, 'period', 3, volume) over (partition by sym order by sort_key) vwema_period_part, " +
+                            "avg(price, 'second', 1, volume) over (order by sort_key) vwema_second, " +
+                            "avg(price, 'second', 1, volume) over (partition by sym order by sort_key) vwema_second_part " +
+                            "from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testVwemaPeriodCachedWindowPartitionedReorderedReplay() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tab (ts timestamp, sort_key long, sym symbol, price double, volume double) timestamp(ts)");
+            execute("insert into tab values " +
+                    "('2024-01-01T00:00:00.000000Z'::timestamp, 2, 'A', 10.0, 3.0), " +
+                    "('2024-01-01T00:00:01.000000Z'::timestamp, 2, 'B', 100.0, 1.0), " +
+                    "('2024-01-01T00:00:02.000000Z'::timestamp, 1, 'A', 20.0, 1.0), " +
+                    "('2024-01-01T00:00:03.000000Z'::timestamp, 3, 'B', 300.0, 4.0), " +
+                    "('2024-01-01T00:00:04.000000Z'::timestamp, 3, 'A', 30.0, 1.0), " +
+                    "('2024-01-01T00:00:05.000000Z'::timestamp, 1, 'B', 200.0, 2.0)");
+
+            assertQueryNoLeakCheck(
+                    """
+                            ts\tsort_key\tsym\tprice\tvolume\tvwema
+                            2024-01-01T00:00:00.000000Z\t2\tA\t10.0\t3.0\t12.5
+                            2024-01-01T00:00:01.000000Z\t2\tB\t100.0\t1.0\t166.66666666666666
+                            2024-01-01T00:00:02.000000Z\t1\tA\t20.0\t1.0\t20.0
+                            2024-01-01T00:00:03.000000Z\t3\tB\t300.0\t4.0\t263.6363636363636
+                            2024-01-01T00:00:04.000000Z\t3\tA\t30.0\t1.0\t18.333333333333332
+                            2024-01-01T00:00:05.000000Z\t1\tB\t200.0\t2.0\t200.0
+                            """,
+                    "select ts, sort_key, sym, price, volume, avg(price, 'period', 3, volume) over (partition by sym order by sort_key) as vwema from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testVwemaPeriodMode() throws Exception {
         // Test avg() VWEMA with period mode (alpha = 2 / (period + 1))
         // With period=2, alpha = 2/3
@@ -553,65 +614,6 @@ public class VwemaWindowFunctionTest extends AbstractCairoTest {
                                 Frame forward scan on: tab
                         """
         );
-    }
-
-    @Test
-    public void testVwemaPeriodCachedWindowPartitionedReorderedReplay() throws Exception {
-        assertMemoryLeak(() -> {
-            execute("create table tab (ts timestamp, sort_key long, sym symbol, price double, volume double) timestamp(ts)");
-            execute("insert into tab values ('2024-01-01T00:00:00.000000Z'::timestamp, 2, 'A', 10.0, 3.0)");
-            execute("insert into tab values ('2024-01-01T00:00:01.000000Z'::timestamp, 2, 'B', 100.0, 1.0)");
-            execute("insert into tab values ('2024-01-01T00:00:02.000000Z'::timestamp, 1, 'A', 20.0, 1.0)");
-            execute("insert into tab values ('2024-01-01T00:00:03.000000Z'::timestamp, 3, 'B', 300.0, 4.0)");
-            execute("insert into tab values ('2024-01-01T00:00:04.000000Z'::timestamp, 3, 'A', 30.0, 1.0)");
-            execute("insert into tab values ('2024-01-01T00:00:05.000000Z'::timestamp, 1, 'B', 200.0, 2.0)");
-
-            assertQueryNoLeakCheck(
-                    """
-                            ts\tsort_key\tsym\tprice\tvolume\tvwema
-                            2024-01-01T00:00:00.000000Z\t2\tA\t10.0\t3.0\t12.5
-                            2024-01-01T00:00:01.000000Z\t2\tB\t100.0\t1.0\t166.66666666666666
-                            2024-01-01T00:00:02.000000Z\t1\tA\t20.0\t1.0\t20.0
-                            2024-01-01T00:00:03.000000Z\t3\tB\t300.0\t4.0\t263.6363636363636
-                            2024-01-01T00:00:04.000000Z\t3\tA\t30.0\t1.0\t18.333333333333332
-                            2024-01-01T00:00:05.000000Z\t1\tB\t200.0\t2.0\t200.0
-                            """,
-                    "select ts, sort_key, sym, price, volume, avg(price, 'period', 3, volume) over (partition by sym order by sort_key) as vwema from tab",
-                    "ts",
-                    true,
-                    true
-            );
-        });
-    }
-
-    @Test
-    public void testVwemaCachedWindowAllPass1Variants() throws Exception {
-        assertMemoryLeak(() -> {
-            execute("create table tab (ts timestamp, sort_key long, sym symbol, price double, volume double) timestamp(ts)");
-            execute("insert into tab values ('2024-01-01T00:00:01.000000Z'::timestamp, 1, 'A', 10.0, 1.0)");
-            execute("insert into tab values ('2024-01-01T00:00:02.000000Z'::timestamp, 2, 'B', 100.0, 1.0)");
-            execute("insert into tab values ('2024-01-01T00:00:03.000000Z'::timestamp, 3, 'A', 20.0, 1.0)");
-            execute("insert into tab values ('2024-01-01T00:00:04.000000Z'::timestamp, 4, 'B', 200.0, 1.0)");
-
-            assertQueryNoLeakCheck(
-                    """
-                            ts\tsort_key\tsym\tprice\tvolume\tvwema_period\tvwema_period_part\tvwema_second\tvwema_second_part
-                            2024-01-01T00:00:01.000000Z\t1\tA\t10.0\t1.0\t10.0\t10.0\t10.0\t10.0
-                            2024-01-01T00:00:02.000000Z\t2\tB\t100.0\t1.0\t55.0\t100.0\t66.89085029457019\t100.0
-                            2024-01-01T00:00:03.000000Z\t3\tA\t20.0\t1.0\t37.5\t15.0\t37.25017980242024\t18.646647167633873
-                            2024-01-01T00:00:04.000000Z\t4\tB\t200.0\t1.0\t118.75\t150.0\t140.12768709496163\t186.46647167633873
-                            """,
-                    "select ts, sort_key, sym, price, volume, " +
-                            "avg(price, 'period', 3, volume) over (order by sort_key) vwema_period, " +
-                            "avg(price, 'period', 3, volume) over (partition by sym order by sort_key) vwema_period_part, " +
-                            "avg(price, 'second', 1, volume) over (order by sort_key) vwema_second, " +
-                            "avg(price, 'second', 1, volume) over (partition by sym order by sort_key) vwema_second_part " +
-                            "from tab",
-                    "ts",
-                    true,
-                    true
-            );
-        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/VwemaWindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/VwemaWindowFunctionTest.java
@@ -375,6 +375,51 @@ public class VwemaWindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testVwemaCachedWindowWithNullVolume() throws Exception {
+        // Forces cached execution via order-by-non-timestamp column and exercises invalid-input
+        // handling (NULL volume, zero volume) through pass1() for both VwemaOverPartitionFunction
+        // and VwemaOverUnboundedRowsFrameFunction. Invalid rows must keep the previous VWEMA;
+        // a partition that starts with an invalid row (lowest sort_key in the partition has NULL
+        // volume) must produce NULL until the first valid one.
+        assertMemoryLeak(() -> {
+            execute("create table tab (ts timestamp, sort_key long, sym symbol, price double, volume double) timestamp(ts)");
+            execute("insert into tab values " +
+                    "('2024-01-01T00:00:01.000000Z'::timestamp, 3, 'A', 30.0, 1.0), " +
+                    "('2024-01-01T00:00:02.000000Z'::timestamp, 2, 'B', 100.0, 1.0), " +
+                    "('2024-01-01T00:00:03.000000Z'::timestamp, 5, 'A', 50.0, 0.0), " +
+                    "('2024-01-01T00:00:04.000000Z'::timestamp, 1, 'B', 10.0, NULL), " +
+                    "('2024-01-01T00:00:05.000000Z'::timestamp, 4, 'A', 100.0, 1.0)");
+
+            // sort_key order, alpha = 2/(period+1) = 0.5:
+            //   no-partition stream:
+            //     sk=1 (B, p=10, v=NULL) invalid; never seen a valid row -> vwema=NULL
+            //     sk=2 (B, p=100, v=1)   first valid                    -> num=100, den=1, vwema=100
+            //     sk=3 (A, p=30, v=1)    valid                          -> num=65,  den=1, vwema=65
+            //     sk=4 (A, p=100, v=1)   valid                          -> num=82.5,den=1, vwema=82.5
+            //     sk=5 (A, p=50, v=0)    invalid (vol<=0)               -> keep            vwema=82.5
+            //   partition A: (sk=3,30,1) (sk=4,100,1) (sk=5,50,0)          -> 30, 65, 65
+            //   partition B: (sk=1,10,NULL) (sk=2,100,1)                   -> NULL (first row invalid), 100 (first valid)
+            assertQueryNoLeakCheck(
+                    """
+                            ts\tsort_key\tsym\tprice\tvolume\tvwema_no_part\tvwema_part
+                            2024-01-01T00:00:01.000000Z\t3\tA\t30.0\t1.0\t65.0\t30.0
+                            2024-01-01T00:00:02.000000Z\t2\tB\t100.0\t1.0\t100.0\t100.0
+                            2024-01-01T00:00:03.000000Z\t5\tA\t50.0\t0.0\t82.5\t65.0
+                            2024-01-01T00:00:04.000000Z\t1\tB\t10.0\tnull\tnull\tnull
+                            2024-01-01T00:00:05.000000Z\t4\tA\t100.0\t1.0\t82.5\t65.0
+                            """,
+                    "select ts, sort_key, sym, price, volume, " +
+                            "avg(price, 'period', 3, volume) over (order by sort_key) vwema_no_part, " +
+                            "avg(price, 'period', 3, volume) over (partition by sym order by sort_key) vwema_part " +
+                            "from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testVwemaExceptionAlphaEqualsZero() throws Exception {
         // alpha=0.0 should be invalid (exclusive lower bound) - caught by general positive check
         assertException(

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/VwemaWindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/VwemaWindowFunctionTest.java
@@ -33,6 +33,29 @@ import org.junit.Test;
 public class VwemaWindowFunctionTest extends AbstractCairoTest {
 
     @Test
+    public void testVwemaAlphaEqualsOne() throws Exception {
+        // alpha=1.0 should be valid (inclusive upper bound) - each new value fully replaces the previous
+        assertQuery(
+                """
+                        ts\tprice\tvolume\tvwema
+                        2024-01-01T00:00:00.000000Z\t10.0\t100.0\t10.0
+                        2024-01-01T00:00:01.000000Z\t20.0\t200.0\t20.0
+                        2024-01-01T00:00:02.000000Z\t30.0\t300.0\t30.0
+                        """,
+                "select ts, price, volume, avg(price, 'alpha', 1.0, volume) over (order by ts) as vwema from tab",
+                "create table tab as (" +
+                        "select timestamp_sequence('2024-01-01', 1000000) as ts, " +
+                        "(x * 10.0) as price, " +
+                        "(x * 100.0) as volume " +
+                        "from long_sequence(3)" +
+                        ") timestamp(ts) partition by day",
+                "ts",
+                false,
+                true
+        );
+    }
+
+    @Test
     public void testVwemaAlphaMode() throws Exception {
         // Test avg() VWEMA with alpha mode
         assertQuery(
@@ -118,29 +141,6 @@ public class VwemaWindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testVwemaAlphaEqualsOne() throws Exception {
-        // alpha=1.0 should be valid (inclusive upper bound) - each new value fully replaces the previous
-        assertQuery(
-                """
-                        ts\tprice\tvolume\tvwema
-                        2024-01-01T00:00:00.000000Z\t10.0\t100.0\t10.0
-                        2024-01-01T00:00:01.000000Z\t20.0\t200.0\t20.0
-                        2024-01-01T00:00:02.000000Z\t30.0\t300.0\t30.0
-                        """,
-                "select ts, price, volume, avg(price, 'alpha', 1.0, volume) over (order by ts) as vwema from tab",
-                "create table tab as (" +
-                        "select timestamp_sequence('2024-01-01', 1000000) as ts, " +
-                        "(x * 10.0) as price, " +
-                        "(x * 100.0) as volume " +
-                        "from long_sequence(3)" +
-                        ") timestamp(ts) partition by day",
-                "ts",
-                false,
-                true
-        );
-    }
-
-    @Test
     public void testVwemaAlphaModeNegativeVolume() throws Exception {
         // Negative volume should be treated as invalid like zero volume
         assertQuery(
@@ -155,6 +155,29 @@ public class VwemaWindowFunctionTest extends AbstractCairoTest {
                         "select timestamp_sequence('2024-01-01', 1000000) as ts, " +
                         "(x * 10.0) as price, " +
                         "case when x = 1 then -100.0 else (x * 100.0) end as volume " +
+                        "from long_sequence(3)" +
+                        ") timestamp(ts) partition by day",
+                "ts",
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testVwemaAlphaModeZeroVolume() throws Exception {
+        // L558 false via volume <= 0 in VwemaOverUnboundedRowsFrameFunction
+        assertQuery(
+                """
+                        ts\tprice\tvolume\tvwema
+                        2024-01-01T00:00:00.000000Z\t10.0\t0.0\tnull
+                        2024-01-01T00:00:01.000000Z\t20.0\t200.0\t20.0
+                        2024-01-01T00:00:02.000000Z\t30.0\t300.0\t26.0
+                        """,
+                "select ts, price, volume, avg(price, 'alpha', 0.5, volume) over (order by ts) as vwema from tab",
+                "create table tab as (" +
+                        "select timestamp_sequence('2024-01-01', 1000000) as ts, " +
+                        "(x * 10.0) as price, " +
+                        "case when x = 1 then 0.0 else (x * 100.0) end as volume " +
                         "from long_sequence(3)" +
                         ") timestamp(ts) partition by day",
                 "ts",
@@ -321,6 +344,48 @@ public class VwemaWindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testVwemaCachedWindowAllPass1Variants() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tab (ts timestamp, sort_key long, sym symbol, price double, volume double) timestamp(ts)");
+            execute("insert into tab values " +
+                    "('2024-01-01T00:00:01.000000Z'::timestamp, 1, 'A', 10.0, 1.0), " +
+                    "('2024-01-01T00:00:02.000000Z'::timestamp, 2, 'B', 100.0, 1.0), " +
+                    "('2024-01-01T00:00:03.000000Z'::timestamp, 3, 'A', 20.0, 1.0), " +
+                    "('2024-01-01T00:00:04.000000Z'::timestamp, 4, 'B', 200.0, 1.0)");
+
+            assertQueryNoLeakCheck(
+                    """
+                            ts\tsort_key\tsym\tprice\tvolume\tvwema_period\tvwema_period_part\tvwema_second\tvwema_second_part
+                            2024-01-01T00:00:01.000000Z\t1\tA\t10.0\t1.0\t10.0\t10.0\t10.0\t10.0
+                            2024-01-01T00:00:02.000000Z\t2\tB\t100.0\t1.0\t55.0\t100.0\t66.89085029457019\t100.0
+                            2024-01-01T00:00:03.000000Z\t3\tA\t20.0\t1.0\t37.5\t15.0\t37.25017980242024\t18.646647167633873
+                            2024-01-01T00:00:04.000000Z\t4\tB\t200.0\t1.0\t118.75\t150.0\t140.12768709496163\t186.46647167633873
+                            """,
+                    "select ts, sort_key, sym, price, volume, " +
+                            "avg(price, 'period', 3, volume) over (order by sort_key) vwema_period, " +
+                            "avg(price, 'period', 3, volume) over (partition by sym order by sort_key) vwema_period_part, " +
+                            "avg(price, 'second', 1, volume) over (order by sort_key) vwema_second, " +
+                            "avg(price, 'second', 1, volume) over (partition by sym order by sort_key) vwema_second_part " +
+                            "from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testVwemaExceptionAlphaEqualsZero() throws Exception {
+        // alpha=0.0 should be invalid (exclusive lower bound) - caught by general positive check
+        assertException(
+                "select ts, price, volume, avg(price, 'alpha', 0.0, volume) over (order by ts) from tab",
+                "create table tab (ts timestamp, price double, volume double) timestamp(ts)",
+                46,
+                "parameter value must be a positive number"
+        );
+    }
+
+    @Test
     public void testVwemaExceptionAlphaMustBeBetween0And1() throws Exception {
         assertException(
                 "select ts, price, volume, avg(price, 'alpha', 1.5, volume) over (order by ts) from tab",
@@ -400,6 +465,8 @@ public class VwemaWindowFunctionTest extends AbstractCairoTest {
         );
     }
 
+    // ========================= Period and Time-Weighted Mode Tests =========================
+
     @Test
     public void testVwemaExceptionZeroParameterValue() throws Exception {
         assertException(
@@ -408,73 +475,6 @@ public class VwemaWindowFunctionTest extends AbstractCairoTest {
                 46,
                 "parameter value must be a positive number"
         );
-    }
-
-    @Test
-    public void testVwemaAlphaModeZeroVolume() throws Exception {
-        // L558 false via volume <= 0 in VwemaOverUnboundedRowsFrameFunction
-        assertQuery(
-                """
-                        ts\tprice\tvolume\tvwema
-                        2024-01-01T00:00:00.000000Z\t10.0\t0.0\tnull
-                        2024-01-01T00:00:01.000000Z\t20.0\t200.0\t20.0
-                        2024-01-01T00:00:02.000000Z\t30.0\t300.0\t26.0
-                        """,
-                "select ts, price, volume, avg(price, 'alpha', 0.5, volume) over (order by ts) as vwema from tab",
-                "create table tab as (" +
-                        "select timestamp_sequence('2024-01-01', 1000000) as ts, " +
-                        "(x * 10.0) as price, " +
-                        "case when x = 1 then 0.0 else (x * 100.0) end as volume " +
-                        "from long_sequence(3)" +
-                        ") timestamp(ts) partition by day",
-                "ts",
-                false,
-                true
-        );
-    }
-
-    @Test
-    public void testVwemaExceptionAlphaEqualsZero() throws Exception {
-        // alpha=0.0 should be invalid (exclusive lower bound) - caught by general positive check
-        assertException(
-                "select ts, price, volume, avg(price, 'alpha', 0.0, volume) over (order by ts) from tab",
-                "create table tab (ts timestamp, price double, volume double) timestamp(ts)",
-                46,
-                "parameter value must be a positive number"
-        );
-    }
-
-    // ========================= Period and Time-Weighted Mode Tests =========================
-
-    @Test
-    public void testVwemaCachedWindowAllPass1Variants() throws Exception {
-        assertMemoryLeak(() -> {
-            execute("create table tab (ts timestamp, sort_key long, sym symbol, price double, volume double) timestamp(ts)");
-            execute("insert into tab values " +
-                    "('2024-01-01T00:00:01.000000Z'::timestamp, 1, 'A', 10.0, 1.0), " +
-                    "('2024-01-01T00:00:02.000000Z'::timestamp, 2, 'B', 100.0, 1.0), " +
-                    "('2024-01-01T00:00:03.000000Z'::timestamp, 3, 'A', 20.0, 1.0), " +
-                    "('2024-01-01T00:00:04.000000Z'::timestamp, 4, 'B', 200.0, 1.0)");
-
-            assertQueryNoLeakCheck(
-                    """
-                            ts\tsort_key\tsym\tprice\tvolume\tvwema_period\tvwema_period_part\tvwema_second\tvwema_second_part
-                            2024-01-01T00:00:01.000000Z\t1\tA\t10.0\t1.0\t10.0\t10.0\t10.0\t10.0
-                            2024-01-01T00:00:02.000000Z\t2\tB\t100.0\t1.0\t55.0\t100.0\t66.89085029457019\t100.0
-                            2024-01-01T00:00:03.000000Z\t3\tA\t20.0\t1.0\t37.5\t15.0\t37.25017980242024\t18.646647167633873
-                            2024-01-01T00:00:04.000000Z\t4\tB\t200.0\t1.0\t118.75\t150.0\t140.12768709496163\t186.46647167633873
-                            """,
-                    "select ts, sort_key, sym, price, volume, " +
-                            "avg(price, 'period', 3, volume) over (order by sort_key) vwema_period, " +
-                            "avg(price, 'period', 3, volume) over (partition by sym order by sort_key) vwema_period_part, " +
-                            "avg(price, 'second', 1, volume) over (order by sort_key) vwema_second, " +
-                            "avg(price, 'second', 1, volume) over (partition by sym order by sort_key) vwema_second_part " +
-                            "from tab",
-                    "ts",
-                    true,
-                    true
-            );
-        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/VwemaWindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/VwemaWindowFunctionTest.java
@@ -585,6 +585,36 @@ public class VwemaWindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testVwemaCachedWindowAllPass1Variants() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tab (ts timestamp, sort_key long, sym symbol, price double, volume double) timestamp(ts)");
+            execute("insert into tab values ('2024-01-01T00:00:01.000000Z'::timestamp, 1, 'A', 10.0, 1.0)");
+            execute("insert into tab values ('2024-01-01T00:00:02.000000Z'::timestamp, 2, 'B', 100.0, 1.0)");
+            execute("insert into tab values ('2024-01-01T00:00:03.000000Z'::timestamp, 3, 'A', 20.0, 1.0)");
+            execute("insert into tab values ('2024-01-01T00:00:04.000000Z'::timestamp, 4, 'B', 200.0, 1.0)");
+
+            assertQueryNoLeakCheck(
+                    """
+                            ts\tsort_key\tsym\tprice\tvolume\tvwema_period\tvwema_period_part\tvwema_second\tvwema_second_part
+                            2024-01-01T00:00:01.000000Z\t1\tA\t10.0\t1.0\t10.0\t10.0\t10.0\t10.0
+                            2024-01-01T00:00:02.000000Z\t2\tB\t100.0\t1.0\t55.0\t100.0\t66.89085029457019\t100.0
+                            2024-01-01T00:00:03.000000Z\t3\tA\t20.0\t1.0\t37.5\t15.0\t37.25017980242024\t18.646647167633873
+                            2024-01-01T00:00:04.000000Z\t4\tB\t200.0\t1.0\t118.75\t150.0\t140.12768709496163\t186.46647167633873
+                            """,
+                    "select ts, sort_key, sym, price, volume, " +
+                            "avg(price, 'period', 3, volume) over (order by sort_key) vwema_period, " +
+                            "avg(price, 'period', 3, volume) over (partition by sym order by sort_key) vwema_period_part, " +
+                            "avg(price, 'second', 1, volume) over (order by sort_key) vwema_second, " +
+                            "avg(price, 'second', 1, volume) over (partition by sym order by sort_key) vwema_second_part " +
+                            "from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testVwemaTimeWeightedModeHours() throws Exception {
         // Test 'hour' time unit parsing
         assertQuery(

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
@@ -4814,6 +4814,29 @@ public class WindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testKSumPartitionedRangeCachedWindow() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sym symbol, val double) timestamp(ts)", timestampType.getTypeName());
+            execute("insert into tab values (1000000::timestamp, 'A', 10.0)");
+            execute("insert into tab values (2000000::timestamp, 'B', 100.0)");
+            execute("insert into tab values (2000000::timestamp, 'A', 30.0)");
+            execute("insert into tab values (3000000::timestamp, 'B', 200.0)");
+
+            assertSql(
+                    replaceTimestampSuffix("""
+                            ts\tsym\tval\tksum_val\tavg_all
+                            1970-01-01T00:00:01.000000Z\tA\t10.0\t10.0\t85.0
+                            1970-01-01T00:00:02.000000Z\tB\t100.0\t100.0\t85.0
+                            1970-01-01T00:00:02.000000Z\tA\t30.0\t40.0\t85.0
+                            1970-01-01T00:00:03.000000Z\tB\t200.0\t300.0\t85.0
+                            """),
+                    "select ts, sym, val, ksum(val) over (partition by sym order by ts range between 1 second preceding and current row) as ksum_val, avg(val) over () as avg_all " +
+                            "from tab"
+            );
+        });
+    }
+
+    @Test
     public void testKSumPartitionedRangeUnboundedPreceding() throws Exception {
         // Test ksum() with partition by and range between unbounded preceding and N preceding
         // This tests the else branch (frameLoBounded=false) in KSumOverPartitionRangeFrameFunction
@@ -5087,6 +5110,29 @@ public class WindowFunctionTest extends AbstractCairoTest {
                             "        Row forward scan\n" +
                             "        Frame forward scan on: tab\n",
                     "explain select ts, val, ksum(val) over (order by ts range between unbounded preceding and 2 second preceding) from tab"
+            );
+        });
+    }
+
+    @Test
+    public void testKSumRangeCachedWindow() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sym symbol, val double) timestamp(ts)", timestampType.getTypeName());
+            execute("insert into tab values (1000000::timestamp, 'A', 10.0)");
+            execute("insert into tab values (2000000::timestamp, 'B', 20.0)");
+            execute("insert into tab values (3000000::timestamp, 'A', 30.0)");
+            execute("insert into tab values (4000000::timestamp, 'B', 40.0)");
+
+            assertSql(
+                    replaceTimestampSuffix("""
+                            ts\tsym\tval\tksum_val\tavg_all
+                            1970-01-01T00:00:01.000000Z\tA\t10.0\t10.0\t25.0
+                            1970-01-01T00:00:02.000000Z\tB\t20.0\t30.0\t25.0
+                            1970-01-01T00:00:03.000000Z\tA\t30.0\t50.0\t25.0
+                            1970-01-01T00:00:04.000000Z\tB\t40.0\t70.0\t25.0
+                            """),
+                    "select ts, sym, val, ksum(val) over (order by ts range between 1 second preceding and current row) as ksum_val, avg(val) over () as avg_all " +
+                            "from tab"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
@@ -4713,6 +4713,50 @@ public class WindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testKSumPartitionedRangeCachedWindowWithNulls() throws Exception {
+        // Forces cached execution via avg(val) over () and exercises NULL handling through
+        // pass1() in KSumOverPartitionRangeFrameFunction. Covers a partition that opens with a
+        // NULL value, NULL rows that arrive while the frame is non-empty, and frames that
+        // become empty after the bottom-border eviction removes the only valid row.
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sym symbol, val double) timestamp(ts)", timestampType.getTypeName());
+            execute("insert into tab values " +
+                    "(1_000_000::timestamp, 'A', NULL), " +
+                    "(2_000_000::timestamp, 'B', 20.0), " +
+                    "(3_000_000::timestamp, 'A', 10.0), " +
+                    "(4_000_000::timestamp, 'B', NULL), " +
+                    "(5_000_000::timestamp, 'A', NULL), " +
+                    "(6_000_000::timestamp, 'B', 30.0)");
+
+            // Partition A in ts order: (1s,NULL) (3s,10) (5s,NULL)
+            //   1s: first row NULL -> NaN
+            //   3s: 1s out of 1s range (and was NULL anyway) -> 10
+            //   5s: 3s out of range, current NULL, frameSize=0 -> NaN
+            // Partition B in ts order: (2s,20) (4s,NULL) (6s,30)
+            //   2s: first valid -> 20
+            //   4s: 2s out of 1s range, current NULL, frameSize=0 -> NaN
+            //   6s: 4s was NULL, 2s out of range -> 30
+            // avg(val) over () counts non-null values: (20+10+30)/3 = 20.0
+            assertQueryNoLeakCheck(
+                    replaceTimestampSuffix("""
+                            ts\tsym\tval\tksum_val\tavg_all
+                            1970-01-01T00:00:01.000000Z\tA\tnull\tnull\t20.0
+                            1970-01-01T00:00:02.000000Z\tB\t20.0\t20.0\t20.0
+                            1970-01-01T00:00:03.000000Z\tA\t10.0\t10.0\t20.0
+                            1970-01-01T00:00:04.000000Z\tB\tnull\tnull\t20.0
+                            1970-01-01T00:00:05.000000Z\tA\tnull\tnull\t20.0
+                            1970-01-01T00:00:06.000000Z\tB\t30.0\t30.0\t20.0
+                            """),
+                    "select ts, sym, val, ksum(val) over (partition by sym order by ts range between 1 second preceding and current row) as ksum_val, avg(val) over () as avg_all " +
+                            "from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testKSumPartitionedRangeFirstRowNull() throws Exception {
         // Test ksum() with partition by range frame where first row in partition is NULL
         // This tests lines 503-507 in KSumOverPartitionRangeFrameFunction
@@ -5049,6 +5093,45 @@ public class WindowFunctionTest extends AbstractCairoTest {
                             1970-01-01T00:00:04.000000Z\tB\t40.0\t70.0\t25.0
                             """),
                     "select ts, sym, val, ksum(val) over (order by ts range between 1 second preceding and current row) as ksum_val, avg(val) over () as avg_all " +
+                            "from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testKSumRangeCachedWindowWithNulls() throws Exception {
+        // Forces cached execution via avg(val) over () and exercises NULL handling through
+        // pass1() in KSumOverRangeFrameFunction (no partition). Covers NULL rows arriving with
+        // a non-empty frame as well as a NULL row whose only frame neighbor just aged out.
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, val double) timestamp(ts)", timestampType.getTypeName());
+            execute("insert into tab values " +
+                    "(1_000_000::timestamp, 10.0), " +
+                    "(2_000_000::timestamp, NULL), " +
+                    "(3_000_000::timestamp, 20.0), " +
+                    "(4_000_000::timestamp, NULL), " +
+                    "(5_000_000::timestamp, 30.0)");
+
+            // Range = 1 second preceding to current row:
+            //   1s, val=10  -> frame = [10]                 -> 10
+            //   2s, val=NULL -> 1s still in 1-second range  -> 10
+            //   3s, val=20  -> 1s out of range, NULL gap    -> 20
+            //   4s, val=NULL -> 3s still in range           -> 20
+            //   5s, val=30  -> 3s out of range, NULL gap    -> 30
+            // avg(val) over () counts non-null only: (10+20+30)/3 = 20.0
+            assertQueryNoLeakCheck(
+                    replaceTimestampSuffix("""
+                            ts\tval\tksum_val\tavg_all
+                            1970-01-01T00:00:01.000000Z\t10.0\t10.0\t20.0
+                            1970-01-01T00:00:02.000000Z\tnull\t10.0\t20.0
+                            1970-01-01T00:00:03.000000Z\t20.0\t20.0\t20.0
+                            1970-01-01T00:00:04.000000Z\tnull\t20.0\t20.0
+                            1970-01-01T00:00:05.000000Z\t30.0\t30.0\t20.0
+                            """),
+                    "select ts, val, ksum(val) over (order by ts range between 1 second preceding and current row) as ksum_val, avg(val) over () as avg_all " +
                             "from tab",
                     "ts",
                     true,
@@ -13682,23 +13765,23 @@ public class WindowFunctionTest extends AbstractCairoTest {
                         func.contains("first_value") || func.contains("last_value") ?
                                 "Window\n" +
                                         "  functions: [#FUNCT_NAME(1) over (partition by [i] rows between 1 preceding and current row)]\n".replace("#FUNCT_NAME(1)", replace) +
-                                        "    FilterOnValues\n" +
-                                        "        Table-order scan\n" +
-                                        "            Index forward scan on: sym deferred: true\n" +
-                                        "              filter: sym='B'\n" +
-                                        "            Index forward scan on: sym deferred: true\n" +
-                                        "              filter: sym='A'\n" +
-                                        "        Frame forward scan on: tab\n"
+                                "    FilterOnValues\n" +
+                                "        Table-order scan\n" +
+                                "            Index forward scan on: sym deferred: true\n" +
+                                "              filter: sym='B'\n" +
+                                "            Index forward scan on: sym deferred: true\n" +
+                                "              filter: sym='A'\n" +
+                                "        Frame forward scan on: tab\n"
                                 :
                                 "CachedWindow\n" +
                                         "  orderedFunctions: [[ts] => [#FUNCT_NAME(1) over (partition by [i] rows between 1 preceding and current row)]]\n".replace("#FUNCT_NAME(1)", replace) +
-                                        "    FilterOnValues symbolOrder: desc\n" +
-                                        "        Cursor-order scan\n" +
-                                        "            Index forward scan on: sym deferred: true\n" +
-                                        "              filter: sym='B'\n" +
-                                        "            Index forward scan on: sym deferred: true\n" +
-                                        "              filter: sym='A'\n" +
-                                        "        Frame forward scan on: tab\n"
+                                "    FilterOnValues symbolOrder: desc\n" +
+                                "        Cursor-order scan\n" +
+                                "            Index forward scan on: sym deferred: true\n" +
+                                "              filter: sym='B'\n" +
+                                "            Index forward scan on: sym deferred: true\n" +
+                                "              filter: sym='A'\n" +
+                                "        Frame forward scan on: tab\n"
 
                 );
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
@@ -4686,6 +4686,33 @@ public class WindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testKSumPartitionedRangeCachedWindow() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sym symbol, val double) timestamp(ts)", timestampType.getTypeName());
+            execute("insert into tab values " +
+                    "(1_000_000::timestamp, 'A', 10.0), " +
+                    "(2_000_000::timestamp, 'B', 100.0), " +
+                    "(2_000_000::timestamp, 'A', 30.0), " +
+                    "(3_000_000::timestamp, 'B', 200.0)");
+
+            assertQueryNoLeakCheck(
+                    replaceTimestampSuffix("""
+                            ts\tsym\tval\tksum_val\tavg_all
+                            1970-01-01T00:00:01.000000Z\tA\t10.0\t10.0\t85.0
+                            1970-01-01T00:00:02.000000Z\tB\t100.0\t100.0\t85.0
+                            1970-01-01T00:00:02.000000Z\tA\t30.0\t40.0\t85.0
+                            1970-01-01T00:00:03.000000Z\tB\t200.0\t300.0\t85.0
+                            """),
+                    "select ts, sym, val, ksum(val) over (partition by sym order by ts range between 1 second preceding and current row) as ksum_val, avg(val) over () as avg_all " +
+                            "from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testKSumPartitionedRangeFirstRowNull() throws Exception {
         // Test ksum() with partition by range frame where first row in partition is NULL
         // This tests lines 503-507 in KSumOverPartitionRangeFrameFunction
@@ -4809,33 +4836,6 @@ public class WindowFunctionTest extends AbstractCairoTest {
                             "        Row forward scan\n" +
                             "        Frame forward scan on: tab\n",
                     "explain select ts, i, val, ksum(val) over (partition by i order by ts range between unbounded preceding and 2 second preceding) from tab"
-            );
-        });
-    }
-
-    @Test
-    public void testKSumPartitionedRangeCachedWindow() throws Exception {
-        assertMemoryLeak(() -> {
-            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sym symbol, val double) timestamp(ts)", timestampType.getTypeName());
-            execute("insert into tab values " +
-                    "(1_000_000::timestamp, 'A', 10.0), " +
-                    "(2_000_000::timestamp, 'B', 100.0), " +
-                    "(2_000_000::timestamp, 'A', 30.0), " +
-                    "(3_000_000::timestamp, 'B', 200.0)");
-
-            assertQueryNoLeakCheck(
-                    replaceTimestampSuffix("""
-                            ts\tsym\tval\tksum_val\tavg_all
-                            1970-01-01T00:00:01.000000Z\tA\t10.0\t10.0\t85.0
-                            1970-01-01T00:00:02.000000Z\tB\t100.0\t100.0\t85.0
-                            1970-01-01T00:00:02.000000Z\tA\t30.0\t40.0\t85.0
-                            1970-01-01T00:00:03.000000Z\tB\t200.0\t300.0\t85.0
-                            """),
-                    "select ts, sym, val, ksum(val) over (partition by sym order by ts range between 1 second preceding and current row) as ksum_val, avg(val) over () as avg_all " +
-                            "from tab",
-                    "ts",
-                    true,
-                    true
             );
         });
     }
@@ -5031,6 +5031,33 @@ public class WindowFunctionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testKSumRangeCachedWindow() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sym symbol, val double) timestamp(ts)", timestampType.getTypeName());
+            execute("insert into tab values " +
+                    "(1_000_000::timestamp, 'A', 10.0), " +
+                    "(2_000_000::timestamp, 'B', 20.0), " +
+                    "(3_000_000::timestamp, 'A', 30.0), " +
+                    "(4_000_000::timestamp, 'B', 40.0)");
+
+            assertQueryNoLeakCheck(
+                    replaceTimestampSuffix("""
+                            ts\tsym\tval\tksum_val\tavg_all
+                            1970-01-01T00:00:01.000000Z\tA\t10.0\t10.0\t25.0
+                            1970-01-01T00:00:02.000000Z\tB\t20.0\t30.0\t25.0
+                            1970-01-01T00:00:03.000000Z\tA\t30.0\t50.0\t25.0
+                            1970-01-01T00:00:04.000000Z\tB\t40.0\t70.0\t25.0
+                            """),
+                    "select ts, sym, val, ksum(val) over (order by ts range between 1 second preceding and current row) as ksum_val, avg(val) over () as avg_all " +
+                            "from tab",
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
     public void testKSumRangeFrame() throws Exception {
         // Test ksum() over (order by ts range between N preceding and current row) - KSumOverRangeFrameFunction
         assertMemoryLeak(() -> {
@@ -5114,33 +5141,6 @@ public class WindowFunctionTest extends AbstractCairoTest {
                             "        Row forward scan\n" +
                             "        Frame forward scan on: tab\n",
                     "explain select ts, val, ksum(val) over (order by ts range between unbounded preceding and 2 second preceding) from tab"
-            );
-        });
-    }
-
-    @Test
-    public void testKSumRangeCachedWindow() throws Exception {
-        assertMemoryLeak(() -> {
-            executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sym symbol, val double) timestamp(ts)", timestampType.getTypeName());
-            execute("insert into tab values " +
-                    "(1_000_000::timestamp, 'A', 10.0), " +
-                    "(2_000_000::timestamp, 'B', 20.0), " +
-                    "(3_000_000::timestamp, 'A', 30.0), " +
-                    "(4_000_000::timestamp, 'B', 40.0)");
-
-            assertQueryNoLeakCheck(
-                    replaceTimestampSuffix("""
-                            ts\tsym\tval\tksum_val\tavg_all
-                            1970-01-01T00:00:01.000000Z\tA\t10.0\t10.0\t25.0
-                            1970-01-01T00:00:02.000000Z\tB\t20.0\t30.0\t25.0
-                            1970-01-01T00:00:03.000000Z\tA\t30.0\t50.0\t25.0
-                            1970-01-01T00:00:04.000000Z\tB\t40.0\t70.0\t25.0
-                            """),
-                    "select ts, sym, val, ksum(val) over (order by ts range between 1 second preceding and current row) as ksum_val, avg(val) over () as avg_all " +
-                            "from tab",
-                    "ts",
-                    true,
-                    true
             );
         });
     }
@@ -13682,23 +13682,23 @@ public class WindowFunctionTest extends AbstractCairoTest {
                         func.contains("first_value") || func.contains("last_value") ?
                                 "Window\n" +
                                         "  functions: [#FUNCT_NAME(1) over (partition by [i] rows between 1 preceding and current row)]\n".replace("#FUNCT_NAME(1)", replace) +
-                                        "    FilterOnValues\n" +
-                                        "        Table-order scan\n" +
-                                        "            Index forward scan on: sym deferred: true\n" +
-                                        "              filter: sym='B'\n" +
-                                        "            Index forward scan on: sym deferred: true\n" +
-                                        "              filter: sym='A'\n" +
-                                        "        Frame forward scan on: tab\n"
+                                "    FilterOnValues\n" +
+                                "        Table-order scan\n" +
+                                "            Index forward scan on: sym deferred: true\n" +
+                                "              filter: sym='B'\n" +
+                                "            Index forward scan on: sym deferred: true\n" +
+                                "              filter: sym='A'\n" +
+                                "        Frame forward scan on: tab\n"
                                 :
                                 "CachedWindow\n" +
                                         "  orderedFunctions: [[ts] => [#FUNCT_NAME(1) over (partition by [i] rows between 1 preceding and current row)]]\n".replace("#FUNCT_NAME(1)", replace) +
-                                        "    FilterOnValues symbolOrder: desc\n" +
-                                        "        Cursor-order scan\n" +
-                                        "            Index forward scan on: sym deferred: true\n" +
-                                        "              filter: sym='B'\n" +
-                                        "            Index forward scan on: sym deferred: true\n" +
-                                        "              filter: sym='A'\n" +
-                                        "        Frame forward scan on: tab\n"
+                                "    FilterOnValues symbolOrder: desc\n" +
+                                "        Cursor-order scan\n" +
+                                "            Index forward scan on: sym deferred: true\n" +
+                                "              filter: sym='B'\n" +
+                                "            Index forward scan on: sym deferred: true\n" +
+                                "              filter: sym='A'\n" +
+                                "        Frame forward scan on: tab\n"
 
                 );
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
@@ -4817,12 +4817,13 @@ public class WindowFunctionTest extends AbstractCairoTest {
     public void testKSumPartitionedRangeCachedWindow() throws Exception {
         assertMemoryLeak(() -> {
             executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sym symbol, val double) timestamp(ts)", timestampType.getTypeName());
-            execute("insert into tab values (1000000::timestamp, 'A', 10.0)");
-            execute("insert into tab values (2000000::timestamp, 'B', 100.0)");
-            execute("insert into tab values (2000000::timestamp, 'A', 30.0)");
-            execute("insert into tab values (3000000::timestamp, 'B', 200.0)");
+            execute("insert into tab values " +
+                    "(1_000_000::timestamp, 'A', 10.0), " +
+                    "(2_000_000::timestamp, 'B', 100.0), " +
+                    "(2_000_000::timestamp, 'A', 30.0), " +
+                    "(3_000_000::timestamp, 'B', 200.0)");
 
-            assertSql(
+            assertQueryNoLeakCheck(
                     replaceTimestampSuffix("""
                             ts\tsym\tval\tksum_val\tavg_all
                             1970-01-01T00:00:01.000000Z\tA\t10.0\t10.0\t85.0
@@ -4831,7 +4832,10 @@ public class WindowFunctionTest extends AbstractCairoTest {
                             1970-01-01T00:00:03.000000Z\tB\t200.0\t300.0\t85.0
                             """),
                     "select ts, sym, val, ksum(val) over (partition by sym order by ts range between 1 second preceding and current row) as ksum_val, avg(val) over () as avg_all " +
-                            "from tab"
+                            "from tab",
+                    "ts",
+                    true,
+                    true
             );
         });
     }
@@ -5118,12 +5122,13 @@ public class WindowFunctionTest extends AbstractCairoTest {
     public void testKSumRangeCachedWindow() throws Exception {
         assertMemoryLeak(() -> {
             executeWithRewriteTimestamp("create table tab (ts #TIMESTAMP, sym symbol, val double) timestamp(ts)", timestampType.getTypeName());
-            execute("insert into tab values (1000000::timestamp, 'A', 10.0)");
-            execute("insert into tab values (2000000::timestamp, 'B', 20.0)");
-            execute("insert into tab values (3000000::timestamp, 'A', 30.0)");
-            execute("insert into tab values (4000000::timestamp, 'B', 40.0)");
+            execute("insert into tab values " +
+                    "(1_000_000::timestamp, 'A', 10.0), " +
+                    "(2_000_000::timestamp, 'B', 20.0), " +
+                    "(3_000_000::timestamp, 'A', 30.0), " +
+                    "(4_000_000::timestamp, 'B', 40.0)");
 
-            assertSql(
+            assertQueryNoLeakCheck(
                     replaceTimestampSuffix("""
                             ts\tsym\tval\tksum_val\tavg_all
                             1970-01-01T00:00:01.000000Z\tA\t10.0\t10.0\t25.0
@@ -5132,7 +5137,10 @@ public class WindowFunctionTest extends AbstractCairoTest {
                             1970-01-01T00:00:04.000000Z\tB\t40.0\t70.0\t25.0
                             """),
                     "select ts, sym, val, ksum(val) over (order by ts range between 1 second preceding and current row) as ksum_val, avg(val) over () as avg_all " +
-                            "from tab"
+                            "from tab",
+                    "ts",
+                    true,
+                    true
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
@@ -13682,23 +13682,23 @@ public class WindowFunctionTest extends AbstractCairoTest {
                         func.contains("first_value") || func.contains("last_value") ?
                                 "Window\n" +
                                         "  functions: [#FUNCT_NAME(1) over (partition by [i] rows between 1 preceding and current row)]\n".replace("#FUNCT_NAME(1)", replace) +
-                                "    FilterOnValues\n" +
-                                "        Table-order scan\n" +
-                                "            Index forward scan on: sym deferred: true\n" +
-                                "              filter: sym='B'\n" +
-                                "            Index forward scan on: sym deferred: true\n" +
-                                "              filter: sym='A'\n" +
-                                "        Frame forward scan on: tab\n"
+                                        "    FilterOnValues\n" +
+                                        "        Table-order scan\n" +
+                                        "            Index forward scan on: sym deferred: true\n" +
+                                        "              filter: sym='B'\n" +
+                                        "            Index forward scan on: sym deferred: true\n" +
+                                        "              filter: sym='A'\n" +
+                                        "        Frame forward scan on: tab\n"
                                 :
                                 "CachedWindow\n" +
                                         "  orderedFunctions: [[ts] => [#FUNCT_NAME(1) over (partition by [i] rows between 1 preceding and current row)]]\n".replace("#FUNCT_NAME(1)", replace) +
-                                "    FilterOnValues symbolOrder: desc\n" +
-                                "        Cursor-order scan\n" +
-                                "            Index forward scan on: sym deferred: true\n" +
-                                "              filter: sym='B'\n" +
-                                "            Index forward scan on: sym deferred: true\n" +
-                                "              filter: sym='A'\n" +
-                                "        Frame forward scan on: tab\n"
+                                        "    FilterOnValues symbolOrder: desc\n" +
+                                        "        Cursor-order scan\n" +
+                                        "            Index forward scan on: sym deferred: true\n" +
+                                        "              filter: sym='B'\n" +
+                                        "            Index forward scan on: sym deferred: true\n" +
+                                        "              filter: sym='A'\n" +
+                                        "        Frame forward scan on: tab\n"
 
                 );
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowFunctionTest.java
@@ -13765,23 +13765,23 @@ public class WindowFunctionTest extends AbstractCairoTest {
                         func.contains("first_value") || func.contains("last_value") ?
                                 "Window\n" +
                                         "  functions: [#FUNCT_NAME(1) over (partition by [i] rows between 1 preceding and current row)]\n".replace("#FUNCT_NAME(1)", replace) +
-                                "    FilterOnValues\n" +
-                                "        Table-order scan\n" +
-                                "            Index forward scan on: sym deferred: true\n" +
-                                "              filter: sym='B'\n" +
-                                "            Index forward scan on: sym deferred: true\n" +
-                                "              filter: sym='A'\n" +
-                                "        Frame forward scan on: tab\n"
+                                        "    FilterOnValues\n" +
+                                        "        Table-order scan\n" +
+                                        "            Index forward scan on: sym deferred: true\n" +
+                                        "              filter: sym='B'\n" +
+                                        "            Index forward scan on: sym deferred: true\n" +
+                                        "              filter: sym='A'\n" +
+                                        "        Frame forward scan on: tab\n"
                                 :
                                 "CachedWindow\n" +
                                         "  orderedFunctions: [[ts] => [#FUNCT_NAME(1) over (partition by [i] rows between 1 preceding and current row)]]\n".replace("#FUNCT_NAME(1)", replace) +
-                                "    FilterOnValues symbolOrder: desc\n" +
-                                "        Cursor-order scan\n" +
-                                "            Index forward scan on: sym deferred: true\n" +
-                                "              filter: sym='B'\n" +
-                                "            Index forward scan on: sym deferred: true\n" +
-                                "              filter: sym='A'\n" +
-                                "        Frame forward scan on: tab\n"
+                                        "    FilterOnValues symbolOrder: desc\n" +
+                                        "        Cursor-order scan\n" +
+                                        "            Index forward scan on: sym deferred: true\n" +
+                                        "              filter: sym='B'\n" +
+                                        "            Index forward scan on: sym deferred: true\n" +
+                                        "              filter: sym='A'\n" +
+                                        "        Frame forward scan on: tab\n"
 
                 );
 


### PR DESCRIPTION
Fixes #7006

Fixes valid window queries using `EMA`, `VWEMA`, or `KSUM` that could fail when the planner chose cached window execution.

These functions already worked in streaming execution, but some query shapes require cached execution, for example when an incremental window function is used together with another window expression. In those cases, users could hit an execution failure even though the SQL was valid.