### PR TITLE
feat(core): auto-seal covering posting index past gen threshold

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -10916,17 +10916,20 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 continue;
             }
             IntList coveringCols = metadata.getColumnMetadata(colIdx).getCoveringColumnIndices();
-            if (coveringCols != null && coveringCols.size() > 0) {
-                // Covering POSTING indexes need the full reseal in
-                // sealPostingIndexForPartition (covering-file remap +
-                // rebuildSidecars). The fast-lag commit path is followed by
-                // a full O3 commit when more transactions accumulate, which
-                // catches the covering reseal then. Non-covering POSTING is
-                // the only path that has no later sweep.
-                continue;
-            }
+            boolean isCovering = coveringCols != null && coveringCols.size() > 0;
             indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn());
-            indexer.seal();
+            if (isCovering) {
+                // Covering POSTING reseal is expensive (sidecar rebuild via
+                // sealPostingIndexForPartition with covering-file remap), so
+                // it normally waits for the next O3 commit. With pure in-order
+                // ingestion (no O3, no partition rollover), gens accumulate
+                // without bound and per-key cursor probes turn into walks
+                // over every gen. The threshold caps unsealed gen count;
+                // sealIfMultiGen is a no-op below the threshold.
+                indexer.getWriter().sealIfMultiGen(configuration.getPostingSealGenThreshold());
+            } else {
+                indexer.seal();
+            }
             indexer.publishPendingPurges(messageBus, tableToken, partitionBy, timestampType, txWriter.getTxn());
         }
     }

--- a/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
@@ -361,6 +361,11 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
     }
 
     @TestOnly
+    public int getGenCount() {
+        return genCount;
+    }
+
+    @TestOnly
     public void setGenLookupCacheBudget(long budget) {
         genLookup.setCacheMemoryBudget(budget);
     }

--- a/core/src/test/java/io/questdb/test/cairo/PostingSealGenThresholdTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingSealGenThresholdTest.java
@@ -1,0 +1,147 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.idx.PostingIndexFwdReader;
+import io.questdb.std.str.Path;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers {@link io.questdb.cairo.TableWriter#sealPostingIndexesForLastPartitionFastLag()}
+ * sealing covering POSTING indexes once unsealed gen count crosses
+ * {@code cairo.posting.seal.gen.threshold}.
+ *
+ * <p>Pure in-order WAL ingestion to a single partition routes through fast-lag.
+ * Without this gating, covering posting accumulates one gen per commit because
+ * the fast-lag path historically exempted covering (waiting for the next O3
+ * commit). For workloads that never produce O3, gen count grew without bound
+ * and per-key cursor probes scaled linearly with it.
+ */
+public class PostingSealGenThresholdTest extends AbstractCairoTest {
+
+    @Test
+    public void testHighThresholdLetsGensAccumulate() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, Integer.MAX_VALUE);
+        assertMemoryLeak(() -> {
+            createCoveringTable("t_high");
+            int commits = 8;
+            for (int i = 0; i < commits; i++) {
+                execute("INSERT INTO t_high VALUES ('2024-01-01T00:00:0" + i + ".000000Z', 'A', " + i + ".0)");
+                drainWalQueue();
+            }
+            assertEquals(
+                    "MAX_VALUE threshold disables auto-seal; gen per commit stays unsealed",
+                    commits,
+                    readGenCount("t_high")
+            );
+        });
+    }
+
+    @Test
+    public void testThresholdCapsGenCount() throws Exception {
+        // sealIfMultiGen seals when genCount > threshold. With threshold=4 and
+        // 10 in-order commits, the writer cycles 1..5 -> seal -> 1..5 -> seal,
+        // so genCount never exceeds 5.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 4);
+        assertMemoryLeak(() -> {
+            createCoveringTable("t_cap");
+            int commits = 10;
+            for (int i = 0; i < commits; i++) {
+                execute("INSERT INTO t_cap VALUES ('2024-01-01T00:00:0" + i + ".000000Z', 'A', " + i + ".0)");
+                drainWalQueue();
+            }
+            int genCount = readGenCount("t_cap");
+            assertTrue(
+                    "threshold=4 must cap genCount at <= 5 after " + commits
+                            + " commits, got " + genCount,
+                    genCount <= 5
+            );
+            assertTrue(
+                    "threshold=4 must allow some accumulation between seals, got " + genCount,
+                    genCount >= 1
+            );
+        });
+    }
+
+    @Test
+    public void testThresholdZeroSealsEveryCommit() throws Exception {
+        // sealIfMultiGen seals when genCount > threshold. threshold=0 means
+        // every commit that produces a gen triggers a seal, so the next read
+        // always sees a single dense gen.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
+        assertMemoryLeak(() -> {
+            createCoveringTable("t_zero");
+            int commits = 6;
+            for (int i = 0; i < commits; i++) {
+                execute("INSERT INTO t_zero VALUES ('2024-01-01T00:00:0" + i + ".000000Z', 'A', " + i + ".0)");
+                drainWalQueue();
+            }
+            assertEquals(
+                    "threshold=0 seals after every commit; reader sees one dense gen",
+                    1,
+                    readGenCount("t_zero")
+            );
+        });
+    }
+
+    private void createCoveringTable(String name) throws Exception {
+        execute("CREATE TABLE " + name + " ("
+                + "ts TIMESTAMP, "
+                + "sym SYMBOL INDEX TYPE POSTING INCLUDE (price), "
+                + "price DOUBLE"
+                + ") TIMESTAMP(ts) PARTITION BY DAY WAL");
+    }
+
+    private int readGenCount(String tableName) {
+        try (TableReader r = engine.getReader(tableName);
+             Path path = new Path()) {
+            long partitionTs = r.getPartitionTimestampByIndex(0);
+            long partitionNameTxn = r.getTxFile().getPartitionNameTxn(0);
+            path.of(configuration.getDbRoot()).concat(r.getTableToken().getDirName());
+            TableUtils.setPathForNativePartition(
+                    path,
+                    ColumnType.TIMESTAMP_MICRO,
+                    PartitionBy.DAY,
+                    partitionTs,
+                    partitionNameTxn
+            );
+            try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                    configuration, path, "sym", COLUMN_NAME_TXN_NONE, partitionTs, 0,
+                    r.getMetadata(), r.getColumnVersionReader(), partitionTs)) {
+                return reader.getGenCount();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`sealPostingIndexesForLastPartitionFastLag` exempts covering POSTING from the per-commit seal because covering reseal is more expensive than non-covering (sidecar rebuild + covering-file remap). The exemption defers to the next O3 commit. For pure in-order WAL ingestion into a single partition (the common forward-only ILP path), no O3 commit ever runs, so covering gens accumulate one per commit until the writer closes.

This adds a threshold check using the existing `cairo.posting.seal.gen.threshold` config so covering reseal kicks in proactively once unsealed gen count crosses the threshold.

## What changed

- `TableWriter.sealPostingIndexesForLastPartitionFastLag` calls `sealIfMultiGen(threshold)` for covering instead of unconditionally skipping. Below the threshold the behaviour is unchanged (still defers to O3); at or above, covering reseals on the fast-lag commit.
- The threshold key is reused — same value, same default — so a deployment already setting it sees consistent behaviour at both the partition-rollover and fast-lag callsites. No new config to document.
- `@TestOnly` accessor `AbstractPostingIndexReader.getGenCount()` so tests can observe gen-count cycling.
- `PostingSealGenThresholdTest` covers three settings: 0 (seal every commit), 4 (cycle, cap at 5), Integer.MAX_VALUE (no auto-seal).

## Numbers

Synthetic harness, 10K-key sweep, in-order commits to one partition, scan throughput vs sealed layout:

| gen count | scan ops/s | scan vs sealed | point ops/s | point vs sealed |
|---:|---:|---:|---:|---:|
| 1 | 504 | 100% | 688 | 100% |
| 8 | 188 | **55%** | 455 | 68% |
| 16 | 170 | 49% | 415 | 60% |
| 32 | 107 | 34% | 276 | 43% |
| 100 | 59 | 17% | 133 | 19% |

The default threshold of 16 keeps scan within 2x of sealed and point reads within ~1.7x. Lower thresholds tighten the read window at write-throughput cost — rough numbers from a 200-commit / 400K-row covering write loop:

| seal frequency | covering commits/s | vs no-auto-seal |
|---|---:|---:|
| every commit | 89 | 0.03x |
| every 8 | 680 | 0.23x |
| every 16 | 1,415 | **0.48x** |
| every 32 | 1,990 | 0.67x |
| every 64 | 2,893 | 0.97x |
| no auto-seal | 2,973 | 1.00x |

So 16 sits at the inflection point where doubling the threshold buys ~2x writes for ~1.2x worse reads, and halving it costs ~2x writes for marginal read gains.

## Tradeoffs

- Pure-O3 workloads see no behavioural change (their covering reseal already runs via `sealPostingIndexesForO3Partitions`).
- Forward-only ILP into a single partition: covering write throughput drops to roughly half of the no-auto-seal baseline, in exchange for read latency staying bounded. The previous behaviour was effectively unbounded gen accumulation until writer close — a state most users would have hit on hot-shard ingest.
- Threshold is configurable; setting it to `Integer.MAX_VALUE` restores the prior behaviour exactly.
- Non-covering POSTING is unchanged. Fast-lag has always sealed it unconditionally on the last partition, and that path is preserved.

## Test plan

- mvn test --batch-mode -pl questdb/core -Dtest.include="%regex[.*PostingSealGenThresholdTest.*]"
- mvn test --batch-mode -pl questdb/core -Dtest.include="%regex[.*CoveringIndexTest.*]" (the three FSST failures observed on master also fail without this patch — pre-existing, unrelated)
- Spot-check `cairo.posting.seal.gen.threshold` set to a low value with a covering POSTING table under in-order WAL ingestion: confirm gen count stays bounded across many commits.