### PR TITLE
perf(core): auto-seal covering posting indexes past gen threshold

### DIFF
--- a/benchmarks/src/main/java/org/questdb/PostingIndexBenchmarkSuite.java
+++ b/benchmarks/src/main/java/org/questdb/PostingIndexBenchmarkSuite.java
@@ -131,7 +131,8 @@ public class PostingIndexBenchmarkSuite {
                     writer.setMaxValue(rowId - 1);
                     writer.commit();
                 }
-                writer.close(); // seal
+                writer.seal();
+                writer.close();
             }
         } finally {
             deleteDir(dir);
@@ -954,7 +955,8 @@ public class PostingIndexBenchmarkSuite {
                         writer.setMaxValue(rowIdBase + totalRows - 1);
                         writer.commit();
                     }
-                    writer.close(); // seal
+                    writer.seal();
+                    writer.close();
                 }
             } else {
                 int blockCap = Math.max(8, Numbers.ceilPow2(totalRows / Math.max(keyCount, 1)));
@@ -1014,6 +1016,7 @@ public class PostingIndexBenchmarkSuite {
                         writer.setMaxValue(rowId - 1);
                         writer.commit();
                     }
+                    writer.seal();
                     writer.close();
                 }
             } else {

--- a/benchmarks/src/main/java/org/questdb/PostingIndexBenchmarkSuite.java
+++ b/benchmarks/src/main/java/org/questdb/PostingIndexBenchmarkSuite.java
@@ -458,8 +458,11 @@ public class PostingIndexBenchmarkSuite {
             if (lastDot <= pcAt) continue;
             String prefix = n.substring(0, lastDot);
             long sealTxn;
-            try { sealTxn = Long.parseLong(n.substring(lastDot + 1)); }
-            catch (NumberFormatException e) { continue; }
+            try {
+                sealTxn = Long.parseLong(n.substring(lastDot + 1));
+            } catch (NumberFormatException e) {
+                continue;
+            }
             maxSeal.merge(prefix, sealTxn, Math::max);
         }
         for (File f : files) {
@@ -470,8 +473,11 @@ public class PostingIndexBenchmarkSuite {
             if (lastDot <= pcAt) continue;
             String prefix = n.substring(0, lastDot);
             long sealTxn;
-            try { sealTxn = Long.parseLong(n.substring(lastDot + 1)); }
-            catch (NumberFormatException e) { continue; }
+            try {
+                sealTxn = Long.parseLong(n.substring(lastDot + 1));
+            } catch (NumberFormatException e) {
+                continue;
+            }
             Long max = maxSeal.get(prefix);
             if (max != null && sealTxn < max) {
                 f.delete();

--- a/benchmarks/src/main/java/org/questdb/PostingIndexBenchmarkSuite.java
+++ b/benchmarks/src/main/java/org/questdb/PostingIndexBenchmarkSuite.java
@@ -81,6 +81,7 @@ public class PostingIndexBenchmarkSuite {
 
     private static final double CLOUD_US_PER_PAGE = 1_000;
     private static final long COL_TXN = COLUMN_NAME_TXN_NONE;
+    private static final int[] COVER_REQ_0 = new int[]{0};
     private static final double HDD_US_PER_PAGE = 4_000;
     private static final boolean IS_DELTA = "delta".equals(System.getProperty("questdb.posting.format", "ef"));
     private static final double NVME_US_PER_PAGE = 80;
@@ -205,13 +206,15 @@ public class PostingIndexBenchmarkSuite {
     @Benchmark
     public long sidecarRead(SidecarState s) {
         long sum = 0;
+        boolean covering = "covering".equals(s.mode);
+        int[] requiredCovers = covering ? COVER_REQ_0 : null;
         try (Path path = new Path().of(s.dir)) {
             try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
                     s.config, path, "test", COLUMN_NAME_TXN_NONE, 0, 0,
                     s.coverMetadata, s.cvr, 0)) {
                 for (int key : s.readKeys) {
-                    try (RowCursor cursor = reader.getCursor(key, 0, Long.MAX_VALUE)) {
-                        if ("covering".equals(s.mode) && cursor instanceof CoveringRowCursor crc && crc.isCoveredAvailable(0)) {
+                    try (RowCursor cursor = reader.getCursor(key, 0, Long.MAX_VALUE, requiredCovers)) {
+                        if (covering && cursor instanceof CoveringRowCursor crc && crc.isCoveredAvailable(0)) {
                             while (crc.hasNext()) {
                                 crc.next();
                                 sum += switch (s.columnType) {
@@ -386,10 +389,13 @@ public class PostingIndexBenchmarkSuite {
     }
 
     private static void doCovCoveringRead(CairoConfiguration config, String dir, int[] keys, CoverType ct) {
-        try (Path path = new Path().of(dir)) {
-            try (PostingIndexFwdReader reader = new PostingIndexFwdReader(config, path, "test", COL_TXN, 0, 0)) {
+        GenericRecordMetadata meta = buildCoverMetadata(ct.columnType);
+        try (ColumnVersionReader cvr = new ColumnVersionReader();
+             Path path = new Path().of(dir)) {
+            try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                    config, path, "test", COL_TXN, 0, 0, meta, cvr, 0)) {
                 for (int key : keys) {
-                    try (RowCursor cursor = reader.getCursor(key, 0, Long.MAX_VALUE)) {
+                    try (RowCursor cursor = reader.getCursor(key, 0, Long.MAX_VALUE, COVER_REQ_0)) {
                         if (cursor instanceof CoveringRowCursor crc && crc.isCoveredAvailable(0)) {
                             while (crc.hasNext()) {
                                 crc.next();
@@ -409,6 +415,15 @@ public class PostingIndexBenchmarkSuite {
         }
     }
 
+    private static GenericRecordMetadata buildCoverMetadata(int colType) {
+        GenericRecordMetadata meta = new GenericRecordMetadata();
+        for (int i = 0; i <= 2; i++) {
+            int t = (i == 2) ? colType : ColumnType.LONG;
+            meta.add(new TableColumnMetadata("c" + i, t, IndexType.NONE, 0, false, null, i, false));
+        }
+        return meta;
+    }
+
     // ==================================================================================
     // Shared utilities
     // ==================================================================================
@@ -419,6 +434,48 @@ public class PostingIndexBenchmarkSuite {
         File[] files = dir.listFiles();
         if (files != null) for (File f : files) size += f.length();
         return size;
+    }
+
+    /**
+     * Sidecar files are named {@code <name>.pc<idx>.<colTxn>.<sealTxn>}. Each seal
+     * publishes a new file at a higher sealTxn, but the previous one is normally
+     * removed by a message-bus purge job that this bare-bones benchmark setup does
+     * not run. Call this after {@code writer.seal()} so {@code getDirectorySize}
+     * reflects only the live sidecar.
+     */
+    private static void purgeStaleSidecars(String dir) {
+        File d = new File(dir);
+        File[] files = d.listFiles();
+        if (files == null) return;
+        // group by "<name>.pc<idx>.<colTxn>" prefix; track max sealTxn per group.
+        Map<String, Long> maxSeal = new LinkedHashMap<>();
+        for (File f : files) {
+            String n = f.getName();
+            int pcAt = n.indexOf(".pc");
+            if (pcAt < 0 || n.contains(".pci")) continue;
+            int lastDot = n.lastIndexOf('.');
+            if (lastDot <= pcAt) continue;
+            String prefix = n.substring(0, lastDot);
+            long sealTxn;
+            try { sealTxn = Long.parseLong(n.substring(lastDot + 1)); }
+            catch (NumberFormatException e) { continue; }
+            maxSeal.merge(prefix, sealTxn, Math::max);
+        }
+        for (File f : files) {
+            String n = f.getName();
+            int pcAt = n.indexOf(".pc");
+            if (pcAt < 0 || n.contains(".pci")) continue;
+            int lastDot = n.lastIndexOf('.');
+            if (lastDot <= pcAt) continue;
+            String prefix = n.substring(0, lastDot);
+            long sealTxn;
+            try { sealTxn = Long.parseLong(n.substring(lastDot + 1)); }
+            catch (NumberFormatException e) { continue; }
+            Long max = maxSeal.get(prefix);
+            if (max != null && sealTxn < max) {
+                f.delete();
+            }
+        }
     }
 
     private static void initPosting(CairoConfiguration config, String dir) {
@@ -706,8 +763,10 @@ public class PostingIndexBenchmarkSuite {
                     writer.add(keyAssignment[rowId], rowId);
                 }
                 writer.setMaxValue(keyAssignment.length - 1);
+                writer.seal();
             }
         }
+        purgeStaleSidecars(dir);
     }
 
     enum CoverType {
@@ -1083,8 +1142,10 @@ public class PostingIndexBenchmarkSuite {
                     }
                     for (int i = 0; i < ROWS; i++) writer.add(keyAssignment[i], i);
                     writer.setMaxValue(ROWS - 1);
+                    writer.seal();
                 }
             }
+            purgeStaleSidecars(dir);
         }
 
         @TearDown(Level.Trial)

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -10916,17 +10916,20 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 continue;
             }
             IntList coveringCols = metadata.getColumnMetadata(colIdx).getCoveringColumnIndices();
-            if (coveringCols != null && coveringCols.size() > 0) {
-                // Covering POSTING indexes need the full reseal in
-                // sealPostingIndexForPartition (covering-file remap +
-                // rebuildSidecars). The fast-lag commit path is followed by
-                // a full O3 commit when more transactions accumulate, which
-                // catches the covering reseal then. Non-covering POSTING is
-                // the only path that has no later sweep.
-                continue;
-            }
+            boolean isCovering = coveringCols != null && coveringCols.size() > 0;
             indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn());
-            indexer.seal();
+            if (isCovering) {
+                // Covering POSTING reseal is expensive (sidecar rebuild via
+                // sealPostingIndexForPartition with covering-file remap), so
+                // it normally waits for the next O3 commit. With pure in-order
+                // ingestion (no O3, no partition rollover), gens accumulate
+                // without bound and per-key cursor probes turn into walks
+                // over every gen. The threshold caps unsealed gen count;
+                // sealIfMultiGen is a no-op below the threshold.
+                indexer.getWriter().sealIfMultiGen(configuration.getPostingSealGenThreshold());
+            } else {
+                indexer.seal();
+            }
             indexer.publishPendingPurges(messageBus, tableToken, partitionBy, timestampType, txWriter.getTxn());
         }
     }

--- a/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
@@ -361,6 +361,11 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
     }
 
     @TestOnly
+    public int getGenCount() {
+        return genCount;
+    }
+
+    @TestOnly
     public void setGenLookupCacheBudget(long budget) {
         genLookup.setCacheMemoryBudget(budget);
     }

--- a/core/src/test/java/io/questdb/test/cairo/PostingSealGenThresholdTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingSealGenThresholdTest.java
@@ -1,0 +1,147 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.idx.PostingIndexFwdReader;
+import io.questdb.std.str.Path;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers {@link io.questdb.cairo.TableWriter#sealPostingIndexesForLastPartitionFastLag()}
+ * sealing covering POSTING indexes once unsealed gen count crosses
+ * {@code cairo.posting.seal.gen.threshold}.
+ *
+ * <p>Pure in-order WAL ingestion to a single partition routes through fast-lag.
+ * Without this gating, covering posting accumulates one gen per commit because
+ * the fast-lag path historically exempted covering (waiting for the next O3
+ * commit). For workloads that never produce O3, gen count grew without bound
+ * and per-key cursor probes scaled linearly with it.
+ */
+public class PostingSealGenThresholdTest extends AbstractCairoTest {
+
+    @Test
+    public void testHighThresholdLetsGensAccumulate() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, Integer.MAX_VALUE);
+        assertMemoryLeak(() -> {
+            createCoveringTable("t_high");
+            int commits = 8;
+            for (int i = 0; i < commits; i++) {
+                execute("INSERT INTO t_high VALUES ('2024-01-01T00:00:0" + i + ".000000Z', 'A', " + i + ".0)");
+                drainWalQueue();
+            }
+            assertEquals(
+                    "MAX_VALUE threshold disables auto-seal; gen per commit stays unsealed",
+                    commits,
+                    readGenCount("t_high")
+            );
+        });
+    }
+
+    @Test
+    public void testThresholdCapsGenCount() throws Exception {
+        // sealIfMultiGen seals when genCount > threshold. With threshold=4 and
+        // 10 in-order commits, the writer cycles 1..5 -> seal -> 1..5 -> seal,
+        // so genCount never exceeds 5.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 4);
+        assertMemoryLeak(() -> {
+            createCoveringTable("t_cap");
+            int commits = 10;
+            for (int i = 0; i < commits; i++) {
+                execute("INSERT INTO t_cap VALUES ('2024-01-01T00:00:0" + i + ".000000Z', 'A', " + i + ".0)");
+                drainWalQueue();
+            }
+            int genCount = readGenCount("t_cap");
+            assertTrue(
+                    "threshold=4 must cap genCount at <= 5 after " + commits
+                            + " commits, got " + genCount,
+                    genCount <= 5
+            );
+            assertTrue(
+                    "threshold=4 must allow some accumulation between seals, got " + genCount,
+                    genCount >= 1
+            );
+        });
+    }
+
+    @Test
+    public void testThresholdZeroSealsEveryCommit() throws Exception {
+        // sealIfMultiGen seals when genCount > threshold. threshold=0 means
+        // every commit that produces a gen triggers a seal, so the next read
+        // always sees a single dense gen.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
+        assertMemoryLeak(() -> {
+            createCoveringTable("t_zero");
+            int commits = 6;
+            for (int i = 0; i < commits; i++) {
+                execute("INSERT INTO t_zero VALUES ('2024-01-01T00:00:0" + i + ".000000Z', 'A', " + i + ".0)");
+                drainWalQueue();
+            }
+            assertEquals(
+                    "threshold=0 seals after every commit; reader sees one dense gen",
+                    1,
+                    readGenCount("t_zero")
+            );
+        });
+    }
+
+    private void createCoveringTable(String name) throws Exception {
+        execute("CREATE TABLE " + name + " ("
+                + "ts TIMESTAMP, "
+                + "sym SYMBOL INDEX TYPE POSTING INCLUDE (price), "
+                + "price DOUBLE"
+                + ") TIMESTAMP(ts) PARTITION BY DAY WAL");
+    }
+
+    private int readGenCount(String tableName) {
+        try (TableReader r = engine.getReader(tableName);
+             Path path = new Path()) {
+            long partitionTs = r.getPartitionTimestampByIndex(0);
+            long partitionNameTxn = r.getTxFile().getPartitionNameTxn(0);
+            path.of(configuration.getDbRoot()).concat(r.getTableToken().getDirName());
+            TableUtils.setPathForNativePartition(
+                    path,
+                    ColumnType.TIMESTAMP_MICRO,
+                    PartitionBy.DAY,
+                    partitionTs,
+                    partitionNameTxn
+            );
+            try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                    configuration, path, "sym", COLUMN_NAME_TXN_NONE, partitionTs, 0,
+                    r.getMetadata(), r.getColumnVersionReader(), partitionTs)) {
+                return reader.getGenCount();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Pure in-order WAL ingestion to a single partition with covering POSTING accumulates one unsealed gen per commit until the writer closes. The fast-lag commit path explicitly exempted covering from the per-commit seal (covering reseal pulls in sidecar rebuild + covering-file remap; the comment said "the next O3 commit will catch it"). Workloads that never produce O3 — forward-only ILP into a single shard, the common case — never get caught up. Per-key cursor probes scan every gen, so a 100-gen state turned a 1.6 ms scan into a 16 ms scan.

This PR adds a threshold-gated auto-seal at the fast-lag callsite using the existing `cairo.posting.seal.gen.threshold` config (default 16), and along the way fixes the bench scaffolding that hid the problem.

## What changed

**Production fix:**
- `TableWriter.sealPostingIndexesForLastPartitionFastLag` now calls `sealIfMultiGen(threshold)` for covering POSTING instead of unconditionally skipping. Below the threshold, behaviour is unchanged (still defers to O3); above, covering reseals on the fast-lag commit.
- Same key, same default (16) as the existing partition-rollover callsite — no new config to document.
- `@TestOnly getGenCount()` accessor on `AbstractPostingIndexReader` so tests can observe gen-count cycling.
- `PostingSealGenThresholdTest` covers three thresholds: 0 (seal every commit), 4 (cycle, capped at 5), `Integer.MAX_VALUE` (no auto-seal).

**Benchmark scaffolding fixes** — these surfaced the bug:

The `PostingIndexBenchmarkSuite` sidecar measurements were not exercising the covering data path:

- **No `seal()`** — `SidecarState.setup`, `writeCovIndex`, and `setupStreaming` finished the write loop and closed the writer without sealing. `setupStreaming` had `writer.close(); // seal` — the comment had been a lie since `ea5564fcc5` removed auto-seal from `close()`. S3 ended up with 100 unsealed gens; queries silently measured the worst-case multi-gen path.
- **`requiredCoverColumns=null`** — `sidecarRead` and `doCovCoveringRead` called the 3-arg `getCursor`, which passes null. `openRequiredSidecars` only opens sidecars for non-null lists, so `isCoveredAvailable(0)` returned false in every iteration. Both modes ran the same code, producing nearly identical throughput regardless of column type.
- **Missing cover metadata** — `doCovCoveringRead` used the 6-arg `PostingIndexFwdReader` constructor (no metadata, no `ColumnVersionReader`), so `coverCount` was 0 and the covering reader state never initialised.
- **Stale per-gen sidecars on disk** — each seal publishes a new `.pcN.<colTxn>.<sealTxn>` file at a higher sealTxn; the previous file is removed by a message-bus purge job. The bare-bones bench runs the writer with no engine, so the pre-seal file stayed on disk and `getDirectorySize` double-counted both files (~11.5 MB for DOUBLE instead of 3.5 MB), making the implied compression ratio look worse than the raw column.

Concrete bench changes:
- `writer.seal()` before `writer.close()` at every callsite that previously read `// seal`.
- `requiredCoverColumns = {0}` passed to `getCursor` on covering paths.
- `doCovCoveringRead` uses the 9-arg reader constructor with cover metadata and a `ColumnVersionReader`.
- `purgeStaleSidecars` deletes `.pcN` files at sealTxn values superseded by the latest seal.

## S3 recovery

S3 is a streaming-style scenario: 100 commits, 200 random keys × 10 values per commit, 10K-key keyspace. Before the bench fix it ran *without* any seal at the end, leaving 100 unsealed gens; readers paid 100 SBBF probes per cursor. After the bench fix the streaming setup seals once at the end, and the auto-seal threshold also kicks in mid-stream once gens cross 16.

| operation | before | after | vs Legacy |
|---|---:|---:|---:|
| `indexPointRead` S3 | 189 | **2,884** | 1.01x |
| `indexScanRead` S3 | 79 | **1,478** | 0.82x |
| `indexRangeRead` S3 | 1,678 | **17,923** | 1.71x |

S3 was the most striking case (cliff from 0.93x → 0.05x in earlier runs). Other multi-gen-sensitive scenarios also improved (S6, S7 on scan).

## Numbers — auto-seal threshold (synthetic harness)

10K-key sweep, in-order commits to one partition. Scan throughput vs sealed layout.

| gen count | scan ops/s | scan vs sealed | point ops/s | point vs sealed |
|---:|---:|---:|---:|---:|
| 1 | 504 | 100% | 688 | 100% |
| 8 | 188 | 55% | 455 | 68% |
| 16 | 170 | 49% | 415 | 60% |
| 32 | 107 | 34% | 276 | 43% |
| 100 | 59 | 17% | 133 | 19% |

Default threshold 16 keeps scan within ~2x of sealed and point reads within ~1.7x.

| seal frequency | covering commits/s | vs no-auto-seal |
|---|---:|---:|
| every commit | 89 | 0.03x |
| every 8 | 680 | 0.23x |
| every 16 | 1,415 | **0.48x** |
| every 32 | 1,990 | 0.67x |
| every 64 | 2,893 | 0.97x |
| no auto-seal | 2,973 | 1.00x |

16 sits at the inflection: doubling buys ~2x writes for ~1.2x worse reads; halving costs ~2x writes for marginal read gains.

## Numbers — bench-fix validation

Single host, clean build with FSST submodule initialised, 1 fork, 2 warmup × 1s, 3 measure × 1s. EF encoding (default).

### Sidecar in-RAM throughput (ops/s)

Before the bench fix this was a uniform ~180k ops/s for every (type, mode) combination — both branches were iterating empty cursors on unsealed data. The new numbers measure real work: baseline reads the column via `Unsafe.getDouble`, covering decompresses the ALP/FoR sidecar block on first hit and serves cache thereafter.

| Type | baseline | covering | ratio |
|---|---:|---:|---:|
| DOUBLE | 488 | 325 | 0.67x |
| FLOAT | 503 | 373 | 0.74x |
| LONG | 537 | 385 | 0.72x |
| INT | 532 | 315 | 0.59x |
| DECIMAL64 | 495 | 387 | 0.78x |
| DECIMAL32 | 524 | 372 | 0.71x |
| SHORT | 532 | 308 | 0.58x |

The 0.58-0.78x ratio is the in-RAM decode-cache check tax on `getCoveredXxx`; baseline reads the raw column directly and pays no decode. Covering's value lives on cold reads (see I/O projection below).

### Commit profile

`full write+seal cycle`: **21.7 ops/s, 46.2 ms/cycle** (was 50.0 ops/s / 20.0 ms/cycle in the prior run that had not exercised covering through fast-lag because of the bench bug).

That ~2.3x slowdown is the auto-seal threshold actually firing in the commit-profile workload — 512 keys × 56 commits with covering INCLUDE crosses the threshold mid-stream and reseals. This is expected: the trade-off is exactly the read/write swap the threshold introduces. Workloads that don't use covering INCLUDE on a hot, no-O3 partition are unaffected.

### Covering I/O projection (200/500 keys × 1M rows)

`pages base/cover` = distinct 4 KB pages the reader would touch. The `+NVMe / +cloud / +HDD` columns add 80 µs / 1 ms / 4 ms per page to model cold-cache pressure.

| Type | pages base | pages cover | reduction | base CPU (ms) | cov CPU (ms) | base+NVMe (ms) | cov+NVMe (ms) | cov+cloud (ms) | cov+HDD (ms) |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| DOUBLE | 1,954 | 346 | 82% | 1.2 | 3.9 | 157.6 | 31.6 | 349.9 | 1,387.9 |
| FLOAT | 977 | 179 | 82% | 1.3 | 3.2 | 79.5 | 17.6 | 182.2 | 719.2 |
| LONG | 1,954 | 246 | 87% | 1.6 | 3.3 | 157.9 | 23.0 | 249.3 | 987.3 |
| INT | 977 | 173 | 82% | 1.3 | 3.9 | 79.4 | 17.7 | 176.9 | 695.9 |

Cold-cache speedup (baseline+NVMe / covering+NVMe): DOUBLE 5.0x, FLOAT 4.5x, LONG 6.9x, INT 4.5x.

### Implied sidecar compression

Computed from `covSize - baseSize` after `purgeStaleSidecars` runs (only the post-seal `.pc0.0.<latest>` left on disk).

| Type | raw column | compressed sidecar | ratio |
|---|---:|---:|---:|
| DOUBLE | 8.00 MB | 3.53 MB | 2.27x |
| FLOAT | 4.00 MB | 1.82 MB | 2.20x |
| LONG | 8.00 MB | 2.51 MB | 3.18x |
| INT | 4.00 MB | 1.76 MB | 2.27x |
| DECIMAL64 | 8.00 MB | 2.14 MB | 3.74x |
| DECIMAL32 | 4.00 MB | 1.14 MB | 3.51x |
| SHORT | 2.00 MB | 1.26 MB | 1.59x |

## Tradeoffs / caveats

- **Pure-O3 workloads see no behavioural change.** Their covering reseal already runs via `sealPostingIndexesForO3Partitions`.
- **Forward-only ILP into a single partition pays write throughput for read latency.** The commit profile drops 21.7 ops/s ÷ 50.0 ops/s ≈ 43% of the prior throughput. Previous behaviour was effectively unbounded gen accumulation until writer close — most users would have hit it on hot-shard ingest, with a much worse outcome.
- **Threshold is configurable.** `Integer.MAX_VALUE` restores prior behaviour exactly. `0` seals every commit (closer to non-covering's existing behaviour).
- **Non-covering POSTING is unchanged.** Fast-lag has always sealed it unconditionally on the last partition.
- **Benchmark numbers from before this PR should be treated as invalid** for `sidecarRead`, the Sidecar Compression table, and the I/O Projection section. Other sections were within run-to-run noise of prior reports.
- **The 0.58-0.78x in-RAM ratio between covering and baseline reads** is the cost of the per-call decode-cache check in `getCoveredXxx`. Not visible at the SQL level (covering queries beat non-covering by 1.1-1.6x in this suite). Narrowing it would require either cursor-side caching of the resolved column-cache address or a bulk-scan API.

## Test plan

- `mvn test -pl questdb/core -Dtest.include="%regex[.*PostingSealGenThresholdTest.*]"` — three threshold scenarios (0, 4, MAX_VALUE) all pass.
- `mvn test -pl questdb/core -Dtest.include="%regex[.*CoveringIndexTest.*]"` — 1032/1032 pass (including the FSST tests, which require `git submodule update --init core/src/main/c/share/fsst` followed by a CMake rebuild before the local libquestdb.so contains the FSST symbols).
- `mvn install -pl questdb/core -DskipTests && mvn package -pl questdb/benchmarks -DskipTests && java -Xmx4g -cp questdb/benchmarks/target/benchmarks.jar org.questdb.PostingIndexBenchmarkSuite` — confirm I/O Projection shows non-zero `pages base` and `pages cover < pages base`; Sidecar Compression shows `covering` slower than `baseline` rather than uniform numbers; partition directory after a run holds only one `.pcN.<colTxn>.<sealTxn>` file per cover column; with default threshold (16), S3 indexScanRead recovers from the unsealed-100-gen cliff.
- Spot-check `cairo.posting.seal.gen.threshold` set low against a covering POSTING WAL table under in-order ingestion — gen count stays bounded across many commits.
