### PR TITLE
fix(sql): keep JIT filter active for ::TYPE casts in WHERE clauses

### DIFF
--- a/core/src/main/java/io/questdb/jit/CompiledFilterIRSerializer.java
+++ b/core/src/main/java/io/questdb/jit/CompiledFilterIRSerializer.java
@@ -52,6 +52,7 @@ import io.questdb.std.GenericLexer;
 import io.questdb.std.IntStack;
 import io.questdb.std.LongList;
 import io.questdb.std.LongObjHashMap;
+import io.questdb.std.Misc;
 import io.questdb.std.Mutable;
 import io.questdb.std.Numbers;
 import io.questdb.std.NumericException;
@@ -184,6 +185,43 @@ public class CompiledFilterIRSerializer implements PostOrderTreeTraversalAlgo.Vi
                 // Store negation node for later backfilling
                 serializeConstantStub(node);
                 return false;
+            }
+        }
+
+        // Fold cast(<inner>, T) when T matches the operand's type, so the various
+        // ::TYPE workarounds (constants from PR #6413, bind variables from the same
+        // PR's predecessor, and redundant column-side casts) all keep using JIT
+        // instead of tripping the "invalid operator: cast" rejection. Mismatched
+        // casts fall through here and bail out at serializeOperator -> Java handles.
+        if (node.type == ExpressionNode.FUNCTION && node.paramCount == 2 && SqlKeywords.isCastKeyword(node.token)) {
+            ExpressionNode argNode = node.lhs;
+            if (argNode != null && isCastTargetTypeLiteral(node.rhs)) {
+                // Constant or negated-constant cast: defer the type-match check to
+                // backfill (column hasn't been visited yet in post-order).
+                if (isFoldableConstantArg(argNode)) {
+                    serializeConstantStub(node);
+                    return false;
+                }
+                // Bind-variable cast: same deferral pattern. backfillCast checks both
+                // the cast target type (against the column) and the bind variable's
+                // bound type (against the cast target).
+                if (argNode.type == ExpressionNode.BIND_VARIABLE && argNode.paramCount == 0) {
+                    serializeConstantStub(node);
+                    return false;
+                }
+                // Column-side cast: only fold when the cast is a no-op (target type
+                // matches the column's actual type). The check uses metadata directly
+                // since the column type doesn't depend on the predicate context.
+                if (argNode.type == ExpressionNode.LITERAL && argNode.paramCount == 0) {
+                    int columnIndex = metadata.getColumnIndexQuiet(argNode.token);
+                    if (columnIndex != -1
+                            && metadata.getColumnType(columnIndex) == ColumnType.typeOf(node.rhs.token)) {
+                        // Behave as if we descended into the column literal directly.
+                        serializeColumn(argNode.position, argNode.token);
+                        predicateContext.onNodeVisited(argNode);
+                        return false;
+                    }
+                }
             }
         }
 
@@ -358,6 +396,26 @@ public class CompiledFilterIRSerializer implements PostOrderTreeTraversalAlgo.Vi
         return Chars.equals(token, "/");
     }
 
+    // The cast's rhs is the type literal (e.g. CONSTANT "uuid"). We need a non-null
+    // CONSTANT token here so we can resolve its ColumnType tag at backfill time.
+    private static boolean isCastTargetTypeLiteral(ExpressionNode node) {
+        return node != null && node.type == ExpressionNode.CONSTANT && node.token != null;
+    }
+
+    // Returns true for a leaf node that the backfill consumer can serialize as a single
+    // constant operand. Accepts a bare CONSTANT and the unary-`-` over a CONSTANT shape
+    // that the existing negation lookahead already produces.
+    private static boolean isFoldableConstantArg(ExpressionNode node) {
+        if (node.paramCount == 0 && node.type == ExpressionNode.CONSTANT) {
+            return true;
+        }
+        if (node.type == ExpressionNode.OPERATION && node.paramCount == 1 && Chars.equals(node.token, "-")) {
+            ExpressionNode inner = node.lhs != null ? node.lhs : node.rhs;
+            return inner != null && inner.paramCount == 0 && inner.type == ExpressionNode.CONSTANT;
+        }
+        return false;
+    }
+
     private static boolean isGeoHash(int columnType) {
         return switch (ColumnType.tagOf(columnType)) {
             case ColumnType.GEOBYTE, ColumnType.GEOSHORT, ColumnType.GEOINT, ColumnType.GEOLONG -> true;
@@ -407,6 +465,77 @@ public class CompiledFilterIRSerializer implements PostOrderTreeTraversalAlgo.Vi
         return type == STRING_HEADER_TYPE || type == BINARY_HEADER_TYPE || type == VARCHAR_HEADER_TYPE;
     }
 
+    // Parses with the sign baked in. Routing negation through parseLong rather than
+    // multiplying by -1 lets LONG_MIN round-trip: "9223372036854775808" overflows
+    // when parsed unsigned but is a valid long when parsed as "-9223372036854775808".
+    private static long parseSignedLong(CharSequence token, boolean negated) throws NumericException {
+        if (negated) {
+            StringSink sink = Misc.getThreadLocalSink();
+            sink.put('-').put(token);
+            return Numbers.parseLong(sink);
+        }
+        return Numbers.parseLong(token);
+    }
+
+    private void backfillBindVariableCast(long offset, ExpressionNode varNode, int castType) throws SqlException {
+        // The cast target type already matches the column type (checked by the caller).
+        // Additionally require the bind variable's bound type to match the cast target;
+        // a mismatch means the cast performs runtime coercion (e.g. STRING -> UUID),
+        // which the JIT IR cannot replicate, so we bail out.
+        Function varFunction = getBindVariableFunction(varNode.position, varNode.token);
+        int boundType = varFunction.getType();
+        if (boundType != castType) {
+            throw SqlException.position(varNode.position)
+                    .put("bind variable type does not match cast target: bound=")
+                    .put(ColumnType.nameOf(boundType))
+                    .put(", cast=")
+                    .put(ColumnType.nameOf(castType));
+        }
+        int columnTypeTag = ColumnType.tagOf(boundType);
+        if (columnTypeTag == ColumnType.STRING) {
+            // Defensive: unreachable today. The outer `castType == columnType` guard
+            // requires a STRING column, and STRING columns have no IMM constant path
+            // in serializeConstant, so STRING-vs-STRING never gets this far. Kept as
+            // a sentinel in case someone later adds STRING-column JIT support without
+            // wiring the deferred-symbol backfill into this fold.
+            throw SqlException.position(varNode.position)
+                    .put("string bind variable cast not foldable: ")
+                    .put(varNode.token);
+        }
+        int typeCode = bindVariableTypeCode(columnTypeTag);
+        if (typeCode == UNDEFINED_CODE) {
+            // Defensive: unreachable today. VARCHAR/BINARY/LONG256/etc. columns don't
+            // JIT, so their bound types never reach this path. Kept as a guard against
+            // silent miscompilation if someone later expands JIT column support.
+            throw SqlException.position(varNode.position)
+                    .put("unsupported bind variable type: ")
+                    .put(ColumnType.nameOf(columnTypeTag));
+        }
+        bindVarFunctions.add(varFunction);
+        int index = bindVarFunctions.size() - 1;
+        putOperand(offset, VAR, typeCode, index);
+    }
+
+    private void backfillCast(long offset, final ExpressionNode castNode) throws SqlException {
+        // Only fold when the cast's full target type matches the predicate's column type.
+        // Tag-only matching is unsafe: TIMESTAMP_MICRO and TIMESTAMP_NANO share the
+        // TIMESTAMP tag but use different drivers, so `cast(str, timestamp_ns)` against
+        // a micro column would parse the literal at the wrong precision. Type mismatches
+        // also cover cases like INT_MIN-as-LONG which is the INT NULL sentinel when
+        // reinterpreted as INT.
+        int castType = ColumnType.typeOf(castNode.rhs.token);
+        if (castType != predicateContext.columnType) {
+            throw SqlException.position(castNode.position)
+                    .put("cast target type does not match column type: ")
+                    .put(castNode.rhs.token);
+        }
+        if (castNode.lhs.type == ExpressionNode.BIND_VARIABLE) {
+            backfillBindVariableCast(offset, castNode.lhs, castType);
+            return;
+        }
+        backfillConstant(offset, castNode.lhs);
+    }
+
     private void backfillConstant(long offset, final ExpressionNode node) throws SqlException {
         int position = node.position;
         CharSequence token = node.token;
@@ -430,6 +559,9 @@ public class CompiledFilterIRSerializer implements PostOrderTreeTraversalAlgo.Vi
                 case ExpressionNode.CONSTANT:
                 case ExpressionNode.OPERATION: // constant negation case
                     backfillConstant(key, value);
+                    break;
+                case ExpressionNode.FUNCTION: // cast(<constant>, <type>)
+                    backfillCast(key, value);
                     break;
                 case ExpressionNode.BIND_VARIABLE:
                     backfillSymbolBindVariable(key, value);
@@ -1165,18 +1297,17 @@ public class CompiledFilterIRSerializer implements PostOrderTreeTraversalAlgo.Vi
         try {
             switch (typeCode) {
                 case I1_TYPE:
-                    final byte b = (byte) Numbers.parseInt(token);
-                    putOperand(offset, IMM, I1_TYPE, sign * b);
+                    // Bake the sign into the parse: `sign * (byte) parseInt("128")`
+                    // would re-overflow -128 back to 128 at long width. See parseSignedLong.
+                    putOperand(offset, IMM, I1_TYPE, (byte) parseSignedLong(token, negated));
                     break;
                 case I2_TYPE:
-                    final short s = (short) Numbers.parseInt(token);
-                    putOperand(offset, IMM, I2_TYPE, sign * s);
+                    putOperand(offset, IMM, I2_TYPE, (short) parseSignedLong(token, negated));
                     break;
                 case I4_TYPE:
                 case F4_TYPE:
                     try {
-                        final int i = Numbers.parseInt(token);
-                        putOperand(offset, IMM, I4_TYPE, sign * i);
+                        putOperand(offset, IMM, I4_TYPE, (int) parseSignedLong(token, negated));
                     } catch (NumericException e) {
                         final float fi = Numbers.parseFloat(token);
                         putDoubleOperand(offset, F4_TYPE, sign * fi);
@@ -1185,8 +1316,7 @@ public class CompiledFilterIRSerializer implements PostOrderTreeTraversalAlgo.Vi
                 case I8_TYPE:
                 case F8_TYPE:
                     try {
-                        final long l = Numbers.parseLong(token);
-                        putOperand(offset, IMM, I8_TYPE, sign * l);
+                        putOperand(offset, IMM, I8_TYPE, parseSignedLong(token, negated));
                     } catch (NumericException e) {
                         final double dl = Numbers.parseDouble(token);
                         putDoubleOperand(offset, F8_TYPE, sign * dl);

--- a/core/src/test/java/io/questdb/test/griffin/CompiledFilterCastFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CompiledFilterCastFuzzTest.java
@@ -1,0 +1,376 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin;
+
+import io.questdb.cairo.SqlJitMode;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.jit.JitUtil;
+import io.questdb.log.Log;
+import io.questdb.log.LogFactory;
+import io.questdb.std.Rnd;
+import io.questdb.std.Uuid;
+import io.questdb.std.str.StringSink;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Validates that wrapping a constant in {@code cast(<const>, <type>)} (including
+ * the {@code <const>::TYPE} shorthand) preserves both JIT eligibility and result
+ * semantics.
+ *
+ * <p>The fold in {@link io.questdb.jit.CompiledFilterIRSerializer} only unwraps a
+ * cast when its target type tag matches the predicate's column type tag. The fuzz
+ * covers two shapes:
+ * <ul>
+ *   <li><b>Matching cast.</b> {@code <col_T> op <const>::T}. The fold engages and
+ *       JIT runs. The harness asserts: JIT cast form == bare-constant JIT form
+ *       (proves the fold reduces to the bare path identically), and JIT cast form
+ *       == Java cast form (proves end-to-end correctness against the user's
+ *       semantics).</li>
+ *   <li><b>Cross-type cast.</b> {@code <col_T> op <const>::U}, where U != T. The
+ *       fold refuses (semantics could differ -- e.g. cross-type NULL sentinels),
+ *       JIT bails out, and the Java filter handles the query as written. The
+ *       harness asserts JIT does NOT engage.</li>
+ * </ul>
+ *
+ * <p>Probes include the negated MIN boundary for byte/short/int/long, which
+ * exercises both the truncate-after-sign path in {@code serializeNumber} and the
+ * null-aware compare in the JIT C++ backend ({@code INT_MIN}/{@code LONG_MIN}
+ * are QuestDB's NULL sentinels, and the default {@code enableJitNullChecks=true}
+ * keeps SQL three-valued semantics intact).
+ */
+public class CompiledFilterCastFuzzTest extends AbstractCairoTest {
+    private static final Log LOG = LogFactory.getLog(CompiledFilterCastFuzzTest.class);
+    private static final int ROW_COUNT = 200;
+    private final StringSink javaSink = new StringSink();
+    private final StringSink jitBareSink = new StringSink();
+    private final StringSink jitCastSink = new StringSink();
+
+    @Override
+    @Before
+    public void setUp() {
+        Assume.assumeTrue(JitUtil.isJitSupported());
+        super.setUp();
+    }
+
+    @Test
+    public void testFuzz() throws Exception {
+        Rnd rnd = TestUtils.generateRandom(LOG);
+        assertMemoryLeak(() -> {
+            execute(
+                    "create table x as (select " +
+                            " rnd_boolean() abool," +
+                            " rnd_byte() abyte," +
+                            " rnd_short() ashort," +
+                            " rnd_char() achar," +
+                            " rnd_int() anint," +
+                            " rnd_long() along," +
+                            " rnd_float() afloat," +
+                            " rnd_double() adouble," +
+                            " rnd_uuid4() auuid," +
+                            " rnd_symbol('A','B','C','D') asymbol," +
+                            " rnd_date(to_date('2025', 'yyyy'), to_date('2027', 'yyyy'), 0) adate," +
+                            " rnd_timestamp(" +
+                            "   to_timestamp('2026-01-01', 'yyyy-MM-dd')," +
+                            "   to_timestamp('2026-12-31', 'yyyy-MM-dd'), 0) ats2," +
+                            " timestamp_sequence(400000000000, 500000000) ats" +
+                            " from long_sequence(" + ROW_COUNT + ")) timestamp(ats)"
+            );
+
+            // Matching cast/column type pairs: must fold, must JIT, must agree with
+            // Java. Probes include the negated MIN boundary for every numeric type:
+            // INT_MIN/LONG_MIN coincide with QuestDB's NULL sentinels, but the JIT
+            // backend's null-aware compare (default enableJitNullChecks=true) preserves
+            // SQL three-valued semantics, so JIT and Java agree on those values.
+            assertMatchingProbe("abool", "boolean", new String[]{"true", "false"});
+            assertMatchingProbe("abyte", "byte", numericProbes(rnd, 8));
+            assertMatchingProbe("ashort", "short", numericProbes(rnd, 16));
+            assertMatchingProbe("anint", "int", numericProbes(rnd, 32));
+            assertMatchingProbe("along", "long", numericProbes(rnd, 64));
+            assertMatchingProbe("adouble", "double", floatProbes(rnd));
+            assertMatchingProbe("achar", "char", charProbes(rnd));
+            assertMatchingProbe("auuid", "uuid", uuidProbes(rnd));
+            assertMatchingProbe("asymbol", "symbol", new String[]{"A", "B", "C", "D", "E"});
+            assertMatchingProbe("adate", "date", dateProbes());
+            assertMatchingProbe("ats2", "timestamp", timestampProbes());
+
+            // No-op column-side casts: `col::T op const` where T == col's type.
+            // The fold should engage and produce identical results to the bare column.
+            // Coverage spans every supported type so the metadata-direct match check
+            // in descend exercises each columnTypeCode entry.
+            assertColumnSideCastProbe("abool", "boolean", new String[]{"true", "false"});
+            assertColumnSideCastProbe("abyte", "byte", numericProbes(rnd, 8));
+            assertColumnSideCastProbe("ashort", "short", numericProbes(rnd, 16));
+            assertColumnSideCastProbe("achar", "char", charProbes(rnd));
+            assertColumnSideCastProbe("anint", "int", numericProbes(rnd, 32));
+            assertColumnSideCastProbe("along", "long", numericProbes(rnd, 64));
+            assertColumnSideCastProbe("adouble", "double", floatProbes(rnd));
+            assertColumnSideCastProbe("auuid", "uuid", uuidProbes(rnd));
+            assertColumnSideCastProbe("asymbol", "symbol", new String[]{"A", "B", "C", "D", "E"});
+            assertColumnSideCastProbe("adate", "date", dateProbes());
+            assertColumnSideCastProbe("ats2", "timestamp", timestampProbes());
+
+            // Cross-type casts (constant side): fold refuses, JIT bails, Java handles.
+            assertCrossTypeProbe("abyte", "short", numericProbes(rnd, 7));
+            assertCrossTypeProbe("abyte", "int", numericProbes(rnd, 7));
+            assertCrossTypeProbe("abyte", "long", numericProbes(rnd, 7));
+            assertCrossTypeProbe("ashort", "int", numericProbes(rnd, 15));
+            assertCrossTypeProbe("ashort", "long", numericProbes(rnd, 15));
+            assertCrossTypeProbe("anint", "long", numericProbes(rnd, 31));
+            assertCrossTypeProbe("afloat", "double", floatProbes(rnd));
+
+            // Cross-type column-side casts: same -- fold refuses, Java handles.
+            assertCrossTypeColumnProbe("abyte", "long", numericProbes(rnd, 7));
+            assertCrossTypeColumnProbe("anint", "long", numericProbes(rnd, 31));
+        });
+    }
+
+    private void assertColumnSideCastProbe(String col, String castType, String[] values) throws Exception {
+        // `col::T op const` is fold-equivalent to `col op const`. We assert end-to-end
+        // correctness against Java and that the cast form actually JITs.
+        for (String v : values) {
+            String literal = needsQuoting(castType) ? "'" + v + "'" : v;
+            String constLiteral = literal.startsWith("-") ? "(" + literal + ")" : literal;
+            String bareQuery = "x where " + col + " = " + literal;
+            String castQuery = "x where " + col + "::" + castType + " = " + constLiteral;
+
+            sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_DISABLED);
+            runIntoSink(castQuery, javaSink, false);
+
+            sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_FORCE_SCALAR);
+            runIntoSink(bareQuery, jitBareSink, true);
+            runIntoSink(castQuery, jitCastSink, true);
+            TestUtils.assertEquals(
+                    "scalar JIT diverged from Java for column-side cast: " + castQuery,
+                    javaSink, jitCastSink
+            );
+            TestUtils.assertEquals(
+                    "scalar JIT diverged between bare and column-side cast: " + castQuery,
+                    jitBareSink, jitCastSink
+            );
+
+            sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_ENABLED);
+            runIntoSink(castQuery, jitCastSink, true);
+            TestUtils.assertEquals(
+                    "vectorized JIT diverged from Java for column-side cast: " + castQuery,
+                    javaSink, jitCastSink
+            );
+        }
+    }
+
+    private void assertCrossTypeColumnProbe(String col, String castType, String[] values) throws Exception {
+        for (String v : values) {
+            String literal = needsQuoting(castType) ? "'" + v + "'" : v;
+            String castQuery = "x where " + col + "::" + castType + " = " + literal;
+            sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_ENABLED);
+            try (RecordCursorFactory factory = select(castQuery)) {
+                Assert.assertFalse(
+                        "cross-type column-side cast must NOT JIT: " + castQuery,
+                        factory.usesCompiledFilter()
+                );
+                try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                    println(factory.getMetadata(), cursor, jitCastSink);
+                }
+            }
+            sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_DISABLED);
+            runIntoSink(castQuery, javaSink, false);
+            TestUtils.assertEquals(
+                    "Java result inconsistent across modes for: " + castQuery,
+                    javaSink, jitCastSink
+            );
+        }
+    }
+
+    private void assertCrossTypeProbe(String col, String castType, String[] values) throws Exception {
+        // Cross-type cast: the fold must refuse. Compares JIT-enabled (which bails
+        // back to Java) against pure Java reference to confirm both produce the same
+        // output -- a regression that lets cross-type casts JIT would surface here.
+        for (String v : values) {
+            String literal = needsQuoting(castType) ? "'" + v + "'" : v;
+            String castLiteral = literal.startsWith("-") ? "(" + literal + ")" : literal;
+            String castExpr = castLiteral + "::" + castType;
+            for (String op : new String[]{"=", "<>"}) {
+                String castQuery = "x where " + col + " " + op + " " + castExpr;
+                sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_DISABLED);
+                runIntoSink(castQuery, javaSink, false);
+                sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_ENABLED);
+                runIntoSink(castQuery, jitCastSink, false);
+                TestUtils.assertEquals(
+                        "JIT fallback diverged from Java reference for cross-type cast: " + castQuery,
+                        javaSink, jitCastSink
+                );
+            }
+        }
+    }
+
+    private void assertEqualBareAndCastJit(String col, String op, String literal, String castExpr) throws Exception {
+        String bareQuery = "x where " + col + " " + op + " " + literal;
+        String castQuery = "x where " + col + " " + op + " " + castExpr;
+
+        sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_FORCE_SCALAR);
+        runIntoSink(bareQuery, jitBareSink, true);
+        runIntoSink(castQuery, jitCastSink, true);
+        TestUtils.assertEquals(
+                "scalar JIT diverged between bare and cast form for: " + castQuery,
+                jitBareSink, jitCastSink
+        );
+
+        sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_ENABLED);
+        runIntoSink(bareQuery, jitBareSink, true);
+        runIntoSink(castQuery, jitCastSink, true);
+        TestUtils.assertEquals(
+                "vectorized JIT diverged between bare and cast form for: " + castQuery,
+                jitBareSink, jitCastSink
+        );
+    }
+
+    private void assertEqualJavaAndCastJit(String col, String op, String castExpr) throws Exception {
+        String castQuery = "x where " + col + " " + op + " " + castExpr;
+
+        sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_DISABLED);
+        runIntoSink(castQuery, javaSink, false);
+
+        sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_FORCE_SCALAR);
+        runIntoSink(castQuery, jitCastSink, true);
+        TestUtils.assertEquals(
+                "scalar JIT diverged from Java for cast form: " + castQuery,
+                javaSink, jitCastSink
+        );
+
+        sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_ENABLED);
+        runIntoSink(castQuery, jitCastSink, true);
+        TestUtils.assertEquals(
+                "vectorized JIT diverged from Java for cast form: " + castQuery,
+                javaSink, jitCastSink
+        );
+    }
+
+    private void assertMatchingProbe(String col, String castType, String[] values) throws Exception {
+        for (String v : values) {
+            String literal = needsQuoting(castType) ? "'" + v + "'" : v;
+            String castLiteral = literal.startsWith("-") ? "(" + literal + ")" : literal;
+            String castExpr = castLiteral + "::" + castType;
+            String castAsExpr = "cast(" + literal + " AS " + castType + ")";
+
+            for (String op : new String[]{"=", "<>"}) {
+                assertEqualBareAndCastJit(col, op, literal, castExpr);
+                assertEqualBareAndCastJit(col, op, literal, castAsExpr);
+                assertEqualJavaAndCastJit(col, op, castExpr);
+                assertEqualJavaAndCastJit(col, op, castAsExpr);
+            }
+
+            if (supportsOrdering(castType)) {
+                for (String op : new String[]{"<", "<=", ">", ">="}) {
+                    assertEqualBareAndCastJit(col, op, literal, castExpr);
+                    assertEqualJavaAndCastJit(col, op, castExpr);
+                }
+            }
+        }
+    }
+
+    private String[] charProbes(Rnd rnd) {
+        return new String[]{
+                "A", "Z", "a", "z", "0",
+                String.valueOf((char) ('A' + rnd.nextPositiveInt() % 26)),
+        };
+    }
+
+    private String[] dateProbes() {
+        return new String[]{
+                "2025-01-01", "2026-06-15", "2027-03-09",
+        };
+    }
+
+    private String[] floatProbes(Rnd rnd) {
+        return new String[]{
+                "0.0", "1.5", "-3.25", "123.456",
+                Double.toString(rnd.nextDouble() * 1000.0 - 500.0),
+        };
+    }
+
+    private boolean needsQuoting(String castType) {
+        return switch (castType) {
+            case "char", "uuid", "symbol", "date", "timestamp" -> true;
+            default -> false;
+        };
+    }
+
+    private String[] numericProbes(Rnd rnd, int bits) {
+        long max = bits == 64 ? Long.MAX_VALUE : (1L << (bits - 1)) - 1;
+        long min = -max - 1;
+        long midRange = Math.max(1, Math.min(Integer.MAX_VALUE, max / 2));
+        return new String[]{
+                "0", "1", "-1",
+                Long.toString(max),
+                Long.toString(min),       // negated MIN: NULL sentinel for INT/LONG
+                Long.toString(min + 1),
+                Long.toString(rnd.nextLong(midRange)),
+                Long.toString(-rnd.nextLong(midRange)),
+        };
+    }
+
+    private void runIntoSink(String query, StringSink target, boolean expectJit) throws Exception {
+        try (RecordCursorFactory factory = select(query)) {
+            Assert.assertEquals(
+                    (expectJit ? "expected JIT for: " : "expected NO JIT for: ") + query,
+                    expectJit, factory.usesCompiledFilter()
+            );
+            try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                println(factory.getMetadata(), cursor, target);
+            }
+        }
+    }
+
+    private boolean supportsOrdering(String castType) {
+        return switch (castType) {
+            case "boolean", "uuid", "symbol" -> false;
+            default -> true;
+        };
+    }
+
+    private String[] timestampProbes() {
+        return new String[]{
+                "2026-01-01T00:00:00.000000Z",
+                "2026-06-15T12:34:56.000000Z",
+                "2027-12-31T23:59:59.999999Z",
+        };
+    }
+
+    private String[] uuidProbes(Rnd rnd) {
+        Uuid u = new Uuid(rnd.nextLong(), rnd.nextLong());
+        StringSink s = new StringSink();
+        u.toSink(s);
+        return new String[]{
+                "11111111-2222-3333-4444-555555555555",
+                "00000000-0000-0000-0000-000000000000",
+                s.toString(),
+        };
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/CompiledFilterTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CompiledFilterTest.java
@@ -124,6 +124,134 @@ public class CompiledFilterTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testBindVariableCastPreservesJit() throws Exception {
+        // PR #6413's `<col> = $1::TYPE` workaround: when the bind variable is bound
+        // as the cast target type, the cast is a no-op and JIT can engage. When the
+        // bound type differs, the cast does real coercion that the JIT IR can't
+        // replicate, so we bail to Java. Covers every JIT-supported scalar type so
+        // bindVariableTypeCode dispatch is exercised end-to-end.
+        Uuid uuidValue = new Uuid();
+        uuidValue.of("11111111-2222-3333-4444-555555555555");
+        assertMemoryLeak(() -> {
+            execute(
+                    "create table x (" +
+                            "abool BOOLEAN, abyte BYTE, ashort SHORT, achar CHAR, " +
+                            "anint INT, along LONG, afloat FLOAT, adouble DOUBLE, " +
+                            "auuid UUID, aipv4 IPv4, " +
+                            "adate DATE, ats2 TIMESTAMP, ats TIMESTAMP" +
+                            ") timestamp(ats)"
+            );
+            execute(
+                    "insert into x values (true, 1, 10, 'A', 100, 1000, 1.5, 2.5, " +
+                            "'11111111-2222-3333-4444-555555555555', " +
+                            "'1.2.3.4', " +
+                            "'2026-06-15T00:00:00.000Z', " +
+                            "'2026-01-01T00:00:00.000000Z', '2026-01-01T00:00:00.000000Z')"
+            );
+
+            // Read back the row's date and timestamp so the bind values match without
+            // magic epoch numbers.
+            long rowDate, rowTs;
+            try (RecordCursorFactory factory = select("select adate, ats2 from x");
+                 RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Assert.assertTrue(cursor.hasNext());
+                rowDate = cursor.getRecord().getDate(0);
+                rowTs = cursor.getRecord().getTimestamp(1);
+            }
+
+            // Bind variables bound to types matching the cast target -> fold engages.
+            // IPv4 covers the I4_TYPE-mapping `bindVariableTypeCode` branch shared with
+            // INT/SYMBOL/etc. Parametrised types (GEOHASH(Nb), TIMESTAMP_NANO) aren't
+            // covered here because their type literals are not bare CONSTANT nodes, so
+            // `isCastTargetTypeLiteral` correctly refuses to fold them.
+            bindVariableService.clear();
+            bindVariableService.setBoolean(0, true);
+            bindVariableService.setByte(1, (byte) 1);
+            bindVariableService.setShort(2, (short) 10);
+            bindVariableService.setChar(3, 'A');
+            bindVariableService.setInt(4, 100);
+            bindVariableService.setLong(5, 1000L);
+            bindVariableService.setFloat(6, 1.5f);
+            bindVariableService.setDouble(7, 2.5d);
+            bindVariableService.setUuid(8, uuidValue.getLo(), uuidValue.getHi());
+            bindVariableService.setIPv4(9, "1.2.3.4");
+            bindVariableService.setDate(10, rowDate);
+            bindVariableService.setTimestamp(11, rowTs);
+
+            String[] queriesThatMustJit = {
+                    "select * from x where abool = $1::boolean",
+                    "select * from x where abyte = $2::byte",
+                    "select * from x where ashort = $3::short",
+                    "select * from x where achar = $4::char",
+                    "select * from x where anint = $5::int",
+                    "select * from x where along = $6::long",
+                    "select * from x where afloat = cast($7 AS float)",
+                    "select * from x where adouble = $8::double",
+                    "select * from x where auuid = $9::uuid",
+                    "select * from x where aipv4 = $10::ipv4",
+                    "select * from x where adate = $11::date",
+                    "select * from x where ats2 = $12::timestamp",
+            };
+            for (String q : queriesThatMustJit) {
+                try (RecordCursorFactory factory = select(q)) {
+                    Assert.assertTrue("expected JIT for: " + q, factory.usesCompiledFilter());
+                    try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                        Assert.assertTrue("expected at least one row for: " + q, cursor.hasNext());
+                    }
+                }
+            }
+
+            // NULL bind variable with matching cast: fold must engage and produce the
+            // same output as the bare-bind form. We compare cast vs bare bind (rather
+            // than vs Java) so the assertion proves only what's in scope here -- the
+            // fold doesn't change semantics relative to the bare bind path.
+            bindVariableService.clear();
+            bindVariableService.setLong(0); // typed NULL LONG
+            sink.clear();
+            try (RecordCursorFactory factory = select("select * from x where along = $1");
+                 RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Assert.assertTrue(
+                        "expected JIT for bare NULL LONG bind var",
+                        factory.usesCompiledFilter()
+                );
+                println(factory.getMetadata(), cursor, sink);
+            }
+            String bareOut = sink.toString();
+            try (RecordCursorFactory factory = select("select * from x where along = $1::long");
+                 RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                Assert.assertTrue(
+                        "expected JIT for NULL LONG bind var with ::long cast",
+                        factory.usesCompiledFilter()
+                );
+                sink.clear();
+                println(factory.getMetadata(), cursor, sink);
+            }
+            Assert.assertEquals("cast form must match bare bind form for NULL LONG", bareOut, sink.toString());
+
+            // Mismatched bound vs cast target: cast performs real coercion that the
+            // JIT IR can't replicate, so we bail to Java. STRING -> INT exercises the
+            // boundType != castType path with a STRING bind var (PG's typical default
+            // before binding); LONG -> INT covers two non-STRING types differing.
+            bindVariableService.clear();
+            bindVariableService.setStr(0, "100");
+            try (RecordCursorFactory factory = select("select * from x where anint = $1::int")) {
+                Assert.assertFalse(
+                        "expected Java fallback for STRING bind var with ::int cast",
+                        factory.usesCompiledFilter()
+                );
+            }
+            bindVariableService.clear();
+            bindVariableService.setLong(0, 100L);
+            try (RecordCursorFactory factory = select("select * from x where anint = $1::int")) {
+                Assert.assertFalse(
+                        "expected Java fallback for LONG bind var with ::int cast",
+                        factory.usesCompiledFilter()
+                );
+            }
+        });
+    }
+
+    @Test
     public void testBindVariableNullCheckScalar() throws Exception {
         testBindVariableNullCheck(SqlJitMode.JIT_MODE_FORCE_SCALAR);
     }
@@ -147,6 +275,204 @@ public class CompiledFilterTest extends AbstractCairoTest {
                     """;
 
             testFilterWithColTops(query, expected, SqlJitMode.JIT_MODE_ENABLED);
+        });
+    }
+
+    @Test
+    public void testColumnCastPreservesJit() throws Exception {
+        // No-op casts wrapped around a column should fold to the bare column for JIT.
+        // Cross-type column casts must still bail to Java since the JIT IR has no
+        // cast op to perform the runtime conversion.
+        assertMemoryLeak(() -> {
+            execute(
+                    "create table x (" +
+                            "abyte BYTE, ashort SHORT, anint INT, along LONG, " +
+                            "auuid UUID, asymbol SYMBOL, " +
+                            "ats2 TIMESTAMP, ats TIMESTAMP" +
+                            ") timestamp(ats)"
+            );
+            execute(
+                    "insert into x values (1, 10, 100, 1000, " +
+                            "'11111111-2222-3333-4444-555555555555', 'sym', " +
+                            "'2026-01-01T00:00:00.000000Z', '2026-01-01T00:00:00.000000Z')"
+            );
+
+            String[] queriesThatMustJit = {
+                    "select * from x where abyte::byte = 1",
+                    "select * from x where ashort::short = 10",
+                    "select * from x where anint::int = 100",
+                    "select * from x where along::long = 1000",
+                    "select * from x where auuid::uuid = '11111111-2222-3333-4444-555555555555'",
+                    "select * from x where asymbol::symbol = 'sym'",
+                    "select * from x where ats2::timestamp = '2026-01-01T00:00:00.000000Z'",
+                    // Both sides cast (matching their own column types).
+                    "select * from x where auuid::uuid = '11111111-2222-3333-4444-555555555555'::uuid",
+            };
+            String[] queriesThatMustNotJit = {
+                    // Cross-type column cast: JIT can't perform the actual coercion.
+                    "select * from x where anint::long = 100",
+                    "select * from x where abyte::int = 1",
+            };
+
+            StringBuilder failures = new StringBuilder();
+            for (String q : queriesThatMustJit) {
+                try (RecordCursorFactory factory = select(q)) {
+                    if (!factory.usesCompiledFilter()) {
+                        failures.append("\n  expected JIT, got Java: ").append(q);
+                    }
+                }
+            }
+            for (String q : queriesThatMustNotJit) {
+                try (RecordCursorFactory factory = select(q)) {
+                    if (factory.usesCompiledFilter()) {
+                        failures.append("\n  expected Java fallback, got JIT: ").append(q);
+                    }
+                }
+            }
+            if (failures.length() > 0) {
+                Assert.fail("Column-cast-fold expectations not met:" + failures);
+            }
+        });
+    }
+
+    @Test
+    public void testConstantCastPreservesJit() throws Exception {
+        // Regression for the legacy `<col> = '...'::uuid` workaround from PR #6413
+        // (and any other literal `'...'::TYPE`): the cast was tripping the JIT IR
+        // serializer's "invalid operator: cast" rejection and silently falling back
+        // to the Java filter. Asserts JIT engagement for matching cast/column types,
+        // and asserts NO JIT for cross-type or PG-rewritten casts (where folding
+        // would change semantics). Aggregates failures so a single run lists every
+        // miss.
+        assertMemoryLeak(() -> {
+            execute(
+                    "create table x (" +
+                            "abool BOOLEAN, " +
+                            "abyte BYTE, " +
+                            "ashort SHORT, " +
+                            "achar CHAR, " +
+                            "anint INT, " +
+                            "along LONG, " +
+                            "afloat FLOAT, " +
+                            "adouble DOUBLE, " +
+                            "auuid UUID, " +
+                            "asymbol SYMBOL, " +
+                            "adate DATE, " +
+                            // ats is the designated timestamp -- predicates on it are
+                            // pushed down as interval scans, so we JIT against ats2.
+                            "ats2 TIMESTAMP, " +
+                            "ats TIMESTAMP" +
+                            ") timestamp(ats)"
+            );
+            execute(
+                    "insert into x values (" +
+                            "true, 1, 10, 'A', 100, 1000, 1.5, 2.5, " +
+                            "'11111111-2222-3333-4444-555555555555', " +
+                            "'sym', " +
+                            "'2026-01-01', " +
+                            "'2026-01-01T00:00:00.000000Z', " +
+                            "'2026-01-01T00:00:00.000000Z')"
+            );
+
+            // NB: in QuestDB, `::float` is rewritten to DOUBLE for PG compatibility,
+            // so `afloat = 1.5::float` is semantically `afloat = 1.5::double`. The
+            // type-tag-match guard correctly refuses to fold this, and the query
+            // falls back to Java. Test FLOAT via the unambiguous `cast(... AS float)`
+            // form instead.
+            String[] queriesThatMustJit = {
+                    // baseline: constant without cast already JITs
+                    "select * from x where abool = true",
+                    "select * from x where abyte = 1",
+                    "select * from x where ashort = 10",
+                    "select * from x where achar = 'A'",
+                    "select * from x where anint = 100",
+                    "select * from x where along = 1000",
+                    "select * from x where afloat = 1.5",
+                    "select * from x where adouble = 2.5",
+                    "select * from x where auuid = '11111111-2222-3333-4444-555555555555'",
+                    "select * from x where asymbol = 'sym'",
+                    "select * from x where adate = '2026-01-01'",
+                    "select * from x where ats2 = '2026-01-01T00:00:00.000000Z'",
+                    // matching `::TYPE` cast on the constant side
+                    "select * from x where abool = true::boolean",
+                    "select * from x where abyte = 1::byte",
+                    "select * from x where ashort = 10::short",
+                    "select * from x where achar = 'A'::char",
+                    "select * from x where anint = 100::int",
+                    "select * from x where along = 1000::long",
+                    "select * from x where afloat = cast(1.5 AS float)",
+                    "select * from x where adouble = 2.5::double",
+                    "select * from x where auuid = '11111111-2222-3333-4444-555555555555'::uuid",
+                    "select * from x where asymbol = 'sym'::symbol",
+                    "select * from x where adate = '2026-01-01'::date",
+                    "select * from x where ats2 = '2026-01-01T00:00:00.000000Z'::timestamp",
+                    // `cast(<const> AS TYPE)` form parses to the same FUNCTION/cast AST node
+                    "select * from x where auuid = cast('11111111-2222-3333-4444-555555555555' AS uuid)",
+                    "select * from x where ats2 = cast('2026-01-01T00:00:00.000000Z' AS timestamp)",
+                    // mirrors the user-reported shape: AND-chain with literal casts on the constant side
+                    "select * from x where auuid = '11111111-2222-3333-4444-555555555555'::uuid and adate = '2026-01-01'::date",
+                    // negated-constant cast: exercises the OPERATION(-, CONSTANT) branch of
+                    // isFoldableConstantArg AND the LONG_MIN/INT_MIN/SHORT_MIN/BYTE_MIN
+                    // sign-truncate path in serializeNumber. The negative MIN values
+                    // happen to coincide with INT/LONG NULL sentinels; the JIT's
+                    // null-aware compare keeps Java semantics intact.
+                    "select * from x where abyte > (-128)::byte",
+                    "select * from x where ashort > (-32768)::short",
+                    "select * from x where anint > (-2147483648)::int",
+                    "select * from x where along > (-9223372036854775808)::long",
+            };
+
+            // Cross-type or PG-rewritten casts must NOT fold. They fall back to the Java
+            // filter, which preserves the user's stated cast semantics. The Java path
+            // produces correct results; the only assertion here is that JIT does not
+            // engage (since folding would change semantics, e.g. INT NULL sentinel,
+            // or different timestamp precision drivers for ::timestamp_ns vs ::timestamp).
+            String[] queriesThatMustNotJit = {
+                    "select * from x where afloat = 1.5::float",         // ::float -> DOUBLE
+                    "select * from x where anint = 100::long",           // wider cast
+                    "select * from x where abyte = 1::short",            // wider cast
+                    // ::timestamp_ns and ::timestamp share the TIMESTAMP tag but use
+                    // different precision drivers; the full-type guard must reject this.
+                    "select * from x where ats2 = '2026-01-01T00:00:00.000000Z'::timestamp_ns",
+            };
+
+            StringBuilder failures = new StringBuilder();
+            for (String q : queriesThatMustJit) {
+                try (RecordCursorFactory factory = select(q)) {
+                    if (!factory.usesCompiledFilter()) {
+                        failures.append("\n  expected JIT, got Java: ").append(q);
+                    }
+                }
+            }
+            for (String q : queriesThatMustNotJit) {
+                try (RecordCursorFactory factory = select(q)) {
+                    if (factory.usesCompiledFilter()) {
+                        failures.append("\n  expected Java fallback, got JIT: ").append(q);
+                    }
+                }
+            }
+            if (failures.length() > 0) {
+                Assert.fail("Cast-fold expectations not met:" + failures);
+            }
+
+            // Result-correctness checks for load-bearing cases. The fuzz covers the
+            // wide surface end-to-end; these explicit assertions verify that the
+            // user-reported scenario and the negated-MIN boundaries (which exercise
+            // parseSignedLong and the JIT null-aware compare) produce the same rows
+            // as the Java filter would. A bug where JIT engages but emits incorrect
+            // IR would surface here even when usesCompiledFilter() is true.
+            assertSql(
+                    "count\n1\n",
+                    "select count() from x where auuid = '11111111-2222-3333-4444-555555555555'::uuid and adate = '2026-01-01'::date"
+            );
+            // BYTE_MIN/SHORT_MIN are NOT NULL sentinels in QuestDB, so `col > -MIN`
+            // matches every non-null row.
+            assertSql("count\n1\n", "select count() from x where abyte > (-128)::byte");
+            assertSql("count\n1\n", "select count() from x where ashort > (-32768)::short");
+            // INT_MIN and LONG_MIN ARE NULL sentinels, so the cast result is NULL and
+            // `col > NULL` evaluates to NULL (no rows match).
+            assertSql("count\n0\n", "select count() from x where anint > (-2147483648)::int");
+            assertSql("count\n0\n", "select count() from x where along > (-9223372036854775808)::long");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -9182,7 +9182,7 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 """);
     }
 
-    @Test // jit is not used due to type mismatch
+    @Test // jit is not used due to type mismatch -- the cast-fold guard only unwraps when target type matches column type
     public void testSelectWithNonJittedFilter1() throws Exception {
         assertPlan("create table tab ( l long, ts timestamp);", "select * from tab where l = 12::short ", """
                 Async Filter workers: 1
@@ -9193,10 +9193,10 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 """);
     }
 
-    @Test // jit filter doesn't work with type casts
+    @Test
     public void testSelectWithNonJittedFilter10() throws Exception {
         assertPlan("create table tab ( s short, ts timestamp);", "select * from tab where s = 1::short ", """
-                Async Filter workers: 1
+                Async JIT Filter workers: 1
                   filter: s=1
                     PageFrame
                         Row forward scan
@@ -9204,10 +9204,10 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 """);
     }
 
-    @Test // TODO: should run with jitted filter just like b = true
+    @Test
     public void testSelectWithNonJittedFilter11() throws Exception {
         assertPlan("create table tab ( b boolean, ts timestamp);", "select * from tab where b = true::boolean ", """
-                Async Filter workers: 1
+                Async JIT Filter workers: 1
                   filter: b=true
                     PageFrame
                         Row forward scan
@@ -9215,10 +9215,10 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 """);
     }
 
-    @Test // TODO: should run with jitted filter just like l = 1024
+    @Test
     public void testSelectWithNonJittedFilter12() throws Exception {
         assertPlan("create table tab ( l long, ts timestamp);", "select * from tab where l = 1024::long ", """
-                Async Filter workers: 1
+                Async JIT Filter workers: 1
                   filter: l=1024L
                     PageFrame
                         Row forward scan
@@ -9226,10 +9226,10 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 """);
     }
 
-    @Test // TODO: should run with jitted filter just like d = 1024.1
+    @Test
     public void testSelectWithNonJittedFilter13() throws Exception {
         assertPlan("create table tab ( d double, ts timestamp);", "select * from tab where d = 1024.1::double ", """
-                Async Filter workers: 1
+                Async JIT Filter workers: 1
                   filter: d=1024.1
                     PageFrame
                         Row forward scan
@@ -9237,10 +9237,10 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 """);
     }
 
-    @Test // TODO: should run with jitted filter just like d = null
+    @Test
     public void testSelectWithNonJittedFilter14() throws Exception {
         assertPlan("create table tab ( d double, ts timestamp);", "select * from tab where d = null::double ", """
-                Async Filter workers: 1
+                Async JIT Filter workers: 1
                   filter: d is null
                     PageFrame
                         Row forward scan
@@ -9308,7 +9308,7 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 """);
     }
 
-    @Test // jit is not used due to type mismatch
+    @Test // jit is not used due to type mismatch -- the cast-fold guard only unwraps when target type matches column type
     public void testSelectWithNonJittedFilter2() throws Exception {
         assertPlan("create table tab ( l long, ts timestamp);", "select * from tab where l = 12::byte ", """
                 Async Filter workers: 1
@@ -9375,10 +9375,10 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 """);
     }
 
-    @Test // jit filter doesn't work with type casts
+    @Test
     public void testSelectWithNonJittedFilter9() throws Exception {
         assertPlan("create table tab ( b byte, ts timestamp);", "select * from tab where b = 1::byte ", """
-                Async Filter workers: 1
+                Async JIT Filter workers: 1
                   filter: b=1
                     PageFrame
                         Row forward scan

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -9182,7 +9182,8 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 """);
     }
 
-    @Test // jit is not used due to type mismatch -- the cast-fold guard only unwraps when target type matches column type
+    @Test
+    // jit is not used due to type mismatch -- the cast-fold guard only unwraps when target type matches column type
     public void testSelectWithNonJittedFilter1() throws Exception {
         assertPlan("create table tab ( l long, ts timestamp);", "select * from tab where l = 12::short ", """
                 Async Filter workers: 1
@@ -9308,7 +9309,8 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 """);
     }
 
-    @Test // jit is not used due to type mismatch -- the cast-fold guard only unwraps when target type matches column type
+    @Test
+    // jit is not used due to type mismatch -- the cast-fold guard only unwraps when target type matches column type
     public void testSelectWithNonJittedFilter2() throws Exception {
         assertPlan("create table tab ( l long, ts timestamp);", "select * from tab where l = 12::byte ", """
                 Async Filter workers: 1
@@ -9319,7 +9321,8 @@ public class ExplainPlanTest extends AbstractCairoTest {
                 """);
     }
 
-    @Test // jit is not used due to type mismatch
+    @Test
+    // jit is not used due to type mismatch
     public void testSelectWithNonJittedFilter3() throws Exception {
         assertPlan("create table tab ( l long, ts timestamp);", "select * from tab where l = '123' ", """
                 Async Filter workers: 1


### PR DESCRIPTION
## Summary

- Folds `cast(<inner>, T)` into the inner operand in JIT-compiled
  filters when T matches the column's full type, so the legacy
  `::uuid` workaround from PR #6413 (and any other literal
  `'...'::TYPE`) keeps using JIT instead of falling back to the
  Java filter.
- Three fold paths: literal constants (incl. negated), bind
  variables (when bound type matches), and no-op column-side casts.
- Fixes a latent sign-truncation in `serializeNumber` that emitted
  the negated MIN value of each integer width (BYTE_MIN, SHORT_MIN,
  INT_MIN, LONG_MIN) as the positive sentinel instead of the
  negative MIN.

## What is NOT covered

- Cross-type casts (e.g. `cast(int_col, long) = 100`) still bail
  out — the JIT IR has no cast opcode to perform runtime coercion,
  and folding would change semantics.
- PG's `::float` is rewritten by the parser to DOUBLE, so
  `afloat = 1.5::float` against a FLOAT column is treated as a
  cross-type cast and bails out. The unambiguous
  `cast(1.5 AS float)` form folds correctly.
- TIMESTAMP_MICRO and TIMESTAMP_NANO share the TIMESTAMP type tag
  but use different precision drivers — the guard compares full
  type, not tag, to prevent silent precision loss.
- STRING bind variables with `::symbol` cast on SYMBOL columns
  don't fold (they route through the deferred-symbol backfill
  path which the fold doesn't hook into).

## Test plan

- New \`CompiledFilterTest.testConstantCastPreservesJit\`,
  \`testColumnCastPreservesJit\`, \`testBindVariableCastPreservesJit\`
- New \`CompiledFilterCastFuzzTest\` with three probe shapes
  (matching, column-side, cross-type) across all supported numeric
  types including the negated MIN boundary
- Updated 8 fixtures in \`ExplainPlanTest.testSelectWithNonJittedFilter*\`
  — 6 flipped to \`Async JIT Filter\`, 2 kept as cross-type Java
- Verified across 4 random fuzz seeds and the full
  \`CompiledFilter*\`, \`JIT*\`, \`AsyncFiltered*\`, \`ExplainPlan*\`,
  \`ParallelFilter\` suites (833 tests, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)