### PR TITLE
chore(core): fix NPE on ORDER BY against an unknown indexed symbol

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/CoveringIndexRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/CoveringIndexRecordCursorFactory.java
@@ -184,7 +184,6 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
                 }
                 SymbolMapReader smr = frameCursor.getTableReader().getSymbolMapReader(indexColumnIndex);
                 multiKeyCursor.multiKeys.clear();
-                boolean hasAnyKey = false;
                 for (int i = 0, n = resolvedKeys.size(); i < n; i++) {
                     int key = resolvedKeys.getQuick(i);
                     if (key == SymbolTable.VALUE_NOT_FOUND && keyValueFuncs != null) {
@@ -193,14 +192,13 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
                     }
                     if (key != SymbolTable.VALUE_NOT_FOUND) {
                         multiKeyCursor.multiKeys.add(key);
-                        hasAnyKey = true;
                     }
                 }
-                if (!hasAnyKey) {
-                    Misc.free(frameCursor);
-                    multiKeyCursor.ofEmpty();
-                    return multiKeyCursor;
-                }
+                // Always wire up the frame cursor and table reader, even when no
+                // keys resolve. Callers wrap us in operators (e.g. ORDER BY on a
+                // SYMBOL column) that probe baseCursor.getSymbolTable() during
+                // init, before any iteration. An empty multiKeys list naturally
+                // makes advanceKey() report no rows.
                 multiKeyCursor.of(frameCursor);
                 multiKeyCursor.latestByFilter = latestByFilter;
                 if (latestByFilter != null) {
@@ -217,11 +215,6 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
                 SymbolMapReader symbolMapReader = frameCursor.getTableReader().getSymbolMapReader(indexColumnIndex);
                 CharSequence symValue = symbolFunction.getStrA(null);
                 resolvedKey = symValue != null ? symbolMapReader.keyOf(symValue) : SymbolTable.VALUE_NOT_FOUND;
-            }
-            if (resolvedKey == SymbolTable.VALUE_NOT_FOUND) {
-                Misc.free(frameCursor);
-                singleKeyCursor.ofEmpty();
-                return singleKeyCursor;
             }
             singleKeyCursor.resolveKey(resolvedKey);
             singleKeyCursor.of(frameCursor);
@@ -269,11 +262,8 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
                         multiKeyPageFrameCursor.multiKeys.add(key);
                     }
                 }
-                if (multiKeyPageFrameCursor.multiKeys.size() == 0) {
-                    Misc.free(frameCursor);
-                    multiKeyPageFrameCursor.ofEmpty();
-                    return multiKeyPageFrameCursor;
-                }
+                // Always wire the frame cursor; callers may probe getSymbolTable()
+                // before iteration. Empty multiKeys list yields no frames.
                 multiKeyPageFrameCursor.of(frameCursor);
                 return multiKeyPageFrameCursor;
             }
@@ -286,11 +276,6 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
                 SymbolMapReader smr = reader.getSymbolMapReader(indexColumnIndex);
                 CharSequence symValue = symbolFunction.getStrA(null);
                 resolvedKey = symValue != null ? smr.keyOf(symValue) : SymbolTable.VALUE_NOT_FOUND;
-            }
-            if (resolvedKey == SymbolTable.VALUE_NOT_FOUND) {
-                Misc.free(frameCursor);
-                singleKeyPageFrameCursor.ofEmpty();
-                return singleKeyPageFrameCursor;
             }
             singleKeyPageFrameCursor.resolvedKey = resolvedKey;
             singleKeyPageFrameCursor.of(frameCursor);
@@ -565,13 +550,6 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
                 }
                 coveringRecord.setIncludeSymbolTables(symTablesCache);
             }
-        }
-
-        void ofEmpty() {
-            this.frameCursor = null;
-            this.tableReader = null;
-            this.currentRowCursor = Misc.free(this.currentRowCursor);
-            this.coveringRecord.of(null);
         }
 
         abstract void resetIterationState();
@@ -1220,13 +1198,6 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
             freeBuffers();
         }
 
-        void ofEmpty() {
-            this.frameCursor = null;
-            this.tableReader = null;
-            this.isExhausted = true;
-            resetIterationState();
-        }
-
         abstract void resetIterationState();
     }
 
@@ -1677,6 +1648,9 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
 
         @Override
         boolean advanceKey() {
+            if (multiKeys.size() == 0) {
+                return false;
+            }
             if (cachedPartitionIndex >= 0) {
                 currentKeyIdx++;
                 while (currentKeyIdx < multiKeys.size()) {
@@ -1745,6 +1719,10 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
         @Override
         @Nullable
         PageFrame nextImpl() {
+            if (multiKeys.size() == 0) {
+                isExhausted = true;
+                return null;
+            }
             while (true) {
                 while (currentKeyIdx < multiKeys.size()) {
                     if (cachedPartFrame != null) {
@@ -1827,6 +1805,12 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
 
         @Override
         boolean advanceKey() {
+            // VALUE_NOT_FOUND must short-circuit: TableUtils.toIndexKey(-1) maps
+            // to 0, the index slot reserved for VALUE_IS_NULL — letting it through
+            // would silently match NULL rows for an unknown literal.
+            if (symbolKey == SymbolTable.VALUE_NOT_FOUND) {
+                return false;
+            }
             while (true) {
                 PartitionFrame frame = frameCursor.next();
                 if (frame == null) {
@@ -1840,7 +1824,7 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
 
         @Override
         boolean hasNextLatestBy() {
-            if (isLatestByDone) {
+            if (isLatestByDone || symbolKey == SymbolTable.VALUE_NOT_FOUND) {
                 return false;
             }
             if (findLatestRow(symbolKey)) {
@@ -1881,6 +1865,12 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
         @Override
         @Nullable
         PageFrame nextImpl() {
+            // See SingleKeyCoveringCursor.advanceKey() for why VALUE_NOT_FOUND
+            // must short-circuit before reaching toIndexKey().
+            if (resolvedKey == SymbolTable.VALUE_NOT_FOUND) {
+                isExhausted = true;
+                return null;
+            }
             while (true) {
                 PartitionFrame partFrame = frameCursor.next();
                 if (partFrame == null) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/CoveringIndexRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/CoveringIndexRecordCursorFactory.java
@@ -52,7 +52,6 @@ import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
-import io.questdb.griffin.engine.table.parquet.ParquetDecoder;
 import io.questdb.std.BinarySequence;
 import io.questdb.std.Decimal128;
 import io.questdb.std.Decimal256;
@@ -639,11 +638,6 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
         }
 
         @Override
-        public ParquetDecoder getParquetDecoder() {
-            return null;
-        }
-
-        @Override
         public int getParquetRowGroup() {
             return 0;
         }
@@ -951,7 +945,8 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
                             addr + (long) count * Double.BYTES, crc.getCoveredDouble(includeIdx));
                     case ColumnType.FLOAT -> Unsafe.putFloat(
                             addr + (long) count * Float.BYTES, crc.getCoveredFloat(includeIdx));
-                    case ColumnType.LONG, ColumnType.TIMESTAMP, ColumnType.DATE, ColumnType.GEOLONG ->
+                    case ColumnType.LONG, ColumnType.TIMESTAMP, ColumnType.DATE, ColumnType.GEOLONG,
+                         ColumnType.DECIMAL64 ->
                             Unsafe.putLong(addr + (long) count * Long.BYTES, crc.getCoveredLong(includeIdx));
                     case ColumnType.INT, ColumnType.IPv4, ColumnType.GEOINT, ColumnType.SYMBOL ->
                             Unsafe.putInt(addr + (long) count * Integer.BYTES, crc.getCoveredInt(includeIdx));
@@ -959,8 +954,6 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
                             Unsafe.putShort(addr + (long) count * Short.BYTES, crc.getCoveredShort(includeIdx));
                     case ColumnType.BYTE, ColumnType.BOOLEAN, ColumnType.GEOBYTE ->
                             Unsafe.putByte(addr + count, crc.getCoveredByte(includeIdx));
-                    case ColumnType.DECIMAL64 ->
-                            Unsafe.putLong(addr + (long) count * Long.BYTES, crc.getCoveredLong(includeIdx));
                     case ColumnType.DECIMAL32 ->
                             Unsafe.putInt(addr + (long) count * Integer.BYTES, crc.getCoveredInt(includeIdx));
                     case ColumnType.DECIMAL16 ->

--- a/core/src/main/java/io/questdb/griffin/engine/table/CoveringIndexRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/CoveringIndexRecordCursorFactory.java
@@ -1798,9 +1798,9 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
 
         @Override
         boolean advanceKey() {
-            // VALUE_NOT_FOUND must short-circuit: TableUtils.toIndexKey(-1) maps
-            // to 0, the index slot reserved for VALUE_IS_NULL — letting it through
-            // would silently match NULL rows for an unknown literal.
+            // Skip iteration entirely when the literal did not resolve to any
+            // known symbol; otherwise we would open every partition's index
+            // reader to read empty cursors.
             if (symbolKey == SymbolTable.VALUE_NOT_FOUND) {
                 return false;
             }
@@ -1858,8 +1858,9 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
         @Override
         @Nullable
         PageFrame nextImpl() {
-            // See SingleKeyCoveringCursor.advanceKey() for why VALUE_NOT_FOUND
-            // must short-circuit before reaching toIndexKey().
+            // See SingleKeyCoveringCursor.advanceKey(): skip iteration when
+            // the literal did not resolve, instead of scanning every partition
+            // for empty cursors.
             if (resolvedKey == SymbolTable.VALUE_NOT_FOUND) {
                 isExhausted = true;
                 return null;

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
@@ -7843,6 +7843,78 @@ public class CoveringIndexTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testEqFilterOnUnknownSymbolWithOrderBy() throws Exception {
+        // Regression: an ORDER BY on a SYMBOL column wraps the base cursor in
+        // EncodedSortRecordCursor, whose init() phase probes baseCursor.getSymbolTable()
+        // before iteration to build symbol-rank maps. When the WHERE literal is
+        // unknown to the symbol map (no rows match), the covering cursor must still
+        // expose a usable symbol table for that probe, even though iteration yields
+        // nothing. Realistic shape: a populated table with a few known symbols, a
+        // dashboard query for a value that has never been written. The fuzz hit
+        // this via CREATE VIEW; assertQuery exercises the same API path directly.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_unknown_sym (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING,
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            execute("""
+                    INSERT INTO t_unknown_sym
+                    SELECT dateadd('s', x::INT, '2024-01-01')::TIMESTAMP,
+                           ('K' || (x % 5))::SYMBOL,
+                           (x % 100) * 1.5
+                    FROM long_sequence(2_000)
+                    """);
+            engine.releaseAllWriters();
+
+            // Sanity: known symbols return the expected row counts. Defends against
+            // a future change accidentally short-circuiting the populated path too.
+            assertQueryNoLeakCheck(
+                    "count\n400\n",
+                    "SELECT count() FROM t_unknown_sym WHERE sym = 'K0'",
+                    null, false, true
+            );
+
+            String singleKeyPlan = getPlan("SELECT sym FROM t_unknown_sym WHERE sym = 'qrsw' ORDER BY 1 DESC LIMIT 86");
+            assertTrue("Expected CoveringIndex plan for single-key filter:\n" + singleKeyPlan,
+                    singleKeyPlan.contains("CoveringIndex"));
+
+            assertQueryNoLeakCheck(
+                    "sym\n",
+                    "SELECT sym FROM t_unknown_sym WHERE sym = 'qrsw' ORDER BY 1 DESC LIMIT 86",
+                    null, true, false
+            );
+
+            assertQueryNoLeakCheck(
+                    "sym\n",
+                    "SELECT sym FROM t_unknown_sym WHERE sym = 'qrsw' ORDER BY 1",
+                    null, true, false
+            );
+
+            String multiKeyPlan = getPlan("SELECT sym FROM t_unknown_sym WHERE sym IN ('qrsw', 'zzz') ORDER BY 1");
+            assertTrue("Expected CoveringIndex plan for multi-key filter:\n" + multiKeyPlan,
+                    multiKeyPlan.contains("CoveringIndex"));
+
+            assertQueryNoLeakCheck(
+                    "sym\n",
+                    "SELECT sym FROM t_unknown_sym WHERE sym IN ('qrsw', 'zzz') ORDER BY 1",
+                    null, true, false
+            );
+
+            // Mixed list: one known value, one unknown. Result must contain only
+            // the known symbol's rows; the unknown literal must not poison the
+            // multi-key path or short-circuit the cursor.
+            assertQueryNoLeakCheck(
+                    "count\n400\n",
+                    "SELECT count() FROM t_unknown_sym WHERE sym IN ('K0', 'qrsw')",
+                    null, false, true
+            );
+        });
+    }
+
+    @Test
     public void testFallbackInList3Keys() throws Exception {
         assertMemoryLeak(() -> {
             execute("""
@@ -10556,8 +10628,9 @@ public class CoveringIndexTest extends AbstractCairoTest {
     @Test
     public void testPageFrameCursor_OfEmptyMultiKey() throws Exception {
         // Multi-key page frame cursor: an IN-list with all values resolving to
-        // VALUE_NOT_FOUND drives multiKeyPageFrameCursor.ofEmpty() via the
-        // multiKeys.size() == 0 short-circuit in getPageFrameCursor().
+        // VALUE_NOT_FOUND must produce no frames. The cursor is still wired to
+        // the table reader so symbol-table lookups remain valid for upstream
+        // operators that probe before iteration.
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_pf_ofempty_mk (
@@ -10587,12 +10660,12 @@ public class CoveringIndexTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testPageFrameCursor_OfEmptyNullSymbolTables() throws Exception {
-        // When the WHERE key resolves to VALUE_NOT_FOUND, the page frame
-        // cursor's ofEmpty() path runs (tableReader = null, isExhausted = true).
-        // Calling getSymbolTable / newSymbolTable on that cursor must hit the
-        // null-tableReader branches and return null without throwing. The
-        // record cursor path is checked separately via assertQueryNoLeakCheck.
+    public void testPageFrameCursor_OfEmptySingleKeyKeepsSymbolTables() throws Exception {
+        // When the WHERE key resolves to VALUE_NOT_FOUND, the page frame cursor
+        // produces no frames but must still expose working symbol tables. Upstream
+        // operators (e.g. ORDER BY on a SYMBOL column) probe getSymbolTable() on
+        // the base cursor during init, before any iteration; returning null there
+        // would break that contract.
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_pf_ofempty (
@@ -10606,8 +10679,8 @@ public class CoveringIndexTest extends AbstractCairoTest {
 
             try (var factory = select("SELECT sym, price FROM t_pf_ofempty WHERE sym = 'NOPE'")) {
                 try (PageFrameCursor cursor = factory.getPageFrameCursor(sqlExecutionContext, PartitionFrameCursorFactory.ORDER_ASC)) {
-                    assertNull("getSymbolTable on empty cursor must be null", cursor.getSymbolTable(0));
-                    assertNull("newSymbolTable on empty cursor must be null", cursor.newSymbolTable(0));
+                    assertNotNull("getSymbolTable must be usable on an empty cursor", cursor.getSymbolTable(0));
+                    assertNotNull("newSymbolTable must be usable on an empty cursor", cursor.newSymbolTable(0));
                     assertNull(cursor.next(0));
                     cursor.toTop();
                     assertNull(cursor.next(0));

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
@@ -7862,7 +7862,7 @@ public class CoveringIndexTest extends AbstractCairoTest {
                     """);
             execute("""
                     INSERT INTO t_unknown_sym
-                    SELECT dateadd('s', x::INT, '2024-01-01')::TIMESTAMP,
+                    SELECT dateadd('h', x::INT, '2024-01-01')::TIMESTAMP,
                            ('K' || (x % 5))::SYMBOL,
                            (x % 100) * 1.5
                     FROM long_sequence(2_000)
@@ -7871,6 +7871,8 @@ public class CoveringIndexTest extends AbstractCairoTest {
 
             // Sanity: known symbols return the expected row counts. Defends against
             // a future change accidentally short-circuiting the populated path too.
+            // Hourly spacing over 2_000 rows spans ~83 day-partitions, exercising
+            // the multi-partition advanceKey()/nextImpl() loops.
             assertQueryNoLeakCheck(
                     "count\n400\n",
                     "SELECT count() FROM t_unknown_sym WHERE sym = 'K0'",
@@ -7879,7 +7881,7 @@ public class CoveringIndexTest extends AbstractCairoTest {
 
             String singleKeyPlan = getPlan("SELECT sym FROM t_unknown_sym WHERE sym = 'qrsw' ORDER BY 1 DESC LIMIT 86");
             assertTrue("Expected CoveringIndex plan for single-key filter:\n" + singleKeyPlan,
-                    singleKeyPlan.contains("CoveringIndex"));
+                    singleKeyPlan.contains("CoveringIndex on: sym"));
 
             assertQueryNoLeakCheck(
                     "sym\n",
@@ -7895,7 +7897,7 @@ public class CoveringIndexTest extends AbstractCairoTest {
 
             String multiKeyPlan = getPlan("SELECT sym FROM t_unknown_sym WHERE sym IN ('qrsw', 'zzz') ORDER BY 1");
             assertTrue("Expected CoveringIndex plan for multi-key filter:\n" + multiKeyPlan,
-                    multiKeyPlan.contains("CoveringIndex"));
+                    multiKeyPlan.contains("CoveringIndex on: sym"));
 
             assertQueryNoLeakCheck(
                     "sym\n",
@@ -7910,6 +7912,21 @@ public class CoveringIndexTest extends AbstractCairoTest {
                     "count\n400\n",
                     "SELECT count() FROM t_unknown_sym WHERE sym IN ('K0', 'qrsw')",
                     null, false, true
+            );
+
+            // LATEST ON path: SingleKeyCoveringCursor.hasNextLatestBy() carries
+            // its own VALUE_NOT_FOUND guard. Combine with an outer ORDER BY on
+            // the SYMBOL column so the upstream sort still probes the empty
+            // cursor's getSymbolTable() before iteration.
+            String latestPlan = getPlan(
+                    "SELECT sym FROM t_unknown_sym WHERE sym = 'qrsw' LATEST ON ts PARTITION BY sym ORDER BY 1");
+            assertTrue("Expected CoveringIndex latest plan:\n" + latestPlan,
+                    latestPlan.contains("CoveringIndex op: latest on: sym"));
+
+            assertQueryNoLeakCheck(
+                    "sym\n",
+                    "SELECT sym FROM t_unknown_sym WHERE sym = 'qrsw' LATEST ON ts PARTITION BY sym ORDER BY 1",
+                    null, true, false
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
@@ -7879,13 +7879,31 @@ public class CoveringIndexTest extends AbstractCairoTest {
                     null, false, true
             );
 
-            String singleKeyPlan = getPlan("SELECT sym FROM t_unknown_sym WHERE sym = 'qrsw' ORDER BY 1 DESC LIMIT 86");
+            // Positive baseline for the same factory chain that produced the
+            // original NPE stack (LimitRecordCursorFactory + EncodedSortRecordCursor
+            // + SortKeyEncoder). Confirms ORDER BY DESC + LIMIT works on a
+            // populated key.
+            assertQueryNoLeakCheck(
+                    """
+                            sym
+                            K0
+                            K0
+                            K0
+                            K0
+                            K0
+                            """,
+                    "SELECT sym FROM t_unknown_sym WHERE sym = 'K0' ORDER BY 1 DESC LIMIT 5",
+                    null, true, true
+            );
+
+            String singleKeyPlan = getPlan("SELECT sym FROM t_unknown_sym WHERE sym = 'qrsw' ORDER BY 1 DESC LIMIT 5");
             assertTrue("Expected CoveringIndex plan for single-key filter:\n" + singleKeyPlan,
                     singleKeyPlan.contains("CoveringIndex on: sym"));
 
+            // Empty result through the same LIMIT + ORDER BY chain.
             assertQueryNoLeakCheck(
                     "sym\n",
-                    "SELECT sym FROM t_unknown_sym WHERE sym = 'qrsw' ORDER BY 1 DESC LIMIT 86",
+                    "SELECT sym FROM t_unknown_sym WHERE sym = 'qrsw' ORDER BY 1 DESC LIMIT 5",
                     null, true, false
             );
 
@@ -7914,6 +7932,42 @@ public class CoveringIndexTest extends AbstractCairoTest {
                     null, false, true
             );
 
+            // Mixed list under ORDER BY: exercises the same EncodedSortRecordCursor
+            // probe with partial key resolution. LIMIT samples the head of the
+            // sorted stream to confirm only K0 rows are produced.
+            assertQueryNoLeakCheck(
+                    """
+                            sym
+                            K0
+                            K0
+                            K0
+                            """,
+                    "SELECT sym FROM t_unknown_sym WHERE sym IN ('K0', 'qrsw') ORDER BY 1 LIMIT 3",
+                    null, true, false
+            );
+
+            // Bind-variable single-key path: getCursor() takes the
+            // symbolFunctionRuntimeConstant branch, resolving the value at
+            // runtime. Pre-fix, an unknown bind value hit the same NPE.
+            bindVariableService.clear();
+            bindVariableService.setStr("sym", "qrsw");
+            assertQueryNoLeakCheck(
+                    "sym\n",
+                    "SELECT sym FROM t_unknown_sym WHERE sym = :sym ORDER BY 1",
+                    null, true, false
+            );
+
+            // Bind-variable IN-list path: keyValueFuncs branch in the multi-key
+            // code, both bind values unknown.
+            bindVariableService.clear();
+            bindVariableService.setStr(0, "qrsw");
+            bindVariableService.setStr(1, "zzz");
+            assertQueryNoLeakCheck(
+                    "sym\n",
+                    "SELECT sym FROM t_unknown_sym WHERE sym IN ($1, $2) ORDER BY 1",
+                    null, true, false
+            );
+
             // LATEST ON path: SingleKeyCoveringCursor.hasNextLatestBy() carries
             // its own VALUE_NOT_FOUND guard. Combine with an outer ORDER BY on
             // the SYMBOL column so the upstream sort still probes the empty
@@ -7926,6 +7980,24 @@ public class CoveringIndexTest extends AbstractCairoTest {
             assertQueryNoLeakCheck(
                     "sym\n",
                     "SELECT sym FROM t_unknown_sym WHERE sym = 'qrsw' LATEST ON ts PARTITION BY sym ORDER BY 1",
+                    null, true, false
+            );
+
+            // LATEST ON multi-key, all unknown. MultiKeyCoveringCursor.hasNextLatestBy()
+            // has no explicit guard; it relies on the empty multiKeys list keeping
+            // the inner loop from running. The outer ORDER BY still triggers the
+            // getSymbolTable() probe.
+            assertQueryNoLeakCheck(
+                    "sym\n",
+                    "SELECT sym FROM t_unknown_sym WHERE sym IN ('qrsw', 'zzz') LATEST ON ts PARTITION BY sym ORDER BY 1",
+                    null, true, false
+            );
+
+            // LATEST ON multi-key, mixed: returns the latest K0 row; the
+            // unknown 'qrsw' partition is naturally absent.
+            assertQueryNoLeakCheck(
+                    "sym\nK0\n",
+                    "SELECT sym FROM t_unknown_sym WHERE sym IN ('K0', 'qrsw') LATEST ON ts PARTITION BY sym ORDER BY 1",
                     null, true, false
             );
         });


### PR DESCRIPTION
## Summary

- A query that filters a posting-indexed `SYMBOL` column by a literal the symbol map has never seen, and orders results by that column, crashed with `NullPointerException` instead of returning an empty result. The same crash propagated through `CREATE VIEW` validation, which is how the Fuzz Tests pipeline first surfaced it (Azure build [231547](https://dev.azure.com/questdb/questdb/_build/results?buildId=231547), `ViewFuzzTest.testMultipleLevelDependencyViewsWithRandomSelect`).
- The fix keeps the cursor wired up even when no keys resolve, so upstream operators (`ORDER BY`, etc.) can probe `getSymbolTable()` before iteration. A regression test driven by `assertQueryNoLeakCheck` would have caught this directly without waiting for a fuzz hit.

## Cause

When the WHERE literal resolved to `VALUE_NOT_FOUND`, `CoveringIndexRecordCursorFactory.getCursor()` freed the partition frame cursor and called `ofEmpty()`, leaving `frameCursor` and `tableReader` null. `ORDER BY` on a `SYMBOL` column wraps the base cursor in `EncodedSortRecordCursor`, whose `init()` phase probes `baseCursor.getSymbolTable()` before any iteration to build symbol-rank maps. That probe then dereferenced the null `frameCursor`.

```
java.lang.NullPointerException: Cannot invoke "PartitionFrameCursor.getSymbolTable(int)" because "this.frameCursor" is null
  at CoveringIndexRecordCursorFactory$CoveringCursor.getSymbolTable(...:441)
  at SortKeyEncoder.init(...:217)
  at EncodedSortRecordCursor.of(...:148)
  at EncodedSortRecordCursorFactory.getCursor(...:70)
  at LimitRecordCursorFactory.getCursor(...:63)
  at StaleViewCheckFactory.getCursor(...:102)
  at SqlCompilerImpl.executeCreateView(...:4450)
```

## Change

- `getCursor()` and `getPageFrameCursor()` now wire the cursor up via `of()` in all cases. Symbol-table probes always work; iteration short-circuits naturally when the multi-key list is empty.
- Explicit guards in `SingleKeyCoveringCursor.advanceKey()` / `hasNextLatestBy()` and `SingleKeyCoveringPageFrameCursor.nextImpl()` short-circuit when the resolved key is `VALUE_NOT_FOUND`. The guards also stop `VALUE_NOT_FOUND` (-2) from reaching `TableUtils.toIndexKey()`, which would otherwise produce `-1` and force every partition's index reader to be opened just to return an empty cursor.
- Multi-key paths short-circuit on empty key lists, removing a redundant full-partition scan when an `IN` list contains only unknown literals.
- The dead `ofEmpty()` methods are removed.

## Tradeoffs

- One extra integer comparison per `advanceKey()` / `nextImpl()` call. Offset by the removed full-partition scan in the empty multi-key case.
- The previous page-frame variant returned `null` from `getSymbolTable()` on an empty cursor, which was already unsafe for any caller that did not null-check; one existing test (`testPageFrameCursor_OfEmptyNullSymbolTables`) was pinning down that contract. The new contract always returns a usable symbol table.

## Test plan

- New regression test `testEqFilterOnUnknownSymbolWithOrderBy` in `CoveringIndexTest`. Populated table (2,000 rows across 5 known symbols), queries known and unknown symbols with `ORDER BY` in single-key, single-key + `LIMIT`, `IN`-list, mixed `IN`-list (one known + one unknown), bind-variable single-key, bind-variable `IN`-list, and `LATEST ON` (single-key, multi-key all-unknown, multi-key mixed) shapes. Verifies the EXPLAIN plan still picks the CoveringIndex path. Includes a positive `ORDER BY ... DESC LIMIT` baseline on a known symbol so the same factory chain that produced the original NPE stack is exercised on populated data. Verified red against unfixed code with the same NPE; green with the fix.
- `testPageFrameCursor_OfEmptyNullSymbolTables` was documenting the buggy contract; renamed to `testPageFrameCursor_OfEmptySingleKeyKeepsSymbolTables` and the assertions inverted to require non-null.
- All 1,035 covering-index tests pass across the three code-path variants (`CoveringIndexTest`, `CoveringIndexTestEf`, `CoveringIndexTestDelta`).
- All 4 `ViewFuzzTest` cases pass.
- Posting-index suite (`PostingIndexStressTest`, `PostingIndexNativeTest`, `PostingIndexOracleTest`, `PostingIndexCriticalIssuesTest`, `PostingIndexConcurrencyTest`, `PostingSealPurgeTest`, plus `Delta`/`Ef` variants and `IndexTypeTest`, `SymbolNotEqualsValueTest`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
