### PR TITLE
chore(core): seal POSTING indexes after WAL fast-lag commit

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3681,6 +3681,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 }
             }
             updateIndexesParallel(initialTransientRowCount, newTransientRowCount);
+            sealPostingIndexesForLastPartitionFastLag();
         }
         // set append position on columns so that the files are truncated to the correct size
         // if the partition is closed after the commit.
@@ -10889,6 +10890,45 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             path.trimTo(pathSize);
         }
         return processed;
+    }
+
+    private void sealPostingIndexesForLastPartitionFastLag() {
+        // applyLagToLastPartition runs OUTSIDE the o3 commit window — there
+        // is no sealPostingIndexesForO3Partitions sweep to follow. The
+        // writer for each indexed column is already open at the last
+        // partition (configured by openPartition), and updateIndexesParallel
+        // has just called writer.add() for every fresh row. POSTING writers
+        // hold those entries in memory until seal() flushes them to .pv;
+        // BITMAP writers persist incrementally and need no extra step.
+        // Without this seal, queries hit the .pv file and return zero rows
+        // for symbols added through the fast-lag path.
+        if (lastPartitionTimestamp == Long.MIN_VALUE) {
+            return;
+        }
+        for (int colIdx = 0; colIdx < columnCount; colIdx++) {
+            if (metadata.getColumnType(colIdx) <= 0
+                    || !metadata.isColumnIndexed(colIdx)
+                    || !IndexType.isPosting(metadata.getColumnIndexType(colIdx))) {
+                continue;
+            }
+            ColumnIndexer indexer = indexers.getQuick(colIdx);
+            if (indexer == null) {
+                continue;
+            }
+            IntList coveringCols = metadata.getColumnMetadata(colIdx).getCoveringColumnIndices();
+            if (coveringCols != null && coveringCols.size() > 0) {
+                // Covering POSTING indexes need the full reseal in
+                // sealPostingIndexForPartition (covering-file remap +
+                // rebuildSidecars). The fast-lag commit path is followed by
+                // a full O3 commit when more transactions accumulate, which
+                // catches the covering reseal then. Non-covering POSTING is
+                // the only path that has no later sweep.
+                continue;
+            }
+            indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn());
+            indexer.seal();
+            indexer.publishPendingPurges(messageBus, tableToken, partitionBy, timestampType, txWriter.getTxn());
+        }
     }
 
     private void sealPostingIndexesForO3Partitions() {


### PR DESCRIPTION
## Summary

The fast-lag commit path (`applyLagToLastPartition`) used by WAL apply when transactions land entirely inside the open last partition calls `updateIndexesParallel` to populate the in-memory state of each column indexer, but it does not seal the result. POSTING writers hold their entries in memory until `seal()` flushes them to the `.pv` file; BITMAP writers persist incrementally so they were unaffected. The O3 commit path catches every POSTING column it touches via `sealPostingIndexesForO3Partitions`, but the fast-lag path bypasses `processO3Block` entirely.

The visible effect: partitions whose data arrives exclusively through the fast-lag path - typically the very first partition of an empty WAL table - end up with an empty `.pv` for any non-covering POSTING column. Indexed queries (`WHERE sym = 'X'`) over those partitions return zero rows, while full scans return the data correctly. Tables that fall through to a full O3 commit on every transaction are unaffected.

This PR adds `sealPostingIndexesForLastPartitionFastLag()`, which iterates indexed POSTING columns on the last partition and runs the non-covering seal sequence (`setNextTxnAtSeal`, `seal`, `publishPendingPurges`). It is invoked from `applyLagToLastPartition` immediately after `updateIndexesParallel`. Covering POSTING indexes are intentionally skipped: they require the full reseal in `sealPostingIndexForPartition` (covering-file remap plus `rebuildSidecars`), which the next O3 commit catches; wiring covering reseal into the fast-lag path is left for a follow-up so it can be exercised under its own focused tests.

## Tradeoffs

- Each fast-lag commit on a table with non-covering POSTING indexes now does an extra `seal()` plus `publishPendingPurges()` per indexed column. For tables that mostly batch through fast-lag, this adds I/O proportional to the number of indexed columns per commit. Tables with no POSTING indexes (BITMAP-only or no indexes) take an early-return on the column-type check and pay nothing measurable.
- Covering POSTING indexes still go through the existing O3-driven seal path. If a table has only covering POSTING indexes and stays exclusively on the fast-lag path for many commits, the seal happens later than it does for non-covering columns. Behavior is not worse than today; it is the unchanged baseline.
- The bug exists only on the unreleased `master` introduced by #6861, hence `chore` rather than `fix`.

## Test plan

- `WalWriterFuzzTest.testWalSmallWalFdReuse` with seeds `7012496711609388L,1777753420105L` and `7012496713968699L,1777753420107L` deterministically failed before this change with row mismatches in `assertRandomIndexes`; passes after.
- Full `WalWriterFuzzTest` class (24 tests, all 4 symbol-index flavours: BITMAP, POSTING, POSTING DELTA, POSTING EF) passes with random seeds.
- Wider sweep across `*FuzzTest`, `WalTableSqlTest`, `WalAlterTableSqlTest`: 15,609 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)