### PR TITLE
chore(build): move aux-job to hetzner from azure

### DIFF
--- a/ci/templates/aux-job.yml
+++ b/ci/templates/aux-job.yml
@@ -4,8 +4,7 @@ jobs:
     strategy:
       matrix:
         linux-jdk25:
-          imageName: "ubuntu-latest"
-          poolName: "Azure Pipelines"
+          poolName: hetzner-incus
           os: Linux
           jdk: "1.25"
     pool:

--- a/ci/templates/aux-job.yml
+++ b/ci/templates/aux-job.yml
@@ -22,6 +22,12 @@ jobs:
         fetchDepth: 1
         lfs: false
         submodules: false
+      - bash: |
+          JAVA_PATH="/usr/lib/jvm/java-25-openjdk-amd64"
+          echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_PATH"
+          echo "##vso[task.setvariable variable=JAVA_HOME_25_X64]$JAVA_PATH"
+          echo "JAVA_HOME will be set to: $JAVA_PATH"
+        displayName: "Activate JDK 25 (openjdk amd64)"
       - template: detect-local-client.yml
 
       - template: java-lint.yml

--- a/ci/templates/java-lint.yml
+++ b/ci/templates/java-lint.yml
@@ -2,17 +2,33 @@ steps:
   - bash: python3 find_unterminated_logs.py core/src --exclude=LogParanoiaTest.java
     displayName: "Check for unterminated log statements"
   - bash: |
-      wget "https://download.jetbrains.com/product?code=IIU&latest&distribution=linux" -O intellij.tar.gz
-      mkdir -p /opt/intellij
-      tar xvz -C /opt/intellij -f intellij.tar.gz
-      rm intellij.tar.gz
-      cd /opt/intellij
-      ln -s idea-* idea
+      set -eux
+      if [ -x /opt/intellij/idea/bin/idea.sh ]; then
+        IDEA_HOME=/opt/intellij/idea
+      else
+        IDEA_ROOT="$(Build.SourcesDirectory)/.ci/intellij"
+        rm -rf "$IDEA_ROOT"
+        mkdir -p "$IDEA_ROOT"
+        wget "https://download.jetbrains.com/product?code=IIU&latest&distribution=linux" -O intellij.tar.gz
+        tar xzf intellij.tar.gz -C "$IDEA_ROOT"
+        rm intellij.tar.gz
+        cd "$IDEA_ROOT"
+        ln -s idea-* idea
+        IDEA_HOME="$IDEA_ROOT/idea"
+      fi
+      echo "IDEA_HOME: $IDEA_HOME"
       echo "JAVA_HOME: $JAVA_HOME"
       echo "java --version"
-      java --version
+      "$JAVA_HOME/bin/java" --version
     displayName: "Install IntelliJ"
-  - bash: /opt/intellij/idea/bin/idea.sh format -s .idea/codeStyles/Project.xml -m "*.java" -r .
+  - bash: |
+      set -eux
+      if [ -x /opt/intellij/idea/bin/idea.sh ]; then
+        IDEA_BIN=/opt/intellij/idea/bin/idea.sh
+      else
+        IDEA_BIN="$(Build.SourcesDirectory)/.ci/intellij/idea/bin/idea.sh"
+      fi
+      "$IDEA_BIN" format -s .idea/codeStyles/Project.xml -m "*.java" -r .
     displayName: "Applying formatting"
   - bash: git submodule foreach --quiet 'git checkout -- . 2>/dev/null; git clean -fd 2>/dev/null' || true
     displayName: "Reset submodules after formatting"


### PR DESCRIPTION
We were running out of (limited) Azure-hosted runner disk space for this job:
- https://dev.azure.com/questdb/questdb/_build/results?buildId=230314&view=logs&j=15fcbb50-299f-54aa-7bc6-0adaa8ee8ac1&t=9d67f5d9-abe1-553c-d329-ad67fbf60647&s=97fbbc7f-2be6-5bdf-d682-5cd663fa3ced
- https://dev.azure.com/questdb/questdb/_build/results?buildId=230979&view=logs&jobId=15fcbb50-299f-54aa-7bc6-0adaa8ee8ac1&j=15fcbb50-299f-54aa-7bc6-0adaa8ee8ac1&t=e39acc1e-76f3-5fd3-3643-2b46ec210976