### PR TITLE
chore(core): fix yet another posting index bug found by fuzz

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -4816,7 +4816,21 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         try {
             keyFileName(indexType, path.trimTo(plen), columnName, columnNameTxn);
 
-            if (!force && ff.exists(path.$())) {
+            if (IndexType.isPosting(indexType)) {
+                // POSTING preserves chain history across the partition's
+                // lifecycle: the genCounter in the .pk header is the
+                // high-water sealTxn that pending orphan purges may target.
+                // Wiping and reinitialising the .pk would reset genCounter to
+                // -1, so the writer's next appendNewEntry would reuse
+                // sealTxn=0 and recreate .pv.0 at a path that an outstanding
+                // orphan purge for sealTxn=0 would then delete out from under
+                // the live writer. Skip the recreate when the .pk already
+                // exists; the writer's recovery walk drops abandoned chain
+                // entries on reopen, which is the right cleanup for POSTING.
+                if (ff.exists(path.$())) {
+                    return;
+                }
+            } else if (!force && ff.exists(path.$())) {
                 return;
             } else {
                 ff.removeQuiet(path.$());

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -4825,11 +4825,18 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 // sealTxn=0 and recreate .pv.0 at a path that an outstanding
                 // orphan purge for sealTxn=0 would then delete out from under
                 // the live writer. Skip the recreate when the .pk already
-                // exists; the writer's recovery walk drops abandoned chain
-                // entries on reopen, which is the right cleanup for POSTING.
-                if (ff.exists(path.$())) {
+                // exists with a published seqlock header; the writer's
+                // recovery walk drops abandoned chain entries on reopen,
+                // which is the right cleanup for POSTING. A .pk that is
+                // missing, truncated, or has zeroed seqlock pages is a
+                // leftover from an earlier init that failed before
+                // publishing Page A (e.g. mmap failure mid-write); it
+                // carries no chain history worth preserving and would crash
+                // the next reader, so wipe it and recreate from scratch.
+                if (PostingIndexUtils.hasInitialisedKeyFileHeader(ff, path.$())) {
                     return;
                 }
+                ff.removeQuiet(path.$());
             } else if (!force && ff.exists(path.$())) {
                 return;
             } else {

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexUtils.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexUtils.java
@@ -991,6 +991,43 @@ public final class PostingIndexUtils {
     }
 
     /**
+     * Returns true when the file at {@code keyFilePath} exists and at least
+     * one of its two seqlock header pages is in the published, stable state
+     * that {@code PostingIndexWriter.initKeyMemory} leaves behind on a
+     * successful init. Returns false for missing files, files shorter than
+     * {@link #KEY_FILE_RESERVED} (truncated mid-init), and files whose
+     * Page A and Page B both have zeroed/torn seqlocks (the shape we observe
+     * when an earlier writer mapped the file but never wrote a complete
+     * header before failing).
+     * <p>
+     * Used by {@code TableWriter.createIndexFiles} to decide whether to
+     * preserve an existing .pk (so its chain history survives a writer
+     * reopen) or wipe it as garbage from a previous failed init. Does not
+     * validate entry-region pointers, which can legitimately be empty on a
+     * freshly initialised chain.
+     */
+    public static boolean hasInitialisedKeyFileHeader(FilesFacade ff, LPSZ keyFilePath) {
+        if (!ff.exists(keyFilePath) || ff.length(keyFilePath) < KEY_FILE_RESERVED) {
+            return false;
+        }
+        long fd = ff.openRO(keyFilePath);
+        if (fd < 0) {
+            return false;
+        }
+        try {
+            long seqStartA = ff.readNonNegativeLong(fd, PAGE_A_OFFSET + V2_HEADER_OFFSET_SEQUENCE_START);
+            long seqEndA = ff.readNonNegativeLong(fd, PAGE_A_OFFSET + V2_HEADER_OFFSET_SEQUENCE_END);
+            long seqStartB = ff.readNonNegativeLong(fd, PAGE_B_OFFSET + V2_HEADER_OFFSET_SEQUENCE_START);
+            long seqEndB = ff.readNonNegativeLong(fd, PAGE_B_OFFSET + V2_HEADER_OFFSET_SEQUENCE_END);
+            boolean aStable = seqStartA != 0L && seqStartA == seqEndA && (seqStartA & 1L) == 0L;
+            boolean bStable = seqStartB != 0L && seqStartB == seqEndB && (seqStartB & 1L) == 0L;
+            return aStable || bStable;
+        } finally {
+            ff.close(fd);
+        }
+    }
+
+    /**
      * Builds the full path to the key file (.pk).
      * <p>
      * Filename format: <code>&lt;name&gt;.pk.&lt;postingColumnNameTxn&gt;</code>.


### PR DESCRIPTION
## Summary

When `TableWriter.createIndexFiles` runs against a partition that already
has a `.pk` posting-index key file, it used to wipe and reinitialise the
file. That reset `genCounter` to `-1`, so the writer's next
`appendNewEntry` reused `sealTxn=0` and recreated `.pv.0` at a path that
an outstanding orphan-purge for `sealTxn=0` would then delete out from
under the live writer. The resulting failure mode is a runtime
`could not open, file does not exist: .../sym2.pv.0` from the next
reader, or — when the purge races with the writer rather than killing it
outright — a silent row mismatch between WAL and non-WAL views of the
same data.

This PR makes the POSTING branch of `createIndexFiles` preserve an
existing `.pk` whose seqlock header is in a published, stable state, so
its chain history survives writer reopen. The `.pk` only gets wiped when
its header is missing, truncated, or zeroed — leftovers from an earlier
init that crashed before publishing Page A and that carry no chain
history worth preserving. Validation lives in a new
`PostingIndexUtils.hasInitialisedKeyFileHeader` helper.

## Tradeoffs

- POSTING now ignores the `force` flag in `createIndexFiles`. Callers
  that pass `force=true` to recreate an index from scratch will instead
  reuse the existing `.pk` if it has a valid header. This is by design:
  `genCounter` is a high-water mark for orphan purges and must not
  regress, so wiping a valid `.pk` is unsafe regardless of intent.
- The validity check opens the file read-only and reads four 8-byte
  fields. That's one extra `openRO`/`close` per indexed column per
  partition open compared to the previous bare `ff.exists` check.
  Negligible against partition-open cost.

## Verification

Fuzz reproducers (frozen seeds) run locally against this branch:

- `WalWriterFuzzTest.testWalWriteRollbackTruncateHeavy` — seeds
  `4160224326802423175L, 630096581114372683L` (failure originally
  manifested as `could not open, file does not exist:
  .../sym2.pv.0` from `PostingIndexFwdReader`).
- `com.questdb.cairo.fuzz.SequencerV2ToV1MigrationFuzzTest.testMigrationWithSchemaChanges`
  — seeds `7259504071682373373L, 6177862713324340969L` (failure
  originally manifested as a row-mismatch in
  `FuzzRunner.checkIndexRandomValueScan`). This test lives in
  questdb-enterprise and depends on parquet APIs that have moved on
  this branch; it was not re-run end-to-end locally. The architectural
  invariant the fix relies on — preserve any `.pk` written by a
  successful `initKeyMemory`, wipe only partial/zeroed leftovers — is
  identical to what the original orphan-purge race needed, so the same
  fuzz failure mode remains covered.

Test plan:

- `mvn -pl core -Dtest=FullFwdPartitionFrameCursorTest test` — 165 pass
  (the three `testIndexFailInConstructorByNoneEmpty{1,2,3}k` cases that
  regressed when the early version of this fix preserved any existing
  `.pk` now go through the header-validity path correctly).
- `mvn -pl core -Dtest='PostingSealPurgeTest,PostingIndexChainTest,PostingIndexChainWriterTest,IndexFactoryTest,IndexBuilderTest,IndexTypeTest,CoveringIndexTest' test`
  — 433 pass.
- Full Cairo and Griffin CI on Azure Pipelines.
