### PR TITLE
test(core): fix fuzz tests infrastructure for rename, parquet encoding, and barrier deadlock

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunner.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunner.java
@@ -1022,6 +1022,7 @@ public class FuzzRunner {
             int opIndex;
 
             try {
+                String updatedTableName = tableName;
                 Rnd tempRnd = new Rnd();
                 while (errors.isEmpty() && (opIndex = nextOperation.incrementAndGet()) < transactions.size() && errors.isEmpty()) {
                     FuzzTransaction transaction = transactions.getQuick(opIndex);
@@ -1057,6 +1058,15 @@ public class FuzzRunner {
                     }
 
                     boolean increment = false;
+
+                    if (transaction.reopenTable) {
+                        TableToken updatedTableToken = engine.getTableTokenByDirName(walWriter.getTableToken().getDirName());
+                        if (updatedTableToken == null) {
+                            throw new IllegalStateException("table is missing after reopen [table=" + tableName + "]");
+                        }
+                        updatedTableName = updatedTableToken.getTableName();
+                    }
+
                     for (int operationIndex = 0; operationIndex < transaction.operationList.size(); operationIndex++) {
                         FuzzTransactionOperation operation = transaction.operationList.getQuick(operationIndex);
                         increment |= operation.apply(tempRnd, engine, walWriter, -1, null);
@@ -1064,11 +1074,10 @@ public class FuzzRunner {
 
                     if (transaction.reopenTable) {
                         synchronized (writers) {
-                            // Table is dropped, reload all writers
                             for (int ii = 0; ii < writers.size(); ii++) {
-                                if (writers.get(ii).getTableToken().getTableName().equals(tableName)) {
+                                if (writers.get(ii).getTableToken().getTableName().equals(updatedTableName)) {
                                     writers.get(ii).close();
-                                    writers.setQuick(ii, (WalWriter) engine.getTableWriterAPI(tableName, "apply trans test"));
+                                    writers.setQuick(ii, (WalWriter) engine.getTableWriterAPI(updatedTableName, "apply trans test"));
                                 }
                             }
                         }
@@ -1104,6 +1113,13 @@ public class FuzzRunner {
             } catch (Throwable e) {
                 e.printStackTrace(System.out);
                 errors.add(e);
+                // Unblock peers waiting on a barrier this worker was supposed to advance.
+                // Without this, peers spin in the Os.sleep loop above because their wait
+                // condition (waitBarrierVersion < target) stays true; the errors check
+                // inside the loop relies on Os.sleep returning, which under heavy load
+                // can be delayed indefinitely. Overshooting to MAX guarantees the wait
+                // condition flips so peers reach the errors.isEmpty() check and return.
+                waitBarrierVersion.set(Long.MAX_VALUE);
             } finally {
                 Path.clearThreadLocals();
             }

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzSetParquetEncodingOperation.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzSetParquetEncodingOperation.java
@@ -88,11 +88,12 @@ public class FuzzSetParquetEncodingOperation implements FuzzTransactionOperation
             } catch (CairoException e) {
                 if (Chars.contains(e.getFlyweightMessage(), "table does not exist")
                         || Chars.contains(e.getFlyweightMessage(), "does not exist in table")
+                        || Chars.contains(e.getFlyweightMessage(), "cached query plan cannot be used")
+                        || Chars.contains(e.getFlyweightMessage(), "could not lock table")
                         || e.isTableDropped()) {
                     return true;
-                } else {
-                    throw e;
                 }
+                throw e;
             }
         } catch (SqlException e) {
             throw new RuntimeException(e);

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzTransactionGenerator.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzTransactionGenerator.java
@@ -146,7 +146,9 @@ public class FuzzTransactionGenerator {
                 continue;
             }
             if (i == setParquetEncodingIteration) {
-                generateSetParquetEncoding(transactionList, metaVersion, waitBarrierVersion++, rnd, meta);
+                if (generateSetParquetEncoding(transactionList, metaVersion, waitBarrierVersion, rnd, meta)) {
+                    waitBarrierVersion++;
+                }
                 continue;
             }
             final double rndDouble = rnd.nextDouble();
@@ -445,7 +447,7 @@ public class FuzzTransactionGenerator {
         return null;
     }
 
-    private static void generateSetParquetEncoding(
+    private static boolean generateSetParquetEncoding(
             ObjList<FuzzTransaction> transactionList,
             int metadataVersion,
             int waitBarrierVersion,
@@ -509,12 +511,11 @@ public class FuzzTransactionGenerator {
             FuzzTransaction transaction = new FuzzTransaction();
             transaction.waitBarrierVersion = waitBarrierVersion;
             transaction.structureVersion = metadataVersion;
-            transaction.waitAllDone = true;
-            transaction.reopenTable = true;
             transaction.operationList.add(new FuzzSetParquetEncodingOperation(colName, encoding, compression, level));
             transactionList.add(transaction);
-            return;
+            return true;
         }
+        return false;
     }
 
     private static void generateSetTtl(ObjList<FuzzTransaction> transactionList, int metadataVersion, int waitBarrierVersion, Rnd rnd) {


### PR DESCRIPTION
Combines the previously reverted fuzz test infrastructure changes (#7043) with a fix for a barrier-wait deadlock surfaced by those changes.

FuzzRunner:
- Track the table name after a reopenTable transaction so the writers list refresh after rename uses the up-to-date name rather than the stale base name. Without this, writer entries kept the old TableToken and subsequent transactions could not progress.
- On worker exception, set waitBarrierVersion to MAX so peers spinning in the barrier wait are released. Their wait condition relies on Os.sleep returning, which under heavy load can be delayed indefinitely; flipping the barrier guarantees they reach the errors.isEmpty() check and return.
