### PR TITLE
fix(core): avoid server-main error on WAL table rename race

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/WalPurgeJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalPurgeJob.java
@@ -32,6 +32,7 @@ import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.TxReader;
 import io.questdb.cairo.mv.MatViewState;
 import io.questdb.cairo.sql.TableMetadata;
+import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.cairo.wal.seq.TableSequencerAPI;
 import io.questdb.cairo.wal.seq.TransactionLogCursor;
 import io.questdb.log.Log;
@@ -267,6 +268,12 @@ public class WalPurgeJob extends SynchronizedJob implements Closeable {
                     .$(", msg=").$((Throwable) ce)
                     .$(", errno=").$(ff.errno())
                     .I$();
+        } catch (TableReferenceOutOfDateException ignore) {
+            // forAllWalTables() works from a table token snapshot. A table may be
+            // renamed and a new table created with the old name before this sweep
+            // gets to verify the token; skip it and let the next purge pass see the
+            // current registry state.
+            LOG.debug().$("skipping stale table token during broad sweep [table=").$(tableToken).I$();
         }
     }
 
@@ -804,19 +811,19 @@ public class WalPurgeJob extends SynchronizedJob implements Closeable {
         }
 
         @Override
-        public boolean isSeqPartInUse(long seqPart) {
-            return walDirectoryPolicy.isSeqPartInUse(
-                    path.of(configuration.getDbRoot()).concat(tableToken).concat(WalUtils.SEQ_DIR),
-                    seqPart
-            );
-        }
-
-        @Override
         public void deleteWalDirectory(int walId) {
             LOG.debug().$("deleting WAL directory [table=").$(tableToken)
                     .$(", walId=").$(walId)
                     .I$();
             recursiveDelete(setWalPath(tableToken, walId));
+        }
+
+        @Override
+        public boolean isSeqPartInUse(long seqPart) {
+            return walDirectoryPolicy.isSeqPartInUse(
+                    path.of(configuration.getDbRoot()).concat(tableToken).concat(WalUtils.SEQ_DIR),
+                    seqPart
+            );
         }
 
         @Override


### PR DESCRIPTION
WalPurgeJob can process a table token snapshot after the table has been renamed and the original name reused. Treat the resulting stale-token exception as a retryable purge race and leave the current registry state for the next purge pass.

Example error:
```
2026-04-29T19:00:18.754926Z C server-main unhandled error [job=io.questdb.cairo.wal.WalPurgeJob@2b62442c, ex=io.questdb.cairo.sql.TableReferenceOutOfDateException: cached query plan cannot be used because table schema has changed [table=table_name, expectedTableId=4358, actualTableId=4360, expectedMetadataVersion=4360, actualMetadataVersion=-1]
```