### PR TITLE
fix(core): refresh covering sidecar mappings on posting-index reader reload

### DIFF
--- a/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
@@ -72,6 +72,11 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
     protected final IntList sidecarColumnIndices = new IntList();
     protected final IntList sidecarColumnTypes = new IntList();
     protected final LongList sidecarCovTs = new LongList();
+    // Per-cover-column file extents picked from the chain entry. Slot c is
+    // the writer's published append offset in .pc{c}.<...>.<sealTxn> at the
+    // moment the picked entry was (re)published. Sized by openSidecarFilesIfPresent
+    // to coverCount; refreshed on each readIndexMetadataFromChain() success.
+    protected final LongList sidecarFileEndOffsets = new LongList();
     protected final ObjList<MemoryMR> sidecarMems = new ObjList<>();
     protected final MemoryMR valueMem = Vm.getCMRInstance();
     protected long columnTop;
@@ -257,6 +262,12 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
                     -1
             );
 
+            // Discover coverCount from .pci before reading the chain entry
+            // — the entry's cover end-offset footer length is sized by
+            // coverCount, and PostingIndexChainPicker.pick() needs it to
+            // populate the snapshot's coverFileEndOffsets list.
+            openSidecarFilesIfPresent(path.trimTo(pLen), columnName, columnNameTxn);
+
             readIndexMetadataFromChain();
 
             if (headEntryOffset == PostingIndexUtils.V2_NO_HEAD || valueMemSize <= 0) {
@@ -264,12 +275,10 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
                 // the value file — readers will treat the partition as empty.
                 // A subsequent reloadConditionally() will lazily map .pv if
                 // the writer publishes an entry while we're open.
-                openSidecarFilesIfPresent(path.trimTo(pLen), columnName, columnNameTxn);
                 return;
             }
 
             mapValueMem(path.trimTo(pLen), columnName, columnNameTxn);
-            openSidecarFilesIfPresent(path.trimTo(pLen), columnName, columnNameTxn);
         } catch (Throwable e) {
             close();
             throw e;
@@ -314,7 +323,8 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
         if (valueMemSize <= 0) {
             return;
         }
-        if (valueFileTxn != prevValueFileTxn || valueMem.size() == 0) {
+        boolean sealTxnAdvanced = valueFileTxn != prevValueFileTxn;
+        if (sealTxnAdvanced || valueMem.size() == 0) {
             // sealTxn advanced (new .pv.{N} filename) or .pv was never opened
             // because the chain was previously empty. Close and reopen
             // against the new path / size.
@@ -325,6 +335,28 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
             // the head entry but advances valueMemSize, so we must resize
             // valueMem here even though headEntryOffset is unchanged.
             ((MemoryCMR) this.valueMem).changeSize(valueMemSize);
+        }
+        // Refresh sidecar mappings to track .pcN file changes.
+        // sealTxn advance: drop existing mappings; the new sealTxn names
+        // different .pcN files (sealTxn is part of coverDataFileName), so
+        // ensureSidecarOpen() must lazy-remap on the next covering read.
+        // Same sealTxn, gen flushed: writeSidecarGenData() may have extended
+        // .pcN past the writer's previous extent; resize each mapping to the
+        // chain-published end offset so covered reads in the new gen stay
+        // in bounds.
+        for (int c = 0, n = sidecarMems.size(); c < n; c++) {
+            MemoryMR mem = sidecarMems.getQuick(c);
+            if (mem == null || mem.size() == 0) {
+                continue;
+            }
+            if (sealTxnAdvanced) {
+                mem.close();
+                continue;
+            }
+            long publishedEnd = c < sidecarFileEndOffsets.size() ? sidecarFileEndOffsets.getQuick(c) : 0L;
+            if (publishedEnd > mem.size()) {
+                ((MemoryCMR) mem).changeSize(publishedEnd);
+            }
         }
     }
 
@@ -517,6 +549,7 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
         sidecarColumnIndices.clear();
         sidecarColumnTypes.clear();
         sidecarCovTs.clear();
+        sidecarFileEndOffsets.clear();
     }
 
     private int collectDenseGenKeys(long genFileOffset, int genKeyCount, DirectBitSet foundKeys) {
@@ -677,7 +710,7 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
                     }
                 }
             }
-            int result = PostingIndexChainPicker.pick(keyMem, pinnedTableTxn, headerScratch, entryScratch);
+            int result = PostingIndexChainPicker.pick(keyMem, pinnedTableTxn, coverCount, headerScratch, entryScratch);
             if (result == PostingIndexChainPicker.RESULT_HEADER_UNREADABLE) {
                 if (clock.getTicks() > deadline) {
                     LOG.error().$(INDEX_CORRUPT).$(" [timeout=").$(spinLockTimeoutMs).$("ms]").$();
@@ -724,6 +757,15 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
                 this.genCount = entryScratch.genCount;
                 this.valueFileTxn = entryScratch.sealTxn;
                 this.keyCountIncludingNulls = columnTop > 0 ? keyCount + 1 : keyCount;
+                // Promote the picked entry's per-cover end offsets into the
+                // active snapshot. Slots are zero-padded to coverCount so
+                // callers can read them by includeIdx without bounds checks.
+                sidecarFileEndOffsets.clear();
+                sidecarFileEndOffsets.setPos(coverCount);
+                int picked = entryScratch.coverFileEndOffsets.size();
+                for (int c = 0; c < coverCount; c++) {
+                    sidecarFileEndOffsets.setQuick(c, c < picked ? entryScratch.coverFileEndOffsets.getQuick(c) : 0L);
+                }
                 return;
             }
 
@@ -739,6 +781,11 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
             this.genCount = 0;
             this.valueFileTxn = 0;
             this.keyCountIncludingNulls = columnTop > 0 ? 1 : 0;
+            sidecarFileEndOffsets.clear();
+            sidecarFileEndOffsets.setPos(coverCount);
+            for (int c = 0; c < coverCount; c++) {
+                sidecarFileEndOffsets.setQuick(c, 0L);
+            }
             // Reset gen lookup to an empty staging snapshot and promote it.
             genLookup.snapshotMetadata(keyMem, 0, 0L);
             genLookup.commitSnapshot();
@@ -851,6 +898,12 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
 
     protected void ensureSidecarOpen(int c) {
         MemoryMR mem = sidecarMems.getQuick(c);
+        long publishedEnd = c < sidecarFileEndOffsets.size() ? sidecarFileEndOffsets.getQuick(c) : 0L;
+        if (publishedEnd <= 0) {
+            // Writer has not (yet) published any sidecar bytes for this slot.
+            // Nothing safe to map.
+            return;
+        }
         if (mem.size() > 0) {
             return;
         }
@@ -867,7 +920,11 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
             if (!ff.exists(pcFile)) {
                 return;
             }
-            mem.of(ff, pcFile, ff.getMapPageSize(), -1, MemoryTag.MMAP_INDEX_READER, CairoConfiguration.O_NONE, -1);
+            // Use the chain-published end offset rather than ff.length(fd):
+            // the file may be page-pre-allocated past valid data, and the
+            // chain's value is the only authoritative upper bound that's
+            // ordered with the seqlock that brought us here.
+            mem.of(ff, pcFile, ff.getMapPageSize(), publishedEnd, MemoryTag.MMAP_INDEX_READER, CairoConfiguration.O_NONE, -1);
         } finally {
             sidecarBasePath.trimTo(pLen);
         }

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainEntry.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainEntry.java
@@ -24,8 +24,10 @@
 
 package io.questdb.cairo.idx;
 
+import io.questdb.cairo.vm.api.MemoryARW;
 import io.questdb.cairo.vm.api.MemoryR;
 import io.questdb.cairo.vm.api.MemoryW;
+import io.questdb.std.LongList;
 import io.questdb.std.Unsafe;
 
 /**
@@ -38,18 +40,22 @@ import io.questdb.std.Unsafe;
  * <p>
  * Entry layout (header is V2_ENTRY_HEADER_SIZE = 64 bytes):
  * <pre>
- *   [0..7]    LEN
- *   [8..15]   SEAL_TXN
- *   [16..23]  TXN_AT_SEAL
- *   [24..31]  VALUE_MEM_SIZE
- *   [32..39]  MAX_VALUE
- *   [40..43]  KEY_COUNT
- *   [44..47]  GEN_COUNT
- *   [48..51]  BLOCK_CAPACITY
- *   [52..55]  COVERING_FORMAT (reserved)
- *   [56..63]  PREV_ENTRY_OFFSET
- *   [64..]    GEN_DIR  (GEN_COUNT * GEN_DIR_ENTRY_SIZE bytes)
+ *   [0..7]                                              LEN
+ *   [8..15]                                             SEAL_TXN
+ *   [16..23]                                            TXN_AT_SEAL
+ *   [24..31]                                            VALUE_MEM_SIZE
+ *   [32..39]                                            MAX_VALUE
+ *   [40..43]                                            KEY_COUNT
+ *   [44..47]                                            GEN_COUNT
+ *   [48..51]                                            BLOCK_CAPACITY
+ *   [52..55]                                            COVERING_FORMAT (reserved)
+ *   [56..63]                                            PREV_ENTRY_OFFSET
+ *   [64 ..)                                             GEN_DIR (GEN_COUNT * GEN_DIR_ENTRY_SIZE)
+ *   [64 + GEN_COUNT*GEN_DIR_ENTRY_SIZE ..)              COVER_END_OFFSETS (COVER_COUNT * 8 bytes)
  * </pre>
+ * COVER_COUNT is constant for the .pk file's posting column instance and is
+ * published in the .pci sidecar header, so every entry in this .pk shares the
+ * same cover footer length.
  */
 public final class PostingIndexChainEntry {
 
@@ -58,6 +64,7 @@ public final class PostingIndexChainEntry {
      */
     public static final class Snapshot {
         public int blockCapacity;
+        public final LongList coverFileEndOffsets = new LongList();
         public int coveringFormat;
         public int genCount;
         public long genDirOffset;
@@ -83,6 +90,7 @@ public final class PostingIndexChainEntry {
             this.coveringFormat = 0;
             this.prevEntryOffset = PostingIndexUtils.V2_NO_HEAD;
             this.genDirOffset = 0;
+            this.coverFileEndOffsets.clear();
         }
     }
 
@@ -90,30 +98,55 @@ public final class PostingIndexChainEntry {
     }
 
     /**
-     * Total entry size in bytes for a given gen count: header + gen dir
-     * payload, padded to an 8-byte boundary.
+     * Convenience overload: entry size for a no-cover-columns layout.
+     * Equivalent to {@code entrySize(genCount, 0)}.
      */
     public static int entrySize(int genCount) {
+        return entrySize(genCount, 0);
+    }
+
+    /**
+     * Total entry size in bytes: header + gen dir + cover end-offset footer,
+     * padded to an 8-byte boundary. {@code coverCount} is the .pci-published
+     * fixed cover-column count for this posting column instance and is the
+     * same for every entry in a given .pk file.
+     */
+    public static int entrySize(int genCount, int coverCount) {
         long bytes = (long) PostingIndexUtils.V2_ENTRY_HEADER_SIZE
-                + (long) genCount * (long) PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+                + (long) genCount * (long) PostingIndexUtils.GEN_DIR_ENTRY_SIZE
+                + (long) coverCount * (long) PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE;
         // Round up to 8 to keep subsequent entries 8-byte aligned.
         bytes = (bytes + 7L) & ~7L;
         return (int) bytes;
     }
 
     /**
-     * Read an entry header at {@code entryOffset} into {@code into}. Returns
-     * the offset just past this entry's bytes (useful for forward scans).
+     * Convenience overload that skips the cover end-offset footer. Useful for
+     * callers that only care about header fields (chain-writer recovery,
+     * test fixtures).
      */
     public static long read(MemoryR keyMem, long entryOffset, Snapshot into) {
+        return read(keyMem, entryOffset, 0, into);
+    }
+
+    /**
+     * Read an entry header at {@code entryOffset} into {@code into}. Returns
+     * the offset just past this entry's bytes (useful for forward scans).
+     * <p>
+     * {@code coverCount} must match the .pci value for this posting column
+     * instance — readers source it from {@code openSidecarFilesIfPresent}
+     * before calling this method.
+     */
+    public static long read(MemoryR keyMem, long entryOffset, int coverCount, Snapshot into) {
         into.offset = entryOffset;
         // GEN_COUNT must be read FIRST. Pairs with the storeFence-guarded
         // GEN_COUNT store in PostingIndexChainWriter.extendHead: the writer
-        // updates KEY_COUNT, LEN, VALUE_MEM_SIZE and MAX_VALUE in place,
-        // fences, then bumps GEN_COUNT last. By reading GEN_COUNT first
-        // and fencing after, this reader sees an old GEN_COUNT (with
-        // matching old fields) or a new GEN_COUNT (with matching new
-        // fields), but never new GEN_COUNT with old VALUE_MEM_SIZE.
+        // updates KEY_COUNT, LEN, VALUE_MEM_SIZE, MAX_VALUE and the cover
+        // end-offset footer in place, fences, then bumps GEN_COUNT last. By
+        // reading GEN_COUNT first and fencing after, this reader sees an
+        // old GEN_COUNT (with matching old fields) or a new GEN_COUNT (with
+        // matching new fields), but never new GEN_COUNT with old
+        // VALUE_MEM_SIZE / cover sizes.
         into.genCount = keyMem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
         Unsafe.loadFence();
         into.len = keyMem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN);
@@ -126,7 +159,28 @@ public final class PostingIndexChainEntry {
         into.coveringFormat = keyMem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_COVERING_FORMAT);
         into.prevEntryOffset = keyMem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET);
         into.genDirOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE;
+        into.coverFileEndOffsets.clear();
+        if (coverCount > 0) {
+            long footerOffset = resolveCoverFooterOffset(entryOffset, into.genCount);
+            into.coverFileEndOffsets.setPos(coverCount);
+            for (int c = 0; c < coverCount; c++) {
+                into.coverFileEndOffsets.setQuick(
+                        c,
+                        keyMem.getLong(footerOffset + (long) c * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE)
+                );
+            }
+        }
         return entryOffset + into.len;
+    }
+
+    /**
+     * Compute the byte offset of the cover end-offset footer (right after the
+     * gen-dir region of {@code genCount} entries).
+     */
+    public static long resolveCoverFooterOffset(long entryOffset, int genCount) {
+        return entryOffset
+                + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                + (long) genCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
     }
 
     /**
@@ -139,9 +193,42 @@ public final class PostingIndexChainEntry {
     }
 
     /**
+     * Update the c-th cover end-offset footer slot in place. Used by
+     * {@link PostingIndexChainWriter#extendHead} so a same-sealTxn gen flush
+     * republishes the new sidecar extent atomically with VALUE_MEM_SIZE.
+     */
+    public static void writeCoverEndOffset(MemoryARW keyMem, long entryOffset, int genCount, int coverIndex, long endOffset) {
+        long footerOffset = resolveCoverFooterOffset(entryOffset, genCount);
+        keyMem.putLong(footerOffset + (long) coverIndex * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE, endOffset);
+    }
+
+    /**
+     * Convenience overload that writes no cover end-offset footer. For
+     * call sites that don't need covering (chain-writer tests, the empty
+     * sentinel writes during truncate / initialiseEmpty).
+     */
+    public static void writeHeader(
+            MemoryW keyMem,
+            long entryOffset,
+            long sealTxn,
+            long txnAtSeal,
+            long valueMemSize,
+            long maxValue,
+            int keyCount,
+            int genCount,
+            int blockCapacity,
+            int coveringFormat,
+            long prevEntryOffset
+    ) {
+        writeHeader(keyMem, entryOffset, sealTxn, txnAtSeal, valueMemSize, maxValue, keyCount,
+                genCount, blockCapacity, coveringFormat, prevEntryOffset, null);
+    }
+
+    /**
      * Write a complete entry header at {@code entryOffset}. Caller must
      * write the gen dir payload itself afterward (or before the entry is
-     * made visible by publishing the chain head).
+     * made visible by publishing the chain head). When {@code coverEndOffsets}
+     * is non-null, this method also fills the cover end-offset footer.
      * <p>
      * The entry must be fully written and durable on disk before
      * {@link PostingIndexChainHeader#publish} advances the chain head;
@@ -158,9 +245,11 @@ public final class PostingIndexChainEntry {
             int genCount,
             int blockCapacity,
             int coveringFormat,
-            long prevEntryOffset
+            long prevEntryOffset,
+            LongList coverEndOffsets
     ) {
-        long len = entrySize(genCount);
+        int coverCount = coverEndOffsets != null ? coverEndOffsets.size() : 0;
+        long len = entrySize(genCount, coverCount);
         keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, len);
         keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_SEAL_TXN, sealTxn);
         keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_TXN_AT_SEAL, txnAtSeal);
@@ -171,5 +260,14 @@ public final class PostingIndexChainEntry {
         keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_BLOCK_CAPACITY, blockCapacity);
         keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_COVERING_FORMAT, coveringFormat);
         keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET, prevEntryOffset);
+        if (coverCount > 0) {
+            long footerOffset = resolveCoverFooterOffset(entryOffset, genCount);
+            for (int c = 0; c < coverCount; c++) {
+                keyMem.putLong(
+                        footerOffset + (long) c * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE,
+                        coverEndOffsets.getQuick(c)
+                );
+            }
+        }
     }
 }

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainPicker.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainPicker.java
@@ -69,9 +69,23 @@ public final class PostingIndexChainPicker {
      *       exhausted; caller should treat as I/O error.</li>
      * </ul>
      */
+    /**
+     * Convenience overload for callers that don't read covering. Equivalent
+     * to {@code pick(keyMem, pinnedTableTxn, 0, headerScratch, into)}.
+     */
     public static int pick(
             MemoryR keyMem,
             long pinnedTableTxn,
+            PostingIndexChainHeader.Snapshot headerScratch,
+            PostingIndexChainEntry.Snapshot into
+    ) {
+        return pick(keyMem, pinnedTableTxn, 0, headerScratch, into);
+    }
+
+    public static int pick(
+            MemoryR keyMem,
+            long pinnedTableTxn,
+            int coverCount,
             PostingIndexChainHeader.Snapshot headerScratch,
             PostingIndexChainEntry.Snapshot into
     ) {
@@ -114,10 +128,10 @@ public final class PostingIndexChainPicker {
                 return RESULT_HEADER_UNREADABLE;
             }
 
-            PostingIndexChainEntry.read(keyMem, entryOffset, into);
-            // The full entry (header + gen-dir payload) must fit inside
-            // the mapped region too. snapshotMetadata reads gen-dir
-            // entries at offsets up to entryOffset + into.len.
+            PostingIndexChainEntry.read(keyMem, entryOffset, coverCount, into);
+            // The full entry (header + gen-dir payload + cover end-offset
+            // footer) must fit inside the mapped region too. snapshotMetadata
+            // reads gen-dir entries at offsets up to entryOffset + into.len.
             if (into.len <= 0 || entryOffset + into.len > mappedLimit) {
                 return RESULT_HEADER_UNREADABLE;
             }

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainPicker.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainPicker.java
@@ -54,22 +54,6 @@ public final class PostingIndexChainPicker {
     }
 
     /**
-     * Walk the chain backwards from head and pick the first entry where
-     * {@code txnAtSeal <= pinnedTableTxn}. Populates {@code into} with the
-     * picked entry on success.
-     *
-     * @return one of the RESULT_* codes:
-     * <ul>
-     *   <li>{@code RESULT_OK} — entry was found and {@code into} is populated;</li>
-     *   <li>{@code RESULT_EMPTY_CHAIN} — chain has no entries at all;</li>
-     *   <li>{@code RESULT_NO_VISIBLE_ENTRY} — chain is non-empty but every
-     *       entry has {@code txnAtSeal > pinnedTableTxn} (only happens
-     *       immediately after a snapshot restore or pre-first-seal);</li>
-     *   <li>{@code RESULT_HEADER_UNREADABLE} — header seqlock retries
-     *       exhausted; caller should treat as I/O error.</li>
-     * </ul>
-     */
-    /**
      * Convenience overload for callers that don't read covering. Equivalent
      * to {@code pick(keyMem, pinnedTableTxn, 0, headerScratch, into)}.
      */
@@ -82,6 +66,25 @@ public final class PostingIndexChainPicker {
         return pick(keyMem, pinnedTableTxn, 0, headerScratch, into);
     }
 
+    /**
+     * Walk the chain backwards from head and pick the first entry where
+     * {@code txnAtSeal <= pinnedTableTxn}. Populates {@code into} with the
+     * picked entry on success.
+     *
+     * @param coverCount number of cover columns published in {@code .pci};
+     *                   the entry's per-cover end-offset footer is read in
+     *                   full when {@code coverCount > 0}.
+     * @return one of the RESULT_* codes:
+     * <ul>
+     *   <li>{@code RESULT_OK} — entry was found and {@code into} is populated;</li>
+     *   <li>{@code RESULT_EMPTY_CHAIN} — chain has no entries at all;</li>
+     *   <li>{@code RESULT_NO_VISIBLE_ENTRY} — chain is non-empty but every
+     *       entry has {@code txnAtSeal > pinnedTableTxn} (only happens
+     *       immediately after a snapshot restore or pre-first-seal);</li>
+     *   <li>{@code RESULT_HEADER_UNREADABLE} — header seqlock retries
+     *       exhausted; caller should treat as I/O error.</li>
+     * </ul>
+     */
     public static int pick(
             MemoryR keyMem,
             long pinnedTableTxn,

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
@@ -115,6 +115,10 @@ public final class PostingIndexChainWriter {
      *                       evolve per-seal in future.
      * @return the byte offset where the new entry starts.
      */
+    /**
+     * Convenience overload for callers without covering (e.g. chain-writer
+     * tests). Equivalent to passing {@code coverEndOffsets = null}.
+     */
     public long appendNewEntry(
             MemoryARW keyMem,
             long sealTxn,
@@ -126,11 +130,28 @@ public final class PostingIndexChainWriter {
             int blockCapacity,
             int coveringFormat
     ) {
+        return appendNewEntry(keyMem, sealTxn, txnAtSeal, valueMemSize, maxValue, keyCount,
+                genCount, blockCapacity, coveringFormat, null);
+    }
+
+    public long appendNewEntry(
+            MemoryARW keyMem,
+            long sealTxn,
+            long txnAtSeal,
+            long valueMemSize,
+            long maxValue,
+            int keyCount,
+            int genCount,
+            int blockCapacity,
+            int coveringFormat,
+            LongList coverEndOffsets
+    ) {
         if (sealTxn <= genCounter) {
             throw CairoException.critical(0)
                     .put("posting index sealTxn must advance [current=").put(genCounter)
                     .put(", attempted=").put(sealTxn).put(']');
         }
+        int coverCount = coverEndOffsets != null ? coverEndOffsets.size() : 0;
         long entryOffset = regionLimit;
         long prevHead = headEntryOffset;
         PostingIndexChainEntry.writeHeader(
@@ -144,12 +165,13 @@ public final class PostingIndexChainWriter {
                 genCount,
                 blockCapacity,
                 coveringFormat,
-                prevHead
+                prevHead,
+                coverEndOffsets
         );
         Unsafe.storeFence();
         // Update mirrors before publishing so accessors see the new state
         // by the time the publish becomes visible to readers.
-        long newRegionLimit = entryOffset + PostingIndexChainEntry.entrySize(genCount);
+        long newRegionLimit = entryOffset + PostingIndexChainEntry.entrySize(genCount, coverCount);
         headEntryOffset = entryOffset;
         regionLimit = newRegionLimit;
         entryCount++;
@@ -182,6 +204,10 @@ public final class PostingIndexChainWriter {
      *
      * @throws IllegalStateException if the chain is empty.
      */
+    /**
+     * Convenience overload for callers without covering. Equivalent to
+     * passing {@code newCoverEndOffsets = null}.
+     */
     public void extendHead(
             MemoryARW keyMem,
             int newGenCount,
@@ -189,24 +215,52 @@ public final class PostingIndexChainWriter {
             long newValueMemSize,
             long newMaxValue
     ) {
+        extendHead(keyMem, newGenCount, newKeyCount, newValueMemSize, newMaxValue, null);
+    }
+
+    public void extendHead(
+            MemoryARW keyMem,
+            int newGenCount,
+            int newKeyCount,
+            long newValueMemSize,
+            long newMaxValue,
+            LongList newCoverEndOffsets
+    ) {
         if (headEntryOffset == PostingIndexUtils.V2_NO_HEAD) {
             throw new IllegalStateException("posting index chain is empty; no head entry to extend");
         }
-        long newLen = PostingIndexChainEntry.entrySize(newGenCount);
+        int coverCount = newCoverEndOffsets != null ? newCoverEndOffsets.size() : 0;
+        long newLen = PostingIndexChainEntry.entrySize(newGenCount, coverCount);
         // GEN_COUNT must be written LAST. It is the field readers latch on
         // to (via PostingIndexChainEntry.read which reads it first under a
         // loadFence) to gate visibility of all the other in-place updates,
         // including VALUE_MEM_SIZE which sizes the readers' valueMem
-        // mapping. Storing GEN_COUNT before VALUE_MEM_SIZE — even with a
-        // single trailing storeFence — would let a reader observe a new
-        // GEN_COUNT with an old VALUE_MEM_SIZE and dereference past the
-        // mapping. The chain header's outer seqlock does NOT cover these
-        // in-place stores: extendHead mutates the entry before the
-        // publish() call that bumps the seqlock.
+        // mapping and COVER_END_OFFSETS which size the readers' sidecar
+        // mappings. Storing GEN_COUNT before those — even with a single
+        // trailing storeFence — would let a reader observe a new GEN_COUNT
+        // with old sizes and dereference past the mapping. The chain
+        // header's outer seqlock does NOT cover these in-place stores:
+        // extendHead mutates the entry before the publish() call that
+        // bumps the seqlock.
         keyMem.putInt(headEntryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT, newKeyCount);
         keyMem.putLong(headEntryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, newLen);
         keyMem.putLong(headEntryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE, newValueMemSize);
         keyMem.putLong(headEntryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE, newMaxValue);
+        // Cover end-offset footer slots are at offset
+        // (header + newGenCount * GEN_DIR_ENTRY_SIZE). The footer's location
+        // depends on newGenCount, so we must write the cover sizes at the
+        // location matching the GEN_COUNT we are about to publish.
+        if (coverCount > 0) {
+            for (int c = 0; c < coverCount; c++) {
+                PostingIndexChainEntry.writeCoverEndOffset(
+                        keyMem,
+                        headEntryOffset,
+                        newGenCount,
+                        c,
+                        newCoverEndOffsets.getQuick(c)
+                );
+            }
+        }
         // Fence pairs with the loadFence after GEN_COUNT in
         // PostingIndexChainEntry.read: if a reader observes the new
         // GEN_COUNT, all stores above (and the gen-dir bytes the caller
@@ -281,12 +335,12 @@ public final class PostingIndexChainWriter {
         if (headEntryOffset == PostingIndexUtils.V2_NO_HEAD || entryCount < 2) {
             return -1L;
         }
-        PostingIndexChainEntry.read(keyMem, headEntryOffset, entryScratch);
+        PostingIndexChainEntry.read(keyMem, headEntryOffset, 0, entryScratch);
         long prevOffset = entryScratch.prevEntryOffset;
         if (prevOffset == PostingIndexUtils.V2_NO_HEAD) {
             return -1L;
         }
-        PostingIndexChainEntry.read(keyMem, prevOffset, entryScratch);
+        PostingIndexChainEntry.read(keyMem, prevOffset, 0, entryScratch);
         return entryScratch.txnAtSeal;
     }
 
@@ -325,7 +379,11 @@ public final class PostingIndexChainWriter {
         if (headEntryOffset == PostingIndexUtils.V2_NO_HEAD) {
             throw new IllegalStateException("posting index chain is empty");
         }
-        PostingIndexChainEntry.read(keyMem, headEntryOffset, into);
+        // Writer state-restore from the head entry uses only header fields
+        // (sealTxn, valueMemSize, etc.); cover end-offsets in the entry are
+        // re-established from the writer's own sidecarMems on reopen, so we
+        // skip the cover footer read here.
+        PostingIndexChainEntry.read(keyMem, headEntryOffset, 0, into);
     }
 
     /**
@@ -351,7 +409,7 @@ public final class PostingIndexChainWriter {
         entryCount = headerScratch.entryCount;
         genCounter = headerScratch.generationCounter;
         if (headEntryOffset != PostingIndexUtils.V2_NO_HEAD) {
-            PostingIndexChainEntry.read(keyMem, headEntryOffset, entryScratch);
+            PostingIndexChainEntry.read(keyMem, headEntryOffset, 0, entryScratch);
             currentTxnAtSeal = entryScratch.txnAtSeal;
             headSealTxn = entryScratch.sealTxn;
         } else {
@@ -421,7 +479,7 @@ public final class PostingIndexChainWriter {
                         .put(offset).put(", regionBase=").put(regionBase)
                         .put(", regionLimit=").put(newRegionLimit).put(']');
             }
-            PostingIndexChainEntry.read(keyMem, offset, entryScratch);
+            PostingIndexChainEntry.read(keyMem, offset, 0, entryScratch);
             if (entryScratch.txnAtSeal <= currentTableTxn) {
                 break;
             }
@@ -441,7 +499,7 @@ public final class PostingIndexChainWriter {
         entryCount = newEntryCount;
         regionLimit = newRegionLimit;
         if (newHead != PostingIndexUtils.V2_NO_HEAD) {
-            PostingIndexChainEntry.read(keyMem, newHead, entryScratch);
+            PostingIndexChainEntry.read(keyMem, newHead, 0, entryScratch);
             currentTxnAtSeal = entryScratch.txnAtSeal;
             headSealTxn = entryScratch.sealTxn;
         } else {

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
@@ -87,35 +87,6 @@ public final class PostingIndexChainWriter {
     }
 
     /**
-     * Append a new immutable chain entry at the current {@code regionLimit}
-     * and publish it as the new head. Caller must have already written the
-     * gen-dir bytes at {@code (returnedEntryOffset + V2_ENTRY_HEADER_SIZE)};
-     * otherwise readers will see uninitialised gen-dir bytes.
-     * <p>
-     * On return the {@code keyMem} is durable as far as user-space stores —
-     * the caller is still responsible for syncing the file if durability
-     * across power loss is required.
-     *
-     * @param keyMem         the .pk memory mapping (writable + readable)
-     * @param sealTxn        the suffix for {@code .pv.{sealTxn}} and
-     *                       {@code .pc{i}.{sealTxn}} files. Must be greater than
-     *                       the current {@link #getGenCounter()} so monotonicity
-     *                       is preserved across the chain.
-     * @param txnAtSeal      the table {@code _txn} value this entry takes
-     *                       effect at. Readers pin via the scoreboard before
-     *                       querying and pick the entry where
-     *                       {@code txnAtSeal <= pinned _txn}.
-     * @param valueMemSize   bytes in {@code .pv.{sealTxn}}.
-     * @param maxValue       highest row id covered by this entry.
-     * @param keyCount       distinct keys at this seal.
-     * @param genCount       number of gen-dir entries the caller has written
-     *                       starting at the entry's gen-dir region.
-     * @param blockCapacity  block capacity for this entry.
-     * @param coveringFormat reserved (currently 0). Lets sidecar formats
-     *                       evolve per-seal in future.
-     * @return the byte offset where the new entry starts.
-     */
-    /**
      * Convenience overload for callers without covering (e.g. chain-writer
      * tests). Equivalent to passing {@code coverEndOffsets = null}.
      */
@@ -134,6 +105,39 @@ public final class PostingIndexChainWriter {
                 genCount, blockCapacity, coveringFormat, null);
     }
 
+    /**
+     * Append a new immutable chain entry at the current {@code regionLimit}
+     * and publish it as the new head. Caller must have already written the
+     * gen-dir bytes at {@code (returnedEntryOffset + V2_ENTRY_HEADER_SIZE)};
+     * otherwise readers will see uninitialised gen-dir bytes.
+     * <p>
+     * On return the {@code keyMem} is durable as far as user-space stores —
+     * the caller is still responsible for syncing the file if durability
+     * across power loss is required.
+     *
+     * @param keyMem          the .pk memory mapping (writable + readable)
+     * @param sealTxn         the suffix for {@code .pv.{sealTxn}} and
+     *                        {@code .pc{i}.{sealTxn}} files. Must be greater than
+     *                        the current {@link #getGenCounter()} so monotonicity
+     *                        is preserved across the chain.
+     * @param txnAtSeal       the table {@code _txn} value this entry takes
+     *                        effect at. Readers pin via the scoreboard before
+     *                        querying and pick the entry where
+     *                        {@code txnAtSeal <= pinned _txn}.
+     * @param valueMemSize    bytes in {@code .pv.{sealTxn}}.
+     * @param maxValue        highest row id covered by this entry.
+     * @param keyCount        distinct keys at this seal.
+     * @param genCount        number of gen-dir entries the caller has written
+     *                        starting at the entry's gen-dir region.
+     * @param blockCapacity   block capacity for this entry.
+     * @param coveringFormat  reserved (currently 0). Lets sidecar formats
+     *                        evolve per-seal in future.
+     * @param coverEndOffsets per-cover-column authoritative valid-byte extent
+     *                        in {@code .pc{i}.{sealTxn}}, written into the
+     *                        entry's footer; {@code null} or empty means no
+     *                        covering (footer omitted).
+     * @return the byte offset where the new entry starts.
+     */
     public long appendNewEntry(
             MemoryARW keyMem,
             long sealTxn,
@@ -191,20 +195,6 @@ public final class PostingIndexChainWriter {
     }
 
     /**
-     * Extend the current head entry with a freshly-appended gen-dir entry.
-     * Caller must have already written the new gen-dir bytes at offset
-     * {@code (head + V2_ENTRY_HEADER_SIZE + currentGenCount * GEN_DIR_ENTRY_SIZE)}.
-     * <p>
-     * This bumps the head entry's GEN_COUNT, KEY_COUNT, LEN, VALUE_MEM_SIZE
-     * and MAX_VALUE in place, then republishes the header so readers see the
-     * new {@code regionLimit}. The fields are 4- or 8-byte aligned so single
-     * stores are atomic on x86 / aarch64; combined with the storeFence after
-     * the gen-dir bytes, this is the sparse-gen sub-protocol described in
-     * section 4.5 of POSTING_INDEX_CHAIN_DESIGN.md.
-     *
-     * @throws IllegalStateException if the chain is empty.
-     */
-    /**
      * Convenience overload for callers without covering. Equivalent to
      * passing {@code newCoverEndOffsets = null}.
      */
@@ -218,6 +208,24 @@ public final class PostingIndexChainWriter {
         extendHead(keyMem, newGenCount, newKeyCount, newValueMemSize, newMaxValue, null);
     }
 
+    /**
+     * Extend the current head entry with a freshly-appended gen-dir entry.
+     * Caller must have already written the new gen-dir bytes at offset
+     * {@code (head + V2_ENTRY_HEADER_SIZE + currentGenCount * GEN_DIR_ENTRY_SIZE)}.
+     * <p>
+     * This bumps the head entry's GEN_COUNT, KEY_COUNT, LEN, VALUE_MEM_SIZE
+     * and MAX_VALUE in place, then republishes the header so readers see the
+     * new {@code regionLimit}. The fields are 4- or 8-byte aligned so single
+     * stores are atomic on x86 / aarch64; combined with the storeFence after
+     * the gen-dir bytes, this is the sparse-gen sub-protocol described in
+     * section 4.5 of POSTING_INDEX_CHAIN_DESIGN.md.
+     *
+     * @param newCoverEndOffsets per-cover-column updated valid-byte extent in
+     *                           {@code .pc{i}.{sealTxn}}, written into the
+     *                           head entry's footer; {@code null} or empty
+     *                           leaves the existing footer untouched.
+     * @throws IllegalStateException if the chain is empty.
+     */
     public void extendHead(
             MemoryARW keyMem,
             int newGenCount,

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexUtils.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexUtils.java
@@ -159,6 +159,12 @@ import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;
 public final class PostingIndexUtils {
 
     public static final int BLOCK_CAPACITY = 64;
+    // Per-cover-column footer entry size in chain entries: one long that
+    // publishes the authoritative valid byte extent of the .pc{c}.{...}.{sealTxn}
+    // file as of this chain entry. Readers size their sidecar mappings from
+    // this published value rather than ff.length(fd) so the upper bound is
+    // tied to the same seqlock that publishes VALUE_MEM_SIZE for .pv.
+    public static final int COVER_END_OFFSET_ENTRY_SIZE = Long.BYTES;
     // .pci layout: magic(4B) + count(4B) + writerIndex[count](4B each, -1 = tombstoned).
     public static final int COVER_INFO_MAGIC = 0x50434931; // "PCI1"
     public static final int DENSE_STRIDE = 256;
@@ -245,6 +251,16 @@ public final class PostingIndexUtils {
     //                 this is the oldest entry. Lets readers walk backwards
     //                 from head without scanning the whole region.
     //   [64..]      gen dir, GEN_COUNT * GEN_DIR_ENTRY_SIZE bytes.
+    //   [64 + GEN_COUNT * GEN_DIR_ENTRY_SIZE ..]
+    //               cover end-offset footer, COVER_COUNT * COVER_END_OFFSET_ENTRY_SIZE
+    //               bytes. The c-th long is the writer's append offset in
+    //               .pc{c}.<...>.<SEAL_TXN> at the moment this entry was
+    //               (re)published. COVER_COUNT is fixed for the .pk file's
+    //               posting column instance and lives in the .pci sidecar
+    //               header (not the chain entry), so it is constant across
+    //               every entry in this .pk file. The footer is empty when
+    //               COVER_COUNT == 0. The whole entry is then 8-byte aligned
+    //               via PostingIndexChainEntry.entrySize.
     public static final int V2_ENTRY_HEADER_SIZE = 64;
     public static final int V2_ENTRY_OFFSET_BLOCK_CAPACITY = 48;
     public static final int V2_ENTRY_OFFSET_COVERING_FORMAT = 52;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -126,6 +126,10 @@ public class PostingIndexWriter implements IndexWriter {
     // background job removes the .pv.{N} / .pc{i}.{N} files. Cleared on
     // every of() call to avoid leaking entries across reopens.
     private final LongList recoveryOrphanScratch = new LongList();
+    // Reusable scratch list passed to PostingIndexChainWriter.appendNewEntry /
+    // extendHead — built once per chain publish from each cover column's
+    // current sidecar append offset. Reused across calls to avoid allocations.
+    private final LongList coverEndOffsetsScratch = new LongList();
     private int coverCount;
     private long[] coveredAuxReadAddrs;
     private long[] coveredAuxReadSizes;
@@ -4108,6 +4112,12 @@ public class PostingIndexWriter implements IndexWriter {
         keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MIN_KEY, overrideMinKey);
         keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY, overrideMaxKey);
 
+        // Snapshot the current append offset of each open sidecar. Tombstoned
+        // and not-yet-opened slots publish 0 — readers treat them as "no file
+        // / nothing to map", consistent with how isCoveredAvailable handles
+        // missing sidecars.
+        captureCoverEndOffsets();
+
         if (newEntry) {
             // pendingTxnAtSeal supplied by the upstream caller is the
             // table _txn this seal's chain entry should be tagged with.
@@ -4140,10 +4150,36 @@ public class PostingIndexWriter implements IndexWriter {
                     /* keyCount */ keyCount,
                     /* genCount */ newGenCount,
                     /* blockCapacity */ blockCapacity,
-                    /* coveringFormat */ 0
+                    /* coveringFormat */ 0,
+                    coverEndOffsetsScratch
             );
         } else {
-            chain.extendHead(keyMem, newGenCount, keyCount, valueMemSize, maxValue);
+            chain.extendHead(keyMem, newGenCount, keyCount, valueMemSize, maxValue, coverEndOffsetsScratch);
+        }
+    }
+
+    /**
+     * Refresh {@link #coverEndOffsetsScratch} so it has exactly {@code coverCount}
+     * entries and each slot reflects the current append offset of the matching
+     * {@code sidecarMems} entry (or 0 when the slot is tombstoned / unopened).
+     * The result is the authoritative valid-byte extent of each .pcN at the
+     * moment the chain entry is republished.
+     */
+    private void captureCoverEndOffsets() {
+        coverEndOffsetsScratch.clear();
+        if (coverCount <= 0) {
+            return;
+        }
+        coverEndOffsetsScratch.setPos(coverCount);
+        for (int c = 0; c < coverCount; c++) {
+            long endOffset = 0L;
+            if (c < sidecarMems.size()) {
+                MemoryMARW mem = sidecarMems.getQuick(c);
+                if (mem != null && mem.isOpen()) {
+                    endOffset = mem.getAppendOffset();
+                }
+            }
+            coverEndOffsetsScratch.setQuick(c, endOffset);
         }
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
@@ -2289,6 +2289,145 @@ public class CoveringIndexTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCoveringReloadRefreshesAllSidecarMmapsMultiColumn() throws Exception {
+        // Same scenario as the single-column reload test, but with three cover
+        // columns of different fixed widths (Long / Int / Double). Exercises
+        // includeIdx = 0, 1, 2 of sidecarMems / sidecarFileEndOffsets so the
+        // chain entry's per-cover-column footer is verified slot by slot.
+        //
+        // Each cover column gets its own column buffer; gen 1 forces every
+        // .pcN file past gen 0's mmap, and the post-reload reads must
+        // round-trip every value through every slot.
+        final long osPage = io.questdb.std.Files.PAGE_SIZE;
+        CairoConfiguration smallPageCfg = new CairoConfigurationWrapper(configuration) {
+            @Override
+            public long getDataIndexValueAppendPageSize() {
+                return osPage;
+            }
+        };
+        assertMemoryLeak(() -> {
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                String name = "stale_sidecar_red_multi";
+                int plen = path.size();
+                int rowsPerGen = (int) (osPage / 8);
+                int totalRows = rowsPerGen * 2;
+
+                // Cover column 0: LONG (8B), values 1000 + i.
+                // Cover column 1: INT  (4B), values 2_000_000 + i.
+                // Cover column 2: DOUBLE (8B), values 3.5 * (i + 1).
+                long longAddr = Unsafe.malloc((long) totalRows * Long.BYTES, MemoryTag.NATIVE_DEFAULT);
+                long intAddr = Unsafe.malloc((long) totalRows * Integer.BYTES, MemoryTag.NATIVE_DEFAULT);
+                long doubleAddr = Unsafe.malloc((long) totalRows * Double.BYTES, MemoryTag.NATIVE_DEFAULT);
+                try {
+                    for (int i = 0; i < totalRows; i++) {
+                        Unsafe.putLong(longAddr + (long) i * Long.BYTES, 1000L + i);
+                        Unsafe.putInt(intAddr + (long) i * Integer.BYTES, 2_000_000 + i);
+                        Unsafe.putDouble(doubleAddr + (long) i * Double.BYTES, 3.5d * (i + 1));
+                    }
+                    try (PostingIndexWriter writer = new PostingIndexWriter(smallPageCfg, path, name, COLUMN_NAME_TXN_NONE)) {
+                        writer.configureCovering(
+                                new long[]{longAddr, intAddr, doubleAddr},
+                                new long[]{0, 0, 0},
+                                new int[]{3, 2, 3},                              // shifts: LONG=8(2^3), INT=4(2^2), DOUBLE=8(2^3)
+                                new int[]{1, 2, 3},                              // covered column writer indices
+                                new int[]{ColumnType.LONG, ColumnType.INT, ColumnType.DOUBLE},
+                                3
+                        );
+
+                        // Gen 0: first half of rows for key 0.
+                        for (int i = 0; i < rowsPerGen; i++) writer.add(0, i);
+                        writer.setMaxValue(rowsPerGen - 1);
+                        writer.commit();
+
+                        try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                                smallPageCfg, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, -1, 0,
+                                coveringMetadata(
+                                        new int[]{1, 2, 3},
+                                        new int[]{ColumnType.LONG, ColumnType.INT, ColumnType.DOUBLE}
+                                ),
+                                EMPTY_CVR, 0
+                        )) {
+                            // First read populates sidecarMems[0..2] via
+                            // ensureSidecarOpen(), each mmaped to the
+                            // chain-published gen-0 extent for its slot.
+                            CoveringRowCursor cc = (CoveringRowCursor) reader.getCursor(
+                                    0, 0, Long.MAX_VALUE, new int[]{0, 1, 2});
+                            assertTrue("slot 0 covered after gen0", cc.isCoveredAvailable(0));
+                            assertTrue("slot 1 covered after gen0", cc.isCoveredAvailable(1));
+                            assertTrue("slot 2 covered after gen0", cc.isCoveredAvailable(2));
+                            for (int i = 0; i < rowsPerGen; i++) {
+                                assertTrue("gen0 row " + i, cc.hasNext());
+                                assertEquals(i, cc.next());
+                                assertEquals("gen0 LONG @row " + i, 1000L + i, cc.getCoveredLong(0));
+                                assertEquals("gen0 INT @row " + i, 2_000_000 + i, cc.getCoveredInt(1));
+                                assertEquals("gen0 DOUBLE @row " + i, 3.5d * (i + 1), cc.getCoveredDouble(2), 1e-9);
+                            }
+                            assertFalse(cc.hasNext());
+                            Misc.free(cc);
+
+                            long[] gen0Sizes = new long[3];
+                            for (int slot = 0; slot < 3; slot++) {
+                                gen0Sizes[slot] = readSidecarMmapSize(reader, slot);
+                                assertTrue(
+                                        "sanity: slot " + slot + " mmap populated by first read",
+                                        gen0Sizes[slot] > 0
+                                );
+                            }
+
+                            // Gen 1: second half. Same writer, same sealTxn —
+                            // every .pcN extends past gen-0's mmap.
+                            for (int i = rowsPerGen; i < totalRows; i++) writer.add(0, i);
+                            writer.setMaxValue(totalRows - 1);
+                            writer.commit();
+
+                            for (int slot = 0; slot < 3; slot++) {
+                                long fileLen = sidecarFileLengthOnDisk(path.trimTo(plen), name, slot);
+                                assertTrue(
+                                        "sanity: slot " + slot + " .pcN must extend past gen-0 mmap" +
+                                                " [gen0Mmap=" + gen0Sizes[slot] +
+                                                ", fileLenGen1=" + fileLen + "]",
+                                        fileLen > gen0Sizes[slot]
+                                );
+                            }
+
+                            // Reload and read everything — every covered value
+                            // for every slot must round-trip.
+                            cc = (CoveringRowCursor) reader.getCursor(
+                                    0, 0, Long.MAX_VALUE, new int[]{0, 1, 2});
+                            assertTrue(cc.isCoveredAvailable(0));
+                            assertTrue(cc.isCoveredAvailable(1));
+                            assertTrue(cc.isCoveredAvailable(2));
+                            for (int i = 0; i < totalRows; i++) {
+                                assertTrue("post-reload row " + i, cc.hasNext());
+                                assertEquals(i, cc.next());
+                                assertEquals("post-reload LONG @row " + i, 1000L + i, cc.getCoveredLong(0));
+                                assertEquals("post-reload INT @row " + i, 2_000_000 + i, cc.getCoveredInt(1));
+                                assertEquals("post-reload DOUBLE @row " + i, 3.5d * (i + 1), cc.getCoveredDouble(2), 1e-9);
+                            }
+                            assertFalse(cc.hasNext());
+                            Misc.free(cc);
+
+                            for (int slot = 0; slot < 3; slot++) {
+                                long postReload = readSidecarMmapSize(reader, slot);
+                                assertTrue(
+                                        "reload must extend slot " + slot + " mmap past the gen-0 extent" +
+                                                " [gen0Mmap=" + gen0Sizes[slot] +
+                                                ", afterReload=" + postReload + "]",
+                                        postReload > gen0Sizes[slot]
+                                );
+                            }
+                        }
+                    }
+                } finally {
+                    Unsafe.free(longAddr, (long) totalRows * Long.BYTES, MemoryTag.NATIVE_DEFAULT);
+                    Unsafe.free(intAddr, (long) totalRows * Integer.BYTES, MemoryTag.NATIVE_DEFAULT);
+                    Unsafe.free(doubleAddr, (long) totalRows * Double.BYTES, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
     public void testCoveringFileNaming() {
         try (Path path = new Path().of("/db/2024-01-01")) {
             int plen = path.size();

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
@@ -24,6 +24,8 @@
 
 package io.questdb.test.cairo.covering;
 
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoConfigurationWrapper;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.ColumnVersionReader;
@@ -49,6 +51,7 @@ import io.questdb.cairo.sql.RecordMetadata;
 import io.questdb.cairo.sql.RowCursor;
 import io.questdb.cairo.sql.StaticSymbolTable;
 import io.questdb.cairo.sql.SymbolTable;
+import io.questdb.cairo.vm.api.MemoryMR;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionContextImpl;
@@ -70,6 +73,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -2150,6 +2154,135 @@ public class CoveringIndexTest extends AbstractCairoTest {
                     w2.close();
                 } finally {
                     Unsafe.free(colAddr, (long) rowCount * Double.BYTES, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testCoveringReloadDoesNotRefreshStaleSidecarMmap() throws Exception {
+        // Regression test for: long-lived posting-index readers must refresh
+        // covering sidecar mmaps when reloadConditionally() picks up a new
+        // chain entry produced by a gen flush that extended .pcN past the
+        // reader's previous extent.
+        //
+        // The default 1 MiB append-page pre-allocation would hide the bug,
+        // because both gens would land within one writer-side chunk and the
+        // reader's initial mmap (sized to the file's pre-allocated length)
+        // would happen to cover the new gen's bytes too. The OS-page override
+        // forces the writer to extend the file between gens so the bug
+        // manifests reliably.
+        //
+        // The fix publishes each .pcN's authoritative valid byte extent in
+        // the chain entry (one long per cover column, in the cover end-offset
+        // footer). reloadConditionally() resizes the sidecar mapping to the
+        // newly-published extent, so reads in the new gen stay in bounds and
+        // return the writer's actual values.
+        final long osPage = io.questdb.std.Files.PAGE_SIZE;
+        CairoConfiguration smallPageCfg = new CairoConfigurationWrapper(configuration) {
+            @Override
+            public long getDataIndexValueAppendPageSize() {
+                return osPage;
+            }
+        };
+        assertMemoryLeak(() -> {
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                String name = "stale_sidecar_red";
+                int plen = path.size();
+                // Enough rows that gen0 + gen1 sidecar bytes overflow one OS
+                // page (header 1144 + per-gen raw blocks of 4 + V*8 each).
+                int rowsPerGen = (int) (osPage / 8);
+                int totalRows = rowsPerGen * 2;
+                long colAddr = Unsafe.malloc((long) totalRows * Long.BYTES, MemoryTag.NATIVE_DEFAULT);
+                try {
+                    for (int i = 0; i < totalRows; i++) {
+                        Unsafe.putLong(colAddr + (long) i * Long.BYTES, 1000L + i);
+                    }
+                    try (PostingIndexWriter writer = new PostingIndexWriter(smallPageCfg, path, name, COLUMN_NAME_TXN_NONE)) {
+                        writer.configureCovering(
+                                new long[]{colAddr},
+                                new long[]{0},
+                                new int[]{3},               // shift for LONG (8 bytes = 2^3)
+                                new int[]{1},               // covered column writer index
+                                new int[]{ColumnType.LONG},
+                                1
+                        );
+
+                        // Gen 0: first half of rows for key 0.
+                        for (int i = 0; i < rowsPerGen; i++) writer.add(0, i);
+                        writer.setMaxValue(rowsPerGen - 1);
+                        writer.commit();
+
+                        try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                                smallPageCfg, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, -1, 0,
+                                coveringMetadata(new int[]{1}, new int[]{ColumnType.LONG}), EMPTY_CVR, 0)) {
+                            // First covering read populates sidecarMems[0] via
+                            // ensureSidecarOpen(), mmaping to the chain-published
+                            // gen-0 extent.
+                            CoveringRowCursor cc = (CoveringRowCursor) reader.getCursor(
+                                    0, 0, Long.MAX_VALUE, new int[]{0});
+                            assertTrue(cc.isCoveredAvailable(0));
+                            for (int i = 0; i < rowsPerGen; i++) {
+                                assertTrue("gen0 row " + i, cc.hasNext());
+                                assertEquals(i, cc.next());
+                                assertEquals("gen0 covered value at row " + i,
+                                        1000L + i, cc.getCoveredLong(0));
+                            }
+                            assertFalse(cc.hasNext());
+                            Misc.free(cc);
+
+                            long mmapSizeAfterGen0 = readSidecarMmapSize(reader, 0);
+                            assertTrue("sanity: sidecar mmap was populated by first covering read",
+                                    mmapSizeAfterGen0 > 0);
+
+                            // Gen 1: second half of rows for key 0. Same writer,
+                            // no seal between commits, so sealTxn stays at 0 and
+                            // writeSidecarGenData() appends another block to the
+                            // same .pc0 file. With the small append page size this
+                            // forces the writer to allocate a fresh chunk past the
+                            // gen-0 extent.
+                            for (int i = rowsPerGen; i < totalRows; i++) writer.add(0, i);
+                            writer.setMaxValue(totalRows - 1);
+                            writer.commit();
+
+                            long fileSizeAfterGen1 = sidecarFileLengthOnDisk(path.trimTo(plen), name, 0);
+                            assertTrue(
+                                    "sanity: writer must extend .pc0 past the gen-0 mmap" +
+                                            " [gen0Mmap=" + mmapSizeAfterGen0 +
+                                            ", fileLenGen1=" + fileSizeAfterGen1 + "]",
+                                    fileSizeAfterGen1 > mmapSizeAfterGen0
+                            );
+
+                            // Trigger reloadConditionally() through getCursor and
+                            // iterate every row across both gens. Without the
+                            // chain-published cover end-offset, this would
+                            // dereference past the stale gen-0 mapping (SIGBUS) or
+                            // return zero-padded bytes. With the fix the mapping is
+                            // resized to the new published extent and every value
+                            // round-trips.
+                            cc = (CoveringRowCursor) reader.getCursor(
+                                    0, 0, Long.MAX_VALUE, new int[]{0});
+                            assertTrue(cc.isCoveredAvailable(0));
+                            for (int i = 0; i < totalRows; i++) {
+                                assertTrue("post-reload row " + i, cc.hasNext());
+                                assertEquals(i, cc.next());
+                                assertEquals("post-reload covered value at row " + i,
+                                        1000L + i, cc.getCoveredLong(0));
+                            }
+                            assertFalse(cc.hasNext());
+                            Misc.free(cc);
+
+                            long mmapSizeAfterReload = readSidecarMmapSize(reader, 0);
+                            assertTrue(
+                                    "reload must extend the sidecar mmap past the gen-0" +
+                                            " extent [gen0Mmap=" + mmapSizeAfterGen0 +
+                                            ", afterReload=" + mmapSizeAfterReload + "]",
+                                    mmapSizeAfterReload > mmapSizeAfterGen0
+                            );
+                        }
+                    }
+                } finally {
+                    Unsafe.free(colAddr, (long) totalRows * Long.BYTES, MemoryTag.NATIVE_DEFAULT);
                 }
             }
         });
@@ -12826,6 +12959,30 @@ public class CoveringIndexTest extends AbstractCairoTest {
             m.add(new TableColumnMetadata("c" + i, type, IndexType.NONE, 0, false, null, i, false));
         }
         return m;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static long readSidecarMmapSize(PostingIndexFwdReader reader, int includeIdx) throws Exception {
+        Class<?> base = reader.getClass().getSuperclass();
+        Field f = base.getDeclaredField("sidecarMems");
+        f.setAccessible(true);
+        ObjList<MemoryMR> mems = (ObjList<MemoryMR>) f.get(reader);
+        if (includeIdx >= mems.size()) {
+            return -1;
+        }
+        MemoryMR mem = mems.getQuick(includeIdx);
+        return mem == null ? -1 : mem.size();
+    }
+
+    private static long sidecarFileLengthOnDisk(Path basePath, CharSequence name, int includeIdx) {
+        int len = basePath.size();
+        try {
+            LPSZ pcFile = PostingIndexUtils.coverDataFileName(
+                    basePath, name, includeIdx, COLUMN_NAME_TXN_NONE, COLUMN_NAME_TXN_NONE, 0);
+            return TestFilesFacadeImpl.INSTANCE.length(pcFile);
+        } finally {
+            basePath.trimTo(len);
+        }
     }
 
     private void assertPlanDoesNotContain(String query) throws SqlException {


### PR DESCRIPTION
## Summary

- Long-lived posting-index readers (e.g. those reused by `TableReader` across queries) call `reloadConditionally()` to track writer publishes. The reader resized `.pv` to the new `VALUE_MEM_SIZE` from the picked chain entry but never touched the covering `.pcN` mappings. After a same-`sealTxn` gen flush extended `.pcN` past the reader's pre-allocated extent, covered reads of the new gen dereferenced past the mapping. After a `sealTxn` advance, the reader kept reading the old `sealTxn`-suffixed sidecar file with offsets from the new chain entry. The first case risks `SIGBUS`; the second silently returns wrong data.
- This PR publishes each `.pcN`'s authoritative valid-byte extent in the chain entry itself, in a per-cover-column footer that lives right after the gen-dir region. The writer fills the footer in `extendHead` (in-place, ordered before the `GEN_COUNT` store) and `appendNewEntry` (alongside the rest of the header). The reader picks the footer under the same chain seqlock and sizes its sidecar mappings from the published value rather than `ff.length(fd)`.
- The footer length is derived from `coverCount`, which is fixed for the `.pk` file's posting column instance and lives in the `.pci` sidecar header. Because `coverCount` is constant for every entry in a `.pk`, no `coveringFormat` flip or format-version bump is required. Per-entry overhead is `coverCount * 8` bytes (16 bytes for the typical `coverCount=2` — about 0.4% on a full 4068-byte entry). No change for entries with no cover columns.

### Reader-side flow changes

- `of()` now opens `.pci` before the chain pick so `coverCount` is known when reading the entry's footer.
- `reloadConditionally()` drops sidecar mappings on a `sealTxn` advance (so the next `ensureSidecarOpen` lazy-maps the new `sealTxn` file) and resizes them in place to the new published end-offset on same-`sealTxn` growth.
- `ensureSidecarOpen()` maps to the chain-published extent rather than `ff.length(fd)`, so the mapping is tight to actual data even when the writer pre-allocates pages past it.

### Considerations / tradeoffs

- 8 bytes per cover column added per chain entry. Negligible in absolute terms; chain entries are GCed once no reader is pinned on them.
- The chain reader (`PostingIndexChainPicker.pick`) and the entry codec (`PostingIndexChainEntry.read/writeHeader`) gained an explicit `coverCount` parameter. Backward-compat overloads delegate to `coverCount=0` so existing chain-writer recovery paths and unit-test fixtures compile unchanged.
- The chain writer's `appendNewEntry` / `extendHead` now also take a `LongList coverEndOffsets`; same backward-compat overloads cover the no-cover call sites.

## Test plan

- New regression test `CoveringIndexTest#testCoveringReloadDoesNotRefreshStaleSidecarMmap`. It overrides `cairo.writer.data.index.value.append.page.size` down to the OS page size so two same-`sealTxn` gens force the writer to extend the file beyond gen-0's mmap, then reads every row across both gens through one long-lived reader. Without this fix the post-reload reads dereference past the stale mapping (SIGBUS, or zero-padded data depending on FS / page state). With the fix every covered value round-trips and the post-reload sidecar mmap covers the new extent.
- Full posting-index + covering-index suites: `Tests run: 1479, Failures: 0, Errors: 0, Skipped: 1` (the one skip is pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)