### PR TITLE
chore(qwp): advertise role on /write/v4 upgrade for primary failover

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -33,6 +33,8 @@ import io.questdb.TelemetryConfiguration;
 import io.questdb.VolumeDefinitions;
 import io.questdb.cairo.idx.PostingIndexUtils;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
+import io.questdb.cutlass.qwp.codec.DefaultQwpServerInfoProvider;
+import io.questdb.cutlass.qwp.codec.QwpServerInfoProvider;
 import io.questdb.cutlass.text.TextConfiguration;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.IOURingFacade;
@@ -503,6 +505,8 @@ public interface CairoConfiguration {
         return PostingIndexUtils.ENCODING_ADAPTIVE;
     }
 
+    int getPostingSealGenThreshold();
+
     /**
      * Hard cap on the per-writer in-memory outbox of superseded posting-seal
      * generations awaiting publish to the global purge queue. When the cap
@@ -519,8 +523,6 @@ public interface CairoConfiguration {
         return 8192;
     }
 
-    int getPostingSealGenThreshold();
-
     int getPreferencesStringPoolCapacity();
 
     int getQueryCacheEventQueueCapacity();
@@ -534,8 +536,8 @@ public interface CairoConfiguration {
      * live replication role so clients can route reads to primary vs replica.
      */
     @NotNull
-    default io.questdb.cutlass.qwp.codec.QwpServerInfoProvider getQwpServerInfoProvider() {
-        return io.questdb.cutlass.qwp.codec.DefaultQwpServerInfoProvider.INSTANCE;
+    default QwpServerInfoProvider getQwpServerInfoProvider() {
+        return DefaultQwpServerInfoProvider.INSTANCE;
     }
 
     @NotNull

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -32,6 +32,7 @@ import io.questdb.Metrics;
 import io.questdb.TelemetryConfiguration;
 import io.questdb.VolumeDefinitions;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreakerConfiguration;
+import io.questdb.cutlass.qwp.codec.QwpServerInfoProvider;
 import io.questdb.cutlass.text.TextConfiguration;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.ObjObjHashMap;
@@ -827,7 +828,7 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
-    public io.questdb.cutlass.qwp.codec.@NotNull QwpServerInfoProvider getQwpServerInfoProvider() {
+    public @NotNull QwpServerInfoProvider getQwpServerInfoProvider() {
         return getDelegate().getQwpServerInfoProvider();
     }
 

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -911,7 +911,8 @@ public class CairoEngine implements Closeable, WriterSource {
     }
 
     public @NotNull QwpServerInfoProvider getQwpServerInfoProvider() {
-        return qwpServerInfoProvider != null ? qwpServerInfoProvider : configuration.getQwpServerInfoProvider();
+        QwpServerInfoProvider provider = qwpServerInfoProvider;
+        return provider != null ? provider : configuration.getQwpServerInfoProvider();
     }
 
     public TableReader getReader(CharSequence tableName) {
@@ -1784,7 +1785,7 @@ public class CairoEngine implements Closeable, WriterSource {
         this.viewWalWriterPool.setPoolListener(poolListener);
     }
 
-    public void setQwpServerInfoProvider(QwpServerInfoProvider provider) {
+    public void setQwpServerInfoProvider(@NotNull QwpServerInfoProvider provider) {
         this.qwpServerInfoProvider = provider;
     }
 

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -94,6 +94,7 @@ import io.questdb.cairo.wal.WalWriter;
 import io.questdb.cairo.wal.seq.SeqTxnTracker;
 import io.questdb.cairo.wal.seq.SequencerMetadata;
 import io.questdb.cairo.wal.seq.TableSequencerAPI;
+import io.questdb.cutlass.qwp.codec.QwpServerInfoProvider;
 import io.questdb.cutlass.text.CopyExportContext;
 import io.questdb.cutlass.text.CopyImportContext;
 import io.questdb.griffin.CompiledQuery;
@@ -222,6 +223,7 @@ public class CairoEngine implements Closeable, WriterSource {
     private volatile @NotNull DurableAckRegistry durableAckRegistry = DefaultDurableAckRegistry.INSTANCE;
     private FrameFactory frameFactory;
     private @NotNull MatViewStateStore matViewStateStore = NoOpMatViewStateStore.INSTANCE;
+    private volatile QwpServerInfoProvider qwpServerInfoProvider;
     private volatile Runnable recentWriteTrackerHydrationCallback;
     private @NotNull ViewStateStore viewStateStore = NoOpViewStateStore.INSTANCE;
     private @NotNull WalDirectoryPolicy walDirectoryPolicy = DefaultWalDirectoryPolicy.INSTANCE;
@@ -836,6 +838,10 @@ public class CairoEngine implements Closeable, WriterSource {
         return tableFlagResolver.isSystem(tableName) ? DefaultDdlListener.INSTANCE : ddlListener;
     }
 
+    public @NotNull DurableAckRegistry getDurableAckRegistry() {
+        return durableAckRegistry;
+    }
+
     public FrameFactory getFrameFactory() {
         return frameFactory;
     }
@@ -902,6 +908,10 @@ public class CairoEngine implements Closeable, WriterSource {
 
     public QueryRegistry getQueryRegistry() {
         return queryRegistry;
+    }
+
+    public @NotNull QwpServerInfoProvider getQwpServerInfoProvider() {
+        return qwpServerInfoProvider != null ? qwpServerInfoProvider : configuration.getQwpServerInfoProvider();
     }
 
     public TableReader getReader(CharSequence tableName) {
@@ -1209,10 +1219,6 @@ public class CairoEngine implements Closeable, WriterSource {
             }
             throw e;
         }
-    }
-
-    public @NotNull DurableAckRegistry getDurableAckRegistry() {
-        return durableAckRegistry;
     }
 
     public @NotNull WalDirectoryPolicy getWalDirectoryPolicy() {
@@ -1764,6 +1770,10 @@ public class CairoEngine implements Closeable, WriterSource {
         this.ddlListener = ddlListener;
     }
 
+    public void setDurableAckRegistry(@NotNull DurableAckRegistry durableAckRegistry) {
+        this.durableAckRegistry = durableAckRegistry;
+    }
+
     @TestOnly
     public void setPoolListener(PoolListener poolListener) {
         this.tableMetadataPool.setPoolListener(poolListener);
@@ -1772,6 +1782,10 @@ public class CairoEngine implements Closeable, WriterSource {
         this.readerPool.setPoolListener(poolListener);
         this.walWriterPool.setPoolListener(poolListener);
         this.viewWalWriterPool.setPoolListener(poolListener);
+    }
+
+    public void setQwpServerInfoProvider(QwpServerInfoProvider provider) {
+        this.qwpServerInfoProvider = provider;
     }
 
     @TestOnly
@@ -1792,10 +1806,6 @@ public class CairoEngine implements Closeable, WriterSource {
 
     @TestOnly
     public void setUp() {
-    }
-
-    public void setDurableAckRegistry(@NotNull DurableAckRegistry durableAckRegistry) {
-        this.durableAckRegistry = durableAckRegistry;
     }
 
     public void setWalDirectoryPolicy(@NotNull WalDirectoryPolicy walDirectoryPolicy) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/codec/DefaultQwpServerInfoProvider.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/codec/DefaultQwpServerInfoProvider.java
@@ -61,7 +61,7 @@ public final class DefaultQwpServerInfoProvider implements QwpServerInfoProvider
     }
 
     @Override
-    public byte getRole() {
+    public byte role() {
         return QwpEgressMsgKind.ROLE_STANDALONE;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/qwp/codec/QwpEgressMsgKind.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/codec/QwpEgressMsgKind.java
@@ -106,4 +106,14 @@ public final class QwpEgressMsgKind {
 
     private QwpEgressMsgKind() {
     }
+
+    public static String roleName(byte role) {
+        return switch (role) {
+            case ROLE_STANDALONE -> "STANDALONE";
+            case ROLE_PRIMARY -> "PRIMARY";
+            case ROLE_REPLICA -> "REPLICA";
+            case ROLE_PRIMARY_CATCHUP -> "PRIMARY_CATCHUP";
+            default -> "UNKNOWN";
+        };
+    }
 }

--- a/core/src/main/java/io/questdb/cutlass/qwp/codec/QwpEgressMsgKind.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/codec/QwpEgressMsgKind.java
@@ -24,6 +24,8 @@
 
 package io.questdb.cutlass.qwp.codec;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * QWP egress message-kind discriminator. The first byte of every egress payload
  * identifies which of the egress message types it carries. See
@@ -103,6 +105,11 @@ public final class QwpEgressMsgKind {
      * {@link #CACHE_RESET}; SERVER_INFO lives at 0x18.
      */
     public static final byte SERVER_INFO = 0x18;
+    private static final byte[] ROLE_NAME_BYTES_PRIMARY = "PRIMARY".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] ROLE_NAME_BYTES_PRIMARY_CATCHUP = "PRIMARY_CATCHUP".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] ROLE_NAME_BYTES_REPLICA = "REPLICA".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] ROLE_NAME_BYTES_STANDALONE = "STANDALONE".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] ROLE_NAME_BYTES_UNKNOWN = "UNKNOWN".getBytes(StandardCharsets.US_ASCII);
 
     private QwpEgressMsgKind() {
     }
@@ -114,6 +121,16 @@ public final class QwpEgressMsgKind {
             case ROLE_REPLICA -> "REPLICA";
             case ROLE_PRIMARY_CATCHUP -> "PRIMARY_CATCHUP";
             default -> "UNKNOWN";
+        };
+    }
+
+    public static byte[] roleNameBytes(byte role) {
+        return switch (role) {
+            case ROLE_STANDALONE -> ROLE_NAME_BYTES_STANDALONE;
+            case ROLE_PRIMARY -> ROLE_NAME_BYTES_PRIMARY;
+            case ROLE_REPLICA -> ROLE_NAME_BYTES_REPLICA;
+            case ROLE_PRIMARY_CATCHUP -> ROLE_NAME_BYTES_PRIMARY_CATCHUP;
+            default -> ROLE_NAME_BYTES_UNKNOWN;
         };
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/qwp/codec/QwpServerInfoProvider.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/codec/QwpServerInfoProvider.java
@@ -78,5 +78,5 @@ public interface QwpServerInfoProvider {
      * at handshake time; a role transition after the handshake is not reflected
      * on the already-open WebSocket (clients detect it on reconnect).
      */
-    byte getRole();
+    byte role();
 }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketHttpProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketHttpProcessor.java
@@ -276,21 +276,21 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         return responseSize(acceptKey, qwpVersion, contentEncoding, null);
     }
 
-    public static int responseSize(String acceptKey, int qwpVersion, String contentEncoding, String role) {
+    public static int responseSize(String acceptKey, int qwpVersion, String contentEncoding, byte[] roleBytes) {
         int size = RESPONSE_PREFIX.length + acceptKey.length()
                 + RESPONSE_AFTER_ACCEPT.length + digitCount(qwpVersion)
                 + RESPONSE_SUFFIX.length;
         if (contentEncoding != null) {
             size += RESPONSE_CONTENT_ENCODING_PREFIX.length + contentEncoding.length();
         }
-        if (role != null) {
-            size += RESPONSE_ROLE_PREFIX.length + role.length();
+        if (roleBytes != null) {
+            size += RESPONSE_ROLE_PREFIX.length + roleBytes.length;
         }
         return size;
     }
 
-    public static int serviceUnavailableWithRoleSize(String role) {
-        return SERVICE_UNAVAILABLE_PREFIX.length + role.length() + RESPONSE_SUFFIX.length;
+    public static int serviceUnavailableWithRoleSize(byte[] roleBytes) {
+        return SERVICE_UNAVAILABLE_PREFIX.length + roleBytes.length + RESPONSE_SUFFIX.length;
     }
 
     /**
@@ -367,7 +367,7 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         return writeResponse(buf, acceptKey, qwpVersion, contentEncoding, null);
     }
 
-    public static int writeResponse(long buf, String acceptKey, int qwpVersion, String contentEncoding, String role) {
+    public static int writeResponse(long buf, String acceptKey, int qwpVersion, String contentEncoding, byte[] roleBytes) {
         int offset = 0;
 
         for (byte b : RESPONSE_PREFIX) {
@@ -397,11 +397,10 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
             }
         }
 
-        if (role != null) {
+        if (roleBytes != null) {
             for (byte b : RESPONSE_ROLE_PREFIX) {
                 Unsafe.putByte(buf + offset++, b);
             }
-            byte[] roleBytes = role.getBytes(StandardCharsets.US_ASCII);
             for (byte b : roleBytes) {
                 Unsafe.putByte(buf + offset++, b);
             }
@@ -414,8 +413,8 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         return offset;
     }
 
-    public static int writeServiceUnavailableWithRole(long buf, int bufferSize, String role) {
-        int needed = serviceUnavailableWithRoleSize(role);
+    public static int writeServiceUnavailableWithRole(long buf, int bufferSize, byte[] roleBytes) {
+        int needed = serviceUnavailableWithRoleSize(roleBytes);
         if (needed > bufferSize) {
             return -1;
         }
@@ -423,7 +422,6 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         for (byte b : SERVICE_UNAVAILABLE_PREFIX) {
             Unsafe.putByte(buf + offset++, b);
         }
-        byte[] roleBytes = role.getBytes(StandardCharsets.US_ASCII);
         for (byte b : roleBytes) {
             Unsafe.putByte(buf + offset++, b);
         }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketHttpProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketHttpProcessor.java
@@ -99,7 +99,13 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
     // Response template
     private static final byte[] RESPONSE_PREFIX =
             "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] RESPONSE_ROLE_PREFIX = "\r\nX-QuestDB-Role: ".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] RESPONSE_SUFFIX = "\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] SERVICE_UNAVAILABLE_PREFIX =
+            ("HTTP/1.1 503 Service Unavailable\r\n"
+                    + "Connection: close\r\n"
+                    + "Content-Length: 0\r\n"
+                    + "X-QuestDB-Role: ").getBytes(StandardCharsets.US_ASCII);
     private static final int SHA1_BASE64_SIZE = 28;
     private static final ThreadLocal<byte[]> BASE64_SCRATCH = ThreadLocal.withInitial(() -> new byte[SHA1_BASE64_SIZE]);
     // Thread-local SHA-1 digest for computing Sec-WebSocket-Accept
@@ -258,7 +264,7 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
      * @return the total response size in bytes
      */
     public static int responseSize(String acceptKey, int qwpVersion) {
-        return responseSize(acceptKey, qwpVersion, null);
+        return responseSize(acceptKey, qwpVersion, null, null);
     }
 
     /**
@@ -267,13 +273,24 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
      * the server chose during negotiation. Pass {@code null} for no header.
      */
     public static int responseSize(String acceptKey, int qwpVersion, String contentEncoding) {
+        return responseSize(acceptKey, qwpVersion, contentEncoding, null);
+    }
+
+    public static int responseSize(String acceptKey, int qwpVersion, String contentEncoding, String role) {
         int size = RESPONSE_PREFIX.length + acceptKey.length()
                 + RESPONSE_AFTER_ACCEPT.length + digitCount(qwpVersion)
                 + RESPONSE_SUFFIX.length;
         if (contentEncoding != null) {
             size += RESPONSE_CONTENT_ENCODING_PREFIX.length + contentEncoding.length();
         }
+        if (role != null) {
+            size += RESPONSE_ROLE_PREFIX.length + role.length();
+        }
         return size;
+    }
+
+    public static int serviceUnavailableWithRoleSize(String role) {
+        return SERVICE_UNAVAILABLE_PREFIX.length + role.length() + RESPONSE_SUFFIX.length;
     }
 
     /**
@@ -338,7 +355,7 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
      * @return the number of bytes written
      */
     public static int writeResponse(long buf, String acceptKey, int qwpVersion) {
-        return writeResponse(buf, acceptKey, qwpVersion, null);
+        return writeResponse(buf, acceptKey, qwpVersion, null, null);
     }
 
     /**
@@ -347,20 +364,21 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
      * codec (e.g. {@code zstd;level=3}). Pass {@code null} for no header.
      */
     public static int writeResponse(long buf, String acceptKey, int qwpVersion, String contentEncoding) {
+        return writeResponse(buf, acceptKey, qwpVersion, contentEncoding, null);
+    }
+
+    public static int writeResponse(long buf, String acceptKey, int qwpVersion, String contentEncoding, String role) {
         int offset = 0;
 
-        // Write prefix
         for (byte b : RESPONSE_PREFIX) {
             Unsafe.putByte(buf + offset++, b);
         }
 
-        // Write accept key
         byte[] acceptBytes = acceptKey.getBytes(StandardCharsets.US_ASCII);
         for (byte b : acceptBytes) {
             Unsafe.putByte(buf + offset++, b);
         }
 
-        // Write X-QWP-Version header
         for (byte b : RESPONSE_AFTER_ACCEPT) {
             Unsafe.putByte(buf + offset++, b);
         }
@@ -369,10 +387,6 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
             Unsafe.putByte(buf + offset++, b);
         }
 
-        // Optional X-QWP-Content-Encoding header. Emitted only when the
-        // handshake negotiated a compression codec; omitted entirely when the
-        // wire stays raw so clients that ignore the header see the same bytes
-        // as before.
         if (contentEncoding != null) {
             for (byte b : RESPONSE_CONTENT_ENCODING_PREFIX) {
                 Unsafe.putByte(buf + offset++, b);
@@ -383,11 +397,39 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
             }
         }
 
-        // Write suffix
+        if (role != null) {
+            for (byte b : RESPONSE_ROLE_PREFIX) {
+                Unsafe.putByte(buf + offset++, b);
+            }
+            byte[] roleBytes = role.getBytes(StandardCharsets.US_ASCII);
+            for (byte b : roleBytes) {
+                Unsafe.putByte(buf + offset++, b);
+            }
+        }
+
         for (byte b : RESPONSE_SUFFIX) {
             Unsafe.putByte(buf + offset++, b);
         }
 
+        return offset;
+    }
+
+    public static int writeServiceUnavailableWithRole(long buf, int bufferSize, String role) {
+        int needed = serviceUnavailableWithRoleSize(role);
+        if (needed > bufferSize) {
+            return -1;
+        }
+        int offset = 0;
+        for (byte b : SERVICE_UNAVAILABLE_PREFIX) {
+            Unsafe.putByte(buf + offset++, b);
+        }
+        byte[] roleBytes = role.getBytes(StandardCharsets.US_ASCII);
+        for (byte b : roleBytes) {
+            Unsafe.putByte(buf + offset++, b);
+        }
+        for (byte b : RESPONSE_SUFFIX) {
+            Unsafe.putByte(buf + offset++, b);
+        }
         return offset;
     }
 

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketHttpProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketHttpProcessor.java
@@ -55,6 +55,8 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
     public static final Utf8String HEADER_SEC_WEBSOCKET_VERSION = new Utf8String("Sec-WebSocket-Version");
     // Header names (case-insensitive)
     public static final Utf8String HEADER_UPGRADE = new Utf8String("Upgrade");
+    // Expected value for HEADER_X_QWP_REQUEST_DURABLE_ACK to enable durable-ack; compared case-insensitively.
+    public static final Utf8String HEADER_VALUE_DURABLE_ACK_ENABLED = new Utf8String("true");
     // QWP version negotiation headers
     public static final Utf8String HEADER_X_QWP_ACCEPT_ENCODING = new Utf8String("X-QWP-Accept-Encoding");
     public static final Utf8String HEADER_X_QWP_CLIENT_ID = new Utf8String("X-QWP-Client-Id");
@@ -63,8 +65,6 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
     // Client opt-in for STATUS_DURABLE_ACK frames. Value "true" (case-insensitive) enables.
     // Any other value, or header absent, leaves the feature disabled for this connection.
     public static final Utf8String HEADER_X_QWP_REQUEST_DURABLE_ACK = new Utf8String("X-QWP-Request-Durable-Ack");
-    // Expected value for HEADER_X_QWP_REQUEST_DURABLE_ACK to enable durable-ack; compared case-insensitively.
-    public static final Utf8String HEADER_VALUE_DURABLE_ACK_ENABLED = new Utf8String("true");
     // Header values
     public static final Utf8String VALUE_WEBSOCKET = new Utf8String("websocket");
     /**
@@ -93,6 +93,12 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
     // allocates (28 chars) but that's the only irreducible cost without changing
     // the writeResponse contract to consume raw bytes.
     private static final ThreadLocal<byte[]> KEY_SCRATCH = ThreadLocal.withInitial(() -> new byte[KEY_SCRATCH_SIZE]);
+    private static final byte[] MISDIRECTED_REQUEST_PREFIX =
+            ("""
+                    HTTP/1.1 421 Misdirected Request\r
+                    Connection: close\r
+                    Content-Length: 0\r
+                    X-QuestDB-Role:\s""").getBytes(StandardCharsets.US_ASCII);
     private static final byte[] RESPONSE_AFTER_ACCEPT = "\r\nX-QWP-Version: ".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] RESPONSE_CONTENT_ENCODING_PREFIX =
             "\r\nX-QWP-Content-Encoding: ".getBytes(StandardCharsets.US_ASCII);
@@ -101,11 +107,6 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
             "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] RESPONSE_ROLE_PREFIX = "\r\nX-QuestDB-Role: ".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] RESPONSE_SUFFIX = "\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
-    private static final byte[] SERVICE_UNAVAILABLE_PREFIX =
-            ("HTTP/1.1 503 Service Unavailable\r\n"
-                    + "Connection: close\r\n"
-                    + "Content-Length: 0\r\n"
-                    + "X-QuestDB-Role: ").getBytes(StandardCharsets.US_ASCII);
     private static final int SHA1_BASE64_SIZE = 28;
     private static final ThreadLocal<byte[]> BASE64_SCRATCH = ThreadLocal.withInitial(() -> new byte[SHA1_BASE64_SIZE]);
     // Thread-local SHA-1 digest for computing Sec-WebSocket-Accept
@@ -256,6 +257,10 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         return upgradeHeader != null && Utf8s.equalsIgnoreCaseAscii(upgradeHeader, VALUE_WEBSOCKET);
     }
 
+    public static int misdirectedRequestWithRoleSize(byte[] roleBytes) {
+        return MISDIRECTED_REQUEST_PREFIX.length + roleBytes.length + RESPONSE_SUFFIX.length;
+    }
+
     /**
      * Returns the size of the handshake response for the given accept key and QWP version.
      *
@@ -287,10 +292,6 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
             size += RESPONSE_ROLE_PREFIX.length + roleBytes.length;
         }
         return size;
-    }
-
-    public static int serviceUnavailableWithRoleSize(byte[] roleBytes) {
-        return SERVICE_UNAVAILABLE_PREFIX.length + roleBytes.length + RESPONSE_SUFFIX.length;
     }
 
     /**
@@ -344,6 +345,24 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         }
 
         return null;
+    }
+
+    public static int writeMisdirectedRequestWithRole(long buf, int bufferSize, byte[] roleBytes) {
+        int needed = misdirectedRequestWithRoleSize(roleBytes);
+        if (needed > bufferSize) {
+            return -1;
+        }
+        int offset = 0;
+        for (byte b : MISDIRECTED_REQUEST_PREFIX) {
+            Unsafe.putByte(buf + offset++, b);
+        }
+        for (byte b : roleBytes) {
+            Unsafe.putByte(buf + offset++, b);
+        }
+        for (byte b : RESPONSE_SUFFIX) {
+            Unsafe.putByte(buf + offset++, b);
+        }
+        return offset;
     }
 
     /**
@@ -410,24 +429,6 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
             Unsafe.putByte(buf + offset++, b);
         }
 
-        return offset;
-    }
-
-    public static int writeServiceUnavailableWithRole(long buf, int bufferSize, byte[] roleBytes) {
-        int needed = serviceUnavailableWithRoleSize(roleBytes);
-        if (needed > bufferSize) {
-            return -1;
-        }
-        int offset = 0;
-        for (byte b : SERVICE_UNAVAILABLE_PREFIX) {
-            Unsafe.putByte(buf + offset++, b);
-        }
-        for (byte b : roleBytes) {
-            Unsafe.putByte(buf + offset++, b);
-        }
-        for (byte b : RESPONSE_SUFFIX) {
-            Unsafe.putByte(buf + offset++, b);
-        }
         return offset;
     }
 

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
@@ -32,6 +32,7 @@ import io.questdb.cutlass.http.HttpRawSocket;
 import io.questdb.cutlass.http.HttpRequestHeader;
 import io.questdb.cutlass.http.HttpRequestProcessor;
 import io.questdb.cutlass.http.LocalValue;
+import io.questdb.cutlass.qwp.codec.QwpEgressMsgKind;
 import io.questdb.cutlass.qwp.protocol.QwpConstants;
 import io.questdb.cutlass.qwp.websocket.WebSocketCloseCode;
 import io.questdb.cutlass.qwp.websocket.WebSocketFrameParser;
@@ -253,8 +254,30 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
 
         // Read QWP version negotiation headers
         int negotiatedVersion = negotiateQwpVersion(requestHeader, context.getFd());
+
+        byte role = engine.getQwpServerInfoProvider().role();
+        String roleName = QwpEgressMsgKind.roleName(role);
+        if (role == QwpEgressMsgKind.ROLE_REPLICA || role == QwpEgressMsgKind.ROLE_PRIMARY_CATCHUP) {
+            int unavailableSize = QwpWebSocketHttpProcessor.serviceUnavailableWithRoleSize(roleName);
+            if (unavailableSize > bufferSize) {
+                throw responseDoesNotFitSendBuffer(context.getFd(), "503 ingress role-reject response", bufferSize, unavailableSize);
+            }
+            int unavailableBytes = QwpWebSocketHttpProcessor.writeServiceUnavailableWithRole(bufferAddr, bufferSize, roleName);
+            if (unavailableBytes <= 0) {
+                throw responseDoesNotFitSendBuffer(context.getFd(), "503 ingress role-reject response", bufferSize, unavailableSize);
+            }
+            try {
+                rawSocket.send(unavailableBytes);
+            } catch (PeerIsSlowToReadException e) {
+                throw HttpException.instance("WebSocket ingress role-reject 503 blocked");
+            }
+            LOG.info().$("ingress upgrade rejected by role [fd=").$(context.getFd())
+                    .$(", role=").$(roleName).I$();
+            return;
+        }
+
         String acceptKey = QwpWebSocketHttpProcessor.computeAcceptKey(wsKey);
-        int requiredHandshakeSize = QwpWebSocketHttpProcessor.responseSize(acceptKey, negotiatedVersion);
+        int requiredHandshakeSize = QwpWebSocketHttpProcessor.responseSize(acceptKey, negotiatedVersion, null, roleName);
         if (requiredHandshakeSize > bufferSize) {
             throw responseDoesNotFitSendBuffer(context.getFd(), "101 handshake response", bufferSize, requiredHandshakeSize);
         }
@@ -286,7 +309,7 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
         state.setDurableAckEnabled(durableAckRequested && engine.getDurableAckRegistry().isEnabled());
 
         // Write the 101 Switching Protocols response (reuse the pre-computed accept key)
-        int bytesWritten = QwpWebSocketHttpProcessor.writeResponse(bufferAddr, acceptKey, negotiatedVersion);
+        int bytesWritten = QwpWebSocketHttpProcessor.writeResponse(bufferAddr, acceptKey, negotiatedVersion, null, roleName);
         if (bytesWritten <= 0) {
             throw responseDoesNotFitSendBuffer(context.getFd(), "101 handshake response", bufferSize, requiredHandshakeSize);
         }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
@@ -249,20 +249,14 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
             return;
         }
 
-        HttpRequestHeader requestHeader = context.getRequestHeader();
-        Utf8Sequence wsKey = QwpWebSocketHttpProcessor.getWebSocketKey(requestHeader);
-
-        // Read QWP version negotiation headers
-        int negotiatedVersion = negotiateQwpVersion(requestHeader, context.getFd());
-
         byte role = engine.getQwpServerInfoProvider().role();
-        String roleName = QwpEgressMsgKind.roleName(role);
+        byte[] roleBytes = QwpEgressMsgKind.roleNameBytes(role);
         if (role == QwpEgressMsgKind.ROLE_REPLICA || role == QwpEgressMsgKind.ROLE_PRIMARY_CATCHUP) {
-            int unavailableSize = QwpWebSocketHttpProcessor.serviceUnavailableWithRoleSize(roleName);
+            int unavailableSize = QwpWebSocketHttpProcessor.serviceUnavailableWithRoleSize(roleBytes);
             if (unavailableSize > bufferSize) {
                 throw responseDoesNotFitSendBuffer(context.getFd(), "503 ingress role-reject response", bufferSize, unavailableSize);
             }
-            int unavailableBytes = QwpWebSocketHttpProcessor.writeServiceUnavailableWithRole(bufferAddr, bufferSize, roleName);
+            int unavailableBytes = QwpWebSocketHttpProcessor.writeServiceUnavailableWithRole(bufferAddr, bufferSize, roleBytes);
             if (unavailableBytes <= 0) {
                 throw responseDoesNotFitSendBuffer(context.getFd(), "503 ingress role-reject response", bufferSize, unavailableSize);
             }
@@ -272,12 +266,18 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
                 throw HttpException.instance("WebSocket ingress role-reject 503 blocked");
             }
             LOG.info().$("ingress upgrade rejected by role [fd=").$(context.getFd())
-                    .$(", role=").$(roleName).I$();
+                    .$(", role=").$(QwpEgressMsgKind.roleName(role)).I$();
             return;
         }
 
+        HttpRequestHeader requestHeader = context.getRequestHeader();
+        Utf8Sequence wsKey = QwpWebSocketHttpProcessor.getWebSocketKey(requestHeader);
+
+        // Read QWP version negotiation headers
+        int negotiatedVersion = negotiateQwpVersion(requestHeader, context.getFd());
+
         String acceptKey = QwpWebSocketHttpProcessor.computeAcceptKey(wsKey);
-        int requiredHandshakeSize = QwpWebSocketHttpProcessor.responseSize(acceptKey, negotiatedVersion, null, roleName);
+        int requiredHandshakeSize = QwpWebSocketHttpProcessor.responseSize(acceptKey, negotiatedVersion, null, roleBytes);
         if (requiredHandshakeSize > bufferSize) {
             throw responseDoesNotFitSendBuffer(context.getFd(), "101 handshake response", bufferSize, requiredHandshakeSize);
         }
@@ -309,7 +309,7 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
         state.setDurableAckEnabled(durableAckRequested && engine.getDurableAckRegistry().isEnabled());
 
         // Write the 101 Switching Protocols response (reuse the pre-computed accept key)
-        int bytesWritten = QwpWebSocketHttpProcessor.writeResponse(bufferAddr, acceptKey, negotiatedVersion, null, roleName);
+        int bytesWritten = QwpWebSocketHttpProcessor.writeResponse(bufferAddr, acceptKey, negotiatedVersion, null, roleBytes);
         if (bytesWritten <= 0) {
             throw responseDoesNotFitSendBuffer(context.getFd(), "101 handshake response", bufferSize, requiredHandshakeSize);
         }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
@@ -252,18 +252,18 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
         byte role = engine.getQwpServerInfoProvider().role();
         byte[] roleBytes = QwpEgressMsgKind.roleNameBytes(role);
         if (role == QwpEgressMsgKind.ROLE_REPLICA || role == QwpEgressMsgKind.ROLE_PRIMARY_CATCHUP) {
-            int unavailableSize = QwpWebSocketHttpProcessor.serviceUnavailableWithRoleSize(roleBytes);
-            if (unavailableSize > bufferSize) {
-                throw responseDoesNotFitSendBuffer(context.getFd(), "503 ingress role-reject response", bufferSize, unavailableSize);
+            int rejectSize = QwpWebSocketHttpProcessor.misdirectedRequestWithRoleSize(roleBytes);
+            if (rejectSize > bufferSize) {
+                throw responseDoesNotFitSendBuffer(context.getFd(), "421 ingress role-reject response", bufferSize, rejectSize);
             }
-            int unavailableBytes = QwpWebSocketHttpProcessor.writeServiceUnavailableWithRole(bufferAddr, bufferSize, roleBytes);
-            if (unavailableBytes <= 0) {
-                throw responseDoesNotFitSendBuffer(context.getFd(), "503 ingress role-reject response", bufferSize, unavailableSize);
+            int rejectBytes = QwpWebSocketHttpProcessor.writeMisdirectedRequestWithRole(bufferAddr, bufferSize, roleBytes);
+            if (rejectBytes <= 0) {
+                throw responseDoesNotFitSendBuffer(context.getFd(), "421 ingress role-reject response", bufferSize, rejectSize);
             }
             try {
-                rawSocket.send(unavailableBytes);
+                rawSocket.send(rejectBytes);
             } catch (PeerIsSlowToReadException e) {
-                throw HttpException.instance("WebSocket ingress role-reject 503 blocked");
+                throw HttpException.instance("WebSocket ingress role-reject 421 blocked");
             }
             LOG.info().$("ingress upgrade rejected by role [fd=").$(context.getFd())
                     .$(", role=").$(QwpEgressMsgKind.roleName(role)).I$();

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressUpgradeProcessor.java
@@ -135,6 +135,21 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
      * into no-ops.
      */
     public static final int MAX_ROWS_PER_BATCH = 16_384;
+    private static final Log LOG = LogFactory.getLog(QwpEgressUpgradeProcessor.class);
+    private static final LocalValue<QwpEgressProcessorState> LV = new LocalValue<>();
+    private static final NoOpAssociativeCache<RecordCursorFactory> NO_OP_SELECT_CACHE = new NoOpAssociativeCache<>();
+    /**
+     * Upper bound for the SERVER_INFO body: 26 bytes fixed fields plus 65535
+     * bytes for each of cluster_id and node_id. The frame writer truncates each
+     * id at the u16 wire cap, so the bound is tight rather than defensive.
+     */
+    private static final int SERVER_INFO_BODY_MAX_BYTES = 26 + 0xFFFF + 0xFFFF;
+    /**
+     * Largest WebSocket frame header the server emits for its own frames:
+     * 2-byte base + 8-byte extended length (no masking on server-to-client).
+     * Used as a fit check when reserving space in the handshake send buffer.
+     */
+    private static final int WS_HEADER_MAX_BYTES = 10;
     /**
      * Test-only. When {@code > 0}, the next entry into {@link #resumeSend} (or
      * {@link #handleCredit} on the credit-suspended resume path) throws a
@@ -162,21 +177,6 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
      * per batch, no effect on production streams.
      */
     public static volatile int DEBUG_FORCE_TRANSPORT_FAILURE_AFTER_BATCHES = 0;
-    private static final Log LOG = LogFactory.getLog(QwpEgressUpgradeProcessor.class);
-    private static final LocalValue<QwpEgressProcessorState> LV = new LocalValue<>();
-    private static final NoOpAssociativeCache<RecordCursorFactory> NO_OP_SELECT_CACHE = new NoOpAssociativeCache<>();
-    /**
-     * Upper bound for the SERVER_INFO body: 26 bytes fixed fields plus 65535
-     * bytes for each of cluster_id and node_id. The frame writer truncates each
-     * id at the u16 wire cap, so the bound is tight rather than defensive.
-     */
-    private static final int SERVER_INFO_BODY_MAX_BYTES = 26 + 0xFFFF + 0xFFFF;
-    /**
-     * Largest WebSocket frame header the server emits for its own frames:
-     * 2-byte base + 8-byte extended length (no masking on server-to-client).
-     * Used as a fit check when reserving space in the handshake send buffer.
-     */
-    private static final int WS_HEADER_MAX_BYTES = 10;
     private final CairoEngine engine;
     private final int forceRecvFragmentationChunkSize;
     private final WebSocketFrameParser frameParser = new WebSocketFrameParser();
@@ -369,7 +369,7 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
                     bufferAddr + bytesWritten,
                     bufferSize - bytesWritten,
                     (byte) negotiatedVersion,
-                    engine.getConfiguration().getQwpServerInfoProvider(),
+                    engine.getQwpServerInfoProvider(),
                     serverWallNs
             );
             if (frameBytes < 0) {
@@ -609,7 +609,7 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
         long bodyEnd = QwpEgressFrameWriter.writeServerInfo(
                 bodyStart,
                 bodyCap,
-                provider.getRole(),
+                provider.role(),
                 provider.getEpoch(),
                 provider.getCapabilities(),
                 serverWallNs,
@@ -1167,6 +1167,51 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
         }
     }
 
+    /**
+     * Checks whether any connection-scoped cache has exceeded its soft cap and,
+     * if so, emits a {@code CACHE_RESET} frame and applies the matching server-
+     * side reset so both peers stay in lockstep. Called at query-completion
+     * boundaries (after {@code RESULT_END}, {@code EXEC_DONE}, or
+     * {@code QUERY_ERROR}) -- never mid-stream, because resetting the dict or
+     * the schema cache mid-stream would invalidate ids referenced by in-flight
+     * RESULT_BATCH frames.
+     */
+    private void maybeEmitCacheReset(
+            HttpConnectionContext context,
+            QwpEgressProcessorState state
+    ) throws PeerDisconnectedException, PeerIsSlowToReadException {
+        byte resetMask = state.computeCacheResetMask();
+        if (resetMask == 0) {
+            return;
+        }
+        HttpRawSocket rawSocket = context.getRawResponseSocket();
+        long bufAddr = rawSocket.getBufferAddress();
+        long qwpStart = bufAddr + QwpEgressFrameWriter.WS_HEADER_RESERVATION;
+        long bodyStart = QwpEgressFrameWriter.writeMessageHeader(
+                qwpStart, state.getNegotiatedVersion(), (byte) 0, 0, 0 /* payload len patched */);
+        long bodyEnd = QwpEgressFrameWriter.writeCacheReset(bodyStart, resetMask);
+        int qwpSize = (int) (bodyEnd - qwpStart);
+        int qwpPayloadLen = qwpSize - QwpConstants.HEADER_SIZE;
+        QwpEgressFrameWriter.patchPayloadLength(qwpStart, qwpPayloadLen);
+        // Apply the local reset BEFORE sending. rawSocket.send commits bytes
+        // to the response sink before it attempts the flush that may throw
+        // PeerIsSlowToReadException; bytes queued that way flush on resume,
+        // so the client is guaranteed to see the CACHE_RESET frame once the
+        // connection drains. Applying the reset first keeps server and client
+        // views aligned even on the parked-send path.
+        state.applyCacheReset(resetMask);
+        if ((resetMask & QwpEgressMsgKind.RESET_MASK_DICT) != 0) {
+            metrics.markCacheResetDict();
+        }
+        if ((resetMask & QwpEgressMsgKind.RESET_MASK_SCHEMAS) != 0) {
+            metrics.markCacheResetSchemas();
+        }
+        LOG.debug().$("Egress cache reset [fd=").$(context.getFd())
+                .$(", mask=0x").$(Integer.toHexString(resetMask & 0xFF))
+                .I$();
+        sendFrame(rawSocket, bufAddr, qwpStart, qwpSize);
+    }
+
     private int negotiateQwpVersion(HttpRequestHeader requestHeader, long fd) {
         int clientMaxVersion = parseClientMaxVersion(requestHeader);
         int negotiated = Math.min(clientMaxVersion, QwpConstants.MAX_SUPPORTED_VERSION);
@@ -1183,6 +1228,8 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
         }
         return negotiated;
     }
+
+    // Outbound frame serialisation
 
     private void processWebSocketFrames(HttpConnectionContext context, QwpEgressProcessorState state, long buffer, int bufferLen)
             throws ServerDisconnectException, PeerDisconnectedException, PeerIsSlowToReadException {
@@ -1228,53 +1275,6 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
             }
             state.setRecvBufferLen(remaining);
         }
-    }
-
-    // Outbound frame serialisation
-
-    /**
-     * Checks whether any connection-scoped cache has exceeded its soft cap and,
-     * if so, emits a {@code CACHE_RESET} frame and applies the matching server-
-     * side reset so both peers stay in lockstep. Called at query-completion
-     * boundaries (after {@code RESULT_END}, {@code EXEC_DONE}, or
-     * {@code QUERY_ERROR}) -- never mid-stream, because resetting the dict or
-     * the schema cache mid-stream would invalidate ids referenced by in-flight
-     * RESULT_BATCH frames.
-     */
-    private void maybeEmitCacheReset(
-            HttpConnectionContext context,
-            QwpEgressProcessorState state
-    ) throws PeerDisconnectedException, PeerIsSlowToReadException {
-        byte resetMask = state.computeCacheResetMask();
-        if (resetMask == 0) {
-            return;
-        }
-        HttpRawSocket rawSocket = context.getRawResponseSocket();
-        long bufAddr = rawSocket.getBufferAddress();
-        long qwpStart = bufAddr + QwpEgressFrameWriter.WS_HEADER_RESERVATION;
-        long bodyStart = QwpEgressFrameWriter.writeMessageHeader(
-                qwpStart, state.getNegotiatedVersion(), (byte) 0, 0, 0 /* payload len patched */);
-        long bodyEnd = QwpEgressFrameWriter.writeCacheReset(bodyStart, resetMask);
-        int qwpSize = (int) (bodyEnd - qwpStart);
-        int qwpPayloadLen = qwpSize - QwpConstants.HEADER_SIZE;
-        QwpEgressFrameWriter.patchPayloadLength(qwpStart, qwpPayloadLen);
-        // Apply the local reset BEFORE sending. rawSocket.send commits bytes
-        // to the response sink before it attempts the flush that may throw
-        // PeerIsSlowToReadException; bytes queued that way flush on resume,
-        // so the client is guaranteed to see the CACHE_RESET frame once the
-        // connection drains. Applying the reset first keeps server and client
-        // views aligned even on the parked-send path.
-        state.applyCacheReset(resetMask);
-        if ((resetMask & QwpEgressMsgKind.RESET_MASK_DICT) != 0) {
-            metrics.markCacheResetDict();
-        }
-        if ((resetMask & QwpEgressMsgKind.RESET_MASK_SCHEMAS) != 0) {
-            metrics.markCacheResetSchemas();
-        }
-        LOG.debug().$("Egress cache reset [fd=").$(context.getFd())
-                .$(", mask=0x").$(Integer.toHexString(resetMask & 0xFF))
-                .I$();
-        sendFrame(rawSocket, bufAddr, qwpStart, qwpSize);
     }
 
     /**

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressUpgradeProcessor.java
@@ -1229,8 +1229,6 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
         return negotiated;
     }
 
-    // Outbound frame serialisation
-
     private void processWebSocketFrames(HttpConnectionContext context, QwpEgressProcessorState state, long buffer, int bufferLen)
             throws ServerDisconnectException, PeerDisconnectedException, PeerIsSlowToReadException {
         long bufferEnd = buffer + bufferLen;

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/QwpWebSocketUpgradeProcessorOnHeadersReadyTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/QwpWebSocketUpgradeProcessorOnHeadersReadyTest.java
@@ -135,7 +135,7 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
     }
 
     @Test
-    public void testOnHeadersReadyFailsHardWhenServiceUnavailableResponseDoesNotFitBuffer() throws Exception {
+    public void testOnHeadersReadyFailsHardWhenMisdirectedRequestResponseDoesNotFitBuffer() throws Exception {
         assertMemoryLeak(() -> {
             QwpServerInfoProvider previous = engine.getQwpServerInfoProvider();
             engine.setQwpServerInfoProvider(new FakeRoleProvider(QwpEgressMsgKind.ROLE_REPLICA));
@@ -153,7 +153,7 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
                 header.setHeader("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
                 header.setHeader("Sec-WebSocket-Version", "13");
 
-                assertBufferTooSmallFailure(processor, context, "503 ingress role-reject response");
+                assertBufferTooSmallFailure(processor, context, "421 ingress role-reject response");
 
                 Assert.assertEquals(0, context.getMockRawSocket().sentSize);
                 Assert.assertFalse(context.isSwitchProtocolCalled());
@@ -361,8 +361,8 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
             Assert.assertNull("rejected handshake must not allocate processor state", lv.get(context));
 
             String response = readResponse(bufferAddr, context.getMockRawSocket().sentSize);
-            Assert.assertTrue("response must be 503: " + response,
-                    response.startsWith("HTTP/1.1 503 Service Unavailable\r\n"));
+            Assert.assertTrue("response must be 421: " + response,
+                    response.startsWith("HTTP/1.1 421 Misdirected Request\r\n"));
             Assert.assertTrue("response must carry X-QuestDB-Role: " + expectedRoleName + ", got: " + response,
                     response.contains("\r\nX-QuestDB-Role: " + expectedRoleName + "\r\n"));
         } finally {

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/QwpWebSocketUpgradeProcessorOnHeadersReadyTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/QwpWebSocketUpgradeProcessorOnHeadersReadyTest.java
@@ -33,6 +33,8 @@ import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpRawSocket;
 import io.questdb.cutlass.http.HttpRequestHeader;
 import io.questdb.cutlass.http.LocalValue;
+import io.questdb.cutlass.qwp.codec.QwpEgressMsgKind;
+import io.questdb.cutlass.qwp.codec.QwpServerInfoProvider;
 import io.questdb.cutlass.qwp.server.QwpProcessorState;
 import io.questdb.cutlass.qwp.server.QwpWebSocketUpgradeProcessor;
 import io.questdb.network.PeerDisconnectedException;
@@ -56,6 +58,26 @@ import java.nio.charset.StandardCharsets;
 public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCairoTest {
     private static final int HANDSHAKE_BUFFER_SIZE = 1024;
     private static final int TINY_BUFFER_SIZE = 64;
+
+    @Test
+    public void testOnHeadersReadyAcceptsPrimaryRole() throws Exception {
+        assertMemoryLeak(() -> assertHandshakeAcceptedForRole(QwpEgressMsgKind.ROLE_PRIMARY, "PRIMARY"));
+    }
+
+    @Test
+    public void testOnHeadersReadyAcceptsStandaloneRole() throws Exception {
+        assertMemoryLeak(() -> assertHandshakeAcceptedForRole(QwpEgressMsgKind.ROLE_STANDALONE, "STANDALONE"));
+    }
+
+    @Test
+    public void testOnHeadersReadyDoesNotEnableDurableAckWhenHeaderAbsent() throws Exception {
+        assertMemoryLeak(() -> assertDurableAckStateAfterHandshake(null, new FakeEnabledDurableAckRegistry(), false));
+    }
+
+    @Test
+    public void testOnHeadersReadyEnablesDurableAckWhenHeaderTrueAndRegistryEnabled() throws Exception {
+        assertMemoryLeak(() -> assertDurableAckStateAfterHandshake("true", new FakeEnabledDurableAckRegistry(), true));
+    }
 
     @Test
     public void testOnHeadersReadyFailsHardWhenBadRequestResponseDoesNotFitBuffer() throws Exception {
@@ -113,6 +135,37 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
     }
 
     @Test
+    public void testOnHeadersReadyFailsHardWhenServiceUnavailableResponseDoesNotFitBuffer() throws Exception {
+        assertMemoryLeak(() -> {
+            QwpServerInfoProvider previous = engine.getQwpServerInfoProvider();
+            engine.setQwpServerInfoProvider(new FakeRoleProvider(QwpEgressMsgKind.ROLE_REPLICA));
+            HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+            QwpWebSocketUpgradeProcessor processor = new QwpWebSocketUpgradeProcessor(engine, httpConfig);
+            LocalValue<QwpProcessorState> lv = getLV();
+
+            long bufferAddr = Unsafe.malloc(TINY_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+            try (
+                    MockHttpRequestHeader header = new MockHttpRequestHeader();
+                    TestableContext context = new TestableContext(httpConfig, header, new MockRawSocket(bufferAddr, TINY_BUFFER_SIZE))
+            ) {
+                header.setHeader("Upgrade", "websocket");
+                header.setHeader("Connection", "Upgrade");
+                header.setHeader("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
+                header.setHeader("Sec-WebSocket-Version", "13");
+
+                assertBufferTooSmallFailure(processor, context, "503 ingress role-reject response");
+
+                Assert.assertEquals(0, context.getMockRawSocket().sentSize);
+                Assert.assertFalse(context.isSwitchProtocolCalled());
+                Assert.assertNull(lv.get(context));
+            } finally {
+                Unsafe.free(bufferAddr, TINY_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                engine.setQwpServerInfoProvider(previous);
+            }
+        });
+    }
+
+    @Test
     public void testOnHeadersReadyFailsHardWhenUpgradeRequiredResponseDoesNotFitBuffer() throws Exception {
         assertMemoryLeak(() -> {
             HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
@@ -138,6 +191,40 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
                 Unsafe.free(bufferAddr, TINY_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
             }
         });
+    }
+
+    @Test
+    public void testOnHeadersReadyHeaderValueIsCaseInsensitive() throws Exception {
+        assertMemoryLeak(() -> {
+            assertDurableAckStateAfterHandshake("TRUE", new FakeEnabledDurableAckRegistry(), true);
+            assertDurableAckStateAfterHandshake("TrUe", new FakeEnabledDurableAckRegistry(), true);
+        });
+    }
+
+    @Test
+    public void testOnHeadersReadyIgnoresDurableAckWhenRegistryDisabled() throws Exception {
+        // Default OSS behavior: DefaultDurableAckRegistry.isEnabled() returns false,
+        // so even when the client requests durable ack, the state stays disabled.
+        assertMemoryLeak(() -> assertDurableAckStateAfterHandshake("true", DefaultDurableAckRegistry.INSTANCE, false));
+    }
+
+    @Test
+    public void testOnHeadersReadyIgnoresNonTrueHeaderValue() throws Exception {
+        assertMemoryLeak(() -> {
+            assertDurableAckStateAfterHandshake("false", new FakeEnabledDurableAckRegistry(), false);
+            assertDurableAckStateAfterHandshake("", new FakeEnabledDurableAckRegistry(), false);
+            assertDurableAckStateAfterHandshake("yes", new FakeEnabledDurableAckRegistry(), false);
+        });
+    }
+
+    @Test
+    public void testOnHeadersReadyRejectsPrimaryCatchupRole() throws Exception {
+        assertMemoryLeak(() -> assertHandshakeRejectedForRole(QwpEgressMsgKind.ROLE_PRIMARY_CATCHUP, "PRIMARY_CATCHUP"));
+    }
+
+    @Test
+    public void testOnHeadersReadyRejectsReplicaRole() throws Exception {
+        assertMemoryLeak(() -> assertHandshakeRejectedForRole(QwpEgressMsgKind.ROLE_REPLICA, "REPLICA"));
     }
 
     @Test
@@ -167,38 +254,19 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
         });
     }
 
-    @Test
-    public void testOnHeadersReadyDoesNotEnableDurableAckWhenHeaderAbsent() throws Exception {
-        assertMemoryLeak(() -> assertDurableAckStateAfterHandshake(null, new FakeEnabledDurableAckRegistry(), false));
-    }
-
-    @Test
-    public void testOnHeadersReadyEnablesDurableAckWhenHeaderTrueAndRegistryEnabled() throws Exception {
-        assertMemoryLeak(() -> assertDurableAckStateAfterHandshake("true", new FakeEnabledDurableAckRegistry(), true));
-    }
-
-    @Test
-    public void testOnHeadersReadyHeaderValueIsCaseInsensitive() throws Exception {
-        assertMemoryLeak(() -> {
-            assertDurableAckStateAfterHandshake("TRUE", new FakeEnabledDurableAckRegistry(), true);
-            assertDurableAckStateAfterHandshake("TrUe", new FakeEnabledDurableAckRegistry(), true);
-        });
-    }
-
-    @Test
-    public void testOnHeadersReadyIgnoresDurableAckWhenRegistryDisabled() throws Exception {
-        // Default OSS behavior: DefaultDurableAckRegistry.isEnabled() returns false,
-        // so even when the client requests durable ack, the state stays disabled.
-        assertMemoryLeak(() -> assertDurableAckStateAfterHandshake("true", DefaultDurableAckRegistry.INSTANCE, false));
-    }
-
-    @Test
-    public void testOnHeadersReadyIgnoresNonTrueHeaderValue() throws Exception {
-        assertMemoryLeak(() -> {
-            assertDurableAckStateAfterHandshake("false", new FakeEnabledDurableAckRegistry(), false);
-            assertDurableAckStateAfterHandshake("", new FakeEnabledDurableAckRegistry(), false);
-            assertDurableAckStateAfterHandshake("yes", new FakeEnabledDurableAckRegistry(), false);
-        });
+    private static void assertBufferTooSmallFailure(
+            QwpWebSocketUpgradeProcessor processor,
+            TestableContext context,
+            CharSequence expectedResponseType
+    )
+            throws PeerDisconnectedException {
+        try {
+            processor.onHeadersReady(context);
+            Assert.fail("Expected HttpException");
+        } catch (HttpException e) {
+            TestUtils.assertContains(e.getFlyweightMessage(), expectedResponseType);
+            TestUtils.assertContains(e.getFlyweightMessage(), "does not fit send buffer");
+        }
     }
 
     private static void assertDurableAckStateAfterHandshake(
@@ -237,18 +305,69 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
         }
     }
 
-    private static void assertBufferTooSmallFailure(
-            QwpWebSocketUpgradeProcessor processor,
-            TestableContext context,
-            CharSequence expectedResponseType
-    )
-            throws PeerDisconnectedException {
-        try {
+    private static void assertHandshakeAcceptedForRole(byte role, String expectedRoleName) throws Exception {
+        QwpServerInfoProvider previous = engine.getQwpServerInfoProvider();
+        engine.setQwpServerInfoProvider(new FakeRoleProvider(role));
+        HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+        QwpWebSocketUpgradeProcessor processor = new QwpWebSocketUpgradeProcessor(engine, httpConfig);
+        LocalValue<QwpProcessorState> lv = getLV();
+
+        long bufferAddr = Unsafe.malloc(HANDSHAKE_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+        try (
+                MockHttpRequestHeader header = new MockHttpRequestHeader();
+                TestableContext context = new TestableContext(httpConfig, header, new MockRawSocket(bufferAddr, HANDSHAKE_BUFFER_SIZE))
+        ) {
+            header.setHeader("Upgrade", "websocket");
+            header.setHeader("Connection", "Upgrade");
+            header.setHeader("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
+            header.setHeader("Sec-WebSocket-Version", "13");
+
             processor.onHeadersReady(context);
-            Assert.fail("Expected HttpException");
-        } catch (HttpException e) {
-            TestUtils.assertContains(e.getFlyweightMessage(), expectedResponseType);
-            TestUtils.assertContains(e.getFlyweightMessage(), "does not fit send buffer");
+
+            Assert.assertTrue("handshake must have switched protocol", context.isSwitchProtocolCalled());
+            Assert.assertNotNull("state must be populated after successful handshake", lv.get(context));
+
+            String response = readResponse(bufferAddr, context.getMockRawSocket().sentSize);
+            Assert.assertTrue("response must start with 101: " + response,
+                    response.startsWith("HTTP/1.1 101 Switching Protocols\r\n"));
+            Assert.assertTrue("response must carry X-QuestDB-Role: " + expectedRoleName + ", got: " + response,
+                    response.contains("\r\nX-QuestDB-Role: " + expectedRoleName + "\r\n"));
+        } finally {
+            Unsafe.free(bufferAddr, HANDSHAKE_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+            engine.setQwpServerInfoProvider(previous);
+        }
+    }
+
+    private static void assertHandshakeRejectedForRole(byte role, String expectedRoleName) throws Exception {
+        QwpServerInfoProvider previous = engine.getQwpServerInfoProvider();
+        engine.setQwpServerInfoProvider(new FakeRoleProvider(role));
+        HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+        QwpWebSocketUpgradeProcessor processor = new QwpWebSocketUpgradeProcessor(engine, httpConfig);
+        LocalValue<QwpProcessorState> lv = getLV();
+
+        long bufferAddr = Unsafe.malloc(HANDSHAKE_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+        try (
+                MockHttpRequestHeader header = new MockHttpRequestHeader();
+                TestableContext context = new TestableContext(httpConfig, header, new MockRawSocket(bufferAddr, HANDSHAKE_BUFFER_SIZE))
+        ) {
+            header.setHeader("Upgrade", "websocket");
+            header.setHeader("Connection", "Upgrade");
+            header.setHeader("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
+            header.setHeader("Sec-WebSocket-Version", "13");
+
+            processor.onHeadersReady(context);
+
+            Assert.assertFalse("rejected handshake must not switch protocol", context.isSwitchProtocolCalled());
+            Assert.assertNull("rejected handshake must not allocate processor state", lv.get(context));
+
+            String response = readResponse(bufferAddr, context.getMockRawSocket().sentSize);
+            Assert.assertTrue("response must be 503: " + response,
+                    response.startsWith("HTTP/1.1 503 Service Unavailable\r\n"));
+            Assert.assertTrue("response must carry X-QuestDB-Role: " + expectedRoleName + ", got: " + response,
+                    response.contains("\r\nX-QuestDB-Role: " + expectedRoleName + "\r\n"));
+        } finally {
+            Unsafe.free(bufferAddr, HANDSHAKE_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+            engine.setQwpServerInfoProvider(previous);
         }
     }
 
@@ -257,6 +376,49 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
         Field lvField = QwpWebSocketUpgradeProcessor.class.getDeclaredField("LV");
         lvField.setAccessible(true);
         return (LocalValue<QwpProcessorState>) lvField.get(null);
+    }
+
+    private static String readResponse(long bufferAddr, int size) {
+        byte[] bytes = new byte[size];
+        for (int i = 0; i < size; i++) {
+            bytes[i] = Unsafe.getUnsafe().getByte(bufferAddr + i);
+        }
+        return new String(bytes, StandardCharsets.US_ASCII);
+    }
+
+    private static final class FakeEnabledDurableAckRegistry implements DurableAckRegistry {
+        @Override
+        public long getDurablyUploadedSeqTxn(CharSequence tableDirName) {
+            return -1L;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return true;
+        }
+    }
+
+    private record FakeRoleProvider(byte role) implements QwpServerInfoProvider {
+
+        @Override
+        public int getCapabilities() {
+            return 0;
+        }
+
+        @Override
+        public CharSequence getClusterId() {
+            return "";
+        }
+
+        @Override
+        public long getEpoch() {
+            return 0L;
+        }
+
+        @Override
+        public CharSequence getNodeId() {
+            return "";
+        }
     }
 
     private static class MockHttpRequestHeader implements HttpRequestHeader, AutoCloseable {
@@ -454,18 +616,6 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
 
         boolean isSwitchProtocolCalled() {
             return switchProtocolCalled;
-        }
-    }
-
-    private static final class FakeEnabledDurableAckRegistry implements DurableAckRegistry {
-        @Override
-        public long getDurablyUploadedSeqTxn(CharSequence tableDirName) {
-            return -1L;
-        }
-
-        @Override
-        public boolean isEnabled() {
-            return true;
         }
     }
 }


### PR DESCRIPTION
`/write/v4` upgrade now advertises the server's replication role on every response: `X-QuestDB-Role` is attached to the 101 success path, and `REPLICA` / `PRIMARY_CATCHUP` nodes return `421 Misdirected Request` + the same header instead of upgrading. Clients with multiple `addr=` entries use this signal to fail over past non-writable nodes and route to the current `PRIMARY` automatically.

OSS behavior unchanged — `DefaultQwpServerInfoProvider` always returns `STANDALONE`, which always upgrades.