### PR TITLE
chore(build): fix AWS AMI build issues

### DIFF
--- a/pkg/ami/marketplace/assets/server.conf
+++ b/pkg/ami/marketplace/assets/server.conf
@@ -1178,4 +1178,3 @@ pg.user=admin
 ## Polling rate of a replica instance to check for new changes (milliseconds).
 #replication.replica.poll.interval=1000
 
-'

--- a/pkg/ami/marketplace/assets/systemd.service
+++ b/pkg/ami/marketplace/assets/systemd.service
@@ -1,16 +1,21 @@
 [Unit]
 Description=QuestDB
 Documentation=https://www.questdb.io/docs/introduction
-After=network.target
+Wants=network-online.target
+After=network-online.target
 RequiresMountsFor=/var/lib/questdb
 
 [Service]
-Type=simple
+Type=exec
 Restart=always
 RestartSec=2
-LimitNOFILE=134217728
 User=questdb
 Group=questdb
+
+# Resource limits
+LimitNOFILE=infinity
+TasksMax=infinity
+
 Environment=QDB_PACKAGE=ami-market
 ExecStart=/usr/bin/java \
     -XX:+UnlockExperimentalVMOptions \
@@ -23,10 +28,11 @@ ExecStart=/usr/bin/java \
     -m io.questdb/io.questdb.ServerMain \
     -d /var/lib/questdb
 ExecReload=/bin/kill -s HUP $MAINPID
+
 # Prevent writes to /usr, /boot, and /etc
 ProtectSystem=full
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=questdb
 
 [Install]

--- a/pkg/ami/marketplace/build.bash
+++ b/pkg/ami/marketplace/build.bash
@@ -30,7 +30,7 @@ QUESTDB_DATA_DIR=/var/lib/questdb
 # Install dependencies
 sudo dnf update -y -q
 sudo dnf install -y -q \
-    java-11-amazon-corretto-headless \
+    java-17-amazon-corretto-headless \
     ec2-instance-connect \
     amazon-ssm-agent \
     amazon-cloudwatch-agent \

--- a/pkg/ami/marketplace/build.bash
+++ b/pkg/ami/marketplace/build.bash
@@ -26,15 +26,27 @@
 
 set -euxo pipefail
 QUESTDB_DATA_DIR=/var/lib/questdb
+GRAALVM_VERSION=25.0.2
+GRAALVM_HOME=/usr/lib/jvm/graalvm-community-java25
+GRAALVM_TARBALL=graalvm-community-jdk-${GRAALVM_VERSION}_linux-x64_bin.tar.gz
 
 # Install dependencies
 sudo dnf update -y -q
 sudo dnf install -y -q \
-    java-17-amazon-corretto-headless \
     ec2-instance-connect \
     amazon-ssm-agent \
     amazon-cloudwatch-agent \
     jq
+
+# Install GraalVM Community JDK 25 and make it the system default JVM.
+wget -q https://github.com/graalvm/graalvm-ce-builds/releases/download/jdk-${GRAALVM_VERSION}/${GRAALVM_TARBALL}
+sudo mkdir -p ${GRAALVM_HOME}
+sudo tar -xzf ${GRAALVM_TARBALL} --strip-components=1 -C ${GRAALVM_HOME}
+rm -f ${GRAALVM_TARBALL}
+sudo alternatives --install /usr/bin/java java ${GRAALVM_HOME}/bin/java 250000
+sudo alternatives --set java ${GRAALVM_HOME}/bin/java
+sudo alternatives --install /usr/bin/javac javac ${GRAALVM_HOME}/bin/javac 250000
+sudo alternatives --set javac ${GRAALVM_HOME}/bin/javac
 
 sudo mv /tmp/scripts/1-per-boot.sh /var/lib/cloud/scripts/per-boot/
 sudo mv /tmp/assets/99-questdb.conf /etc/sysctl.d/


### PR DESCRIPTION
This PR fixes several issues:
1. Removes an errant apostrophe at the end of the bundled `server.conf`
2. Modernizes systemd service for AWS Linux '23
3. Bumps java runtime to corretto 17

Will post testing details in comments once I've run a new build (should be tomorrow)

Fixes #7093 