### PR TITLE
fix(core): fix JVM crash and dropped cover footers on covering posting indexes

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnIndexer.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnIndexer.java
@@ -124,6 +124,15 @@ public interface ColumnIndexer extends QuietCloseable {
 
     void refreshSourceAndIndex(long loRow, long hiRow);
 
+    /**
+     * Drop the read-side state set up for the most recent seal but keep
+     * the covering schema intact, so a subsequent commit() still publishes
+     * a chain entry with a correct cover footer. See
+     * {@link io.questdb.cairo.idx.PostingIndexWriter#releaseCoveredColumnReadMappings()}.
+     */
+    default void releaseCoveredColumnReadMappings() {
+    }
+
     void releaseIndexWriter();
 
     void resetColumnTop();

--- a/core/src/main/java/io/questdb/cairo/SymbolColumnIndexer.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolColumnIndexer.java
@@ -240,6 +240,11 @@ public class SymbolColumnIndexer implements ColumnIndexer, Mutable {
         index(ff, fd, loRow, hiRow);
     }
 
+    @Override
+    public void releaseCoveredColumnReadMappings() {
+        writer.releaseCoveredColumnReadMappings();
+    }
+
     public void releaseIndexWriter() {
         Misc.free(writer);
     }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -11186,9 +11186,13 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         }
                         // Clear the writer's reference to o3SealAddrs so that
                         // a subsequent close() → seal() cannot dereference the
-                        // unmapped addresses. The seal would return early (gen0
-                        // is already dense), but this is a defensive measure.
-                        indexer.clearCovering();
+                        // unmapped addresses. Keep the covering schema
+                        // (coverCount, sidecarMems) intact so a subsequent
+                        // commit() between seals still publishes a chain
+                        // entry with a correct cover footer; clearCovering()
+                        // would zero coverCount and the next captureCoverEnd
+                        // Offsets would short-circuit, dropping the footer.
+                        indexer.releaseCoveredColumnReadMappings();
                     }
                 } else {
                     indexer.configureFollowerAndWriter(
@@ -11364,7 +11368,11 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                                 o3SealAuxAddrs.setQuick(c, 0);
                             }
                         }
-                        indexer.clearCovering();
+                        // Drop the borrowed o3SealAddrs pointers from the
+                        // indexer but keep coverCount and sidecarMems set,
+                        // so a follow-up commit() between fast-lag seals
+                        // still publishes with a correct cover footer.
+                        indexer.releaseCoveredColumnReadMappings();
                     }
                     continue;
                 }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -257,9 +257,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     private final DirectIntList parquetBloomFilterIndexes;
     private final DirectIntList parquetColumnIdsAndTypes;
     private final ParquetPartitionDecoder parquetDecoder = new ParquetPartitionDecoder();
+    private final ParquetFileDecoder parquetFileDecoder = new ParquetFileDecoder();
     private final ParquetMetaFileReader parquetMetaReader = new ParquetMetaFileReader();
     private final int partitionBy;
-    private final ParquetFileDecoder parquetFileDecoder = new ParquetFileDecoder();
     private final DateFormat partitionDirFmt;
     private final LongList partitionRemoveCandidates = new LongList();
     private final Path path;

--- a/core/src/main/java/io/questdb/cairo/idx/IndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/IndexWriter.java
@@ -196,6 +196,14 @@ public interface IndexWriter extends Closeable, Mutable {
     }
 
     /**
+     * Drop the read-side state set up for the most recent seal but keep
+     * the covering schema intact. See
+     * {@link io.questdb.cairo.idx.PostingIndexWriter#releaseCoveredColumnReadMappings()}.
+     */
+    default void releaseCoveredColumnReadMappings() {
+    }
+
+    /**
      * Rolls back values that are strictly greater than the given row.
      * <p>
      * This operation is only supported by some index implementations.

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainEntry.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainEntry.java
@@ -59,41 +59,6 @@ import io.questdb.std.Unsafe;
  */
 public final class PostingIndexChainEntry {
 
-    /**
-     * Reusable read snapshot. Fields populated by {@link #read}.
-     */
-    public static final class Snapshot {
-        public int blockCapacity;
-        public final LongList coverFileEndOffsets = new LongList();
-        public int coveringFormat;
-        public int genCount;
-        public long genDirOffset;
-        public int keyCount;
-        public long len;
-        public long maxValue;
-        public long offset;
-        public long prevEntryOffset;
-        public long sealTxn;
-        public long txnAtSeal;
-        public long valueMemSize;
-
-        public void reset() {
-            this.offset = 0;
-            this.len = 0;
-            this.sealTxn = 0;
-            this.txnAtSeal = 0;
-            this.valueMemSize = 0;
-            this.maxValue = 0;
-            this.keyCount = 0;
-            this.genCount = 0;
-            this.blockCapacity = 0;
-            this.coveringFormat = 0;
-            this.prevEntryOffset = PostingIndexUtils.V2_NO_HEAD;
-            this.genDirOffset = 0;
-            this.coverFileEndOffsets.clear();
-        }
-    }
-
     private PostingIndexChainEntry() {
     }
 
@@ -282,6 +247,41 @@ public final class PostingIndexChainEntry {
                         coverEndOffsets.getQuick(c)
                 );
             }
+        }
+    }
+
+    /**
+     * Reusable read snapshot. Fields populated by {@link #read}.
+     */
+    public static final class Snapshot {
+        public final LongList coverFileEndOffsets = new LongList();
+        public int blockCapacity;
+        public int coveringFormat;
+        public int genCount;
+        public long genDirOffset;
+        public int keyCount;
+        public long len;
+        public long maxValue;
+        public long offset;
+        public long prevEntryOffset;
+        public long sealTxn;
+        public long txnAtSeal;
+        public long valueMemSize;
+
+        public void reset() {
+            this.offset = 0;
+            this.len = 0;
+            this.sealTxn = 0;
+            this.txnAtSeal = 0;
+            this.valueMemSize = 0;
+            this.maxValue = 0;
+            this.keyCount = 0;
+            this.genCount = 0;
+            this.blockCapacity = 0;
+            this.coveringFormat = 0;
+            this.prevEntryOffset = PostingIndexUtils.V2_NO_HEAD;
+            this.genDirOffset = 0;
+            this.coverFileEndOffsets.clear();
         }
     }
 }

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainEntry.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainEntry.java
@@ -162,12 +162,26 @@ public final class PostingIndexChainEntry {
         into.coverFileEndOffsets.clear();
         if (coverCount > 0) {
             long footerOffset = resolveCoverFooterOffset(entryOffset, into.genCount);
+            // Self-bound the footer reads against the entry's own LEN. If the
+            // entry was sealed with fewer cover slots than the reader expects
+            // (e.g., the writer's coverCount was 0 at seal time but the .pci
+            // sidecar later advertised covers), reading all of coverCount
+            // slots would step past entryOffset + len and, when the entry
+            // hugs the end of the mapping, past the mmap itself - producing
+            // a SIGSEGV in MemoryCR.getLong. Treat absent footer slots as
+            // "no published bytes" (0) so the reader leaves the corresponding
+            // sidecars unmapped instead of dereferencing past the entry.
+            long footerBytesAvailable = Math.max(0L, entryOffset + into.len - footerOffset);
+            int writtenCovers = (int) Math.min(coverCount, footerBytesAvailable / PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE);
             into.coverFileEndOffsets.setPos(coverCount);
-            for (int c = 0; c < coverCount; c++) {
+            for (int c = 0; c < writtenCovers; c++) {
                 into.coverFileEndOffsets.setQuick(
                         c,
                         keyMem.getLong(footerOffset + (long) c * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE)
                 );
+            }
+            for (int c = writtenCovers; c < coverCount; c++) {
+                into.coverFileEndOffsets.setQuick(c, 0L);
             }
         }
         return entryOffset + into.len;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainPicker.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainPicker.java
@@ -130,8 +130,11 @@ public final class PostingIndexChainPicker {
             // gen-dir read. The post-read variant of this check used to fire
             // too late: a corrupted or truncated entry whose footer landed
             // past the mmap would already have SIGSEGV'd inside read().
+            // Compare against (mappedLimit - entryOffset) so a stomped
+            // peekedLen near Long.MAX_VALUE cannot overflow the addition
+            // and silently pass the bound check.
             long peekedLen = keyMem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN);
-            if (peekedLen <= 0 || entryOffset + peekedLen > mappedLimit) {
+            if (peekedLen <= 0 || peekedLen > mappedLimit - entryOffset) {
                 return RESULT_HEADER_UNREADABLE;
             }
             // Hard cap on iterations to defend against a corrupted prev

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainPicker.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainPicker.java
@@ -125,6 +125,15 @@ public final class PostingIndexChainPicker {
             if (entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE > mappedLimit) {
                 return RESULT_HEADER_UNREADABLE;
             }
+            // Peek the entry's declared LEN before invoking read(), so the
+            // full-entry bound check happens BEFORE any cover-footer or
+            // gen-dir read. The post-read variant of this check used to fire
+            // too late: a corrupted or truncated entry whose footer landed
+            // past the mmap would already have SIGSEGV'd inside read().
+            long peekedLen = keyMem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN);
+            if (peekedLen <= 0 || entryOffset + peekedLen > mappedLimit) {
+                return RESULT_HEADER_UNREADABLE;
+            }
             // Hard cap on iterations to defend against a corrupted prev
             // pointer that loops back on itself.
             if (visited++ > entryCount) {
@@ -132,10 +141,10 @@ public final class PostingIndexChainPicker {
             }
 
             PostingIndexChainEntry.read(keyMem, entryOffset, coverCount, into);
-            // The full entry (header + gen-dir payload + cover end-offset
-            // footer) must fit inside the mapped region too. snapshotMetadata
-            // reads gen-dir entries at offsets up to entryOffset + into.len.
-            if (into.len <= 0 || entryOffset + into.len > mappedLimit) {
+            // Sanity: the entry's own len must match what we peeked. read()
+            // re-reads LEN, so a torn or racing write could in principle
+            // surface a different value here. If so, treat as unreadable.
+            if (into.len != peekedLen) {
                 return RESULT_HEADER_UNREADABLE;
             }
             if (into.txnAtSeal <= pinnedTableTxn) {

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -82,7 +82,15 @@ public class PostingIndexWriter implements IndexWriter {
     private static final int MAX_GEN_COUNT = PostingIndexUtils.MAX_GEN_COUNT;
     private static final int PENDING_SLOT_CAPACITY = 8;
     private final double alignedBitWidthThreshold;
+    // v2 chain helper: owns the in-memory mirror of the chain header,
+    // exposes append/extend/recovery primitives. Single instance per writer
+    // — reused across reopens via resetState().
+    private final PostingIndexChainWriter chain = new PostingIndexChainWriter();
     private final CairoConfiguration configuration;
+    // Reusable scratch list passed to PostingIndexChainWriter.appendNewEntry /
+    // extendHead — built once per chain publish from each cover column's
+    // current sidecar append offset. Reused across calls to avoid allocations.
+    private final LongList coverEndOffsetsScratch = new LongList();
     // O3 addr-based covering: caller-provided native memory addresses
     private final LongList coveredColumnAddrs = new LongList();
     private final LongList coveredColumnAuxAddrs = new LongList();
@@ -101,6 +109,13 @@ public class PostingIndexWriter implements IndexWriter {
     private final Utf8StringSink partitionPath = new Utf8StringSink();
     private final ObjList<PendingSealPurge> pendingPurgePool = new ObjList<>();
     private final ObjList<PendingSealPurge> pendingPurges = new ObjList<>();
+    // Reusable scratch list for sealTxns that recoveryDropAbandoned dropped
+    // out of the chain on writer-open. Populated by of(...) when
+    // currentTableTxn was supplied via setCurrentTableTxn; the orphan
+    // sealTxns are then forwarded to the seal-purge outbox so the
+    // background job removes the .pv.{N} / .pc{i}.{N} files. Cleared on
+    // every of() call to avoid leaking entries across reopens.
+    private final LongList recoveryOrphanScratch = new LongList();
     private final byte rowIdEncoding;
     private final MemoryMARW sealValueMem = Vm.getCMARWInstance();
     private final ObjList<MemoryMARW> sidecarMems = new ObjList<>();
@@ -115,21 +130,6 @@ public class PostingIndexWriter implements IndexWriter {
     private int activeKeyCount;
     private int[] activeKeyIds = new int[INITIAL_KEY_CAPACITY];
     private int blockCapacity;
-    // v2 chain helper: owns the in-memory mirror of the chain header,
-    // exposes append/extend/recovery primitives. Single instance per writer
-    // — reused across reopens via resetState().
-    private final PostingIndexChainWriter chain = new PostingIndexChainWriter();
-    // Reusable scratch list for sealTxns that recoveryDropAbandoned dropped
-    // out of the chain on writer-open. Populated by of(...) when
-    // currentTableTxn was supplied via setCurrentTableTxn; the orphan
-    // sealTxns are then forwarded to the seal-purge outbox so the
-    // background job removes the .pv.{N} / .pc{i}.{N} files. Cleared on
-    // every of() call to avoid leaking entries across reopens.
-    private final LongList recoveryOrphanScratch = new LongList();
-    // Reusable scratch list passed to PostingIndexChainWriter.appendNewEntry /
-    // extendHead — built once per chain publish from each cover column's
-    // current sidecar append offset. Reused across calls to avoid allocations.
-    private final LongList coverEndOffsetsScratch = new LongList();
     private int coverCount;
     private long[] coveredAuxReadAddrs;
     private long[] coveredAuxReadSizes;
@@ -301,36 +301,6 @@ public class PostingIndexWriter implements IndexWriter {
         this.coveredColumnNames.clear();
         this.coveredColumnNameTxns.clear();
         this.coverCount = 0;
-    }
-
-    /**
-     * Release the read-side state set up for the most recent seal: the
-     * covered-column read mappings and the borrowed source-column addresses
-     * passed in via {@link #configureCovering}. Keeps the covering schema
-     * (coverCount, coveredColumnIndices, coveredColumnNames,
-     * coveredColumnNameTxns, coveredColumnTops, coveredColumnShifts,
-     * coveredColumnTypes, sidecarMems) intact so a subsequent commit() can
-     * still publish a chain entry with a correctly-sized cover footer
-     * sourced from {@link #sidecarMems}' append offsets at the last seal.
-     * <p>
-     * Called from {@code TableWriter}'s post-seal finally blocks where the
-     * caller is about to munmap the covered-column files it mapped RO for
-     * the seal. Without dropping the borrowed pointers held in
-     * {@code coveredColumnAddrs} / {@code coveredColumnAuxAddrs} here, a
-     * subsequent ensureCoveredColumnReadMaps would dereference garbage.
-     * <p>
-     * Use {@link #clearCovering()} only when truly tearing down covering
-     * (writer discard, swap to a different cover schema). For the typical
-     * "seal done, release temporary read mmaps, keep schema" lifecycle,
-     * use this method - {@code clearCovering()} would zero {@code
-     * coverCount} and the next {@code commit()}'s {@code
-     * captureCoverEndOffsets} would short-circuit, dropping the cover
-     * footer from the published chain entry.
-     */
-    public void releaseCoveredColumnReadMappings() {
-        unmapCoveredColumnReads();
-        this.coveredColumnAddrs.clear();
-        this.coveredColumnAuxAddrs.clear();
     }
 
     @Override
@@ -680,16 +650,6 @@ public class PostingIndexWriter implements IndexWriter {
     }
 
     /**
-     * Number of pending purge entries that have not yet been forwarded to
-     * the global PostingSealPurge queue. Tests use this to verify that the
-     * outbox is bounded under saturation.
-     */
-    @TestOnly
-    public int getPendingPurgesSizeForTesting() {
-        return pendingPurges.size();
-    }
-
-    /**
      * Read-only access to a queued purge entry's
      * {@code [fromTableTxn, toTableTxn)} window for testing. Returns
      * {@code -1} components if the index is out of range. Tests use this
@@ -710,6 +670,16 @@ public class PostingIndexWriter implements IndexWriter {
             return -1L;
         }
         return pendingPurges.getQuick(idx).toTableTxn;
+    }
+
+    /**
+     * Number of pending purge entries that have not yet been forwarded to
+     * the global PostingSealPurge queue. Tests use this to verify that the
+     * outbox is bounded under saturation.
+     */
+    @TestOnly
+    public int getPendingPurgesSizeForTesting() {
+        return pendingPurges.size();
     }
 
     @TestOnly
@@ -1064,6 +1034,36 @@ public class PostingIndexWriter implements IndexWriter {
             // sidecar opening at newSealTxn.
             seal();
         }
+    }
+
+    /**
+     * Release the read-side state set up for the most recent seal: the
+     * covered-column read mappings and the borrowed source-column addresses
+     * passed in via {@link #configureCovering}. Keeps the covering schema
+     * (coverCount, coveredColumnIndices, coveredColumnNames,
+     * coveredColumnNameTxns, coveredColumnTops, coveredColumnShifts,
+     * coveredColumnTypes, sidecarMems) intact so a subsequent commit() can
+     * still publish a chain entry with a correctly-sized cover footer
+     * sourced from {@link #sidecarMems}' append offsets at the last seal.
+     * <p>
+     * Called from {@code TableWriter}'s post-seal finally blocks where the
+     * caller is about to munmap the covered-column files it mapped RO for
+     * the seal. Without dropping the borrowed pointers held in
+     * {@code coveredColumnAddrs} / {@code coveredColumnAuxAddrs} here, a
+     * subsequent ensureCoveredColumnReadMaps would dereference garbage.
+     * <p>
+     * Use {@link #clearCovering()} only when truly tearing down covering
+     * (writer discard, swap to a different cover schema). For the typical
+     * "seal done, release temporary read mmaps, keep schema" lifecycle,
+     * use this method - {@code clearCovering()} would zero {@code
+     * coverCount} and the next {@code commit()}'s {@code
+     * captureCoverEndOffsets} would short-circuit, dropping the cover
+     * footer from the published chain entry.
+     */
+    public void releaseCoveredColumnReadMappings() {
+        unmapCoveredColumnReads();
+        this.coveredColumnAddrs.clear();
+        this.coveredColumnAuxAddrs.clear();
     }
 
     @Override
@@ -1590,6 +1590,31 @@ public class PostingIndexWriter implements IndexWriter {
         Unsafe.setMemory(pendingCountsAddr, countBufSize, (byte) 0);
 
         activeKeyIds = new int[keyCapacity];
+    }
+
+    /**
+     * Refresh {@link #coverEndOffsetsScratch} so it has exactly {@code coverCount}
+     * entries and each slot reflects the current append offset of the matching
+     * {@code sidecarMems} entry (or 0 when the slot is tombstoned / unopened).
+     * The result is the authoritative valid-byte extent of each .pcN at the
+     * moment the chain entry is republished.
+     */
+    private void captureCoverEndOffsets() {
+        coverEndOffsetsScratch.clear();
+        if (coverCount <= 0) {
+            return;
+        }
+        coverEndOffsetsScratch.setPos(coverCount);
+        for (int c = 0; c < coverCount; c++) {
+            long endOffset = 0L;
+            if (c < sidecarMems.size()) {
+                MemoryMARW mem = sidecarMems.getQuick(c);
+                if (mem != null && mem.isOpen()) {
+                    endOffset = mem.getAppendOffset();
+                }
+            }
+            coverEndOffsetsScratch.setQuick(c, endOffset);
+        }
     }
 
     private void closeSidecarMems() {
@@ -2684,6 +2709,98 @@ public class PostingIndexWriter implements IndexWriter {
     }
 
     /**
+     * Persist the writer's in-memory state to the v2 chain. Writes the
+     * supplied gen-dir entry to the right slot, then either extends the
+     * head entry (when the .pv file matches the head's sealTxn) or
+     * appends a brand-new chain entry (when {@code sealTxn} has just
+     * advanced past the head's sealTxn — i.e. a path-based seal).
+     * <p>
+     * The new entry's bytes go to {@code chain.getRegionLimit()}; the
+     * extended head entry's bytes mutate at {@code chain.getHeadEntryOffset()}.
+     * In both cases the chain header is republished under its A/B seqlock so
+     * concurrent readers observe a consistent snapshot.
+     *
+     * @param newGenCount        gen-dir entry count after the publish
+     * @param overrideGenIndex   slot to write the new gen-dir entry to
+     * @param overrideFileOffset {@code .pv} offset of the new gen
+     * @param overrideSize       byte size of the new gen
+     * @param overrideKeyCount   distinct keys in the new gen (negative for sparse)
+     * @param overrideMinKey     min key in the new gen
+     * @param overrideMaxKey     max key in the new gen
+     */
+    private void publishToChain(int newGenCount, int overrideGenIndex,
+                                long overrideFileOffset, long overrideSize,
+                                int overrideKeyCount, int overrideMinKey, int overrideMaxKey) {
+        // The writer's sealTxn always points at the .pv file currently
+        // mapped through valueMem. When chain.getHeadSealTxn() == sealTxn
+        // (head matches the same .pv file) we extend the head entry. When
+        // sealTxn advances past the head's sealTxn (a seal switched .pv),
+        // we append a fresh entry. The same applies to the empty-chain
+        // case (headSealTxn = -1 < sealTxn) — first flush after init/
+        // truncate. The comparison is against the head's sealTxn rather
+        // than chain.getGenCounter() because recoveryDropAbandoned can
+        // leave the chain with headSealTxn < genCounter (the dropped
+        // sealTxn .pv files are still on disk awaiting purge, so
+        // genCounter cannot be safely rewound). Using genCounter here
+        // would force a newEntry append at this.sealTxn = head.sealTxn,
+        // tripping the appendNewEntry monotonicity assertion.
+        boolean newEntry = !chain.hasHead() || this.sealTxn != chain.getHeadSealTxn();
+        long entryBase = newEntry ? chain.getRegionLimit() : chain.getHeadEntryOffset();
+
+        long dirOffset = PostingIndexChainEntry.resolveGenDirOffset(entryBase, overrideGenIndex);
+        keyMem.putLong(dirOffset + GEN_DIR_OFFSET_FILE_OFFSET, overrideFileOffset);
+        keyMem.putLong(dirOffset + GEN_DIR_OFFSET_SIZE, overrideSize);
+        keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_KEY_COUNT, overrideKeyCount);
+        keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MIN_KEY, overrideMinKey);
+        keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY, overrideMaxKey);
+
+        // Snapshot the current append offset of each open sidecar. Tombstoned
+        // and not-yet-opened slots publish 0 — readers treat them as "no file
+        // / nothing to map", consistent with how isCoveredAvailable handles
+        // missing sidecars.
+        captureCoverEndOffsets();
+
+        if (newEntry) {
+            // pendingTxnAtSeal supplied by the upstream caller is the
+            // table _txn this seal's chain entry should be tagged with.
+            // The required value depends on the context:
+            //   - commit-in-progress paths (TableWriter syncColumns,
+            //     sealPostingIndexesForO3Partitions, ALTER ADD COLUMN/INDEX
+            //     index build): txnAtSeal = txWriter.getTxn() + 1, so a
+            //     writer-open recovery walk after a partial-publish
+            //     failure can drop entries with txnAtSeal > committedTxn.
+            //   - current-state paths (switchPartitionToLast rollback,
+            //     IndexBuilder REINDEX, TableSnapshotRestore, the O3
+            //     covering rebuildSidecars branch): txnAtSeal = current
+            //     committed _txn, so recovery does NOT drop the
+            //     legitimately published entry on the next reopen.
+            // -1 (unset) means the caller didn't wire the setter; fall
+            // back to txnAtSeal=0 so the entry is visible to every pinned
+            // reader. The recovery walk cannot drop a 0-tagged entry
+            // (predicate `0 > committedTxn` never fires), so a partial
+            // publish on this path turns into an undroppable orphan. The
+            // wiring in TableWriter eliminates this for the production
+            // paths that matter; this fallback exists only for legacy
+            // test fixtures and the no-arg of(...) used by O3CopyJob.
+            long txnAtSeal = pendingTxnAtSeal >= 0 ? pendingTxnAtSeal : 0L;
+            chain.appendNewEntry(
+                    keyMem,
+                    /* sealTxn */ this.sealTxn,
+                    /* txnAtSeal */ txnAtSeal,
+                    /* valueMemSize */ valueMemSize,
+                    /* maxValue */ maxValue,
+                    /* keyCount */ keyCount,
+                    /* genCount */ newGenCount,
+                    /* blockCapacity */ blockCapacity,
+                    /* coveringFormat */ 0,
+                    coverEndOffsetsScratch
+            );
+        } else {
+            chain.extendHead(keyMem, newGenCount, keyCount, valueMemSize, maxValue, coverEndOffsetsScratch);
+        }
+    }
+
+    /**
      * Records that the previous-sealTxn files for this column instance are
      * now superseded and eligible for purge. {@link #publishPendingPurges}
      * forwards each entry to the global queue; the background job checks the
@@ -3500,6 +3617,24 @@ public class PostingIndexWriter implements IndexWriter {
         hasSpillData = false;
     }
 
+    private void rollbackToMaxValue(long maxValue) {
+        // Rollback writes to a NEW .pv file (like seal) so concurrent readers
+        // with active mmaps on the old .pv don't SIGSEGV. Allocate the rollback
+        // sealTxn the same way seal() does so the new .pv stays distinct from
+        // any prior sealed generation on disk.
+        // peekNextSealTxn(), not sealTxn+1: after a recovery drop the
+        // writer's sealTxn lags genCounter, and reusing a dropped
+        // sealTxn would race the still-pending .pv purge.
+        final long oldSealTxn = sealTxn;
+        final long newSealTxn = Math.max(1, chain.peekNextSealTxn());
+        reencodeAllGenerations(newSealTxn, maxValue, maxValue);
+        // Skip when reencode bypassed via truncate() — that path already
+        // recorded its own purge entry.
+        if (sealTxn != oldSealTxn) {
+            recordPostingSealPurge(oldSealTxn);
+        }
+    }
+
     /**
      * Run the v2 chain recovery walk if {@link #setCurrentTableTxn} was
      * called with a non-negative value before this {@code of(...)}. Drops
@@ -3545,24 +3680,6 @@ public class PostingIndexWriter implements IndexWriter {
             scheduleOrphanPurge(orphanSealTxn);
         }
         recoveryOrphanScratch.clear();
-    }
-
-    private void rollbackToMaxValue(long maxValue) {
-        // Rollback writes to a NEW .pv file (like seal) so concurrent readers
-        // with active mmaps on the old .pv don't SIGSEGV. Allocate the rollback
-        // sealTxn the same way seal() does so the new .pv stays distinct from
-        // any prior sealed generation on disk.
-        // peekNextSealTxn(), not sealTxn+1: after a recovery drop the
-        // writer's sealTxn lags genCounter, and reusing a dropped
-        // sealTxn would race the still-pending .pv purge.
-        final long oldSealTxn = sealTxn;
-        final long newSealTxn = Math.max(1, chain.peekNextSealTxn());
-        reencodeAllGenerations(newSealTxn, maxValue, maxValue);
-        // Skip when reencode bypassed via truncate() — that path already
-        // recorded its own purge entry.
-        if (sealTxn != oldSealTxn) {
-            recordPostingSealPurge(oldSealTxn);
-        }
     }
 
     /**
@@ -4094,123 +4211,6 @@ public class PostingIndexWriter implements IndexWriter {
 
         long headerAddr = sealTarget.addressOf(headerFilePos);
         Unsafe.copyMemory(localHeaderBuf, headerAddr, deltaHeaderSize);
-    }
-
-    /**
-     * Persist the writer's in-memory state to the v2 chain. Writes the
-     * supplied gen-dir entry to the right slot, then either extends the
-     * head entry (when the .pv file matches the head's sealTxn) or
-     * appends a brand-new chain entry (when {@code sealTxn} has just
-     * advanced past the head's sealTxn — i.e. a path-based seal).
-     * <p>
-     * The new entry's bytes go to {@code chain.getRegionLimit()}; the
-     * extended head entry's bytes mutate at {@code chain.getHeadEntryOffset()}.
-     * In both cases the chain header is republished under its A/B seqlock so
-     * concurrent readers observe a consistent snapshot.
-     *
-     * @param newGenCount        gen-dir entry count after the publish
-     * @param overrideGenIndex   slot to write the new gen-dir entry to
-     * @param overrideFileOffset {@code .pv} offset of the new gen
-     * @param overrideSize       byte size of the new gen
-     * @param overrideKeyCount   distinct keys in the new gen (negative for sparse)
-     * @param overrideMinKey     min key in the new gen
-     * @param overrideMaxKey     max key in the new gen
-     */
-    private void publishToChain(int newGenCount, int overrideGenIndex,
-                                long overrideFileOffset, long overrideSize,
-                                int overrideKeyCount, int overrideMinKey, int overrideMaxKey) {
-        // The writer's sealTxn always points at the .pv file currently
-        // mapped through valueMem. When chain.getHeadSealTxn() == sealTxn
-        // (head matches the same .pv file) we extend the head entry. When
-        // sealTxn advances past the head's sealTxn (a seal switched .pv),
-        // we append a fresh entry. The same applies to the empty-chain
-        // case (headSealTxn = -1 < sealTxn) — first flush after init/
-        // truncate. The comparison is against the head's sealTxn rather
-        // than chain.getGenCounter() because recoveryDropAbandoned can
-        // leave the chain with headSealTxn < genCounter (the dropped
-        // sealTxn .pv files are still on disk awaiting purge, so
-        // genCounter cannot be safely rewound). Using genCounter here
-        // would force a newEntry append at this.sealTxn = head.sealTxn,
-        // tripping the appendNewEntry monotonicity assertion.
-        boolean newEntry = !chain.hasHead() || this.sealTxn != chain.getHeadSealTxn();
-        long entryBase = newEntry ? chain.getRegionLimit() : chain.getHeadEntryOffset();
-
-        long dirOffset = PostingIndexChainEntry.resolveGenDirOffset(entryBase, overrideGenIndex);
-        keyMem.putLong(dirOffset + GEN_DIR_OFFSET_FILE_OFFSET, overrideFileOffset);
-        keyMem.putLong(dirOffset + GEN_DIR_OFFSET_SIZE, overrideSize);
-        keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_KEY_COUNT, overrideKeyCount);
-        keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MIN_KEY, overrideMinKey);
-        keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY, overrideMaxKey);
-
-        // Snapshot the current append offset of each open sidecar. Tombstoned
-        // and not-yet-opened slots publish 0 — readers treat them as "no file
-        // / nothing to map", consistent with how isCoveredAvailable handles
-        // missing sidecars.
-        captureCoverEndOffsets();
-
-        if (newEntry) {
-            // pendingTxnAtSeal supplied by the upstream caller is the
-            // table _txn this seal's chain entry should be tagged with.
-            // The required value depends on the context:
-            //   - commit-in-progress paths (TableWriter syncColumns,
-            //     sealPostingIndexesForO3Partitions, ALTER ADD COLUMN/INDEX
-            //     index build): txnAtSeal = txWriter.getTxn() + 1, so a
-            //     writer-open recovery walk after a partial-publish
-            //     failure can drop entries with txnAtSeal > committedTxn.
-            //   - current-state paths (switchPartitionToLast rollback,
-            //     IndexBuilder REINDEX, TableSnapshotRestore, the O3
-            //     covering rebuildSidecars branch): txnAtSeal = current
-            //     committed _txn, so recovery does NOT drop the
-            //     legitimately published entry on the next reopen.
-            // -1 (unset) means the caller didn't wire the setter; fall
-            // back to txnAtSeal=0 so the entry is visible to every pinned
-            // reader. The recovery walk cannot drop a 0-tagged entry
-            // (predicate `0 > committedTxn` never fires), so a partial
-            // publish on this path turns into an undroppable orphan. The
-            // wiring in TableWriter eliminates this for the production
-            // paths that matter; this fallback exists only for legacy
-            // test fixtures and the no-arg of(...) used by O3CopyJob.
-            long txnAtSeal = pendingTxnAtSeal >= 0 ? pendingTxnAtSeal : 0L;
-            chain.appendNewEntry(
-                    keyMem,
-                    /* sealTxn */ this.sealTxn,
-                    /* txnAtSeal */ txnAtSeal,
-                    /* valueMemSize */ valueMemSize,
-                    /* maxValue */ maxValue,
-                    /* keyCount */ keyCount,
-                    /* genCount */ newGenCount,
-                    /* blockCapacity */ blockCapacity,
-                    /* coveringFormat */ 0,
-                    coverEndOffsetsScratch
-            );
-        } else {
-            chain.extendHead(keyMem, newGenCount, keyCount, valueMemSize, maxValue, coverEndOffsetsScratch);
-        }
-    }
-
-    /**
-     * Refresh {@link #coverEndOffsetsScratch} so it has exactly {@code coverCount}
-     * entries and each slot reflects the current append offset of the matching
-     * {@code sidecarMems} entry (or 0 when the slot is tombstoned / unopened).
-     * The result is the authoritative valid-byte extent of each .pcN at the
-     * moment the chain entry is republished.
-     */
-    private void captureCoverEndOffsets() {
-        coverEndOffsetsScratch.clear();
-        if (coverCount <= 0) {
-            return;
-        }
-        coverEndOffsetsScratch.setPos(coverCount);
-        for (int c = 0; c < coverCount; c++) {
-            long endOffset = 0L;
-            if (c < sidecarMems.size()) {
-                MemoryMARW mem = sidecarMems.getQuick(c);
-                if (mem != null && mem.isOpen()) {
-                    endOffset = mem.getAppendOffset();
-                }
-            }
-            coverEndOffsetsScratch.setQuick(c, endOffset);
-        }
     }
 
     private void writePackedStride(int ks, int[] keyCounts, long[] keyOffsets,

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -303,6 +303,36 @@ public class PostingIndexWriter implements IndexWriter {
         this.coverCount = 0;
     }
 
+    /**
+     * Release the read-side state set up for the most recent seal: the
+     * covered-column read mappings and the borrowed source-column addresses
+     * passed in via {@link #configureCovering}. Keeps the covering schema
+     * (coverCount, coveredColumnIndices, coveredColumnNames,
+     * coveredColumnNameTxns, coveredColumnTops, coveredColumnShifts,
+     * coveredColumnTypes, sidecarMems) intact so a subsequent commit() can
+     * still publish a chain entry with a correctly-sized cover footer
+     * sourced from {@link #sidecarMems}' append offsets at the last seal.
+     * <p>
+     * Called from {@code TableWriter}'s post-seal finally blocks where the
+     * caller is about to munmap the covered-column files it mapped RO for
+     * the seal. Without dropping the borrowed pointers held in
+     * {@code coveredColumnAddrs} / {@code coveredColumnAuxAddrs} here, a
+     * subsequent ensureCoveredColumnReadMaps would dereference garbage.
+     * <p>
+     * Use {@link #clearCovering()} only when truly tearing down covering
+     * (writer discard, swap to a different cover schema). For the typical
+     * "seal done, release temporary read mmaps, keep schema" lifecycle,
+     * use this method - {@code clearCovering()} would zero {@code
+     * coverCount} and the next {@code commit()}'s {@code
+     * captureCoverEndOffsets} would short-circuit, dropping the cover
+     * footer from the published chain entry.
+     */
+    public void releaseCoveredColumnReadMappings() {
+        unmapCoveredColumnReads();
+        this.coveredColumnAddrs.clear();
+        this.coveredColumnAuxAddrs.clear();
+    }
+
     @Override
     public void close() {
         try {

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -294,9 +294,7 @@ public class PostingIndexWriter implements IndexWriter {
     }
 
     public void clearCovering() {
-        unmapCoveredColumnReads();
-        this.coveredColumnAddrs.clear();
-        this.coveredColumnAuxAddrs.clear();
+        releaseCoveredColumnReadMappings();
         this.coveredPartitionPath.clear();
         this.coveredColumnNames.clear();
         this.coveredColumnNameTxns.clear();

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -1405,6 +1405,95 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * Validates the Fix B writer-side change: after a seal, the
+     * post-seal finally block now calls
+     * {@link PostingIndexWriter#releaseCoveredColumnReadMappings()}
+     * instead of {@link PostingIndexWriter#clearCovering()}, preserving
+     * the writer's covering schema (coverCount, sidecarMems) so a
+     * subsequent commit() between seals still publishes a chain entry
+     * with a correctly-sized cover footer. This is the symmetric
+     * counterpart to {@link #testWriterEntrysCoverFooterShrinksAfterClearCoveringCommit},
+     * which documents that the old clearCovering()-then-commit() flow
+     * shrinks the footer.
+     */
+    @Test
+    public void testWriterEntrysCoverFooterPersistsAfterReleaseReadMappingsCommit() throws Exception {
+        assertMemoryLeak(() -> {
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                String name = "writer_release_read_mappings_then_commit";
+                int plen = path.size();
+                FilesFacade ff = configuration.getFilesFacade();
+
+                final int coverCount = 1;
+                final long fakeColRows = 32;
+                final int shift = 3;
+                final long fakeColBytes = fakeColRows << shift;
+                long fakeColAddr = Unsafe.malloc(fakeColBytes, MemoryTag.NATIVE_DEFAULT);
+                try {
+                    Unsafe.getUnsafe().setMemory(fakeColAddr, fakeColBytes, (byte) 0);
+
+                    long[] addrs = {fakeColAddr};
+                    long[] tops = {0L};
+                    int[] shifts = {shift};
+                    int[] indices = {1};
+                    int[] types = {io.questdb.cairo.ColumnType.LONG};
+
+                    try (PostingIndexWriter writer = new PostingIndexWriter(
+                            configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                        writer.configureCovering(addrs, tops, shifts, indices, types, coverCount);
+                        for (int i = 0; i < 8; i++) {
+                            writer.add(i % 4, i);
+                        }
+                        writer.setMaxValue(7);
+                        writer.setNextTxnAtSeal(1L);
+                        writer.seal();
+
+                        // Models the production post-seal finally block:
+                        // release the borrowed read-side addrs but keep
+                        // the covering schema (coverCount, sidecarMems).
+                        writer.releaseCoveredColumnReadMappings();
+
+                        for (int i = 0; i < 4; i++) {
+                            writer.add(i, 100 + i);
+                        }
+                        writer.setMaxValue(103);
+                        writer.setNextTxnAtSeal(2L);
+                        writer.commit();
+
+                        LPSZ keyFile = PostingIndexUtils.keyFileName(
+                                path.trimTo(plen), name, COLUMN_NAME_TXN_NONE);
+                        long fileSize = ff.length(keyFile);
+                        try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
+                                ff, keyFile, ff.getPageSize(), fileSize,
+                                MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
+                            PostingIndexChainWriter chain = new PostingIndexChainWriter();
+                            chain.openExisting(mem);
+                            PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
+                            chain.loadHeadEntry(mem, head);
+                            Assert.assertEquals(
+                                    "Fix B: with releaseCoveredColumnReadMappings the "
+                                            + "writer's coverCount stays > 0 across the "
+                                            + "post-seal release, so the next commit's "
+                                            + "extendHead writes a LEN that includes the "
+                                            + "cover footer",
+                                    PostingIndexChainEntry.entrySize(head.genCount, coverCount),
+                                    head.len
+                            );
+                            Assert.assertNotEquals(
+                                    "Fix B: the head LEN must NOT match the no-cover sizing",
+                                    PostingIndexChainEntry.entrySize(head.genCount, 0),
+                                    head.len
+                            );
+                        }
+                    }
+                } finally {
+                    Unsafe.free(fakeColAddr, fakeColBytes, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    /**
      * Critical #4 and #5 are style violations enforced by static
      * analysis, not JUnit. They cannot be expressed as red unit tests.
      * Reference checks:

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -24,14 +24,19 @@
 
 package io.questdb.test.cairo;
 
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.idx.BitpackUtils;
 import io.questdb.cairo.idx.PostingIndexChainEntry;
+import io.questdb.cairo.idx.PostingIndexChainHeader;
+import io.questdb.cairo.idx.PostingIndexChainPicker;
 import io.questdb.cairo.idx.PostingIndexChainWriter;
 import io.questdb.cairo.idx.PostingIndexNative;
 import io.questdb.cairo.idx.PostingIndexUtils;
 import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cairo.vm.MemoryCMARWImpl;
 import io.questdb.std.FilesFacade;
@@ -50,7 +55,6 @@ import org.junit.Test;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;
 
@@ -444,13 +448,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                 try {
                     try (RecordCursorFactory factory = select(
                             "SELECT count(*) AS c FROM (SELECT DISTINCT sym FROM t_stale_pk)")) {
-                        try (io.questdb.cairo.sql.RecordCursor c = factory.getCursor(sqlExecutionContext)) {
+                        try (RecordCursor c = factory.getCursor(sqlExecutionContext)) {
                             if (c.hasNext()) {
                                 count = c.getRecord().getLong(0);
                             }
                         }
                     }
-                } catch (io.questdb.cairo.CairoException ok) {
+                } catch (CairoException ok) {
                     // Acceptable post-fix outcome: clean error surfaced.
                     return;
                 } catch (AssertionError jvmAssert) {
@@ -668,7 +672,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                             INSERT INTO t_truncate_half VALUES
                             ('2024-01-02T00:00:00', 'C')
                             """);
-                } catch (io.questdb.cairo.CairoException expected) {
+                } catch (CairoException expected) {
                     // OK — this is the clean failure mode.
                 } catch (NullPointerException | AssertionError leaked) {
                     Assert.fail(
@@ -1160,7 +1164,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             String[] sampleKeys = {"AAAA", "BBBB", "CCCC"};
             try (RecordCursorFactory f = select("SELECT DISTINCT sym FROM walbench LIMIT 3")) {
                 int idx = 0;
-                try (io.questdb.cairo.sql.RecordCursor c = f.getCursor(sqlExecutionContext)) {
+                try (RecordCursor c = f.getCursor(sqlExecutionContext)) {
                     while (c.hasNext() && idx < sampleKeys.length) {
                         sampleKeys[idx++] = c.getRecord().getSymA(0).toString();
                     }
@@ -1183,7 +1187,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                 long count = -1;
                 try (RecordCursorFactory f = select(
                         "SELECT count() FROM walbench WHERE sym = '" + key + "'")) {
-                    try (io.questdb.cairo.sql.RecordCursor c = f.getCursor(sqlExecutionContext)) {
+                    try (RecordCursor c = f.getCursor(sqlExecutionContext)) {
                         if (c.hasNext()) {
                             count = c.getRecord().getLong(0);
                         }
@@ -1232,7 +1236,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                     long[] tops = {0L};
                     int[] shifts = {shift};
                     int[] indices = {1};
-                    int[] types = {io.questdb.cairo.ColumnType.LONG};
+                    int[] types = {ColumnType.LONG};
 
                     try (PostingIndexWriter writer = new PostingIndexWriter(
                             configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
@@ -1336,7 +1340,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                     long[] tops = {0L};
                     int[] shifts = {shift};
                     int[] indices = {1}; // dummy writer-side index
-                    int[] types = {io.questdb.cairo.ColumnType.LONG};
+                    int[] types = {ColumnType.LONG};
 
                     try (PostingIndexWriter writer = new PostingIndexWriter(
                             configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
@@ -1464,14 +1468,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                             final long sentinel = 0xDEAD_BEEF_CAFE_BABEL;
                             mem.putLong(footerOffset, sentinel);
 
-                            io.questdb.cairo.idx.PostingIndexChainHeader.Snapshot header =
-                                    new io.questdb.cairo.idx.PostingIndexChainHeader.Snapshot();
+                            PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
                             PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
-                            int rc = io.questdb.cairo.idx.PostingIndexChainPicker.pick(
+                            int rc = PostingIndexChainPicker.pick(
                                     mem, /* pinnedTableTxn */ Long.MAX_VALUE,
                                     /* coverCount */ coverCount, header, entry);
                             Assert.assertEquals(
-                                    io.questdb.cairo.idx.PostingIndexChainPicker.RESULT_OK, rc);
+                                    PostingIndexChainPicker.RESULT_OK, rc);
                             Assert.assertEquals(
                                     "Fix A: missing cover slot is zero-filled instead "
                                             + "of dereferencing past the entry",

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -1195,10 +1195,12 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                 }
                 Assert.assertTrue(
                         "iter=" + iter + ", key=" + key + ", count=" + count
-                                + " - reader did not crash but returned a "
-                                + "non-positive count, indicating the chain walk "
-                                + "skipped or mis-read entries",
-                        count >= 0
+                                + " - sampleKeys are sourced from the preloaded "
+                                + "2_000-row batch (DISTINCT sym LIMIT 3), so "
+                                + "each must have count>0; a zero or negative "
+                                + "count means the chain walk skipped or "
+                                + "mis-read the entries holding this symbol",
+                        count > 0
                 );
             }
         });

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -1119,6 +1119,292 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * Reproduces the SIGSEGV from the JMH walFastLag bench (hs_err_pid19555):
+     * MemoryCR.getLong over-read inside PostingIndexChainEntry.read on a
+     * covering posting index. The bench ran walFastLagInsertAndQuery in a
+     * tight INSERT/drain/SELECT loop; a chain entry sealed with coverCount=0
+     * (because PostingIndexWriter's coverCount field is reset to 0 by the
+     * post-fast-lag-seal clearCovering(), and a subsequent commit() flushes
+     * pending data via extendHead with coverCount=0) ended up flush against
+     * the end of the .pk mmap. The reader, opened with coverCount=1 from
+     * the .pci sidecar, stepped past the entry's LEN reading the cover
+     * footer and SIGSEGV'd when the read crossed the mapping boundary.
+     * <p>
+     * This test mirrors the bench shape (covering posting index, WAL
+     * INSERT, drain, SELECT, repeat). With the picker/read fix in place,
+     * the cover-mismatched entries no longer crash readers - readers see
+     * zero-filled cover end offsets for those entries, fall back to the
+     * non-covering path, and queries return correct row counts. Without
+     * the fix, this test crashes the JVM (no AssertionError, just SIGSEGV).
+     */
+    @Test
+    public void testWalFastLagCoveringPostingDoesNotCrashReader() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE walbench (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            execute("""
+                    INSERT INTO walbench(ts, sym, price)
+                    SELECT dateadd('u', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP),
+                           rnd_symbol(50, 4, 8, 0), rnd_double() * 1000
+                    FROM long_sequence(2_000)
+                    """);
+            drainWalQueue();
+
+            // Sample a few keys that exist in the preloaded data so the
+            // SELECT below has something to count.
+            String[] sampleKeys = {"AAAA", "BBBB", "CCCC"};
+            try (RecordCursorFactory f = select("SELECT DISTINCT sym FROM walbench LIMIT 3")) {
+                int idx = 0;
+                try (io.questdb.cairo.sql.RecordCursor c = f.getCursor(sqlExecutionContext)) {
+                    while (c.hasNext() && idx < sampleKeys.length) {
+                        sampleKeys[idx++] = c.getRecord().getSymA(0).toString();
+                    }
+                }
+            }
+
+            // Loop the bench's per-iteration shape: INSERT batch -> drain ->
+            // SELECT count. The fast-lag commit path runs inside drainWalQueue,
+            // so each iteration pushes a new chain entry that, on the buggy
+            // writer, has coverCount=0 even though .pci advertises 1 cover.
+            for (int iter = 0; iter < 64; iter++) {
+                int batchOffset = iter + 1;
+                execute("INSERT INTO walbench(ts, sym, price) " +
+                        "SELECT dateadd('u', x::INT, dateadd('s', " + batchOffset + ", '2024-01-01T00:00:00.000000Z'::TIMESTAMP)), " +
+                        "rnd_symbol(50, 4, 8, 0), rnd_double() * 1000 " +
+                        "FROM long_sequence(200)");
+                drainWalQueue();
+
+                String key = sampleKeys[iter % sampleKeys.length];
+                long count = -1;
+                try (RecordCursorFactory f = select(
+                        "SELECT count() FROM walbench WHERE sym = '" + key + "'")) {
+                    try (io.questdb.cairo.sql.RecordCursor c = f.getCursor(sqlExecutionContext)) {
+                        if (c.hasNext()) {
+                            count = c.getRecord().getLong(0);
+                        }
+                    }
+                }
+                Assert.assertTrue(
+                        "iter=" + iter + ", key=" + key + ", count=" + count
+                                + " - reader did not crash but returned a "
+                                + "non-positive count, indicating the chain walk "
+                                + "skipped or mis-read entries",
+                        count >= 0
+                );
+            }
+        });
+    }
+
+    /**
+     * Reproduces the writer-side root cause of the GraalVM SIGSEGV in
+     * hs_err_pid19555 (PostingIndexBenchmarkSuite.walFastLagInsertAndQuery
+     * on bench/posting-wal-fastlag): a covering posting index whose chain
+     * head had LEN=96 (= entrySize(genCount=1, coverCount=0)) while .pci
+     * advertised coverCount=1. This test drives PostingIndexWriter through
+     * the same lifecycle the WAL fast-lag path follows in production:
+     * <p>
+     * 1. configureCovering(...) -> coverCount=1 on the writer.<br>
+     * 2. add() rows, seal() -> publishes a chain entry with cover footer.<br>
+     * 3. clearCovering() -> writer's coverCount field is reset to 0
+     *    (this is what TableWriter does in the finally block of
+     *    sealPostingIndexesForLastPartitionFastLag, line 11367).<br>
+     * 4. add() more rows, commit() -> flushAllPending() publishes via
+     *    extendHead, which rewrites the head entry's LEN using
+     *    entrySize(genCount, coverCount=0), DROPPING the cover footer.<br>
+     * <p>
+     * After step 4, the chain head's LEN no longer accommodates a cover
+     * footer slot, even though the table's covering schema (mirrored in
+     * .pci) still says one cover. A reader sourcing coverCount=1 from the
+     * .pci sidecar and walking the chain steps past the entry's LEN to
+     * read the (non-existent) footer - in production this surfaces as a
+     * SIGSEGV when the entry hugs the end of the .pk mmap. With the
+     * picker/read clamp fix in place the read self-bounds against the
+     * entry's LEN and zero-fills the missing cover slot, so the reader
+     * recovers gracefully.
+     */
+    @Test
+    public void testWriterEntrysCoverFooterShrinksAfterClearCoveringCommit() throws Exception {
+        assertMemoryLeak(() -> {
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                String name = "writer_clear_covering_then_commit";
+                int plen = path.size();
+                FilesFacade ff = configuration.getFilesFacade();
+
+                final int coverCount = 1;
+                final long fakeColRows = 32;
+                final int shift = 3; // 8 bytes per row (LONG-shaped covered column)
+                final long fakeColBytes = fakeColRows << shift;
+                long fakeColAddr = Unsafe.malloc(fakeColBytes, MemoryTag.NATIVE_DEFAULT);
+                try {
+                    Unsafe.getUnsafe().setMemory(fakeColAddr, fakeColBytes, (byte) 0);
+
+                    long[] addrs = {fakeColAddr};
+                    long[] tops = {0L};
+                    int[] shifts = {shift};
+                    int[] indices = {1}; // dummy writer-side index
+                    int[] types = {io.questdb.cairo.ColumnType.LONG};
+
+                    try (PostingIndexWriter writer = new PostingIndexWriter(
+                            configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                        // Step 1+2: configure covering, add rows, seal.
+                        // The seal publishes the first chain entry with a
+                        // proper cover footer (LEN includes coverCount=1).
+                        writer.configureCovering(addrs, tops, shifts, indices, types, coverCount);
+                        for (int i = 0; i < 8; i++) {
+                            writer.add(i % 4, i);
+                        }
+                        writer.setMaxValue(7);
+                        writer.setNextTxnAtSeal(1L);
+                        writer.seal();
+
+                        long lenAfterSeal;
+                        long sealedSealTxn;
+                        {
+                            LPSZ keyFile = PostingIndexUtils.keyFileName(
+                                    path.trimTo(plen), name, COLUMN_NAME_TXN_NONE);
+                            long fileSize = ff.length(keyFile);
+                            try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
+                                    ff, keyFile, ff.getPageSize(), fileSize,
+                                    MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
+                                PostingIndexChainWriter chain = new PostingIndexChainWriter();
+                                chain.openExisting(mem);
+                                PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
+                                chain.loadHeadEntry(mem, head);
+                                lenAfterSeal = head.len;
+                                sealedSealTxn = head.sealTxn;
+                            }
+                        }
+                        Assert.assertEquals(
+                                "post-seal head LEN must include the cover footer "
+                                        + "(64 header + genCount*28 gen-dir + coverCount*8 footer, "
+                                        + "padded to 8): expected entrySize(genCount=1, coverCount=1)=104",
+                                PostingIndexChainEntry.entrySize(1, coverCount), lenAfterSeal
+                        );
+
+                        // Step 3: clearCovering - models the finally block in
+                        // TableWriter.sealPostingIndexesForLastPartitionFastLag.
+                        // This resets the writer's coverCount field to 0
+                        // even though the table's covering schema remains
+                        // unchanged.
+                        writer.clearCovering();
+
+                        // Step 4: add more rows, commit. commit() ->
+                        // flushAllPending() -> publishToChain() ->
+                        // chain.extendHead with coverEndOffsetsScratch empty
+                        // (because captureCoverEndOffsets short-circuits when
+                        // coverCount<=0). extendHead rewrites the head's LEN
+                        // using entrySize(newGenCount, 0).
+                        for (int i = 0; i < 4; i++) {
+                            writer.add(i, 100 + i);
+                        }
+                        writer.setMaxValue(103);
+                        writer.setNextTxnAtSeal(2L);
+                        writer.commit();
+
+                        long lenAfterCommit;
+                        int genCountAfterCommit;
+                        {
+                            LPSZ keyFile = PostingIndexUtils.keyFileName(
+                                    path.trimTo(plen), name, COLUMN_NAME_TXN_NONE);
+                            long fileSize = ff.length(keyFile);
+                            try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
+                                    ff, keyFile, ff.getPageSize(), fileSize,
+                                    MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
+                                PostingIndexChainWriter chain = new PostingIndexChainWriter();
+                                chain.openExisting(mem);
+                                PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
+                                chain.loadHeadEntry(mem, head);
+                                lenAfterCommit = head.len;
+                                genCountAfterCommit = head.genCount;
+                                Assert.assertEquals(
+                                        "extendHead reuses the same chain entry "
+                                                + "(same sealTxn since commit() does not "
+                                                + "advance sealTxn) - confirms the bad LEN "
+                                                + "was written into the head sealed at "
+                                                + "txn=" + sealedSealTxn,
+                                        sealedSealTxn, head.sealTxn
+                                );
+                            }
+                        }
+                        Assert.assertEquals(
+                                "RED: with the writer-side bug, the head's LEN no "
+                                        + "longer includes the cover footer because "
+                                        + "extendHead used coverCount=0 for the size "
+                                        + "calculation. Expected coverCount=1 sized "
+                                        + "entry, observed coverCount=0 sized entry.",
+                                PostingIndexChainEntry.entrySize(genCountAfterCommit, 0),
+                                lenAfterCommit
+                        );
+                        Assert.assertNotEquals(
+                                "RED: the schema-correct LEN would include cover footer "
+                                        + "bytes, but the writer dropped them",
+                                PostingIndexChainEntry.entrySize(genCountAfterCommit, coverCount),
+                                lenAfterCommit
+                        );
+
+                        // Final: prove Fix A keeps the reader from
+                        // dereferencing past the entry on this corrupted-footer
+                        // entry. Plant a sentinel byte pattern into the bytes
+                        // immediately past the entry's LEN - the (mis-computed)
+                        // cover footer offset for coverCount=1 lands on these
+                        // bytes. Without the picker/read clamp, getLong reads
+                        // the sentinel and assigns it as the cover end offset.
+                        // With the clamp, the read self-bounds against the
+                        // entry's LEN and zero-fills the missing slot.
+                        LPSZ keyFile = PostingIndexUtils.keyFileName(
+                                path.trimTo(plen), name, COLUMN_NAME_TXN_NONE);
+                        long fileSize = ff.length(keyFile);
+                        try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
+                                ff, keyFile, ff.getPageSize(), fileSize,
+                                MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
+                            PostingIndexChainWriter chain = new PostingIndexChainWriter();
+                            chain.openExisting(mem);
+                            PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
+                            chain.loadHeadEntry(mem, head);
+                            // The unfixed cover loop would read at offset
+                            // (header + genCount * GEN_DIR_ENTRY_SIZE) for
+                            // each cover slot. Plant a sentinel there so a
+                            // failing clamp surfaces as a non-zero value.
+                            long footerOffset = PostingIndexChainEntry.resolveCoverFooterOffset(
+                                    head.offset, head.genCount);
+                            final long sentinel = 0xDEAD_BEEF_CAFE_BABEL;
+                            mem.putLong(footerOffset, sentinel);
+
+                            io.questdb.cairo.idx.PostingIndexChainHeader.Snapshot header =
+                                    new io.questdb.cairo.idx.PostingIndexChainHeader.Snapshot();
+                            PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
+                            int rc = io.questdb.cairo.idx.PostingIndexChainPicker.pick(
+                                    mem, /* pinnedTableTxn */ Long.MAX_VALUE,
+                                    /* coverCount */ coverCount, header, entry);
+                            Assert.assertEquals(
+                                    io.questdb.cairo.idx.PostingIndexChainPicker.RESULT_OK, rc);
+                            Assert.assertEquals(
+                                    "Fix A: missing cover slot is zero-filled instead "
+                                            + "of dereferencing past the entry",
+                                    coverCount, entry.coverFileEndOffsets.size());
+                            Assert.assertEquals(
+                                    "RED without Fix A: the picker would read the planted "
+                                            + "sentinel " + Long.toHexString(sentinel)
+                                            + "L as the cover end offset because the cover "
+                                            + "footer loop is not clamped against the entry's "
+                                            + "own LEN field. With Fix A, the clamp returns 0 "
+                                            + "instead.",
+                                    0L, entry.coverFileEndOffsets.getQuick(0));
+                        }
+                    }
+                } finally {
+                    Unsafe.free(fakeColAddr, fakeColBytes, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    /**
      * Critical #4 and #5 are style violations enforced by static
      * analysis, not JUnit. They cannot be expressed as red unit tests.
      * Reference checks:

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -1201,6 +1201,95 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * Validates the Fix B writer-side change: after a seal, the
+     * post-seal finally block now calls
+     * {@link PostingIndexWriter#releaseCoveredColumnReadMappings()}
+     * instead of {@link PostingIndexWriter#clearCovering()}, preserving
+     * the writer's covering schema (coverCount, sidecarMems) so a
+     * subsequent commit() between seals still publishes a chain entry
+     * with a correctly-sized cover footer. This is the symmetric
+     * counterpart to {@link #testWriterEntrysCoverFooterShrinksAfterClearCoveringCommit},
+     * which documents that the old clearCovering()-then-commit() flow
+     * shrinks the footer.
+     */
+    @Test
+    public void testWriterEntrysCoverFooterPersistsAfterReleaseReadMappingsCommit() throws Exception {
+        assertMemoryLeak(() -> {
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                String name = "writer_release_read_mappings_then_commit";
+                int plen = path.size();
+                FilesFacade ff = configuration.getFilesFacade();
+
+                final int coverCount = 1;
+                final long fakeColRows = 32;
+                final int shift = 3;
+                final long fakeColBytes = fakeColRows << shift;
+                long fakeColAddr = Unsafe.malloc(fakeColBytes, MemoryTag.NATIVE_DEFAULT);
+                try {
+                    Unsafe.getUnsafe().setMemory(fakeColAddr, fakeColBytes, (byte) 0);
+
+                    long[] addrs = {fakeColAddr};
+                    long[] tops = {0L};
+                    int[] shifts = {shift};
+                    int[] indices = {1};
+                    int[] types = {io.questdb.cairo.ColumnType.LONG};
+
+                    try (PostingIndexWriter writer = new PostingIndexWriter(
+                            configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                        writer.configureCovering(addrs, tops, shifts, indices, types, coverCount);
+                        for (int i = 0; i < 8; i++) {
+                            writer.add(i % 4, i);
+                        }
+                        writer.setMaxValue(7);
+                        writer.setNextTxnAtSeal(1L);
+                        writer.seal();
+
+                        // Models the production post-seal finally block:
+                        // release the borrowed read-side addrs but keep
+                        // the covering schema (coverCount, sidecarMems).
+                        writer.releaseCoveredColumnReadMappings();
+
+                        for (int i = 0; i < 4; i++) {
+                            writer.add(i, 100 + i);
+                        }
+                        writer.setMaxValue(103);
+                        writer.setNextTxnAtSeal(2L);
+                        writer.commit();
+
+                        LPSZ keyFile = PostingIndexUtils.keyFileName(
+                                path.trimTo(plen), name, COLUMN_NAME_TXN_NONE);
+                        long fileSize = ff.length(keyFile);
+                        try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
+                                ff, keyFile, ff.getPageSize(), fileSize,
+                                MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
+                            PostingIndexChainWriter chain = new PostingIndexChainWriter();
+                            chain.openExisting(mem);
+                            PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
+                            chain.loadHeadEntry(mem, head);
+                            Assert.assertEquals(
+                                    "Fix B: with releaseCoveredColumnReadMappings the "
+                                            + "writer's coverCount stays > 0 across the "
+                                            + "post-seal release, so the next commit's "
+                                            + "extendHead writes a LEN that includes the "
+                                            + "cover footer",
+                                    PostingIndexChainEntry.entrySize(head.genCount, coverCount),
+                                    head.len
+                            );
+                            Assert.assertNotEquals(
+                                    "Fix B: the head LEN must NOT match the no-cover sizing",
+                                    PostingIndexChainEntry.entrySize(head.genCount, 0),
+                                    head.len
+                            );
+                        }
+                    }
+                } finally {
+                    Unsafe.free(fakeColAddr, fakeColBytes, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    /**
      * Reproduces the writer-side root cause of the GraalVM SIGSEGV in
      * hs_err_pid19555 (PostingIndexBenchmarkSuite.walFastLagInsertAndQuery
      * on bench/posting-wal-fastlag): a covering posting index whose chain
@@ -1402,115 +1491,5 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                 }
             }
         });
-    }
-
-    /**
-     * Validates the Fix B writer-side change: after a seal, the
-     * post-seal finally block now calls
-     * {@link PostingIndexWriter#releaseCoveredColumnReadMappings()}
-     * instead of {@link PostingIndexWriter#clearCovering()}, preserving
-     * the writer's covering schema (coverCount, sidecarMems) so a
-     * subsequent commit() between seals still publishes a chain entry
-     * with a correctly-sized cover footer. This is the symmetric
-     * counterpart to {@link #testWriterEntrysCoverFooterShrinksAfterClearCoveringCommit},
-     * which documents that the old clearCovering()-then-commit() flow
-     * shrinks the footer.
-     */
-    @Test
-    public void testWriterEntrysCoverFooterPersistsAfterReleaseReadMappingsCommit() throws Exception {
-        assertMemoryLeak(() -> {
-            try (Path path = new Path().of(configuration.getDbRoot())) {
-                String name = "writer_release_read_mappings_then_commit";
-                int plen = path.size();
-                FilesFacade ff = configuration.getFilesFacade();
-
-                final int coverCount = 1;
-                final long fakeColRows = 32;
-                final int shift = 3;
-                final long fakeColBytes = fakeColRows << shift;
-                long fakeColAddr = Unsafe.malloc(fakeColBytes, MemoryTag.NATIVE_DEFAULT);
-                try {
-                    Unsafe.getUnsafe().setMemory(fakeColAddr, fakeColBytes, (byte) 0);
-
-                    long[] addrs = {fakeColAddr};
-                    long[] tops = {0L};
-                    int[] shifts = {shift};
-                    int[] indices = {1};
-                    int[] types = {io.questdb.cairo.ColumnType.LONG};
-
-                    try (PostingIndexWriter writer = new PostingIndexWriter(
-                            configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
-                        writer.configureCovering(addrs, tops, shifts, indices, types, coverCount);
-                        for (int i = 0; i < 8; i++) {
-                            writer.add(i % 4, i);
-                        }
-                        writer.setMaxValue(7);
-                        writer.setNextTxnAtSeal(1L);
-                        writer.seal();
-
-                        // Models the production post-seal finally block:
-                        // release the borrowed read-side addrs but keep
-                        // the covering schema (coverCount, sidecarMems).
-                        writer.releaseCoveredColumnReadMappings();
-
-                        for (int i = 0; i < 4; i++) {
-                            writer.add(i, 100 + i);
-                        }
-                        writer.setMaxValue(103);
-                        writer.setNextTxnAtSeal(2L);
-                        writer.commit();
-
-                        LPSZ keyFile = PostingIndexUtils.keyFileName(
-                                path.trimTo(plen), name, COLUMN_NAME_TXN_NONE);
-                        long fileSize = ff.length(keyFile);
-                        try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
-                                ff, keyFile, ff.getPageSize(), fileSize,
-                                MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
-                            PostingIndexChainWriter chain = new PostingIndexChainWriter();
-                            chain.openExisting(mem);
-                            PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
-                            chain.loadHeadEntry(mem, head);
-                            Assert.assertEquals(
-                                    "Fix B: with releaseCoveredColumnReadMappings the "
-                                            + "writer's coverCount stays > 0 across the "
-                                            + "post-seal release, so the next commit's "
-                                            + "extendHead writes a LEN that includes the "
-                                            + "cover footer",
-                                    PostingIndexChainEntry.entrySize(head.genCount, coverCount),
-                                    head.len
-                            );
-                            Assert.assertNotEquals(
-                                    "Fix B: the head LEN must NOT match the no-cover sizing",
-                                    PostingIndexChainEntry.entrySize(head.genCount, 0),
-                                    head.len
-                            );
-                        }
-                    }
-                } finally {
-                    Unsafe.free(fakeColAddr, fakeColBytes, MemoryTag.NATIVE_DEFAULT);
-                }
-            }
-        });
-    }
-
-    /**
-     * Critical #4 and #5 are style violations enforced by static
-     * analysis, not JUnit. They cannot be expressed as red unit tests.
-     * Reference checks:
-     * #4 Banner comments forbidden by CLAUDE.md:
-     * grep -rn "// ===\|// ---" core/src/test/java/io/questdb/test/cairo/PostingIndex*.java
-     * grep -rn "// ===\|// ---" core/src/test/java/io/questdb/test/cairo/CoveringIndex*.java
-     * Both must return zero matches.
-     * #5 assertSql vs assertQueryNoLeakCheck:
-     * grep -c "assertSql\b" core/src/test/java/io/questdb/test/cairo/CoveringIndexTest.java
-     * Must be zero (or only inside helper methods).
-     * These are noted here so the red-test set covers all critical findings,
-     * even those that are not JUnit-testable.
-     */
-    @SuppressWarnings("unused")
-    private void styleCheckPlaceholder() {
-        // Kept as documentation; no JUnit test.
-        AtomicReference<String> ignore = new AtomicReference<>();
-        ignore.set("see method javadoc");
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -1302,16 +1302,16 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      * head had LEN=96 (= entrySize(genCount=1, coverCount=0)) while .pci
      * advertised coverCount=1. This test drives PostingIndexWriter through
      * the same lifecycle the WAL fast-lag path follows in production:
-     * <p>
-     * 1. configureCovering(...) -> coverCount=1 on the writer.<br>
-     * 2. add() rows, seal() -> publishes a chain entry with cover footer.<br>
-     * 3. clearCovering() -> writer's coverCount field is reset to 0
-     *    (this is what TableWriter does in the finally block of
-     *    sealPostingIndexesForLastPartitionFastLag, line 11367).<br>
-     * 4. add() more rows, commit() -> flushAllPending() publishes via
-     *    extendHead, which rewrites the head entry's LEN using
-     *    entrySize(genCount, coverCount=0), DROPPING the cover footer.<br>
-     * <p>
+     * <ol>
+     * <li> configureCovering(...) -> coverCount=1 on the writer.
+     * <li> add() rows, seal() -> publishes a chain entry with cover footer.
+     * <li> clearCovering() -> writer's coverCount field is reset to 0
+     *     (this is what TableWriter does in the finally block of
+     *     sealPostingIndexesForLastPartitionFastLag, line 11367).
+     * <li> add() more rows, commit() -> flushAllPending() publishes via
+     *     extendHead, which rewrites the head entry's LEN using
+     *     entrySize(genCount, coverCount=0), DROPPING the cover footer.
+     * </ol>
      * After step 4, the chain head's LEN no longer accommodates a cover
      * footer slot, even though the table's covering schema (mirrored in
      * .pci) still says one cover. A reader sourcing coverCount=1 from the

--- a/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainTest.java
@@ -68,44 +68,6 @@ public class PostingIndexChainTest {
     }
 
     @Test
-    public void testInitialiseEmpty() {
-        PostingIndexChainHeader.initialiseEmpty(mem);
-
-        PostingIndexChainHeader.Snapshot snapshot = new PostingIndexChainHeader.Snapshot();
-        boolean ok = PostingIndexChainHeader.readUnderSeqlock(mem, snapshot);
-        Assert.assertTrue(ok);
-        Assert.assertEquals(PostingIndexUtils.V2_FORMAT_VERSION, snapshot.formatVersion);
-        Assert.assertEquals(PostingIndexUtils.V2_NO_HEAD, snapshot.headEntryOffset);
-        Assert.assertEquals(0, snapshot.entryCount);
-        Assert.assertEquals(PostingIndexUtils.V2_ENTRY_REGION_BASE, snapshot.regionBase);
-        Assert.assertEquals(PostingIndexUtils.V2_ENTRY_REGION_BASE, snapshot.regionLimit);
-        // Default initialiseEmpty leaves genCounter at -1 so the first
-        // appendNewEntry can use sealTxn=0 (matches .pv.0 naming).
-        Assert.assertEquals(-1L, snapshot.generationCounter);
-        Assert.assertTrue(snapshot.isEmpty());
-    }
-
-    @Test
-    public void testInitialiseEmptyWithExplicitStartSealTxn() {
-        PostingIndexChainHeader.initialiseEmpty(mem, /* startSealTxn */ 7L);
-
-        PostingIndexChainHeader.Snapshot snapshot = new PostingIndexChainHeader.Snapshot();
-        Assert.assertTrue(PostingIndexChainHeader.readUnderSeqlock(mem, snapshot));
-        Assert.assertEquals(6L, snapshot.generationCounter);
-    }
-
-    @Test
-    public void testPickerEmptyChain() {
-        PostingIndexChainHeader.initialiseEmpty(mem);
-
-        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
-        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
-        int result = PostingIndexChainPicker.pick(mem, /* pinnedTxn */ 100L, header, entry);
-
-        Assert.assertEquals(PostingIndexChainPicker.RESULT_EMPTY_CHAIN, result);
-    }
-
-    @Test
     public void testAbandonedEntrySkipped() {
         // Healthy entries:  (sealTxn=1, txnAtSeal=10), (sealTxn=2, txnAtSeal=20)
         // Abandoned entry:  (sealTxn=3, txnAtSeal=99) — publish landed but
@@ -135,6 +97,23 @@ public class PostingIndexChainTest {
         Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
                 PostingIndexChainPicker.pick(mem, 99L, header, entry));
         Assert.assertEquals(3, entry.sealTxn);
+    }
+
+    @Test
+    public void testCircularChainDetected() {
+        PostingIndexChainHeader.initialiseEmpty(mem);
+        long off1 = PostingIndexUtils.V2_ENTRY_REGION_BASE;
+        long off2 = off1 + PostingIndexChainEntry.entrySize(0);
+
+        PostingIndexChainEntry.writeHeader(mem, off1, 1, 10, 0, 0, 0, 0, 64, 0, off2);
+        PostingIndexChainEntry.writeHeader(mem, off2, 2, 20, 0, 0, 0, 0, 64, 0, off1);
+        publishHead(off2, /* count */ 2, 2, off2 + PostingIndexChainEntry.entrySize(0));
+
+        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
+        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
+
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_HEADER_UNREADABLE,
+                PostingIndexChainPicker.pick(mem, 5L, header, entry));
     }
 
     /**
@@ -251,45 +230,108 @@ public class PostingIndexChainTest {
                 0, inconsistencies.get());
     }
 
+    /**
+     * Picker pre-validates entry.LEN against mappedLimit before invoking
+     * read(). A torn or corrupted LEN that overruns the mapping must be
+     * caught up front - never produce a SEGV inside read().
+     */
     @Test
-    public void testMultiEntryPicker() {
+    public void testCorruptedLenExceedingMappingDetected() {
         PostingIndexChainHeader.initialiseEmpty(mem);
-        long off1 = appendEntry(1, 10, PostingIndexUtils.V2_NO_HEAD);
-        long off2 = appendEntry(2, 20, off1);
-        long off3 = appendEntry(3, 30, off2);
-        publishHead(off3, /* count */ 3, /* genCounter */ 3);
+        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
+        PostingIndexChainEntry.writeHeader(
+                mem, entryOffset,
+                1, 10, 0, 0, 0, 0, 64, 0,
+                PostingIndexUtils.V2_NO_HEAD
+        );
+        // Stomp LEN to a wildly out-of-range value.
+        mem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, 99_999_999L);
+        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(0));
+
+        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
+        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_HEADER_UNREADABLE,
+                PostingIndexChainPicker.pick(mem, 100L, /* coverCount */ 1, header, entry));
+    }
+
+    @Test
+    public void testCorruptedPrevPointerDetected() {
+        PostingIndexChainHeader.initialiseEmpty(mem);
+        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
+        PostingIndexChainEntry.writeHeader(
+                mem, entryOffset,
+                1, 10, 0, 0, 0, 0, 64, 0,
+                /* prevEntryOffset */ 999_999L
+        );
+        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(0));
 
         PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
         PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
 
-        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
-                PostingIndexChainPicker.pick(mem, 30L, header, entry));
-        Assert.assertEquals(3, entry.sealTxn);
-
-        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
-                PostingIndexChainPicker.pick(mem, 100L, header, entry));
-        Assert.assertEquals(3, entry.sealTxn);
-
-        // Pin at 25 → picks middle (sealTxn=2 with txnAtSeal=20).
-        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
-                PostingIndexChainPicker.pick(mem, 25L, header, entry));
-        Assert.assertEquals(2, entry.sealTxn);
-        Assert.assertEquals(20, entry.txnAtSeal);
-
-        // Pin at exactly 20 → still picks middle.
-        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
-                PostingIndexChainPicker.pick(mem, 20L, header, entry));
-        Assert.assertEquals(2, entry.sealTxn);
-
-        // Pin at 19 → picks oldest.
-        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
-                PostingIndexChainPicker.pick(mem, 19L, header, entry));
-        Assert.assertEquals(1, entry.sealTxn);
-        Assert.assertEquals(10, entry.txnAtSeal);
-
-        // Pin below all entries.
-        Assert.assertEquals(PostingIndexChainPicker.RESULT_NO_VISIBLE_ENTRY,
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_HEADER_UNREADABLE,
                 PostingIndexChainPicker.pick(mem, 5L, header, entry));
+    }
+
+    /**
+     * Regression for the same bug, scoped to PostingIndexChainEntry.read()
+     * directly: with the entry hugging the end of the mapping, an over-eager
+     * cover-footer loop would step past the entry's LEN. The clamp must keep
+     * reads inside [entryOffset, entryOffset + entry.len).
+     */
+    @Test
+    public void testEntryReadClampsCoverFooterToEntryLen() {
+        PostingIndexChainHeader.initialiseEmpty(mem);
+        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
+        PostingIndexChainEntry.writeHeader(
+                mem, entryOffset,
+                /* sealTxn */ 1, /* txnAtSeal */ 5,
+                0, 0, 0, /* genCount */ 1, 64, 0,
+                PostingIndexUtils.V2_NO_HEAD, /* coverEndOffsets */ null
+        );
+        // Sentinel bytes immediately past the entry: if the clamp regresses,
+        // the cover loop would read these as cover end-offset values.
+        long pastEntry = entryOffset + PostingIndexChainEntry.entrySize(1, 0);
+        mem.putLong(pastEntry, 0xDEAD_BEEFL);
+        mem.putLong(pastEntry + 8, 0xCAFE_BABEL);
+
+        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
+        long endOffset = PostingIndexChainEntry.read(mem, entryOffset, /* coverCount */ 3, entry);
+
+        Assert.assertEquals(96, entry.len);
+        Assert.assertEquals(entryOffset + entry.len, endOffset);
+        Assert.assertEquals(3, entry.coverFileEndOffsets.size());
+        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(0));
+        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(1));
+        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(2));
+    }
+
+    /**
+     * When the entry was sealed with the same coverCount the reader expects,
+     * the existing footer round-trips correctly. Guards the clamp against
+     * regressing the happy path.
+     */
+    @Test
+    public void testEntryReadReturnsWrittenCoverEndOffsets() {
+        PostingIndexChainHeader.initialiseEmpty(mem);
+        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
+        LongList covers = new LongList();
+        covers.add(111L);
+        covers.add(222L);
+        PostingIndexChainEntry.writeHeader(
+                mem, entryOffset,
+                /* sealTxn */ 1, /* txnAtSeal */ 5,
+                0, 0, 0, /* genCount */ 1, 64, 0,
+                PostingIndexUtils.V2_NO_HEAD, covers
+        );
+        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(1, 2));
+
+        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
+        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
+                PostingIndexChainPicker.pick(mem, 100L, /* coverCount */ 2, header, entry));
+        Assert.assertEquals(2, entry.coverFileEndOffsets.size());
+        Assert.assertEquals(111L, entry.coverFileEndOffsets.getQuick(0));
+        Assert.assertEquals(222L, entry.coverFileEndOffsets.getQuick(1));
     }
 
     @Test
@@ -363,38 +405,146 @@ public class PostingIndexChainTest {
     }
 
     @Test
-    public void testCorruptedPrevPointerDetected() {
+    public void testInitialiseEmpty() {
+        PostingIndexChainHeader.initialiseEmpty(mem);
+
+        PostingIndexChainHeader.Snapshot snapshot = new PostingIndexChainHeader.Snapshot();
+        boolean ok = PostingIndexChainHeader.readUnderSeqlock(mem, snapshot);
+        Assert.assertTrue(ok);
+        Assert.assertEquals(PostingIndexUtils.V2_FORMAT_VERSION, snapshot.formatVersion);
+        Assert.assertEquals(PostingIndexUtils.V2_NO_HEAD, snapshot.headEntryOffset);
+        Assert.assertEquals(0, snapshot.entryCount);
+        Assert.assertEquals(PostingIndexUtils.V2_ENTRY_REGION_BASE, snapshot.regionBase);
+        Assert.assertEquals(PostingIndexUtils.V2_ENTRY_REGION_BASE, snapshot.regionLimit);
+        // Default initialiseEmpty leaves genCounter at -1 so the first
+        // appendNewEntry can use sealTxn=0 (matches .pv.0 naming).
+        Assert.assertEquals(-1L, snapshot.generationCounter);
+        Assert.assertTrue(snapshot.isEmpty());
+    }
+
+    @Test
+    public void testInitialiseEmptyWithExplicitStartSealTxn() {
+        PostingIndexChainHeader.initialiseEmpty(mem, /* startSealTxn */ 7L);
+
+        PostingIndexChainHeader.Snapshot snapshot = new PostingIndexChainHeader.Snapshot();
+        Assert.assertTrue(PostingIndexChainHeader.readUnderSeqlock(mem, snapshot));
+        Assert.assertEquals(6L, snapshot.generationCounter);
+    }
+
+    @Test
+    public void testMultiEntryPicker() {
+        PostingIndexChainHeader.initialiseEmpty(mem);
+        long off1 = appendEntry(1, 10, PostingIndexUtils.V2_NO_HEAD);
+        long off2 = appendEntry(2, 20, off1);
+        long off3 = appendEntry(3, 30, off2);
+        publishHead(off3, /* count */ 3, /* genCounter */ 3);
+
+        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
+        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
+
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
+                PostingIndexChainPicker.pick(mem, 30L, header, entry));
+        Assert.assertEquals(3, entry.sealTxn);
+
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
+                PostingIndexChainPicker.pick(mem, 100L, header, entry));
+        Assert.assertEquals(3, entry.sealTxn);
+
+        // Pin at 25 → picks middle (sealTxn=2 with txnAtSeal=20).
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
+                PostingIndexChainPicker.pick(mem, 25L, header, entry));
+        Assert.assertEquals(2, entry.sealTxn);
+        Assert.assertEquals(20, entry.txnAtSeal);
+
+        // Pin at exactly 20 → still picks middle.
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
+                PostingIndexChainPicker.pick(mem, 20L, header, entry));
+        Assert.assertEquals(2, entry.sealTxn);
+
+        // Pin at 19 → picks oldest.
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
+                PostingIndexChainPicker.pick(mem, 19L, header, entry));
+        Assert.assertEquals(1, entry.sealTxn);
+        Assert.assertEquals(10, entry.txnAtSeal);
+
+        // Pin below all entries.
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_NO_VISIBLE_ENTRY,
+                PostingIndexChainPicker.pick(mem, 5L, header, entry));
+    }
+
+    /**
+     * A non-positive LEN (zero or negative) is also a corruption signal -
+     * the picker rejects it without invoking read().
+     */
+    @Test
+    public void testNonPositiveLenDetected() {
         PostingIndexChainHeader.initialiseEmpty(mem);
         long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
         PostingIndexChainEntry.writeHeader(
                 mem, entryOffset,
                 1, 10, 0, 0, 0, 0, 64, 0,
-                /* prevEntryOffset */ 999_999L
+                PostingIndexUtils.V2_NO_HEAD
         );
+        mem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, 0L);
         publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(0));
 
         PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
         PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
-
         Assert.assertEquals(PostingIndexChainPicker.RESULT_HEADER_UNREADABLE,
-                PostingIndexChainPicker.pick(mem, 5L, header, entry));
+                PostingIndexChainPicker.pick(mem, 100L, header, entry));
     }
 
     @Test
-    public void testCircularChainDetected() {
+    public void testPickerEmptyChain() {
         PostingIndexChainHeader.initialiseEmpty(mem);
-        long off1 = PostingIndexUtils.V2_ENTRY_REGION_BASE;
-        long off2 = off1 + PostingIndexChainEntry.entrySize(0);
 
-        PostingIndexChainEntry.writeHeader(mem, off1, 1, 10, 0, 0, 0, 0, 64, 0, off2);
-        PostingIndexChainEntry.writeHeader(mem, off2, 2, 20, 0, 0, 0, 0, 64, 0, off1);
-        publishHead(off2, /* count */ 2, 2, off2 + PostingIndexChainEntry.entrySize(0));
+        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
+        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
+        int result = PostingIndexChainPicker.pick(mem, /* pinnedTxn */ 100L, header, entry);
+
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_EMPTY_CHAIN, result);
+    }
+
+    /**
+     * Regression for the GraalVM crash in the WAL fast-lag bench: the writer
+     * sealed an entry with coverCount=0 (no .pcN footer) but the reader's
+     * .pci sidecar reported coverCount>0, so the cover-footer loop in
+     * PostingIndexChainEntry.read() would step past the entry's LEN. When
+     * the entry hugged the end of the mmap, that stepped past the mapping
+     * itself and SIGSEGV'd. The clamp must zero-fill the missing slots
+     * instead of dereferencing past the entry.
+     */
+    @Test
+    public void testPickerHandlesEntryWrittenWithFewerCoversThanReaderExpects() {
+        PostingIndexChainHeader.initialiseEmpty(mem);
+        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
+        // genCount=1, coverEndOffsets=null - entry is written with no cover
+        // footer (LEN = entrySize(1, 0) = 96).
+        PostingIndexChainEntry.writeHeader(
+                mem, entryOffset,
+                /* sealTxn */ 1, /* txnAtSeal */ 5,
+                /* valueMemSize */ 0, /* maxValue */ 0,
+                /* keyCount */ 0, /* genCount */ 1,
+                /* blockCapacity */ 64, /* coveringFormat */ 0,
+                /* prevEntryOffset */ PostingIndexUtils.V2_NO_HEAD,
+                /* coverEndOffsets */ null
+        );
+        long entryLen = PostingIndexChainEntry.entrySize(1, 0);
+        Assert.assertEquals(96, entryLen);
+        publishHead(entryOffset, 1, 1, entryOffset + entryLen);
 
         PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
         PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
 
-        Assert.assertEquals(PostingIndexChainPicker.RESULT_HEADER_UNREADABLE,
-                PostingIndexChainPicker.pick(mem, 5L, header, entry));
+        // Reader passes coverCount=2 even though the entry has zero cover
+        // slots. The picker must succeed and the snapshot's
+        // coverFileEndOffsets must be zero-filled - never dereference the
+        // missing footer bytes.
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
+                PostingIndexChainPicker.pick(mem, /* pinnedTxn */ 100L, /* coverCount */ 2, header, entry));
+        Assert.assertEquals(2, entry.coverFileEndOffsets.size());
+        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(0));
+        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(1));
     }
 
     @Test
@@ -500,155 +650,5 @@ public class PostingIndexChainTest {
 
     private int readGenCount(long entryOffset) {
         return mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
-    }
-
-    /**
-     * Regression for the GraalVM crash in the WAL fast-lag bench: the writer
-     * sealed an entry with coverCount=0 (no .pcN footer) but the reader's
-     * .pci sidecar reported coverCount>0, so the cover-footer loop in
-     * PostingIndexChainEntry.read() would step past the entry's LEN. When
-     * the entry hugged the end of the mmap, that stepped past the mapping
-     * itself and SIGSEGV'd. The clamp must zero-fill the missing slots
-     * instead of dereferencing past the entry.
-     */
-    @Test
-    public void testPickerHandlesEntryWrittenWithFewerCoversThanReaderExpects() {
-        PostingIndexChainHeader.initialiseEmpty(mem);
-        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
-        // genCount=1, coverEndOffsets=null - entry is written with no cover
-        // footer (LEN = entrySize(1, 0) = 96).
-        PostingIndexChainEntry.writeHeader(
-                mem, entryOffset,
-                /* sealTxn */ 1, /* txnAtSeal */ 5,
-                /* valueMemSize */ 0, /* maxValue */ 0,
-                /* keyCount */ 0, /* genCount */ 1,
-                /* blockCapacity */ 64, /* coveringFormat */ 0,
-                /* prevEntryOffset */ PostingIndexUtils.V2_NO_HEAD,
-                /* coverEndOffsets */ null
-        );
-        long entryLen = PostingIndexChainEntry.entrySize(1, 0);
-        Assert.assertEquals(96, entryLen);
-        publishHead(entryOffset, 1, 1, entryOffset + entryLen);
-
-        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
-        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
-
-        // Reader passes coverCount=2 even though the entry has zero cover
-        // slots. The picker must succeed and the snapshot's
-        // coverFileEndOffsets must be zero-filled - never dereference the
-        // missing footer bytes.
-        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
-                PostingIndexChainPicker.pick(mem, /* pinnedTxn */ 100L, /* coverCount */ 2, header, entry));
-        Assert.assertEquals(2, entry.coverFileEndOffsets.size());
-        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(0));
-        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(1));
-    }
-
-    /**
-     * Regression for the same bug, scoped to PostingIndexChainEntry.read()
-     * directly: with the entry hugging the end of the mapping, an over-eager
-     * cover-footer loop would step past the entry's LEN. The clamp must keep
-     * reads inside [entryOffset, entryOffset + entry.len).
-     */
-    @Test
-    public void testEntryReadClampsCoverFooterToEntryLen() {
-        PostingIndexChainHeader.initialiseEmpty(mem);
-        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
-        PostingIndexChainEntry.writeHeader(
-                mem, entryOffset,
-                /* sealTxn */ 1, /* txnAtSeal */ 5,
-                0, 0, 0, /* genCount */ 1, 64, 0,
-                PostingIndexUtils.V2_NO_HEAD, /* coverEndOffsets */ null
-        );
-        // Sentinel bytes immediately past the entry: if the clamp regresses,
-        // the cover loop would read these as cover end-offset values.
-        long pastEntry = entryOffset + PostingIndexChainEntry.entrySize(1, 0);
-        mem.putLong(pastEntry, 0xDEAD_BEEFL);
-        mem.putLong(pastEntry + 8, 0xCAFE_BABEL);
-
-        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
-        long endOffset = PostingIndexChainEntry.read(mem, entryOffset, /* coverCount */ 3, entry);
-
-        Assert.assertEquals(96, entry.len);
-        Assert.assertEquals(entryOffset + entry.len, endOffset);
-        Assert.assertEquals(3, entry.coverFileEndOffsets.size());
-        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(0));
-        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(1));
-        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(2));
-    }
-
-    /**
-     * When the entry was sealed with the same coverCount the reader expects,
-     * the existing footer round-trips correctly. Guards the clamp against
-     * regressing the happy path.
-     */
-    @Test
-    public void testEntryReadReturnsWrittenCoverEndOffsets() {
-        PostingIndexChainHeader.initialiseEmpty(mem);
-        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
-        LongList covers = new LongList();
-        covers.add(111L);
-        covers.add(222L);
-        PostingIndexChainEntry.writeHeader(
-                mem, entryOffset,
-                /* sealTxn */ 1, /* txnAtSeal */ 5,
-                0, 0, 0, /* genCount */ 1, 64, 0,
-                PostingIndexUtils.V2_NO_HEAD, covers
-        );
-        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(1, 2));
-
-        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
-        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
-        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
-                PostingIndexChainPicker.pick(mem, 100L, /* coverCount */ 2, header, entry));
-        Assert.assertEquals(2, entry.coverFileEndOffsets.size());
-        Assert.assertEquals(111L, entry.coverFileEndOffsets.getQuick(0));
-        Assert.assertEquals(222L, entry.coverFileEndOffsets.getQuick(1));
-    }
-
-    /**
-     * Picker pre-validates entry.LEN against mappedLimit before invoking
-     * read(). A torn or corrupted LEN that overruns the mapping must be
-     * caught up front - never produce a SEGV inside read().
-     */
-    @Test
-    public void testCorruptedLenExceedingMappingDetected() {
-        PostingIndexChainHeader.initialiseEmpty(mem);
-        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
-        PostingIndexChainEntry.writeHeader(
-                mem, entryOffset,
-                1, 10, 0, 0, 0, 0, 64, 0,
-                PostingIndexUtils.V2_NO_HEAD
-        );
-        // Stomp LEN to a wildly out-of-range value.
-        mem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, 99_999_999L);
-        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(0));
-
-        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
-        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
-        Assert.assertEquals(PostingIndexChainPicker.RESULT_HEADER_UNREADABLE,
-                PostingIndexChainPicker.pick(mem, 100L, /* coverCount */ 1, header, entry));
-    }
-
-    /**
-     * A non-positive LEN (zero or negative) is also a corruption signal -
-     * the picker rejects it without invoking read().
-     */
-    @Test
-    public void testNonPositiveLenDetected() {
-        PostingIndexChainHeader.initialiseEmpty(mem);
-        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
-        PostingIndexChainEntry.writeHeader(
-                mem, entryOffset,
-                1, 10, 0, 0, 0, 0, 64, 0,
-                PostingIndexUtils.V2_NO_HEAD
-        );
-        mem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, 0L);
-        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(0));
-
-        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
-        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
-        Assert.assertEquals(PostingIndexChainPicker.RESULT_HEADER_UNREADABLE,
-                PostingIndexChainPicker.pick(mem, 100L, header, entry));
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainTest.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.idx.PostingIndexChainHeader;
 import io.questdb.cairo.idx.PostingIndexChainPicker;
 import io.questdb.cairo.idx.PostingIndexUtils;
 import io.questdb.cairo.vm.MemoryCARWImpl;
+import io.questdb.std.LongList;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
 import org.junit.After;
@@ -499,5 +500,155 @@ public class PostingIndexChainTest {
 
     private int readGenCount(long entryOffset) {
         return mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
+    }
+
+    /**
+     * Regression for the GraalVM crash in the WAL fast-lag bench: the writer
+     * sealed an entry with coverCount=0 (no .pcN footer) but the reader's
+     * .pci sidecar reported coverCount>0, so the cover-footer loop in
+     * PostingIndexChainEntry.read() would step past the entry's LEN. When
+     * the entry hugged the end of the mmap, that stepped past the mapping
+     * itself and SIGSEGV'd. The clamp must zero-fill the missing slots
+     * instead of dereferencing past the entry.
+     */
+    @Test
+    public void testPickerHandlesEntryWrittenWithFewerCoversThanReaderExpects() {
+        PostingIndexChainHeader.initialiseEmpty(mem);
+        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
+        // genCount=1, coverEndOffsets=null - entry is written with no cover
+        // footer (LEN = entrySize(1, 0) = 96).
+        PostingIndexChainEntry.writeHeader(
+                mem, entryOffset,
+                /* sealTxn */ 1, /* txnAtSeal */ 5,
+                /* valueMemSize */ 0, /* maxValue */ 0,
+                /* keyCount */ 0, /* genCount */ 1,
+                /* blockCapacity */ 64, /* coveringFormat */ 0,
+                /* prevEntryOffset */ PostingIndexUtils.V2_NO_HEAD,
+                /* coverEndOffsets */ null
+        );
+        long entryLen = PostingIndexChainEntry.entrySize(1, 0);
+        Assert.assertEquals(96, entryLen);
+        publishHead(entryOffset, 1, 1, entryOffset + entryLen);
+
+        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
+        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
+
+        // Reader passes coverCount=2 even though the entry has zero cover
+        // slots. The picker must succeed and the snapshot's
+        // coverFileEndOffsets must be zero-filled - never dereference the
+        // missing footer bytes.
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
+                PostingIndexChainPicker.pick(mem, /* pinnedTxn */ 100L, /* coverCount */ 2, header, entry));
+        Assert.assertEquals(2, entry.coverFileEndOffsets.size());
+        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(0));
+        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(1));
+    }
+
+    /**
+     * Regression for the same bug, scoped to PostingIndexChainEntry.read()
+     * directly: with the entry hugging the end of the mapping, an over-eager
+     * cover-footer loop would step past the entry's LEN. The clamp must keep
+     * reads inside [entryOffset, entryOffset + entry.len).
+     */
+    @Test
+    public void testEntryReadClampsCoverFooterToEntryLen() {
+        PostingIndexChainHeader.initialiseEmpty(mem);
+        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
+        PostingIndexChainEntry.writeHeader(
+                mem, entryOffset,
+                /* sealTxn */ 1, /* txnAtSeal */ 5,
+                0, 0, 0, /* genCount */ 1, 64, 0,
+                PostingIndexUtils.V2_NO_HEAD, /* coverEndOffsets */ null
+        );
+        // Sentinel bytes immediately past the entry: if the clamp regresses,
+        // the cover loop would read these as cover end-offset values.
+        long pastEntry = entryOffset + PostingIndexChainEntry.entrySize(1, 0);
+        mem.putLong(pastEntry, 0xDEAD_BEEFL);
+        mem.putLong(pastEntry + 8, 0xCAFE_BABEL);
+
+        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
+        long endOffset = PostingIndexChainEntry.read(mem, entryOffset, /* coverCount */ 3, entry);
+
+        Assert.assertEquals(96, entry.len);
+        Assert.assertEquals(entryOffset + entry.len, endOffset);
+        Assert.assertEquals(3, entry.coverFileEndOffsets.size());
+        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(0));
+        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(1));
+        Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(2));
+    }
+
+    /**
+     * When the entry was sealed with the same coverCount the reader expects,
+     * the existing footer round-trips correctly. Guards the clamp against
+     * regressing the happy path.
+     */
+    @Test
+    public void testEntryReadReturnsWrittenCoverEndOffsets() {
+        PostingIndexChainHeader.initialiseEmpty(mem);
+        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
+        LongList covers = new LongList();
+        covers.add(111L);
+        covers.add(222L);
+        PostingIndexChainEntry.writeHeader(
+                mem, entryOffset,
+                /* sealTxn */ 1, /* txnAtSeal */ 5,
+                0, 0, 0, /* genCount */ 1, 64, 0,
+                PostingIndexUtils.V2_NO_HEAD, covers
+        );
+        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(1, 2));
+
+        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
+        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
+                PostingIndexChainPicker.pick(mem, 100L, /* coverCount */ 2, header, entry));
+        Assert.assertEquals(2, entry.coverFileEndOffsets.size());
+        Assert.assertEquals(111L, entry.coverFileEndOffsets.getQuick(0));
+        Assert.assertEquals(222L, entry.coverFileEndOffsets.getQuick(1));
+    }
+
+    /**
+     * Picker pre-validates entry.LEN against mappedLimit before invoking
+     * read(). A torn or corrupted LEN that overruns the mapping must be
+     * caught up front - never produce a SEGV inside read().
+     */
+    @Test
+    public void testCorruptedLenExceedingMappingDetected() {
+        PostingIndexChainHeader.initialiseEmpty(mem);
+        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
+        PostingIndexChainEntry.writeHeader(
+                mem, entryOffset,
+                1, 10, 0, 0, 0, 0, 64, 0,
+                PostingIndexUtils.V2_NO_HEAD
+        );
+        // Stomp LEN to a wildly out-of-range value.
+        mem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, 99_999_999L);
+        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(0));
+
+        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
+        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_HEADER_UNREADABLE,
+                PostingIndexChainPicker.pick(mem, 100L, /* coverCount */ 1, header, entry));
+    }
+
+    /**
+     * A non-positive LEN (zero or negative) is also a corruption signal -
+     * the picker rejects it without invoking read().
+     */
+    @Test
+    public void testNonPositiveLenDetected() {
+        PostingIndexChainHeader.initialiseEmpty(mem);
+        long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
+        PostingIndexChainEntry.writeHeader(
+                mem, entryOffset,
+                1, 10, 0, 0, 0, 0, 64, 0,
+                PostingIndexUtils.V2_NO_HEAD
+        );
+        mem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, 0L);
+        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(0));
+
+        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
+        PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_HEADER_UNREADABLE,
+                PostingIndexChainPicker.pick(mem, 100L, header, entry));
     }
 }


### PR DESCRIPTION
## Summary

A SIGSEGV reproduced on the `bench/posting-wal-fastlag` benchmark branch (`hs_err_pid19555.log` from `PostingIndexBenchmarkSuite.walFastLagInsertAndQuery` against a `posting_covering` table) traced to two cooperating bugs - a writer-side bug that produced chain entries with no cover footer, and a reader-side bug that over-read past the entry's `LEN` and crossed the .pk mmap boundary.

This PR fixes both.

### Reader fix - bound chain reads against entry LEN

`PostingIndexChainEntry.read()` trusted the reader-supplied `coverCount` unconditionally and stepped past the entry's own `LEN` to read the cover end-offset footer. When the entry's actual cover-footer size did not match the reader's `coverCount` (sourced from the `.pci` sidecar) and the entry sat flush against the end of the `.pk` mmap, the over-read crossed the mapping boundary and SIGSEGV'd the JVM. The picker's `entry.len` bound check ran AFTER `read()` and so could not catch this class of failure.

- `PostingIndexChainEntry.read()` self-bounds the cover-footer loop against the entry's own `LEN`. Slots the entry does not actually contain are zero-filled, which the rest of the reader treats as "no published cover bytes for this slot" - the same fallback the existing code already uses for tombstoned or not-yet-opened sidecars.
- `PostingIndexChainPicker.pick()` peeks `LEN` before invoking `read()` so the full-entry-fits-in-mapping check happens before any cover read. A torn or corrupted `LEN` that overruns the mapping now produces `RESULT_HEADER_UNREADABLE` consistently.

### Writer fix - preserve covering schema across post-seal cleanup

`PostingIndexWriter.clearCovering()` did two things at once: released the read-side state set up for the most recent seal (covered-column RO mmaps and borrowed source-column addresses), and forgot the covering schema (zeroed `coverCount`, dropped `coveredColumnIndices`, etc.). `TableWriter`'s two post-seal `finally` blocks used `clearCovering()` to do the first job, but the second job was a side effect they did not want: between fast-lag seals, a follow-up `commit()` ran `flushAllPending() -> publishToChain() -> chain.extendHead` with `coverEndOffsetsScratch` empty (because `captureCoverEndOffsets` short-circuits when `coverCount<=0`), and `extendHead` rewrote the head entry's `LEN` using `entrySize(genCount, 0)` - dropping the cover footer.

- New `PostingIndexWriter.releaseCoveredColumnReadMappings()` drops the read-side state but keeps `coverCount`, `coveredColumnIndices`, `coveredColumnNames`, `coveredColumnNameTxns`, `coveredColumnTops`, `coveredColumnShifts`, `coveredColumnTypes`, and `sidecarMems` intact. A subsequent `commit()` between seals reads cover end offsets directly from `sidecarMems[c].getAppendOffset()` (the last seal's published extents) and writes a chain entry whose `LEN` includes a correctly populated cover footer. The footer values match the previous seal's extents, which is correct: covers do not advance between seals.
- `IndexWriter`, `ColumnIndexer`, and `SymbolColumnIndexer` gain matching default and forwarding declarations.
- `TableWriter.sealPostingIndexesForO3Partitions` and `sealPostingIndexesForLastPartitionFastLag` finally blocks switch from `indexer.clearCovering()` to `indexer.releaseCoveredColumnReadMappings()`. `clearCovering()` retains its full-teardown semantics for legitimate uses (writer `discardAndClose`, swap to a different cover schema).

## Effect on existing behavior

- For a chain entry whose physical cover-footer size matches the reader's `coverCount`, behavior is unchanged.
- For a chain entry whose cover footer is missing or truncated relative to the reader's `coverCount` (which can still happen via the fd-based O3CopyJob publish window before `sealPostingIndexesForO3Partitions` republishes), the reader no longer SEGVs and falls back to the non-covering path for that entry.
- The new picker pre-check is a single 8-byte read per chain step. No measurable impact on hot paths.
- `clearCovering()`'s contract is unchanged. Production callers that previously misused it for read-mapping cleanup now use the narrower `releaseCoveredColumnReadMappings()`.

## Test plan

- `PostingIndexChainTest` - five new low-level cases covering the read clamp and the picker's pre-bound-check: a coverCount-mismatched entry, a `read()` that must stop at LEN even when more slots are requested, the happy-path round trip, a stomped LEN exceeding the mapping, and a non-positive LEN.
- `PostingIndexCriticalIssuesTest#testWriterEntrysCoverFooterShrinksAfterClearCoveringCommit` - drives `PostingIndexWriter` through `configureCovering -> seal -> clearCovering -> add -> commit`, asserts the head LEN reflects `entrySize(genCount, 0)` (documents `clearCovering()`'s contract for legitimate teardown), plants a sentinel byte pattern at the false-footer offset and verifies the picker returns `0` instead of the sentinel (validates the reader fix).
- `PostingIndexCriticalIssuesTest#testWriterEntrysCoverFooterPersistsAfterReleaseReadMappingsCommit` - symmetric counterpart that drives `configureCovering -> seal -> releaseCoveredColumnReadMappings -> add -> commit` and asserts the head LEN equals `entrySize(genCount, coverCount)` (validates the writer fix).
- `PostingIndexCriticalIssuesTest#testWalFastLagCoveringPostingDoesNotCrashReader` - end-to-end reproducer modeled on `walFastLagInsertAndQuery`: covering POSTING index over `CREATE TABLE ... WAL`, repeated INSERT batch -> `drainWalQueue` -> `SELECT count() WHERE sym = ?` over 64 iterations. On unfixed code the JVM SIGSEGVs inside the chain walk; with the fix in place queries return correct counts.

Verification:

- 49 tests in `PostingIndexChainTest`, `PostingIndexCriticalIssuesTest`, and `PostingIndexChainWriterTest` pass.
- Broader run across `*PostingIndex*`, `*Covering*`, `*Indexer*`, `*WalApply*` test classes (1331 tests) passes.
- The new picker-clamp test fails on unfixed code with the planted sentinel surfacing as a cover end offset (`expected:<0> but was:<-2401053089206453570>` = `0xdeadbeefcafebabe`), confirming the reader-side test catches the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
