### PR TITLE
chore(core): remove garbled PARQUET clauses in SHOW CREATE TABLE on pre-9.3.4 tables

### DIFF
--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -215,6 +215,7 @@ public class MetadataCache implements QuietCloseable {
 
             TableUtils.buildColumnListFromMetadataFile(metaMem, columnCount, table.columnOrderList);
             boolean isMetaFormatUpToDate = TableUtils.isMetaFormatUpToDate(metaMem);
+            boolean hasParquetEncodingConfig = TableUtils.hasParquetEncodingConfig(metaMem);
             // populate columns
             for (int i = 0, n = table.columnOrderList.size(); i < n; i += 3) {
                 int writerIndex = table.columnOrderList.get(i);
@@ -246,7 +247,9 @@ public class MetadataCache implements QuietCloseable {
                 column.setIndexBlockCapacity(TableUtils.getIndexBlockCapacity(metaMem, writerIndex));
                 column.setSymbolTableStaticFlag(true);
                 column.setDedupKeyFlag(TableUtils.isColumnDedupKey(metaMem, writerIndex));
-                column.setParquetEncodingConfig(isMetaFormatUpToDate ? TableUtils.getParquetEncodingConfig(metaMem, writerIndex) : 0);
+                // Pre-9.3.4 _meta files can carry non-zero bytes at column-entry offset 20 from
+                // older layouts (e.g. Mig608 wrote a random column hash at 20-27); read 0 there.
+                column.setParquetEncodingConfig(hasParquetEncodingConfig ? TableUtils.getParquetEncodingConfig(metaMem, writerIndex) : 0);
                 column.setWriterIndex(writerIndex);
 
                 boolean isDesignated = writerIndex == timestampWriterIndex;

--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -246,7 +246,7 @@ public class MetadataCache implements QuietCloseable {
                 column.setIndexBlockCapacity(TableUtils.getIndexBlockCapacity(metaMem, writerIndex));
                 column.setSymbolTableStaticFlag(true);
                 column.setDedupKeyFlag(TableUtils.isColumnDedupKey(metaMem, writerIndex));
-                column.setParquetEncodingConfig(TableUtils.getParquetEncodingConfig(metaMem, writerIndex));
+                column.setParquetEncodingConfig(isMetaFormatUpToDate ? TableUtils.getParquetEncodingConfig(metaMem, writerIndex) : 0);
                 column.setWriterIndex(writerIndex);
 
                 boolean isDesignated = writerIndex == timestampWriterIndex;

--- a/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
@@ -316,7 +316,7 @@ public class TableReaderMetadata extends AbstractRecordMetadata implements Table
         TableUtils.buildColumnListFromMetadataFile(mem, columnCount, columnOrderList);
         this.columnNameIndexMap.clear();
 
-        boolean isMetaFormatUpToDate = TableUtils.isMetaFormatUpToDate(mem);
+        boolean hasParquetEncodingConfig = TableUtils.hasParquetEncodingConfig(mem);
         for (int i = 0, n = columnOrderList.size(); i < n; i += 3) {
             int writerIndex = columnOrderList.get(i);
             if (writerIndex < 0) {
@@ -345,7 +345,7 @@ public class TableReaderMetadata extends AbstractRecordMetadata implements Table
                         TableUtils.isSymbolCached(mem, writerIndex),
                         TableUtils.getSymbolCapacity(mem, writerIndex)
                 );
-                colMeta.setParquetEncodingConfig(isMetaFormatUpToDate ? TableUtils.getParquetEncodingConfig(mem, writerIndex) : 0);
+                colMeta.setParquetEncodingConfig(hasParquetEncodingConfig ? TableUtils.getParquetEncodingConfig(mem, writerIndex) : 0);
                 columnMetadata.add(colMeta);
                 int denseIndex = columnMetadata.size() - 1;
                 if (!columnNameIndexMap.put(colName, denseIndex)) {

--- a/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableReaderMetadata.java
@@ -316,6 +316,7 @@ public class TableReaderMetadata extends AbstractRecordMetadata implements Table
         TableUtils.buildColumnListFromMetadataFile(mem, columnCount, columnOrderList);
         this.columnNameIndexMap.clear();
 
+        boolean isMetaFormatUpToDate = TableUtils.isMetaFormatUpToDate(mem);
         for (int i = 0, n = columnOrderList.size(); i < n; i += 3) {
             int writerIndex = columnOrderList.get(i);
             if (writerIndex < 0) {
@@ -344,7 +345,7 @@ public class TableReaderMetadata extends AbstractRecordMetadata implements Table
                         TableUtils.isSymbolCached(mem, writerIndex),
                         TableUtils.getSymbolCapacity(mem, writerIndex)
                 );
-                colMeta.setParquetEncodingConfig(TableUtils.getParquetEncodingConfig(mem, writerIndex));
+                colMeta.setParquetEncodingConfig(isMetaFormatUpToDate ? TableUtils.getParquetEncodingConfig(mem, writerIndex) : 0);
                 columnMetadata.add(colMeta);
                 int denseIndex = columnMetadata.size() - 1;
                 if (!columnNameIndexMap.put(colName, denseIndex)) {

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -115,6 +115,7 @@ public final class TableUtils {
     public static final long META_COLUMN_DATA_SIZE = 32;
     public static final String META_FILE_NAME = "_meta";
     public static final short META_FORMAT_MINOR_VERSION_LATEST = 1;
+    public static final short META_FORMAT_MINOR_VERSION_PARQUET_ENCODING_CONFIG = 1;
     public static final long META_OFFSET_COLUMN_TYPES = 128;
     public static final long META_OFFSET_COUNT = 0;
     public static final long META_OFFSET_MAX_UNCOMMITTED_ROWS = 20; // INT
@@ -1062,6 +1063,18 @@ public final class TableUtils {
         }
     }
 
+    /**
+     * Returns true when the meta file's minor version is at least
+     * {@link #META_FORMAT_MINOR_VERSION_PARQUET_ENCODING_CONFIG}, i.e. the per-column parquet
+     * encoding config field at column-entry offset 20 can be read without picking up stale
+     * bytes from older meta layouts. Spelled separately from {@link #isMetaFormatUpToDate}
+     * because a future bump of {@code META_FORMAT_MINOR_VERSION_LATEST} must not silently
+     * invalidate this field for 9.3.4 / 9.3.5 tables that legitimately have it set.
+     */
+    public static boolean hasParquetEncodingConfig(MemoryR metaMem) {
+        return isMetaFormatAtLeast(metaMem, META_FORMAT_MINOR_VERSION_PARQUET_ENCODING_CONFIG);
+    }
+
     public static LPSZ iFile(Path path, CharSequence columnName, long columnTxn) {
         path.concat(columnName).put(FILE_SUFFIX_I);
         if (columnTxn > COLUMN_NAME_TXN_NONE) {
@@ -1113,14 +1126,7 @@ public final class TableUtils {
      * Table storage itself is forward- and backward-compatible, so it's safe to read regardless of this version.
      */
     public static boolean isMetaFormatUpToDate(MemoryR metaMem) {
-        int metaFormatMinorVersionField = metaMem.getInt(META_OFFSET_META_FORMAT_MINOR_VERSION);
-        short savedChecksum = Numbers.decodeLowShort(metaFormatMinorVersionField);
-        short actualChecksum = checksumForMetaFormatMinorVersionField(
-                metaMem.getLong(TableUtils.META_OFFSET_METADATA_VERSION),
-                metaMem.getInt(TableUtils.META_OFFSET_COUNT)
-        );
-        short savedMetaFormatMinorVersion = Numbers.decodeHighShort(metaFormatMinorVersionField);
-        return savedChecksum == actualChecksum && savedMetaFormatMinorVersion >= META_FORMAT_MINOR_VERSION_LATEST;
+        return isMetaFormatAtLeast(metaMem, META_FORMAT_MINOR_VERSION_LATEST);
     }
 
     /**
@@ -2607,6 +2613,17 @@ public final class TableUtils {
             throw CairoException.critical(0).put("File is too small, size=").put(memSize).put(", required=").put(offset + storageLength);
         }
         return metaMem.getStrA(offset);
+    }
+
+    private static boolean isMetaFormatAtLeast(MemoryR metaMem, short minorVersion) {
+        int metaFormatMinorVersionField = metaMem.getInt(META_OFFSET_META_FORMAT_MINOR_VERSION);
+        short savedChecksum = Numbers.decodeLowShort(metaFormatMinorVersionField);
+        short actualChecksum = checksumForMetaFormatMinorVersionField(
+                metaMem.getLong(TableUtils.META_OFFSET_METADATA_VERSION),
+                metaMem.getInt(TableUtils.META_OFFSET_COUNT)
+        );
+        short savedMetaFormatMinorVersion = Numbers.decodeHighShort(metaFormatMinorVersionField);
+        return savedChecksum == actualChecksum && savedMetaFormatMinorVersion >= minorVersion;
     }
 
     // Utility method for debugging. This method is not used in production.

--- a/core/src/main/java/io/questdb/cairo/TableWriterMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterMetadata.java
@@ -161,6 +161,7 @@ public class TableWriterMetadata extends AbstractRecordMetadata implements Table
         long offset = TableUtils.getColumnNameOffset(columnCount);
         this.symbolMapCount = 0;
         columnNameIndexMap.clear();
+        boolean isMetaFormatUpToDate = TableUtils.isMetaFormatUpToDate(metaMem);
         // don't create strings in this loop, we already have them in columnNameIndexMap
         for (int i = 0; i < columnCount; i++) {
             CharSequence name = metaMem.getStrA(offset);
@@ -180,7 +181,7 @@ public class TableWriterMetadata extends AbstractRecordMetadata implements Table
                     TableUtils.getReplacingColumnIndex(metaMem, i),
                     TableUtils.isSymbolCached(metaMem, i)
             );
-            colMeta.setParquetEncodingConfig(TableUtils.getParquetEncodingConfig(metaMem, i));
+            colMeta.setParquetEncodingConfig(isMetaFormatUpToDate ? TableUtils.getParquetEncodingConfig(metaMem, i) : 0);
             columnMetadata.add(colMeta);
             if (type > -1) {
                 columnNameIndexMap.put(nameStr, i);

--- a/core/src/main/java/io/questdb/cairo/TableWriterMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterMetadata.java
@@ -161,7 +161,7 @@ public class TableWriterMetadata extends AbstractRecordMetadata implements Table
         long offset = TableUtils.getColumnNameOffset(columnCount);
         this.symbolMapCount = 0;
         columnNameIndexMap.clear();
-        boolean isMetaFormatUpToDate = TableUtils.isMetaFormatUpToDate(metaMem);
+        boolean hasParquetEncodingConfig = TableUtils.hasParquetEncodingConfig(metaMem);
         // don't create strings in this loop, we already have them in columnNameIndexMap
         for (int i = 0; i < columnCount; i++) {
             CharSequence name = metaMem.getStrA(offset);
@@ -181,7 +181,7 @@ public class TableWriterMetadata extends AbstractRecordMetadata implements Table
                     TableUtils.getReplacingColumnIndex(metaMem, i),
                     TableUtils.isSymbolCached(metaMem, i)
             );
-            colMeta.setParquetEncodingConfig(isMetaFormatUpToDate ? TableUtils.getParquetEncodingConfig(metaMem, i) : 0);
+            colMeta.setParquetEncodingConfig(hasParquetEncodingConfig ? TableUtils.getParquetEncodingConfig(metaMem, i) : 0);
             columnMetadata.add(colMeta);
             if (type > -1) {
                 columnNameIndexMap.put(nameStr, i);

--- a/core/src/test/java/io/questdb/test/griffin/ShowCreateTableTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ShowCreateTableTest.java
@@ -25,6 +25,12 @@
 package io.questdb.test.griffin;
 
 import io.questdb.cairo.CairoException;
+import io.questdb.cairo.MetadataCacheWriter;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.vm.Vm;
+import io.questdb.cairo.vm.api.MemoryMARW;
+import io.questdb.std.MemoryTag;
 import io.questdb.std.Os;
 import io.questdb.std.str.Path;
 import io.questdb.test.AbstractCairoTest;
@@ -372,6 +378,50 @@ public class ShowCreateTableTest extends AbstractCairoTest {
                             \ta INT PARQUET(bloom_filter),
                             \tb VARCHAR PARQUET(delta_length_byte_array, bloom_filter),
                             \tc DOUBLE
+                            ) timestamp(ts) PARTITION BY DAY BYPASS WAL;
+                            """,
+                    "SHOW CREATE TABLE foo");
+        });
+    }
+
+    @Test
+    public void testParquetIgnoredOnLegacyMetaFormat() throws Exception {
+        // Per-column parquet config lives at offset 20 of each column entry, which earlier
+        // meta layouts used for unrelated data (e.g., the upper half of the removed columnHash).
+        // SHOW CREATE TABLE must not emit PARQUET(...) for columns whose meta format predates
+        // the field, otherwise the output is invalid DDL like PARQUET(unknown(133), ...).
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE foo (ts TIMESTAMP, a INT, b LONG) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+
+            TableToken token = engine.verifyTableName("foo");
+            try (
+                    MemoryMARW mem = Vm.getCMARWInstance();
+                    Path path = new Path()
+            ) {
+                path.of(engine.getConfiguration().getDbRoot()).concat(token).concat(TableUtils.META_FILE_NAME);
+                mem.smallFile(configuration.getFilesFacade(), path.$(), MemoryTag.MMAP_DEFAULT);
+                int columnCount = mem.getInt(TableUtils.META_OFFSET_COUNT);
+                for (int i = 0; i < columnCount; i++) {
+                    long off = TableUtils.META_OFFSET_COLUMN_TYPES + i * TableUtils.META_COLUMN_DATA_SIZE + 20;
+                    // bit 24 set (explicit flag), arbitrary bytes for encoding/compression/level
+                    mem.putInt(off, 0x035ACA85);
+                }
+                // Force isMetaFormatUpToDate() to return false so the legacy-format guard kicks in.
+                mem.putInt(TableUtils.META_OFFSET_META_FORMAT_MINOR_VERSION, 0);
+            }
+
+            engine.releaseAllReaders();
+            try (MetadataCacheWriter w = engine.getMetadataCache().writeLock()) {
+                w.clearCache();
+            }
+            engine.getMetadataCache().onStartupAsyncHydrator();
+
+            assertSql("""
+                            ddl
+                            CREATE TABLE 'foo' (\s
+                            \tts TIMESTAMP,
+                            \ta INT,
+                            \tb LONG
                             ) timestamp(ts) PARTITION BY DAY BYPASS WAL;
                             """,
                     "SHOW CREATE TABLE foo");


### PR DESCRIPTION
## Summary

- On tables whose `_meta` file was last written before 9.3.4, `SHOW CREATE TABLE` could emit invalid DDL of the form `ts TIMESTAMP PARQUET(unknown(133), unknown(202)(90), bloom_filter)`, which the parser rejects. This breaks copy-schema workflows.
- Root cause: PR #6843 (commit `e8387cdd13`, shipped in 9.3.4) added `parquetEncodingConfig` at column-entry offset 20 in the `_meta` file without bumping `META_FORMAT_MINOR_VERSION_LATEST`. The reader paths in `MetadataCache`, `TableReaderMetadata`, and `TableWriterMetadata` read those 4 bytes unconditionally. Pre-9.3.4 `_meta` files can carry non-zero data at that offset from earlier layouts: the migration `Mig608` (meta version 423 -> 424, used on tables created before October 2021) writes a random `Rnd.nextLong()` at offsets 20-27, and `_meta` files written in the Oct 2021 - Nov 2022 column-hash era have the upper half of the old 8-byte column hash sitting at 20-23. Either way, bit 24 (the "explicit" flag) is set in roughly half of all column entries, which trips the parquet-clause emitter in `ShowCreateTableRecordCursorFactory`; the other bytes flow into `ParquetEncoding.getEncodingName` / `ParquetCompression.getCompressionName` and surface as `unknown(<id>)`.
- Fix: introduce `TableUtils.hasParquetEncodingConfig(metaMem)`, gated on a new named constant `META_FORMAT_MINOR_VERSION_PARQUET_ENCODING_CONFIG = 1` (the value of `META_FORMAT_MINOR_VERSION_LATEST` at the time #6843 landed, i.e. the minor version that guarantees offset 20-23 is either zero or a real config and not stale bytes). All three reader sites call the new helper instead of reading the field unconditionally. When the meta checksum is invalid or the saved minor version is below this threshold, the field defaults to `0` (no per-column config).
- A small refactor extracts the checksum + minor-version comparison from `isMetaFormatUpToDate` into a private `isMetaFormatAtLeast(metaMem, minorVersion)` helper, so the parquet gate and the existing "all fields current" check share one implementation while binding to different version constants. This is the future-proof spelling: when the next versioned field is added and `META_FORMAT_MINOR_VERSION_LATEST` is bumped to 2, the parquet gate stays pinned at version 1 and 9.3.4 / 9.3.5 metas keep their per-column configs.

## Tradeoffs

- The fix only suppresses the bogus values during reads. Old `_meta` files on disk still contain the stale bytes at offset 20-23. They are overwritten with a real `parquetEncodingConfig` (zero by default) the next time the meta is rewritten - i.e., on any schema-changing ALTER TABLE. Until then, the on-disk bytes remain incorrect, but the user-facing output is correct.
- Tables created on >= 9.3.4 with an explicit per-column `PARQUET(...)` clause are unaffected: their meta is written with `META_FORMAT_MINOR_VERSION_LATEST = 1` and passes the `hasParquetEncodingConfig` check.
- An alternative would be to bump `META_FORMAT_MINOR_VERSION_LATEST` to 2 and add a one-time meta-rewrite migration that zeros offset 20-23 on legacy entries. That is heavier than necessary: the read-time gate handles correctness at no on-disk cost, and the named-constant gate introduced here preserves the option to do that later if needed.

## Test plan

- New regression test `ShowCreateTableTest#testParquetIgnoredOnLegacyMetaFormat`: creates a non-WAL table, writes a value with bit 24 set at offset 20 of every column entry in `_meta`, sets `META_OFFSET_META_FORMAT_MINOR_VERSION` to 0, clears the metadata cache, and asserts that `SHOW CREATE TABLE` emits no `PARQUET(...)` annotations. Confirmed the test reproduces the bug on the unpatched code (output contains `PARQUET(unknown(133), unknown(201)(89), bloom_filter)` for every column) and passes with the fix applied.