### PR TITLE
chore(sql): allow disabling covering index for refresh queries

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -325,6 +325,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final DateLocale logTimestampLocale;
     private final String logTimestampTimezone;
     private final TimeZoneRules logTimestampTimezoneRules;
+    private final boolean matViewCoveringIndexEnabled;
     private final boolean matViewEnabled;
     private final long matViewInsertAsSelectBatchSize;
     private final int matViewMaxRefreshIntervals;
@@ -2105,6 +2106,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
             this.walParallelExecutionEnabled = getBoolean(properties, env, PropertyKey.CAIRO_WAL_APPLY_PARALLEL_SQL_ENABLED, true);
             this.matViewParallelExecutionEnabled = getBoolean(properties, env, PropertyKey.CAIRO_MAT_VIEW_PARALLEL_SQL_ENABLED, cpuAvailable >= 4);
+            this.matViewCoveringIndexEnabled = getBoolean(properties, env, PropertyKey.CAIRO_MAT_VIEW_COVERING_INDEX_ENABLED, false);
             this.sqlParallelWorkStealingThreshold = getInt(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_WORK_STEALING_THRESHOLD, 16);
             this.sqlParallelWorkStealingSpinTimeout = getNanos(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_WORK_STEALING_SPIN_TIMEOUT, 50_000);
             this.sqlParquetFrameCacheCapacity = Math.max(getInt(properties, env, PropertyKey.CAIRO_SQL_PARQUET_FRAME_CACHE_CAPACITY, 8), 8);
@@ -4856,6 +4858,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean isIOURingEnabled() {
             return ioURingEnabled;
+        }
+
+        @Override
+        public boolean isMatViewCoveringIndexEnabled() {
+            return matViewCoveringIndexEnabled;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -213,6 +213,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     CAIRO_MAT_VIEW_INSERT_AS_SELECT_BATCH_SIZE("cairo.mat.view.insert.as.select.batch.size"),
     CAIRO_MAT_VIEW_ROWS_PER_QUERY_ESTIMATE("cairo.mat.view.rows.per.query.estimate"),
     CAIRO_MAT_VIEW_PARALLEL_SQL_ENABLED("cairo.mat.view.parallel.sql.enabled"),
+    CAIRO_MAT_VIEW_COVERING_INDEX_ENABLED("cairo.mat.view.covering.index.enabled"),
     CAIRO_MAT_VIEW_MAX_REFRESH_INTERVALS("cairo.mat.view.max.refresh.intervals"),
     CAIRO_MAT_VIEW_MAX_REFRESH_STEP("cairo.mat.view.max.refresh.step"),
     CAIRO_MAT_VIEW_REFRESH_INTERVALS_UPDATE_PERIOD("cairo.mat.view.refresh.intervals.update.period"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -886,6 +886,8 @@ public interface CairoConfiguration {
 
     boolean isIOURingEnabled();
 
+    boolean isMatViewCoveringIndexEnabled();
+
     boolean isMatViewEnabled();
 
     boolean isMatViewParallelSqlEnabled();

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -1527,6 +1527,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public boolean isMatViewCoveringIndexEnabled() {
+        return getDelegate().isMatViewCoveringIndexEnabled();
+    }
+
+    @Override
     public boolean isMatViewEnabled() {
         return getDelegate().isMatViewEnabled();
     }

--- a/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/DefaultCairoConfiguration.java
@@ -1536,6 +1536,11 @@ public class DefaultCairoConfiguration implements CairoConfiguration {
     }
 
     @Override
+    public boolean isMatViewCoveringIndexEnabled() {
+        return false;
+    }
+
+    @Override
     public boolean isMatViewEnabled() {
         return true;
     }

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshSqlExecutionContext.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshSqlExecutionContext.java
@@ -44,6 +44,7 @@ import io.questdb.std.str.CharSink;
 import org.jetbrains.annotations.NotNull;
 
 public class MatViewRefreshSqlExecutionContext extends SqlExecutionContextImpl {
+    private final boolean coveringIndexEnabled;
     private TableReader baseTableReader;
     private TableToken viewTableToken;
 
@@ -56,6 +57,7 @@ public class MatViewRefreshSqlExecutionContext extends SqlExecutionContextImpl {
             setParallelWindowJoinEnabled(false);
             setParallelReadParquetEnabled(false);
         }
+        this.coveringIndexEnabled = engine.getConfiguration().isMatViewCoveringIndexEnabled();
         this.securityContext = new ReadOnlySecurityContext() {
             @Override
             public void authorizeInsert(TableToken tableToken) {
@@ -108,6 +110,11 @@ public class MatViewRefreshSqlExecutionContext extends SqlExecutionContextImpl {
             return getCairoEngine().getReaderAtTxn(baseTableReader);
         }
         return getCairoEngine().getReader(tableToken);
+    }
+
+    @Override
+    public boolean isCoveringIndexEnabled() {
+        return coveringIndexEnabled;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -5765,7 +5765,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                     ? SymbolTable.VALUE_NOT_FOUND
                                     : symbolMapReader.keyOf(symbolValueFunc.getStrA(null));
 
-                            if (!SqlHints.hasNoCoveringHint(model)) {
+                            if (!SqlHints.hasNoCoveringHint(model) && executionContext.isCoveringIndexEnabled()) {
                                 // Check if covering index can serve LATEST ON (with or without filter)
                                 int keyReaderColIdx = columnIndexes.getQuick(latestByIndex);
                                 int[] coveringMapping = buildCoveringIndexMapping(
@@ -5848,7 +5848,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     }
 
                     // Check if covering index can serve LATEST ON multi-key (with or without filter)
-                    if (!SqlHints.hasNoCoveringHint(model)) {
+                    if (!SqlHints.hasNoCoveringHint(model) && executionContext.isCoveringIndexEnabled()) {
                         int keyReaderColIdx = columnIndexes.getQuick(latestByIndex);
                         int[] coveringMapping = buildCoveringIndexMapping(
                                 reader, keyReaderColIdx, columnIndexes, metadata
@@ -7663,7 +7663,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             // is pushed into IntervalPartitionFrameCursorFactory which bounds the row range per partition.
             if (columns.size() == 1 && columns.getQuick(0).getAst().type == LITERAL
                     && !SqlHints.hasNoIndexHint(model)
-                    && !SqlHints.hasNoCoveringHint(model)) {
+                    && !SqlHints.hasNoCoveringHint(model)
+                    && executionContext.isCoveringIndexEnabled()) {
                 CharSequence colName = columns.getQuick(0).getAst().token;
                 IQueryModel tableModel = model.getNestedModel();
                 if (tableModel != null && tableModel.getTableName() != null
@@ -9504,7 +9505,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                         ? SymbolTable.VALUE_NOT_FOUND
                                         : symbolMapReader.keyOf(symbolFunc.getStrA(null));
 
-                                if (!SqlHints.hasNoCoveringHint(model) && !model.isUpdate()) {
+                                if (!SqlHints.hasNoCoveringHint(model) && !model.isUpdate() && executionContext.isCoveringIndexEnabled()) {
                                     int keyReaderColIdx = columnIndexes.getQuick(keyColumnIndex);
                                     int[] coveringMapping = buildCoveringIndexMapping(
                                             reader, keyReaderColIdx, columnIndexes, queryMeta
@@ -9605,7 +9606,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                         }
 
                         // Check if covering index can serve IN-list queries
-                        if (!orderByKeyColumn && !SqlHints.hasNoCoveringHint(model) && !model.isUpdate()) {
+                        if (!orderByKeyColumn && !SqlHints.hasNoCoveringHint(model) && !model.isUpdate() && executionContext.isCoveringIndexEnabled()) {
                             int keyReaderColIdx = columnIndexes.getQuick(keyColumnIndex);
                             int[] coveringMapping = buildCoveringIndexMapping(
                                     reader, keyReaderColIdx, columnIndexes, queryMeta

--- a/core/src/main/java/io/questdb/griffin/SqlExecutionContext.java
+++ b/core/src/main/java/io/questdb/griffin/SqlExecutionContext.java
@@ -205,6 +205,13 @@ public interface SqlExecutionContext extends Sinkable, Closeable {
 
     boolean isCacheHit();
 
+    // Returns false only for materialized view refresh contexts when the
+    // cairo.mat.view.covering.index.enabled property is set to false.
+    // All other contexts always return true.
+    default boolean isCoveringIndexEnabled() {
+        return true;
+    }
+
     // Returns true when where intrinsics are overridden, i.e. by a materialized view refresh
     default boolean isOverriddenIntrinsics(TableToken tableToken) {
         return false;

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -208,6 +208,7 @@ public class PropServerConfigurationTest {
         Assert.assertEquals(5, configuration.getCairoConfiguration().getCreateAsSelectRetryCount());
         Assert.assertEquals(8, configuration.getCairoConfiguration().getViewLexerPoolCapacity());
         Assert.assertTrue(configuration.getCairoConfiguration().isMatViewEnabled());
+        Assert.assertFalse(configuration.getCairoConfiguration().isMatViewCoveringIndexEnabled());
         Assert.assertEquals(10, configuration.getCairoConfiguration().getMatViewMaxRefreshRetries());
         Assert.assertEquals(200, configuration.getCairoConfiguration().getMatViewRefreshOomRetryTimeout());
         Assert.assertEquals(1_000_000, configuration.getCairoConfiguration().getMatViewInsertAsSelectBatchSize());
@@ -1700,6 +1701,7 @@ public class PropServerConfigurationTest {
             Assert.assertEquals(1000, configuration.getCairoConfiguration().getMatViewInsertAsSelectBatchSize());
             Assert.assertEquals(10000, configuration.getCairoConfiguration().getMatViewRowsPerQueryEstimate());
             Assert.assertFalse(configuration.getCairoConfiguration().isMatViewParallelSqlEnabled());
+            Assert.assertTrue(configuration.getCairoConfiguration().isMatViewCoveringIndexEnabled());
             Assert.assertEquals(10, configuration.getCairoConfiguration().getMatViewMaxRefreshIntervals());
             Assert.assertEquals(4200, configuration.getCairoConfiguration().getMatViewRefreshIntervalsUpdatePeriod());
             Assert.assertEquals(1_000_000, configuration.getCairoConfiguration().getMatViewMaxRefreshStepUs());

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -904,6 +904,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "metrics.enabled\tQDB_METRICS_ENABLED\tfalse\tconf\tfalse\tfalse\n" +
                                     "cairo.metadata.cache.snapshot.ordered\tQDB_CAIRO_METADATA_CACHE_SNAPSHOT_ORDERED\ttrue\tdefault\tfalse\tfalse\n" +
                                     "cairo.mat.view.enabled\tQDB_CAIRO_MAT_VIEW_ENABLED\ttrue\tdefault\tfalse\tfalse\n" +
+                                    "cairo.mat.view.covering.index.enabled\tQDB_CAIRO_MAT_VIEW_COVERING_INDEX_ENABLED\tfalse\tdefault\tfalse\tfalse\n" +
                                     "cairo.mat.view.max.refresh.retries\tQDB_CAIRO_MAT_VIEW_MAX_REFRESH_RETRIES\t10\tdefault\tfalse\ttrue\n" +
                                     "cairo.mat.view.refresh.oom.retry.timeout\tQDB_CAIRO_MAT_VIEW_REFRESH_OOM_RETRY_TIMEOUT\t200\tdefault\tfalse\tfalse\n" +
                                     "cairo.mat.view.insert.as.select.batch.size\tQDB_CAIRO_MAT_VIEW_INSERT_AS_SELECT_BATCH_SIZE\t1000000\tdefault\tfalse\ttrue\n" +

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewCoveringIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewCoveringIndexTest.java
@@ -1,0 +1,153 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.mv;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.mv.MatViewRefreshSqlExecutionContext;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.Chars;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MatViewCoveringIndexTest extends AbstractCairoTest {
+
+    // Plan signature emitted by CoveringIndexRecordCursorFactory.
+    private static final String COVERING_INDEX_MARKER = "CoveringIndex";
+    // Plan signature emitted by PostingIndexDistinctRecordCursorFactory.
+    private static final String POSTING_DISTINCT_MARKER = "PostingIndex op: distinct on:";
+
+    @Test
+    public void testEnabledOverrideRestoresCoveringInRefresh() throws Exception {
+        // With the config flipped to true, the mat-view refresh context must use
+        // covering again for at least the simplest covering-eligible query.
+        setProperty(PropertyKey.CAIRO_MAT_VIEW_COVERING_INDEX_ENABLED, "true");
+        assertMemoryLeak(() -> {
+            createCoveringTable();
+            try (MatViewRefreshSqlExecutionContext refreshCtx = new MatViewRefreshSqlExecutionContext(engine, 0);
+                 TableReader baseReader = engine.getReader("t_cov")) {
+                refreshCtx.of(baseReader);
+                Assert.assertTrue(refreshCtx.isCoveringIndexEnabled());
+                assertPlanContains(refreshCtx, "SELECT sym, price FROM t_cov WHERE sym = 'A'", COVERING_INDEX_MARKER);
+            }
+        });
+    }
+
+    @Test
+    public void testGateAtAllCoveringSites() throws Exception {
+        // Each query shape exercises a distinct covering-index gate site in
+        // SqlCodeGenerator. Under the default config (covering disabled for
+        // mat view refresh) the refresh context must NOT pick the covering
+        // factory at any of them, while the regular context still does.
+        assertMemoryLeak(() -> {
+            createCoveringTable();
+            assertGated("SELECT sym, price FROM t_cov WHERE sym = 'A'", COVERING_INDEX_MARKER);
+            assertGated("SELECT sym, price FROM t_cov WHERE sym IN ('A', 'B')", COVERING_INDEX_MARKER);
+            assertGated("SELECT sym, price FROM t_cov WHERE sym = 'A' LATEST ON ts PARTITION BY sym", COVERING_INDEX_MARKER);
+            assertGated("SELECT sym, price FROM t_cov WHERE sym IN ('A', 'B') LATEST ON ts PARTITION BY sym", COVERING_INDEX_MARKER);
+            assertGated("SELECT DISTINCT sym FROM t_cov", POSTING_DISTINCT_MARKER);
+        });
+    }
+
+    @Test
+    public void testRegularContextUnaffectedByDefault() throws Exception {
+        // The flag is mat-view-only. Regular ad-hoc queries must still pick
+        // covering even with the default-off config.
+        assertMemoryLeak(() -> {
+            createCoveringTable();
+            Assert.assertTrue(sqlExecutionContext.isCoveringIndexEnabled());
+            assertPlanContains(sqlExecutionContext, "SELECT sym, price FROM t_cov WHERE sym = 'A'", COVERING_INDEX_MARKER);
+            assertPlanContains(sqlExecutionContext, "SELECT sym, price FROM t_cov WHERE sym IN ('A', 'B')", COVERING_INDEX_MARKER);
+            assertPlanContains(sqlExecutionContext, "SELECT sym, price FROM t_cov WHERE sym = 'A' LATEST ON ts PARTITION BY sym", COVERING_INDEX_MARKER);
+            assertPlanContains(sqlExecutionContext, "SELECT sym, price FROM t_cov WHERE sym IN ('A', 'B') LATEST ON ts PARTITION BY sym", COVERING_INDEX_MARKER);
+            assertPlanContains(sqlExecutionContext, "SELECT DISTINCT sym FROM t_cov", POSTING_DISTINCT_MARKER);
+        });
+    }
+
+    private void assertGated(String query, String marker) throws Exception {
+        // Sanity: regular context picks the covering/posting plan.
+        assertPlanContains(sqlExecutionContext, query, marker);
+        // Refresh context (default config: disabled) must avoid it.
+        try (MatViewRefreshSqlExecutionContext refreshCtx = new MatViewRefreshSqlExecutionContext(engine, 0);
+             TableReader baseReader = engine.getReader("t_cov")) {
+            refreshCtx.of(baseReader);
+            Assert.assertFalse(refreshCtx.isCoveringIndexEnabled());
+            assertPlanDoesNotContain(refreshCtx, query, marker);
+        }
+    }
+
+    private void assertPlanContains(SqlExecutionContext ctx, String query, String marker) throws Exception {
+        String plan = compilePlan(ctx, query);
+        Assert.assertTrue(
+                "expected plan for [" + query + "] to contain '" + marker + "', got:\n" + plan,
+                plan.contains(marker)
+        );
+    }
+
+    private void assertPlanDoesNotContain(SqlExecutionContext ctx, String query, String marker) throws Exception {
+        String plan = compilePlan(ctx, query);
+        Assert.assertFalse(
+                "expected plan for [" + query + "] to not contain '" + marker + "', got:\n" + plan,
+                plan.contains(marker)
+        );
+    }
+
+    private String compilePlan(SqlExecutionContext ctx, String query) throws Exception {
+        try (SqlCompiler compiler = engine.getSqlCompiler();
+             RecordCursorFactory factory = compiler.compile(query, ctx).getRecordCursorFactory()) {
+            planSink.clear();
+            planSink.of(factory, ctx);
+            StringBuilder sb = new StringBuilder();
+            for (int i = 1, n = planSink.getLineCount(); i <= n; i++) {
+                if (i > 1) {
+                    sb.append('\n');
+                }
+                sb.append(Chars.toString(planSink.getLine(i)));
+            }
+            return sb.toString();
+        }
+    }
+
+    private void createCoveringTable() throws Exception {
+        execute("""
+                CREATE TABLE t_cov (
+                    ts TIMESTAMP,
+                    sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                    price DOUBLE
+                ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                """);
+        execute("""
+                INSERT INTO t_cov
+                SELECT dateadd('s', x::INT, '2024-01-01')::TIMESTAMP,
+                       rnd_symbol('A','B','C'),
+                       rnd_double() * 100
+                FROM long_sequence(100)
+                """);
+        engine.releaseAllWriters();
+    }
+}

--- a/core/src/test/resources/server.conf
+++ b/core/src/test/resources/server.conf
@@ -74,6 +74,7 @@ cairo.mat.view.refresh.oom.retry.timeout=10
 cairo.mat.view.insert.as.select.batch.size=1000
 cairo.mat.view.rows.per.query.estimate=10000
 cairo.mat.view.parallel.sql.enabled=false
+cairo.mat.view.covering.index.enabled=true
 cairo.mat.view.max.refresh.intervals=10
 cairo.mat.view.refresh.intervals.update.period=4200
 cairo.mat.view.max.refresh.step=1000000


### PR DESCRIPTION
This is a temporary measure whilst we improve async group by performance for queries leveraging the covering index.

## Summary

- Adds the `cairo.mat.view.covering.index.enabled` configuration option (default `false`). When false, the SQL planner skips the covering-index path for materialized view refresh queries and uses the regular plan instead.
- Covering-index group-by and multi-threaded performance currently lags the regular plan, which can hurt mat view refresh latency for queries that would otherwise pick up the new path. This option lets operators opt out until that gap is closed.
- Tradeoff: setups where covering would have made the refresh faster (small, highly selective filters with INCLUDE columns) lose that speed-up while the option is left at its default. Ad-hoc queries are unaffected — they always use covering when eligible.

The gate is implemented as a `default` method on `SqlExecutionContext` returning `true`. `MatViewRefreshSqlExecutionContext` is the sole override; it caches the config value at construction. `SqlCodeGenerator` AND's the new check into the existing `!SqlHints.hasNoCoveringHint(model)` condition at all five covering-eligible decision points (LATEST ON single-key, LATEST ON multi-key, IN-list / equality single-key, IN-list multi-key, DISTINCT-via-posting symbol enumeration).

## Test plan

- new `MatViewCoveringIndexTest` exercises all five covering-index gate sites in `SqlCodeGenerator` and verifies the refresh context drops covering by default while the regular context still picks it
- `MatViewCoveringIndexTest` also covers the override path (`cairo.mat.view.covering.index.enabled=true` restores covering for refresh)
- `PropServerConfigurationTest` updated for both default-off and override-on assertions
- regression check: existing `CoveringIndexTest` (344) and `MatViewTest` (175) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)