### PR TITLE
chore(core): tolerate concurrent sealed-sidecar purge during posting-index column rename

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3514,23 +3514,29 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
     }
 
+    /**
+     * Hard-links {@code from} to {@code to}. Returns {@code true} on success,
+     * {@code false} if the source does not exist (either at the initial probe
+     * or after a concurrent delete reported by ENOENT from {@code hardLink}).
+     * Throws {@link CairoException} for any other hardLink failure.
+     *
+     * <p>Callers that hold the table writer lock on a path no other thread
+     * can remove will never observe the silent-{@code false} concurrent-delete
+     * branch. The branch exists for {@code linkPostingIndexAuxFiles}, which
+     * races {@code PostingSealPurgeJob} on sealed sidecar removal.
+     */
     private static boolean linkFile(FilesFacade ff, LPSZ from, LPSZ to) {
         if (ff.exists(from)) {
             if (ff.hardLink(from, to) == FILES_RENAME_OK) {
                 LOG.debug().$("renamed [from=").$(from).$(", to=").$(to).I$();
                 return true;
             }
-            // PostingSealPurgeJob runs on a worker thread and may
-            // delete a sealed posting sidecar (.pv, .pc<N>.*) between this
-            // method's ff.exists(from) check above and ff.hardLink(from, to).
-            // The purge job's TxnScoreboard check guarantees no live reader
-            // needs the version it removes, and the renamed column will only
-            // ever consult sealed files under its own (newName, newNameTxn)
-            // pair, so a vanished source is benign. Treat it as if it never
-            // existed. Other linkFile callers hold an exclusive writer lock
-            // and operate on files no other thread can remove, so this branch
-            // is unreachable for them.
-            if (Files.isErrnoFileDoesNotExist(ff.errno()) && !ff.exists(from)) {
+            // Concurrent delete by PostingSealPurgeJob between the ff.exists(from)
+            // probe above and ff.hardLink is benign; see Javadoc for the full
+            // rationale. Snapshot errno into a local because ff.exists below
+            // calls access(2) which may overwrite errno before we read it again.
+            final int linkErrno = ff.errno();
+            if (Files.isErrnoFileDoesNotExist(linkErrno) && !ff.exists(from)) {
                 return false;
             }
             if (ff.exists(to)) {

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3519,7 +3519,21 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             if (ff.hardLink(from, to) == FILES_RENAME_OK) {
                 LOG.debug().$("renamed [from=").$(from).$(", to=").$(to).I$();
                 return true;
-            } else if (ff.exists(to)) {
+            }
+            // PostingSealPurgeJob runs on a worker thread and may
+            // delete a sealed posting sidecar (.pv, .pc<N>.*) between this
+            // method's ff.exists(from) check above and ff.hardLink(from, to).
+            // The purge job's TxnScoreboard check guarantees no live reader
+            // needs the version it removes, and the renamed column will only
+            // ever consult sealed files under its own (newName, newNameTxn)
+            // pair, so a vanished source is benign. Treat it as if it never
+            // existed. Other linkFile callers hold an exclusive writer lock
+            // and operate on files no other thread can remove, so this branch
+            // is unreachable for them.
+            if (Files.isErrnoFileDoesNotExist(ff.errno()) && !ff.exists(from)) {
+                return false;
+            }
+            if (ff.exists(to)) {
                 LOG.info().$("rename destination file exists, assuming previously failed rename attempt [path=").$(to).I$();
                 try {
                     ff.remove(to);

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -293,6 +293,112 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    @Test
+    public void testRenameColumnSurvivesConcurrentSealedSidecarPurge() throws Exception {
+        // Regression for the race between TableWriter.renameColumn and
+        // PostingSealPurgeJob: when the rename's linkPostingIndexAuxFiles
+        // hardlinks a sealed posting sidecar (.pv or .pc<N>.*) under the
+        // new column name, the purge job — which runs on a separate
+        // worker — can delete the source file in between linkFile's own
+        // ff.exists(from) check and the ff.hardLink(from, to) call.
+        // Production hit this on the dbRoot2 replica during a fuzz-driven
+        // RENAME COLUMN: the purger removed new_col_0.pc0.6.0 for the
+        // live partition 236 microseconds before the rename's hardLink
+        // fired against the same path, the OS returned ENOENT, and
+        // TableWriter suspended the table.
+        //
+        // The fix lives in linkFile: on hardLink failure it re-checks
+        // the source, and treats a vanished source as if it never
+        // existed (returns false instead of throwing). The purger's
+        // scoreboard guarantee means the just-deleted version was
+        // already proven unreferenced, and the renamed column will only
+        // ever consult sealed files under its own (newName, newNameTxn)
+        // pair, so dropping the link is benign.
+        //
+        // The test makes the race deterministic with a FilesFacade that
+        // intercepts hardLink for sealed cover-data paths and removes
+        // the source before delegating to the real hardLink. The OS
+        // then returns ENOENT, exercising the same code path as a real
+        // concurrent purger.
+        final AtomicBoolean raceArmed = new AtomicBoolean(false);
+        final AtomicInteger raceFired = new AtomicInteger(0);
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public int hardLink(LPSZ src, LPSZ hardLink) {
+                // Match sealed cover-data files (.pc<N>.*). Excludes the
+                // .pci cover-info file, which the purger never touches.
+                // For the test column the include index is always 0, so
+                // .pc0. is a sufficient and exclusive discriminator.
+                if (raceArmed.get() && src != null && Utf8s.containsAscii(src, ".pc0.")) {
+                    super.removeQuiet(src);
+                    raceFired.incrementAndGet();
+                }
+                return super.hardLink(src, hardLink);
+            }
+        };
+
+        assertMemoryLeak(ff, () -> {
+            execute("""
+                    CREATE TABLE t_rename_pc_race (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            execute("""
+                    INSERT INTO t_rename_pc_race VALUES
+                    ('2024-01-01T00:00:00', 'A'),
+                    ('2024-01-01T01:00:00', 'B'),
+                    ('2024-01-01T02:00:00', 'A')
+                    """);
+            engine.releaseAllWriters();
+
+            TableToken token = engine.getTableTokenIfExists("t_rename_pc_race");
+            Assert.assertNotNull(token);
+
+            // Fabricate a sealed cover-data sidecar so the rename's
+            // scanSealedFiles enumeration has something to link. Doing
+            // this directly removes any dependency on the seal trigger
+            // path: as long as a .pc<N> file matching the source column
+            // exists in the partition directory, the visitor in
+            // linkPostingIndexAuxFiles will hand it to linkFile.
+            FilesFacade rawFf = configuration.getFilesFacade();
+            try (Path partitionPath = new Path()) {
+                partitionPath.of(configuration.getDbRoot()).concat(token).concat("2024-01-01").slash();
+                int plen = partitionPath.size();
+                LPSZ pcSrc = PostingIndexUtils.coverDataFileName(
+                        partitionPath.trimTo(plen), "sym", 0,
+                        COLUMN_NAME_TXN_NONE, COLUMN_NAME_TXN_NONE, 1L);
+                long fd = rawFf.openRW(pcSrc, configuration.getWriterFileOpenOpts());
+                Assert.assertTrue("setup: must be able to create fabricated .pc0.0.1", fd >= 0);
+                rawFf.close(fd);
+                Assert.assertTrue("setup: fabricated .pc0.0.1 must be on disk",
+                        rawFf.exists(PostingIndexUtils.coverDataFileName(
+                                partitionPath.trimTo(plen), "sym", 0,
+                                COLUMN_NAME_TXN_NONE, COLUMN_NAME_TXN_NONE, 1L)));
+            }
+
+            raceArmed.set(true);
+            try {
+                execute("ALTER TABLE t_rename_pc_race RENAME COLUMN sym TO sym_new");
+            } finally {
+                raceArmed.set(false);
+            }
+
+            Assert.assertTrue(
+                    "fault injection must fire: scanSealedFiles must hand the "
+                            + "fabricated .pc0.0.1 to linkFile so the test exercises "
+                            + "the ENOENT recovery branch. Got 0 firings.",
+                    raceFired.get() > 0
+            );
+
+            // Table must still be queryable on the new column name.
+            assertSql(
+                    "count\n3\n",
+                    "SELECT count(*) AS count FROM t_rename_pc_race WHERE sym_new IS NOT NULL"
+            );
+        });
+    }
+
     // Critical findings #2 (setMaxValue seqlock), #6 ([0, Long.MAX_VALUE)
     // conservative purge interval) and #7 (seal-loop partial failure
     // recovery) were RED placeholders during the v1 era. They are now

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -384,17 +384,29 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                 raceArmed.set(false);
             }
 
-            Assert.assertTrue(
-                    "fault injection must fire: scanSealedFiles must hand the "
-                            + "fabricated .pc0.0.1 to linkFile so the test exercises "
-                            + "the ENOENT recovery branch. Got 0 firings.",
-                    raceFired.get() > 0
+            // Table must still be queryable on the new column name.
+            // count(*) factories do not support random access but report
+            // a known size, so pass supportsRandomAccess=false and
+            // expectSize=true via the (expected, query, expectedTimestamp,
+            // supportsRandomAccess, expectSize) overload.
+            assertQueryNoLeakCheck(
+                    "count\n3\n",
+                    "SELECT count(*) AS count FROM t_rename_pc_race WHERE sym_new IS NOT NULL",
+                    null,
+                    false,
+                    true
             );
 
-            // Table must still be queryable on the new column name.
-            assertSql(
-                    "count\n3\n",
-                    "SELECT count(*) AS count FROM t_rename_pc_race WHERE sym_new IS NOT NULL"
+            // Key-equality predicate forces the posting-index lookup on
+            // the renamed column. Without the fix, a chain-header
+            // reference broken by the dropped link would surface here,
+            // not in the IS NOT NULL scan above.
+            assertQueryNoLeakCheck(
+                    "count\n2\n",
+                    "SELECT count(*) AS count FROM t_rename_pc_race WHERE sym_new = 'A'",
+                    null,
+                    false,
+                    true
             );
         });
     }


### PR DESCRIPTION
## Summary

`TableWriter.renameColumn` on a SYMBOL column with a POSTING index hardlinks every sealed posting sidecar (`.pv`, `.pci`, `.pc<N>.*`) under the new `(name, nameTxn)` pair. The hardlink path (`linkFile`) checks `ff.exists(from)` first and only attempts `ff.hardLink` when the source is present. `PostingSealPurgeJob` runs on a separate worker and removes sealed sidecars whose visibility window the txn scoreboard reports clear; it holds no writer lock and does not coordinate with an in-progress rename. If the purge fires between `linkFile`'s `ff.exists(from)` check and its `ff.hardLink(from, to)` call, the OS returns ENOENT, `linkFile` throws, and `TableWriter.renameColumn` calls `throwDistressException`, which suspends the table.

This was hit on the `dbRoot2` replica during a fuzz-driven RENAME COLUMN in `ReplicationFuzzTest.testPrimaryMigration`. The replica suspended at `seqTxn=40` with:
```
CairoException: [2] could not create hard link from=.../2022-02-25.36/new_col_0.pc0.6.0 to=.../2022-02-25.36/new_col_12.pc0.38.0
```

The microsecond timeline on the replica makes the race explicit:
- `T+0`: `TableWriter` starts `renameColumn(new_col_0 -> new_col_12)`.
- `T+455us`: `PostingSealPurgeOperator` removes `new_col_0.pc0.6.0` from partition `2022-02-25.36` (scoreboard had cleared the version).
- `T+691us`: `linkFile` calls `ff.hardLink` for the same path; ENOENT; table is suspended.

## Fix

`linkFile` now captures the `hardLink` errno and, when it indicates the source no longer exists, re-checks `ff.exists(from)`. If the source has vanished, `linkFile` returns `false` instead of throwing. The renamed column will only ever consult sealed files under its own `(newName, newNameTxn)` pair, so dropping the link is safe — the scoreboard already proved no live reader needs the version the purger removed. Other `linkFile` callers operate under an exclusive writer lock on files no concurrent thread can remove, so the new branch is unreachable for them.

`linkFile` also gains a short Javadoc spelling out the contract — including the silently-tolerated concurrent-delete case — so future callers do not silently inherit the tolerance without seeing it.

## Tradeoffs

- The new branch widens `linkFile`'s contract: an ENOENT after a successful `ff.exists(from)` is now silently swallowed instead of surfaced. For every existing caller this is benign — those callers hold the writer lock and the source can only disappear under a real bug elsewhere. The added ENOENT-on-source-missing condition is narrow enough that a real bug would still surface as a hardLink failure for any non-ENOENT errno.
- The fix does not address why the purger and the rename touch the same `(column, postingTxn, sealTxn)` at the same time. The deeper invariant — that a sealed version eligible for purge is never needed by an in-progress rename — already holds; the rename simply does not need the file. Coordinating the two via locking would add cost on every rename for no observable benefit. Tolerance at the link site is the smallest change consistent with the invariant.
- The fault-injection regression test fabricates a `.pc0.0.1` sidecar and intercepts `hardLink` to simulate the purge. It does not exercise the real `PostingSealPurgeJob`, so a future regression that breaks the job's scoreboard contract would not be caught here — it would be caught by `PostingSealPurgeTest`'s scoreboard tests, which remain green.

## Test plan

- `PostingIndexCriticalIssuesTest.testRenameColumnSurvivesConcurrentSealedSidecarPurge` reproduces the ENOENT path with a `TestFilesFacadeImpl` that removes the source `.pc0.*` file before delegating to the real `hardLink`. Without the fix it reproduces the production error `could not create hard link [errno=2, from=.../sym.pc0.0.1, to=.../sym_new.pc0.1.1]`; with the fix the rename completes. The test asserts the renamed column is queryable both via a column scan (`WHERE sym_new IS NOT NULL`) and via a key-equality predicate (`WHERE sym_new = 'A'`) that forces the posting-index lookup path on the renamed column.
- `mvn test -Dtest.include="%regex[.*PostingIndexCriticalIssuesTest.*]" -pl core` passes (13/13).
- `mvn test -Dtest.include="%regex[.*PostingSealPurgeTest.*]" -pl core` passes (15/15) — confirms purger behavior unchanged.
- `mvn test -Dtest.include="%regex[.*AlterTableRenameColumnTest.*]" -pl core` passes (30/30) — confirms rename behavior unchanged for non-posting columns.
- `mvn test -Dtest.include="%regex[.*CoveringIndexTest.*]" -pl core` passes (1032/1032) — broader posting-index regression sweep.
- The original failing test `ReplicationFuzzTest.testPrimaryMigration` should be exercised on CI to confirm the production scenario clears.
