### PR TITLE
fix(sql): between and inside sub-expression

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -1063,7 +1063,7 @@ public class ExpressionParser {
             int betweenAndCount = 0;
             int caseCount = 0;
             int argStackDepth = 0;
-            int betweenStartCaseCount = 0;
+            int betweenStartScopeDepth = 0;
             savedScopeStackBottom = scopeStack.getBottom();
             scopeStack.setBottom(scopeStack.sizeRaw());
             boolean parsedDeclaration = false;
@@ -1528,7 +1528,8 @@ public class ExpressionParser {
                                 processDefaultBranch = true;
                             }
                         } else if (SqlKeywords.isAndKeyword(tok)) {
-                            if (caseCount == betweenStartCaseCount && betweenCount > betweenAndCount) {
+                            if (scopeStack.size() == betweenStartScopeDepth
+                                    && betweenCount > betweenAndCount) {
                                 betweenAndCount++;
                                 thisBranch = BRANCH_BETWEEN_END;
                                 argStackDepth = popAndOpStack(listener, argStackDepth, prevBranch);
@@ -1603,7 +1604,7 @@ public class ExpressionParser {
                                 throw SqlException.$(lastPos, "between statements cannot be nested");
                             }
                             betweenCount++;
-                            betweenStartCaseCount = caseCount;
+                            betweenStartScopeDepth = scopeStack.size();
                         }
                         processDefaultBranch = true;
                         break;

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -14746,6 +14746,51 @@ public class SqlParserTest extends AbstractSqlParserTest {
         );
     }
 
+    @Test
+    public void testBetweenAndSeparatorRespectsScopeDepth() throws Exception {
+        // AND inside a sub-expression that opens a new scope must NOT be claimed as
+        // BETWEEN's separator; only an AND at the same scope depth as BETWEEN is the
+        // separator. Covers every scope kind on scopeStack: PAREN, BRACKET, ARRAY,
+        // CASE, CAST/CAST_AS.
+
+        // PAREN
+        assertQuery(
+                "select-virtual 1 between (0 and 2, 3) column from (long_sequence(1))",
+                "SELECT 1 BETWEEN (0 AND 2) AND 3"
+        );
+
+        // ARRAY constructor
+        assertQuery(
+                "select-virtual 1 between (ARRAY[0 and 1], 3) column from (long_sequence(1))",
+                "SELECT 1 BETWEEN ARRAY[0 AND 1] AND 3"
+        );
+
+        // BRACKET (array indexing)
+        assertQuery(
+                "select-virtual 1 between (ARRAY[10, 20, 30][1 and 1], 3) column from (long_sequence(1))",
+                "SELECT 1 BETWEEN (ARRAY[10, 20, 30])[1 AND 1] AND 3"
+        );
+
+        // CASE
+        assertQuery(
+                "select-virtual 1 between (case when 1 = 1 and 2 = 2 then 0 else 0 end, 3) column from (long_sequence(1))",
+                "SELECT 1 BETWEEN CASE WHEN 1=1 AND 2=2 THEN 0 ELSE 0 END AND 3"
+        );
+
+        // CAST (and CAST_AS)
+        assertQuery(
+                "select-virtual 1 between ((0 and 1)::INT, 3) column from (long_sequence(1))",
+                "SELECT 1 BETWEEN CAST(0 AND 1 AS INT) AND 3"
+        );
+    }
+
+    @Test
+    public void testBetweenIssue6534() throws Exception {
+        // https://github.com/questdb/questdb/issues/6534
+        // Malformed SQL must throw SqlException, not AssertionError.
+        assertSyntaxError("SELECT fun(col BETWEEN (0 AND 1, col), col;", 42, "dangling literal");
+    }
+
     private void assertCreateTable(String expected, String ddl, TableModel... tableModels) throws SqlException {
         assertModel(expected, ddl, ExecutionModel.CREATE_TABLE, tableModels);
     }


### PR DESCRIPTION
## Summary

Fixes <https://github.com/questdb/questdb/issues/6534>

The issue here is not the malformed query. The problem is the `AND` inside a sub-expression. Currently, the parser thinks that the `AND` inside the sub-expression refers to `BETWEEN`'s `AND` operator. 

There was a special treatment for `BETWEEN-CASE`, so the problem does not arise in 

```sql
SELECT x BETWEEN 0 AND CASE WHEN 1 AND 2 THEN 5 ELSE 10 END
```

but in other cases, such as

```sql
SELECT 1 BETWEEN (1 and 2) and 3;
SELECT 1 BETWEEN ARRAY[0 AND 1] AND 2 
SELECT 1 BETWEEN (ARRAY[10, 20, 30])[1 AND 1] AND 3
SELECT 1 BETWEEN CAST(0 AND 1 AS INT) AND 3
```

the issue arises. These are syntactically correct statements, and they should throw a type mismatch error.

## The fix

We keep track of the scope depth when we reach `BETWEEN` on a variable called `betweenStartScopeDepth`, and whenever we see an `AND` we use the current scope depth to know whether the `AND` refers to `BETWEEN` or not.

This fix is identical to the treatment given to the `BETWEEN-CASE`, but it's more generic. We had a `betweenStartCaseCount` variable that we removed.

## How this was tested

This was manually tested, and a unit test was added for each one of the scope cases. 
