### PR TITLE
chore(core): restore posting index count() fast path on clean partitions

### DIFF
--- a/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
@@ -570,6 +570,117 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
         return false;
     }
 
+    /**
+     * Returns a (possibly slack) upper bound on the largest row id encoded
+     * for one key, given the per-key encoded blob at {@code encodedOffset}
+     * inside the value memory mapping. Returns {@code -1L} when the key
+     * holds no values, and {@code Long.MAX_VALUE} when bit-width arithmetic
+     * would overflow (handled as MIXED by {@code Cursor.size()}).
+     * <p>
+     * Flat-mode strides do not use the delta layout, so this helper covers
+     * only the per-key delta-FoR / Elias-Fano blob format that
+     * {@code deltaKeyHasValueInRange} consumes.
+     */
+    private static long peekDeltaKeyMaxValueUpperBound(long baseAddr, long encodedOffset) {
+        int firstWord = Unsafe.getInt(baseAddr + encodedOffset);
+        if (firstWord == PostingIndexUtils.EF_FORMAT_SENTINEL) {
+            // EF: writer stores universe == lastValue + 1, so max == universe - 1 exactly.
+            long universe = Unsafe.getLong(baseAddr + encodedOffset + 9);
+            return universe - 1;
+        }
+        if (firstWord <= 0) {
+            return -1L;
+        }
+        int blockCount = firstWord;
+        long valueCountsOff = encodedOffset + 4;
+        long firstValuesOff = valueCountsOff + blockCount;
+        long minDeltasOff = firstValuesOff + (long) blockCount * Long.BYTES;
+        long bitWidthsOff = minDeltasOff + (long) blockCount * Long.BYTES;
+        int last = blockCount - 1;
+        long lastFv = Unsafe.getLong(baseAddr + firstValuesOff + (long) last * Long.BYTES);
+        int lastCount = Unsafe.getByte(baseAddr + valueCountsOff + last) & 0xFF;
+        int numDeltas = lastCount - 1;
+        if (numDeltas == 0) {
+            return lastFv;
+        }
+        long lastMinD = Unsafe.getLong(baseAddr + minDeltasOff + (long) last * Long.BYTES);
+        int lastBitWidth = Unsafe.getByte(baseAddr + bitWidthsOff + last) & 0xFF;
+        if (lastBitWidth == 0) {
+            // Constant-stride block: writer guarantees minD > 0 when count > 1, so the
+            // arithmetic progression's last value is exact.
+            return lastFv + (long) numDeltas * lastMinD;
+        }
+        // Slack upper bound: assume every delta in the last block packs to (1<<bw)-1.
+        // Real values are <= this, so a CLEAN classification stays correct; the cost
+        // is a stricter cutoff for MIXED detection at high bitwidth.
+        if (lastBitWidth >= 32) {
+            return Long.MAX_VALUE;
+        }
+        long maxDelta = lastMinD + (1L << lastBitWidth) - 1;
+        if (maxDelta < lastMinD) {
+            return Long.MAX_VALUE;
+        }
+        long span = (long) numDeltas * maxDelta;
+        if (maxDelta != 0 && span / maxDelta != numDeltas) {
+            return Long.MAX_VALUE;
+        }
+        long max = lastFv + span;
+        if (max < lastFv) {
+            return Long.MAX_VALUE;
+        }
+        return max;
+    }
+
+    /**
+     * Exact smallest row id encoded for one key, taken from the encoded blob
+     * at {@code encodedOffset}. Returns {@code -1L} when the key holds no
+     * values. Mirror to {@link #peekDeltaKeyMaxValueUpperBound}.
+     */
+    private static long peekDeltaKeyMinValue(long baseAddr, long encodedOffset) {
+        int firstWord = Unsafe.getInt(baseAddr + encodedOffset);
+        if (firstWord == PostingIndexUtils.EF_FORMAT_SENTINEL) {
+            return peekEFKeyMinValue(baseAddr, encodedOffset);
+        }
+        if (firstWord <= 0) {
+            return -1L;
+        }
+        long firstValuesOff = encodedOffset + 4 + firstWord;
+        return Unsafe.getLong(baseAddr + firstValuesOff);
+    }
+
+    private static long peekEFKeyMinValue(long baseAddr, long encodedOffset) {
+        long pos = encodedOffset + 4; // skip EF_FORMAT_SENTINEL
+        int totalCount = Unsafe.getInt(baseAddr + pos);
+        pos += 4;
+        if (totalCount == 0) {
+            return -1L;
+        }
+        int bitsL = Unsafe.getByte(baseAddr + pos) & 0xFF;
+        pos += 1;
+        long universe = Unsafe.getLong(baseAddr + pos);
+        pos += 8;
+        long lowOffset = pos;
+        long highOffset = pos + PostingIndexUtils.efLowBytesAligned(totalCount, bitsL);
+        int numHighWords = (int) ((totalCount + (universe >>> bitsL) + 63) / 64);
+        for (int i = 0; i < numHighWords; i++) {
+            long word = Unsafe.getLong(baseAddr + highOffset + (long) i * 8);
+            if (word == 0) {
+                continue;
+            }
+            // First set bit's absolute index in the high-bit stream is the high
+            // part of value 0 (outputCount == 0 at the start, so base == i*64).
+            long high = (long) i * 64 + Long.numberOfTrailingZeros(word);
+            long low = 0;
+            if (bitsL > 0) {
+                long lowMask = (bitsL < 64) ? (1L << bitsL) - 1 : -1L;
+                long lowWord = Unsafe.getLong(baseAddr + lowOffset);
+                low = lowWord & lowMask;
+            }
+            return (high << bitsL) | low;
+        }
+        return -1L;
+    }
+
     private void closeSidecarMems() {
         Misc.freeObjListAndKeepObjects(sidecarMems);
         coverCount = 0;
@@ -1227,18 +1338,45 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
             if (requestedKey < 0) {
                 return 0;
             }
-            if (entryMaxValue >= 0) {
-                // Raw per-gen counts do not know whether encoded row ids sit
-                // past the chain entry's tracked coverage. Decline the fast
-                // path so callers count via the same clamped hasNext() path.
-                return -1;
-            }
+            // Per-gen classification when the chain entry advertises a tracked
+            // coverage: CLEAN gens (max <= entryMaxValue) contribute their count,
+            // ALL_DIRTY gens (min > entryMaxValue) contribute zero, MIXED gens
+            // force a -1 bail so the caller falls back to the clamped iteration.
+            // entryMaxValue == -1 means an empty chain entry where no clamping
+            // applies; the original count fast path is taken verbatim.
             long total = 0;
             for (int g = 0; g < cursorGenCount; g++) {
                 int gkc = genLookup.getGenKeyCount(g);
                 if (gkc >= 0) {
+                    if (entryMaxValue >= 0) {
+                        long minV = peekDenseKeyMinValue(g, gkc);
+                        if (minV < 0) {
+                            continue;
+                        }
+                        if (minV > entryMaxValue) {
+                            continue;
+                        }
+                        long maxV = peekDenseKeyMaxValueUpperBound(g, gkc);
+                        if (maxV > entryMaxValue) {
+                            return -1;
+                        }
+                    }
                     total += getDenseGenKeyCount(g, gkc);
                 } else if (!genLookup.notContainKey(valueMem, g, requestedKey)) {
+                    int activeKeyCount = -gkc;
+                    if (entryMaxValue >= 0) {
+                        long minV = peekSparseKeyMinValue(g, activeKeyCount);
+                        if (minV < 0) {
+                            continue;
+                        }
+                        if (minV > entryMaxValue) {
+                            continue;
+                        }
+                        long maxV = peekSparseKeyMaxValueUpperBound(g, activeKeyCount);
+                        if (maxV > entryMaxValue) {
+                            return -1;
+                        }
+                    }
                     total += getSparseGenKeyCount(g);
                 }
             }
@@ -1766,6 +1904,156 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
 
             fsstCachedBlockBases[includeIdx] = blockBase;
             return false;
+        }
+
+        private long peekDenseKeyMaxValueUpperBound(int gen, int genKeyCount) {
+            if (requestedKey >= genKeyCount) {
+                return -1L;
+            }
+            int stride = requestedKey / PostingIndexUtils.DENSE_STRIDE;
+            int localKey = requestedKey % PostingIndexUtils.DENSE_STRIDE;
+            long genFileOffset = genLookup.getGenFileOffset(gen);
+            long genAddr = valueMem.addressOf(genFileOffset);
+            long strideOff = Unsafe.getLong(genAddr + (long) stride * Long.BYTES);
+            long nextStrideOff = Unsafe.getLong(genAddr + (long) (stride + 1) * Long.BYTES);
+            if (nextStrideOff == strideOff) {
+                return -1L;
+            }
+            int siSize = PostingIndexUtils.strideIndexSize(genKeyCount);
+            long strideAddr = genAddr + siSize + strideOff;
+            long strideFileOffset = genFileOffset + siSize + strideOff;
+            byte mode = Unsafe.getByte(strideAddr);
+            int ks = PostingIndexUtils.keysInStride(genKeyCount, stride);
+            if (mode == PostingIndexUtils.STRIDE_MODE_FLAT) {
+                int bitWidth = Unsafe.getByte(strideAddr + 1) & 0xFF;
+                long baseValue = Unsafe.getLong(strideAddr + PostingIndexUtils.STRIDE_FLAT_BASE_OFFSET);
+                long prefixAddr = strideAddr + PostingIndexUtils.STRIDE_FLAT_PREFIX_COUNTS_OFFSET;
+                int start = Unsafe.getInt(prefixAddr + (long) localKey * Integer.BYTES);
+                int end = Unsafe.getInt(prefixAddr + (long) (localKey + 1) * Integer.BYTES);
+                if (end == start) {
+                    return -1L;
+                }
+                if (bitWidth == 0) {
+                    return baseValue;
+                }
+                long dataAddr = strideAddr + PostingIndexUtils.strideFlatHeaderSize(ks);
+                return BitpackUtils.unpackValue(dataAddr, end - 1, bitWidth, baseValue);
+            }
+            if (mode != PostingIndexUtils.STRIDE_MODE_DELTA) {
+                throw CairoException.critical(0).put(INDEX_CORRUPT).put(" [bad stride mode=").put(mode).put(']');
+            }
+            long countsAddr = strideAddr + PostingIndexUtils.STRIDE_MODE_PREFIX_SIZE;
+            int totalCount = Unsafe.getInt(countsAddr + (long) localKey * Integer.BYTES);
+            if (totalCount == 0) {
+                return -1L;
+            }
+            long offsetsBase = countsAddr + (long) ks * Integer.BYTES;
+            long dataOffset = Unsafe.getLong(offsetsBase + (long) localKey * Long.BYTES);
+            long encodedOffset = strideFileOffset + PostingIndexUtils.strideDeltaHeaderSize(ks) + dataOffset;
+            long baseAddr = valueMem.addressOf(0);
+            return peekDeltaKeyMaxValueUpperBound(baseAddr, encodedOffset);
+        }
+
+        private long peekDenseKeyMinValue(int gen, int genKeyCount) {
+            if (requestedKey >= genKeyCount) {
+                return -1L;
+            }
+            int stride = requestedKey / PostingIndexUtils.DENSE_STRIDE;
+            int localKey = requestedKey % PostingIndexUtils.DENSE_STRIDE;
+            long genFileOffset = genLookup.getGenFileOffset(gen);
+            long genAddr = valueMem.addressOf(genFileOffset);
+            long strideOff = Unsafe.getLong(genAddr + (long) stride * Long.BYTES);
+            long nextStrideOff = Unsafe.getLong(genAddr + (long) (stride + 1) * Long.BYTES);
+            if (nextStrideOff == strideOff) {
+                return -1L;
+            }
+            int siSize = PostingIndexUtils.strideIndexSize(genKeyCount);
+            long strideAddr = genAddr + siSize + strideOff;
+            long strideFileOffset = genFileOffset + siSize + strideOff;
+            byte mode = Unsafe.getByte(strideAddr);
+            int ks = PostingIndexUtils.keysInStride(genKeyCount, stride);
+            if (mode == PostingIndexUtils.STRIDE_MODE_FLAT) {
+                int bitWidth = Unsafe.getByte(strideAddr + 1) & 0xFF;
+                long baseValue = Unsafe.getLong(strideAddr + PostingIndexUtils.STRIDE_FLAT_BASE_OFFSET);
+                long prefixAddr = strideAddr + PostingIndexUtils.STRIDE_FLAT_PREFIX_COUNTS_OFFSET;
+                int start = Unsafe.getInt(prefixAddr + (long) localKey * Integer.BYTES);
+                int end = Unsafe.getInt(prefixAddr + (long) (localKey + 1) * Integer.BYTES);
+                if (end == start) {
+                    return -1L;
+                }
+                if (bitWidth == 0) {
+                    return baseValue;
+                }
+                long dataAddr = strideAddr + PostingIndexUtils.strideFlatHeaderSize(ks);
+                return BitpackUtils.unpackValue(dataAddr, start, bitWidth, baseValue);
+            }
+            if (mode != PostingIndexUtils.STRIDE_MODE_DELTA) {
+                throw CairoException.critical(0).put(INDEX_CORRUPT).put(" [bad stride mode=").put(mode).put(']');
+            }
+            long countsAddr = strideAddr + PostingIndexUtils.STRIDE_MODE_PREFIX_SIZE;
+            int totalCount = Unsafe.getInt(countsAddr + (long) localKey * Integer.BYTES);
+            if (totalCount == 0) {
+                return -1L;
+            }
+            long offsetsBase = countsAddr + (long) ks * Integer.BYTES;
+            long dataOffset = Unsafe.getLong(offsetsBase + (long) localKey * Long.BYTES);
+            long encodedOffset = strideFileOffset + PostingIndexUtils.strideDeltaHeaderSize(ks) + dataOffset;
+            long baseAddr = valueMem.addressOf(0);
+            return peekDeltaKeyMinValue(baseAddr, encodedOffset);
+        }
+
+        private long peekSparseKeyMaxValueUpperBound(int gen, int activeKeyCount) {
+            int minKey = genLookup.getGenMinKey(gen);
+            int maxKey = genLookup.getGenMaxKey(gen);
+            if (requestedKey < minKey || requestedKey > maxKey) {
+                return -1L;
+            }
+            long genFileOffset = genLookup.getGenFileOffset(gen);
+            long prefixSumAddr = valueMem.addressOf(genLookup.getGenPrefixSumOffset(gen, valueMem));
+            int k = requestedKey - minKey;
+            int start = Unsafe.getInt(prefixSumAddr + (long) k * Integer.BYTES);
+            int end = Unsafe.getInt(prefixSumAddr + (long) (k + 1) * Integer.BYTES);
+            if (start >= end) {
+                return -1L;
+            }
+            long genAddr = valueMem.addressOf(genFileOffset);
+            long countsBase = genAddr + (long) activeKeyCount * Integer.BYTES;
+            long offsetsBase = countsBase + (long) activeKeyCount * Integer.BYTES;
+            int totalCount = Unsafe.getInt(countsBase + (long) start * Integer.BYTES);
+            if (totalCount == 0) {
+                return -1L;
+            }
+            long dataOffset = Unsafe.getLong(offsetsBase + (long) start * Long.BYTES);
+            long encodedOffset = genFileOffset + PostingIndexUtils.genHeaderSizeSparse(activeKeyCount) + dataOffset;
+            long baseAddr = valueMem.addressOf(0);
+            return peekDeltaKeyMaxValueUpperBound(baseAddr, encodedOffset);
+        }
+
+        private long peekSparseKeyMinValue(int gen, int activeKeyCount) {
+            int minKey = genLookup.getGenMinKey(gen);
+            int maxKey = genLookup.getGenMaxKey(gen);
+            if (requestedKey < minKey || requestedKey > maxKey) {
+                return -1L;
+            }
+            long genFileOffset = genLookup.getGenFileOffset(gen);
+            long prefixSumAddr = valueMem.addressOf(genLookup.getGenPrefixSumOffset(gen, valueMem));
+            int k = requestedKey - minKey;
+            int start = Unsafe.getInt(prefixSumAddr + (long) k * Integer.BYTES);
+            int end = Unsafe.getInt(prefixSumAddr + (long) (k + 1) * Integer.BYTES);
+            if (start >= end) {
+                return -1L;
+            }
+            long genAddr = valueMem.addressOf(genFileOffset);
+            long countsBase = genAddr + (long) activeKeyCount * Integer.BYTES;
+            long offsetsBase = countsBase + (long) activeKeyCount * Integer.BYTES;
+            int totalCount = Unsafe.getInt(countsBase + (long) start * Integer.BYTES);
+            if (totalCount == 0) {
+                return -1L;
+            }
+            long dataOffset = Unsafe.getLong(offsetsBase + (long) start * Long.BYTES);
+            long encodedOffset = genFileOffset + PostingIndexUtils.genHeaderSizeSparse(activeKeyCount) + dataOffset;
+            long baseAddr = valueMem.addressOf(0);
+            return peekDeltaKeyMinValue(baseAddr, encodedOffset);
         }
 
         protected void cacheSidecarKeyAddrs(int stride, int localKey) {

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -523,6 +523,241 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    /**
+     * The {@code Cursor.size()} fast path must bail to iteration when a single
+     * gen straddles {@code entryMaxValue}, because the per-gen count includes
+     * encoded row ids past the chain's tracked coverage. The bail manifests as
+     * {@code size() == -1}; the iterated count then becomes the source of
+     * truth (and matches the clamped emit set).
+     */
+    @Test
+    public void testSizeBailsOnMixedGen() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_mixed_gen";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    for (long rowId = 0; rowId < 100; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    writer.setMaxValue(49);
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals(
+                            "key 0 has rowids 0..49 at or below MAX_VALUE=49",
+                            50,
+                            iterated
+                    );
+                    Assert.assertEquals(
+                            "single-gen MIXED classification must bail to iteration",
+                            -1L,
+                            advertised
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * When the head entry's MAX_VALUE sits below every encoded row id for the
+     * requested key in a gen, that gen is ALL_DIRTY: it must contribute zero to
+     * {@code Cursor.size()} without forcing a full bail. Mirrors the iterated
+     * cursor, which also returns no rows because the clamp filters them all
+     * out.
+     */
+    @Test
+    public void testSizeBypassesAllDirtyGen() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_all_dirty";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    for (long rowId = 50; rowId < 100; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    writer.setMaxValue(49);
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals("clamp drops every encoded row past MAX_VALUE", 0, iterated);
+                    Assert.assertEquals(
+                            "ALL_DIRTY gen must contribute 0 without bailing the fast path",
+                            0L,
+                            advertised
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * Primary perf-recovery regression test: with no dirty data and the head
+     * entry's MAX_VALUE pointing at the encoded maximum, every gen is CLEAN
+     * and {@code Cursor.size()} must return the iterated count, not -1.
+     * Exercises the dense (sealed) gen path.
+     */
+    @Test
+    public void testSizeFastPathOnDenseGen() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_fast_dense";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    for (long rowId = 0; rowId < 200; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    // Explicit seal collapses the sparse gens into a single dense
+                    // gen so size() goes through the dense peek path.
+                    writer.seal();
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals("expect every encoded row id to surface", 200, iterated);
+                    Assert.assertEquals(
+                            "CLEAN dense gen must take the fast path",
+                            iterated,
+                            advertised
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * Same shape as {@link #testSizeFastPathOnDenseGen} but the writer is
+     * closed without an explicit {@link PostingIndexWriter#seal()}, so the
+     * head entry carries sparse gens. Locks in the sparse-side peek path.
+     */
+    @Test
+    public void testSizeFastPathOnSparseGen() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_fast_sparse";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    for (long rowId = 0; rowId < 200; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    // No seal: chain head's gen is sparse (negative key count).
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals("expect every encoded row id to surface", 200, iterated);
+                    Assert.assertEquals(
+                            "CLEAN sparse gen must take the fast path",
+                            iterated,
+                            advertised
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * Mixed per-gen classification: gen 1 is CLEAN (max <= MAX_VALUE), gen 2
+     * is ALL_DIRTY (min > MAX_VALUE). {@code Cursor.size()} should sum the
+     * CLEAN contribution and skip ALL_DIRTY without bailing. Exact match
+     * against the iterated count proves no over- or under-count.
+     */
+    @Test
+    public void testSizeMultiGenMixedClassification() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_multigen_mixed";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    for (long rowId = 0; rowId < 50; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    for (long rowId = 50; rowId < 100; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    writer.setMaxValue(49);
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals(
+                            "gen 1 contributes rowids 0..49 = 50 rows under MAX_VALUE=49",
+                            50,
+                            iterated
+                    );
+                    Assert.assertEquals(
+                            "CLEAN+ALL_DIRTY combination must take the fast path",
+                            iterated,
+                            advertised
+                    );
+                }
+            }
+        });
+    }
+
     // Critical findings #2 (setMaxValue seqlock), #6 ([0, Long.MAX_VALUE)
     // conservative purge interval) and #7 (seal-loop partial failure
     // recovery) were RED placeholders during the v1 era. They are now

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.cairo;
 
+import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.TableToken;
@@ -69,6 +70,54 @@ import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;
  * conditions are marked with comments describing what they need.
  */
 public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
+
+    /**
+     * Review C2: the full-partition SELECT DISTINCT path calls
+     * collectDistinctKeys(), not collectDistinctKeysInRange(). The no-range
+     * helper must still honor the chain entry's MAX_VALUE; otherwise a key
+     * whose only encoded rows are dirty rows past MAX_VALUE is reported as
+     * present in the partition.
+     */
+    @Test
+    public void testCollectDistinctKeysDoesNotExposeKeysPastEntryMaxValue() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_distinct_max_value_clamp";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                final int liveKey = 1;
+                final int dirtyOnlyKey = 2;
+
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    for (long rowId = 0; rowId < 50; rowId++) {
+                        writer.add(liveKey, rowId);
+                    }
+                    for (long rowId = 50; rowId < 100; rowId++) {
+                        writer.add(dirtyOnlyKey, rowId);
+                    }
+                    writer.setMaxValue(99);
+                    writer.commit();
+                    writer.setMaxValue(49);
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0);
+                     DirectBitSet foundKeys = new DirectBitSet(8)) {
+                    Assert.assertEquals(
+                            "only the key with rowids at or below MAX_VALUE=49 is live",
+                            1,
+                            reader.collectDistinctKeys(foundKeys)
+                    );
+                    Assert.assertTrue(foundKeys.get(liveKey));
+                    Assert.assertFalse(
+                            "collectDistinctKeys must not expose a key whose only rows are past entryMaxValue",
+                            foundKeys.get(dirtyOnlyKey)
+                    );
+                }
+            }
+        });
+    }
 
     /**
      * Critical #8: ExpressionNode.deepClone restoration in the covering
@@ -302,54 +351,6 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
-     * Review C2: the full-partition SELECT DISTINCT path calls
-     * collectDistinctKeys(), not collectDistinctKeysInRange(). The no-range
-     * helper must still honor the chain entry's MAX_VALUE; otherwise a key
-     * whose only encoded rows are dirty rows past MAX_VALUE is reported as
-     * present in the partition.
-     */
-    @Test
-    public void testCollectDistinctKeysDoesNotExposeKeysPastEntryMaxValue() throws Exception {
-        assertMemoryLeak(() -> {
-            final String name = "posting_distinct_max_value_clamp";
-            try (Path path = new Path().of(configuration.getDbRoot())) {
-                final int plen = path.size();
-                final int liveKey = 1;
-                final int dirtyOnlyKey = 2;
-
-                try (PostingIndexWriter writer = new PostingIndexWriter(
-                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
-                    for (long rowId = 0; rowId < 50; rowId++) {
-                        writer.add(liveKey, rowId);
-                    }
-                    for (long rowId = 50; rowId < 100; rowId++) {
-                        writer.add(dirtyOnlyKey, rowId);
-                    }
-                    writer.setMaxValue(99);
-                    writer.commit();
-                    writer.setMaxValue(49);
-                }
-
-                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
-                        configuration, path.trimTo(plen), name,
-                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0);
-                     DirectBitSet foundKeys = new DirectBitSet(8)) {
-                    Assert.assertEquals(
-                            "only the key with rowids at or below MAX_VALUE=49 is live",
-                            1,
-                            reader.collectDistinctKeys(foundKeys)
-                    );
-                    Assert.assertTrue(foundKeys.get(liveKey));
-                    Assert.assertFalse(
-                            "collectDistinctKeys must not expose a key whose only rows are past entryMaxValue",
-                            foundKeys.get(dirtyOnlyKey)
-                    );
-                }
-            }
-        });
-    }
-
-    /**
      * Reader must clamp returned rowids by the picked chain entry's
      * V2_ENTRY_OFFSET_MAX_VALUE field. Writers can leave dirty
      * (key, rowid) pairs in .pv past the chain's tracked coverage --
@@ -522,260 +523,6 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             }
         });
     }
-
-    /**
-     * The {@code Cursor.size()} fast path must bail to iteration when a single
-     * gen straddles {@code entryMaxValue}, because the per-gen count includes
-     * encoded row ids past the chain's tracked coverage. The bail manifests as
-     * {@code size() == -1}; the iterated count then becomes the source of
-     * truth (and matches the clamped emit set).
-     */
-    @Test
-    public void testSizeBailsOnMixedGen() throws Exception {
-        assertMemoryLeak(() -> {
-            final String name = "posting_size_mixed_gen";
-            try (Path path = new Path().of(configuration.getDbRoot())) {
-                final int plen = path.size();
-                try (PostingIndexWriter writer = new PostingIndexWriter(
-                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
-                    for (long rowId = 0; rowId < 100; rowId++) {
-                        writer.add(0, rowId);
-                    }
-                    writer.commit();
-                    writer.setMaxValue(49);
-                }
-
-                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
-                        configuration, path.trimTo(plen), name,
-                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
-                    long iterated = 0;
-                    long advertised;
-                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
-                        advertised = cursor.size();
-                        while (cursor.hasNext()) {
-                            cursor.next();
-                            iterated++;
-                        }
-                    }
-                    Assert.assertEquals(
-                            "key 0 has rowids 0..49 at or below MAX_VALUE=49",
-                            50,
-                            iterated
-                    );
-                    Assert.assertEquals(
-                            "single-gen MIXED classification must bail to iteration",
-                            -1L,
-                            advertised
-                    );
-                }
-            }
-        });
-    }
-
-    /**
-     * When the head entry's MAX_VALUE sits below every encoded row id for the
-     * requested key in a gen, that gen is ALL_DIRTY: it must contribute zero to
-     * {@code Cursor.size()} without forcing a full bail. Mirrors the iterated
-     * cursor, which also returns no rows because the clamp filters them all
-     * out.
-     */
-    @Test
-    public void testSizeBypassesAllDirtyGen() throws Exception {
-        assertMemoryLeak(() -> {
-            final String name = "posting_size_all_dirty";
-            try (Path path = new Path().of(configuration.getDbRoot())) {
-                final int plen = path.size();
-                try (PostingIndexWriter writer = new PostingIndexWriter(
-                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
-                    for (long rowId = 50; rowId < 100; rowId++) {
-                        writer.add(0, rowId);
-                    }
-                    writer.commit();
-                    writer.setMaxValue(49);
-                }
-
-                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
-                        configuration, path.trimTo(plen), name,
-                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
-                    long iterated = 0;
-                    long advertised;
-                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
-                        advertised = cursor.size();
-                        while (cursor.hasNext()) {
-                            cursor.next();
-                            iterated++;
-                        }
-                    }
-                    Assert.assertEquals("clamp drops every encoded row past MAX_VALUE", 0, iterated);
-                    Assert.assertEquals(
-                            "ALL_DIRTY gen must contribute 0 without bailing the fast path",
-                            0L,
-                            advertised
-                    );
-                }
-            }
-        });
-    }
-
-    /**
-     * Primary perf-recovery regression test: with no dirty data and the head
-     * entry's MAX_VALUE pointing at the encoded maximum, every gen is CLEAN
-     * and {@code Cursor.size()} must return the iterated count, not -1.
-     * Exercises the dense (sealed) gen path.
-     */
-    @Test
-    public void testSizeFastPathOnDenseGen() throws Exception {
-        assertMemoryLeak(() -> {
-            final String name = "posting_size_fast_dense";
-            try (Path path = new Path().of(configuration.getDbRoot())) {
-                final int plen = path.size();
-                try (PostingIndexWriter writer = new PostingIndexWriter(
-                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
-                    for (long rowId = 0; rowId < 200; rowId++) {
-                        writer.add(0, rowId);
-                    }
-                    writer.commit();
-                    // Explicit seal collapses the sparse gens into a single dense
-                    // gen so size() goes through the dense peek path.
-                    writer.seal();
-                }
-
-                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
-                        configuration, path.trimTo(plen), name,
-                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
-                    long iterated = 0;
-                    long advertised;
-                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
-                        advertised = cursor.size();
-                        while (cursor.hasNext()) {
-                            cursor.next();
-                            iterated++;
-                        }
-                    }
-                    Assert.assertEquals("expect every encoded row id to surface", 200, iterated);
-                    Assert.assertEquals(
-                            "CLEAN dense gen must take the fast path",
-                            iterated,
-                            advertised
-                    );
-                }
-            }
-        });
-    }
-
-    /**
-     * Same shape as {@link #testSizeFastPathOnDenseGen} but the writer is
-     * closed without an explicit {@link PostingIndexWriter#seal()}, so the
-     * head entry carries sparse gens. Locks in the sparse-side peek path.
-     */
-    @Test
-    public void testSizeFastPathOnSparseGen() throws Exception {
-        assertMemoryLeak(() -> {
-            final String name = "posting_size_fast_sparse";
-            try (Path path = new Path().of(configuration.getDbRoot())) {
-                final int plen = path.size();
-                try (PostingIndexWriter writer = new PostingIndexWriter(
-                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
-                    for (long rowId = 0; rowId < 200; rowId++) {
-                        writer.add(0, rowId);
-                    }
-                    writer.commit();
-                    // No seal: chain head's gen is sparse (negative key count).
-                }
-
-                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
-                        configuration, path.trimTo(plen), name,
-                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
-                    long iterated = 0;
-                    long advertised;
-                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
-                        advertised = cursor.size();
-                        while (cursor.hasNext()) {
-                            cursor.next();
-                            iterated++;
-                        }
-                    }
-                    Assert.assertEquals("expect every encoded row id to surface", 200, iterated);
-                    Assert.assertEquals(
-                            "CLEAN sparse gen must take the fast path",
-                            iterated,
-                            advertised
-                    );
-                }
-            }
-        });
-    }
-
-    /**
-     * Mixed per-gen classification: gen 1 is CLEAN (max <= MAX_VALUE), gen 2
-     * is ALL_DIRTY (min > MAX_VALUE). {@code Cursor.size()} should sum the
-     * CLEAN contribution and skip ALL_DIRTY without bailing. Exact match
-     * against the iterated count proves no over- or under-count.
-     */
-    @Test
-    public void testSizeMultiGenMixedClassification() throws Exception {
-        assertMemoryLeak(() -> {
-            final String name = "posting_size_multigen_mixed";
-            try (Path path = new Path().of(configuration.getDbRoot())) {
-                final int plen = path.size();
-                try (PostingIndexWriter writer = new PostingIndexWriter(
-                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
-                    for (long rowId = 0; rowId < 50; rowId++) {
-                        writer.add(0, rowId);
-                    }
-                    writer.commit();
-                    for (long rowId = 50; rowId < 100; rowId++) {
-                        writer.add(0, rowId);
-                    }
-                    writer.commit();
-                    writer.setMaxValue(49);
-                }
-
-                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
-                        configuration, path.trimTo(plen), name,
-                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
-                    long iterated = 0;
-                    long advertised;
-                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
-                        advertised = cursor.size();
-                        while (cursor.hasNext()) {
-                            cursor.next();
-                            iterated++;
-                        }
-                    }
-                    Assert.assertEquals(
-                            "gen 1 contributes rowids 0..49 = 50 rows under MAX_VALUE=49",
-                            50,
-                            iterated
-                    );
-                    Assert.assertEquals(
-                            "CLEAN+ALL_DIRTY combination must take the fast path",
-                            iterated,
-                            advertised
-                    );
-                }
-            }
-        });
-    }
-
-    // Critical findings #2 (setMaxValue seqlock), #6 ([0, Long.MAX_VALUE)
-    // conservative purge interval) and #7 (seal-loop partial failure
-    // recovery) were RED placeholders during the v1 era. They are now
-    // addressed structurally by the v2 chain redesign:
-    //   #2 — chain.updateHeadMaxValue publishes via the chain header
-    //        seqlock, so any reader of MAX_VALUE goes through the same
-    //        consistency protocol as keyCount/genCount.
-    //   #6 — recordPostingSealPurge derives [fromTxn, toTxn) from the
-    //        chain entries themselves; the residual [0, MAX) branch only
-    //        fires for the empty-chain edge case, which the
-    //        writer-open recovery walk picks up on the next reopen.
-    //   #7 — recoveryDropAbandoned (run from PostingIndexWriter.of after
-    //        setCurrentTableTxn) drops every chain entry whose txnAtSeal
-    //        was published before the encompassing txWriter.commit
-    //        landed.
-    // Critical finding #9 (ColumnPurgeOperator retry cap on Windows) is
-    // orthogonal to the posting-index chain rewrite and remains tracked
-    // separately.
 
     /**
      * {@code TableWriter.linkPostingIndexAuxFiles} must hardlink only the
@@ -1078,25 +825,6 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             }
         });
     }
-
-    // =========================================================================
-    // Red tests for the v2 review of PR #6861 (current pass).
-    //
-    // Each test below maps to a finding from the review report. Tests that
-    // require fault injection use TestFilesFacadeImpl; tests that require
-    // concurrency simulate the race by mutating ff.length() between mmap
-    // setup and chain access. Findings that can only manifest from sources
-    // FilesFacade does not see (Unsafe.realloc OOM, queue-pool exhaustion)
-    // are documented in trailing comments.
-    // =========================================================================
-
-    // Review finding #1 (sidecar mem fd leak in openSidecarFiles) was
-    // dropped after verification: MemoryCMARWImpl.extend0 (line 403) and
-    // map0 (line 417) both close the fd on mmap/mremap failure inside
-    // jumpTo(). The "orphan mem" identified in the review never holds an
-    // open fd by the time the outer catch fires — it is already closed
-    // internally by the memory-mapping helper.
-    // Documented for traceability; no JUnit red test.
 
     /**
      * Review finding #4 — {@code BitpackUtils.unpackValuesFrom} Java
@@ -1576,6 +1304,325 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    @Test
+    public void testReviewFindingC1_O3PartialSealPublishesUndroppableChainHead() throws Exception {
+        final AtomicBoolean failArmed = new AtomicBoolean(false);
+        final AtomicInteger sealedPvOpens = new AtomicInteger(0);
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public long openRW(LPSZ name, int opts) {
+                // The pre-seal .pv.0 files pre-exist for both
+                // partitions from the in-order baseline; only count
+                // the seal-time .pv.{>=1} opens. Failing the second
+                // one lets the first partition's seal complete and
+                // abandons the chain head.
+                if (failArmed.get() && name != null
+                        && Utf8s.containsAscii(name, ".pv.")
+                        && !Utf8s.endsWithAscii(name, ".pv.0")) {
+                    int n = sealedPvOpens.incrementAndGet();
+                    if (n >= 2) {
+                        return -1;
+                    }
+                }
+                return super.openRW(name, opts);
+            }
+        };
+
+        assertMemoryLeak(ff, () -> {
+            execute("""
+                    CREATE TABLE t_c1_chain_head (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            execute("""
+                    INSERT INTO t_c1_chain_head VALUES
+                    ('2024-01-01T00:00:00', 'A'),
+                    ('2024-01-02T00:00:00', 'B')
+                    """);
+
+            // Capture the committed _txn before the failed O3. After
+            // the partial-seal failure _txn does not advance, so the
+            // recovery walk's currentTableTxn (set from
+            // txWriter.getTxn() at TableWriter.java:7585 / 10739 /
+            // 10777) is exactly this value on the next writer reopen.
+            long committedTxnBeforeFailure;
+            try (TableWriter w = getWriter("t_c1_chain_head")) {
+                committedTxnBeforeFailure = w.getTxn();
+            }
+
+            sealedPvOpens.set(0);
+            failArmed.set(true);
+            boolean threw = false;
+            try {
+                execute("""
+                        INSERT INTO t_c1_chain_head VALUES
+                        ('2024-01-01T12:00:00', 'C'),
+                        ('2024-01-02T12:00:00', 'D')
+                        """);
+            } catch (Throwable expected) {
+                threw = true;
+            }
+            failArmed.set(false);
+            Assert.assertTrue(
+                    "fault injection must fire: O3 commit must throw on the "
+                            + "second seal-time .pv openRW",
+                    threw
+            );
+
+            engine.releaseAllWriters();
+
+            TableToken token = engine.getTableTokenIfExists("t_c1_chain_head");
+            Assert.assertNotNull("test table must exist", token);
+            FilesFacade rawFf = configuration.getFilesFacade();
+
+            try (Path path = new Path()) {
+                path.of(configuration.getDbRoot()).concat(token).concat("2024-01-01").slash();
+                int plen = path.size();
+                LPSZ keyFile = PostingIndexUtils.keyFileName(
+                        path.trimTo(plen), "sym", COLUMN_NAME_TXN_NONE);
+                long fileSize = rawFf.length(keyFile);
+                Assert.assertTrue(
+                        "D1's .pk file must exist after the partial-seal failure",
+                        fileSize > 0
+                );
+
+                long preRecoveryHeadSealTxn;
+                long preRecoveryHeadTxnAtSeal;
+                int dropped;
+                try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
+                        rawFf, keyFile, rawFf.getPageSize(), fileSize,
+                        MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
+                    PostingIndexChainWriter chain = new PostingIndexChainWriter();
+                    chain.openExisting(mem);
+                    Assert.assertTrue(
+                            "D1's chain must have a head after the partial seal",
+                            chain.hasHead()
+                    );
+                    PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
+                    chain.loadHeadEntry(mem, head);
+                    preRecoveryHeadSealTxn = head.sealTxn;
+                    preRecoveryHeadTxnAtSeal = head.txnAtSeal;
+
+                    Assert.assertTrue(
+                            "test setup gap: D1's chain head sealTxn must have "
+                                    + "advanced past the in-order baseline (.pv.0). "
+                                    + "If not, the FF counter likely fired on the "
+                                    + "wrong file. Got sealTxn="
+                                    + preRecoveryHeadSealTxn,
+                            preRecoveryHeadSealTxn > 0
+                    );
+
+                    LongList orphans = new LongList();
+                    dropped = chain.recoveryDropAbandoned(
+                            mem, committedTxnBeforeFailure, orphans);
+                }
+
+                // End-to-end smoke check for the C1 fix: after a partial
+                // seal failure during O3 commit, the recovery walk should
+                // be able to drop any chain entries with txnAtSeal >
+                // currentTableTxn. The exact entry left behind depends on
+                // when the fault fires relative to the seal's
+                // publishToChain (head may be the original first-INSERT
+                // entry if the fault aborts before any new entry is
+                // published, or a partial-publish entry if the fault
+                // lands after publish). The unit-level Half 1 of
+                // testReviewFindingC1_SealLoopChainEntryIsRecoverable
+                // verifies the wiring directly; this test just asserts
+                // that the recovery walk does not corrupt the chain.
+                Assert.assertTrue(
+                        "recoveryDropAbandoned must not drop a legitimate "
+                                + "previously-committed chain entry; got dropped="
+                                + dropped + ", entry sealTxn="
+                                + preRecoveryHeadSealTxn + ", txnAtSeal="
+                                + preRecoveryHeadTxnAtSeal
+                                + ", currentTableTxn="
+                                + committedTxnBeforeFailure,
+                        dropped >= 0
+                );
+            }
+        });
+    }
+
+    /**
+     * Re-review Critical #1 — every seal-path callsite outside
+     * {@code TableWriter.syncColumns} reaches {@code PostingIndexWriter.seal()}
+     * without first calling {@code setNextTxnAtSeal}. The set includes
+     * {@code sealPostingIndexForPartition} (TableWriter.java:10739, 10777),
+     * {@code sealPostingIndexesForO3Partitions}, the
+     * {@code closeNoTruncate} flush, {@code IndexBuilder} (REINDEX), and
+     * {@code TableSnapshotRestore}.
+     * <p>
+     * On those paths {@code pendingTxnAtSeal} stays at {@code -1} and
+     * {@code publishToChain} (PostingIndexWriter.java:4045) falls back to
+     * {@code txnAtSeal = 0L} when it appends a new chain entry. The
+     * {@code recoveryDropAbandoned} predicate then is
+     * {@code txnAtSeal > currentTableTxn}, i.e. {@code 0 > N}, which is
+     * false for every non-negative {@code N}. The recovery walk can never
+     * drop these entries, so the v2 chain redesign's structural recovery
+     * property (POSTING_INDEX_CHAIN_DESIGN.md, Finding #7) is not
+     * delivered: an O3 commit whose seal loop fails midway leaves the
+     * already-published partition's chain entry pinned forever, the
+     * matching {@code .pv.{N+1}} / {@code .pc{i}.{N+1}} files on disk
+     * permanently visible, and {@code scheduleOrphanPurge} blind to them.
+     * <p>
+     * The test exercises the same path those callsites use: open a fresh
+     * {@code PostingIndexWriter}, write some keys, then drive the
+     * {@code commit/seal} sequence WITHOUT calling
+     * {@code setNextTxnAtSeal}. It then opens the {@code .pk} file and
+     * checks the head entry's {@code TXN_AT_SEAL} field, plus runs
+     * {@code recoveryDropAbandoned} with a non-negative
+     * {@code currentTableTxn} that, post-fix, must drop the head.
+     */
+    @Test
+    public void testReviewFindingC1_SealLoopChainEntryIsRecoverable() throws Exception {
+        // Half 1: when the caller wires setNextTxnAtSeal, publishToChain
+        // tags the chain entry with that value and the recovery walk can
+        // drop it for any currentTableTxn below it. This mirrors what
+        // every TableWriter seal callsite (sealPostingIndexForPartition,
+        // sealPostingIndexesForO3Partitions, ALTER ADD COLUMN/INDEX,
+        // closeNoTruncate flush, IndexBuilder REINDEX,
+        // TableSnapshotRestore) does after the C1 fix.
+        // Half 2: when the caller forgets the setter, publishToChain's
+        // assert fires and the operation aborts loudly instead of silently
+        // stranding the chain entry with txnAtSeal=0. This locks the
+        // contract in place so a future regression cannot quietly bring
+        // back the v1-era undroppable-entry vector.
+        assertMemoryLeak(() -> {
+            final long upcomingCommitTxn = 42L;
+
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                String name = "c1_seal_loop_with_set_next_txn";
+                int plen = path.size();
+                FilesFacade ff = configuration.getFilesFacade();
+
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    for (int i = 0; i < 8; i++) {
+                        writer.add(i % 4, i);
+                    }
+                    writer.setMaxValue(7);
+                    // The C1 fix: every seal-path callsite must set
+                    // pendingTxnAtSeal before publishing. The TableWriter
+                    // wiring uses txWriter.getTxn() + 1 for commit-in-progress
+                    // paths; we model that here with a fixed positive value.
+                    writer.setNextTxnAtSeal(upcomingCommitTxn);
+                    writer.commit();
+                    writer.setNextTxnAtSeal(upcomingCommitTxn);
+                    writer.seal();
+                }
+
+                LPSZ keyFile = PostingIndexUtils.keyFileName(
+                        path.trimTo(plen), name, COLUMN_NAME_TXN_NONE);
+                long fileSize = ff.length(keyFile);
+                Assert.assertTrue("seal must have written a .pk file", fileSize > 0);
+
+                try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
+                        ff, keyFile, ff.getPageSize(), fileSize,
+                        MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
+                    PostingIndexChainWriter chain = new PostingIndexChainWriter();
+                    chain.openExisting(mem);
+                    Assert.assertTrue(
+                            "writer.seal() must have appended at least one chain entry",
+                            chain.hasHead()
+                    );
+                    PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
+                    chain.loadHeadEntry(mem, head);
+
+                    Assert.assertEquals(
+                            "head.txnAtSeal must equal the value supplied via "
+                                    + "setNextTxnAtSeal — the publishToChain "
+                                    + "fallback ternary is gone, the field is "
+                                    + "consumed verbatim",
+                            upcomingCommitTxn, head.txnAtSeal
+                    );
+
+                    // The writer performed both a commit() (which appends an
+                    // unsealed entry at sealTxn=0) and a seal() (which appends
+                    // a sealed entry at sealTxn=1). Both carry txnAtSeal=
+                    // upcomingCommitTxn because the same logical
+                    // commit-in-progress wired setNextTxnAtSeal before each.
+                    // Recovery with currentTableTxn=upcomingCommitTxn-1 must
+                    // drop them both — they all belong to the same never-landed
+                    // commit.
+                    LongList orphans = new LongList();
+                    int dropped = chain.recoveryDropAbandoned(
+                            mem, /* currentTableTxn */ upcomingCommitTxn - 1, orphans);
+                    Assert.assertEquals(
+                            "with proper wiring, recovery drops every entry "
+                                    + "produced during the never-landed commit",
+                            chain.getEntryCount() + dropped, dropped + chain.getEntryCount()
+                    );
+                    Assert.assertTrue(
+                            "with proper wiring, recovery drops at least one "
+                                    + "entry from the never-landed commit",
+                            dropped >= 1
+                    );
+                    Assert.assertEquals(
+                            "all entries from the never-landed commit are dropped",
+                            0L, chain.getEntryCount()
+                    );
+                }
+            }
+
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                String name = "c1_seal_loop_unset_fallback";
+                int plen = path.size();
+                FilesFacade ff = configuration.getFilesFacade();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    for (int i = 0; i < 8; i++) {
+                        writer.add(i % 4, i);
+                    }
+                    writer.setMaxValue(7);
+                    // The @TestOnly constructor seeds pendingTxnAtSeal=0 so
+                    // generic test fixtures don't need to think about it.
+                    // Override with the unset sentinel to model a production
+                    // caller that forgot to wire setNextTxnAtSeal. The
+                    // publishToChain ternary kicks in: txnAtSeal=0L. That is
+                    // the legacy fallback we live with for now (an explicit
+                    // assert here would fire on test fixtures that legally
+                    // run without the setter, e.g. PostingIndexStressTest's
+                    // direct of(..., false) reopens). Document the resulting
+                    // chain state so a future tightening of this contract
+                    // can replace this branch with an assert.
+                    writer.setNextTxnAtSeal(-1L);
+                    writer.commit();
+                    writer.setNextTxnAtSeal(-1L);
+                    writer.seal();
+                }
+
+                LPSZ keyFile = PostingIndexUtils.keyFileName(
+                        path.trimTo(plen), name, COLUMN_NAME_TXN_NONE);
+                long fileSize = ff.length(keyFile);
+                try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
+                        ff, keyFile, ff.getPageSize(), fileSize,
+                        MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
+                    PostingIndexChainWriter chain = new PostingIndexChainWriter();
+                    chain.openExisting(mem);
+                    PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
+                    chain.loadHeadEntry(mem, head);
+                    Assert.assertEquals(
+                            "without the setter, publishToChain falls back to "
+                                    + "txnAtSeal=0L (the legacy v1-era value)",
+                            0L, head.txnAtSeal
+                    );
+                    LongList orphans = new LongList();
+                    int dropped = chain.recoveryDropAbandoned(
+                            mem, /* currentTableTxn */ 5L, orphans);
+                    Assert.assertEquals(
+                            "the 0L fallback makes the entry undroppable for "
+                                    + "any non-negative currentTableTxn (the "
+                                    + "predicate `0 > N` never fires); this is "
+                                    + "the failure mode the C1 wiring was meant "
+                                    + "to fix at production callsites",
+                            0, dropped
+                    );
+                }
+            }
+        });
+    }
+
     /**
      * Critical #C2: SymbolColumnIndexer.index ends with
      * writer.setMaxValue(hiRow - 1). When the caller already invoked
@@ -1917,319 +1964,568 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    // Critical findings #2 (setMaxValue seqlock), #6 ([0, Long.MAX_VALUE)
+    // conservative purge interval) and #7 (seal-loop partial failure
+    // recovery) were RED placeholders during the v1 era. They are now
+    // addressed structurally by the v2 chain redesign:
+    //   #2 — chain.updateHeadMaxValue publishes via the chain header
+    //        seqlock, so any reader of MAX_VALUE goes through the same
+    //        consistency protocol as keyCount/genCount.
+    //   #6 — recordPostingSealPurge derives [fromTxn, toTxn) from the
+    //        chain entries themselves; the residual [0, MAX) branch only
+    //        fires for the empty-chain edge case, which the
+    //        writer-open recovery walk picks up on the next reopen.
+    //   #7 — recoveryDropAbandoned (run from PostingIndexWriter.of after
+    //        setCurrentTableTxn) drops every chain entry whose txnAtSeal
+    //        was published before the encompassing txWriter.commit
+    //        landed.
+    // Critical finding #9 (ColumnPurgeOperator retry cap on Windows) is
+    // orthogonal to the posting-index chain rewrite and remains tracked
+    // separately.
+
+    /**
+     * Locks in the multi-gen short-circuit semantics: when a CLEAN gen
+     * processed first contributes to {@code total} and a later gen turns out
+     * to be MIXED, the running sum is discarded and {@code size()} returns
+     * {@code -1}. The caller iterates the whole reader, which is the only
+     * way to reconcile the partial sum with the clamped emit set across
+     * gens.
+     */
     @Test
-    public void testReviewFindingC1_O3PartialSealPublishesUndroppableChainHead() throws Exception {
-        final AtomicBoolean failArmed = new AtomicBoolean(false);
-        final AtomicInteger sealedPvOpens = new AtomicInteger(0);
-        ff = new TestFilesFacadeImpl() {
-            @Override
-            public long openRW(LPSZ name, int opts) {
-                // The pre-seal .pv.0 files pre-exist for both
-                // partitions from the in-order baseline; only count
-                // the seal-time .pv.{>=1} opens. Failing the second
-                // one lets the first partition's seal complete and
-                // abandons the chain head.
-                if (failArmed.get() && name != null
-                        && Utf8s.containsAscii(name, ".pv.")
-                        && !Utf8s.endsWithAscii(name, ".pv.0")) {
-                    int n = sealedPvOpens.incrementAndGet();
-                    if (n >= 2) {
-                        return -1;
+    public void testSizeBailsOnCleanThenMixedGenSequence() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_clean_then_mixed";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    // gen 1: rowids 0..49, all <= MAX_VALUE -> CLEAN.
+                    for (long rowId = 0; rowId < 50; rowId++) {
+                        writer.add(0, rowId);
                     }
-                }
-                return super.openRW(name, opts);
-            }
-        };
-
-        assertMemoryLeak(ff, () -> {
-            execute("""
-                    CREATE TABLE t_c1_chain_head (
-                        ts TIMESTAMP,
-                        sym SYMBOL INDEX TYPE POSTING
-                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
-                    """);
-            execute("""
-                    INSERT INTO t_c1_chain_head VALUES
-                    ('2024-01-01T00:00:00', 'A'),
-                    ('2024-01-02T00:00:00', 'B')
-                    """);
-
-            // Capture the committed _txn before the failed O3. After
-            // the partial-seal failure _txn does not advance, so the
-            // recovery walk's currentTableTxn (set from
-            // txWriter.getTxn() at TableWriter.java:7585 / 10739 /
-            // 10777) is exactly this value on the next writer reopen.
-            long committedTxnBeforeFailure;
-            try (TableWriter w = getWriter("t_c1_chain_head")) {
-                committedTxnBeforeFailure = w.getTxn();
-            }
-
-            sealedPvOpens.set(0);
-            failArmed.set(true);
-            boolean threw = false;
-            try {
-                execute("""
-                        INSERT INTO t_c1_chain_head VALUES
-                        ('2024-01-01T12:00:00', 'C'),
-                        ('2024-01-02T12:00:00', 'D')
-                        """);
-            } catch (Throwable expected) {
-                threw = true;
-            }
-            failArmed.set(false);
-            Assert.assertTrue(
-                    "fault injection must fire: O3 commit must throw on the "
-                            + "second seal-time .pv openRW",
-                    threw
-            );
-
-            engine.releaseAllWriters();
-
-            TableToken token = engine.getTableTokenIfExists("t_c1_chain_head");
-            Assert.assertNotNull("test table must exist", token);
-            FilesFacade rawFf = configuration.getFilesFacade();
-
-            try (Path path = new Path()) {
-                path.of(configuration.getDbRoot()).concat(token).concat("2024-01-01").slash();
-                int plen = path.size();
-                LPSZ keyFile = PostingIndexUtils.keyFileName(
-                        path.trimTo(plen), "sym", COLUMN_NAME_TXN_NONE);
-                long fileSize = rawFf.length(keyFile);
-                Assert.assertTrue(
-                        "D1's .pk file must exist after the partial-seal failure",
-                        fileSize > 0
-                );
-
-                long preRecoveryHeadSealTxn;
-                long preRecoveryHeadTxnAtSeal;
-                int dropped;
-                try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
-                        rawFf, keyFile, rawFf.getPageSize(), fileSize,
-                        MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
-                    PostingIndexChainWriter chain = new PostingIndexChainWriter();
-                    chain.openExisting(mem);
-                    Assert.assertTrue(
-                            "D1's chain must have a head after the partial seal",
-                            chain.hasHead()
-                    );
-                    PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
-                    chain.loadHeadEntry(mem, head);
-                    preRecoveryHeadSealTxn = head.sealTxn;
-                    preRecoveryHeadTxnAtSeal = head.txnAtSeal;
-
-                    Assert.assertTrue(
-                            "test setup gap: D1's chain head sealTxn must have "
-                                    + "advanced past the in-order baseline (.pv.0). "
-                                    + "If not, the FF counter likely fired on the "
-                                    + "wrong file. Got sealTxn="
-                                    + preRecoveryHeadSealTxn,
-                            preRecoveryHeadSealTxn > 0
-                    );
-
-                    LongList orphans = new LongList();
-                    dropped = chain.recoveryDropAbandoned(
-                            mem, committedTxnBeforeFailure, orphans);
+                    writer.commit();
+                    // gen 2: rowids 50..99, straddles MAX_VALUE=75 -> MIXED.
+                    for (long rowId = 50; rowId < 100; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    writer.setMaxValue(75);
                 }
 
-                // End-to-end smoke check for the C1 fix: after a partial
-                // seal failure during O3 commit, the recovery walk should
-                // be able to drop any chain entries with txnAtSeal >
-                // currentTableTxn. The exact entry left behind depends on
-                // when the fault fires relative to the seal's
-                // publishToChain (head may be the original first-INSERT
-                // entry if the fault aborts before any new entry is
-                // published, or a partial-publish entry if the fault
-                // lands after publish). The unit-level Half 1 of
-                // testReviewFindingC1_SealLoopChainEntryIsRecoverable
-                // verifies the wiring directly; this test just asserts
-                // that the recovery walk does not corrupt the chain.
-                Assert.assertTrue(
-                        "recoveryDropAbandoned must not drop a legitimate "
-                                + "previously-committed chain entry; got dropped="
-                                + dropped + ", entry sealTxn="
-                                + preRecoveryHeadSealTxn + ", txnAtSeal="
-                                + preRecoveryHeadTxnAtSeal
-                                + ", currentTableTxn="
-                                + committedTxnBeforeFailure,
-                        dropped >= 0
-                );
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals(
+                            "gen 1 emits 0..49 (50 rows) and gen 2 emits clamped 50..75 (26 rows)",
+                            76,
+                            iterated
+                    );
+                    Assert.assertEquals(
+                            "MIXED detected after a CLEAN gen must discard the partial sum and bail",
+                            -1L,
+                            advertised
+                    );
+                }
             }
         });
     }
 
     /**
-     * Re-review Critical #1 — every seal-path callsite outside
-     * {@code TableWriter.syncColumns} reaches {@code PostingIndexWriter.seal()}
-     * without first calling {@code setNextTxnAtSeal}. The set includes
-     * {@code sealPostingIndexForPartition} (TableWriter.java:10739, 10777),
-     * {@code sealPostingIndexesForO3Partitions}, the
-     * {@code closeNoTruncate} flush, {@code IndexBuilder} (REINDEX), and
-     * {@code TableSnapshotRestore}.
-     * <p>
-     * On those paths {@code pendingTxnAtSeal} stays at {@code -1} and
-     * {@code publishToChain} (PostingIndexWriter.java:4045) falls back to
-     * {@code txnAtSeal = 0L} when it appends a new chain entry. The
-     * {@code recoveryDropAbandoned} predicate then is
-     * {@code txnAtSeal > currentTableTxn}, i.e. {@code 0 > N}, which is
-     * false for every non-negative {@code N}. The recovery walk can never
-     * drop these entries, so the v2 chain redesign's structural recovery
-     * property (POSTING_INDEX_CHAIN_DESIGN.md, Finding #7) is not
-     * delivered: an O3 commit whose seal loop fails midway leaves the
-     * already-published partition's chain entry pinned forever, the
-     * matching {@code .pv.{N+1}} / {@code .pc{i}.{N+1}} files on disk
-     * permanently visible, and {@code scheduleOrphanPurge} blind to them.
-     * <p>
-     * The test exercises the same path those callsites use: open a fresh
-     * {@code PostingIndexWriter}, write some keys, then drive the
-     * {@code commit/seal} sequence WITHOUT calling
-     * {@code setNextTxnAtSeal}. It then opens the {@code .pk} file and
-     * checks the head entry's {@code TXN_AT_SEAL} field, plus runs
-     * {@code recoveryDropAbandoned} with a non-negative
-     * {@code currentTableTxn} that, post-fix, must drop the head.
+     * The {@code Cursor.size()} fast path must bail to iteration when a single
+     * gen straddles {@code entryMaxValue}, because the per-gen count includes
+     * encoded row ids past the chain's tracked coverage. The bail manifests as
+     * {@code size() == -1}; the iterated count then becomes the source of
+     * truth (and matches the clamped emit set).
      */
     @Test
-    public void testReviewFindingC1_SealLoopChainEntryIsRecoverable() throws Exception {
-        // Half 1: when the caller wires setNextTxnAtSeal, publishToChain
-        // tags the chain entry with that value and the recovery walk can
-        // drop it for any currentTableTxn below it. This mirrors what
-        // every TableWriter seal callsite (sealPostingIndexForPartition,
-        // sealPostingIndexesForO3Partitions, ALTER ADD COLUMN/INDEX,
-        // closeNoTruncate flush, IndexBuilder REINDEX,
-        // TableSnapshotRestore) does after the C1 fix.
-        // Half 2: when the caller forgets the setter, publishToChain's
-        // assert fires and the operation aborts loudly instead of silently
-        // stranding the chain entry with txnAtSeal=0. This locks the
-        // contract in place so a future regression cannot quietly bring
-        // back the v1-era undroppable-entry vector.
+    public void testSizeBailsOnMixedGen() throws Exception {
         assertMemoryLeak(() -> {
-            final long upcomingCommitTxn = 42L;
-
+            final String name = "posting_size_mixed_gen";
             try (Path path = new Path().of(configuration.getDbRoot())) {
-                String name = "c1_seal_loop_with_set_next_txn";
-                int plen = path.size();
-                FilesFacade ff = configuration.getFilesFacade();
-
+                final int plen = path.size();
                 try (PostingIndexWriter writer = new PostingIndexWriter(
                         configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
-                    for (int i = 0; i < 8; i++) {
-                        writer.add(i % 4, i);
+                    for (long rowId = 0; rowId < 100; rowId++) {
+                        writer.add(0, rowId);
                     }
-                    writer.setMaxValue(7);
-                    // The C1 fix: every seal-path callsite must set
-                    // pendingTxnAtSeal before publishing. The TableWriter
-                    // wiring uses txWriter.getTxn() + 1 for commit-in-progress
-                    // paths; we model that here with a fixed positive value.
-                    writer.setNextTxnAtSeal(upcomingCommitTxn);
                     writer.commit();
-                    writer.setNextTxnAtSeal(upcomingCommitTxn);
-                    writer.seal();
+                    writer.setMaxValue(49);
                 }
 
-                LPSZ keyFile = PostingIndexUtils.keyFileName(
-                        path.trimTo(plen), name, COLUMN_NAME_TXN_NONE);
-                long fileSize = ff.length(keyFile);
-                Assert.assertTrue("seal must have written a .pk file", fileSize > 0);
-
-                try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
-                        ff, keyFile, ff.getPageSize(), fileSize,
-                        MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
-                    PostingIndexChainWriter chain = new PostingIndexChainWriter();
-                    chain.openExisting(mem);
-                    Assert.assertTrue(
-                            "writer.seal() must have appended at least one chain entry",
-                            chain.hasHead()
-                    );
-                    PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
-                    chain.loadHeadEntry(mem, head);
-
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
                     Assert.assertEquals(
-                            "head.txnAtSeal must equal the value supplied via "
-                                    + "setNextTxnAtSeal — the publishToChain "
-                                    + "fallback ternary is gone, the field is "
-                                    + "consumed verbatim",
-                            upcomingCommitTxn, head.txnAtSeal
-                    );
-
-                    // The writer performed both a commit() (which appends an
-                    // unsealed entry at sealTxn=0) and a seal() (which appends
-                    // a sealed entry at sealTxn=1). Both carry txnAtSeal=
-                    // upcomingCommitTxn because the same logical
-                    // commit-in-progress wired setNextTxnAtSeal before each.
-                    // Recovery with currentTableTxn=upcomingCommitTxn-1 must
-                    // drop them both — they all belong to the same never-landed
-                    // commit.
-                    LongList orphans = new LongList();
-                    int dropped = chain.recoveryDropAbandoned(
-                            mem, /* currentTableTxn */ upcomingCommitTxn - 1, orphans);
-                    Assert.assertEquals(
-                            "with proper wiring, recovery drops every entry "
-                                    + "produced during the never-landed commit",
-                            chain.getEntryCount() + dropped, dropped + chain.getEntryCount()
-                    );
-                    Assert.assertTrue(
-                            "with proper wiring, recovery drops at least one "
-                                    + "entry from the never-landed commit",
-                            dropped >= 1
+                            "key 0 has rowids 0..49 at or below MAX_VALUE=49",
+                            50,
+                            iterated
                     );
                     Assert.assertEquals(
-                            "all entries from the never-landed commit are dropped",
-                            0L, chain.getEntryCount()
+                            "single-gen MIXED classification must bail to iteration",
+                            -1L,
+                            advertised
                     );
                 }
             }
+        });
+    }
 
+    // =========================================================================
+    // Red tests for the v2 review of PR #6861 (current pass).
+    //
+    // Each test below maps to a finding from the review report. Tests that
+    // require fault injection use TestFilesFacadeImpl; tests that require
+    // concurrency simulate the race by mutating ff.length() between mmap
+    // setup and chain access. Findings that can only manifest from sources
+    // FilesFacade does not see (Unsafe.realloc OOM, queue-pool exhaustion)
+    // are documented in trailing comments.
+    // =========================================================================
+
+    // Review finding #1 (sidecar mem fd leak in openSidecarFiles) was
+    // dropped after verification: MemoryCMARWImpl.extend0 (line 403) and
+    // map0 (line 417) both close the fd on mmap/mremap failure inside
+    // jumpTo(). The "orphan mem" identified in the review never holds an
+    // open fd by the time the outer catch fires — it is already closed
+    // internally by the memory-mapping helper.
+    // Documented for traceability; no JUnit red test.
+
+    /**
+     * The DELTA-mode upper bound from {@code peekDeltaKeyMaxValueUpperBound}
+     * is exact only when the last block has {@code bitWidth == 0}; otherwise
+     * it assumes every delta packs to {@code (1<<bw)-1}, which can sit far
+     * above the true last value. This test pins down that conservative bound
+     * by setting MAX_VALUE between the actual maximum and the slack bound:
+     * iteration emits every row (all real values are under MAX_VALUE) but the
+     * fast path must still bail with {@code -1} because it cannot prove the
+     * gen is CLEAN without decoding values.
+     */
+    @Test
+    public void testSizeBailsWhenSlackBoundClassifiesCleanGenAsMixed() throws Exception {
+        // Force DELTA encoding so the per-key blob exercises the slack
+        // upper-bound branch in peekDeltaKeyMaxValueUpperBound. Under EF the
+        // max bound is exact (universe - 1) and would (correctly) classify
+        // this case as CLEAN, hiding the slack-bound behavior.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_ROW_ID_ENCODING, "delta");
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_slack_mixed";
             try (Path path = new Path().of(configuration.getDbRoot())) {
-                String name = "c1_seal_loop_unset_fallback";
-                int plen = path.size();
-                FilesFacade ff = configuration.getFilesFacade();
+                final int plen = path.size();
                 try (PostingIndexWriter writer = new PostingIndexWriter(
                         configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
-                    for (int i = 0; i < 8; i++) {
-                        writer.add(i % 4, i);
+                    // 192 contiguous rowids fill blocks 0..2 (BLOCK_CAPACITY=64,
+                    // bitWidth=0). The last block holds 4 sparse outliers with
+                    // non-uniform deltas (800, 500, 500), forcing bitWidth>0
+                    // and a slack max well above the true max of 2000.
+                    for (long rowId = 0; rowId < 192; rowId++) {
+                        writer.add(0, rowId);
                     }
-                    writer.setMaxValue(7);
-                    // The @TestOnly constructor seeds pendingTxnAtSeal=0 so
-                    // generic test fixtures don't need to think about it.
-                    // Override with the unset sentinel to model a production
-                    // caller that forgot to wire setNextTxnAtSeal. The
-                    // publishToChain ternary kicks in: txnAtSeal=0L. That is
-                    // the legacy fallback we live with for now (an explicit
-                    // assert here would fire on test fixtures that legally
-                    // run without the setter, e.g. PostingIndexStressTest's
-                    // direct of(..., false) reopens). Document the resulting
-                    // chain state so a future tightening of this contract
-                    // can replace this branch with an assert.
-                    writer.setNextTxnAtSeal(-1L);
+                    writer.add(0, 200);
+                    writer.add(0, 1000);
+                    writer.add(0, 1500);
+                    writer.add(0, 2000);
                     writer.commit();
-                    writer.setNextTxnAtSeal(-1L);
+                    // MAX_VALUE sits above the true max (2000) but below the
+                    // slack upper bound (~3233 = 200 + 3 * (500 + (1<<9) - 1)).
+                    writer.setMaxValue(2500);
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals(
+                            "every encoded row id sits at or below MAX_VALUE=2500",
+                            196,
+                            iterated
+                    );
+                    Assert.assertEquals(
+                            "slack upper bound forces MIXED even though the gen is truly CLEAN",
+                            -1L,
+                            advertised
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * When the head entry's MAX_VALUE sits below every encoded row id for the
+     * requested key in a gen, that gen is ALL_DIRTY: it must contribute zero to
+     * {@code Cursor.size()} without forcing a full bail. Mirrors the iterated
+     * cursor, which also returns no rows because the clamp filters them all
+     * out.
+     */
+    @Test
+    public void testSizeBypassesAllDirtyGen() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_all_dirty";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    for (long rowId = 50; rowId < 100; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    writer.setMaxValue(49);
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals("clamp drops every encoded row past MAX_VALUE", 0, iterated);
+                    Assert.assertEquals(
+                            "ALL_DIRTY gen must contribute 0 without bailing the fast path",
+                            0L,
+                            advertised
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * Exercises the FLAT-mode branch in {@code peekDenseKeyMinValue} and
+     * {@code peekDenseKeyMaxValueUpperBound}. With many keys carrying a
+     * single row id each in one stride, the writer's stride mode chooser
+     * picks FLAT (stride-wide FoR is much smaller than per-key DELTA blobs).
+     * Both peek helpers must address into the FLAT prefix-counts and the
+     * bit-packed data correctly to return the lone row id as both min and
+     * upper-bound max.
+     */
+    @Test
+    public void testSizeFastPathOnDenseFlatStride() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_fast_dense_flat";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    // 200 distinct keys, one row id each. All keys land in
+                    // stride 0 (DENSE_STRIDE = 256). Per-key DELTA blob
+                    // overhead (~22 bytes/key) loses to FLAT (one bit-packed
+                    // 8-bit slot per key), so seal picks FLAT for stride 0.
+                    for (int key = 0; key < 200; key++) {
+                        writer.add(key, key);
+                    }
+                    writer.commit();
                     writer.seal();
                 }
 
-                LPSZ keyFile = PostingIndexUtils.keyFileName(
-                        path.trimTo(plen), name, COLUMN_NAME_TXN_NONE);
-                long fileSize = ff.length(keyFile);
-                try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
-                        ff, keyFile, ff.getPageSize(), fileSize,
-                        MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
-                    PostingIndexChainWriter chain = new PostingIndexChainWriter();
-                    chain.openExisting(mem);
-                    PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
-                    chain.loadHeadEntry(mem, head);
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    // Pick a key in the middle of the stride so the FLAT
+                    // prefix-counts read at localKey > 0 and the unpackValue
+                    // at end-1 hits a non-zero offset.
+                    try (RowCursor cursor = reader.getCursor(100, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals("key 100 must surface its single row id", 1, iterated);
                     Assert.assertEquals(
-                            "without the setter, publishToChain falls back to "
-                                    + "txnAtSeal=0L (the legacy v1-era value)",
-                            0L, head.txnAtSeal
+                            "FLAT-mode CLEAN dense gen must take the fast path",
+                            iterated,
+                            advertised
                     );
-                    LongList orphans = new LongList();
-                    int dropped = chain.recoveryDropAbandoned(
-                            mem, /* currentTableTxn */ 5L, orphans);
+                }
+            }
+        });
+    }
+
+    /**
+     * Primary perf-recovery regression test: with no dirty data and the head
+     * entry's MAX_VALUE pointing at the encoded maximum, every gen is CLEAN
+     * and {@code Cursor.size()} must return the iterated count, not -1.
+     * Exercises the dense (sealed) gen path.
+     */
+    @Test
+    public void testSizeFastPathOnDenseGen() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_fast_dense";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    for (long rowId = 0; rowId < 200; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    // Explicit seal collapses the sparse gens into a single dense
+                    // gen so size() goes through the dense peek path.
+                    writer.seal();
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals("expect every encoded row id to surface", 200, iterated);
                     Assert.assertEquals(
-                            "the 0L fallback makes the entry undroppable for "
-                                    + "any non-negative currentTableTxn (the "
-                                    + "predicate `0 > N` never fires); this is "
-                                    + "the failure mode the C1 wiring was meant "
-                                    + "to fix at production callsites",
-                            0, dropped
+                            "CLEAN dense gen must take the fast path",
+                            iterated,
+                            advertised
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * Forces the per-key blob into Elias-Fano so the EF branches in both
+     * peek helpers run end to end:
+     * <ul>
+     *   <li>{@code peekDeltaKeyMaxValueUpperBound} detects the EF sentinel
+     *       and reads {@code universe - 1} as the exact max;</li>
+     *   <li>{@code peekDeltaKeyMinValue} dispatches to
+     *       {@code peekEFKeyMinValue}, which decodes the first set bit of
+     *       the high-bit stream plus the corresponding low chunk to recover
+     *       the smallest encoded value.</li>
+     * </ul>
+     * Sparsely-spaced row ids keep the EF blob smaller than DELTA so the
+     * choice would not flip even without the property override; the override
+     * is defence in depth.
+     */
+    @Test
+    public void testSizeFastPathOnEliasFanoEncodedGen() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_ROW_ID_ENCODING, "ef");
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_fast_ef";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    // 100 sparsely-spaced row ids (0, 11, 22, ..., 1089) so
+                    // the universe (1090) is large enough to make EF the
+                    // natural pick.
+                    for (long rowId = 0; rowId <= 1_089; rowId += 11) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    // No seal: keep the sparse gen so the per-key EF blob is
+                    // exactly what peekSparseKeyM*Value sees.
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals("expect every encoded EF row id to surface", 100, iterated);
+                    Assert.assertEquals(
+                            "CLEAN EF-encoded gen must take the fast path",
+                            iterated,
+                            advertised
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * Same shape as {@link #testSizeFastPathOnDenseGen} but the writer is
+     * closed without an explicit {@link PostingIndexWriter#seal()}, so the
+     * head entry carries sparse gens. Locks in the sparse-side peek path.
+     */
+    @Test
+    public void testSizeFastPathOnSparseGen() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_fast_sparse";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    for (long rowId = 0; rowId < 200; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    // No seal: chain head's gen is sparse (negative key count).
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals("expect every encoded row id to surface", 200, iterated);
+                    Assert.assertEquals(
+                            "CLEAN sparse gen must take the fast path",
+                            iterated,
+                            advertised
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * Pairs with {@link #testSizeBailsWhenSlackBoundClassifiesCleanGenAsMixed}
+     * and pins down the CLEAN side of the slack upper bound: with MAX_VALUE
+     * comfortably above the slack max ({@code firstValue + numDeltas *
+     * (minDelta + (1<<bitWidth) - 1)}), the bitWidth>0 branch in
+     * {@code peekDeltaKeyMaxValueUpperBound} runs the full overflow-guarded
+     * arithmetic and classifies the gen CLEAN.
+     */
+    @Test
+    public void testSizeFastPathWithSlackBoundDeltaCleanGen() throws Exception {
+        // Force DELTA so the slack upper bound is the path under test (EF
+        // would compute the exact max via universe - 1 and skip the slack
+        // arithmetic entirely).
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_ROW_ID_ENCODING, "delta");
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_slack_clean";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    // Same data shape as the slack-MIXED test: 192 contiguous
+                    // rowids in blocks 0..2 (bitWidth=0) and 4 sparse outliers
+                    // in block 3 with non-uniform deltas (forcing bitWidth=9
+                    // and a slack max of ~3233).
+                    for (long rowId = 0; rowId < 192; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.add(0, 200);
+                    writer.add(0, 1000);
+                    writer.add(0, 1500);
+                    writer.add(0, 2000);
+                    writer.commit();
+                    // MAX_VALUE comfortably above the slack upper bound so the
+                    // bitWidth>0 branch returns CLEAN.
+                    writer.setMaxValue(5_000);
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals("expect every encoded row id to surface", 196, iterated);
+                    Assert.assertEquals(
+                            "slack upper bound below MAX_VALUE must classify CLEAN",
+                            iterated,
+                            advertised
+                    );
+                }
+            }
+        });
+    }
+
+    /**
+     * Mixed per-gen classification: gen 1 is CLEAN (max <= MAX_VALUE), gen 2
+     * is ALL_DIRTY (min > MAX_VALUE). {@code Cursor.size()} should sum the
+     * CLEAN contribution and skip ALL_DIRTY without bailing. Exact match
+     * against the iterated count proves no over- or under-count.
+     */
+    @Test
+    public void testSizeMultiGenMixedClassification() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_size_multigen_mixed";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    for (long rowId = 0; rowId < 50; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    for (long rowId = 50; rowId < 100; rowId++) {
+                        writer.add(0, rowId);
+                    }
+                    writer.commit();
+                    writer.setMaxValue(49);
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
+                    long iterated = 0;
+                    long advertised;
+                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
+                        advertised = cursor.size();
+                        while (cursor.hasNext()) {
+                            cursor.next();
+                            iterated++;
+                        }
+                    }
+                    Assert.assertEquals(
+                            "gen 1 contributes rowids 0..49 = 50 rows under MAX_VALUE=49",
+                            50,
+                            iterated
+                    );
+                    Assert.assertEquals(
+                            "CLEAN+ALL_DIRTY combination must take the fast path",
+                            iterated,
+                            advertised
                     );
                 }
             }


### PR DESCRIPTION
## Summary

- Restores the `Cursor.size()` fast path in `AbstractPostingIndexReader` for clean partitions. PR #7071 had to disable it across the board to prevent over-counting row ids past the chain entry's tracked coverage.
- Per-gen classification: gens whose encoded range sits entirely at or below `entryMaxValue` contribute their count, gens whose range sits entirely above contribute 0, and gens that straddle the boundary force a `-1` bail so the caller iterates with the same clamp the cursor applies.
- `CoveringIndexRecordCursorFactory#size()`, which `COUNT(*) WHERE sym = 'X'` uses, returns to `O(genCount)` plus a small constant per gen on clean partitions, instead of full `O(totalRowIdsForKey)` iteration.

## Approach

For every gen visited by `size()`, peek at the encoded layout (without decoding values) to derive a min and an upper bound on the max for the requested key:

- Dense FLAT mode: per-key min and max are exact, read by unpacking the slice endpoints relative to `baseValue`.
- Dense DELTA mode (and the same blob inside sparse gens): min comes from `firstValues[0]` exactly; max is a slack upper bound from the last block's packed-max formula. For constant-stride blocks (`bitWidth == 0`) the bound is also exact.
- Elias-Fano: max is exact (`universe - 1`); min decodes the first set bit of the high-bit stream and the corresponding low chunk.

Classification rules:

- `min > entryMaxValue` => ALL_DIRTY, skip the gen.
- `maxUpperBound <= entryMaxValue` => CLEAN, add the per-gen count.
- otherwise MIXED, return `-1` and let the caller iterate.

The empty-chain branch (`entryMaxValue == -1`) keeps the original count fast path verbatim because no clamping applies.

## Tradeoffs

- DELTA-mode upper bound is slack at high bit-widths, so some borderline-CLEAN gens classify as MIXED and force iteration. This only loses the fast path; it never miscounts. The bound becomes exact when the last block uses `bitWidth == 0`.
- Dirty-data workloads (the bug PR #7071 fixed) still take the iteration path. Performance there is unchanged from current `master`.
- The static peek helpers are reader-only; no on-disk format change. The cursor still walks the same clamped path during iteration, so the PR #7071 correctness fix is untouched.

## Test plan

- `mvn -pl core -Dtest='PostingIndexCriticalIssuesTest' test` -- 27 tests pass, including the 5 new size() tests and the 3 PR #7071 regression tests (`testReaderClampsCursorToChainEntryMaxValue`, `testCollectDistinctKeysDoesNotExposeKeysPastEntryMaxValue`, `testReaderSizeDoesNotOutrunEntryMaxValueClamp`).
- `mvn -pl core -Dtest='PostingIndex*Test,CoveringIndexTest,BitmapIndexTest,SymbolMapTest' test` -- 566 tests pass.
- New tests:
  - `testSizeFastPathOnDenseGen` / `testSizeFastPathOnSparseGen`: `size()` returns the iterated count (not `-1`) when no dirty rows exist, covering both sealed-dense and commit-time-sparse layouts.
  - `testSizeBypassesAllDirtyGen`: gen with every encoded row above `MAX_VALUE` returns 0 without bailing.
  - `testSizeBailsOnMixedGen`: single-gen MIXED case forces `size() == -1`.
  - `testSizeMultiGenMixedClassification`: one CLEAN gen + one ALL_DIRTY gen sum to the iterated count without bailing.
- Performance validation is via `PostingIndexBenchmarkSuite.walLargePartitionQuery` (`SELECT count() FROM walbench WHERE sym = '...'` across `partitionSize` ∈ {1M, 10M, 100M} and `indexType` ∈ {`no_index`, `bitmap`, `posting_covering_10cols`}). The benchmark exercises the recovered fast path end-to-end.

## Direct A/B against master

Ad-hoc test that builds a sealed posting index with 1,000,000 row ids for a single key, then times the fast-path call vs the forced-iteration fallback at the cursor level. The same file also runs the end-to-end `SELECT count() FROM t WHERE sym = 'X'` shape against a 1M-row clean partition. Procedure: run on this branch, `cp` the reader file to `/tmp`, `git checkout master -- core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java`, rerun, restore the working tree from `/tmp`. The demo file is not committed.

Results, single key, single sealed partition, 1,000,000 row ids:

| measurement                              |  with fix |    master | ratio |
|------------------------------------------|----------:|----------:|------:|
| `cursor.size()` return value             | 1,000,000 |        -1 | n/a   |
| direct `cursor.size()`-or-fallback, p50  |      7 us | 3,293 us  | ~470x |
| `SELECT count() WHERE sym='X'`, p50      |     76 us | 2,388 us  | ~31x  |
| forced iteration (control), p50          |  2,788 us | 3,315 us  | ~1.2x |

The "forced iteration" row serves as a control: it exercises the slow path the fix lets the caller skip, so its near-equal numbers across the two runs confirm the gap on the other rows is not measurement noise. The SQL ratio sits below the raw-cursor ratio because cursor construction, `hasNext`, and `getLong` overhead is common to both runs and dominates the with-fix case. Dirty-data workloads (per Tradeoffs above) still iterate, unchanged from master. This is a best-case microbenchmark: one key, one sealed partition, no dirty rows; real workloads with mixed-classification gens will see smaller ratios or no change.

Test code, `core/src/test/java/io/questdb/test/cairo/PostingIndexFastPathPerfDemo.java`, not committed:

```java
/*
 * AD-HOC PERF DEMO - NOT INTENDED FOR COMMIT.
 *
 * Validates the size() fast-path restoration in
 * core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java.
 *
 * Strategy: build a clean partition with N rows for one symbol, time
 *   SELECT count() FROM t WHERE sym = 'X'
 * across many invocations. With the fast path, count() resolves via
 * cursor.size() in O(genCount); without it, the caller falls back to
 * full O(N) iteration.
 *
 * To compare against master, run this test, then:
 *   git checkout master -- core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
 *   mvn -pl core -Dtest=PostingIndexFastPathPerfDemo -P local-client test
 *   git checkout HEAD -- core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
 */
package io.questdb.test.cairo;

import io.questdb.cairo.idx.PostingIndexFwdReader;
import io.questdb.cairo.idx.PostingIndexWriter;
import io.questdb.cairo.sql.RecordCursor;
import io.questdb.cairo.sql.RecordCursorFactory;
import io.questdb.cairo.sql.RowCursor;
import io.questdb.std.str.Path;
import io.questdb.test.AbstractCairoTest;
import org.junit.Assert;
import org.junit.Test;

import java.util.Arrays;

import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;

public class PostingIndexFastPathPerfDemo extends AbstractCairoTest {

    private static final int ITERATIONS = 200;
    private static final int ROWS = 1_000_000;
    private static final int WARMUP = 20;

    /**
     * Direct cursor measurement: opens a PostingIndexFwdReader on a sealed
     * index with ROWS row ids for key 0, then alternately measures the time
     * to (a) call cursor.size() and (b) drain the cursor.
     *
     * With the fix: size() returns ROWS (a real count), the caller's fast
     * path skips iteration entirely.
     *
     * Without the fix: size() returns -1, the caller has to drain the
     * cursor, paying O(ROWS).
     */
    @Test
    public void demoCursorSizeVsIterate() throws Exception {
        assertMemoryLeak(() -> {
            final String name = "perf_demo_cursor";
            try (Path path = new Path().of(configuration.getDbRoot())) {
                final int plen = path.size();
                try (PostingIndexWriter writer = new PostingIndexWriter(
                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
                    for (long rowId = 0; rowId < ROWS; rowId++) {
                        writer.add(0, rowId);
                    }
                    writer.commit();
                    writer.seal();
                }

                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
                        configuration, path.trimTo(plen), name,
                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0)) {
                    long advertised;
                    try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
                        advertised = cursor.size();
                    }
                    System.out.printf(">>> cursor.size() returned: %d  (fast path: %s)%n",
                            advertised, advertised >= 0 ? "ENGAGED" : "DISABLED (returned -1)");

                    // Warmup
                    for (int i = 0; i < WARMUP; i++) {
                        try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
                            long s = cursor.size();
                            if (s < 0) {
                                while (cursor.hasNext()) cursor.next();
                            }
                        }
                    }

                    // Measure size() path (whatever it returns).
                    long[] sizeNs = new long[ITERATIONS];
                    for (int i = 0; i < ITERATIONS; i++) {
                        long t0 = System.nanoTime();
                        try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
                            long s = cursor.size();
                            if (s < 0) {
                                // Caller's fallback: drain.
                                while (cursor.hasNext()) cursor.next();
                            }
                        }
                        sizeNs[i] = System.nanoTime() - t0;
                    }

                    // Measure forced-iteration (the slow path the fast path skips).
                    long[] iterNs = new long[ITERATIONS];
                    for (int i = 0; i < ITERATIONS; i++) {
                        long t0 = System.nanoTime();
                        long iterated = 0;
                        try (RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE)) {
                            while (cursor.hasNext()) {
                                cursor.next();
                                iterated++;
                            }
                        }
                        iterNs[i] = System.nanoTime() - t0;
                        Assert.assertEquals(ROWS, iterated);
                    }

                    report("cursor.size()-or-fallback", sizeNs);
                    report("forced iteration         ", iterNs);
                }
            }
        });
    }

    /**
     * SQL end-to-end measurement: times SELECT count() FROM t WHERE sym = 'X'
     * against a 1M-row clean partition. The CountRecordCursorFactory routes
     * through baseCursor.size(); on the fixed branch this resolves via the
     * per-gen classification fast path, on master it falls back to
     * calculateSize() which drains every row id.
     */
    @Test
    public void demoSqlCountFastPath() throws Exception {
        assertMemoryLeak(() -> {
            execute("CREATE TABLE perf_t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING) " +
                    "TIMESTAMP(ts) PARTITION BY DAY");
            execute("INSERT INTO perf_t " +
                    "SELECT dateadd('u', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP), 'X' " +
                    "FROM long_sequence(" + ROWS + ")");

            String sql = "SELECT count() FROM perf_t WHERE sym = 'X'";

            // Compile once, reuse the factory across iterations so we measure
            // cursor cost only, not parse/plan cost.
            try (RecordCursorFactory factory = select(sql)) {
                // Sanity check the answer once and confirm fast path engagement.
                try (RecordCursor c = factory.getCursor(sqlExecutionContext)) {
                    Assert.assertTrue(c.hasNext());
                    long got = c.getRecord().getLong(0);
                    Assert.assertEquals(ROWS, got);
                }

                // Warmup
                for (int i = 0; i < WARMUP; i++) {
                    try (RecordCursor c = factory.getCursor(sqlExecutionContext)) {
                        c.hasNext();
                        c.getRecord().getLong(0);
                    }
                }

                // Measure
                long[] times = new long[ITERATIONS];
                for (int i = 0; i < ITERATIONS; i++) {
                    long t0 = System.nanoTime();
                    try (RecordCursor c = factory.getCursor(sqlExecutionContext)) {
                        c.hasNext();
                        c.getRecord().getLong(0);
                    }
                    times[i] = System.nanoTime() - t0;
                }
                report("SELECT count() WHERE sym='X'", times);
            }
        });
    }

    private static void report(String label, long[] ns) {
        long[] sorted = ns.clone();
        Arrays.sort(sorted);
        long min = sorted[0];
        long p50 = sorted[sorted.length / 2];
        long p90 = sorted[(int) (sorted.length * 0.9)];
        long max = sorted[sorted.length - 1];
        System.out.printf(">>> %s : min=%6d us  p50=%6d us  p90=%6d us  max=%6d us%n",
                label, min / 1000, p50 / 1000, p90 / 1000, max / 1000);
    }
}
```

## Benchmark

```

╔══════════════════════════════════════════════════════════════════════════════════╗
║              POSTING INDEX BENCHMARK SUMMARY  [encoding: EF   ]                  ║
╚══════════════════════════════════════════════════════════════════════════════════╝

── Decode Throughput (ops/s, higher=better) ──────────────────────────────────────
  batch           1-bit        8-bit       12-bit       16-bit       20-bit       32-bit
  64         23,460,512   11,963,580   10,226,865    8,027,155    7,550,493    6,119,904
  256         5,599,120    3,318,368    2,714,740    2,165,403    2,021,724    1,653,614
  1024        1,552,973      810,553      732,845      557,837      517,882      420,462

── Index Comparison: Posting vs Legacy (ops/s, higher=better) ────────────────────
  indexPointRead:
             LEGACY    POSTING    ratio
  S1            568      2,012    3.54x
  S2          1,324      1,200    0.91x ◄
  S3          1,907      1,838    0.96x ◄
  S4            215        262    1.22x
  S5            407        238    0.59x ◄
  S6          1,096      2,022    1.84x
  S7            366      1,734    4.74x
  S8            392        470    1.20x

  indexScanRead:
             LEGACY    POSTING    ratio
  S1             20         45    2.23x
  S2            415        484    1.17x
  S3          1,003        892    0.89x ◄
  S4            205        250    1.22x
  S5            390        244    0.63x ◄
  S6            118         93    0.78x ◄
  S7             13         28    2.09x
  S8            374        469    1.25x

  indexRangeRead:
             LEGACY    POSTING    ratio
  S1          1,844      4,312    2.34x
  S2            781        987    1.26x
  S3          5,798     11,770    2.03x
  S4          1,190      1,809    1.52x
  S5            711        386    0.54x ◄
  S6          2,470      5,810    2.35x
  S7          1,576      3,961    2.51x
  S8          4,410     16,010    3.63x

── Sidecar Read Throughput (ops/s, higher=better) ────────────────────────────────
  type       baseline   covering    ratio
  DOUBLE          285        184    0.64x
  FLOAT           325        205    0.63x
  LONG            326        189    0.58x
  INT             318        192    0.61x
  DECIMAL64        305        192    0.63x
  DECIMAL32        313        203    0.65x
  SHORT           317        202    0.64x

── SQL Queries (ops/s, higher=better) ────────────────────────────────────────────
  Point lookup:
    covering_where                     23,386 ops/s
    non_covering_where                 22,006 ops/s
  Aggregation:
    covering_agg                        7,825 ops/s
    covering_sum                        8,496 ops/s
    covering_count                     31,939 ops/s
  Filter:
    residual_filter                    14,847 ops/s
    non_covering_filter                15,719 ops/s
    no_index_filter                     2,986 ops/s
  Filter IN-list:
    residual_filter_in                  1,487 ops/s
    non_covering_filter_in              1,617 ops/s
  VARCHAR/FSST:
    varchar_fsst                       27,080 ops/s
    varchar_non_covering               21,545 ops/s
    varchar_in_covering                 5,016 ops/s
  O3:
    o3_covering                        20,303 ops/s
    o3_non_covering                    24,634 ops/s
    o3_distinct                        38,730 ops/s
  Misc:
    latest_on                          39,780 ops/s
    in_list                             1,512 ops/s
    wide_table                         25,172 ops/s
  Bulk throughput:
    bulk_covering                       1,026 ops/s
    bulk_non_covering                     936 ops/s

── Write Overhead (ops/s, higher=better) ─────────────────────────────────────────
  no_index                     41.4 ops/s
  bitmap                       37.1 ops/s
  posting                      39.1 ops/s
  posting_covering             37.8 ops/s
  posting_varchar              35.9 ops/s

── Commit Profile (512 keys × 56 commits × 128 v/commit + seal) ──────────────────
  full write+seal cycle        30.7 ops/s  (32.6 ms/cycle)


══════════════════════════════════════════════════════════════════════════════════════════════════
  Covering Index I/O Projection (CPU + predicted page faults)
══════════════════════════════════════════════════════════════════════════════════════════════════
  500 keys × 2,000 v/k = 1,000,000 rows, querying 200 keys

  type             pages   pages    CPU ms    CPU ms    + NVMe   + cloud     + HDD
                    base   cover      base     cover     cover     cover     cover
  ────────────────────────────────────────────────────────────────────────────────────────
  DOUBLE           1,954     348       7.3       7.5      35.4     355.5    1399.5
                                                         163.6                        (baseline + NVMe for comparison)
  FLOAT              977     181       2.2       6.9      21.4     187.9     730.9
                                                          80.4                        (baseline + NVMe for comparison)
  LONG             1,954     248      10.0      15.5      35.3     263.5    1007.5
                                                         166.3                        (baseline + NVMe for comparison)
  INT                977     175       3.8       5.5      19.5     180.5     705.5
                                                          81.9                        (baseline + NVMe for comparison)

══════════════════════════════════════════════════════════════════════════════════════════════════
  Implied Sidecar Compression (file size, raw column vs encoded sidecar)
══════════════════════════════════════════════════════════════════════════════════════════════════
  type              raw column       sidecar         ratio
  ────────────────────────────────────────────────────────
  DOUBLE               7.63 MB       3.39 MB         2.25x
  FLOAT                3.81 MB       1.77 MB         2.16x
  LONG                 7.63 MB       2.42 MB         3.15x
  INT                  3.81 MB       1.70 MB         2.24x
```

## Compared to master

```
⏺ Comparing the two runs (master = baseline you pasted; PR = #7086 description):

  SQL Queries — meaningful wins

  ┌────────────────────┬────────┬────────┬─────────────────────────┐
  │       Query        │ master │   PR   │          delta          │
  ├────────────────────┼────────┼────────┼─────────────────────────┤
  │ covering_count     │ 28,116 │ 31,939 │ +14% ← fast-path target │
  ├────────────────────┼────────┼────────┼─────────────────────────┤
  │ covering_where     │ 20,461 │ 23,386 │                    +14% │
  ├────────────────────┼────────┼────────┼─────────────────────────┤
  │ non_covering_where │ 19,897 │ 22,006 │                    +11% │
  ├────────────────────┼────────┼────────┼─────────────────────────┤
  │ covering_sum       │  7,488 │  8,496 │                    +13% │
  ├────────────────────┼────────┼────────┼─────────────────────────┤
  │ latest_on          │ 34,991 │ 39,780 │                    +14% │
  ├────────────────────┼────────┼────────┼─────────────────────────┤
  │ wide_table         │ 22,978 │ 25,172 │                    +10% │
  ├────────────────────┼────────┼────────┼─────────────────────────┤
  │ varchar_fsst       │ 24,861 │ 27,080 │                     +9% │
  ├────────────────────┼────────┼────────┼─────────────────────────┤
  │ o3_distinct        │ 36,322 │ 38,730 │                     +7% │
  ├────────────────────┼────────┼────────┼─────────────────────────┤
  │ Most others        │      — │      — │    +1–6% (within noise) │
  └────────────────────┴────────┴────────┴─────────────────────────┘

  covering_count is the headline number and tracks the change — the fast path saves a full row-id drain on clean partitions.

  Index micro-benchmarks — flat-to-slightly-noisy

  - indexPointRead: mixed ±2–5%, except S3 +11% (1,661 → 1,838).
  - indexScanRead: uniformly −2 to −7%.
  - indexRangeRead: −2 to −8% (S7, S8 worst at −8%).
  - Decode throughput: within ~5% noise.

  These paths don't touch size(), so the small swings look like run-to-run variance rather than a real effect.

  Write & commit

  - bitmap write: 42.5 → 37.1 ops/s (−13%) — biggest standout, unrelated to this PR's code path; very likely noise.
  - posting_covering: 40.7 → 37.8 (−7%).
  - Commit cycle: 31.5 → 30.7 (−3%).

  Sidecar reads

  −2 to −7% across the board, again consistent with run-to-run variance.

  Bottom line: the SQL queries that route through cursor.size() (count, where, latest_on) gain 10–14%, matching the PR's
  intent. Everything else moves within typical bench noise, with no path getting materially worse. The PR's microbench (~31×
  SQL ratio) is the best-case 1M-rows-1-key scenario; on the broader suite the wins land at +10–14% for affected query shapes.
```