### PR TITLE
fix(pgwire): fix partial query result when re-binding a suspended portal

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -722,9 +722,11 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
         }
 
         if (pipelineCurrentEntry.isSuspended()) {
-            // Symmetric to the pre-lookup check above. The lookup may have brought in
-            // a named entry whose cursor was retained from a previous Execute (e.g.,
-            // queued onto pipeline by an earlier Close-S that displaced it). A new
+            // Symmetric to the pre-lookup check above. The lookup may have re-introduced
+            // a named entry whose cursor was retained from a previous suspended Execute
+            // (e.g., a Close-S of an unrelated statement landed in between, intentionally
+            // preserving the suspended cursor; an intervening Sync then nulled
+            // pipelineCurrentEntry, so the pre-lookup guard could not see it). A new
             // Bind always starts a fresh execution, so the prior cursor must be freed.
             pipelineCurrentEntry.closeSuspendedCursor();
         }
@@ -1553,12 +1555,6 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
             if (pe.isCopy || (!pe.isPreparedStatement() && !pe.isPortal())) {
                 releaseToPool(pe);
             } else {
-                if (pe.isSuspended()) {
-                    // The entry is being displaced (not retained as the current entry).
-                    // Its cursor must be freed here because nothing else will resume it,
-                    // and clearState() does not touch stateSuspended or cursor.
-                    pe.closeSuspendedCursor();
-                }
                 pe.clearState();
             }
         }

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -721,6 +721,14 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
             throw msgKaput().put("received a Bind message without a matching Parse");
         }
 
+        if (pipelineCurrentEntry.isSuspended()) {
+            // Symmetric to the pre-lookup check above. The lookup may have brought in
+            // a named entry whose cursor was retained from a previous Execute (e.g.,
+            // queued onto pipeline by an earlier Close-S that displaced it). A new
+            // Bind always starts a fresh execution, so the prior cursor must be freed.
+            pipelineCurrentEntry.closeSuspendedCursor();
+        }
+
         pipelineCurrentEntry.setStateBind(true);
 
         // "bind" is asking us to create portal. We take the conservative approach and assume
@@ -1545,6 +1553,12 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
             if (pe.isCopy || (!pe.isPreparedStatement() && !pe.isPortal())) {
                 releaseToPool(pe);
             } else {
+                if (pe.isSuspended()) {
+                    // The entry is being displaced (not retained as the current entry).
+                    // Its cursor must be freed here because nothing else will resume it,
+                    // and clearState() does not touch stateSuspended or cursor.
+                    pe.closeSuspendedCursor();
+                }
                 pe.clearState();
             }
         }

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGPipelineEntry.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGPipelineEntry.java
@@ -3555,9 +3555,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
     }
 
     boolean isDirty() {
-        return error || stateSync != SYNC_PARSE || stateParse || stateBind
-                || stateDesc != SYNC_DESC_NONE || stateExec || stateClosed
-                || stateSuspended;
+        return error || stateSync != SYNC_PARSE || stateParse || stateBind || stateDesc != SYNC_DESC_NONE || stateExec || stateClosed;
     }
 
     // When we pick up SQL (insert or select) from cache we have to check that the SQL was compiled with

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGPipelineEntry.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGPipelineEntry.java
@@ -3393,6 +3393,13 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
         }
     }
 
+    /**
+     * Resets per-iteration state so the entry can serve another execution.
+     * Intentionally does NOT touch {@code stateSuspended} or {@code cursor}:
+     * a suspended named portal must keep both alive across iterations so the
+     * next Execute can resume the same cursor. Callers that mean to discard
+     * the suspended cursor must invoke {@link #closeSuspendedCursor()} first.
+     */
     void clearState() {
         error = false;
         stalePlanError = false;

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGPipelineEntry.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGPipelineEntry.java
@@ -3548,7 +3548,9 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
     }
 
     boolean isDirty() {
-        return error || stateSync != SYNC_PARSE || stateParse || stateBind || stateDesc != SYNC_DESC_NONE || stateExec || stateClosed;
+        return error || stateSync != SYNC_PARSE || stateParse || stateBind
+                || stateDesc != SYNC_DESC_NONE || stateExec || stateClosed
+                || stateSuspended;
     }
 
     // When we pick up SQL (insert or select) from cache we have to check that the SQL was compiled with

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -3407,17 +3407,18 @@ if __name__ == "__main__":
     @Test
     public void testClosePortalMustNotLeakSuspendedCursorOnAnotherNamedPortal() throws Exception {
         // Portal-side counterpart of testCloseStatementMustNotLeakSuspendedCursorOnAnotherNamedStatement.
-        // msgClose handles 'S' (statement) and 'P' (portal) through the same isDirty()
-        // check, so the same regression must be guarded for portals.
+        // msgClose handles 'S' (statement) and 'P' (portal) through the same
+        // releaseToPoolIfAbandoned path, so the same regression must be guarded for portals.
         //
         // Wire sequence: Parse('', SELECT 1) + Bind(P_1, '') + Sync,
         //                Parse('', SELECT x FROM long_sequence(5)) + Bind(P_2, '') + Execute(P_2, 2) + Sync,
         //                Close-P(P_1) + Sync + Execute(P_2, 10) + Sync.
-        // P_2 is suspended after row 2; Close-P targets the unrelated P_1. Without the
-        // isDirty() fix, msgClose calls releaseToPoolIfAbandoned(P_2), the next Execute(P_2)
-        // resumes from row 3 (returns rows 3,4,5 -- "SELECT 3"). With the fix, the suspended
-        // P_2 is queued via addPipelineEntry, the syncPipeline drain frees its cursor, and
-        // the next Execute(P_2) starts a fresh cursor returning all 5 rows ("SELECT 5").
+        // P_2 is suspended after row 2; Close-P targets the unrelated P_1. Pre-fix, msgClose
+        // ran releaseToPoolIfAbandoned(P_2), which only called clearState() and left the
+        // cursor alive; the next Execute(P_2) resumed from row 3 (returns rows 3,4,5 --
+        // "SELECT 3"). Post-fix, releaseToPoolIfAbandoned closes the suspended cursor inline
+        // before clearState(), so the next Execute(P_2) starts a fresh cursor and returns
+        // all 5 rows ("SELECT 5").
         assertHexScript("""
                 >0000003600030000757365720061646d696e0064617461626173650071646200636c69656e745f656e636f64696e6700555446380000
                 <520000000800000003
@@ -3451,27 +3452,19 @@ if __name__ == "__main__":
         // Bug-trigger (one message group, no intermediate Sync):
         //   Close-S(S_1) + Bind('' -> S_2) + Execute('', 10) + Sync.
         //
-        // What the other fixes do here:
-        //   - The `isDirty()` fix (Fix A) handles the prior Close-S step: when
-        //     `msgClose` swaps `pipelineCurrentEntry` from the suspended S_2 to
-        //     S_1, `isDirty()` now returns true (because `stateSuspended`), so
-        //     S_2 is queued onto `pipeline` via `addPipelineEntry()` instead of
-        //     being silently dropped. But queuing alone does not free the cursor;
-        //     only Sync's syncPipeline drain would, and there is no Sync here.
-        //   - The `releaseToPoolIfAbandoned` fix (Fix C) does not fire on this
-        //     path. `replaceCurrentPipelineEntry` calls `releaseToPoolIfAbandoned`
-        //     on the old `pipelineCurrentEntry` (here null, because the Close-S
-        //     branch in `msgBind` already set it to null before the lookup),
-        //     never on the looked-up entry.
-        //
-        // What the post-lookup `closeSuspendedCursor()` (Fix B) does:
-        //   `lookupPipelineEntryForNamedStatement` brings S_2 back from
-        //   `namedStatements` with cursor still alive and `stateSuspended=true`.
-        //   The post-lookup guard frees that cursor before `setStateBind(true)`,
-        //   so the next Execute calls `factory.getCursor()` fresh.
+        // The Close-S step calls `releaseToPoolIfAbandoned(S_2)`, where Fix C closes
+        // the suspended cursor inline. The Bind that follows finds S_2 with `cursor
+        // == null` and `stateSuspended == false`, so the next Execute calls
+        // `factory.getCursor()` fresh and returns all 5 rows. The post-lookup guard
+        // (Fix B) is the safety net for any path that bypasses Fix C's inline close
+        // -- e.g., if Close-S is dropped entirely and the suspended portal entry is
+        // looked up directly by Bind without prior cleanup.
         //
         // Pre-fix output: 3 DataRows (3,4,5) + "SELECT 3" -- the resumed cursor.
         // Post-fix output: 5 DataRows (1..5) + "SELECT 5" -- a fresh cursor.
+        //
+        // Response order matches the request order: CloseComplete (Close-S),
+        // BindComplete (Bind), 5 DataRows + CommandComplete (Execute), RFQ (Sync).
         assertHexScript("""
                 >0000003600030000757365720061646d696e0064617461626173650071646200636c69656e745f656e636f64696e6700555446380000
                 <520000000800000003
@@ -3484,7 +3477,7 @@ if __name__ == "__main__":
                 >420000000f00535f3200000000000000450000000900000000025300000004
                 <3200000004440000000b00010000000131440000000b0001000000013273000000045a0000000549
                 >430000000953535f3100420000000f00535f32000000000000004500000009000000000a5300000004
-                <3200000004440000000b00010000000131440000000b00010000000132440000000b00010000000133440000000b00010000000134440000000b00010000000135430000000d53454c45435420350033000000045a0000000549
+                <33000000043200000004440000000b00010000000131440000000b00010000000132440000000b00010000000133440000000b00010000000134440000000b00010000000135430000000d53454c4543542035005a0000000549
                 >5800000004
                 """);
     }
@@ -3524,10 +3517,10 @@ if __name__ == "__main__":
                 ps1.close();
 
                 // Wire sequence pgjdbc emits: Close-S(S_1), Sync, Bind('' -> S_2), Execute, Sync.
-                // Without the isDirty() fix, the suspended S_2 is dropped via clearState() in
-                // msgClose; without the post-lookup closeSuspendedCursor() in msgBind, the
-                // subsequent lookup brings S_2 back with its cursor alive, msgExecuteSelect
-                // skips factory.getCursor() and resumes from row 2 -- so this would return
+                // Pre-fix, msgClose ran releaseToPoolIfAbandoned on the suspended S_2, which
+                // only called clearState() and left the cursor alive. The subsequent Bind
+                // looked S_2 up with its cursor still alive, msgExecuteSelect skipped
+                // factory.getCursor() and resumed from row 2 -- so this would return
                 // just `ts` instead of all 3 rows.
                 ps2.setMaxRows(6);
                 sink.clear();

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -3405,44 +3405,8 @@ if __name__ == "__main__":
     }
 
     @Test
-    public void testClosePortalMustNotLeakSuspendedCursorOnAnotherNamedPortal() throws Exception {
-        // Portal-side counterpart of testCloseStatementMustNotLeakSuspendedCursorOnAnotherNamedStatement.
-        // msgClose handles 'S' (statement) and 'P' (portal) through the same
-        // releaseToPoolIfAbandoned path, so the same regression must be guarded for portals.
-        //
-        // Wire sequence: Parse('', SELECT 1) + Bind(P_1, '') + Sync,
-        //                Parse('', SELECT x FROM long_sequence(5)) + Bind(P_2, '') + Execute(P_2, 2) + Sync,
-        //                Close-P(P_1) + Sync + Execute(P_2, 10) + Sync.
-        // P_2 is suspended after row 2; Close-P targets the unrelated P_1. Pre-fix, msgClose
-        // ran releaseToPoolIfAbandoned(P_2), which only called clearState() and left the
-        // cursor alive; the next Execute(P_2) resumed from row 3 (returns rows 3,4,5 --
-        // "SELECT 3"). Post-fix, releaseToPoolIfAbandoned closes the suspended cursor inline
-        // before clearState(), so the next Execute(P_2) starts a fresh cursor and returns
-        // all 5 rows ("SELECT 5").
-        assertHexScript("""
-                >0000003600030000757365720061646d696e0064617461626173650071646200636c69656e745f656e636f64696e6700555446380000
-                <520000000800000003
-                >700000000a717565737400
-                <520000000800000000530000001154696d655a6f6e6500474d5400530000001d6170706c69636174696f6e5f6e616d6500517565737444420053000000187365727665725f76657273696f6e0031312e33005300000019696e74656765725f6461746574696d6573006f6e005300000019636c69656e745f656e636f64696e670055544638004b0000000c0000003fbb8b96505a0000000549
-                >50000000100053454c4543542031000000420000000f505f3100000000000000005300000004
-                <310000000432000000045a0000000549
-                >50000000260053454c45435420782046524f4d206c6f6e675f73657175656e6365283529000000420000000f505f320000000000000000450000000c505f3200000000025300000004
-                <31000000043200000004440000000b00010000000131440000000b0001000000013273000000045a0000000549
-                >430000000950505f31005300000004
-                <33000000045a0000000549
-                >450000000c505f32000000000a5300000004
-                <440000000b00010000000131440000000b00010000000132440000000b00010000000133440000000b00010000000134440000000b00010000000135430000000d53454c4543542035005a0000000549
-                >5800000004
-                """);
-    }
-
-    @Test
     public void testCloseStatementBeforeBindMustNotResumeSuspendedCursor() throws Exception {
-        // Targets the post-lookup `closeSuspendedCursor()` guard in `msgBind`. The
-        // critical part of the wire sequence is that there is NO Sync between the
-        // Close-S and the next Bind; without that gap, the suspended cursor is
-        // never drained by syncPipeline and only the post-lookup guard can free
-        // it before the next Execute resumes from the wrong row.
+        // Targets the post-lookup `closeSuspendedCursor()` guard in `msgBind`.
         //
         // Setup:
         //   Parse(S_1, "SELECT 1") + Sync,
@@ -3452,13 +3416,15 @@ if __name__ == "__main__":
         // Bug-trigger (one message group, no intermediate Sync):
         //   Close-S(S_1) + Bind('' -> S_2) + Execute('', 10) + Sync.
         //
-        // The Close-S step calls `releaseToPoolIfAbandoned(S_2)`, where Fix C closes
-        // the suspended cursor inline. The Bind that follows finds S_2 with `cursor
-        // == null` and `stateSuspended == false`, so the next Execute calls
-        // `factory.getCursor()` fresh and returns all 5 rows. The post-lookup guard
-        // (Fix B) is the safety net for any path that bypasses Fix C's inline close
-        // -- e.g., if Close-S is dropped entirely and the suspended portal entry is
-        // looked up directly by Bind without prior cleanup.
+        // After the previous suspended Execute, `pipelineCurrentEntry` is S_2 with
+        // `stateSuspended = true`. `Close-S(S_1)` runs `releaseToPoolIfAbandoned(S_2)`,
+        // which calls `clearState()` but does NOT touch the cursor or `stateSuspended`.
+        // The pre-lookup `closeSuspendedCursor()` in `msgBind` then sees `S_1` (the close
+        // target, not suspended) and skips. The lookup re-introduces S_2 with the
+        // cursor still alive, and without the post-lookup guard `msgExecuteSelect`
+        // would skip `factory.getCursor()` and resume from row 3. The post-lookup
+        // guard frees the cursor before `setStateBind(true)`, so the next Execute
+        // calls `factory.getCursor()` fresh.
         //
         // Pre-fix output: 3 DataRows (3,4,5) + "SELECT 3" -- the resumed cursor.
         // Post-fix output: 5 DataRows (1..5) + "SELECT 5" -- a fresh cursor.
@@ -3893,44 +3859,6 @@ if __name__ == "__main__":
                 }
             }
         });
-    }
-
-    @Test
-    public void testDescribeStatementMustNotLeakSuspendedCursorOfAnotherNamedPortal() throws Exception {
-        // A `Describe-Statement` for one named prepared statement must not leave a stale
-        // suspended cursor on a different named portal. msgDescribe goes through
-        // lookupPipelineEntryForNamedStatement, which calls replaceCurrentPipelineEntry,
-        // which calls releaseToPoolIfAbandoned on the displaced entry. Without the
-        // closeSuspendedCursor() guard in releaseToPoolIfAbandoned, the displaced portal
-        // keeps its cursor and stateSuspended; the next Execute on that portal then
-        // resumes from the suspended position instead of starting fresh.
-        //
-        // Wire sequence: Parse('', SELECT x FROM long_sequence(5)) + Bind(P_1, '') + Sync,
-        //                Parse(S_2, SELECT 1) + Sync,
-        //                Execute(P_1, 2) + Sync  -- P_1 suspended at row 2,
-        //                Describe-S(S_2) + Sync  -- displaces P_1, leaks its cursor pre-fix,
-        //                Execute(P_1, 10) + Sync.
-        // No Bind precedes the second Execute, so the msgBind suspended-cursor guard does
-        // not protect this path -- only releaseToPoolIfAbandoned can free the cursor.
-        // Pre-fix the second Execute returns rows 3,4,5 -- "SELECT 3"; with the fix it
-        // returns all 5 rows -- "SELECT 5".
-        assertHexScript("""
-                >0000003600030000757365720061646d696e0064617461626173650071646200636c69656e745f656e636f64696e6700555446380000
-                <520000000800000003
-                >700000000a717565737400
-                <520000000800000000530000001154696d655a6f6e6500474d5400530000001d6170706c69636174696f6e5f6e616d6500517565737444420053000000187365727665725f76657273696f6e0031312e33005300000019696e74656765725f6461746574696d6573006f6e005300000019636c69656e745f656e636f64696e670055544638004b0000000c0000003fbb8b96505a0000000549
-                >50000000260053454c45435420782046524f4d206c6f6e675f73657175656e6365283529000000420000000f505f3100000000000000005300000004
-                <310000000432000000045a0000000549
-                >5000000013535f320053454c45435420310000005300000004
-                <31000000045a0000000549
-                >450000000c505f3100000000025300000004
-                <440000000b00010000000131440000000b0001000000013273000000045a0000000549
-                >440000000953535f32005300000004
-                <74000000060000540000001a00013100000000000001000000170004ffffffff00005a0000000549
-                >450000000c505f31000000000a5300000004
-                <440000000b00010000000131440000000b00010000000132440000000b00010000000133440000000b00010000000134440000000b00010000000135430000000d53454c4543542035005a0000000549
-                >5800000004
-                """);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -3405,6 +3405,65 @@ if __name__ == "__main__":
     }
 
     @Test
+    public void testCloseStatementMustNotLeakSuspendedCursorOnAnotherNamedStatement() throws Exception {
+        // A `Close-Statement` for one named prepared statement must not leak a
+        // suspended cursor on a different named prepared statement.
+        //
+        // pgjdbc only sends `Close-S` when its local cache evicts a CachedQuery.
+        // Setting preparedStatementCacheQueries=0 evicts on every close(), which
+        // makes the wire sequence deterministic. prepareThreshold=-1 forces a
+        // server-side named statement on the first execution (default = 5 would
+        // use an anonymous statement on the first call, leaving no name to close).
+        assertWithPgServer(Mode.EXTENDED, true, -1, (ignoredConn, binary, mode, port) -> {
+            Properties properties = new Properties();
+            properties.setProperty("user", "admin");
+            properties.setProperty("password", "quest");
+            properties.setProperty("prepareThreshold", "-1");
+            properties.setProperty("preparedStatementCacheQueries", "0");
+            try (Connection connection = DriverManager.getConnection(
+                    "jdbc:postgresql://127.0.0.1:" + port + "/qdb", properties)) {
+                try (Statement stmt = connection.createStatement()) {
+                    stmt.executeUpdate("create table tab ( a int, b long, ts timestamp)");
+                }
+
+                // S_1 -- something to close later.
+                PreparedStatement ps1 = connection.prepareStatement("select 1");
+                ps1.executeQuery().close();
+
+                // S_2 -- suspended after row 2 of 3.
+                PreparedStatement ps2 = connection.prepareStatement("show columns from tab");
+                ps2.setMaxRows(2);
+                ps2.executeQuery().close();
+
+                // Triggers Close-S for S_1 to be queued on the next executeQuery.
+                ps1.close();
+
+                // Wire sequence: Close-S(S_1), Bind('' -> S_2), Execute, Sync.
+                // Without the fix, msgClose drops the suspended S_2 from
+                // pipelineCurrentEntry; the Bind that follows enters with the
+                // wrong entry, the lookup brings S_2 back with cursor alive,
+                // msgExecuteSelect skips factory.getCursor() and resumes from
+                // row 2 -- so this returns just `ts` instead of all 3 rows.
+                ps2.setMaxRows(6);
+                sink.clear();
+                try (ResultSet rs = ps2.executeQuery()) {
+                    assertResultSet(
+                            """
+                                    column[VARCHAR],type[VARCHAR],indexed[BIT],indexBlockCapacity[INTEGER],symbolCached[BIT],symbolCapacity[INTEGER],symbolTableSize[INTEGER],designated[BIT],upsertKey[BIT],indexType[VARCHAR],indexInclude[VARCHAR]
+                                    a,INT,false,0,false,0,0,false,false,,
+                                    b,LONG,false,0,false,0,0,false,false,,
+                                    ts,TIMESTAMP,false,0,false,0,0,false,false,,
+                                    """,
+                            sink,
+                            rs
+                    );
+                }
+                ps2.close();
+            }
+        });
+    }
+
+    @Test
     public void testContextClearsTransactionFlag() throws Exception {
         assertWithPgServer(CONN_AWARE_ALL, (connection, binary, mode, port) -> {
             connection.setAutoCommit(true);

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGJobContextTest.java
@@ -3405,6 +3405,91 @@ if __name__ == "__main__":
     }
 
     @Test
+    public void testClosePortalMustNotLeakSuspendedCursorOnAnotherNamedPortal() throws Exception {
+        // Portal-side counterpart of testCloseStatementMustNotLeakSuspendedCursorOnAnotherNamedStatement.
+        // msgClose handles 'S' (statement) and 'P' (portal) through the same isDirty()
+        // check, so the same regression must be guarded for portals.
+        //
+        // Wire sequence: Parse('', SELECT 1) + Bind(P_1, '') + Sync,
+        //                Parse('', SELECT x FROM long_sequence(5)) + Bind(P_2, '') + Execute(P_2, 2) + Sync,
+        //                Close-P(P_1) + Sync + Execute(P_2, 10) + Sync.
+        // P_2 is suspended after row 2; Close-P targets the unrelated P_1. Without the
+        // isDirty() fix, msgClose calls releaseToPoolIfAbandoned(P_2), the next Execute(P_2)
+        // resumes from row 3 (returns rows 3,4,5 -- "SELECT 3"). With the fix, the suspended
+        // P_2 is queued via addPipelineEntry, the syncPipeline drain frees its cursor, and
+        // the next Execute(P_2) starts a fresh cursor returning all 5 rows ("SELECT 5").
+        assertHexScript("""
+                >0000003600030000757365720061646d696e0064617461626173650071646200636c69656e745f656e636f64696e6700555446380000
+                <520000000800000003
+                >700000000a717565737400
+                <520000000800000000530000001154696d655a6f6e6500474d5400530000001d6170706c69636174696f6e5f6e616d6500517565737444420053000000187365727665725f76657273696f6e0031312e33005300000019696e74656765725f6461746574696d6573006f6e005300000019636c69656e745f656e636f64696e670055544638004b0000000c0000003fbb8b96505a0000000549
+                >50000000100053454c4543542031000000420000000f505f3100000000000000005300000004
+                <310000000432000000045a0000000549
+                >50000000260053454c45435420782046524f4d206c6f6e675f73657175656e6365283529000000420000000f505f320000000000000000450000000c505f3200000000025300000004
+                <31000000043200000004440000000b00010000000131440000000b0001000000013273000000045a0000000549
+                >430000000950505f31005300000004
+                <33000000045a0000000549
+                >450000000c505f32000000000a5300000004
+                <440000000b00010000000131440000000b00010000000132440000000b00010000000133440000000b00010000000134440000000b00010000000135430000000d53454c4543542035005a0000000549
+                >5800000004
+                """);
+    }
+
+    @Test
+    public void testCloseStatementBeforeBindMustNotResumeSuspendedCursor() throws Exception {
+        // Targets the post-lookup `closeSuspendedCursor()` guard in `msgBind`. The
+        // critical part of the wire sequence is that there is NO Sync between the
+        // Close-S and the next Bind; without that gap, the suspended cursor is
+        // never drained by syncPipeline and only the post-lookup guard can free
+        // it before the next Execute resumes from the wrong row.
+        //
+        // Setup:
+        //   Parse(S_1, "SELECT 1") + Sync,
+        //   Parse(S_2, "SELECT x FROM long_sequence(5)") + Sync,
+        //   Bind('' -> S_2) + Execute('', 2) + Sync   -- S_2 suspended after row 2.
+        //
+        // Bug-trigger (one message group, no intermediate Sync):
+        //   Close-S(S_1) + Bind('' -> S_2) + Execute('', 10) + Sync.
+        //
+        // What the other fixes do here:
+        //   - The `isDirty()` fix (Fix A) handles the prior Close-S step: when
+        //     `msgClose` swaps `pipelineCurrentEntry` from the suspended S_2 to
+        //     S_1, `isDirty()` now returns true (because `stateSuspended`), so
+        //     S_2 is queued onto `pipeline` via `addPipelineEntry()` instead of
+        //     being silently dropped. But queuing alone does not free the cursor;
+        //     only Sync's syncPipeline drain would, and there is no Sync here.
+        //   - The `releaseToPoolIfAbandoned` fix (Fix C) does not fire on this
+        //     path. `replaceCurrentPipelineEntry` calls `releaseToPoolIfAbandoned`
+        //     on the old `pipelineCurrentEntry` (here null, because the Close-S
+        //     branch in `msgBind` already set it to null before the lookup),
+        //     never on the looked-up entry.
+        //
+        // What the post-lookup `closeSuspendedCursor()` (Fix B) does:
+        //   `lookupPipelineEntryForNamedStatement` brings S_2 back from
+        //   `namedStatements` with cursor still alive and `stateSuspended=true`.
+        //   The post-lookup guard frees that cursor before `setStateBind(true)`,
+        //   so the next Execute calls `factory.getCursor()` fresh.
+        //
+        // Pre-fix output: 3 DataRows (3,4,5) + "SELECT 3" -- the resumed cursor.
+        // Post-fix output: 5 DataRows (1..5) + "SELECT 5" -- a fresh cursor.
+        assertHexScript("""
+                >0000003600030000757365720061646d696e0064617461626173650071646200636c69656e745f656e636f64696e6700555446380000
+                <520000000800000003
+                >700000000a717565737400
+                <520000000800000000530000001154696d655a6f6e6500474d5400530000001d6170706c69636174696f6e5f6e616d6500517565737444420053000000187365727665725f76657273696f6e0031312e33005300000019696e74656765725f6461746574696d6573006f6e005300000019636c69656e745f656e636f64696e670055544638004b0000000c0000003fbb8b96505a0000000549
+                >5000000013535f310053454c45435420310000005300000004
+                <31000000045a0000000549
+                >5000000029535f320053454c45435420782046524f4d206c6f6e675f73657175656e63652835290000005300000004
+                <31000000045a0000000549
+                >420000000f00535f3200000000000000450000000900000000025300000004
+                <3200000004440000000b00010000000131440000000b0001000000013273000000045a0000000549
+                >430000000953535f3100420000000f00535f32000000000000004500000009000000000a5300000004
+                <3200000004440000000b00010000000131440000000b00010000000132440000000b00010000000133440000000b00010000000134440000000b00010000000135430000000d53454c45435420350033000000045a0000000549
+                >5800000004
+                """);
+    }
+
+    @Test
     public void testCloseStatementMustNotLeakSuspendedCursorOnAnotherNamedStatement() throws Exception {
         // A `Close-Statement` for one named prepared statement must not leak a
         // suspended cursor on a different named prepared statement.
@@ -3438,12 +3523,12 @@ if __name__ == "__main__":
                 // Triggers Close-S for S_1 to be queued on the next executeQuery.
                 ps1.close();
 
-                // Wire sequence: Close-S(S_1), Bind('' -> S_2), Execute, Sync.
-                // Without the fix, msgClose drops the suspended S_2 from
-                // pipelineCurrentEntry; the Bind that follows enters with the
-                // wrong entry, the lookup brings S_2 back with cursor alive,
-                // msgExecuteSelect skips factory.getCursor() and resumes from
-                // row 2 -- so this returns just `ts` instead of all 3 rows.
+                // Wire sequence pgjdbc emits: Close-S(S_1), Sync, Bind('' -> S_2), Execute, Sync.
+                // Without the isDirty() fix, the suspended S_2 is dropped via clearState() in
+                // msgClose; without the post-lookup closeSuspendedCursor() in msgBind, the
+                // subsequent lookup brings S_2 back with its cursor alive, msgExecuteSelect
+                // skips factory.getCursor() and resumes from row 2 -- so this would return
+                // just `ts` instead of all 3 rows.
                 ps2.setMaxRows(6);
                 sink.clear();
                 try (ResultSet rs = ps2.executeQuery()) {
@@ -3815,6 +3900,44 @@ if __name__ == "__main__":
                 }
             }
         });
+    }
+
+    @Test
+    public void testDescribeStatementMustNotLeakSuspendedCursorOfAnotherNamedPortal() throws Exception {
+        // A `Describe-Statement` for one named prepared statement must not leave a stale
+        // suspended cursor on a different named portal. msgDescribe goes through
+        // lookupPipelineEntryForNamedStatement, which calls replaceCurrentPipelineEntry,
+        // which calls releaseToPoolIfAbandoned on the displaced entry. Without the
+        // closeSuspendedCursor() guard in releaseToPoolIfAbandoned, the displaced portal
+        // keeps its cursor and stateSuspended; the next Execute on that portal then
+        // resumes from the suspended position instead of starting fresh.
+        //
+        // Wire sequence: Parse('', SELECT x FROM long_sequence(5)) + Bind(P_1, '') + Sync,
+        //                Parse(S_2, SELECT 1) + Sync,
+        //                Execute(P_1, 2) + Sync  -- P_1 suspended at row 2,
+        //                Describe-S(S_2) + Sync  -- displaces P_1, leaks its cursor pre-fix,
+        //                Execute(P_1, 10) + Sync.
+        // No Bind precedes the second Execute, so the msgBind suspended-cursor guard does
+        // not protect this path -- only releaseToPoolIfAbandoned can free the cursor.
+        // Pre-fix the second Execute returns rows 3,4,5 -- "SELECT 3"; with the fix it
+        // returns all 5 rows -- "SELECT 5".
+        assertHexScript("""
+                >0000003600030000757365720061646d696e0064617461626173650071646200636c69656e745f656e636f64696e6700555446380000
+                <520000000800000003
+                >700000000a717565737400
+                <520000000800000000530000001154696d655a6f6e6500474d5400530000001d6170706c69636174696f6e5f6e616d6500517565737444420053000000187365727665725f76657273696f6e0031312e33005300000019696e74656765725f6461746574696d6573006f6e005300000019636c69656e745f656e636f64696e670055544638004b0000000c0000003fbb8b96505a0000000549
+                >50000000260053454c45435420782046524f4d206c6f6e675f73657175656e6365283529000000420000000f505f3100000000000000005300000004
+                <310000000432000000045a0000000549
+                >5000000013535f320053454c45435420310000005300000004
+                <31000000045a0000000549
+                >450000000c505f3100000000025300000004
+                <440000000b00010000000131440000000b0001000000013273000000045a0000000549
+                >440000000953535f32005300000004
+                <74000000060000540000001a00013100000000000001000000170004ffffffff00005a0000000549
+                >450000000c505f31000000000a5300000004
+                <440000000b00010000000131440000000b00010000000132440000000b00010000000133440000000b00010000000134440000000b00010000000135430000000d53454c4543542035005a0000000549
+                >5800000004
+                """);
     }
 
     @Test


### PR DESCRIPTION
## Summary

After an Execute suspends a portal, its cursor is intentionally retained so the next Execute on the same portal can resume from the same row. However, when the client sends a `Sync` between that suspended Execute and a follow-up `Bind` for the same statement, `pipelineCurrentEntry` becomes `null` at Sync's end, so the existing pre-lookup `closeSuspendedCursor()` guard in `msgBind` no longer fires. The subsequent `lookupPipelineEntryForNamedStatement` then re-introduces the suspended entry with its cursor still alive, and `msgExecuteSelect` skips `factory.getCursor()`, returning a partial result set.

The fix adds a post-lookup `closeSuspendedCursor()` guard in `msgBind`: a `Bind` always starts a fresh execution, so any suspended cursor on the entry the lookup lands on must be freed before `setStateBind(true)`.

A small documentation comment on `clearState()` records the invariant that callers reach for `closeSuspendedCursor()` if they intend to discard a suspended cursor (since `clearState()` deliberately leaves `stateSuspended` and `cursor` untouched so that suspended portals can be resumed).

## Description

The PG extended-query state machine retains a suspended portal's cursor across `Sync` so that the next `Execute` for that portal can resume from the same row. The bug surfaces when the client interleaves `Close-S` of an unrelated statement and a follow-up `Bind` for the suspended statement.

A representative pgjdbc sequence (driven by `setMaxRows()` and `preparedStatementCacheQueries=0`):

```
Bind('' -> S_2) + Execute('', 2) + Sync     -- S_2 suspended after row 2
... other commands ...
Close-S(S_1) + Sync + Bind('' -> S_2) + Execute('', 6) + Sync
```

State at the start of `Close-S(S_1)`:
- `pipelineCurrentEntry == S_2` with `stateSuspended = true`, cursor alive.

`msgClose` finds the close target (`S_1`) is different from `pipelineCurrentEntry` (`S_2`). Because `S_2` is not "dirty" by the existing `isDirty()` definition (suspended is intentionally not dirty -- a suspended portal must be resumable), `msgClose` calls `releaseToPoolIfAbandoned(S_2)`, which calls `clearState()` only. `clearState()` does NOT touch `cursor` or `stateSuspended`, so `S_2` keeps its suspended cursor (correct: a Close-S on an unrelated statement must not invalidate it). `pipelineCurrentEntry` is then set to `S_1` with `stateClosed = true`.

The intervening `Sync` drains the pipeline (the `Close-S` reply is sent), and `pipelineCurrentEntry` ends up `null`. `S_2` is still in `namedStatements` with cursor alive, `stateSuspended = true`.

`Bind('' -> S_2)` enters `msgBind`. The pre-lookup `closeSuspendedCursor()` guard is not triggered because `pipelineCurrentEntry` is null. `lookupPipelineEntryForNamedStatement(S_2)` re-introduces S_2 as the current entry with its cursor still alive. Without the post-lookup guard, `setStateBind(true)` runs and the next `Execute` lands in `msgExecuteSelect` with `cursor != null`, so `factory.getCursor()` is skipped and the cursor resumes from row 3 instead of starting fresh.

The post-lookup `closeSuspendedCursor()` guard mirrors the existing pre-lookup check: a `Bind` always starts a fresh execution, so any suspended cursor on the entry the lookup lands on must be freed before `setStateBind(true)`.

## What was tried and rejected

Two earlier iterations of the fix turned out to introduce regressions instead of fixing the bug:

- **Adding `stateSuspended` to `isDirty()`** so that `msgClose` would queue the suspended entry onto `pipeline` rather than calling `releaseToPoolIfAbandoned`. This created a duplicate-reference bug: the entry was reachable from both `pipeline` and `namedPortals` simultaneously. A subsequent `Execute` lookup re-introduced it as `pipelineCurrentEntry`, the next `Sync` queued it again, and `syncPipeline` polled the same instance twice -- the second poll triggered the existing `if (nextEntry != null && isSuspended) closeSuspendedCursor()` branch, freeing the cursor mid-stream. `testCursorFetch` reproduced this when pgjdbc evicts an unrelated cached statement (the `CREATE TABLE`) during the cursor-fetch loop.
- **Closing the suspended cursor in `releaseToPoolIfAbandoned`** when the displaced entry was a suspended named entry. This makes any `Close-S` / `Close-P` / `Describe` / `Execute` on an unrelated entity destroy the suspended portal's cursor, which contradicts PG protocol semantics: portals persist across the transaction and are only invalidated by `Close-P` of that portal, `Close-S` of its parent statement, or a re-`Bind`. The same `testCursorFetch` failure mode resulted: pgjdbc's mid-loop `Close-S(S_1)` displaced the suspended portal and reset its cursor, returning row 1 on the next batch instead of continuing.

The accepted fix is narrower: only `msgBind` itself frees the cursor of the entry being rebound. `Close`, `Describe`, and `Execute` on unrelated entities preserve suspended cursors, matching PG semantics.

## Tradeoffs

- Positive: pgjdbc clients that re-execute a `PreparedStatement` (the `setMaxRows` / `preparedStatementCacheQueries=0` pattern, where pgjdbc emits a deferred `Close-S` followed by `Sync` and then a fresh `Bind` for another cached statement) no longer get rows resumed from the wrong cursor.
- `msgBind` (the post-lookup guard) gains one branch and one method call per `Bind`. The branch evaluates `pipelineCurrentEntry.isSuspended()` against a boolean field; cost is a non-issue.
- The `clearState()` doc comment is documentation only. No behavior change.
- No change to `Close-S`, `Close-P`, `Describe`, or `Execute` paths -- their handling of unrelated suspended portals is unchanged from master.

## Test plan

- `testCloseStatementMustNotLeakSuspendedCursorOnAnotherNamedStatement` (new, JDBC). Drives pgjdbc with `preparedStatementCacheQueries=0` to force `Close-S` flush on the next `executeQuery`, and `prepareThreshold=-1` to force named statements from the first execute. Asserts `show columns from tab` returns all 3 rows after `Close-S` of an unrelated named statement followed by re-execute. Pre-fix returns only 1 row; post-fix returns 3.
- `testCloseStatementBeforeBindMustNotResumeSuspendedCursor` (new, hex). Variant of the above with no intermediate `Sync` between `Close-S` and the next `Bind` -- the bug-trigger sequence is `Close-S(S_1) + Bind('' -> S_2) + Execute('', 10) + Sync`. Verifies the post-lookup guard fires whether or not `pipelineCurrentEntry` is null at Bind time. Asserts all 5 rows / `SELECT 5` and the protocol-correct response order: `CloseComplete + BindComplete + 5 DataRows + CommandComplete + RFQ`. Pre-fix returns 3 rows / `SELECT 3`.
- `testCursorFetch` (existing, JDBC). Regression coverage for the rejected approaches: pgjdbc evicts the `CREATE TABLE` statement mid-fetch and continues fetching from the suspended `SELECT` portal. Pre-fix (with the rejected `isDirty()` or `releaseToPoolIfAbandoned` changes) failed intermittently with cursor restart at the start of a new batch. Post-fix: 30 consecutive local runs pass.
- All existing `PGJobContextTest` tests pass, including the four `testUnnamedPortalCursor*` regression tests added by `8708e2bc4e` for the postgres.js cursor-resume pattern.