### PR TITLE
perf(core): add chain-diff posting-index seal primitive

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ColumnIndexer.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnIndexer.java
@@ -88,6 +88,14 @@ public interface ColumnIndexer extends QuietCloseable {
             long partitionNameTxn
     );
 
+    /**
+     * See {@link io.questdb.cairo.idx.PostingIndexWriter#diffAgainstChainHead}.
+     * Default no-op for index types that don't accumulate stale state (e.g.
+     * BitmapIndexWriter persists every add immediately).
+     */
+    default void diffAgainstChainHead(FilesFacade ff, long dataColumnFd, long columnTop, long partitionSize) {
+    }
+
     default void discardAndClose() {
         close();
     }

--- a/core/src/main/java/io/questdb/cairo/SymbolColumnIndexer.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolColumnIndexer.java
@@ -164,6 +164,11 @@ public class SymbolColumnIndexer implements ColumnIndexer, Mutable {
     }
 
     @Override
+    public void diffAgainstChainHead(FilesFacade ff, long dataColumnFd, long columnTop, long partitionSize) {
+        writer.diffAgainstChainHead(ff, dataColumnFd, columnTop, partitionSize);
+    }
+
+    @Override
     public void distress() {
         distressed = true;
     }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -11341,25 +11341,31 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                             // rebuildSidecars publishes the chain as is.
                             indexer.getWriter().rollbackConditionally(partitionSize);
                         } else {
-                            // Diff the existing chain against the column .d file
-                            // and emit a fresh dense chain entry containing only
-                            // the kept (key, rowId) pairs. Stale entries inside
-                            // [columnTop, partitionSize) are evicted in a single
-                            // stride-by-stride pass with bounded peak memory --
-                            // unlike the discardForRebuild + index + commit
-                            // sequence (kept above for reference), the diff does
-                            // not accumulate every (key, rowId) in private spill
-                            // memory and therefore scales to billion-row
-                            // partitions. coverCount is 0 at this point because
-                            // configureCovering runs below; the diff publishes
-                            // an entry without a cover footer, which the trailing
-                            // rebuildSidecars supersedes.
+                            // Rebuild the chain from the column data file.
+                            // rollbackConditionally(partitionSize) only
+                            // evicts entries past the new partition size; it
+                            // leaves stale (key, rowId) pairs within
+                            // [columnTop, partitionSize) that survive
+                            // replace-range, dedup-replace, and O3 splits
+                            // where the same rowid takes a different value
+                            // across writes. discardForRebuild drops the
+                            // in-memory state without rotating .pv or
+                            // rewriting .pk, then index() re-reads sym2.d
+                            // (the source of truth) and the trailing seal
+                            // publishes a fresh single-gen chain entry.
+                            indexer.getWriter().discardForRebuild();
                             long dataFd = openRO(ff, dFile(path.trimTo(plen), colName, colNameTxn), LOG);
                             try {
-                                indexer.diffAgainstChainHead(ff, dataFd, columnTop, partitionSize);
+                                indexer.index(ff, dataFd, columnTop, partitionSize);
                             } finally {
                                 ff.close(dataFd);
                             }
+                            // Flush pending into gen 0 so rebuildSidecars (and seal in
+                            // the non-covering branch) sees a non-empty chain. add()
+                            // populated pending; commit() runs flushAllPending which
+                            // converts pending into a fresh gen and republishes the
+                            // chain head via extendHead at the same sealTxn.
+                            indexer.getWriter().commit();
                         }
                         // Pass the writer-space timestamp index so the
                         // O3 reseal preserves the linear-prediction
@@ -11424,16 +11430,15 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         // See pure-append fast-path comment in the covering branch above.
                         indexer.getWriter().rollbackConditionally(partitionSize);
                     } else {
-                        // See diff comment in the covering branch above. Non-covering
-                        // posting indexes have no cover columns to configure -- the diff
-                        // publishes the canonical entry directly; the trailing seal()
-                        // re-encodes into the dense form at a fresh sealTxn.
+                        // See rebuild-from-data comment in the covering branch.
+                        indexer.getWriter().discardForRebuild();
                         long dataFd = openRO(ff, dFile(path.trimTo(plen), colName, colNameTxn), LOG);
                         try {
-                            indexer.diffAgainstChainHead(ff, dataFd, columnTop, partitionSize);
+                            indexer.index(ff, dataFd, columnTop, partitionSize);
                         } finally {
                             ff.close(dataFd);
                         }
+                        indexer.getWriter().commit();
                     }
                     indexer.seal();
                     indexer.publishPendingPurges(messageBus, tableToken, partitionBy, timestampType, txWriter.getTxn());

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -11341,31 +11341,15 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                             // rebuildSidecars publishes the chain as is.
                             indexer.getWriter().rollbackConditionally(partitionSize);
                         } else {
-                            // Rebuild the chain from the column data file.
-                            // rollbackConditionally(partitionSize) only
-                            // evicts entries past the new partition size; it
-                            // leaves stale (key, rowId) pairs within
-                            // [columnTop, partitionSize) that survive
-                            // replace-range, dedup-replace, and O3 splits
-                            // where the same rowid takes a different value
-                            // across writes. discardForRebuild drops the
-                            // in-memory state without rotating .pv or
-                            // rewriting .pk, then index() re-reads sym2.d
-                            // (the source of truth) and the trailing seal
-                            // publishes a fresh single-gen chain entry.
-                            indexer.getWriter().discardForRebuild();
+                            // Diff the existing chain against the column .d file
+                            // and emit a fresh dense chain entry containing only
+                            // the kept (key, rowId) pairs.
                             long dataFd = openRO(ff, dFile(path.trimTo(plen), colName, colNameTxn), LOG);
                             try {
-                                indexer.index(ff, dataFd, columnTop, partitionSize);
+                                indexer.diffAgainstChainHead(ff, dataFd, columnTop, partitionSize);
                             } finally {
                                 ff.close(dataFd);
                             }
-                            // Flush pending into gen 0 so rebuildSidecars (and seal in
-                            // the non-covering branch) sees a non-empty chain. add()
-                            // populated pending; commit() runs flushAllPending which
-                            // converts pending into a fresh gen and republishes the
-                            // chain head via extendHead at the same sealTxn.
-                            indexer.getWriter().commit();
                         }
                         // Pass the writer-space timestamp index so the
                         // O3 reseal preserves the linear-prediction
@@ -11430,15 +11414,13 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         // See pure-append fast-path comment in the covering branch above.
                         indexer.getWriter().rollbackConditionally(partitionSize);
                     } else {
-                        // See rebuild-from-data comment in the covering branch.
-                        indexer.getWriter().discardForRebuild();
+                        // See diff comment in the covering branch above.
                         long dataFd = openRO(ff, dFile(path.trimTo(plen), colName, colNameTxn), LOG);
                         try {
-                            indexer.index(ff, dataFd, columnTop, partitionSize);
+                            indexer.diffAgainstChainHead(ff, dataFd, columnTop, partitionSize);
                         } finally {
                             ff.close(dataFd);
                         }
-                        indexer.getWriter().commit();
                     }
                     indexer.seal();
                     indexer.publishPendingPurges(messageBus, tableToken, partitionBy, timestampType, txWriter.getTxn());

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -11341,31 +11341,25 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                             // rebuildSidecars publishes the chain as is.
                             indexer.getWriter().rollbackConditionally(partitionSize);
                         } else {
-                            // Rebuild the chain from the column data file.
-                            // rollbackConditionally(partitionSize) only
-                            // evicts entries past the new partition size; it
-                            // leaves stale (key, rowId) pairs within
-                            // [columnTop, partitionSize) that survive
-                            // replace-range, dedup-replace, and O3 splits
-                            // where the same rowid takes a different value
-                            // across writes. discardForRebuild drops the
-                            // in-memory state without rotating .pv or
-                            // rewriting .pk, then index() re-reads sym2.d
-                            // (the source of truth) and the trailing seal
-                            // publishes a fresh single-gen chain entry.
-                            indexer.getWriter().discardForRebuild();
+                            // Diff the existing chain against the column .d file
+                            // and emit a fresh dense chain entry containing only
+                            // the kept (key, rowId) pairs. Stale entries inside
+                            // [columnTop, partitionSize) are evicted in a single
+                            // stride-by-stride pass with bounded peak memory --
+                            // unlike the discardForRebuild + index + commit
+                            // sequence (kept above for reference), the diff does
+                            // not accumulate every (key, rowId) in private spill
+                            // memory and therefore scales to billion-row
+                            // partitions. coverCount is 0 at this point because
+                            // configureCovering runs below; the diff publishes
+                            // an entry without a cover footer, which the trailing
+                            // rebuildSidecars supersedes.
                             long dataFd = openRO(ff, dFile(path.trimTo(plen), colName, colNameTxn), LOG);
                             try {
-                                indexer.index(ff, dataFd, columnTop, partitionSize);
+                                indexer.diffAgainstChainHead(ff, dataFd, columnTop, partitionSize);
                             } finally {
                                 ff.close(dataFd);
                             }
-                            // Flush pending into gen 0 so rebuildSidecars (and seal in
-                            // the non-covering branch) sees a non-empty chain. add()
-                            // populated pending; commit() runs flushAllPending which
-                            // converts pending into a fresh gen and republishes the
-                            // chain head via extendHead at the same sealTxn.
-                            indexer.getWriter().commit();
                         }
                         // Pass the writer-space timestamp index so the
                         // O3 reseal preserves the linear-prediction
@@ -11430,15 +11424,16 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         // See pure-append fast-path comment in the covering branch above.
                         indexer.getWriter().rollbackConditionally(partitionSize);
                     } else {
-                        // See rebuild-from-data comment in the covering branch.
-                        indexer.getWriter().discardForRebuild();
+                        // See diff comment in the covering branch above. Non-covering
+                        // posting indexes have no cover columns to configure -- the diff
+                        // publishes the canonical entry directly; the trailing seal()
+                        // re-encodes into the dense form at a fresh sealTxn.
                         long dataFd = openRO(ff, dFile(path.trimTo(plen), colName, colNameTxn), LOG);
                         try {
-                            indexer.index(ff, dataFd, columnTop, partitionSize);
+                            indexer.diffAgainstChainHead(ff, dataFd, columnTop, partitionSize);
                         } finally {
                             ff.close(dataFd);
                         }
-                        indexer.getWriter().commit();
                     }
                     indexer.seal();
                     indexer.publishPendingPurges(messageBus, tableToken, partitionBy, timestampType, txWriter.getTxn());

--- a/core/src/main/java/io/questdb/cairo/idx/IndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/IndexWriter.java
@@ -90,6 +90,14 @@ public interface IndexWriter extends Closeable, Mutable {
     }
 
     /**
+     * See {@link io.questdb.cairo.idx.PostingIndexWriter#diffAgainstChainHead}.
+     * Default no-op for index types that don't accumulate stale state (e.g.
+     * BitmapIndexWriter persists every add immediately and has no chain).
+     */
+    default void diffAgainstChainHead(io.questdb.std.FilesFacade ff, long dataColumnFd, long columnTop, long partitionSize) {
+    }
+
+    /**
      * Returns the index type for this writer.
      *
      * @return the index type constant from {@link IndexType}

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -737,40 +737,436 @@ public class PostingIndexWriter implements IndexWriter {
                 return;
             }
 
-            // TODO Phase 2: rotate sealTxn, encode kept entries into a fresh .pv
-            // stride-by-stride mirroring sealIncremental's all-strides-dirty pattern,
-            // emit per-stride sidecars via writeSidecarStrideData, then publishToChain
-            // through the appendNewEntry branch. Until Phase 2 is implemented, fall
-            // back to the existing reencode-from-gens path which is correct (it
-            // re-reads from valueMem, which still holds pre-validation gens) but
-            // does NOT evict stale entries -- the diff is incomplete.
+            // Phase 2 currently restricted to path-based writers (the only
+            // production caller is TableWriter.sealPostingIndexForPartition).
+            // fd-based diff would need sealValueMem + switchToSealedValueFile
+            // plumbing; not implemented yet.
+            if (partitionPath.size() == 0) {
+                throw new UnsupportedOperationException(
+                        "diffAgainstChainHead is path-based only; fd-based callers must use the existing seal path"
+                );
+            }
+
+            // Phase 2: rotate sealTxn, decode + filter + encode each stride into
+            // the new .pv, emit per-stride sidecars, append a fresh chain entry.
             //
-            // The Phase 2 implementation must:
-            //   1. closeSidecarMems(); openSealValueFile(newSealTxn);
-            //      openSidecarFiles(...) at newSealTxn if coverCount > 0.
-            //   2. Reserve siSize bytes at the head of sealTarget for the stride
-            //      index. Allocate strideIndexBuf, bpTrialBuf, localHeaderBuf,
-            //      mergedValuesAddr (sized by max-stride-after-filter).
-            //   3. For each stride: decode each key from gen 0 + sparse gens via
-            //      mergeKeyValues, then filter via filterKeyValuesAgainstD into
-            //      the same buffer. Trial-encode delta and flat, pick smaller,
-            //      emit. writeSidecarStrideData against the kept rowIds.
-            //   4. switchToSealedValueFile(newSealTxn). publishToChain takes the
-            //      appendNewEntry branch automatically (sealTxn rotated).
-            //   5. recordPostingSealPurge(oldSealTxn).
+            // Sizing: Phase 1 produced keptCounts[]; the largest single-stride
+            // decode buffer must hold the worst-case PRE-FILTER count for any
+            // stride (mergeKeyValues writes the un-filtered values, then we
+            // filter in place). We size by the per-key max kept count summed
+            // across the stride -- a small overestimate vs PRE-FILTER, which is
+            // safe because filter is non-expanding.
+            int sc = PostingIndexUtils.strideCount(keyCount);
+            int siSize = PostingIndexUtils.strideIndexSize(keyCount);
+            // Need true PRE-FILTER counts for sizing -- recompute from gen-dir
+            // entries directly. Cheap (no decoding, just summing gen-dir
+            // count fields per key).
+            long preFilterCountsSize = (long) keyCount * Integer.BYTES;
+            long preFilterCountsAddr = Unsafe.malloc(preFilterCountsSize, MemoryTag.NATIVE_INDEX_READER);
+            int maxStridePreFilter = 0;
+            try {
+                Unsafe.setMemory(preFilterCountsAddr, preFilterCountsSize, (byte) 0);
+                accumulatePreFilterCounts(preFilterCountsAddr);
+                for (int s = 0; s < sc; s++) {
+                    int strideSum = 0;
+                    int ks = PostingIndexUtils.keysInStride(keyCount, s);
+                    for (int j = 0; j < ks; j++) {
+                        int key = s * PostingIndexUtils.DENSE_STRIDE + j;
+                        strideSum += Unsafe.getInt(preFilterCountsAddr + (long) key * Integer.BYTES);
+                    }
+                    if (strideSum > maxStridePreFilter) {
+                        maxStridePreFilter = strideSum;
+                    }
+                }
+            } finally {
+                Unsafe.free(preFilterCountsAddr, preFilterCountsSize, MemoryTag.NATIVE_INDEX_READER);
+            }
+
+            if (maxStridePreFilter == 0) {
+                // Defensive: Phase 1 reported totalKept > 0 but stride sum is
+                // zero. Should be impossible -- treat as empty.
+                truncate();
+                setMaxValue(Math.max(partitionSize - 1, -1));
+                return;
+            }
+
+            // Rotate sealTxn. Mirrors sealIncremental: open sealValueMem at
+            // the new .pv, leave valueMem on the OLD .pv so the per-stride
+            // decode loop below can still read existing gens. The OLD mmap
+            // stays alive until switchToSealedValueFile at the end of Phase 2.
             //
-            // Until then, throw to surface that the diff is not yet wired to its
-            // Phase 2 emit.
-            throw new UnsupportedOperationException(
-                    "diffAgainstChainHead Phase 2 (encode + sidecar + publish) not yet implemented; "
-                            + "Phase 1 validation produced " + totalKept + " kept entries."
-            );
+            // peekNextSealTxn(), not sealTxn+1: after a recovery drop the
+            // writer's sealTxn lags genCounter, and reusing a dropped sealTxn
+            // would race the still-pending .pv purge.
+            final long oldSealTxn = sealTxn;
+            final long newSealTxn = Math.max(1, chain.peekNextSealTxn());
+
+            // Allocate per-stride decode buffer (sized for max PRE-FILTER count).
+            long mergedValuesSize = (long) maxStridePreFilter * Long.BYTES;
+            long mergedValuesAddr = Unsafe.malloc(mergedValuesSize, MemoryTag.NATIVE_INDEX_READER);
+            long strideIndexBuf = Unsafe.malloc(siSize, MemoryTag.NATIVE_INDEX_READER);
+            int maxLocalHeaderSize = Math.max(
+                    PostingIndexUtils.strideDeltaHeaderSize(PostingIndexUtils.DENSE_STRIDE),
+                    PostingIndexUtils.strideFlatHeaderSize(PostingIndexUtils.DENSE_STRIDE));
+            long localHeaderBuf = Unsafe.malloc(maxLocalHeaderSize, MemoryTag.NATIVE_INDEX_READER);
+            // bpTrialBuf grows on demand per stride.
+            long bpTrialBuf = 0;
+            long bpTrialBufSize = 0;
+            long[] incrSidecarSiBufs = null;
+
+            try {
+                // Open the new .pv via sealValueMem; valueMem stays on the OLD .pv.
+                openSealValueFile(newSealTxn);
+                long sealOffset = sealValueMem.getAppendOffset();
+                // Reserve siSize bytes for the stride index at the head of the .pv.
+                for (int i = 0; i < siSize; i += Long.BYTES) {
+                    sealValueMem.putLong(0L);
+                }
+
+                // Open new sidecars at newSealTxn if covering. closeSidecarMems()
+                // releases the OLD sidecar mmaps (which were at oldSealTxn).
+                if (coverCount > 0) {
+                    if (sidecarMems.size() > 0) {
+                        closeSidecarMems();
+                    }
+                    openSidecarFiles(Path.getThreadLocal(partitionPath), indexName, postingColumnNameTxn, newSealTxn);
+                    incrSidecarSiBufs = new long[coverCount];
+                    for (int c = 0; c < coverCount; c++) {
+                        MemoryMARW mem = sidecarMems.getQuick(c);
+                        if (mem == null) {
+                            incrSidecarSiBufs[c] = 0;
+                            continue;
+                        }
+                        incrSidecarSiBufs[c] = Unsafe.malloc(siSize, MemoryTag.NATIVE_INDEX_READER);
+                        // Reserve siSize for the cover stride index at the head.
+                        for (int i = 0; i < siSize; i += Long.BYTES) {
+                            mem.putLong(0L);
+                        }
+                    }
+                }
+
+                // Snapshot OLD gen 0 metadata for mergeKeyValues.
+                long gen0DirOffset = PostingIndexChainEntry.resolveGenDirOffset(chain.getHeadEntryOffset(), 0);
+                long gen0FileOffset = keyMem.getLong(gen0DirOffset + GEN_DIR_OFFSET_FILE_OFFSET);
+                int gen0KeyCount = keyMem.getInt(gen0DirOffset + PostingIndexUtils.GEN_DIR_OFFSET_KEY_COUNT);
+                int gen0SiSize;
+                if (gen0KeyCount < 0) {
+                    // gen 0 is sparse (rare; usually dense after seal). Treat
+                    // it like the other sparse gens by setting gen0KeyCount=0
+                    // so mergeKeyValues skips its dense branch and instead
+                    // walks all gens via the sparse path.
+                    gen0KeyCount = 0;
+                    gen0SiSize = 0;
+                } else {
+                    gen0SiSize = PostingIndexUtils.strideIndexSize(gen0KeyCount);
+                }
+
+                // Per-stride decode + filter + encode loop.
+                int[] keyCounts = strideKeyCounts;
+                long[] keyOffsets = strideKeyOffsets;
+                int[] bpKeySizes = strideBpKeySizes;
+                long dCacheReuseStart = -1L;
+                long dCacheReuseLen = 0L;
+
+                for (int s = 0; s < sc; s++) {
+                    int ks = PostingIndexUtils.keysInStride(keyCount, s);
+
+                    // Recompute gen0Addr each stride: sealValueMem writes can
+                    // trigger mremap via valueMem in some configurations; safer
+                    // to refresh.
+                    long gen0Addr = gen0KeyCount > 0 ? valueMem.addressOf(gen0FileOffset) : 0;
+
+                    // Decode each key in stride from gen 0 + sparse gens, then
+                    // filter in place. The buffer layout: contiguous per-key
+                    // ranges, with subsequent keys appended after the previous
+                    // key's KEPT count (since filter compresses to front).
+                    long cumOffset = 0;
+                    for (int j = 0; j < ks; j++) {
+                        int key = s * PostingIndexUtils.DENSE_STRIDE + j;
+                        keyOffsets[j] = cumOffset;
+                        int decodedCount = mergeKeyValues(
+                                key, gen0Addr, gen0KeyCount, gen0SiSize,
+                                mergedValuesAddr + cumOffset * Long.BYTES);
+                        // Filter in place. cacheState is reused across keys for
+                        // sequential .d access locality.
+                        long[] cacheState = {dCacheReuseStart, dCacheReuseLen};
+                        int keptCount = filterKeyValuesAgainstD(
+                                key,
+                                mergedValuesAddr + cumOffset * Long.BYTES,
+                                decodedCount,
+                                ff, dataColumnFd, columnTop, partitionSize,
+                                dReadCacheAddr, dReadCacheSize, cacheState
+                        );
+                        dCacheReuseStart = cacheState[0];
+                        dCacheReuseLen = cacheState[1];
+                        keyCounts[j] = keptCount;
+                        cumOffset += keptCount;
+                    }
+
+                    long strideOff = sealValueMem.getAppendOffset() - sealOffset - siSize;
+                    Unsafe.putLong(strideIndexBuf + (long) s * Long.BYTES, strideOff);
+
+                    if (cumOffset == 0) {
+                        // Empty stride after filter -- just record offset and
+                        // skip encode. Sidecar offsets recorded as well.
+                        if (incrSidecarSiBufs != null) {
+                            for (int c = 0; c < coverCount; c++) {
+                                if (incrSidecarSiBufs[c] == 0) continue;
+                                Unsafe.putLong(
+                                        incrSidecarSiBufs[c] + (long) s * Long.BYTES,
+                                        sidecarMems.getQuick(c).getAppendOffset() - siSize);
+                            }
+                        }
+                        continue;
+                    }
+
+                    // Trial encode delta-FoR per key
+                    long strideTrialSize = 0;
+                    for (int j = 0; j < ks; j++) {
+                        strideTrialSize += PostingIndexUtils.computeMaxEncodedSize(keyCounts[j]);
+                    }
+                    if (strideTrialSize > bpTrialBufSize) {
+                        if (bpTrialBuf != 0) {
+                            Unsafe.free(bpTrialBuf, bpTrialBufSize, MemoryTag.NATIVE_INDEX_READER);
+                        }
+                        bpTrialBufSize = strideTrialSize;
+                        bpTrialBuf = Unsafe.malloc(bpTrialBufSize, MemoryTag.NATIVE_INDEX_READER);
+                    }
+                    int bpDataTotal = 0;
+                    for (int j = 0; j < ks; j++) {
+                        int count = keyCounts[j];
+                        if (count > 0) {
+                            long keyAddr = mergedValuesAddr + keyOffsets[j] * Long.BYTES;
+                            encodeCtx.ensureCapacity(count);
+                            bpKeySizes[j] = PostingIndexUtils.encodeKeyNative(
+                                    keyAddr, count, bpTrialBuf + bpDataTotal, encodeCtx, rowIdEncoding);
+                        } else {
+                            bpKeySizes[j] = 0;
+                        }
+                        bpDataTotal += bpKeySizes[j];
+                    }
+
+                    int deltaHeaderSize = PostingIndexUtils.strideDeltaHeaderSize(ks);
+                    int deltaSize = deltaHeaderSize + bpDataTotal;
+
+                    // Compute min/max for flat-mode sizing
+                    long totalStrideValuesL = cumOffset;
+                    long strideMinValue = Long.MAX_VALUE;
+                    long strideMaxValue = Long.MIN_VALUE;
+                    for (int j = 0; j < ks; j++) {
+                        int count = keyCounts[j];
+                        long keyAddr = mergedValuesAddr + keyOffsets[j] * Long.BYTES;
+                        for (int i = 0; i < count; i++) {
+                            long val = Unsafe.getLong(keyAddr + (long) i * Long.BYTES);
+                            if (val < strideMinValue) strideMinValue = val;
+                            if (val > strideMaxValue) strideMaxValue = val;
+                        }
+                    }
+                    if (totalStrideValuesL == 0) {
+                        strideMinValue = 0;
+                        strideMaxValue = 0;
+                    }
+
+                    boolean useFlat;
+                    int localBitWidth = 0;
+                    int flatDataSize = 0;
+                    int flatSize;
+                    int flatHeaderSize = PostingIndexUtils.strideFlatHeaderSize(ks);
+                    if (totalStrideValuesL > Integer.MAX_VALUE) {
+                        useFlat = false;
+                    } else {
+                        int totalStrideValues = (int) totalStrideValuesL;
+                        long strideRange = strideMaxValue - strideMinValue;
+                        int naturalBitWidth = strideRange <= 0 ? 1 : BitpackUtils.bitsNeeded(strideRange);
+                        int alignedBitWidth = maybeAlignBitWidth(naturalBitWidth, alignedBitWidthThreshold);
+                        int naturalFlatDataSize = BitpackUtils.packedDataSize(totalStrideValues, naturalBitWidth);
+                        int naturalFlatSize = flatHeaderSize + naturalFlatDataSize;
+                        if (alignedBitWidth != naturalBitWidth) {
+                            int alignedFlatDataSize = BitpackUtils.packedDataSize(totalStrideValues, alignedBitWidth);
+                            int alignedFlatSize = flatHeaderSize + alignedFlatDataSize;
+                            if (alignedFlatSize < deltaSize) {
+                                localBitWidth = alignedBitWidth;
+                                flatDataSize = alignedFlatDataSize;
+                                flatSize = alignedFlatSize;
+                            } else {
+                                localBitWidth = naturalBitWidth;
+                                flatDataSize = naturalFlatDataSize;
+                                flatSize = naturalFlatSize;
+                            }
+                        } else {
+                            localBitWidth = naturalBitWidth;
+                            flatDataSize = naturalFlatDataSize;
+                            flatSize = naturalFlatSize;
+                        }
+                        useFlat = flatSize < deltaSize;
+                    }
+
+                    if (useFlat) {
+                        writePackedStride(ks, keyCounts, keyOffsets, localBitWidth, strideMinValue,
+                                flatHeaderSize, flatDataSize, localHeaderBuf, mergedValuesAddr);
+                    } else {
+                        writeDeltaStride(ks, keyCounts, deltaHeaderSize, bpTrialBuf, bpKeySizes, localHeaderBuf);
+                    }
+
+                    // Per-stride sidecar emit -- mirrors sealIncremental dirty-stride branch.
+                    if (incrSidecarSiBufs != null) {
+                        for (int c = 0; c < coverCount; c++) {
+                            if (incrSidecarSiBufs[c] == 0) continue;
+                            Unsafe.putLong(
+                                    incrSidecarSiBufs[c] + (long) s * Long.BYTES,
+                                    sidecarMems.getQuick(c).getAppendOffset() - siSize);
+                        }
+                        // sidecarBuf is reused across strides; sized by max
+                        // per-stride values seen.
+                        if (cumOffset > 0) {
+                            // writeSidecarStrideData reads cover values from the
+                            // configured cover .d files (via coveredColReadAddrs)
+                            // at each kept (key, rowId). Bytes are sourced fresh
+                            // from cover .d -- not verbatim-copied from old
+                            // sidecars in this implementation (the design doc
+                            // calls out delta-mode verbatim copy as a future
+                            // optimisation; this revision rebuilds from cover
+                            // .d for every kept entry to keep the implementation
+                            // tractable).
+                            writeSidecarStrideData(ks, keyCounts, keyOffsets,
+                                    mergedValuesAddr, /* sidecarBuf */ 0L);
+                        }
+                    }
+                }
+
+                // Write stride index at sealOffset.
+                long totalStrideBlocksSize = sealValueMem.getAppendOffset() - sealOffset - siSize;
+                Unsafe.putLong(strideIndexBuf + (long) sc * Long.BYTES, totalStrideBlocksSize);
+                long strideIndexAddr = sealValueMem.addressOf(sealOffset);
+                Unsafe.copyMemory(strideIndexBuf, strideIndexAddr, siSize);
+
+                valueMemSize = sealValueMem.getAppendOffset();
+
+                // Finalise sidecar stride indices.
+                if (incrSidecarSiBufs != null) {
+                    for (int c = 0; c < coverCount; c++) {
+                        if (incrSidecarSiBufs[c] == 0) continue;
+                        MemoryMARW mem = sidecarMems.getQuick(c);
+                        Unsafe.putLong(
+                                incrSidecarSiBufs[c] + (long) sc * Long.BYTES,
+                                mem.getAppendOffset() - siSize);
+                        long sidecarIdxAddr = mem.addressOf(PostingIndexUtils.PC_HEADER_SIZE);
+                        Unsafe.copyMemory(incrSidecarSiBufs[c], sidecarIdxAddr, siSize);
+                    }
+                }
+
+                // Sync sealed file + sidecars before publishing the chain entry.
+                sealValueMem.sync(false);
+                for (int c = 0, n = sidecarMems.size(); c < n; c++) {
+                    MemoryMARW mem = sidecarMems.getQuick(c);
+                    if (mem != null && mem.isOpen()) {
+                        mem.sync(false);
+                    }
+                }
+                if (sidecarInfoMem != null && sidecarInfoMem.isOpen()) {
+                    sidecarInfoMem.sync(false);
+                }
+
+                // Swap sealValueMem into valueMem; this updates this.sealTxn = newSealTxn.
+                switchToSealedValueFile(newSealTxn);
+                Unsafe.storeFence();
+
+                // Publish the new chain entry. sealTxn just rotated, so
+                // publishToChain takes the appendNewEntry branch -- never
+                // extendHead -- which is what makes the diff safe under
+                // snapshot isolation: the OLD chain entry stays untouched.
+                this.maxValue = Math.max(partitionSize - 1, -1);
+                this.genCount = 1;
+                publishToChain(
+                        /* newGenCount     */ 1,
+                        /* overrideGenIndex */ 0,
+                        /* overrideFileOffset */ sealOffset,
+                        /* overrideSize     */ valueMemSize - sealOffset,
+                        /* overrideKeyCount */ keyCount,
+                        /* overrideMinKey   */ 0,
+                        /* overrideMaxKey   */ keyCount - 1
+                );
+
+                // Queue the OLD .pv for purge.
+                if (oldSealTxn >= 0) {
+                    recordPostingSealPurge(oldSealTxn);
+                }
+            } finally {
+                Unsafe.free(mergedValuesAddr, mergedValuesSize, MemoryTag.NATIVE_INDEX_READER);
+                Unsafe.free(strideIndexBuf, siSize, MemoryTag.NATIVE_INDEX_READER);
+                Unsafe.free(localHeaderBuf, maxLocalHeaderSize, MemoryTag.NATIVE_INDEX_READER);
+                if (bpTrialBuf != 0) {
+                    Unsafe.free(bpTrialBuf, bpTrialBufSize, MemoryTag.NATIVE_INDEX_READER);
+                }
+                if (incrSidecarSiBufs != null) {
+                    for (int c = 0; c < coverCount; c++) {
+                        if (incrSidecarSiBufs[c] != 0) {
+                            Unsafe.free(incrSidecarSiBufs[c], siSize, MemoryTag.NATIVE_INDEX_READER);
+                        }
+                    }
+                }
+            }
         } finally {
             Unsafe.free(keptCountsAddr, keptCountsSize, MemoryTag.NATIVE_INDEX_READER);
             if (perKeyDecodeAddr != 0) {
                 Unsafe.free(perKeyDecodeAddr, perKeyDecodeCapacity * Long.BYTES, MemoryTag.NATIVE_INDEX_READER);
             }
             Unsafe.free(dReadCacheAddr, dReadCacheSize, MemoryTag.NATIVE_INDEX_READER);
+        }
+    }
+
+    /**
+     * Sum gen-dir count fields per key across every gen of the chain head
+     * into {@code countsAddr} (must be pre-zeroed, sized {@code keyCount * 4}).
+     * Cheap: no value decoding, just header reads. Mirrors
+     * {@link #reencodeAllGenerations} Phase 1.
+     */
+    private void accumulatePreFilterCounts(long countsAddr) {
+        for (int gen = 0; gen < genCount; gen++) {
+            long dirOffset = PostingIndexChainEntry.resolveGenDirOffset(chain.getHeadEntryOffset(), gen);
+            long genFileOffset = keyMem.getLong(dirOffset + GEN_DIR_OFFSET_FILE_OFFSET);
+            int genKeyCount = keyMem.getInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_KEY_COUNT);
+            long genBase = valueMem.addressOf(genFileOffset);
+
+            if (genKeyCount < 0) {
+                int activeKeyCount = -genKeyCount;
+                long countsBase = genBase + (long) activeKeyCount * Integer.BYTES;
+                for (int i = 0; i < activeKeyCount; i++) {
+                    int key = Unsafe.getInt(genBase + (long) i * Integer.BYTES);
+                    int count = Unsafe.getInt(countsBase + (long) i * Integer.BYTES);
+                    int existing = Unsafe.getInt(countsAddr + (long) key * Integer.BYTES);
+                    Unsafe.putInt(countsAddr + (long) key * Integer.BYTES, existing + count);
+                }
+            } else {
+                int genSc = PostingIndexUtils.strideCount(genKeyCount);
+                int genSiSize = PostingIndexUtils.strideIndexSize(genKeyCount);
+                for (int s = 0; s < genSc; s++) {
+                    long strideOff = Unsafe.getLong(genBase + (long) s * Long.BYTES);
+                    long nextStrideOff = Unsafe.getLong(genBase + (long) (s + 1) * Long.BYTES);
+                    if (nextStrideOff == strideOff) continue;
+                    long strideAddr = genBase + genSiSize + strideOff;
+                    int ks = PostingIndexUtils.keysInStride(genKeyCount, s);
+                    byte mode = Unsafe.getByte(strideAddr);
+                    if (mode == PostingIndexUtils.STRIDE_MODE_FLAT) {
+                        long prefixAddr = strideAddr + PostingIndexUtils.STRIDE_FLAT_PREFIX_COUNTS_OFFSET;
+                        for (int j = 0; j < ks; j++) {
+                            int key = s * PostingIndexUtils.DENSE_STRIDE + j;
+                            int count = Unsafe.getInt(prefixAddr + (long) (j + 1) * Integer.BYTES)
+                                    - Unsafe.getInt(prefixAddr + (long) j * Integer.BYTES);
+                            int existing = Unsafe.getInt(countsAddr + (long) key * Integer.BYTES);
+                            Unsafe.putInt(countsAddr + (long) key * Integer.BYTES, existing + count);
+                        }
+                    } else {
+                        long countsBase = strideAddr + PostingIndexUtils.STRIDE_MODE_PREFIX_SIZE;
+                        for (int j = 0; j < ks; j++) {
+                            int key = s * PostingIndexUtils.DENSE_STRIDE + j;
+                            int count = Unsafe.getInt(countsBase + (long) j * Integer.BYTES);
+                            int existing = Unsafe.getInt(countsAddr + (long) key * Integer.BYTES);
+                            Unsafe.putInt(countsAddr + (long) key * Integer.BYTES, existing + count);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -851,21 +851,16 @@ public class PostingIndexWriter implements IndexWriter {
                     }
                 }
 
-                // Snapshot OLD gen 0 metadata for mergeKeyValues.
+                // Snapshot OLD gen 0 metadata for mergeKeyValues. gen0KeyCount is
+                // kept signed: negative means sparse, in which case mergeKeyValues
+                // walks gen 0 via its sparse-gen loop. The diff is the only caller
+                // that reaches mergeKeyValues with a sparse gen 0 (it is the
+                // post-O3CopyJob shape: a single sparse gen produced by
+                // flushAllPending and not yet sealed).
                 long gen0DirOffset = PostingIndexChainEntry.resolveGenDirOffset(chain.getHeadEntryOffset(), 0);
                 long gen0FileOffset = keyMem.getLong(gen0DirOffset + GEN_DIR_OFFSET_FILE_OFFSET);
                 int gen0KeyCount = keyMem.getInt(gen0DirOffset + PostingIndexUtils.GEN_DIR_OFFSET_KEY_COUNT);
-                int gen0SiSize;
-                if (gen0KeyCount < 0) {
-                    // gen 0 is sparse (rare; usually dense after seal). Treat
-                    // it like the other sparse gens by setting gen0KeyCount=0
-                    // so mergeKeyValues skips its dense branch and instead
-                    // walks all gens via the sparse path.
-                    gen0KeyCount = 0;
-                    gen0SiSize = 0;
-                } else {
-                    gen0SiSize = PostingIndexUtils.strideIndexSize(gen0KeyCount);
-                }
+                int gen0SiSize = gen0KeyCount > 0 ? PostingIndexUtils.strideIndexSize(gen0KeyCount) : 0;
 
                 // Per-stride decode + filter + encode loop.
                 int[] keyCounts = strideKeyCounts;
@@ -3287,8 +3282,13 @@ public class PostingIndexWriter implements IndexWriter {
     private int mergeKeyValues(int key, long gen0Addr, int gen0KeyCount, int gen0SiSize, long destAddr) {
         int totalCount = 0;
 
-        // Decode from gen 0 (dense)
-        if (key < gen0KeyCount) {
+        // Decode from gen 0. When gen 0 is dense, do a direct dense-format read;
+        // when it is sparse (sealIncremental never reaches this branch, but
+        // diffAgainstChainHead does when O3CopyJob's commit leaves a sparse-only
+        // gen 0 on disk), fall through to the sparse-gen loop below by widening
+        // its starting index to 0.
+        final int sparseStartGen = gen0KeyCount < 0 ? 0 : 1;
+        if (gen0KeyCount > 0 && key < gen0KeyCount) {
             int stride = key / PostingIndexUtils.DENSE_STRIDE;
             int localKey = key % PostingIndexUtils.DENSE_STRIDE;
             long strideOff = Unsafe.getLong(gen0Addr + (long) stride * Long.BYTES);
@@ -3338,8 +3338,9 @@ public class PostingIndexWriter implements IndexWriter {
             }
         }
 
-        // Decode from sparse gens 1..N
-        for (int g = 1; g < genCount; g++) {
+        // Decode from sparse gens. Starts at 0 if gen 0 itself is sparse,
+        // otherwise at 1 (gen 0 was handled by the dense branch above).
+        for (int g = sparseStartGen; g < genCount; g++) {
             long dirOffset = PostingIndexChainEntry.resolveGenDirOffset(chain.getHeadEntryOffset(), g);
             long genFileOffset = keyMem.getLong(dirOffset + GEN_DIR_OFFSET_FILE_OFFSET);
             int genKeyCount = keyMem.getInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_KEY_COUNT);

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -540,6 +540,302 @@ public class PostingIndexWriter implements IndexWriter {
         configureCovering(addrs, null, tops, shifts, indices, types, coverCount, timestampColumnIndex);
     }
 
+    /**
+     * Validate every (key, rowId) in the chain head's gens against the column
+     * data file and emit a fresh dense chain entry containing only the kept
+     * entries. Used by O3 commits to evict stale (key, rowId) pairs left by
+     * replace-range, dedup-replace, or split commits where the same rowid takes
+     * a different value across writes -- entries that {@code rollbackConditionally}
+     * cannot detect because their rowIds are inside [columnTop, partitionSize).
+     * <p>
+     * Algorithm:
+     * <ol>
+     *     <li>Phase 1 -- walk every gen of the head entry, decoding each key's
+     *     rowIds and validating against the .d file. Count kept entries per key.</li>
+     *     <li>Rotate {@code sealTxn} and open a fresh .pv at the new txn (mirrors
+     *     {@link #truncate()}). The OLD chain head and OLD .pv stay on disk for
+     *     concurrent readers; the OLD .pv is queued for the seal-purge job after
+     *     the new entry lands.</li>
+     *     <li>Phase 2 -- stride-by-stride decode + filter + encode into the new
+     *     .pv, mirroring {@link #sealIncremental} with all strides treated as
+     *     dirty and the per-key merge filtered through the .d validator.
+     *     Sidecar stride blocks are rebuilt from the cover .d files via
+     *     {@link #writeSidecarStrideData} for kept entries.</li>
+     *     <li>{@link #publishToChain} appends a new chain entry (rotated sealTxn
+     *     forces the {@code appendNewEntry} branch -- never {@code extendHead},
+     *     which would corrupt the OLD entry in place).</li>
+     * </ol>
+     * <p>
+     * Memory peak is bounded by the largest single stride's value count, never
+     * by total partition rows -- the diff streams gen -> validate -> encode
+     * stride-by-stride and never accumulates (key, rowId) pairs in private
+     * spill memory the way a full add()-driven rebuild would.
+     *
+     * @param ff             {@link FilesFacade} for the .d file read
+     * @param dataColumnFd   open RO fd of the column's .d file (caller owns,
+     *                       writer does not close)
+     * @param columnTop      partition row at which this column's data begins
+     * @param partitionSize  current partition row count; rowIds &gt;= partitionSize
+     *                       are evicted as a side effect (mirrors
+     *                       {@code rollbackConditionally(partitionSize)}).
+     */
+    public void diffAgainstChainHead(FilesFacade ff, long dataColumnFd, long columnTop, long partitionSize) {
+        if (!keyMem.isOpen()) {
+            return;
+        }
+        flushAllPending();
+        if (genCount == 0 || keyCount == 0) {
+            setMaxValue(Math.max(partitionSize - 1, -1));
+            return;
+        }
+
+        // Phase 1: walk every gen, validate each (key, rowId), count kept per key.
+        // The kept counts drive Phase 2's stride sizing and detect the empty-result
+        // case (no rowId in any gen survives validation) which short-circuits to
+        // truncate().
+        long keptCountsSize = (long) keyCount * Integer.BYTES;
+        long keptCountsAddr = Unsafe.malloc(keptCountsSize, MemoryTag.NATIVE_INDEX_READER);
+        // Per-key decode scratch -- sized for the largest single key after
+        // we've seen all gens. Reallocated on demand inside the loop.
+        long perKeyDecodeAddr = 0;
+        long perKeyDecodeCapacity = 0;
+        // Sliding read cache over .d so sequential rowIds within a key
+        // amortize ff.read calls. 256 KB = 64 K rowIds for SYMBOL (4-byte).
+        final int dReadCacheSize = 256 * 1024;
+        long dReadCacheAddr = Unsafe.malloc(dReadCacheSize, MemoryTag.NATIVE_INDEX_READER);
+        long dReadCacheStart = -1L;
+        long dReadCacheLen = 0L;
+        long totalKept = 0;
+        try {
+            Unsafe.setMemory(keptCountsAddr, keptCountsSize, (byte) 0);
+
+            for (int gen = 0; gen < genCount; gen++) {
+                long dirOffset = PostingIndexChainEntry.resolveGenDirOffset(chain.getHeadEntryOffset(), gen);
+                long genFileOffset = keyMem.getLong(dirOffset + GEN_DIR_OFFSET_FILE_OFFSET);
+                int genKeyCount = keyMem.getInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_KEY_COUNT);
+                long genBase = valueMem.addressOf(genFileOffset);
+
+                if (genKeyCount < 0) {
+                    // Sparse gen
+                    int activeKeyCount = -genKeyCount;
+                    int headerSize = PostingIndexUtils.genHeaderSizeSparse(activeKeyCount);
+                    long countsBase = genBase + (long) activeKeyCount * Integer.BYTES;
+                    long offsetsBase = countsBase + (long) activeKeyCount * Integer.BYTES;
+                    for (int i = 0; i < activeKeyCount; i++) {
+                        int key = Unsafe.getInt(genBase + (long) i * Integer.BYTES);
+                        int count = Unsafe.getInt(countsBase + (long) i * Integer.BYTES);
+                        if (count == 0) continue;
+                        if (count > perKeyDecodeCapacity) {
+                            int newCap = Math.max(count, (int) Math.min(perKeyDecodeCapacity * 2, Integer.MAX_VALUE));
+                            perKeyDecodeAddr = Unsafe.realloc(perKeyDecodeAddr,
+                                    perKeyDecodeCapacity * Long.BYTES,
+                                    (long) newCap * Long.BYTES, MemoryTag.NATIVE_INDEX_READER);
+                            perKeyDecodeCapacity = newCap;
+                        }
+                        long dataOffset = Unsafe.getLong(offsetsBase + (long) i * Long.BYTES);
+                        PostingIndexUtils.decodeKeyToNative(genBase + headerSize + dataOffset, perKeyDecodeAddr, decodeCtx);
+                        // Validate this key's values; bump keptCounts[key] per kept rowId.
+                        long[] cacheState = {dReadCacheStart, dReadCacheLen};
+                        int kept = filterKeyValuesAgainstD(
+                                key, perKeyDecodeAddr, count,
+                                ff, dataColumnFd, columnTop, partitionSize,
+                                dReadCacheAddr, dReadCacheSize, cacheState
+                        );
+                        dReadCacheStart = cacheState[0];
+                        dReadCacheLen = cacheState[1];
+                        int existing = Unsafe.getInt(keptCountsAddr + (long) key * Integer.BYTES);
+                        Unsafe.putInt(keptCountsAddr + (long) key * Integer.BYTES, existing + kept);
+                        totalKept += kept;
+                    }
+                } else {
+                    // Dense gen
+                    int sc = PostingIndexUtils.strideCount(genKeyCount);
+                    int siSize = PostingIndexUtils.strideIndexSize(genKeyCount);
+                    for (int s = 0; s < sc; s++) {
+                        long strideOff = Unsafe.getLong(genBase + (long) s * Long.BYTES);
+                        long nextStrideOff = Unsafe.getLong(genBase + (long) (s + 1) * Long.BYTES);
+                        if (nextStrideOff == strideOff) continue;
+                        long strideAddr = genBase + siSize + strideOff;
+                        int ks = PostingIndexUtils.keysInStride(genKeyCount, s);
+                        byte mode = Unsafe.getByte(strideAddr);
+
+                        if (mode == PostingIndexUtils.STRIDE_MODE_FLAT) {
+                            int bitWidth = Unsafe.getByte(strideAddr + 1) & 0xFF;
+                            long baseValue = Unsafe.getLong(strideAddr + PostingIndexUtils.STRIDE_FLAT_BASE_OFFSET);
+                            long prefixAddr = strideAddr + PostingIndexUtils.STRIDE_FLAT_PREFIX_COUNTS_OFFSET;
+                            int flatHdrSize = PostingIndexUtils.strideFlatHeaderSize(ks);
+                            long flatDataAddr = strideAddr + flatHdrSize;
+                            for (int j = 0; j < ks; j++) {
+                                int key = s * PostingIndexUtils.DENSE_STRIDE + j;
+                                int startIdx = Unsafe.getInt(prefixAddr + (long) j * Integer.BYTES);
+                                int count = Unsafe.getInt(prefixAddr + (long) (j + 1) * Integer.BYTES) - startIdx;
+                                if (count == 0) continue;
+                                if (count > perKeyDecodeCapacity) {
+                                    int newCap = Math.max(count, (int) Math.min(perKeyDecodeCapacity * 2, Integer.MAX_VALUE));
+                                    perKeyDecodeAddr = Unsafe.realloc(perKeyDecodeAddr,
+                                            perKeyDecodeCapacity * Long.BYTES,
+                                            (long) newCap * Long.BYTES, MemoryTag.NATIVE_INDEX_READER);
+                                    perKeyDecodeCapacity = newCap;
+                                }
+                                BitpackUtils.unpackValuesFrom(flatDataAddr, startIdx, count, bitWidth, baseValue, perKeyDecodeAddr);
+                                long[] cacheState = {dReadCacheStart, dReadCacheLen};
+                                int kept = filterKeyValuesAgainstD(
+                                        key, perKeyDecodeAddr, count,
+                                        ff, dataColumnFd, columnTop, partitionSize,
+                                        dReadCacheAddr, dReadCacheSize, cacheState
+                                );
+                                dReadCacheStart = cacheState[0];
+                                dReadCacheLen = cacheState[1];
+                                int existing = Unsafe.getInt(keptCountsAddr + (long) key * Integer.BYTES);
+                                Unsafe.putInt(keptCountsAddr + (long) key * Integer.BYTES, existing + kept);
+                                totalKept += kept;
+                            }
+                        } else {
+                            long countsAddr = strideAddr + PostingIndexUtils.STRIDE_MODE_PREFIX_SIZE;
+                            long offsetsBase = countsAddr + (long) ks * Integer.BYTES;
+                            int deltaHdrSize = PostingIndexUtils.strideDeltaHeaderSize(ks);
+                            for (int j = 0; j < ks; j++) {
+                                int key = s * PostingIndexUtils.DENSE_STRIDE + j;
+                                int count = Unsafe.getInt(countsAddr + (long) j * Integer.BYTES);
+                                if (count == 0) continue;
+                                if (count > perKeyDecodeCapacity) {
+                                    int newCap = Math.max(count, (int) Math.min(perKeyDecodeCapacity * 2, Integer.MAX_VALUE));
+                                    perKeyDecodeAddr = Unsafe.realloc(perKeyDecodeAddr,
+                                            perKeyDecodeCapacity * Long.BYTES,
+                                            (long) newCap * Long.BYTES, MemoryTag.NATIVE_INDEX_READER);
+                                    perKeyDecodeCapacity = newCap;
+                                }
+                                long dataOff = Unsafe.getLong(offsetsBase + (long) j * Long.BYTES);
+                                PostingIndexUtils.decodeKeyToNative(strideAddr + deltaHdrSize + dataOff, perKeyDecodeAddr, decodeCtx);
+                                long[] cacheState = {dReadCacheStart, dReadCacheLen};
+                                int kept = filterKeyValuesAgainstD(
+                                        key, perKeyDecodeAddr, count,
+                                        ff, dataColumnFd, columnTop, partitionSize,
+                                        dReadCacheAddr, dReadCacheSize, cacheState
+                                );
+                                dReadCacheStart = cacheState[0];
+                                dReadCacheLen = cacheState[1];
+                                int existing = Unsafe.getInt(keptCountsAddr + (long) key * Integer.BYTES);
+                                Unsafe.putInt(keptCountsAddr + (long) key * Integer.BYTES, existing + kept);
+                                totalKept += kept;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // No entries survived validation; the partition's index is now empty
+            // for this column. truncate() rotates sealTxn and queues purge.
+            if (totalKept == 0) {
+                Unsafe.free(keptCountsAddr, keptCountsSize, MemoryTag.NATIVE_INDEX_READER);
+                if (perKeyDecodeAddr != 0) {
+                    Unsafe.free(perKeyDecodeAddr, perKeyDecodeCapacity * Long.BYTES, MemoryTag.NATIVE_INDEX_READER);
+                }
+                Unsafe.free(dReadCacheAddr, dReadCacheSize, MemoryTag.NATIVE_INDEX_READER);
+                truncate();
+                setMaxValue(Math.max(partitionSize - 1, -1));
+                return;
+            }
+
+            // TODO Phase 2: rotate sealTxn, encode kept entries into a fresh .pv
+            // stride-by-stride mirroring sealIncremental's all-strides-dirty pattern,
+            // emit per-stride sidecars via writeSidecarStrideData, then publishToChain
+            // through the appendNewEntry branch. Until Phase 2 is implemented, fall
+            // back to the existing reencode-from-gens path which is correct (it
+            // re-reads from valueMem, which still holds pre-validation gens) but
+            // does NOT evict stale entries -- the diff is incomplete.
+            //
+            // The Phase 2 implementation must:
+            //   1. closeSidecarMems(); openSealValueFile(newSealTxn);
+            //      openSidecarFiles(...) at newSealTxn if coverCount > 0.
+            //   2. Reserve siSize bytes at the head of sealTarget for the stride
+            //      index. Allocate strideIndexBuf, bpTrialBuf, localHeaderBuf,
+            //      mergedValuesAddr (sized by max-stride-after-filter).
+            //   3. For each stride: decode each key from gen 0 + sparse gens via
+            //      mergeKeyValues, then filter via filterKeyValuesAgainstD into
+            //      the same buffer. Trial-encode delta and flat, pick smaller,
+            //      emit. writeSidecarStrideData against the kept rowIds.
+            //   4. switchToSealedValueFile(newSealTxn). publishToChain takes the
+            //      appendNewEntry branch automatically (sealTxn rotated).
+            //   5. recordPostingSealPurge(oldSealTxn).
+            //
+            // Until then, throw to surface that the diff is not yet wired to its
+            // Phase 2 emit.
+            throw new UnsupportedOperationException(
+                    "diffAgainstChainHead Phase 2 (encode + sidecar + publish) not yet implemented; "
+                            + "Phase 1 validation produced " + totalKept + " kept entries."
+            );
+        } finally {
+            Unsafe.free(keptCountsAddr, keptCountsSize, MemoryTag.NATIVE_INDEX_READER);
+            if (perKeyDecodeAddr != 0) {
+                Unsafe.free(perKeyDecodeAddr, perKeyDecodeCapacity * Long.BYTES, MemoryTag.NATIVE_INDEX_READER);
+            }
+            Unsafe.free(dReadCacheAddr, dReadCacheSize, MemoryTag.NATIVE_INDEX_READER);
+        }
+    }
+
+    /**
+     * Validate {@code count} rowIds at {@code valuesAddr} for an expected key,
+     * compress kept rowIds to the front of the buffer, and return the kept
+     * count. A rowId is kept iff it falls in {@code [columnTop, partitionSize)}
+     * AND {@code TableUtils.toIndexKey(.d[rowId]) == expectedKey}.
+     * <p>
+     * Maintains a small sliding cache over the .d file in {@code dCacheAddr} so
+     * sequential rowIds within a key amortize {@code ff.read()} calls.
+     * {@code cacheState[0]} is the cache's start offset within .d (-1 = empty);
+     * {@code cacheState[1]} is the byte length of the cache content.
+     */
+    private int filterKeyValuesAgainstD(
+            int expectedKey,
+            long valuesAddr,
+            int count,
+            FilesFacade ff,
+            long dataColumnFd,
+            long columnTop,
+            long partitionSize,
+            long dCacheAddr,
+            int dCacheSize,
+            long[] cacheState
+    ) {
+        long cacheStart = cacheState[0];
+        long cacheLen = cacheState[1];
+        int writeIdx = 0;
+        for (int readIdx = 0; readIdx < count; readIdx++) {
+            long rowId = Unsafe.getLong(valuesAddr + (long) readIdx * Long.BYTES);
+            if (rowId < columnTop || rowId >= partitionSize) {
+                continue;
+            }
+            long dFileOffset = (rowId - columnTop) * 4L;
+            // Refill cache if dFileOffset .. dFileOffset+4 isn't covered.
+            if (cacheStart < 0 || dFileOffset < cacheStart || dFileOffset + 4 > cacheStart + cacheLen) {
+                long bytesRemaining = (partitionSize - columnTop) * 4L - dFileOffset;
+                long bytesToRead = Math.min(dCacheSize, bytesRemaining);
+                long read = ff.read(dataColumnFd, dCacheAddr, bytesToRead, dFileOffset);
+                if (read < 4) {
+                    throw CairoException.critical(ff.errno())
+                            .put("could not read column data file during posting index diff [fd=").put(dataColumnFd)
+                            .put(", offset=").put(dFileOffset)
+                            .put(", expected>=4, actual=").put(read).put(']');
+                }
+                cacheStart = dFileOffset;
+                cacheLen = read;
+            }
+            int actualSym = Unsafe.getInt(dCacheAddr + (dFileOffset - cacheStart));
+            int actualKey = TableUtils.toIndexKey(actualSym);
+            if (actualKey != expectedKey) {
+                continue;
+            }
+            // Kept; compress to write position.
+            if (writeIdx != readIdx) {
+                Unsafe.putLong(valuesAddr + (long) writeIdx * Long.BYTES, rowId);
+            }
+            writeIdx++;
+        }
+        cacheState[0] = cacheStart;
+        cacheState[1] = cacheLen;
+        return writeIdx;
+    }
+
     @TestOnly
     public int getAdaptiveDeltaAtOrAbove() {
         return encodeCtx.adaptiveDeltaAtOrAbove;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -734,12 +734,10 @@ public class PostingIndexWriter implements IndexWriter {
 
             // No entries survived validation; the partition's index is now empty
             // for this column. truncate() rotates sealTxn and queues purge.
+            // keptCountsAddr / perKeyDecodeAddr / dReadCacheAddr are freed by
+            // the outer finally below; the previous version freed them here as
+            // well, which caused a libmalloc double-free abort on this path.
             if (totalKept == 0) {
-                Unsafe.free(keptCountsAddr, keptCountsSize, MemoryTag.NATIVE_INDEX_READER);
-                if (perKeyDecodeAddr != 0) {
-                    Unsafe.free(perKeyDecodeAddr, perKeyDecodeCapacity * Long.BYTES, MemoryTag.NATIVE_INDEX_READER);
-                }
-                Unsafe.free(dReadCacheAddr, dReadCacheSize, MemoryTag.NATIVE_INDEX_READER);
                 truncate();
                 setMaxValue(Math.max(partitionSize - 1, -1));
                 return;

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexDiffTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexDiffTest.java
@@ -1,0 +1,181 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo;
+
+import io.questdb.cairo.idx.PostingIndexChainEntry;
+import io.questdb.cairo.idx.PostingIndexChainWriter;
+import io.questdb.cairo.idx.PostingIndexUtils;
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.cairo.sql.RowCursor;
+import io.questdb.cairo.vm.MemoryCMARWImpl;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Unsafe;
+import io.questdb.std.str.LPSZ;
+import io.questdb.std.str.Path;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;
+
+/**
+ * Tests for {@link PostingIndexWriter#diffAgainstChainHead}. Verifies the
+ * primitive correctly evicts stale (key, rowId) entries by validating each
+ * existing chain entry against the column .d file.
+ */
+public class PostingIndexDiffTest extends AbstractCairoTest {
+
+    /**
+     * Happy path: chain has both an OLD (key, rowId) pair from a pre-O3
+     * write and a NEW (key, rowId) pair from an O3 commit that rewrote the
+     * same rowId with a different symbol. The .d file reflects the post-O3
+     * state. diffAgainstChainHead must keep the NEW pair and evict the OLD.
+     */
+    @Test
+    public void testDiffEvictsStaleEntryKeepsNewEntry() throws Exception {
+        assertMemoryLeak(() -> {
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                String name = "diff_evicts_stale";
+                int plen = path.size();
+                FilesFacade ff = configuration.getFilesFacade();
+
+                // Build a synthetic column .d file at <db>/sym.d. The diff's
+                // validator reads 4-byte ints from this file at rowId * 4. We
+                // place 4 rows: symbols [1, 1, 1, 5]. toIndexKey adds 1 for
+                // non-negative, so the expected keys per rowId are [2, 2, 2, 6].
+                long dataFd;
+                try (Path dpath = new Path().of(configuration.getDbRoot()).concat("sym.d")) {
+                    LPSZ dFilePath = dpath.$();
+                    long buf = Unsafe.malloc(16, MemoryTag.NATIVE_DEFAULT);
+                    try {
+                        Unsafe.putInt(buf, 1);
+                        Unsafe.putInt(buf + 4, 1);
+                        Unsafe.putInt(buf + 8, 1);
+                        Unsafe.putInt(buf + 12, 5);
+                        long writeFd = ff.openRW(dFilePath, configuration.getWriterFileOpenOpts());
+                        Assert.assertTrue("could not create test .d file", writeFd > 0);
+                        long written = ff.write(writeFd, buf, 16, 0);
+                        Assert.assertEquals(16, written);
+                        ff.close(writeFd);
+                    } finally {
+                        Unsafe.free(buf, 16, MemoryTag.NATIVE_DEFAULT);
+                    }
+                    dataFd = ff.openRO(dFilePath);
+                    Assert.assertTrue("could not open test .d file", dataFd > 0);
+                }
+
+                try {
+                    // Build a chain with both stale and fresh entries.
+                    // Pre-O3: every rowId 0..3 was symbol 1, so chain
+                    // had key=2 -> {0,1,2,3}.
+                    // Post-O3: rowId 3 rewritten to symbol 5; O3CopyJob
+                    // added (key=6, rowId=3) but did NOT evict (key=2, rowId=3).
+                    // The chain at this moment has BOTH entries for rowId=3.
+                    try (PostingIndexWriter writer = new PostingIndexWriter(
+                            configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                        writer.setNextTxnAtSeal(10L);
+                        writer.add(2, 0);
+                        writer.add(2, 1);
+                        writer.add(2, 2);
+                        writer.add(2, 3);
+                        writer.add(6, 3);
+                        writer.setMaxValue(3);
+                        writer.commit();
+                        writer.setNextTxnAtSeal(10L);
+                        writer.seal();
+                    }
+
+                    // Reopen and run the diff. partitionSize=4, columnTop=0.
+                    try (PostingIndexWriter writer = new PostingIndexWriter(configuration)) {
+                        writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, /* init */ false);
+                        writer.setNextTxnAtSeal(20L);
+                        writer.diffAgainstChainHead(ff, dataFd, /* columnTop */ 0, /* partitionSize */ 4);
+
+                        // Cursor for key=2 must yield exactly {0, 1, 2} (rowId=3 evicted).
+                        RowCursor key2 = writer.getCursor(2);
+                        long[] key2Rows = drain(key2);
+                        Assert.assertArrayEquals(
+                                "key=2 must keep rowIds 0,1,2 and have rowId=3 evicted as stale",
+                                new long[]{0, 1, 2}, key2Rows
+                        );
+
+                        // Cursor for key=6 must yield exactly {3} (the post-O3 entry).
+                        RowCursor key6 = writer.getCursor(6);
+                        long[] key6Rows = drain(key6);
+                        Assert.assertArrayEquals(
+                                "key=6 must retain rowId=3 (matches .d, post-O3 state)",
+                                new long[]{3}, key6Rows
+                        );
+                    }
+
+                    // Verify on disk: chain has two entries (OLD prev + NEW head).
+                    LPSZ keyFile = PostingIndexUtils.keyFileName(
+                            path.trimTo(plen), name, COLUMN_NAME_TXN_NONE);
+                    long fileSize = ff.length(keyFile);
+                    try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
+                            ff, keyFile, ff.getPageSize(), fileSize,
+                            MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
+                        PostingIndexChainWriter chain = new PostingIndexChainWriter();
+                        chain.openExisting(mem);
+                        Assert.assertTrue("chain must have a head", chain.hasHead());
+                        Assert.assertTrue(
+                                "diff must append a NEW chain entry (sealTxn rotated). "
+                                        + "Got entryCount=" + chain.getEntryCount(),
+                                chain.getEntryCount() >= 2
+                        );
+                        PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
+                        chain.loadHeadEntry(mem, head);
+                        Assert.assertEquals(
+                                "head entry must be a single dense gen", 1, head.genCount
+                        );
+                        Assert.assertEquals(
+                                "head txnAtSeal must reflect the diff's setNextTxnAtSeal",
+                                20L, head.txnAtSeal
+                        );
+                    }
+                } finally {
+                    ff.close(dataFd);
+                }
+            }
+        });
+    }
+
+    private static long[] drain(RowCursor cursor) {
+        long[] out = new long[16];
+        int n = 0;
+        while (cursor.hasNext()) {
+            if (n == out.length) {
+                long[] grown = new long[out.length * 2];
+                System.arraycopy(out, 0, grown, 0, n);
+                out = grown;
+            }
+            out[n++] = cursor.next();
+        }
+        long[] result = new long[n];
+        System.arraycopy(out, 0, result, 0, n);
+        return result;
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexDiffTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexDiffTest.java
@@ -49,6 +49,72 @@ import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;
 public class PostingIndexDiffTest extends AbstractCairoTest {
 
     /**
+     * Every existing chain entry fails validation (the .d file has been
+     * fully rewritten, so {@code totalKept == 0}). The diff must take the
+     * empty-result short-circuit, calling {@code truncate()} without
+     * double-freeing the Phase 1 scratch buffers it allocated.
+     */
+    @Test
+    public void testDiffAllEvictedShortCircuit() throws Exception {
+        assertMemoryLeak(() -> {
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                String name = "diff_all_evicted";
+                int plen = path.size();
+                FilesFacade ff = configuration.getFilesFacade();
+
+                long dataFd;
+                try (Path dpath = new Path().of(configuration.getDbRoot()).concat("sym_all_evicted.d")) {
+                    LPSZ dFilePath = dpath.$();
+                    long buf = Unsafe.malloc(16, MemoryTag.NATIVE_DEFAULT);
+                    try {
+                        Unsafe.putInt(buf, 9);
+                        Unsafe.putInt(buf + 4, 9);
+                        Unsafe.putInt(buf + 8, 9);
+                        Unsafe.putInt(buf + 12, 9);
+                        long writeFd = ff.openRW(dFilePath, configuration.getWriterFileOpenOpts());
+                        Assert.assertTrue("could not create test .d file", writeFd > 0);
+                        long written = ff.write(writeFd, buf, 16, 0);
+                        Assert.assertEquals(16, written);
+                        ff.close(writeFd);
+                    } finally {
+                        Unsafe.free(buf, 16, MemoryTag.NATIVE_DEFAULT);
+                    }
+                    dataFd = ff.openRO(dFilePath);
+                    Assert.assertTrue("could not open test .d file", dataFd > 0);
+                }
+
+                try {
+                    try (PostingIndexWriter writer = new PostingIndexWriter(
+                            configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                        writer.setNextTxnAtSeal(10L);
+                        writer.add(2, 0);
+                        writer.add(2, 1);
+                        writer.add(2, 2);
+                        writer.add(2, 3);
+                        writer.setMaxValue(3);
+                        writer.commit();
+                        writer.setNextTxnAtSeal(10L);
+                        writer.seal();
+                    }
+
+                    try (PostingIndexWriter writer = new PostingIndexWriter(configuration)) {
+                        writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, /* init */ false);
+                        writer.setNextTxnAtSeal(20L);
+                        writer.diffAgainstChainHead(ff, dataFd, /* columnTop */ 0, /* partitionSize */ 4);
+                        RowCursor key2 = writer.getCursor(2);
+                        Assert.assertFalse(
+                                "key=2 must yield no rows: every entry was evicted as stale",
+                                key2.hasNext()
+                        );
+                    }
+                } finally {
+                    ff.close(dataFd);
+                }
+            }
+        });
+    }
+
+    /**
      * Happy path: chain has both an OLD (key, rowId) pair from a pre-O3
      * write and a NEW (key, rowId) pair from an O3 commit that rewrote the
      * same rowId with a different symbol. The .d file reflects the post-O3

--- a/docs/POSTING_INDEX_DIFF_DESIGN.md
+++ b/docs/POSTING_INDEX_DIFF_DESIGN.md
@@ -1,0 +1,203 @@
+# Posting Index Diff-Against-Chain Primitive — Design
+
+## Status
+
+Design captured, implementation not started. This doc records research and design decisions so a future implementation session can pick up cleanly.
+
+## Goal
+
+Replace the full-rebuild path that PR #7077 introduced in `TableWriter.sealPostingIndexForPartition` with a primitive that walks the existing chain head's gens, validates each `(key, rowId)` against the column `.d` file, and emits a fresh dense chain entry containing only the kept entries. This:
+
+1. Fixes the same phantom-match bug (stale entries from O3 replace-range / dedup-replace / split where rowIds are reused with different values).
+2. Closes the OOM hole that PR #7077's `discardForRebuild` path opened for partitions with billions of rows (it accumulated every `(key, rowId)` in private spill memory).
+3. Avoids the chain-protocol violation (`extendHead` with `newGenCount < oldGenCount`) that PR #7077's first cut had — the diff produces a single dense gen and appends a new chain entry at a rotated `sealTxn`, which is the established `appendNewEntry` path.
+
+## Why this is bigger than first sized
+
+Three findings from the research pass:
+
+1. **Sidecar verbatim-copy is partial.** Var-width covers and delta-mode per-key sub-blocks copy verbatim. Flat-mode stride sidecars cannot — bitwidth and base-value depend on the kept rowIds, so the stride is recomputed. A correct implementation needs both paths.
+2. **The encode pipeline is long.** `reencodeAllGenerations` -> `reencodeWithStrideDecoding` -> per-stride trial encode (delta vs flat) -> `writeDeltaStride` / `writePackedStride`, plus `writeSidecarStrideData` for sidecars and `sealIncremental`'s dirty-stride logic for the incremental case. The diff has to either inject into this pipeline or clone a substantial part of it.
+3. **`reencodeWithStrideDecoding` doesn't write sidecars.** Sidecars are written per-stride only in `sealIncremental`'s path (around `PostingIndexWriter.java:3905-3979`); `sealFull` -> `reencodeWithStrideDecoding` writes only the `.pv`, and sidecars come from elsewhere in the seal flow. Either the diff is layered onto `sealIncremental`'s dirty-stride pattern (force every stride to be "dirty") or it carries its own sidecar emit.
+
+Realistic scope for a careful, well-tested implementation: ~1400 LoC across writer, callsites, and tests. ~600 LoC if we skip flat-mode sidecar handling and rely on `sealFull` to rebuild sidecars from cover `.d` files (loses the per-key copy-verbatim perf win for delta-mode sidecars but is much simpler).
+
+## Design — full version
+
+### New method on `PostingIndexWriter`
+
+```java
+public void diffAgainstChainHead(
+        FilesFacade ff,
+        long dataColumnFd,
+        long columnTop,
+        long partitionSize
+);
+```
+
+Side effects, in publish order:
+1. `flushAllPending()` first to settle any in-memory state.
+2. If chain head has 0 gens or 0 keys: `setMaxValue(partitionSize - 1)` and return.
+3. Allocate `keptCountsAddr` (`keyCount * 4` bytes) and a `~256 KB` `.d` read cache.
+4. **Phase 1**: walk every gen of the head; for each `(key, rowId)`, validate `rowId in [columnTop, partitionSize)` AND `toIndexKey(.d[rowId]) == key`. Increment `keptCounts[key]` per validated entry. Compute `totalKept` and `maxStrideKept`.
+5. If `totalKept == 0`: call `truncate()` (rotates `sealTxn`, queues purge) and return.
+6. Allocate `newSealTxn = max(1, chain.peekNextSealTxn())`. Snapshot `oldSealTxn`. `closeSidecarMems()`. Open `valueMem` at the new `sealTxn` (mirrors `truncate()`).
+7. If covering: reopen sidecar files at `newSealTxn`.
+8. **Phase 2**: stride-by-stride decode + validate-filter + encode, mirroring `reencodeWithStrideDecoding` but with the validator filtering values per-key inside `strideValsAddr` between decode and encode. Sidecars: per-stride `writeSidecarStrideData` against the kept rowIds, reading cover bytes from the snapshotted old sidecar buffers (verbatim for delta-mode and var-width, recomputed for flat-mode).
+9. `switchToSealedValueFile(newSealTxn)`. `genCount = 1`. `maxValue = partitionSize - 1`. `publishToChain(...)` (takes `appendNewEntry` because `sealTxn` rotated).
+10. `recordPostingSealPurge(oldSealTxn)`.
+
+### Phase 1 algorithm (pseudocode)
+
+Mirror `reencodeAllGenerations` Phase 1 but validate during the decode:
+
+```
+allocate keptCountsAddr = malloc(keyCount * 4)
+allocate readBuf, readBufCacheStart=-1, readBufCacheLen=0
+totalKept = 0
+
+for gen in 0 .. genCount-1:
+    walk gen's keys (sparse: keyIds; dense: stride+key)
+    for each (key, count, encodedAddr):
+        decodeKeyToNative(encodedAddr, decodeBuf)  # existing primitive
+        kept = 0
+        for v in decodeBuf[0..count]:
+            if v < columnTop or v >= partitionSize: continue
+            sym = readDColumnAt(ff, dataColumnFd, v, columnTop, readBuf, ...)
+            if toIndexKey(sym) != key: continue
+            kept++
+        keptCountsAddr[key] += kept
+        totalKept += kept
+```
+
+`readDColumnAt` keeps a sliding window over `.d` (256 KB) so sequential rowIds within a key amortize file reads.
+
+### Phase 2 algorithm
+
+Clone of `reencodeWithStrideDecoding` (`PostingIndexWriter.java:3370`):
+
+- Use `keptCountsAddr` for stride sizing.
+- After per-stride decode into `strideValsAddr`, run the same validator over each key's slice and compress-in-place.
+- Update `strideKeyCounts[j]` to the filtered count.
+- Trial-encode delta and flat as today.
+- Pick the smaller and emit via `writeDeltaStride` or `writePackedStride`.
+- Sidecar emit per stride: same pattern as `sealIncremental`'s dirty-stride branch (`PostingIndexWriter.java:3943-3979`), but reading source cover bytes from snapshotted old sidecar buffers rather than `coveredColumnAddrs`.
+
+### Sidecar source snapshot
+
+Mirror the snapshot pattern at `PostingIndexWriter.java:1183-1215`: for each cover `c`, mmap the old `.pc{c}.{oldSealTxn}` RO, malloc a buffer, memcpy, munmap. Free in `finally`. This preserves cover bytes across the `closeSidecarMems()` call that precedes Phase 2.
+
+For each kept `(key, indexWithinKey)` in dense-emit order, locate the source bytes in the old sidecar:
+- Delta-mode source: `oldStrideStart + perKeyOffsets[j] + indexWithinKey * shift` (fixed-width) or via var-offset table (var-width).
+- Flat-mode source: `oldStrideStart + flatHeaderSize + (prefixCount[j] + indexWithinKey) * shift`.
+
+Sparse-gen sidecar source: append-order block at `dirOffset[gen] * 8` byte offset in the per-cover header; track per-`(gen, key)` cursors during Phase 1 so Phase 2 has O(1) lookup.
+
+For flat-mode output, the per-stride bitwidth is recomputed from kept values; the cover bytes themselves are still copied from the old sidecar (not re-read from cover `.d`).
+
+### Chain rotation
+
+Mirror `truncate()` (`PostingIndexWriter.java:1334-1378`):
+```java
+final long oldSealTxn = sealTxn;
+final long newSealTxn = Math.max(1, chain.peekNextSealTxn());
+closeSidecarMems();
+valueMem.close(false, (byte) 0);
+LPSZ fileName = PostingIndexUtils.valueFileName(p, indexName, postingColumnNameTxn, newSealTxn);
+valueMem.of(ff, fileName, ...);
+sealTxn = newSealTxn;
+valueMemSize = 0;
+```
+
+After Phase 2 completes:
+```java
+this.maxValue = partitionSize - 1;
+this.genCount = 1;
+publishToChain(1, 0, 0, valueMemSize, keyCount, 0, keyCount - 1);
+if (sealTxn != oldSealTxn) recordPostingSealPurge(oldSealTxn);
+```
+
+`publishToChain`'s `newEntry` predicate (`sealTxn != chain.getHeadSealTxn()`) is true automatically because `sealTxn` rotated. No special-case flag needed.
+
+### Call site changes in `TableWriter.sealPostingIndexForPartition`
+
+Both branches replace `rollbackConditionally(partitionSize)` with the new primitive. Covering branch reorders so `configureCovering` runs BEFORE the diff (the diff needs cover schema to be configured for sidecar emit):
+
+```
+mapCoveringColumnsForSeal
+configureFollowerAndWriter
+mergeTentativeIntoActiveIfAny
+configureCovering(...)              <-- BEFORE the diff
+setCoveredColumnNameTxns
+setNextTxnAtSeal(getTxn())
+indexer.diffAgainstChainHead(ff, primaryColumnFd, columnTop, partitionSize)
+publishPendingPurges
+```
+
+`rebuildSidecars()` and `seal()` go away from these callsites — the diff produces a sealed dense gen directly.
+
+`rollbackConditionally` itself stays — still used by `index()`, `closeNoTruncate`, O3 squash.
+
+## Design — simplified version (~600 LoC)
+
+If full version is too much to land:
+
+- Skip flat-mode sidecar handling (force delta-mode by always picking `useFlat = false` after the diff).
+- Skip the `.d`-read cache (accept slower validation on cold partitions).
+- Skip per-key delta-mode verbatim copy (rebuild sidecars from cover `.d` files like `sealFull` does today).
+
+Net behavior: bounded memory (no spill accumulation), correct, modest perf vs PR #7077's full rebuild — wins are mostly OOM mitigation, not throughput.
+
+## Tests
+
+Writer-fixture in `PostingIndexCriticalIssuesTest`:
+- `testDiffSparseAllMatch_NoOpResult` — every entry validates, output equals input.
+- `testDiffSparseEvictsMismatch` — flip one `.d` value, that one entry evicted.
+- `testDiffDenseGenMismatches` — pre-`seal()`, then mutate; dense walk works.
+- `testDiffCrossFormat_DenseGen0_PlusSparse` — both formats handled.
+- `testDiffCoverSidecarCorrectness` — fixed-width and var-width covers; kept entries' cover values match.
+- `testDiffEvictsRowIdsBeyondPartitionSize` — split-shrink handling.
+- `testDiffEvictsRowIdsBelowColumnTop_Defensive`.
+- `testDiffOomGuard_ManyKeysManyValues` — peak `NATIVE_INDEX_READER` allocation stays bounded for 1M rowIds.
+- `testDiffPureAppend_NoEviction` — every entry kept, output is byte-compacted input.
+- `testDiffRotatesSealTxn_QueuesOldPvForPurge` — `pendingPurges` grew by 1, references `oldSealTxn`.
+
+SQL fuzz in new `PostingIndexDiffFuzzTest`:
+- 100 K-row partitioned table with POSTING-indexed SYMBOL + cover column.
+- Random replace-range + dedup-replace mix.
+- After each commit, assert per-symbol counts match a control table built without the index.
+- Phantom matches manifest as count mismatches; OOM manifests as `OutOfMemoryError`.
+
+## Build / validation
+
+```
+mvn clean package -DskipTests -P local-client
+mvn -Dtest=PostingIndexCriticalIssuesTest test
+mvn -Dtest=PostingIndexDiffFuzzTest test
+mvn -Dtest=PostingIndexStressTest test       # existing concurrent-read regression
+```
+
+## Implementation order
+
+1. Phase 1 validator + small `.d`-read cache. Allocate/free in `freeNativeBuffers()`.
+2. Phase 2 stride emit — clone `reencodeWithStrideDecoding`, add validator, drop unused mode-specific tail.
+3. Sidecar source snapshot + per-stride sidecar emit (delta-mode verbatim, flat-mode recompute).
+4. Chain rotation + publish.
+5. `ColumnIndexer` interface method + `SymbolColumnIndexer` forwarder.
+6. Wire into `TableWriter.sealPostingIndexForPartition` (both branches).
+7. Tests (a) - (j).
+8. Fuzz test.
+9. Validation sweep.
+
+Each step is committable on its own. The diff primitive without sidecars is testable end-to-end on non-covering tables before sidecar work lands.
+
+## Trade-off summary
+
+|                          | PR #7077 rebuild | Option 2 diff | Option 1 chunked-flush |
+|--------------------------|------------------|---------------|------------------------|
+| Memory peak              | O(rows × 8B)     | O(stride × 8B + sidecar snapshots) | O(chunk × 8B) |
+| OOM at 10B rows          | yes              | no            | no                     |
+| Throughput (sparse mut.) | 1× (baseline)    | ~2.5×         | 1×                     |
+| Throughput (full mut.)   | 1×               | ~1.7×         | 1×                     |
+| LoC                      | already merged   | ~1400         | ~200                   |
+| Sidecar verbatim copy    | n/a              | partial       | no                     |


### PR DESCRIPTION
## Summary

Adds `PostingIndexWriter.diffAgainstChainHead`, a seal-time primitive intended to replace #7077's `discardForRebuild` rebuild path. The diff walks the existing chain head's gens, validates each `(key, rowId)` against the column `.d` file via random-read mmap, and emits a single fresh dense chain entry containing only the kept entries.

The motivation is the OOM hole #7077 introduced. `discardForRebuild` walks every row of the column data file and accumulates each `(key, rowId)` in private spill memory before re-encoding — peak native usage is ~8 bytes per partition row, so a 1B-row partition needs ~8 GB and a 10B-row partition is structurally impossible (the `Integer.MAX_VALUE` per-gen guard fires after consuming up to 16 GB of accumulator memory). The diff streams gen → validate → encode stride-by-stride and never accumulates row IDs in private memory; peak is bounded by the largest single stride's value count.

This PR is **preparatory infrastructure** — the diff primitive is added alongside `discardForRebuild`, **not yet wired** into production. See "Status" below.

## Status

Wiring the diff into `TableWriter.sealPostingIndexForPartition` was attempted in this branch (commit `9f86cd5558`) and reverted (`a50ac29e01`) after `WalWriterFuzzTest#testWalWriteManyTablesInOrder` reliably aborts the JVM with SIGABRT. The targeted test surface passes — `PostingIndex*` suite (285 tests), the original `WalWriterFuzzTest#testWalWriteRollbackHeavy`, the new `PostingIndexDiffTest` — but heavier multi-table workloads expose a native-memory corruption bug somewhere in the diff's interaction with the seal infrastructure.

Suspects, in order of likelihood:

- `valueMem.addressOf` returning a stale address after `sealValueMem` writes trigger `mremap` on the underlying mapping. `sealIncremental` refreshes `gen0Addr` per stride for this reason; Phase 2 of the diff caches it once outside the loop.
- `coveredColReadAddrs` / `sidecarMems` in an inconsistent state when the diff calls `writeSidecarStrideData` after `closeSidecarMems` + `openSidecarFiles` at the rotated `sealTxn`. The diff's call order differs from `sealIncremental`'s.
- A subtle interaction with `mergeKeyValues` when gen 0 is sparse on entry to `diffAgainstChainHead`. The Phase 2 prologue zeroes `gen0KeyCount` in that case, which may corrupt `mergeKeyValues`' gen-0 branch.

Diagnosing the crash and re-wiring is a follow-up. With the wiring reverted, this branch is fully test-clean against master.

## What's in this PR

- `docs/POSTING_INDEX_DIFF_DESIGN.md` — design plan: algorithm, sidecar source-snapshot strategy, chain rotation, callsite changes, follow-ups.
- `PostingIndexWriter.diffAgainstChainHead` — Phase 1 (gen walk + `.d` validation + sliding read cache) and Phase 2 (per-stride decode + filter + dense encode + chain rotation + `appendNewEntry` publish + old-`.pv` purge queue).
- `PostingIndexWriter.filterKeyValuesAgainstD` and `accumulatePreFilterCounts` private helpers.
- `ColumnIndexer.diffAgainstChainHead` and `IndexWriter.diffAgainstChainHead` default no-op interface methods; `SymbolColumnIndexer` overrides to forward to the underlying writer.
- `PostingIndexDiffTest.testDiffEvictsStaleEntryKeepsNewEntry` — end-to-end happy-path test: chain with both stale `(key=2, rowId=3)` and fresh `(key=6, rowId=3)`, `.d` reflects post-O3 state `[1, 1, 1, 5]`, diff evicts the stale entry and keeps the fresh one. Validates Phase 1 + Phase 2 correctness in isolation.

## Trade-off vs `discardForRebuild` (when wired)

|                         | `discardForRebuild` (master) | This PR's diff (when wired) |
|-------------------------|--------------------------------|-----------------------------|
| Memory peak             | `O(rows × 8B)` private spill   | `O(maxStrideTotal × 8B)`    |
| OOM at 1B rows          | ~8 GB native peak              | bounded                     |
| OOM at 10B rows         | structurally impossible (Integer.MAX_VALUE guard fires after ~16 GB accumulated) | bounded                     |
| Throughput, no covers   | baseline                       | comparable                  |
| Throughput, covers      | baseline                       | comparable (cover `.d` still re-read; verbatim-copy not implemented in this PR) |
| Chain entries per O3 commit | 2 (REBUILD + SEAL)         | 2 (DIFF + SEAL)             |

The user-visible improvement targeted by this work is **bounded seal-time memory** — large-partition O3 commits stop failing with `OutOfMemoryError` once the wiring lands.

## Outstanding follow-ups before this can supersede `discardForRebuild`

- Diagnose the `WalWriterFuzzTest#testWalWriteManyTablesInOrder` crash (see Status above).
- Re-wire `TableWriter.sealPostingIndexForPartition` to call the diff in both branches.
- Add the remaining writer-fixture tests listed in `docs/POSTING_INDEX_DIFF_DESIGN.md` (sparse-only, dense-only, all-evicted, large-stride, cover correctness, OOM guard, pure-append no-eviction, seal-txn rotation).
- Add a SQL-level fuzz scenario for replace-range / dedup-replace at scale.
- Optionally add the verbatim sidecar copy for delta-mode and var-width covers (perf optimisation captured in the design doc).
- Once wiring is stable, remove `discardForRebuild` and the `pendingDiscardOldSealTxn` machinery as superseded.

## Test plan

- `mvn -pl core compile` passes.
- `mvn -pl core -Dtest=PostingIndexDiffTest test` — 1 test passes.
- `mvn -pl core -Dtest=PostingIndexCriticalIssuesTest test` — 19 tests pass (master's #7077 regression suite intact).
- `mvn -pl core -Dtest='PostingIndex*Test*' test` — 285 tests pass, 1 pre-existing skipped.
- `mvn -pl core -Dtest=WalWriterFuzzTest test` — 24 tests pass, 1 pre-existing skipped.
- Branch is rebased on top of current master; #7077's `discardForRebuild` infrastructure is preserved unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized posting index rebuilding process for improved performance during table operations.

* **Tests**
  * Added comprehensive test coverage for posting index validation scenarios, including edge cases for stale entry handling.

* **Documentation**
  * Added design documentation detailing posting index rebuild optimization and implementation details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/questdb/questdb/pull/7081)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->