### PR TITLE
chore(core): fix POSTING-indexed queries returning wrong rows after a failed commit

### DIFF
--- a/core/src/main/java/io/questdb/cairo/O3CopyJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3CopyJob.java
@@ -820,8 +820,8 @@ public class O3CopyJob extends AbstractQueueConsumerJob<O3CopyTask> {
                         indexWriter.of(tableWriter.getConfiguration(), dstKFd, dstVFd, row == 0, indexBlockCapacity);
                     }
                 }
-                updateIndex(dstFixAddr, Math.abs(dstFixSize), indexWriter, dstIndexOffset / Integer.BYTES, dstIndexAdjust);
                 indexWriter.setNextTxnAtSeal(tableWriter.getTxn() + 1L);
+                updateIndex(dstFixAddr, Math.abs(dstFixSize), indexWriter, dstIndexOffset / Integer.BYTES, dstIndexAdjust);
                 indexWriter.commit();
             } finally {
                 if (closed) {

--- a/core/src/main/java/io/questdb/cairo/O3CopyJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3CopyJob.java
@@ -821,6 +821,7 @@ public class O3CopyJob extends AbstractQueueConsumerJob<O3CopyTask> {
                     }
                 }
                 updateIndex(dstFixAddr, Math.abs(dstFixSize), indexWriter, dstIndexOffset / Integer.BYTES, dstIndexAdjust);
+                indexWriter.setNextTxnAtSeal(tableWriter.getTxn() + 1L);
                 indexWriter.commit();
             } finally {
                 if (closed) {

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -3377,6 +3377,14 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                             indexWriter.setMaxValue(newPartitionSize - 1);
                         }
 
+                        // Tag the chain entry with the upcoming txn so that if
+                        // the surrounding O3 / parquet-rewrite path crashes
+                        // before txWriter.commit lands, recoveryDropAbandoned
+                        // on the next writer-open drops this entry. Without
+                        // the tag, slot[0].TXN_AT_SEAL defaults to 0 and the
+                        // entry would be undroppable, surfacing stale rows.
+                        // No-op on BitmapIndexWriter.
+                        indexWriter.setNextTxnAtSeal(tableWriter.getTxn() + 1L);
                         if (IndexType.isPosting(indexType)) {
                             indexWriter.commitDense();
                         } else {

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -371,6 +371,10 @@ public class TableReader implements Closeable, SymbolTableSource {
         final long partitionTxn = txFile.getPartitionNameTxn(partitionIndex);
         IndexReader indexReader = getIndexReaderIfExists(partitionIndex, columnIndex, direction);
         if (indexReader != null) {
+            // Single choke point for refreshing the scoreboard pin on cached
+            // readers. TableReader.txn advances through several paths
+            // (goActive / reload / ...); setting it here covers all of them.
+            indexReader.setPinnedTableTxn(txn);
             if (
                     !indexReader.isOpen()
                             || indexReader.getColumnTxn() != columnNameTxn
@@ -1055,7 +1059,8 @@ public class TableReader implements Closeable, SymbolTableSource {
                         getColumnTop(columnBase, columnIndex),
                         metadata,
                         columnVersionReader,
-                        partitionTimestamp
+                        partitionTimestamp,
+                        txn
                 );
                 if (direction == IndexReader.DIR_BACKWARD) {
                     indexes.setQuick(globalIndex, reader);

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -7640,7 +7640,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                             setStateForTimestamp(other, newSplitPartitionTimestamp);
                             ff.mkdir(other.$(), configuration.getMkDirMode());
                             try (Frame targetFrame = frameFactory.createRW(other, newSplitPartitionTimestamp, metadata, columnVersionWriter, 0)) {
-                                FrameAlgebra.append(targetFrame, sourceFrame, newPrevPartitionSize, prevPartitionSize, configuration.getCommitMode());
+                                FrameAlgebra.append(targetFrame, sourceFrame, newPrevPartitionSize, prevPartitionSize, txWriter.getTxn() + 1L, configuration.getCommitMode());
                             }
                         }
                         addPhysicallyWrittenRows(prevPartitionSize - newPrevPartitionSize);
@@ -10065,6 +10065,11 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         indexer.configureCovering(o3SealAddrs, o3SealAuxAddrs, o3SealTops, o3SealShifts, coveringCols, o3SealTypes, coverCount,
                                 metadata.getTimestampIndex());
                         indexer.setCoveredColumnNameTxns(o3SealNameTxns);
+                        // WAL fast-lag uses getTxn() (NOT getTxn()+1L like the
+                        // O3 seal paths). See publishToChain javadoc: the
+                        // partition stays attached and openPartition's
+                        // rollbackConditionally evicts orphans on reopen,
+                        // so the chain walk is not the recovery path here.
                         indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn());
                         indexer.getWriter().commit();
                         indexer.publishPendingPurges(messageBus, tableToken, partitionBy, timestampType, txWriter.getTxn());
@@ -10081,6 +10086,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     }
                     continue;
                 }
+                // Non-covering branch of the WAL fast-lag path. See the
+                // covering branch above for why getTxn() (not getTxn()+1L).
                 indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn());
                 indexer.getWriter().commit();
                 indexer.publishPendingPurges(messageBus, tableToken, partitionBy, timestampType, txWriter.getTxn());
@@ -11777,7 +11784,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     LOG.info().$("copying partition to force squash [from=").$substr(pathRootSize, path).$(", to=").$(other).I$();
 
                     targetFrame = frameFactory.openRW(other, targetPartition, metadata, columnVersionWriter, 0);
-                    FrameAlgebra.append(targetFrame, firstPartitionFrame, configuration.getCommitMode());
+                    FrameAlgebra.append(targetFrame, firstPartitionFrame, txWriter.getTxn() + 1L, configuration.getCommitMode());
                     addPhysicallyWrittenRows(firstPartitionFrame.getRowCount());
                     txWriter.updatePartitionSizeAndTxnByRawIndex(targetPartitionIndex * LONGS_PER_TX_ATTACHED_PARTITION, originalSize);
                     partitionRemoveCandidates.add(targetPartition, targetPartitionNameTxn);
@@ -11819,7 +11826,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         .I$();
 
                 try (Frame sourceFrame = frameFactory.openRO(other, sourcePartition, metadata, columnVersionWriter, partitionRowCount)) {
-                    FrameAlgebra.append(targetFrame, sourceFrame, configuration.getCommitMode());
+                    FrameAlgebra.append(targetFrame, sourceFrame, txWriter.getTxn() + 1L, configuration.getCommitMode());
                     addPhysicallyWrittenRows(sourceFrame.getRowCount());
                 } catch (Throwable th) {
                     LOG.critical().$("partition squashing failed [table=").$(tableToken)

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -11303,32 +11303,11 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                                 getPrimaryColumn(colIdx), columnTop,
                                 partitionTimestamp, partitionNameTxn
                         );
-                        // Tag the rebuild's intermediate commit (the
-                        // discardForRebuild + commit dance below) with
-                        // getTxn()+1, NOT getTxn(). discardForRebuild
-                        // rotates sealTxn so the trailing commit takes
-                        // appendNewEntry rather than mutating the OLD
-                        // entry in place; that fresh REBUILD entry sits
-                        // as the chain head from commit() until
-                        // rebuildSidecars() supersedes it. During that
-                        // window, and afterwards as a prev entry, REBUILD
-                        // has no cover footer (configureCovering runs
-                        // after commit), so any reader that picks it
-                        // resolves all cover columns to NULL. Tagging
-                        // with getTxn()+1 keeps REBUILD invisible to
-                        // every snapshot-isolated reader pinned at any
-                        // committed txn (T_pin <= getTxn() < getTxn()+1):
-                        // the picker walks past it to OLD (which still
-                        // has its proper footer) until rebuildSidecars
-                        // publishes SEAL with txnAtSeal=getTxn() and a
-                        // real footer. recoveryDropAbandoned can also
-                        // drop REBUILD on a partial-publish reopen
-                        // (predicate txnAtSeal > committedTxn fires when
-                        // the rebuild aborts before txWriter.commit).
-                        // The non-covering branch below uses getTxn()
-                        // because it has no covering footer to lose;
-                        // the brief-window picker hit there returns the
-                        // posting index alone, which is correct.
+                        // REBUILD intermediate entry: getTxn()+1 keeps it
+                        // invisible to T-pinned readers (it lacks a cover
+                        // footer until rebuildSidecars() supersedes it),
+                        // and recoveryDropAbandoned can drop it on a
+                        // partial-publish distress.
                         indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn() + 1L);
                         // Fold the fd-based O3 tentative state into
                         // the writer view before the reseal.
@@ -11375,23 +11354,16 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         indexer.configureCovering(o3SealAddrs, o3SealAuxAddrs, o3SealTops, o3SealShifts, coveringCols, o3SealTypes, coverCount,
                                 metadata.getTimestampIndex());
                         indexer.setCoveredColumnNameTxns(o3SealNameTxns);
-                        // sealPostingIndexesForO3Partitions runs inside
-                        // finishO3Commit, BEFORE txWriter.commit. The
-                        // chain entry rebuildSidecars publishes is tagged
-                        // with the current committed txn (not the upcoming
-                        // one): tagging with getTxn()+1 corrupts covering
-                        // reads, because publishPendingPurges' purge bound
-                        // would push the scoreboard's max ahead of the
-                        // not-yet-committed table txn and shorten the
-                        // window in which an existing reader can still
-                        // resolve the previous-seal sidecar files. Using
-                        // getTxn() leaves a partial-publish chain entry
-                        // undroppable by the recovery walk for this code
-                        // path; the trade-off is accepted here because the
-                        // failure mode (orphan chain head referencing the
-                        // committed state) is data-correct, while
-                        // getTxn()+1 produces wrong query results.
-                        indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn());
+                        // Same getTxn()+1 convention as the REBUILD entry
+                        // above and as O3CopyJob's setO3PathContext. Picker
+                        // (per-gen visibility via slot[0].TXN_AT_SEAL) keeps
+                        // T-pinned readers on the prev entry until
+                        // txWriter.commit lands, and recoveryDropAbandoned
+                        // can drop the SEAL entry on a partial-publish
+                        // distress. publishPendingPurges clamps toTableTxn
+                        // back to getTxn() so the scoreboard max is not
+                        // pushed past the not-yet-committed table txn.
+                        indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn() + 1L);
                         indexer.rebuildSidecars();
                         indexer.publishPendingPurges(messageBus, tableToken, partitionBy, timestampType, txWriter.getTxn());
                     } finally {
@@ -11413,17 +11385,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                             getPrimaryColumn(colIdx), columnTop,
                             partitionTimestamp, partitionNameTxn
                     );
-                    // See covering branch above: sealPostingIndexesForO3Partitions
-                    // runs inside finishO3Commit BEFORE txWriter.commit, and
-                    // publishPendingPurges below uses txWriter.getTxn() (the
-                    // current committed txn) for its purge bound. Tagging the
-                    // chain entry with getTxn()+1 here would push the
-                    // scoreboard's max past the not-yet-committed table txn,
-                    // shrinking the window in which an existing reader can
-                    // resolve the previous-seal .pv file. The covering branch
-                    // accepts the partial-publish-leaves-orphan trade-off; the
-                    // same trade-off is correct here.
-                    indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn());
+                    // Same getTxn()+1 convention as O3CopyJob and the
+                    // covering branch above. See comment there.
+                    indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn() + 1L);
                     indexer.mergeTentativeIntoActiveIfAny();
                     if (canSkipRebuild) {
                         // See pure-append fast-path comment in the covering branch above.

--- a/core/src/main/java/io/questdb/cairo/frm/FrameAlgebra.java
+++ b/core/src/main/java/io/questdb/cairo/frm/FrameAlgebra.java
@@ -32,16 +32,8 @@ import io.questdb.cairo.TableUtils;
  */
 public class FrameAlgebra {
 
-    public static void append(Frame target, Frame source, int commitMode) {
-        append(target, source, 0, source.getRowCount(), -1L, commitMode);
-    }
-
     public static void append(Frame target, Frame source, long upcomingTableTxn, int commitMode) {
         append(target, source, 0, source.getRowCount(), upcomingTableTxn, commitMode);
-    }
-
-    public static void append(Frame target, Frame source, long sourceLo, long sourceHi, int commitMode) {
-        append(target, source, sourceLo, sourceHi, -1L, commitMode);
     }
 
     /**
@@ -50,8 +42,7 @@ public class FrameAlgebra {
      *                         columns tag posting-index chain entries
      *                         published during this append with the value
      *                         so a partial publish (commit fails before
-     *                         landing) is droppable by recovery. Pass
-     *                         {@code -1L} for the legacy unwired path.
+     *                         landing) is droppable by recovery.
      */
     public static void append(Frame target, Frame source, long sourceLo, long sourceHi, long upcomingTableTxn, int commitMode) {
         if (sourceLo < sourceHi) {

--- a/core/src/main/java/io/questdb/cairo/frm/FrameAlgebra.java
+++ b/core/src/main/java/io/questdb/cairo/frm/FrameAlgebra.java
@@ -33,10 +33,27 @@ import io.questdb.cairo.TableUtils;
 public class FrameAlgebra {
 
     public static void append(Frame target, Frame source, int commitMode) {
-        append(target, source, 0, source.getRowCount(), commitMode);
+        append(target, source, 0, source.getRowCount(), -1L, commitMode);
+    }
+
+    public static void append(Frame target, Frame source, long upcomingTableTxn, int commitMode) {
+        append(target, source, 0, source.getRowCount(), upcomingTableTxn, commitMode);
     }
 
     public static void append(Frame target, Frame source, long sourceLo, long sourceHi, int commitMode) {
+        append(target, source, sourceLo, sourceHi, -1L, commitMode);
+    }
+
+    /**
+     * @param upcomingTableTxn the upcoming table {@code _txn} (typically
+     *                         {@code txWriter.getTxn() + 1L}). Indexed
+     *                         columns tag posting-index chain entries
+     *                         published during this append with the value
+     *                         so a partial publish (commit fails before
+     *                         landing) is droppable by recovery. Pass
+     *                         {@code -1L} for the legacy unwired path.
+     */
+    public static void append(Frame target, Frame source, long sourceLo, long sourceHi, long upcomingTableTxn, int commitMode) {
         if (sourceLo < sourceHi) {
             for (int i = 0, n = source.columnCount(); i < n; i++) {
                 try (
@@ -44,6 +61,7 @@ public class FrameAlgebra {
                         FrameColumn targetColumn = target.createColumn(i)
                 ) {
                     if (sourceColumn.getColumnType() >= 0) {
+                        targetColumn.setUpcomingTableTxn(upcomingTableTxn);
                         append(targetColumn, target.getRowCount(), sourceColumn, sourceLo, sourceHi, commitMode);
                         target.saveChanges(targetColumn);
                     }

--- a/core/src/main/java/io/questdb/cairo/frm/FrameColumn.java
+++ b/core/src/main/java/io/questdb/cairo/frm/FrameColumn.java
@@ -72,4 +72,14 @@ public interface FrameColumn extends Closeable {
     int getStorageType();
 
     void setRecycleBin(RecycleBin<FrameColumn> pool);
+
+    /**
+     * Posting-index hook: tag chain entries published during the next
+     * {@link #append} or {@link #appendNulls} with the supplied upcoming
+     * {@code _txn}. A value below 0 means "unwired" and the column falls
+     * back to its default (legacy) tagging. No-op for column types that
+     * do not own a posting index writer.
+     */
+    default void setUpcomingTableTxn(long upcomingTableTxn) {
+    }
 }

--- a/core/src/main/java/io/questdb/cairo/frm/file/ContiguousFileIndexedFrameColumn.java
+++ b/core/src/main/java/io/questdb/cairo/frm/file/ContiguousFileIndexedFrameColumn.java
@@ -39,6 +39,7 @@ public class ContiguousFileIndexedFrameColumn extends ContiguousFileFixFrameColu
     private final CairoConfiguration configuration;
     private byte indexType = IndexType.NONE;
     private IndexWriter indexWriter;
+    private long upcomingTableTxn = -1L;
 
     public ContiguousFileIndexedFrameColumn(CairoConfiguration configuration) {
         super(configuration);
@@ -62,6 +63,9 @@ public class ContiguousFileIndexedFrameColumn extends ContiguousFileFixFrameColu
                     indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(mappedAddress + (i << shl))), appendOffsetRowCount + i);
                 }
                 indexWriter.setMaxValue(appendOffsetRowCount + size - 1);
+                if (upcomingTableTxn >= 0) {
+                    indexWriter.setNextTxnAtSeal(upcomingTableTxn);
+                }
                 indexWriter.commit();
             } finally {
                 TableUtils.mapAppendColumnBufferRelease(ff, mappedAddress, (appendOffsetRowCount - getColumnTop()) << shl, size << shl, MEMORY_TAG);
@@ -77,6 +81,9 @@ public class ContiguousFileIndexedFrameColumn extends ContiguousFileFixFrameColu
             indexWriter.add(0, rowCount + i);
         }
         indexWriter.setMaxValue(rowCount + sourceColumnTop - 1);
+        if (upcomingTableTxn >= 0) {
+            indexWriter.setNextTxnAtSeal(upcomingTableTxn);
+        }
         indexWriter.commit();
     }
 
@@ -98,6 +105,7 @@ public class ContiguousFileIndexedFrameColumn extends ContiguousFileFixFrameColu
             boolean isEmpty
     ) {
         super.ofRW(partitionPath, columnName, columnTxn, columnType, columnTop, columnIndex);
+        this.upcomingTableTxn = -1L;
         try {
             if (indexWriter == null || this.indexType != indexType) {
                 if (indexWriter != null) {
@@ -140,6 +148,11 @@ public class ContiguousFileIndexedFrameColumn extends ContiguousFileFixFrameColu
         closed = false;
         super.close();
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setUpcomingTableTxn(long upcomingTableTxn) {
+        this.upcomingTableTxn = upcomingTableTxn;
     }
 
     // Useful for debugging

--- a/core/src/main/java/io/questdb/cairo/frm/file/ContiguousFileIndexedFrameColumn.java
+++ b/core/src/main/java/io/questdb/cairo/frm/file/ContiguousFileIndexedFrameColumn.java
@@ -59,13 +59,13 @@ public class ContiguousFileIndexedFrameColumn extends ContiguousFileFixFrameColu
             long mappedAddress = TableUtils.mapAppendColumnBuffer(ff, fd, (appendOffsetRowCount - getColumnTop()) << shl, size << shl, false, MEMORY_TAG);
             try {
                 indexWriter.rollbackConditionally(appendOffsetRowCount);
+                if (upcomingTableTxn >= 0) {
+                    indexWriter.setNextTxnAtSeal(upcomingTableTxn);
+                }
                 for (long i = 0; i < size; i++) {
                     indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(mappedAddress + (i << shl))), appendOffsetRowCount + i);
                 }
                 indexWriter.setMaxValue(appendOffsetRowCount + size - 1);
-                if (upcomingTableTxn >= 0) {
-                    indexWriter.setNextTxnAtSeal(upcomingTableTxn);
-                }
                 indexWriter.commit();
             } finally {
                 TableUtils.mapAppendColumnBufferRelease(ff, mappedAddress, (appendOffsetRowCount - getColumnTop()) << shl, size << shl, MEMORY_TAG);
@@ -77,13 +77,13 @@ public class ContiguousFileIndexedFrameColumn extends ContiguousFileFixFrameColu
     public void appendNulls(long rowCount, long sourceColumnTop, int commitMode) {
         super.appendNulls(rowCount, sourceColumnTop, commitMode);
         indexWriter.rollbackConditionally(rowCount);
+        if (upcomingTableTxn >= 0) {
+            indexWriter.setNextTxnAtSeal(upcomingTableTxn);
+        }
         for (long i = 0; i < sourceColumnTop; i++) {
             indexWriter.add(0, rowCount + i);
         }
         indexWriter.setMaxValue(rowCount + sourceColumnTop - 1);
-        if (upcomingTableTxn >= 0) {
-            indexWriter.setNextTxnAtSeal(upcomingTableTxn);
-        }
         indexWriter.commit();
     }
 

--- a/core/src/main/java/io/questdb/cairo/frm/file/ContiguousFileIndexedFrameColumn.java
+++ b/core/src/main/java/io/questdb/cairo/frm/file/ContiguousFileIndexedFrameColumn.java
@@ -90,6 +90,7 @@ public class ContiguousFileIndexedFrameColumn extends ContiguousFileFixFrameColu
     @Override
     public void close() {
         Misc.free(indexWriter);
+        upcomingTableTxn = -1L;
         super.close();
     }
 

--- a/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
@@ -94,14 +94,6 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
     protected int genCount;
     protected int keyCount;
     protected RecordMetadata metadata;
-    // Strict-pin: the table txn that this reader is pinned at via the
-    // scoreboard. Picker selects the chain entry with the largest
-    // {@code txnAtSeal <= pinnedTableTxn}, and the per-gen filter in
-    // {@link Cursor#advanceToNextRelevantGen} skips gens with
-    // {@code slot.TXN_AT_SEAL > pinnedTableTxn}. Defaults to Long.MAX_VALUE
-    // so a reader opened without explicit plumbing falls back to "see the
-    // head and all its gens".
-    protected long pinnedTableTxn = Long.MAX_VALUE;
     // Last successfully observed seqlock value of the chain header's active
     // page. Used by reloadConditionally to detect any publish (appendNewEntry
     // or extendHead — both republish the header) and skip the picker walk
@@ -118,6 +110,15 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
     private int keyCountIncludingNulls;
     private long partitionTimestamp;
     private long partitionTxn;
+    // Strict-pin: the table txn that this reader is pinned at via the
+    // scoreboard. Picker selects the chain entry with the largest
+    // {@code txnAtSeal <= pinnedTableTxn}; within the picked entry,
+    // {@link #computeVisibleGenCount} (run once at pick time) trims
+    // {@link #genCount} to the visible prefix of gens with
+    // {@code slot.TXN_AT_SEAL <= pinnedTableTxn}. Default {@code Long.MAX_VALUE}
+    // means "see the head and all its gens"; scoreboard plumbing that lowers
+    // the pin is deferred to a follow-up.
+    private long pinnedTableTxn = Long.MAX_VALUE;
     private long spinLockTimeoutMs;
     private long valueFileTxn;
     private long valueMemSize = -1;

--- a/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
@@ -756,11 +756,6 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
                 : genLookup.getGenMaxValue(visibleGenCount - 1);
     }
 
-    // Returns the visible prefix length. Relies on slot.TXN_AT_SEAL being
-    // monotonically non-decreasing across an entry's gens; snapshotMetadata
-    // asserts the invariant in debug builds. The trimmed this.genCount then
-    // bounds every gen-iterating read path, so callers do not repeat the
-    // per-slot check.
     private int computeVisibleGenCount(PostingIndexChainEntry.Snapshot e) {
         for (int g = 0; g < e.genCount; g++) {
             if (genLookup.getGenTxnAtSeal(g) > pinnedTableTxn) {

--- a/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
@@ -154,9 +154,6 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
         }
         int newlyFound = 0;
         for (int g = 0; g < genCount; g++) {
-            if (genLookup.getGenTxnAtSeal(g) > pinnedTableTxn) {
-                continue;
-            }
             int genKeyCount = genLookup.getGenKeyCount(g);
             long genFileOffset = genLookup.getGenFileOffset(g);
             if (genKeyCount >= 0) {
@@ -185,9 +182,6 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
         }
         int newlyFound = 0;
         for (int g = 0; g < genCount; g++) {
-            if (genLookup.getGenTxnAtSeal(g) > pinnedTableTxn) {
-                continue;
-            }
             int genKeyCount = genLookup.getGenKeyCount(g);
             long genFileOffset = genLookup.getGenFileOffset(g);
             if (genKeyCount >= 0) {
@@ -762,6 +756,11 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
                 : genLookup.getGenMaxValue(visibleGenCount - 1);
     }
 
+    // Returns the visible prefix length. Relies on slot.TXN_AT_SEAL being
+    // monotonically non-decreasing across an entry's gens; snapshotMetadata
+    // asserts the invariant in debug builds. The trimmed this.genCount then
+    // bounds every gen-iterating read path, so callers do not repeat the
+    // per-slot check.
     private int computeVisibleGenCount(PostingIndexChainEntry.Snapshot e) {
         for (int g = 0; g < e.genCount; g++) {
             if (genLookup.getGenTxnAtSeal(g) > pinnedTableTxn) {
@@ -1373,9 +1372,6 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
             // applies; the original count fast path is taken verbatim.
             long total = 0;
             for (int g = 0; g < cursorGenCount; g++) {
-                if (genLookup.getGenTxnAtSeal(g) > pinnedTableTxn) {
-                    continue;
-                }
                 int gkc = genLookup.getGenKeyCount(g);
                 if (gkc >= 0) {
                     if (entryMaxValue >= 0) {

--- a/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
@@ -94,6 +94,14 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
     protected int genCount;
     protected int keyCount;
     protected RecordMetadata metadata;
+    // Strict-pin: the table txn that this reader is pinned at via the
+    // scoreboard. Picker selects the chain entry with the largest
+    // {@code txnAtSeal <= pinnedTableTxn}, and the per-gen filter in
+    // {@link Cursor#advanceToNextRelevantGen} skips gens with
+    // {@code slot.TXN_AT_SEAL > pinnedTableTxn}. Defaults to Long.MAX_VALUE
+    // so a reader opened without explicit plumbing falls back to "see the
+    // head and all its gens".
+    protected long pinnedTableTxn = Long.MAX_VALUE;
     // Last successfully observed seqlock value of the chain header's active
     // page. Used by reloadConditionally to detect any publish (appendNewEntry
     // or extendHead — both republish the header) and skip the picker walk
@@ -110,11 +118,6 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
     private int keyCountIncludingNulls;
     private long partitionTimestamp;
     private long partitionTxn;
-    // Strict-pin: the table txn that this reader is pinned at via the
-    // scoreboard. Picker selects the chain entry with the largest
-    // {@code txnAtSeal <= pinnedTableTxn}. Defaults to Long.MAX_VALUE so a
-    // reader opened without explicit plumbing falls back to "see the head".
-    private long pinnedTableTxn = Long.MAX_VALUE;
     private long spinLockTimeoutMs;
     private long valueFileTxn;
     private long valueMemSize = -1;
@@ -151,6 +154,9 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
         }
         int newlyFound = 0;
         for (int g = 0; g < genCount; g++) {
+            if (genLookup.getGenTxnAtSeal(g) > pinnedTableTxn) {
+                continue;
+            }
             int genKeyCount = genLookup.getGenKeyCount(g);
             long genFileOffset = genLookup.getGenFileOffset(g);
             if (genKeyCount >= 0) {
@@ -179,6 +185,9 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
         }
         int newlyFound = 0;
         for (int g = 0; g < genCount; g++) {
+            if (genLookup.getGenTxnAtSeal(g) > pinnedTableTxn) {
+                continue;
+            }
             int genKeyCount = genLookup.getGenKeyCount(g);
             long genFileOffset = genLookup.getGenFileOffset(g);
             if (genKeyCount >= 0) {
@@ -744,6 +753,24 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
         return newlyFound;
     }
 
+    private long computeVisibleEntryMaxValue(PostingIndexChainEntry.Snapshot e, int visibleGenCount) {
+        if (visibleGenCount == 0) {
+            return -1L;
+        }
+        return visibleGenCount == e.genCount
+                ? e.maxValue
+                : genLookup.getGenMaxValue(visibleGenCount - 1);
+    }
+
+    private int computeVisibleGenCount(PostingIndexChainEntry.Snapshot e) {
+        for (int g = 0; g < e.genCount; g++) {
+            if (genLookup.getGenTxnAtSeal(g) > pinnedTableTxn) {
+                return g;
+            }
+        }
+        return e.genCount;
+    }
+
     /**
      * Open the .pv value file using the picked entry's sealTxn-suffixed
      * filename and the entry's recorded valueMemSize. The path is taken from
@@ -890,10 +917,10 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
 
                 this.headEntryOffset = entryScratch.offset;
                 this.chainSequence = headerScratch.sequence;
-                this.entryMaxValue = entryScratch.maxValue;
+                this.genCount = computeVisibleGenCount(entryScratch);
+                this.entryMaxValue = computeVisibleEntryMaxValue(entryScratch, this.genCount);
                 this.valueMemSize = entryScratch.valueMemSize;
                 this.keyCount = entryScratch.keyCount;
-                this.genCount = entryScratch.genCount;
                 this.valueFileTxn = entryScratch.sealTxn;
                 this.keyCountIncludingNulls = columnTop > 0 ? keyCount + 1 : keyCount;
                 // Promote the picked entry's per-cover end offsets into the
@@ -1346,6 +1373,9 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
             // applies; the original count fast path is taken verbatim.
             long total = 0;
             for (int g = 0; g < cursorGenCount; g++) {
+                if (genLookup.getGenTxnAtSeal(g) > pinnedTableTxn) {
+                    continue;
+                }
                 int gkc = genLookup.getGenKeyCount(g);
                 if (gkc >= 0) {
                     if (entryMaxValue >= 0) {

--- a/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
@@ -108,16 +108,17 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
     private long headEntryOffset = PostingIndexUtils.V2_NO_HEAD;
     private CharSequence indexColumnName;
     private int keyCountIncludingNulls;
+    // Pin value used at the most recent successful pick. reloadConditionally
+    // compares against pinnedTableTxn to force a re-pick on pin change even
+    // when the chain seqlock has not advanced.
+    private long lastPickedPinnedTxn = Long.MIN_VALUE;
     private long partitionTimestamp;
     private long partitionTxn;
-    // Strict-pin: the table txn that this reader is pinned at via the
-    // scoreboard. Picker selects the chain entry with the largest
-    // {@code txnAtSeal <= pinnedTableTxn}; within the picked entry,
-    // {@link #computeVisibleGenCount} (run once at pick time) trims
-    // {@link #genCount} to the visible prefix of gens with
-    // {@code slot.TXN_AT_SEAL <= pinnedTableTxn}. Default {@code Long.MAX_VALUE}
-    // means "see the head and all its gens"; scoreboard plumbing that lowers
-    // the pin is deferred to a follow-up.
+    // Strict-pin: the table txn this reader is pinned at via the scoreboard.
+    // Picker selects the entry with the largest {@code txnAtSeal <= pinnedTableTxn};
+    // computeVisibleGenCount trims the head entry's visible genCount to slots
+    // with {@code slot.TXN_AT_SEAL <= pinnedTableTxn}. Default Long.MAX_VALUE
+    // is "unpinned"; production callers replace it via setPinnedTableTxn.
     private long pinnedTableTxn = Long.MAX_VALUE;
     private long spinLockTimeoutMs;
     private long valueFileTxn;
@@ -139,6 +140,7 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
         entryMaxValue = -1L;
         headEntryOffset = PostingIndexUtils.V2_NO_HEAD;
         pinnedTableTxn = Long.MAX_VALUE;
+        lastPickedPinnedTxn = Long.MIN_VALUE;
     }
 
     @Override
@@ -331,14 +333,16 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
             // again. We keep the existing snapshot in the meantime.
             return;
         }
-        if (headerScratch.sequence == chainSequence) {
+        // A pin change can move the picker to a different entry even when
+        // the chain hasn't been republished.
+        boolean chainAdvanced = headerScratch.sequence != chainSequence;
+        boolean pinChanged = lastPickedPinnedTxn != pinnedTableTxn;
+        if (!chainAdvanced && !pinChanged) {
             return;
         }
 
-        // The writer may have appended new chain entries past our current
-        // keyMem mapping. Extend the mapping to cover the whole file before
-        // re-picking. ff.length() is cheap on modern OSes.
-        if (ff != null) {
+        // File can only have grown when the chain advanced.
+        if (chainAdvanced && ff != null) {
             long fd = keyMem.getFd();
             if (fd > 0) {
                 long fileLen = ff.length(fd);
@@ -394,6 +398,11 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
     @TestOnly
     public void setGenLookupCacheBudget(long budget) {
         genLookup.setCacheMemoryBudget(budget);
+    }
+
+    @Override
+    public void setPinnedTableTxn(long pinnedTableTxn) {
+        this.pinnedTableTxn = pinnedTableTxn;
     }
 
     private static boolean deltaKeyHasValueInRange(long baseAddr, long encodedOffset, long rowLo, long rowHi) {
@@ -927,6 +936,7 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
                 for (int c = 0; c < coverCount; c++) {
                     sidecarFileEndOffsets.setQuick(c, c < picked ? entryScratch.coverFileEndOffsets.getQuick(c) : 0L);
                 }
+                this.lastPickedPinnedTxn = this.pinnedTableTxn;
                 return;
             }
 
@@ -952,6 +962,7 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
             genLookup.snapshotMetadata(keyMem, 0, 0L);
             genLookup.commitSnapshot();
             genLookup.invalidateCache();
+            this.lastPickedPinnedTxn = this.pinnedTableTxn;
             return;
         }
     }

--- a/core/src/main/java/io/questdb/cairo/idx/IndexFactory.java
+++ b/core/src/main/java/io/questdb/cairo/idx/IndexFactory.java
@@ -49,9 +49,10 @@ public final class IndexFactory {
             long columnTop,
             RecordMetadata metadata,
             ColumnVersionReader columnVersionReader,
-            long partitionTimestamp
+            long partitionTimestamp,
+            long pinnedTableTxn
     ) {
-        return switch (indexType) {
+        IndexReader reader = switch (indexType) {
             case IndexType.BITMAP -> direction == IndexReader.DIR_FORWARD
                     ? new BitmapIndexFwdReader(configuration, path, columnName, columnNameTxn, partitionTxn, columnTop)
                     : new BitmapIndexBwdReader(configuration, path, columnName, columnNameTxn, partitionTxn, columnTop);
@@ -61,6 +62,9 @@ public final class IndexFactory {
                             : new PostingIndexBwdReader(configuration, path, columnName, columnNameTxn, partitionTxn, columnTop, metadata, columnVersionReader, partitionTimestamp);
             default -> throw unsupportedIndexType(indexType);
         };
+        reader.setPinnedTableTxn(pinnedTableTxn);
+        reader.reloadConditionally();
+        return reader;
     }
 
     public static IndexWriter createWriter(byte indexType, CairoConfiguration configuration) {

--- a/core/src/main/java/io/questdb/cairo/idx/IndexFactory.java
+++ b/core/src/main/java/io/questdb/cairo/idx/IndexFactory.java
@@ -52,19 +52,16 @@ public final class IndexFactory {
             long partitionTimestamp,
             long pinnedTableTxn
     ) {
-        IndexReader reader = switch (indexType) {
+        return switch (indexType) {
             case IndexType.BITMAP -> direction == IndexReader.DIR_FORWARD
                     ? new BitmapIndexFwdReader(configuration, path, columnName, columnNameTxn, partitionTxn, columnTop)
                     : new BitmapIndexBwdReader(configuration, path, columnName, columnNameTxn, partitionTxn, columnTop);
             case IndexType.POSTING, IndexType.POSTING_DELTA, IndexType.POSTING_EF ->
                     direction == IndexReader.DIR_FORWARD
-                            ? new PostingIndexFwdReader(configuration, path, columnName, columnNameTxn, partitionTxn, columnTop, metadata, columnVersionReader, partitionTimestamp)
-                            : new PostingIndexBwdReader(configuration, path, columnName, columnNameTxn, partitionTxn, columnTop, metadata, columnVersionReader, partitionTimestamp);
+                            ? new PostingIndexFwdReader(configuration, path, columnName, columnNameTxn, partitionTxn, columnTop, metadata, columnVersionReader, partitionTimestamp, pinnedTableTxn)
+                            : new PostingIndexBwdReader(configuration, path, columnName, columnNameTxn, partitionTxn, columnTop, metadata, columnVersionReader, partitionTimestamp, pinnedTableTxn);
             default -> throw unsupportedIndexType(indexType);
         };
-        reader.setPinnedTableTxn(pinnedTableTxn);
-        reader.reloadConditionally();
-        return reader;
     }
 
     public static IndexWriter createWriter(byte indexType, CairoConfiguration configuration) {

--- a/core/src/main/java/io/questdb/cairo/idx/IndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/IndexReader.java
@@ -125,4 +125,16 @@ public interface IndexReader extends Closeable {
     );
 
     void reloadConditionally();
+
+    /**
+     * Pin the reader at the given table {@code _txn} for snapshot isolation.
+     * The posting reader's picker selects the chain entry with the highest
+     * {@code txnAtSeal <= pinnedTableTxn} and trims in-flight tail gens
+     * within that entry. Bitmap and null readers ignore the pin.
+     * <p>
+     * The pin takes effect on the next {@link #reloadConditionally} or
+     * {@link #of}; the setter itself does not re-pick.
+     */
+    default void setPinnedTableTxn(long pinnedTableTxn) {
+    }
 }

--- a/core/src/main/java/io/questdb/cairo/idx/POSTING_INDEX_CHAIN_DESIGN.md
+++ b/core/src/main/java/io/questdb/cairo/idx/POSTING_INDEX_CHAIN_DESIGN.md
@@ -148,21 +148,28 @@ and to leave room for future fields without a format bump.
 ### 4.3 Entry layout
 
 Entries are variable-size because each carries its own gen dir. Entry
-header is `V2_ENTRY_HEADER_SIZE = 64` bytes; the gen dir follows.
+header is `V2_ENTRY_HEADER_SIZE = 56` bytes; the gen dir follows.
 
 | Offset | Size | Field | Purpose |
 |---|---|---|---|
 | 0 | 8 | `V2_ENTRY_OFFSET_LEN` | Total entry size (header + gen dir, padded to 8). |
 | 8 | 8 | `V2_ENTRY_OFFSET_SEAL_TXN` | Suffix for `.pv.{sealTxn}` and `.pc{i}.{sealTxn}` files. >= 1, monotonic per `.pk`. |
-| 16 | 8 | `V2_ENTRY_OFFSET_TXN_AT_SEAL` | Table `_txn` value at which this entry takes effect. Reader picks entry where this `<= pinned _txn`. |
-| 24 | 8 | `V2_ENTRY_OFFSET_VALUE_MEM_SIZE` | Bytes in `.pv.{sealTxn}`. |
-| 32 | 8 | `V2_ENTRY_OFFSET_MAX_VALUE` | Highest row id covered by this entry's index data. |
-| 40 | 4 | `V2_ENTRY_OFFSET_KEY_COUNT` | Distinct keys at seal time. |
-| 44 | 4 | `V2_ENTRY_OFFSET_GEN_COUNT` | Number of gen-dir entries. |
-| 48 | 4 | `V2_ENTRY_OFFSET_BLOCK_CAPACITY` | Block capacity for this seal. |
-| 52 | 4 | `V2_ENTRY_OFFSET_COVERING_FORMAT` | Reserved (currently 0). Lets sidecar formats evolve per-seal. |
-| 56 | 8 | `V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET` | Byte offset of the previous entry, or `V2_NO_HEAD` if oldest. |
-| 64+ | `genCount * GEN_DIR_ENTRY_SIZE` | Gen dir entries (existing 28-byte records). |
+| 16 | 8 | `V2_ENTRY_OFFSET_VALUE_MEM_SIZE` | Bytes in `.pv.{sealTxn}`. |
+| 24 | 8 | `V2_ENTRY_OFFSET_MAX_VALUE` | Highest row id covered by this entry's index data. |
+| 32 | 4 | `V2_ENTRY_OFFSET_KEY_COUNT` | Distinct keys at seal time. |
+| 36 | 4 | `V2_ENTRY_OFFSET_GEN_COUNT` | Number of gen-dir entries. |
+| 40 | 4 | `V2_ENTRY_OFFSET_BLOCK_CAPACITY` | Block capacity for this seal. |
+| 44 | 4 | `V2_ENTRY_OFFSET_COVERING_FORMAT` | Reserved (currently 0). Lets sidecar formats evolve per-seal. |
+| 48 | 8 | `V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET` | Byte offset of the previous entry, or `V2_NO_HEAD` if oldest. |
+| 56+ | `genCount * GEN_DIR_ENTRY_SIZE` | Gen dir entries (44-byte records, see 4.5.1). |
+
+The table `_txn` at which the entry takes effect is **not** an entry header
+field — it lives in the first gen-dir slot's `TXN_AT_SEAL` field
+(`slot[0].TXN_AT_SEAL`). With fast-path multi-commit-shares-entry, gens
+within one entry can have different `TXN_AT_SEAL` values; the picker's
+coarse "is this entry visible at all" filter uses the earliest gen
+(slot[0]), and within a visible entry the reader does per-gen filtering
+against pinned `_txn`. See section 4.5.1.
 
 `PostingIndexChainEntry.entrySize(genCount)` returns the total bytes,
 rounded up to 8.

--- a/core/src/main/java/io/questdb/cairo/idx/POSTING_INDEX_CHAIN_DESIGN.md
+++ b/core/src/main/java/io/questdb/cairo/idx/POSTING_INDEX_CHAIN_DESIGN.md
@@ -562,17 +562,22 @@ chain.
   if `sealTxn` advanced (new `.pv.{N}` filename) or the previous
   open found an empty chain, otherwise just `changeSize(...)` if
   same file grew/shrank.
-- `pinnedTableTxn` is the private field on `AbstractPostingIndexReader`
-  that gates per-gen visibility via `slot.TXN_AT_SEAL`. The picker walk
-  filters entries by `entry.txnAtSeal <= pinnedTableTxn`, and
-  `computeVisibleGenCount` (run once at pick time inside
-  `readIndexMetadataFromChain`) trims the reader's `genCount` to the
-  visible prefix. No setter exists yet — `IndexFactory.createReader`
-  plumbing touches O3OpenColumnJob, SymbolMapReaderImpl, and other call
-  sites and is deferred to a follow-up PR. Until then every reader uses
-  the default `Long.MAX_VALUE` pin and sees the head; the recovery walk
-  at writer reopen (`recoveryDropAbandoned` plus `trimInFlightTailGens`)
-  is the load-bearing defence against partial-publish failures.
+- `pinnedTableTxn` on `AbstractPostingIndexReader` gates per-gen visibility
+  via `slot.TXN_AT_SEAL`. The picker walk filters entries by
+  `entry.txnAtSeal <= pinnedTableTxn`; `computeVisibleGenCount` (run at
+  pick time inside `readIndexMetadataFromChain`) trims `genCount` to the
+  visible prefix; `computeVisibleEntryMaxValue` derives the matching
+  cumulative max from the surviving slots.
+  `IndexReader.setPinnedTableTxn` is the public setter; `IndexFactory.createReader`
+  takes the pin as a parameter (applied before the reader returns), and
+  `TableReader.getIndexReader` refreshes the pin on every cache access
+  (so `TableReader.txn` advances via `goActive` / `reload` propagate to
+  every cached reader without chasing the mutating paths individually).
+  `reloadConditionally` re-picks on either a chain advance or a pin
+  change. The writer-side recovery walk (`recoveryDropAbandoned` plus
+  `trimInFlightTailGens`) remains in place; reader-side filtering
+  closes the brief in-flight window between a writer's `extendHead`
+  and its `_txn` advance / crash.
 - `PostingIndexUtils.readSealTxnFromKeyFd` was already migrated to
   walk the v2 chain via `fd` reads in Phase 2b; Phase 3 confirms
   the symmetry between the mapped-memory picker and the fd-based

--- a/core/src/main/java/io/questdb/cairo/idx/POSTING_INDEX_CHAIN_DESIGN.md
+++ b/core/src/main/java/io/questdb/cairo/idx/POSTING_INDEX_CHAIN_DESIGN.md
@@ -562,14 +562,17 @@ chain.
   if `sealTxn` advanced (new `.pv.{N}` filename) or the previous
   open found an empty chain, otherwise just `changeSize(...)` if
   same file grew/shrank.
-- `pinnedTableTxn` is the protected field on `AbstractPostingIndexReader`
-  that gates per-gen visibility via `slot.TXN_AT_SEAL`. No setter exists
-  yet — `IndexFactory.createReader` plumbing touches O3OpenColumnJob,
-  SymbolMapReaderImpl, and other call sites and is deferred to a follow-up
-  PR. Until then every reader uses the default `Long.MAX_VALUE` pin and
-  sees the head; the recovery walk at writer reopen (`recoveryDropAbandoned`
-  plus `trimInFlightTailGens`) is the load-bearing defence against
-  partial-publish failures.
+- `pinnedTableTxn` is the private field on `AbstractPostingIndexReader`
+  that gates per-gen visibility via `slot.TXN_AT_SEAL`. The picker walk
+  filters entries by `entry.txnAtSeal <= pinnedTableTxn`, and
+  `computeVisibleGenCount` (run once at pick time inside
+  `readIndexMetadataFromChain`) trims the reader's `genCount` to the
+  visible prefix. No setter exists yet — `IndexFactory.createReader`
+  plumbing touches O3OpenColumnJob, SymbolMapReaderImpl, and other call
+  sites and is deferred to a follow-up PR. Until then every reader uses
+  the default `Long.MAX_VALUE` pin and sees the head; the recovery walk
+  at writer reopen (`recoveryDropAbandoned` plus `trimInFlightTailGens`)
+  is the load-bearing defence against partial-publish failures.
 - `PostingIndexUtils.readSealTxnFromKeyFd` was already migrated to
   walk the v2 chain via `fd` reads in Phase 2b; Phase 3 confirms
   the symmetry between the mapped-memory picker and the fd-based

--- a/core/src/main/java/io/questdb/cairo/idx/POSTING_INDEX_CHAIN_DESIGN.md
+++ b/core/src/main/java/io/questdb/cairo/idx/POSTING_INDEX_CHAIN_DESIGN.md
@@ -562,13 +562,14 @@ chain.
   if `sealTxn` advanced (new `.pv.{N}` filename) or the previous
   open found an empty chain, otherwise just `changeSize(...)` if
   same file grew/shrank.
-- Public setter `setPinnedTableTxn(long)` is exposed for future
-  Phase-2c plumbing. It is intentionally not threaded through
-  `IndexFactory.createReader` yet — that touches O3OpenColumnJob,
-  SymbolMapReaderImpl, and other call sites and is best done as
-  part of the table-writer ordering work in Phase 4. Until then
-  every reader uses the default `Long.MAX_VALUE` pin and sees the
-  head.
+- `pinnedTableTxn` is the protected field on `AbstractPostingIndexReader`
+  that gates per-gen visibility via `slot.TXN_AT_SEAL`. No setter exists
+  yet — `IndexFactory.createReader` plumbing touches O3OpenColumnJob,
+  SymbolMapReaderImpl, and other call sites and is deferred to a follow-up
+  PR. Until then every reader uses the default `Long.MAX_VALUE` pin and
+  sees the head; the recovery walk at writer reopen (`recoveryDropAbandoned`
+  plus `trimInFlightTailGens`) is the load-bearing defence against
+  partial-publish failures.
 - `PostingIndexUtils.readSealTxnFromKeyFd` was already migrated to
   walk the v2 chain via `fd` reads in Phase 2b; Phase 3 confirms
   the symmetry between the mapped-memory picker and the fd-based

--- a/core/src/main/java/io/questdb/cairo/idx/PostingGenLookup.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingGenLookup.java
@@ -257,7 +257,6 @@ public class PostingGenLookup implements Closeable {
     public void snapshotMetadata(MemoryMR keyMem, int genCount, long entryOffset) {
         Snapshot s = staging;
         s.clear();
-        long prevTxnAtSeal = Long.MIN_VALUE;
         for (int i = 0; i < genCount; i++) {
             long dirOffset = PostingIndexChainEntry.resolveGenDirOffset(entryOffset, i);
             s.genFileOffsets.add(keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET));
@@ -270,10 +269,7 @@ public class PostingGenLookup implements Closeable {
             s.genMinKeys.add(keyMem.getInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MIN_KEY));
             s.genMaxKeys.add(keyMem.getInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY));
             s.genMaxValues.add(keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE));
-            long txnAtSeal = keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL);
-            assert txnAtSeal >= prevTxnAtSeal;
-            prevTxnAtSeal = txnAtSeal;
-            s.genTxnAtSeals.add(txnAtSeal);
+            s.genTxnAtSeals.add(keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL));
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/idx/PostingGenLookup.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingGenLookup.java
@@ -149,8 +149,16 @@ public class PostingGenLookup implements Closeable {
         return active.genMaxKeys.getQuick(gen);
     }
 
+    public long getGenMaxValue(int gen) {
+        return active.genMaxValues.getQuick(gen);
+    }
+
     public int getGenMinKey(int gen) {
         return active.genMinKeys.getQuick(gen);
+    }
+
+    public long getGenTxnAtSeal(int gen) {
+        return active.genTxnAtSeals.getQuick(gen);
     }
 
     // prefix-sum sits between encoded data and the SBBF+footer trailer, so
@@ -248,12 +256,7 @@ public class PostingGenLookup implements Closeable {
      */
     public void snapshotMetadata(MemoryMR keyMem, int genCount, long entryOffset) {
         Snapshot s = staging;
-        s.genFileOffsets.clear();
-        s.genDataSizes.clear();
-        s.genKeyCounts.clear();
-        s.genMinKeys.clear();
-        s.genMaxKeys.clear();
-        s.anySparseGen = false;
+        s.clear();
         for (int i = 0; i < genCount; i++) {
             long dirOffset = PostingIndexChainEntry.resolveGenDirOffset(entryOffset, i);
             s.genFileOffsets.add(keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET));
@@ -265,6 +268,8 @@ public class PostingGenLookup implements Closeable {
             }
             s.genMinKeys.add(keyMem.getInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MIN_KEY));
             s.genMaxKeys.add(keyMem.getInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY));
+            s.genMaxValues.add(keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE));
+            s.genTxnAtSeals.add(keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL));
         }
     }
 
@@ -294,7 +299,9 @@ public class PostingGenLookup implements Closeable {
         final LongList genFileOffsets = new LongList();
         final IntList genKeyCounts = new IntList(); // negative = sparse
         final IntList genMaxKeys = new IntList();
+        final LongList genMaxValues = new LongList();
         final IntList genMinKeys = new IntList();
+        final LongList genTxnAtSeals = new LongList();
         boolean anySparseGen;
 
         void clear() {
@@ -303,6 +310,8 @@ public class PostingGenLookup implements Closeable {
             genKeyCounts.clear();
             genMinKeys.clear();
             genMaxKeys.clear();
+            genMaxValues.clear();
+            genTxnAtSeals.clear();
             anySparseGen = false;
         }
     }

--- a/core/src/main/java/io/questdb/cairo/idx/PostingGenLookup.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingGenLookup.java
@@ -257,6 +257,7 @@ public class PostingGenLookup implements Closeable {
     public void snapshotMetadata(MemoryMR keyMem, int genCount, long entryOffset) {
         Snapshot s = staging;
         s.clear();
+        long prevTxnAtSeal = Long.MIN_VALUE;
         for (int i = 0; i < genCount; i++) {
             long dirOffset = PostingIndexChainEntry.resolveGenDirOffset(entryOffset, i);
             s.genFileOffsets.add(keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET));
@@ -269,7 +270,10 @@ public class PostingGenLookup implements Closeable {
             s.genMinKeys.add(keyMem.getInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MIN_KEY));
             s.genMaxKeys.add(keyMem.getInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY));
             s.genMaxValues.add(keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE));
-            s.genTxnAtSeals.add(keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL));
+            long txnAtSeal = keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL);
+            assert txnAtSeal >= prevTxnAtSeal;
+            prevTxnAtSeal = txnAtSeal;
+            s.genTxnAtSeals.add(txnAtSeal);
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/idx/PostingGenLookup.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingGenLookup.java
@@ -157,10 +157,6 @@ public class PostingGenLookup implements Closeable {
         return active.genMinKeys.getQuick(gen);
     }
 
-    public long getGenTxnAtSeal(int gen) {
-        return active.genTxnAtSeals.getQuick(gen);
-    }
-
     // prefix-sum sits between encoded data and the SBBF+footer trailer, so
     // we walk back from the gen tail.
     public long getGenPrefixSumOffset(int gen, MemoryMR valueMem) {
@@ -174,6 +170,10 @@ public class PostingGenLookup implements Closeable {
                 - PostingIndexUtils.SPARSE_SBBF_NUM_BLOCKS_FOOTER_SIZE
                 - (long) sbbfNumBlocks * SplitBlockBloomFilter.BLOCK_SIZE
                 - (long) (keyRange + 2) * Integer.BYTES;
+    }
+
+    public long getGenTxnAtSeal(int gen) {
+        return active.genTxnAtSeals.getQuick(gen);
     }
 
     public void invalidateCache() {
@@ -257,6 +257,7 @@ public class PostingGenLookup implements Closeable {
     public void snapshotMetadata(MemoryMR keyMem, int genCount, long entryOffset) {
         Snapshot s = staging;
         s.clear();
+        long prevTxnAtSeal = Long.MIN_VALUE;
         for (int i = 0; i < genCount; i++) {
             long dirOffset = PostingIndexChainEntry.resolveGenDirOffset(entryOffset, i);
             s.genFileOffsets.add(keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET));
@@ -269,7 +270,10 @@ public class PostingGenLookup implements Closeable {
             s.genMinKeys.add(keyMem.getInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MIN_KEY));
             s.genMaxKeys.add(keyMem.getInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY));
             s.genMaxValues.add(keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE));
-            s.genTxnAtSeals.add(keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL));
+            long txnAtSeal = keyMem.getLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL);
+            assert txnAtSeal >= prevTxnAtSeal;
+            prevTxnAtSeal = txnAtSeal;
+            s.genTxnAtSeals.add(txnAtSeal);
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexBwdReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexBwdReader.java
@@ -277,10 +277,6 @@ public class PostingIndexBwdReader extends AbstractPostingIndexReader {
             }
             currentGen--;
             while (currentGen >= 0) {
-                if (genLookup.getGenTxnAtSeal(currentGen) > pinnedTableTxn) {
-                    currentGen--;
-                    continue;
-                }
                 int gkc = genLookup.getGenKeyCount(currentGen);
                 if (gkc >= 0) {
                     loadDenseGenerationCached(currentGen);

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexBwdReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexBwdReader.java
@@ -56,6 +56,22 @@ public class PostingIndexBwdReader extends AbstractPostingIndexReader {
         of(configuration, path, name, columnNameTxn, partitionTxn, columnTop, metadata, columnVersionReader, partitionTimestamp);
     }
 
+    public PostingIndexBwdReader(
+            CairoConfiguration configuration,
+            Path path,
+            CharSequence name,
+            long columnNameTxn,
+            long partitionTxn,
+            long columnTop,
+            RecordMetadata metadata,
+            ColumnVersionReader columnVersionReader,
+            long partitionTimestamp,
+            long pinnedTableTxn
+    ) {
+        setPinnedTableTxn(pinnedTableTxn);
+        of(configuration, path, name, columnNameTxn, partitionTxn, columnTop, metadata, columnVersionReader, partitionTimestamp);
+    }
+
     @Override
     public void close() {
         super.close();

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexBwdReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexBwdReader.java
@@ -277,6 +277,10 @@ public class PostingIndexBwdReader extends AbstractPostingIndexReader {
             }
             currentGen--;
             while (currentGen >= 0) {
+                if (genLookup.getGenTxnAtSeal(currentGen) > pinnedTableTxn) {
+                    currentGen--;
+                    continue;
+                }
                 int gkc = genLookup.getGenKeyCount(currentGen);
                 if (gkc >= 0) {
                     loadDenseGenerationCached(currentGen);

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainEntry.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainEntry.java
@@ -116,7 +116,6 @@ public final class PostingIndexChainEntry {
         Unsafe.loadFence();
         into.len = keyMem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN);
         into.sealTxn = keyMem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_SEAL_TXN);
-        into.txnAtSeal = keyMem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_TXN_AT_SEAL);
         into.valueMemSize = keyMem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE);
         into.maxValue = keyMem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE);
         into.keyCount = keyMem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT);
@@ -124,6 +123,10 @@ public final class PostingIndexChainEntry {
         into.coveringFormat = keyMem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_COVERING_FORMAT);
         into.prevEntryOffset = keyMem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET);
         into.genDirOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE;
+        // Entry-level txnAtSeal sources from slot[0] (single source of truth).
+        into.txnAtSeal = into.genCount > 0
+                ? keyMem.getLong(into.genDirOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL)
+                : 0L;
         into.coverFileEndOffsets.clear();
         if (coverCount > 0) {
             long footerOffset = resolveCoverFooterOffset(entryOffset, into.genCount);
@@ -204,14 +207,14 @@ public final class PostingIndexChainEntry {
     }
 
     /**
-     * Write a complete entry header at {@code entryOffset}. Caller must
-     * write the gen dir payload itself afterward (or before the entry is
-     * made visible by publishing the chain head). When {@code coverEndOffsets}
-     * is non-null, this method also fills the cover end-offset footer.
+     * Write a complete entry header at {@code entryOffset}. {@code txnAtSeal}
+     * lands in slot[0]'s {@code TXN_AT_SEAL} field (single on-disk source of
+     * truth for entry-level visibility) when {@code genCount > 0}. Callers
+     * must write the rest of the gen dir payload separately. When
+     * {@code coverEndOffsets} is non-null, also fills the cover footer.
      * <p>
-     * The entry must be fully written and durable on disk before
-     * {@link PostingIndexChainHeader#publish} advances the chain head;
-     * otherwise a reader could observe a stale entry.
+     * The entry must be fully written and durable before
+     * {@link PostingIndexChainHeader#publish} advances the chain head.
      */
     public static void writeHeader(
             MemoryW keyMem,
@@ -231,7 +234,6 @@ public final class PostingIndexChainEntry {
         long len = entrySize(genCount, coverCount);
         keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, len);
         keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_SEAL_TXN, sealTxn);
-        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_TXN_AT_SEAL, txnAtSeal);
         keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE, valueMemSize);
         keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE, maxValue);
         keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT, keyCount);
@@ -239,6 +241,10 @@ public final class PostingIndexChainEntry {
         keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_BLOCK_CAPACITY, blockCapacity);
         keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_COVERING_FORMAT, coveringFormat);
         keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET, prevEntryOffset);
+        if (genCount > 0) {
+            long slot0Offset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE;
+            keyMem.putLong(slot0Offset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, txnAtSeal);
+        }
         if (coverCount > 0) {
             long footerOffset = resolveCoverFooterOffset(entryOffset, genCount);
             for (int c = 0; c < coverCount; c++) {

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainEntry.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainEntry.java
@@ -38,24 +38,29 @@ import io.questdb.std.Unsafe;
  * GC — at which point the entry is no longer reachable from the chain head
  * and no reader can be pinned on it.
  * <p>
- * Entry layout (header is V2_ENTRY_HEADER_SIZE = 64 bytes):
+ * Entry layout (header is V2_ENTRY_HEADER_SIZE = 56 bytes):
  * <pre>
  *   [0..7]                                              LEN
  *   [8..15]                                             SEAL_TXN
- *   [16..23]                                            TXN_AT_SEAL
- *   [24..31]                                            VALUE_MEM_SIZE
- *   [32..39]                                            MAX_VALUE
- *   [40..43]                                            KEY_COUNT
- *   [44..47]                                            GEN_COUNT
- *   [48..51]                                            BLOCK_CAPACITY
- *   [52..55]                                            COVERING_FORMAT (reserved)
- *   [56..63]                                            PREV_ENTRY_OFFSET
- *   [64 ..)                                             GEN_DIR (GEN_COUNT * GEN_DIR_ENTRY_SIZE)
- *   [64 + GEN_COUNT*GEN_DIR_ENTRY_SIZE ..)              COVER_END_OFFSETS (COVER_COUNT * 8 bytes)
+ *   [16..23]                                            VALUE_MEM_SIZE
+ *   [24..31]                                            MAX_VALUE
+ *   [32..35]                                            KEY_COUNT
+ *   [36..39]                                            GEN_COUNT
+ *   [40..43]                                            BLOCK_CAPACITY
+ *   [44..47]                                            COVERING_FORMAT (reserved)
+ *   [48..55]                                            PREV_ENTRY_OFFSET
+ *   [56 ..)                                             GEN_DIR (GEN_COUNT * GEN_DIR_ENTRY_SIZE)
+ *   [56 + GEN_COUNT*GEN_DIR_ENTRY_SIZE ..)              COVER_END_OFFSETS (COVER_COUNT * 8 bytes)
  * </pre>
  * COVER_COUNT is constant for the .pk file's posting column instance and is
  * published in the .pci sidecar header, so every entry in this .pk shares the
  * same cover footer length.
+ * <p>
+ * The entry-level "table _txn this entry takes effect at" (txnAtSeal) is NOT a
+ * header field: it lives in slot[0]'s TXN_AT_SEAL within the gen-dir region.
+ * Entries written with {@code genCount == 0} therefore have no on-disk
+ * txnAtSeal and {@link #read} returns 0 for that case; production writers
+ * always pass {@code genCount >= 1}.
  */
 public final class PostingIndexChainEntry {
 

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
@@ -71,7 +71,6 @@ public final class PostingIndexChainWriter {
     private long entryCount;
     private long genCounter;
     private long headEntryOffset;
-    private boolean isHeadTrimmedOnLastRecovery;
     // Cached sealTxn of the current head entry. Distinct from genCounter:
     // recoveryDropAbandoned can rewind headEntryOffset to a surviving
     // entry whose sealTxn is below the high-water genCounter (it cannot
@@ -80,6 +79,7 @@ public final class PostingIndexChainWriter {
     // instead of genCounter so post-recovery writes extend the survivor
     // rather than tripping the appendNewEntry monotonicity assertion.
     private long headSealTxn;
+    private boolean isHeadTrimmedOnLastRecovery;
     private long regionBase;
     private long regionLimit;
 

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
@@ -508,8 +508,10 @@ public final class PostingIndexChainWriter {
                     dropped++;
                 } else if (trimmedTo < entryScratch.genCount) {
                     isHeadTrimmed = true;
-                    long trimmedEntryLen = applyHeadTrim(keyMem, offset, trimmedTo, entryScratch.len);
-                    newRegionLimit = offset + trimmedEntryLen;
+                    long copyAt = newRegionLimit;
+                    long copyLen = applyHeadTrim(keyMem, offset, trimmedTo, entryScratch.len, copyAt);
+                    newHead = copyAt;
+                    newRegionLimit = copyAt + copyLen;
                 }
                 break;
             }
@@ -599,44 +601,38 @@ public final class PostingIndexChainWriter {
     }
 
     /**
-     * Shrink the head entry's gen dir to {@code keepGenCount}. Stale readers
-     * holding a mapping from before the writer's crash can walk this entry
-     * during the mutation (the chain seqlock is only republished at the end
-     * of {@link #recoveryDropAbandoned}), so the writes must publish in an
-     * order that is safe to observe at any point:
-     * <ol>
-     *   <li>Copy cover footer to its new offset under the OLD {@code GEN_COUNT}
-     *       (readers using OLD count don't read the new-offset bytes).</li>
-     *   <li>storeFence; store new {@code GEN_COUNT}.</li>
-     *   <li>storeFence; store LEN / VALUE_MEM_SIZE / MAX_VALUE / KEY_COUNT.</li>
-     * </ol>
-     * NEW-{@code GEN_COUNT} readers observing the window between steps 2 and
-     * 3 see the just-copied footer at the right offset and OLD (always larger)
-     * tail-header values, all of which are benign: larger VALUE_MEM_SIZE still
-     * fits on disk (.pv is not truncated), larger KEY_COUNT leaves trailing
-     * keys empty, larger MAX_VALUE only inflates size estimates.
+     * Write a trimmed copy of the source entry at {@code destOffset}
+     * (retaining {@code keepGenCount} gens) and return its length.
+     * Copy-on-write avoids in-place mutation; the chain header publish
+     * at the end of {@link #recoveryDropAbandoned} atomically flips the
+     * head pointer, so concurrent readers see either the untouched
+     * source or the fully-written destination, never a half-state.
+     * <p>
+     * The destination reuses the source's {@code sealTxn} -- both
+     * reference the same {@code .pv.{sealTxn}} / {@code .pc{i}.{sealTxn}}
+     * files; the destination's gen-dir indexes a prefix of the same
+     * value-file ranges. The source's bytes remain in the region as an
+     * unreachable gap (no entry's {@code prevEntryOffset} points at it).
      */
-    private long applyHeadTrim(MemoryARW keyMem, long entryOffset, int keepGenCount, long oldEntryLen) {
+    private long applyHeadTrim(MemoryARW keyMem, long sourceOffset, int keepGenCount, long sourceLen, long destOffset) {
         assert keepGenCount >= 1;
-        long lastSlot = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+        long lastSlot = sourceOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
                 + (long) (keepGenCount - 1) * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
         long lastFileOffset = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET);
         long lastSize = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_SIZE);
         long lastMaxValue = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE);
         int newKeyCount = 0;
         for (int g = 0; g < keepGenCount; g++) {
-            long slot = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+            long slot = sourceOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
                     + (long) g * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
             int slotMaxKey = keyMem.getInt(slot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY);
             if (slotMaxKey + 1 > newKeyCount) {
                 newKeyCount = slotMaxKey + 1;
             }
         }
-        // Derive coverCount from the stored LEN: coverPlusPadding mixes
-        // 8-byte cover-end-offset slots with up to 7 bytes of padding, so
-        // integer division by 8 recovers the slot count.
-        int oldGenCount = keyMem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
-        long coverPlusPadding = oldEntryLen
+        // coverPlusPadding's up-to-7-byte trailing pad rounds down on / 8.
+        int oldGenCount = keyMem.getInt(sourceOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
+        long coverPlusPadding = sourceLen
                 - PostingIndexUtils.V2_ENTRY_HEADER_SIZE
                 - (long) oldGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
         int coverCount = coverPlusPadding > 0
@@ -644,28 +640,54 @@ public final class PostingIndexChainWriter {
                 : 0;
         long newLen = PostingIndexChainEntry.entrySize(keepGenCount, coverCount);
 
+        long sourceSealTxn = keyMem.getLong(sourceOffset + PostingIndexUtils.V2_ENTRY_OFFSET_SEAL_TXN);
+        int blockCapacity = keyMem.getInt(sourceOffset + PostingIndexUtils.V2_ENTRY_OFFSET_BLOCK_CAPACITY);
+        int coveringFormat = keyMem.getInt(sourceOffset + PostingIndexUtils.V2_ENTRY_OFFSET_COVERING_FORMAT);
+        long sourcePrevEntryOffset = keyMem.getLong(sourceOffset + PostingIndexUtils.V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET);
+
+        keyMem.putLong(destOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, newLen);
+        keyMem.putLong(destOffset + PostingIndexUtils.V2_ENTRY_OFFSET_SEAL_TXN, sourceSealTxn);
+        keyMem.putLong(destOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE, lastFileOffset + lastSize);
+        keyMem.putLong(destOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE, lastMaxValue);
+        keyMem.putInt(destOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT, newKeyCount);
+        keyMem.putInt(destOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT, keepGenCount);
+        keyMem.putInt(destOffset + PostingIndexUtils.V2_ENTRY_OFFSET_BLOCK_CAPACITY, blockCapacity);
+        keyMem.putInt(destOffset + PostingIndexUtils.V2_ENTRY_OFFSET_COVERING_FORMAT, coveringFormat);
+        keyMem.putLong(destOffset + PostingIndexUtils.V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET, sourcePrevEntryOffset);
+
+        // Slot layout mixes long and int fields; copy field-by-field.
+        long sourceGenDir = sourceOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE;
+        long destGenDir = destOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE;
+        for (int g = 0; g < keepGenCount; g++) {
+            long sSlot = sourceGenDir + (long) g * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+            long dSlot = destGenDir + (long) g * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+            keyMem.putLong(dSlot + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET,
+                    keyMem.getLong(sSlot + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET));
+            keyMem.putLong(dSlot + PostingIndexUtils.GEN_DIR_OFFSET_SIZE,
+                    keyMem.getLong(sSlot + PostingIndexUtils.GEN_DIR_OFFSET_SIZE));
+            keyMem.putInt(dSlot + PostingIndexUtils.GEN_DIR_OFFSET_KEY_COUNT,
+                    keyMem.getInt(sSlot + PostingIndexUtils.GEN_DIR_OFFSET_KEY_COUNT));
+            keyMem.putInt(dSlot + PostingIndexUtils.GEN_DIR_OFFSET_MIN_KEY,
+                    keyMem.getInt(sSlot + PostingIndexUtils.GEN_DIR_OFFSET_MIN_KEY));
+            keyMem.putInt(dSlot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY,
+                    keyMem.getInt(sSlot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY));
+            keyMem.putLong(dSlot + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL,
+                    keyMem.getLong(sSlot + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL));
+            keyMem.putLong(dSlot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE,
+                    keyMem.getLong(sSlot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE));
+        }
+
         if (coverCount > 0) {
-            long oldFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+            long sourceFooterOffset = sourceOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
                     + (long) oldGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
-            long newFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+            long destFooterOffset = destOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
                     + (long) keepGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
-            // Forward copy is safe because dst < src (we are shrinking).
             for (int c = 0; c < coverCount; c++) {
-                long src = oldFooterOffset + (long) c * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE;
-                long dst = newFooterOffset + (long) c * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE;
-                keyMem.putLong(dst, keyMem.getLong(src));
+                keyMem.putLong(destFooterOffset + (long) c * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE,
+                        keyMem.getLong(sourceFooterOffset + (long) c * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE));
             }
         }
-        Unsafe.storeFence();
 
-        keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT, keepGenCount);
-        Unsafe.storeFence();
-
-        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, newLen);
-        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE,
-                lastFileOffset + lastSize);
-        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE, lastMaxValue);
-        keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT, newKeyCount);
         Unsafe.storeFence();
         return newLen;
     }

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
@@ -468,6 +468,7 @@ public final class PostingIndexChainWriter {
         long newHead = headEntryOffset;
         long newEntryCount = entryCount;
         long newRegionLimit = regionLimit;
+        boolean headTrimmed = false;
         // Walk strictly bounded by entryCount: a corrupted prev pointer that
         // loops back on itself would otherwise drop more entries than the
         // chain contains and, for an unbounded cycle, never terminate. The
@@ -489,6 +490,21 @@ public final class PostingIndexChainWriter {
             }
             PostingIndexChainEntry.read(keyMem, offset, 0, entryScratch);
             if (entryScratch.txnAtSeal <= currentTableTxn) {
+                // entry-level visible, but fast-path may have stuffed
+                // in-flight gens in this entry's tail via extendHead. Trim
+                // them off via per-slot TXN_AT_SEAL.
+                int trimmedTo = trimInFlightTailGens(keyMem, offset, entryScratch.genCount, currentTableTxn);
+                if (trimmedTo == 0) {
+                    orphanSealTxns.add(entryScratch.sealTxn);
+                    newHead = entryScratch.prevEntryOffset;
+                    newEntryCount--;
+                    newRegionLimit = offset;
+                    dropped++;
+                } else if (trimmedTo < entryScratch.genCount) {
+                    headTrimmed = true;
+                    long trimmedEntryLen = applyHeadTrim(keyMem, offset, trimmedTo, entryScratch.len);
+                    newRegionLimit = offset + trimmedEntryLen;
+                }
                 break;
             }
             orphanSealTxns.add(entryScratch.sealTxn);
@@ -500,7 +516,7 @@ public final class PostingIndexChainWriter {
             offset = entryScratch.prevEntryOffset;
             dropped++;
         }
-        if (dropped == 0) {
+        if (dropped == 0 && !headTrimmed) {
             return 0;
         }
         headEntryOffset = newHead;
@@ -525,6 +541,89 @@ public final class PostingIndexChainWriter {
                 genCounter
         );
         return dropped;
+    }
+
+    /**
+     * Shrink the head entry's gen dir to {@code keepGenCount} after the
+     * recovery walk trimmed in-flight tail gens. Uses <b>GEN_COUNT-first</b>
+     * write order (the inverse of {@link #extendHead}) so a concurrent
+     * reader never sees OLD large GEN_COUNT paired with NEW small
+     * VALUE_MEM_SIZE -- which would let the reader read past the trimmed
+     * valueMem mapping.
+     */
+    private long applyHeadTrim(MemoryARW keyMem, long entryOffset, int keepGenCount, long oldEntryLen) {
+        long lastSlot = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                + (long) (keepGenCount - 1) * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        long lastFileOffset = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET);
+        long lastSize = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_SIZE);
+        long lastMaxValue = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE);
+        int newKeyCount = 0;
+        for (int g = 0; g < keepGenCount; g++) {
+            long slot = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                    + (long) g * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+            int slotMaxKey = keyMem.getInt(slot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY);
+            if (slotMaxKey + 1 > newKeyCount) {
+                newKeyCount = slotMaxKey + 1;
+            }
+        }
+        // Preserve the existing cover footer position. The new LEN is the
+        // header + the kept gen dir + the cover footer (sized from oldEntryLen
+        // minus the old gen-dir region and rounded the same way as
+        // entrySize()).
+        long oldGenDirBytes = oldEntryLen - PostingIndexUtils.V2_ENTRY_HEADER_SIZE;
+        // Cover footer + alignment padding sits after the gen dir; preserve
+        // it by computing remaining bytes and appending after the trimmed
+        // gen dir region.
+        int oldGenCount = keyMem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
+        long coverPlusPadding = oldGenDirBytes - (long) oldGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        if (coverPlusPadding < 0) {
+            coverPlusPadding = 0;
+        }
+        long newLen = (long) PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                + (long) keepGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE
+                + coverPlusPadding;
+        newLen = (newLen + 7L) & ~7L;
+
+        keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT, keepGenCount);
+        Unsafe.storeFence();
+
+        if (coverPlusPadding > 0) {
+            long oldFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                    + (long) oldGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+            long newFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                    + (long) keepGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+            for (long b = 0; b < coverPlusPadding; b += Long.BYTES) {
+                long v = keyMem.getLong(oldFooterOffset + b);
+                keyMem.putLong(newFooterOffset + b, v);
+            }
+        }
+
+        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, newLen);
+        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE,
+                lastFileOffset + lastSize);
+        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE, lastMaxValue);
+        keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT, newKeyCount);
+        Unsafe.storeFence();
+        return newLen;
+    }
+
+    /**
+     * Returns the number of head-entry gen-dir slots to keep, trimming the
+     * tail of slots whose TXN_AT_SEAL exceeds {@code currentTableTxn}.
+     */
+    private int trimInFlightTailGens(MemoryARW keyMem, long entryOffset, int genCount, long currentTableTxn) {
+        int keep = genCount;
+        while (keep > 0) {
+            long slotOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                    + (long) (keep - 1) * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+            Unsafe.loadFence();
+            long slotTxnAtSeal = keyMem.getLong(slotOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL);
+            if (slotTxnAtSeal <= currentTableTxn) {
+                break;
+            }
+            keep--;
+        }
+        return keep;
     }
 
     /**

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
@@ -71,6 +71,7 @@ public final class PostingIndexChainWriter {
     private long entryCount;
     private long genCounter;
     private long headEntryOffset;
+    private boolean headTrimmedOnLastRecovery;
     // Cached sealTxn of the current head entry. Distinct from genCounter:
     // recoveryDropAbandoned can rewind headEntryOffset to a surviving
     // entry whose sealTxn is below the high-water genCounter (it cannot
@@ -356,6 +357,10 @@ public final class PostingIndexChainWriter {
         return headEntryOffset != PostingIndexUtils.V2_NO_HEAD;
     }
 
+    public boolean isHeadTrimmedOnLastRecovery() {
+        return headTrimmedOnLastRecovery;
+    }
+
     /**
      * Initialise both header pages on a fresh .pk file. Resets in-memory
      * state to the empty-chain defaults: the first append will use
@@ -460,6 +465,7 @@ public final class PostingIndexChainWriter {
      * @return the number of entries that were dropped.
      */
     public int recoveryDropAbandoned(MemoryARW keyMem, long currentTableTxn, LongList orphanSealTxns) {
+        headTrimmedOnLastRecovery = false;
         if (headEntryOffset == PostingIndexUtils.V2_NO_HEAD) {
             return 0;
         }
@@ -519,6 +525,7 @@ public final class PostingIndexChainWriter {
         if (dropped == 0 && !headTrimmed) {
             return 0;
         }
+        headTrimmedOnLastRecovery = headTrimmed;
         headEntryOffset = newHead;
         entryCount = newEntryCount;
         regionLimit = newRegionLimit;
@@ -541,89 +548,6 @@ public final class PostingIndexChainWriter {
                 genCounter
         );
         return dropped;
-    }
-
-    /**
-     * Shrink the head entry's gen dir to {@code keepGenCount} after the
-     * recovery walk trimmed in-flight tail gens. Uses <b>GEN_COUNT-first</b>
-     * write order (the inverse of {@link #extendHead}) so a concurrent
-     * reader never sees OLD large GEN_COUNT paired with NEW small
-     * VALUE_MEM_SIZE -- which would let the reader read past the trimmed
-     * valueMem mapping.
-     */
-    private long applyHeadTrim(MemoryARW keyMem, long entryOffset, int keepGenCount, long oldEntryLen) {
-        long lastSlot = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
-                + (long) (keepGenCount - 1) * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
-        long lastFileOffset = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET);
-        long lastSize = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_SIZE);
-        long lastMaxValue = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE);
-        int newKeyCount = 0;
-        for (int g = 0; g < keepGenCount; g++) {
-            long slot = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
-                    + (long) g * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
-            int slotMaxKey = keyMem.getInt(slot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY);
-            if (slotMaxKey + 1 > newKeyCount) {
-                newKeyCount = slotMaxKey + 1;
-            }
-        }
-        // Preserve the existing cover footer position. The new LEN is the
-        // header + the kept gen dir + the cover footer (sized from oldEntryLen
-        // minus the old gen-dir region and rounded the same way as
-        // entrySize()).
-        long oldGenDirBytes = oldEntryLen - PostingIndexUtils.V2_ENTRY_HEADER_SIZE;
-        // Cover footer + alignment padding sits after the gen dir; preserve
-        // it by computing remaining bytes and appending after the trimmed
-        // gen dir region.
-        int oldGenCount = keyMem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
-        long coverPlusPadding = oldGenDirBytes - (long) oldGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
-        if (coverPlusPadding < 0) {
-            coverPlusPadding = 0;
-        }
-        long newLen = (long) PostingIndexUtils.V2_ENTRY_HEADER_SIZE
-                + (long) keepGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE
-                + coverPlusPadding;
-        newLen = (newLen + 7L) & ~7L;
-
-        keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT, keepGenCount);
-        Unsafe.storeFence();
-
-        if (coverPlusPadding > 0) {
-            long oldFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
-                    + (long) oldGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
-            long newFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
-                    + (long) keepGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
-            for (long b = 0; b < coverPlusPadding; b += Long.BYTES) {
-                long v = keyMem.getLong(oldFooterOffset + b);
-                keyMem.putLong(newFooterOffset + b, v);
-            }
-        }
-
-        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, newLen);
-        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE,
-                lastFileOffset + lastSize);
-        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE, lastMaxValue);
-        keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT, newKeyCount);
-        Unsafe.storeFence();
-        return newLen;
-    }
-
-    /**
-     * Returns the number of head-entry gen-dir slots to keep, trimming the
-     * tail of slots whose TXN_AT_SEAL exceeds {@code currentTableTxn}.
-     */
-    private int trimInFlightTailGens(MemoryARW keyMem, long entryOffset, int genCount, long currentTableTxn) {
-        int keep = genCount;
-        while (keep > 0) {
-            long slotOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
-                    + (long) (keep - 1) * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
-            Unsafe.loadFence();
-            long slotTxnAtSeal = keyMem.getLong(slotOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL);
-            if (slotTxnAtSeal <= currentTableTxn) {
-                break;
-            }
-            keep--;
-        }
-        return keep;
     }
 
     /**
@@ -672,5 +596,84 @@ public final class PostingIndexChainWriter {
                 regionLimit,
                 genCounter
         );
+    }
+
+    /**
+     * Shrink the head entry's gen dir to {@code keepGenCount} after the
+     * recovery walk trimmed in-flight tail gens. Uses <b>GEN_COUNT-first</b>
+     * write order (the inverse of {@link #extendHead}) so a concurrent
+     * reader never sees OLD large GEN_COUNT paired with NEW small
+     * VALUE_MEM_SIZE -- which would let the reader read past the trimmed
+     * valueMem mapping.
+     */
+    private long applyHeadTrim(MemoryARW keyMem, long entryOffset, int keepGenCount, long oldEntryLen) {
+        long lastSlot = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                + (long) (keepGenCount - 1) * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        long lastFileOffset = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET);
+        long lastSize = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_SIZE);
+        long lastMaxValue = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE);
+        int newKeyCount = 0;
+        for (int g = 0; g < keepGenCount; g++) {
+            long slot = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                    + (long) g * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+            int slotMaxKey = keyMem.getInt(slot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY);
+            if (slotMaxKey + 1 > newKeyCount) {
+                newKeyCount = slotMaxKey + 1;
+            }
+        }
+        // Derive coverCount from the stored LEN: coverPlusPadding mixes
+        // 8-byte cover-end-offset slots with up to 7 bytes of padding, so
+        // integer division by 8 recovers the slot count.
+        int oldGenCount = keyMem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
+        long coverPlusPadding = oldEntryLen
+                - PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                - (long) oldGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        int coverCount = coverPlusPadding > 0
+                ? (int) (coverPlusPadding / PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE)
+                : 0;
+        long newLen = PostingIndexChainEntry.entrySize(keepGenCount, coverCount);
+
+        keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT, keepGenCount);
+        Unsafe.storeFence();
+
+        if (coverCount > 0) {
+            long oldFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                    + (long) oldGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+            long newFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                    + (long) keepGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+            // Forward copy is safe because dst < src (we are shrinking).
+            for (int c = 0; c < coverCount; c++) {
+                long src = oldFooterOffset + (long) c * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE;
+                long dst = newFooterOffset + (long) c * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE;
+                keyMem.putLong(dst, keyMem.getLong(src));
+            }
+        }
+
+        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, newLen);
+        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE,
+                lastFileOffset + lastSize);
+        keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE, lastMaxValue);
+        keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT, newKeyCount);
+        Unsafe.storeFence();
+        return newLen;
+    }
+
+    /**
+     * Returns the number of head-entry gen-dir slots to keep, trimming the
+     * tail of slots whose TXN_AT_SEAL exceeds {@code currentTableTxn}.
+     */
+    private int trimInFlightTailGens(MemoryARW keyMem, long entryOffset, int genCount, long currentTableTxn) {
+        Unsafe.loadFence();
+        int keep = genCount;
+        while (keep > 0) {
+            long slotOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                    + (long) (keep - 1) * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+            long slotTxnAtSeal = keyMem.getLong(slotOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL);
+            if (slotTxnAtSeal <= currentTableTxn) {
+                break;
+            }
+            keep--;
+        }
+        return keep;
     }
 }

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
@@ -508,7 +508,18 @@ public final class PostingIndexChainWriter {
                     dropped++;
                 } else if (trimmedTo < entryScratch.genCount) {
                     isHeadTrimmed = true;
-                    long copyAt = newRegionLimit;
+                    // Copy to virgin space past the ORIGINAL regionLimit, not
+                    // newRegionLimit. When entries were dropped ahead of this
+                    // one, newRegionLimit has been rewound onto the bytes of
+                    // those just-dropped entries -- and those entries were
+                    // previously published heads that a concurrent reader may
+                    // still have cached. Writing the trimmed copy there would
+                    // overwrite their bytes before the header republish below,
+                    // letting a straddling reader pass its stillStable re-check
+                    // on torn bytes. regionLimit is always virgin space past
+                    // the head, so the source and every dropped entry stay
+                    // byte-intact as unreachable gaps until GC.
+                    long copyAt = regionLimit;
                     long copyLen = applyHeadTrim(keyMem, offset, trimmedTo, entryScratch.len, copyAt);
                     newHead = copyAt;
                     newRegionLimit = copyAt + copyLen;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
@@ -71,7 +71,7 @@ public final class PostingIndexChainWriter {
     private long entryCount;
     private long genCounter;
     private long headEntryOffset;
-    private boolean headTrimmedOnLastRecovery;
+    private boolean isHeadTrimmedOnLastRecovery;
     // Cached sealTxn of the current head entry. Distinct from genCounter:
     // recoveryDropAbandoned can rewind headEntryOffset to a surviving
     // entry whose sealTxn is below the high-water genCounter (it cannot
@@ -357,10 +357,6 @@ public final class PostingIndexChainWriter {
         return headEntryOffset != PostingIndexUtils.V2_NO_HEAD;
     }
 
-    public boolean isHeadTrimmedOnLastRecovery() {
-        return headTrimmedOnLastRecovery;
-    }
-
     /**
      * Initialise both header pages on a fresh .pk file. Resets in-memory
      * state to the empty-chain defaults: the first append will use
@@ -380,6 +376,10 @@ public final class PostingIndexChainWriter {
         PostingIndexChainHeader.initialiseEmpty(keyMem, startSealTxn);
         resetState();
         genCounter = startSealTxn - 1L;
+    }
+
+    public boolean isHeadTrimmedOnLastRecovery() {
+        return isHeadTrimmedOnLastRecovery;
     }
 
     /**
@@ -465,7 +465,7 @@ public final class PostingIndexChainWriter {
      * @return the number of entries that were dropped.
      */
     public int recoveryDropAbandoned(MemoryARW keyMem, long currentTableTxn, LongList orphanSealTxns) {
-        headTrimmedOnLastRecovery = false;
+        isHeadTrimmedOnLastRecovery = false;
         if (headEntryOffset == PostingIndexUtils.V2_NO_HEAD) {
             return 0;
         }
@@ -474,7 +474,7 @@ public final class PostingIndexChainWriter {
         long newHead = headEntryOffset;
         long newEntryCount = entryCount;
         long newRegionLimit = regionLimit;
-        boolean headTrimmed = false;
+        boolean isHeadTrimmed = false;
         // Walk strictly bounded by entryCount: a corrupted prev pointer that
         // loops back on itself would otherwise drop more entries than the
         // chain contains and, for an unbounded cycle, never terminate. The
@@ -507,7 +507,7 @@ public final class PostingIndexChainWriter {
                     newRegionLimit = offset;
                     dropped++;
                 } else if (trimmedTo < entryScratch.genCount) {
-                    headTrimmed = true;
+                    isHeadTrimmed = true;
                     long trimmedEntryLen = applyHeadTrim(keyMem, offset, trimmedTo, entryScratch.len);
                     newRegionLimit = offset + trimmedEntryLen;
                 }
@@ -522,10 +522,10 @@ public final class PostingIndexChainWriter {
             offset = entryScratch.prevEntryOffset;
             dropped++;
         }
-        if (dropped == 0 && !headTrimmed) {
+        if (dropped == 0 && !isHeadTrimmed) {
             return 0;
         }
-        headTrimmedOnLastRecovery = headTrimmed;
+        isHeadTrimmedOnLastRecovery = isHeadTrimmed;
         headEntryOffset = newHead;
         entryCount = newEntryCount;
         regionLimit = newRegionLimit;
@@ -599,14 +599,25 @@ public final class PostingIndexChainWriter {
     }
 
     /**
-     * Shrink the head entry's gen dir to {@code keepGenCount} after the
-     * recovery walk trimmed in-flight tail gens. Uses <b>GEN_COUNT-first</b>
-     * write order (the inverse of {@link #extendHead}) so a concurrent
-     * reader never sees OLD large GEN_COUNT paired with NEW small
-     * VALUE_MEM_SIZE -- which would let the reader read past the trimmed
-     * valueMem mapping.
+     * Shrink the head entry's gen dir to {@code keepGenCount}. Stale readers
+     * holding a mapping from before the writer's crash can walk this entry
+     * during the mutation (the chain seqlock is only republished at the end
+     * of {@link #recoveryDropAbandoned}), so the writes must publish in an
+     * order that is safe to observe at any point:
+     * <ol>
+     *   <li>Copy cover footer to its new offset under the OLD {@code GEN_COUNT}
+     *       (readers using OLD count don't read the new-offset bytes).</li>
+     *   <li>storeFence; store new {@code GEN_COUNT}.</li>
+     *   <li>storeFence; store LEN / VALUE_MEM_SIZE / MAX_VALUE / KEY_COUNT.</li>
+     * </ol>
+     * NEW-{@code GEN_COUNT} readers observing the window between steps 2 and
+     * 3 see the just-copied footer at the right offset and OLD (always larger)
+     * tail-header values, all of which are benign: larger VALUE_MEM_SIZE still
+     * fits on disk (.pv is not truncated), larger KEY_COUNT leaves trailing
+     * keys empty, larger MAX_VALUE only inflates size estimates.
      */
     private long applyHeadTrim(MemoryARW keyMem, long entryOffset, int keepGenCount, long oldEntryLen) {
+        assert keepGenCount >= 1;
         long lastSlot = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
                 + (long) (keepGenCount - 1) * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
         long lastFileOffset = keyMem.getLong(lastSlot + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET);
@@ -633,9 +644,6 @@ public final class PostingIndexChainWriter {
                 : 0;
         long newLen = PostingIndexChainEntry.entrySize(keepGenCount, coverCount);
 
-        keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT, keepGenCount);
-        Unsafe.storeFence();
-
         if (coverCount > 0) {
             long oldFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
                     + (long) oldGenCount * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
@@ -648,6 +656,10 @@ public final class PostingIndexChainWriter {
                 keyMem.putLong(dst, keyMem.getLong(src));
             }
         }
+        Unsafe.storeFence();
+
+        keyMem.putInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT, keepGenCount);
+        Unsafe.storeFence();
 
         keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, newLen);
         keyMem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE,

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexFwdReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexFwdReader.java
@@ -65,6 +65,22 @@ public class PostingIndexFwdReader extends AbstractPostingIndexReader {
         of(configuration, path, name, columnNameTxn, partitionTxn, columnTop, metadata, columnVersionReader, partitionTimestamp);
     }
 
+    public PostingIndexFwdReader(
+            CairoConfiguration configuration,
+            Path path,
+            CharSequence name,
+            long columnNameTxn,
+            long partitionTxn,
+            long columnTop,
+            io.questdb.cairo.sql.RecordMetadata metadata,
+            io.questdb.cairo.ColumnVersionReader columnVersionReader,
+            long partitionTimestamp,
+            long pinnedTableTxn
+    ) {
+        setPinnedTableTxn(pinnedTableTxn);
+        of(configuration, path, name, columnNameTxn, partitionTxn, columnTop, metadata, columnVersionReader, partitionTimestamp);
+    }
+
     @Override
     public void close() {
         super.close();

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexUtils.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexUtils.java
@@ -198,10 +198,10 @@ public final class PostingIndexUtils {
     public static final int KEY_FILE_RESERVED = 8192;
     public static final int LONG_OFFSETS_FLAG = 0x4000_0000;
     public static final int MAX_BLOCK_COUNT = 1_000_000; // corruption guard: 64M values at BLOCK_CAPACITY=64
-    // Maximum number of generations a single chain entry can carry. The
-    // bound comes from the per-entry gen-dir region, which lives in the
-    // remaining bytes of an entry's 4KB seqlock page (4088 - 64 header
-    // bytes) divided by GEN_DIR_ENTRY_SIZE = 44.
+    // Maximum number of generations a single chain entry can carry. An
+    // entry's gen-dir region must fit alongside the entry header within the
+    // 4088-byte usable area of a 4KB seqlock page: floor((4088 - 56) / 44)
+    // = 91, matching V2_ENTRY_HEADER_SIZE = 56 and GEN_DIR_ENTRY_SIZE = 44.
     public static final int MAX_GEN_COUNT = 91;
     public static final int PACKED_BATCH_SIZE = BLOCK_CAPACITY;
     public static final long PAGE_A_OFFSET = 0;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexUtils.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexUtils.java
@@ -175,20 +175,34 @@ public final class PostingIndexUtils {
     public static final byte ENCODING_ADAPTIVE = 0;
     public static final byte ENCODING_DELTA = 1;
     public static final byte ENCODING_EF = 2;
-    public static final int GEN_DIR_ENTRY_SIZE = 28;
+    public static final int GEN_DIR_ENTRY_SIZE = 44;
     public static final int GEN_DIR_OFFSET_FILE_OFFSET = 0;
     public static final int GEN_DIR_OFFSET_KEY_COUNT = 16;
     public static final int GEN_DIR_OFFSET_MAX_KEY = 24;
+    // Cumulative max row id covered by this gen (the entry-level MAX_VALUE
+    // at the moment the writer published this gen). Lets recovery restore
+    // the entry header's MAX_VALUE after trimming in-flight gens off the
+    // tail without rescanning the gen's encoded row ids.
+    public static final int GEN_DIR_OFFSET_MAX_VALUE = 36;
     public static final int GEN_DIR_OFFSET_MIN_KEY = 20;
     public static final int GEN_DIR_OFFSET_SIZE = 8;
+    // Table _txn the gen anticipated when extendHead/appendNewEntry wrote
+    // it. The writer-open recovery walk trims trailing slots with
+    // txnAtSeal > committedTxn before loading head state, so a commit that
+    // bumped GEN_COUNT but never had its txWriter.commit run gets evicted
+    // instead of surfacing as ghost (key, rowId) pairs to readers. Must be
+    // written LAST in publishToChain (after all the other slot fields,
+    // under a storeFence) so a torn write cannot leave a slot with new
+    // metadata but stale txnAtSeal.
+    public static final int GEN_DIR_OFFSET_TXN_AT_SEAL = 28;
     public static final int KEY_FILE_RESERVED = 8192;
     public static final int LONG_OFFSETS_FLAG = 0x4000_0000;
     public static final int MAX_BLOCK_COUNT = 1_000_000; // corruption guard: 64M values at BLOCK_CAPACITY=64
     // Maximum number of generations a single chain entry can carry. The
     // bound comes from the per-entry gen-dir region, which lives in the
     // remaining bytes of an entry's 4KB seqlock page (4088 - 64 header
-    // bytes) divided by GEN_DIR_ENTRY_SIZE = 28.
-    public static final int MAX_GEN_COUNT = 143;
+    // bytes) divided by GEN_DIR_ENTRY_SIZE = 44.
+    public static final int MAX_GEN_COUNT = 91;
     public static final int PACKED_BATCH_SIZE = BLOCK_CAPACITY;
     public static final long PAGE_A_OFFSET = 0;
     public static final long PAGE_B_OFFSET = 4096;
@@ -241,27 +255,27 @@ public final class PostingIndexUtils {
     //   [56..4087]  reserved
     //   [4088..4095] V2_HEADER_OFFSET_SEQUENCE_END
     //
-    // Entry header (V2_ENTRY_HEADER_SIZE = 64 bytes; gen dir follows):
+    // Entry header (V2_ENTRY_HEADER_SIZE = 56 bytes; gen dir follows):
     //   [0..7]      V2_ENTRY_OFFSET_LEN
     //                 total entry size in bytes (header + gen dir).
     //   [8..15]     V2_ENTRY_OFFSET_SEAL_TXN  (>= 1, monotonic per .pk).
-    //   [16..23]    V2_ENTRY_OFFSET_TXN_AT_SEAL
-    //                 the table _txn this entry takes effect at.
-    //                 Readers pick the entry where TXN_AT_SEAL <= pinned _txn
-    //                 (highest such). Entries with TXN_AT_SEAL > _txn are
-    //                 either uncommitted or abandoned.
-    //   [24..31]    V2_ENTRY_OFFSET_VALUE_MEM_SIZE  (.pv.{sealTxn} bytes).
-    //   [32..39]    V2_ENTRY_OFFSET_MAX_VALUE        (highest row id).
-    //   [40..43]    V2_ENTRY_OFFSET_KEY_COUNT
-    //   [44..47]    V2_ENTRY_OFFSET_GEN_COUNT
-    //   [48..51]    V2_ENTRY_OFFSET_BLOCK_CAPACITY
-    //   [52..55]    V2_ENTRY_OFFSET_COVERING_FORMAT (reserved; 0 for now).
-    //   [56..63]    V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET
+    //                 The entry-level "table _txn this entry takes effect at"
+    //                 lives in slot[0]'s TXN_AT_SEAL field. Fast-path multi-
+    //                 commit shares an entry, so visibility / recovery is
+    //                 per-gen; entry-level uses slot[0] (the earliest gen)
+    //                 as the picker's coarse filter.
+    //   [16..23]    V2_ENTRY_OFFSET_VALUE_MEM_SIZE  (.pv.{sealTxn} bytes).
+    //   [24..31]    V2_ENTRY_OFFSET_MAX_VALUE        (highest row id).
+    //   [32..35]    V2_ENTRY_OFFSET_KEY_COUNT
+    //   [36..39]    V2_ENTRY_OFFSET_GEN_COUNT
+    //   [40..43]    V2_ENTRY_OFFSET_BLOCK_CAPACITY
+    //   [44..47]    V2_ENTRY_OFFSET_COVERING_FORMAT (reserved; 0 for now).
+    //   [48..55]    V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET
     //                 byte offset of the previous entry, or V2_NO_HEAD if
     //                 this is the oldest entry. Lets readers walk backwards
     //                 from head without scanning the whole region.
-    //   [64..]      gen dir, GEN_COUNT * GEN_DIR_ENTRY_SIZE bytes.
-    //   [64 + GEN_COUNT * GEN_DIR_ENTRY_SIZE ..]
+    //   [56..]      gen dir, GEN_COUNT * GEN_DIR_ENTRY_SIZE bytes.
+    //   [56 + GEN_COUNT * GEN_DIR_ENTRY_SIZE ..]
     //               cover end-offset footer, COVER_COUNT * COVER_END_OFFSET_ENTRY_SIZE
     //               bytes. The c-th long is the writer's append offset in
     //               .pc{c}.<...>.<SEAL_TXN> at the moment this entry was
@@ -271,17 +285,16 @@ public final class PostingIndexUtils {
     //               every entry in this .pk file. The footer is empty when
     //               COVER_COUNT == 0. The whole entry is then 8-byte aligned
     //               via PostingIndexChainEntry.entrySize.
-    public static final int V2_ENTRY_HEADER_SIZE = 64;
-    public static final int V2_ENTRY_OFFSET_BLOCK_CAPACITY = 48;
-    public static final int V2_ENTRY_OFFSET_COVERING_FORMAT = 52;
-    public static final int V2_ENTRY_OFFSET_GEN_COUNT = 44;
-    public static final int V2_ENTRY_OFFSET_KEY_COUNT = 40;
+    public static final int V2_ENTRY_HEADER_SIZE = 56;
+    public static final int V2_ENTRY_OFFSET_BLOCK_CAPACITY = 40;
+    public static final int V2_ENTRY_OFFSET_COVERING_FORMAT = 44;
+    public static final int V2_ENTRY_OFFSET_GEN_COUNT = 36;
+    public static final int V2_ENTRY_OFFSET_KEY_COUNT = 32;
     public static final int V2_ENTRY_OFFSET_LEN = 0;
-    public static final int V2_ENTRY_OFFSET_MAX_VALUE = 32;
-    public static final int V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET = 56;
+    public static final int V2_ENTRY_OFFSET_MAX_VALUE = 24;
+    public static final int V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET = 48;
     public static final int V2_ENTRY_OFFSET_SEAL_TXN = 8;
-    public static final int V2_ENTRY_OFFSET_TXN_AT_SEAL = 16;
-    public static final int V2_ENTRY_OFFSET_VALUE_MEM_SIZE = 24;
+    public static final int V2_ENTRY_OFFSET_VALUE_MEM_SIZE = 16;
     public static final long V2_ENTRY_REGION_BASE = 8192L;
     public static final int V2_FORMAT_VERSION = 2;
     public static final int V2_HEADER_OFFSET_ENTRY_COUNT = 24;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexUtils.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexUtils.java
@@ -199,13 +199,11 @@ public final class PostingIndexUtils {
     public static final int LONG_OFFSETS_FLAG = 0x4000_0000;
     public static final int MAX_BLOCK_COUNT = 1_000_000; // corruption guard: 64M values at BLOCK_CAPACITY=64
     // Maximum number of generations a single chain entry can carry before
-    // the writer force-seals. Picked so an entry's header + gen-dir region
-    // fits within a 4KB page: 56 + 91 * 44 = 4060 bytes, leaving room for
-    // cover-end-offset footer + 8-byte alignment within the same page.
-    // PC_HEADER_SIZE is sized off this constant (one long per gen), so any
-    // change here must keep PC_HEADER_SIZE within the .pci sidecar's header
-    // region.
-    public static final int MAX_GEN_COUNT = 91;
+    // the writer force-seals. Soft cap: trades seal frequency (lower with
+    // a larger cap, better write throughput) against entry size (gen-dir
+    // grows linearly, inflating reader snapshot cost). PC_HEADER_SIZE is
+    // sized off this constant (one long per gen).
+    public static final int MAX_GEN_COUNT = 128;
     public static final int PACKED_BATCH_SIZE = BLOCK_CAPACITY;
     public static final long PAGE_A_OFFSET = 0;
     public static final long PAGE_B_OFFSET = 4096;
@@ -224,7 +222,7 @@ public final class PostingIndexUtils {
     public static final int PAGE_OFFSET_SEQUENCE_START = 0;
     public static final int PAGE_OFFSET_VALUE_MEM_SIZE = 8;
     public static final int PAGE_SIZE = 4096;
-    public static final int PC_HEADER_SIZE = MAX_GEN_COUNT * Long.BYTES; // 728 = 91 * 8
+    public static final int PC_HEADER_SIZE = MAX_GEN_COUNT * Long.BYTES;
     public static final byte SIGNATURE = (byte) 0xfb;
     public static final double SPARSE_SBBF_DEFAULT_FPP = 0.01;
     public static final int SPARSE_SBBF_NUM_BLOCKS_FOOTER_SIZE = Integer.BYTES;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexUtils.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexUtils.java
@@ -198,10 +198,13 @@ public final class PostingIndexUtils {
     public static final int KEY_FILE_RESERVED = 8192;
     public static final int LONG_OFFSETS_FLAG = 0x4000_0000;
     public static final int MAX_BLOCK_COUNT = 1_000_000; // corruption guard: 64M values at BLOCK_CAPACITY=64
-    // Maximum number of generations a single chain entry can carry. An
-    // entry's gen-dir region must fit alongside the entry header within the
-    // 4088-byte usable area of a 4KB seqlock page: floor((4088 - 56) / 44)
-    // = 91, matching V2_ENTRY_HEADER_SIZE = 56 and GEN_DIR_ENTRY_SIZE = 44.
+    // Maximum number of generations a single chain entry can carry before
+    // the writer force-seals. Picked so an entry's header + gen-dir region
+    // fits within a 4KB page: 56 + 91 * 44 = 4060 bytes, leaving room for
+    // cover-end-offset footer + 8-byte alignment within the same page.
+    // PC_HEADER_SIZE is sized off this constant (one long per gen), so any
+    // change here must keep PC_HEADER_SIZE within the .pci sidecar's header
+    // region.
     public static final int MAX_GEN_COUNT = 91;
     public static final int PACKED_BATCH_SIZE = BLOCK_CAPACITY;
     public static final long PAGE_A_OFFSET = 0;
@@ -221,7 +224,7 @@ public final class PostingIndexUtils {
     public static final int PAGE_OFFSET_SEQUENCE_START = 0;
     public static final int PAGE_OFFSET_VALUE_MEM_SIZE = 8;
     public static final int PAGE_SIZE = 4096;
-    public static final int PC_HEADER_SIZE = MAX_GEN_COUNT * Long.BYTES; // 1144
+    public static final int PC_HEADER_SIZE = MAX_GEN_COUNT * Long.BYTES; // 728 = 91 * 8
     public static final byte SIGNATURE = (byte) 0xfb;
     public static final double SPARSE_SBBF_DEFAULT_FPP = 0.01;
     public static final int SPARSE_SBBF_NUM_BLOCKS_FOOTER_SIZE = Integer.BYTES;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -2722,8 +2722,9 @@ public class PostingIndexWriter implements IndexWriter {
         hasPendingData = false;
         activeKeyCount = 0;
 
-        // Seal at >= MAX_GEN_COUNT (not >). Entry MAX_GEN_COUNT-1 (index 124)
-        // ends at page offset 4064. Entry 125 would overlap sequence_end at 4088.
+        // Seal at >= MAX_GEN_COUNT (not >). With MAX_GEN_COUNT=91, slot
+        // index 90 ends at entry offset 56 + 91*44 = 4060. Slot 91 would
+        // overlap the seqlock sequence_end at 4088.
         if (genCount >= MAX_GEN_COUNT) {
             seal();
         }
@@ -4779,20 +4780,23 @@ public class PostingIndexWriter implements IndexWriter {
         }
         recoveryOrphanScratch.clear();
         int dropped;
+        boolean headTrimmed;
         try {
             dropped = chain.recoveryDropAbandoned(keyMem, currentTableTxn, recoveryOrphanScratch);
+            headTrimmed = chain.isHeadTrimmedOnLastRecovery();
         } finally {
             // Single-shot consumption — next reopen must call the setter
             // again or recovery is skipped.
             currentTableTxn = -1L;
         }
-        if (dropped <= 0) {
+        if (dropped <= 0 && !headTrimmed) {
             return;
         }
-        LOG.info().$("posting index recovery dropped abandoned chain entries [")
+        LOG.info().$("posting index recovery [")
                 .$("indexName=").$(indexName)
                 .$(", postingColumnNameTxn=").$(postingColumnNameTxn)
                 .$(", dropped=").$(dropped)
+                .$(", headTrimmed=").$(headTrimmed)
                 .$(']').$();
         // Conservatively schedule each orphan .pv.{N} (and .pc{i}.{N}) for
         // purge with the widest possible reader window. Orphans were

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -3502,11 +3502,17 @@ public class PostingIndexWriter implements IndexWriter {
         long entryBase = newEntry ? chain.getRegionLimit() : chain.getHeadEntryOffset();
 
         long dirOffset = PostingIndexChainEntry.resolveGenDirOffset(entryBase, overrideGenIndex);
+        long slotTxnAtSeal = pendingTxnAtSeal >= 0 ? pendingTxnAtSeal : 0L;
         keyMem.putLong(dirOffset + GEN_DIR_OFFSET_FILE_OFFSET, overrideFileOffset);
         keyMem.putLong(dirOffset + GEN_DIR_OFFSET_SIZE, overrideSize);
         keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_KEY_COUNT, overrideKeyCount);
         keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MIN_KEY, overrideMinKey);
         keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY, overrideMaxKey);
+        keyMem.putLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE, maxValue);
+        // TXN_AT_SEAL is the slot's last-write-wins latch for recovery's
+        // tail trim. Must be the last store + storeFence.
+        Unsafe.storeFence();
+        keyMem.putLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, slotTxnAtSeal);
 
         // Snapshot the current append offset of each open sidecar. Tombstoned
         // and not-yet-opened slots publish 0; readers treat them as "no file

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -2722,9 +2722,11 @@ public class PostingIndexWriter implements IndexWriter {
         hasPendingData = false;
         activeKeyCount = 0;
 
-        // Seal at >= MAX_GEN_COUNT (not >). With MAX_GEN_COUNT=91, slot
-        // index 90 ends at entry offset 56 + 91*44 = 4060. Slot 91 would
-        // overlap the seqlock sequence_end at 4088.
+        // Seal at >= MAX_GEN_COUNT (not >). MAX_GEN_COUNT is sized so the
+        // entry header + gen-dir region fits within a 4KB page: at 91 gens
+        // the gen-dir tail ends at entry offset 56 + 91 * 44 = 4060, leaving
+        // room for the cover-end-offset footer; one more gen would push the
+        // footer past the 4096-byte boundary.
         if (genCount >= MAX_GEN_COUNT) {
             seal();
         }
@@ -3510,8 +3512,9 @@ public class PostingIndexWriter implements IndexWriter {
         keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MIN_KEY, overrideMinKey);
         keyMem.putInt(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY, overrideMaxKey);
         keyMem.putLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE, maxValue);
-        // TXN_AT_SEAL is the slot's last-write-wins latch for recovery's
-        // tail trim. Must be the last store + storeFence.
+        // storeFence pairs with the loadFence in trimInFlightTailGens so a
+        // recovery walk that finds slot.TXN_AT_SEAL > currentTableTxn sees
+        // the matching slot payload too.
         Unsafe.storeFence();
         keyMem.putLong(dirOffset + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, slotTxnAtSeal);
 
@@ -4780,23 +4783,23 @@ public class PostingIndexWriter implements IndexWriter {
         }
         recoveryOrphanScratch.clear();
         int dropped;
-        boolean headTrimmed;
+        boolean isHeadTrimmed;
         try {
             dropped = chain.recoveryDropAbandoned(keyMem, currentTableTxn, recoveryOrphanScratch);
-            headTrimmed = chain.isHeadTrimmedOnLastRecovery();
+            isHeadTrimmed = chain.isHeadTrimmedOnLastRecovery();
         } finally {
             // Single-shot consumption — next reopen must call the setter
             // again or recovery is skipped.
             currentTableTxn = -1L;
         }
-        if (dropped <= 0 && !headTrimmed) {
+        if (dropped <= 0 && !isHeadTrimmed) {
             return;
         }
         LOG.info().$("posting index recovery [")
                 .$("indexName=").$(indexName)
                 .$(", postingColumnNameTxn=").$(postingColumnNameTxn)
                 .$(", dropped=").$(dropped)
-                .$(", headTrimmed=").$(headTrimmed)
+                .$(", isHeadTrimmed=").$(isHeadTrimmed)
                 .$(']').$();
         // Conservatively schedule each orphan .pv.{N} (and .pc{i}.{N}) for
         // purge with the widest possible reader window. Orphans were

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -2722,11 +2722,8 @@ public class PostingIndexWriter implements IndexWriter {
         hasPendingData = false;
         activeKeyCount = 0;
 
-        // Seal at >= MAX_GEN_COUNT (not >). MAX_GEN_COUNT is sized so the
-        // entry header + gen-dir region fits within a 4KB page: at 91 gens
-        // the gen-dir tail ends at entry offset 56 + 91 * 44 = 4060, leaving
-        // room for the cover-end-offset footer; one more gen would push the
-        // footer past the 4096-byte boundary.
+        // Soft cap on per-entry gen count; trades seal frequency against
+        // entry size.
         if (genCount >= MAX_GEN_COUNT) {
             seal();
         }
@@ -3718,12 +3715,13 @@ public class PostingIndexWriter implements IndexWriter {
         // pendingTxnAtSeal is intentionally NOT reset here: a single logical
         // TableWriter operation (e.g. sealPostingIndexForPartition) calls
         // setNextTxnAtSeal once and then runs through rollbackConditionally,
-        // rebuildSidecars/seal in sequence — every one of which may reach
-        // publishToChain. The publishToChain assert catches the
-        // never-set case (pendingTxnAtSeal=-1 after open or close); leaving
-        // the value live across sub-operations preserves the right
-        // txnAtSeal. close() resets the field so a future of(...) starts
-        // clean.
+        // rebuildSidecars/seal in sequence -- every one of which may reach
+        // publishToChain. Leaving the value live across sub-operations
+        // preserves the right txnAtSeal. close() resets the field to -1
+        // so a future of(...) starts clean; publishToChain's fallback
+        // turns the never-set case (-1) into slot.TXN_AT_SEAL=0, leaving
+        // the entry undroppable by recovery -- a deliberate trade-off for
+        // test/legacy paths that never wire the setter.
         // Cap the in-memory outbox to prevent unbounded growth when the
         // global PostingSealPurge job is disabled, the queue is permanently
         // saturated, or publishPendingPurges() is never called. When at the

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -431,6 +431,7 @@ public class PostingIndexWriter implements IndexWriter {
                     hasPendingData = false;
                     activeKeyCount = 0;
                     coverCount = 0;
+                    pendingTxnAtSeal = -1;
                     chain.resetState();
                 }
             }

--- a/core/src/test/java/io/questdb/test/cairo/IndexFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/IndexFactoryTest.java
@@ -42,7 +42,7 @@ public class IndexFactoryTest extends AbstractCairoTest {
     public void testCreateReaderNoneThrows() {
         try (Path path = new Path().put("/tmp/test/")) {
             try {
-                IndexFactory.createReader(IndexType.NONE, 1, configuration, path, "col", 0, 0, 0, null, null, 0);
+                IndexFactory.createReader(IndexType.NONE, 1, configuration, path, "col", 0, 0, 0, null, null, 0, Long.MAX_VALUE);
                 Assert.fail("expected CairoException");
             } catch (CairoException e) {
                 Assert.assertTrue(e.getMessage().contains("unsupported index type: NONE"));
@@ -54,7 +54,7 @@ public class IndexFactoryTest extends AbstractCairoTest {
     public void testCreateReaderUnsupportedThrows() {
         try (Path path = new Path().put("/tmp/test/")) {
             try {
-                IndexFactory.createReader((byte) 99, 1, configuration, path, "col", 0, 0, 0, null, null, 0);
+                IndexFactory.createReader((byte) 99, 1, configuration, path, "col", 0, 0, 0, null, null, 0, Long.MAX_VALUE);
                 Assert.fail("expected CairoException");
             } catch (CairoException e) {
                 Assert.assertTrue(e.getMessage().contains("unsupported index type"));

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -704,6 +704,124 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testReaderHidesHeadEntryTailGensAbovePin() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "reader_pin_tail_gen_visibility";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(configuration)) {
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, true);
+                    writer.setNextTxnAtSeal(1L);
+                    writer.add(0, 0);
+                    writer.add(0, 1);
+                    writer.setMaxValue(1);
+                    writer.commit();
+
+                    // currentTableTxn=2 so neither slot is trimmed -- we want
+                    // both gens persisted to disk so the reader-side pin
+                    // filter is what hides slot[1] for low-pinned readers.
+                    writer.setCurrentTableTxn(2L);
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, false);
+
+                    writer.setNextTxnAtSeal(2L);
+                    writer.add(1, 2);
+                    writer.add(1, 3);
+                    writer.setMaxValue(3);
+                    writer.commit();
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0);
+                     DirectBitSet foundKeys = new DirectBitSet(8)) {
+                    reader.setPinnedTableTxn(2L);
+                    reader.reloadConditionally();
+                    int distinct = reader.collectDistinctKeys(foundKeys);
+                    Assert.assertEquals(
+                            "pin >= slot[1].TXN_AT_SEAL: both gens visible",
+                            2, distinct);
+                    Assert.assertTrue(foundKeys.get(0));
+                    Assert.assertTrue(foundKeys.get(1));
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0);
+                     DirectBitSet foundKeys = new DirectBitSet(8)) {
+                    reader.setPinnedTableTxn(1L);
+                    reader.reloadConditionally();
+                    int distinct = reader.collectDistinctKeys(foundKeys);
+                    Assert.assertEquals(
+                            "pin = slot[0].TXN_AT_SEAL: only gen 0 visible",
+                            1, distinct);
+                    Assert.assertTrue(foundKeys.get(0));
+                    Assert.assertFalse(
+                            "key=1 lives in gen 1 (slot[1].TXN_AT_SEAL=2 > pin)",
+                            foundKeys.get(1)
+                    );
+
+                    try (RowCursor cursor = reader.getCursor(/* key */ 1, /* minValue */ 0, /* maxValue */ Long.MAX_VALUE)) {
+                        Assert.assertFalse(
+                                "rowids from the pin-hidden gen must not surface through getCursor",
+                                cursor.hasNext()
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testReaderPinChangeViaReloadConditionallyRePicks() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "reader_pin_reload_repick";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(configuration)) {
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, true);
+                    writer.setNextTxnAtSeal(1L);
+                    writer.add(0, 0);
+                    writer.setMaxValue(0);
+                    writer.commit();
+
+                    writer.setCurrentTableTxn(2L);
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, false);
+
+                    writer.setNextTxnAtSeal(2L);
+                    writer.add(1, 1);
+                    writer.setMaxValue(1);
+                    writer.commit();
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0);
+                     DirectBitSet foundKeys = new DirectBitSet(8)) {
+                    // Default Long.MAX_VALUE pin: both gens visible.
+                    Assert.assertEquals(2, reader.collectDistinctKeys(foundKeys));
+                    foundKeys.clear();
+
+                    // Lower the pin under slot[1]; reloadConditionally must
+                    // re-pick even though the chain header has not advanced.
+                    reader.setPinnedTableTxn(1L);
+                    reader.reloadConditionally();
+                    Assert.assertEquals(1, reader.collectDistinctKeys(foundKeys));
+                    Assert.assertTrue(foundKeys.get(0));
+                    Assert.assertFalse(foundKeys.get(1));
+                    foundKeys.clear();
+
+                    // Raise the pin back above slot[1]; re-pick exposes gen 1.
+                    reader.setPinnedTableTxn(Long.MAX_VALUE);
+                    reader.reloadConditionally();
+                    Assert.assertEquals(2, reader.collectDistinctKeys(foundKeys));
+                    Assert.assertTrue(foundKeys.get(0));
+                    Assert.assertTrue(foundKeys.get(1));
+                }
+            }
+        });
+    }
+
+    @Test
     public void testRecoveryHidesFailedExtendHeadFromReader() throws Exception {
         assertMemoryLeak(() -> {
             final String name = "extend_head_failed_recovery_query";

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -174,6 +174,45 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    @Test
+    public void testExtendHeadFailedCommitNotDroppedByRecovery() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "extend_head_failed_recovery";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(configuration)) {
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, true);
+                    writer.setNextTxnAtSeal(1L);
+                    writer.add(0, 0);
+                    writer.add(0, 1);
+                    writer.setMaxValue(1);
+                    writer.commit(); // appendNewEntry -> txnAtSeal=1, genCount=1
+
+                    // Successful commit at table layer would advance committedTxn to 1.
+                    // The reopen below is what TableWriter does between WAL transactions:
+                    // close + open from disk, then drive recovery via setCurrentTableTxn.
+                    writer.setCurrentTableTxn(1L);
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, false);
+
+                    // Batch 2 anticipates txn 2 but the table commit will not run.
+                    writer.setNextTxnAtSeal(2L);
+                    writer.add(1, 2);
+                    writer.add(1, 3);
+                    writer.setMaxValue(3);
+                    writer.commit(); // extendHead -> genCount=2, txnAtSeal STAYS at 1
+                }
+
+                try (PostingIndexWriter writer = new PostingIndexWriter(configuration)) {
+                    writer.setCurrentTableTxn(1L);
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, false);
+                    Assert.assertEquals(
+                            "recovery walk should drop the failed batch 2 gen because batch 2 anticipated txn 2 > committedTxn 1",
+                            1, writer.getGenCount());
+                }
+            }
+        });
+    }
+
     /**
      * Critical #1: PostingIndexNative Java fallback silently corrupts data
      * at bitWidth=64 because of the 64-bit shift no-op in
@@ -1962,6 +2001,25 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    // Critical findings #2 (setMaxValue seqlock), #6 ([0, Long.MAX_VALUE)
+    // conservative purge interval) and #7 (seal-loop partial failure
+    // recovery) were RED placeholders during the v1 era. They are now
+    // addressed structurally by the v2 chain redesign:
+    //   #2 — chain.updateHeadMaxValue publishes via the chain header
+    //        seqlock, so any reader of MAX_VALUE goes through the same
+    //        consistency protocol as keyCount/genCount.
+    //   #6 — recordPostingSealPurge derives [fromTxn, toTxn) from the
+    //        chain entries themselves; the residual [0, MAX) branch only
+    //        fires for the empty-chain edge case, which the
+    //        writer-open recovery walk picks up on the next reopen.
+    //   #7 — recoveryDropAbandoned (run from PostingIndexWriter.of after
+    //        setCurrentTableTxn) drops every chain entry whose txnAtSeal
+    //        was published before the encompassing txWriter.commit
+    //        landed.
+    // Critical finding #9 (ColumnPurgeOperator retry cap on Windows) is
+    // orthogonal to the posting-index chain rewrite and remains tracked
+    // separately.
+
     /**
      * Review finding M2: the rebuild dance in
      * TableWriter.sealPostingIndexForPartition}'s covering branch
@@ -2143,25 +2201,6 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
-    // Critical findings #2 (setMaxValue seqlock), #6 ([0, Long.MAX_VALUE)
-    // conservative purge interval) and #7 (seal-loop partial failure
-    // recovery) were RED placeholders during the v1 era. They are now
-    // addressed structurally by the v2 chain redesign:
-    //   #2 — chain.updateHeadMaxValue publishes via the chain header
-    //        seqlock, so any reader of MAX_VALUE goes through the same
-    //        consistency protocol as keyCount/genCount.
-    //   #6 — recordPostingSealPurge derives [fromTxn, toTxn) from the
-    //        chain entries themselves; the residual [0, MAX) branch only
-    //        fires for the empty-chain edge case, which the
-    //        writer-open recovery walk picks up on the next reopen.
-    //   #7 — recoveryDropAbandoned (run from PostingIndexWriter.of after
-    //        setCurrentTableTxn) drops every chain entry whose txnAtSeal
-    //        was published before the encompassing txWriter.commit
-    //        landed.
-    // Critical finding #9 (ColumnPurgeOperator retry cap on Windows) is
-    // orthogonal to the posting-index chain rewrite and remains tracked
-    // separately.
-
     /**
      * Locks in the multi-gen short-circuit semantics: when a CLEAN gen
      * processed first contributes to {@code total} and a later gen turns out
@@ -2218,6 +2257,25 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    // =========================================================================
+    // Red tests for the v2 review of PR #6861 (current pass).
+    //
+    // Each test below maps to a finding from the review report. Tests that
+    // require fault injection use TestFilesFacadeImpl; tests that require
+    // concurrency simulate the race by mutating ff.length() between mmap
+    // setup and chain access. Findings that can only manifest from sources
+    // FilesFacade does not see (Unsafe.realloc OOM, queue-pool exhaustion)
+    // are documented in trailing comments.
+    // =========================================================================
+
+    // Review finding #1 (sidecar mem fd leak in openSidecarFiles) was
+    // dropped after verification: MemoryCMARWImpl.extend0 (line 403) and
+    // map0 (line 417) both close the fd on mmap/mremap failure inside
+    // jumpTo(). The "orphan mem" identified in the review never holds an
+    // open fd by the time the outer catch fires — it is already closed
+    // internally by the memory-mapping helper.
+    // Documented for traceability; no JUnit red test.
+
     /**
      * The {@code Cursor.size()} fast path must bail to iteration when a single
      * gen straddles {@code entryMaxValue}, because the per-gen count includes
@@ -2266,25 +2324,6 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             }
         });
     }
-
-    // =========================================================================
-    // Red tests for the v2 review of PR #6861 (current pass).
-    //
-    // Each test below maps to a finding from the review report. Tests that
-    // require fault injection use TestFilesFacadeImpl; tests that require
-    // concurrency simulate the race by mutating ff.length() between mmap
-    // setup and chain access. Findings that can only manifest from sources
-    // FilesFacade does not see (Unsafe.realloc OOM, queue-pool exhaustion)
-    // are documented in trailing comments.
-    // =========================================================================
-
-    // Review finding #1 (sidecar mem fd leak in openSidecarFiles) was
-    // dropped after verification: MemoryCMARWImpl.extend0 (line 403) and
-    // map0 (line 417) both close the fd on mmap/mremap failure inside
-    // jumpTo(). The "orphan mem" identified in the review never holds an
-    // open fd by the time the outer catch fires — it is already closed
-    // internally by the memory-mapping helper.
-    // Documented for traceability; no JUnit red test.
 
     /**
      * The DELTA-mode upper bound from {@code peekDeltaKeyMaxValueUpperBound}
@@ -2888,7 +2927,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      * Reproduces the writer-side root cause of the GraalVM SIGSEGV in
      * hs_err_pid19555 (PostingIndexBenchmarkSuite.walFastLagInsertAndQuery
      * on bench/posting-wal-fastlag): a covering posting index whose chain
-     * head had LEN=96 (= entrySize(genCount=1, coverCount=0)) while .pci
+     * head had LEN=104 (= entrySize(genCount=1, coverCount=0)) while .pci
      * advertised coverCount=1. This test drives PostingIndexWriter through
      * the same lifecycle the WAL fast-lag path follows in production:
      * <ol>
@@ -2965,8 +3004,8 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                         }
                         Assert.assertEquals(
                                 "post-seal head LEN must include the cover footer "
-                                        + "(64 header + genCount*28 gen-dir + coverCount*8 footer, "
-                                        + "padded to 8): expected entrySize(genCount=1, coverCount=1)=104",
+                                        + "(56 header + genCount*44 gen-dir + coverCount*8 footer, "
+                                        + "padded to 8): expected entrySize(genCount=1, coverCount=1)=112",
                                 PostingIndexChainEntry.entrySize(1, coverCount), lenAfterSeal
                         );
 

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -2001,25 +2001,6 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
-    // Critical findings #2 (setMaxValue seqlock), #6 ([0, Long.MAX_VALUE)
-    // conservative purge interval) and #7 (seal-loop partial failure
-    // recovery) were RED placeholders during the v1 era. They are now
-    // addressed structurally by the v2 chain redesign:
-    //   #2 — chain.updateHeadMaxValue publishes via the chain header
-    //        seqlock, so any reader of MAX_VALUE goes through the same
-    //        consistency protocol as keyCount/genCount.
-    //   #6 — recordPostingSealPurge derives [fromTxn, toTxn) from the
-    //        chain entries themselves; the residual [0, MAX) branch only
-    //        fires for the empty-chain edge case, which the
-    //        writer-open recovery walk picks up on the next reopen.
-    //   #7 — recoveryDropAbandoned (run from PostingIndexWriter.of after
-    //        setCurrentTableTxn) drops every chain entry whose txnAtSeal
-    //        was published before the encompassing txWriter.commit
-    //        landed.
-    // Critical finding #9 (ColumnPurgeOperator retry cap on Windows) is
-    // orthogonal to the posting-index chain rewrite and remains tracked
-    // separately.
-
     /**
      * Review finding M2: the rebuild dance in
      * TableWriter.sealPostingIndexForPartition}'s covering branch
@@ -2201,6 +2182,25 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    // Critical findings #2 (setMaxValue seqlock), #6 ([0, Long.MAX_VALUE)
+    // conservative purge interval) and #7 (seal-loop partial failure
+    // recovery) were RED placeholders during the v1 era. They are now
+    // addressed structurally by the v2 chain redesign:
+    //   #2 — chain.updateHeadMaxValue publishes via the chain header
+    //        seqlock, so any reader of MAX_VALUE goes through the same
+    //        consistency protocol as keyCount/genCount.
+    //   #6 — recordPostingSealPurge derives [fromTxn, toTxn) from the
+    //        chain entries themselves; the residual [0, MAX) branch only
+    //        fires for the empty-chain edge case, which the
+    //        writer-open recovery walk picks up on the next reopen.
+    //   #7 — recoveryDropAbandoned (run from PostingIndexWriter.of after
+    //        setCurrentTableTxn) drops every chain entry whose txnAtSeal
+    //        was published before the encompassing txWriter.commit
+    //        landed.
+    // Critical finding #9 (ColumnPurgeOperator retry cap on Windows) is
+    // orthogonal to the posting-index chain rewrite and remains tracked
+    // separately.
+
     /**
      * Locks in the multi-gen short-circuit semantics: when a CLEAN gen
      * processed first contributes to {@code total} and a later gen turns out
@@ -2257,25 +2257,6 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
-    // =========================================================================
-    // Red tests for the v2 review of PR #6861 (current pass).
-    //
-    // Each test below maps to a finding from the review report. Tests that
-    // require fault injection use TestFilesFacadeImpl; tests that require
-    // concurrency simulate the race by mutating ff.length() between mmap
-    // setup and chain access. Findings that can only manifest from sources
-    // FilesFacade does not see (Unsafe.realloc OOM, queue-pool exhaustion)
-    // are documented in trailing comments.
-    // =========================================================================
-
-    // Review finding #1 (sidecar mem fd leak in openSidecarFiles) was
-    // dropped after verification: MemoryCMARWImpl.extend0 (line 403) and
-    // map0 (line 417) both close the fd on mmap/mremap failure inside
-    // jumpTo(). The "orphan mem" identified in the review never holds an
-    // open fd by the time the outer catch fires — it is already closed
-    // internally by the memory-mapping helper.
-    // Documented for traceability; no JUnit red test.
-
     /**
      * The {@code Cursor.size()} fast path must bail to iteration when a single
      * gen straddles {@code entryMaxValue}, because the per-gen count includes
@@ -2324,6 +2305,25 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             }
         });
     }
+
+    // =========================================================================
+    // Red tests for the v2 review of PR #6861 (current pass).
+    //
+    // Each test below maps to a finding from the review report. Tests that
+    // require fault injection use TestFilesFacadeImpl; tests that require
+    // concurrency simulate the race by mutating ff.length() between mmap
+    // setup and chain access. Findings that can only manifest from sources
+    // FilesFacade does not see (Unsafe.realloc OOM, queue-pool exhaustion)
+    // are documented in trailing comments.
+    // =========================================================================
+
+    // Review finding #1 (sidecar mem fd leak in openSidecarFiles) was
+    // dropped after verification: MemoryCMARWImpl.extend0 (line 403) and
+    // map0 (line 417) both close the fd on mmap/mremap failure inside
+    // jumpTo(). The "orphan mem" identified in the review never holds an
+    // open fd by the time the outer catch fires — it is already closed
+    // internally by the memory-mapping helper.
+    // Documented for traceability; no JUnit red test.
 
     /**
      * The DELTA-mode upper bound from {@code peekDeltaKeyMaxValueUpperBound}

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -2022,9 +2022,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      * The fix hoists {@code setNextTxnAtSeal(txWriter.getTxn() + 1L)}
      * BEFORE the rebuild commit so the intermediate REBUILD entry is
      * tagged out of every current reader's visibility window
-     * ({@code T_pin <= getTxn() < getTxn()+1}). The trailing
-     * {@code setNextTxnAtSeal(txWriter.getTxn())} for the SEAL entry
-     * keeps its existing tag.
+     * ({@code T_pin <= getTxn() < getTxn()+1}). The trailing SEAL entry
+     * (published after {@code rebuildSidecars}) now uses the same
+     * {@code getTxn()+1L} tag: per-gen visibility via {@code slot[0].TXN_AT_SEAL}
+     * keeps T-pinned readers on the prev entry until {@code txWriter.commit}
+     * lands, and {@code publishPendingPurges} clamps {@code toTableTxn} back
+     * to {@code getTxn()} so the scoreboard max is not pushed past the
+     * not-yet-committed table txn.
      * <p>
      * This test mirrors the FIXED call order at the writer-fixture
      * level and verifies the chain shape: REBUILD inherits the

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -174,45 +174,6 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
-    @Test
-    public void testExtendHeadFailedCommitNotDroppedByRecovery() throws Exception {
-        assertMemoryLeak(() -> {
-            final String name = "extend_head_failed_recovery";
-            try (Path path = new Path().of(configuration.getDbRoot())) {
-                final int plen = path.size();
-                try (PostingIndexWriter writer = new PostingIndexWriter(configuration)) {
-                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, true);
-                    writer.setNextTxnAtSeal(1L);
-                    writer.add(0, 0);
-                    writer.add(0, 1);
-                    writer.setMaxValue(1);
-                    writer.commit(); // appendNewEntry -> txnAtSeal=1, genCount=1
-
-                    // Successful commit at table layer would advance committedTxn to 1.
-                    // The reopen below is what TableWriter does between WAL transactions:
-                    // close + open from disk, then drive recovery via setCurrentTableTxn.
-                    writer.setCurrentTableTxn(1L);
-                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, false);
-
-                    // Batch 2 anticipates txn 2 but the table commit will not run.
-                    writer.setNextTxnAtSeal(2L);
-                    writer.add(1, 2);
-                    writer.add(1, 3);
-                    writer.setMaxValue(3);
-                    writer.commit(); // extendHead -> genCount=2, txnAtSeal STAYS at 1
-                }
-
-                try (PostingIndexWriter writer = new PostingIndexWriter(configuration)) {
-                    writer.setCurrentTableTxn(1L);
-                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, false);
-                    Assert.assertEquals(
-                            "recovery walk should drop the failed batch 2 gen because batch 2 anticipated txn 2 > committedTxn 1",
-                            1, writer.getGenCount());
-                }
-            }
-        });
-    }
-
     /**
      * Critical #1: PostingIndexNative Java fallback silently corrupts data
      * at bitWidth=64 because of the 64-bit shift no-op in
@@ -737,6 +698,101 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                                     + "[size=" + advertisedSize + ", iterated=" + iterated + "]",
                             advertisedSize < 0 || advertisedSize == iterated
                     );
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testRecoveryHidesFailedExtendHeadFromReader() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "extend_head_failed_recovery_query";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(configuration)) {
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, true);
+                    writer.setNextTxnAtSeal(1L);
+                    for (long row = 0; row < 10; row++) {
+                        writer.add(0, row);
+                    }
+                    writer.setMaxValue(9);
+                    writer.commit();
+
+                    writer.setCurrentTableTxn(1L);
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, false);
+
+                    writer.setNextTxnAtSeal(2L);
+                    for (long row = 10; row < 20; row++) {
+                        writer.add(1, row);
+                    }
+                    writer.setMaxValue(19);
+                    writer.commit();
+                }
+
+                try (PostingIndexWriter writer = new PostingIndexWriter(configuration)) {
+                    writer.setCurrentTableTxn(1L);
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, false);
+                }
+
+                try (PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0);
+                     DirectBitSet foundKeys = new DirectBitSet(8)) {
+                    int distinct = reader.collectDistinctKeys(foundKeys);
+                    Assert.assertEquals(
+                            "only the committed key (0) should remain after recovery",
+                            1, distinct);
+                    Assert.assertTrue(foundKeys.get(0));
+                    Assert.assertFalse(
+                            "key=1 belongs to an uncommitted txn; must not be visible",
+                            foundKeys.get(1)
+                    );
+
+                    try (RowCursor cursor = reader.getCursor(/* key */ 1, /* minValue */ 0, /* maxValue */ Long.MAX_VALUE)) {
+                        Assert.assertFalse(
+                                "uncommitted rowids for key=1 must not surface through getCursor",
+                                cursor.hasNext()
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testRecoveryTrimsExtendHeadFailedTailGens() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "extend_head_failed_recovery";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(configuration)) {
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, true);
+                    writer.setNextTxnAtSeal(1L);
+                    writer.add(0, 0);
+                    writer.add(0, 1);
+                    writer.setMaxValue(1);
+                    writer.commit(); // appendNewEntry -> txnAtSeal=1, genCount=1
+
+                    // Successful commit at table layer would advance committedTxn to 1.
+                    // The reopen below is what TableWriter does between WAL transactions:
+                    // close + open from disk, then drive recovery via setCurrentTableTxn.
+                    writer.setCurrentTableTxn(1L);
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, false);
+
+                    // Batch 2 anticipates txn 2 but the table commit will not run.
+                    writer.setNextTxnAtSeal(2L);
+                    writer.add(1, 2);
+                    writer.add(1, 3);
+                    writer.setMaxValue(3);
+                    writer.commit(); // extendHead -> genCount=2, txnAtSeal STAYS at 1
+                }
+
+                try (PostingIndexWriter writer = new PostingIndexWriter(configuration)) {
+                    writer.setCurrentTableTxn(1L);
+                    writer.of(path.trimTo(plen), name, COLUMN_NAME_TXN_NONE, false);
+                    Assert.assertEquals(
+                            "recovery walk should drop the failed batch 2 gen because batch 2 anticipated txn 2 > committedTxn 1",
+                            1, writer.getGenCount());
                 }
             }
         });

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexOomFallbackTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexOomFallbackTest.java
@@ -163,7 +163,7 @@ public class PostingIndexOomFallbackTest extends AbstractCairoTest {
 
     /**
      * Pathological-budget regression: a per-key spill budget so tight
-     * that periodic flushes accumulate past MAX_GEN_COUNT (143). Each
+     * that periodic flushes accumulate past MAX_GEN_COUNT. Each
      * flush bumps genCount by one; once it crosses MAX_GEN_COUNT,
      * flushAllPending fires an inline seal() which frees both pending
      * and spill buffers. The compactIfOverBudget call site inside

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexStressTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexStressTest.java
@@ -2115,7 +2115,7 @@ public class PostingIndexStressTest extends AbstractCairoTest {
                 final int plen = path.size();
                 String name = "auto_seal_max";
 
-                int batchCount = PostingIndexUtils.MAX_GEN_COUNT + 1; // 92 (91 + 1)
+                int batchCount = PostingIndexUtils.MAX_GEN_COUNT + 1;
 
                 try (PostingIndexWriter writer = new PostingIndexWriter(configuration, path, name, COLUMN_NAME_TXN_NONE)) {
                     for (int batch = 0; batch < batchCount; batch++) {

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexStressTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexStressTest.java
@@ -2115,7 +2115,7 @@ public class PostingIndexStressTest extends AbstractCairoTest {
                 final int plen = path.size();
                 String name = "auto_seal_max";
 
-                int batchCount = PostingIndexUtils.MAX_GEN_COUNT + 1; // 168
+                int batchCount = PostingIndexUtils.MAX_GEN_COUNT + 1; // 92 (91 + 1)
 
                 try (PostingIndexWriter writer = new PostingIndexWriter(configuration, path, name, COLUMN_NAME_TXN_NONE)) {
                     for (int batch = 0; batch < batchCount; batch++) {
@@ -2129,8 +2129,9 @@ public class PostingIndexStressTest extends AbstractCairoTest {
 
                     // After MAX_GEN_COUNT+1 commits, auto-seal should have triggered,
                     // reducing genCount back to 1 (sealed) plus any commits after seal.
-                    // The auto-seal fires at genCount > MAX_GEN_COUNT, so after the 168th
-                    // commit genCount becomes 168 > 167, triggering seal() which sets it to 1.
+                    // The auto-seal fires at genCount >= MAX_GEN_COUNT, so after the
+                    // (MAX_GEN_COUNT+1)-th commit genCount triggers seal() which sets it
+                    // back to 1.
                     Assert.assertTrue(
                             "genCount should be <= MAX_GEN_COUNT after auto-seal, was " + writer.getGenCount(),
                             writer.getGenCount() <= PostingIndexUtils.MAX_GEN_COUNT);

--- a/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainTest.java
@@ -103,11 +103,11 @@ public class PostingIndexChainTest {
     public void testCircularChainDetected() {
         PostingIndexChainHeader.initialiseEmpty(mem);
         long off1 = PostingIndexUtils.V2_ENTRY_REGION_BASE;
-        long off2 = off1 + PostingIndexChainEntry.entrySize(0);
+        long off2 = off1 + PostingIndexChainEntry.entrySize(1);
 
-        PostingIndexChainEntry.writeHeader(mem, off1, 1, 10, 0, 0, 0, 0, 64, 0, off2);
-        PostingIndexChainEntry.writeHeader(mem, off2, 2, 20, 0, 0, 0, 0, 64, 0, off1);
-        publishHead(off2, /* count */ 2, 2, off2 + PostingIndexChainEntry.entrySize(0));
+        PostingIndexChainEntry.writeHeader(mem, off1, 1, 10, 0, 0, 0, 1, 64, 0, off2);
+        PostingIndexChainEntry.writeHeader(mem, off2, 2, 20, 0, 0, 0, 1, 64, 0, off1);
+        publishHead(off2, /* count */ 2, 2, off2 + PostingIndexChainEntry.entrySize(1));
 
         PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
         PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
@@ -128,8 +128,8 @@ public class PostingIndexChainTest {
     public void testConcurrentReaderObservesConsistentSnapshot() throws Exception {
         PostingIndexChainHeader.initialiseEmpty(mem);
         long off1 = PostingIndexUtils.V2_ENTRY_REGION_BASE;
-        PostingIndexChainEntry.writeHeader(mem, off1, 1, 10, 0, 0, 0, 0, 64, 0, PostingIndexUtils.V2_NO_HEAD);
-        long limit = off1 + PostingIndexChainEntry.entrySize(0);
+        PostingIndexChainEntry.writeHeader(mem, off1, 1, 10, 0, 0, 0, 1, 64, 0, PostingIndexUtils.V2_NO_HEAD);
+        long limit = off1 + PostingIndexChainEntry.entrySize(1);
         publishHead(off1, 1, 1, limit);
 
         AtomicBoolean stop = new AtomicBoolean(false);
@@ -146,15 +146,15 @@ public class PostingIndexChainTest {
                 long nextOffset = limit;
                 long sealTxn = 1;
                 long entryCount = 1;
-                long bufferEnd = 64 * 1024 - PostingIndexChainEntry.entrySize(0);
+                long bufferEnd = 64 * 1024 - PostingIndexChainEntry.entrySize(1);
                 while (!stop.get() && nextOffset < bufferEnd) {
                     sealTxn++;
                     long txnAtSeal = sealTxn * 10;
                     PostingIndexChainEntry.writeHeader(
-                            mem, nextOffset, sealTxn, txnAtSeal, 0, 0, 0, 0, 64, 0, prevOffset
+                            mem, nextOffset, sealTxn, txnAtSeal, 0, 0, 0, 1, 64, 0, prevOffset
                     );
                     long thisOffset = nextOffset;
-                    nextOffset += PostingIndexChainEntry.entrySize(0);
+                    nextOffset += PostingIndexChainEntry.entrySize(1);
                     entryCount++;
                     activePage = PostingIndexChainHeader.publish(
                             mem, activePage, thisOffset, entryCount,
@@ -241,12 +241,12 @@ public class PostingIndexChainTest {
         long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
         PostingIndexChainEntry.writeHeader(
                 mem, entryOffset,
-                1, 10, 0, 0, 0, 0, 64, 0,
+                1, 10, 0, 0, 0, 1, 64, 0,
                 PostingIndexUtils.V2_NO_HEAD
         );
         // Stomp LEN to a wildly out-of-range value.
         mem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, 99_999_999L);
-        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(0));
+        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(1));
 
         PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
         PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
@@ -260,10 +260,10 @@ public class PostingIndexChainTest {
         long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
         PostingIndexChainEntry.writeHeader(
                 mem, entryOffset,
-                1, 10, 0, 0, 0, 0, 64, 0,
+                1, 10, 0, 0, 0, 1, 64, 0,
                 /* prevEntryOffset */ 999_999L
         );
-        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(0));
+        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(1));
 
         PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
         PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
@@ -297,7 +297,7 @@ public class PostingIndexChainTest {
         PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
         long endOffset = PostingIndexChainEntry.read(mem, entryOffset, /* coverCount */ 3, entry);
 
-        Assert.assertEquals(96, entry.len);
+        Assert.assertEquals(104, entry.len);
         Assert.assertEquals(entryOffset + entry.len, endOffset);
         Assert.assertEquals(3, entry.coverFileEndOffsets.size());
         Assert.assertEquals(0L, entry.coverFileEndOffsets.getQuick(0));
@@ -391,16 +391,16 @@ public class PostingIndexChainTest {
 
     @Test
     public void testEntrySizeIsAlignedToEightBytes() {
-        Assert.assertEquals(64, PostingIndexChainEntry.entrySize(0));
-        Assert.assertEquals(96, PostingIndexChainEntry.entrySize(1)); // 64+28=92 → 96
-        Assert.assertEquals(120, PostingIndexChainEntry.entrySize(2)); // 64+56=120
-        Assert.assertEquals(152, PostingIndexChainEntry.entrySize(3)); // 64+84=148 → 152
+        Assert.assertEquals(56, PostingIndexChainEntry.entrySize(0));
+        Assert.assertEquals(104, PostingIndexChainEntry.entrySize(1)); // 56+44=100 → 104
+        Assert.assertEquals(144, PostingIndexChainEntry.entrySize(2)); // 56+88=144
+        Assert.assertEquals(192, PostingIndexChainEntry.entrySize(3)); // 56+132=188 → 192
         for (int n = 0; n < 50; n++) {
             int sz = PostingIndexChainEntry.entrySize(n);
             Assert.assertEquals("entry size for genCount=" + n + " must be 8-aligned",
                     0, sz & 7);
-            Assert.assertTrue(sz >= 64 + n * 28);
-            Assert.assertTrue(sz < 64 + n * 28 + 8);
+            Assert.assertTrue(sz >= 56 + n * 44);
+            Assert.assertTrue(sz < 56 + n * 44 + 8);
         }
     }
 
@@ -482,11 +482,11 @@ public class PostingIndexChainTest {
         long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
         PostingIndexChainEntry.writeHeader(
                 mem, entryOffset,
-                1, 10, 0, 0, 0, 0, 64, 0,
+                1, 10, 0, 0, 0, 1, 64, 0,
                 PostingIndexUtils.V2_NO_HEAD
         );
         mem.putLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN, 0L);
-        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(0));
+        publishHead(entryOffset, 1, 1, entryOffset + PostingIndexChainEntry.entrySize(1));
 
         PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
         PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
@@ -519,7 +519,7 @@ public class PostingIndexChainTest {
         PostingIndexChainHeader.initialiseEmpty(mem);
         long entryOffset = PostingIndexUtils.V2_ENTRY_REGION_BASE;
         // genCount=1, coverEndOffsets=null - entry is written with no cover
-        // footer (LEN = entrySize(1, 0) = 96).
+        // footer (LEN = entrySize(1, 0) = 104).
         PostingIndexChainEntry.writeHeader(
                 mem, entryOffset,
                 /* sealTxn */ 1, /* txnAtSeal */ 5,
@@ -530,7 +530,7 @@ public class PostingIndexChainTest {
                 /* coverEndOffsets */ null
         );
         long entryLen = PostingIndexChainEntry.entrySize(1, 0);
-        Assert.assertEquals(96, entryLen);
+        Assert.assertEquals(104, entryLen);
         publishHead(entryOffset, 1, 1, entryOffset + entryLen);
 
         PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
@@ -560,11 +560,13 @@ public class PostingIndexChainTest {
         PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
 
         for (int i = 1; i <= 64; i++) {
+            // genCount=1 so writeHeader populates slot[0].TXN_AT_SEAL; the
+            // entry-level txnAtSeal sourced by read() comes from slot[0].
             PostingIndexChainEntry.writeHeader(
                     mem, offset, /* sealTxn */ i, /* txnAtSeal */ i * 7L,
-                    0, 0, 0, 0, 64, 0, prevOffset
+                    0, 0, 0, /* genCount */ 1, 64, 0, prevOffset
             );
-            long entryLen = PostingIndexChainEntry.entrySize(0);
+            long entryLen = PostingIndexChainEntry.entrySize(1);
             entryCount++;
             activePage = PostingIndexChainHeader.publish(
                     mem, activePage, offset, entryCount,
@@ -618,9 +620,12 @@ public class PostingIndexChainTest {
         } else {
             offset = prevOffset + PostingIndexChainEntry.entrySize(readGenCount(prevOffset));
         }
+        // genCount=1 so writeHeader populates slot[0].TXN_AT_SEAL (the
+        // single on-disk source of entry-level visibility). Tests that read
+        // entry.txnAtSeal back need an actual slot to source it from.
         PostingIndexChainEntry.writeHeader(
                 mem, offset, sealTxn, txnAtSeal, /* valueMemSize */ 0,
-                /* maxValue */ 0, /* keyCount */ 0, 0,
+                /* maxValue */ 0, /* keyCount */ 0, /* genCount */ 1,
                 /* blockCapacity */ 64, /* coveringFormat */ 0, prevOffset
         );
         return offset;

--- a/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainWriterTest.java
@@ -68,9 +68,9 @@ public class PostingIndexChainWriterTest {
         PostingIndexChainWriter w = new PostingIndexChainWriter();
         w.initialiseEmpty(mem);
 
-        long off1 = w.appendNewEntry(mem, 1, 10, 0, 0, 0, 0, 64, 0);
-        long off2 = w.appendNewEntry(mem, 2, 20, 0, 0, 0, 0, 64, 0);
-        long off3 = w.appendNewEntry(mem, 3, 30, 0, 0, 0, 0, 64, 0);
+        long off1 = w.appendNewEntry(mem, 1, 10, 0, 0, 0, 1, 64, 0);
+        long off2 = w.appendNewEntry(mem, 2, 20, 0, 0, 0, 1, 64, 0);
+        long off3 = w.appendNewEntry(mem, 3, 30, 0, 0, 0, 1, 64, 0);
 
         PostingIndexChainEntry.Snapshot snap = new PostingIndexChainEntry.Snapshot();
         PostingIndexChainEntry.read(mem, off3, snap);
@@ -90,17 +90,17 @@ public class PostingIndexChainWriterTest {
     public void testAppendNewEntryRejectsNonMonotonicSealTxn() {
         PostingIndexChainWriter w = new PostingIndexChainWriter();
         w.initialiseEmpty(mem);
-        w.appendNewEntry(mem, 5, 10, 0, 0, 0, 0, 64, 0);
+        w.appendNewEntry(mem, 5, 10, 0, 0, 0, 1, 64, 0);
 
         try {
-            w.appendNewEntry(mem, 5, 11, 0, 0, 0, 0, 64, 0);
+            w.appendNewEntry(mem, 5, 11, 0, 0, 0, 1, 64, 0);
             Assert.fail("expected CairoException for non-monotonic sealTxn");
         } catch (CairoException expected) {
             Assert.assertTrue(expected.getMessage().contains("sealTxn must advance"));
         }
 
         try {
-            w.appendNewEntry(mem, 4, 12, 0, 0, 0, 0, 64, 0);
+            w.appendNewEntry(mem, 4, 12, 0, 0, 0, 1, 64, 0);
             Assert.fail("expected CairoException for backward sealTxn");
         } catch (CairoException expected) {
             Assert.assertTrue(expected.getMessage().contains("sealTxn must advance"));
@@ -141,11 +141,11 @@ public class PostingIndexChainWriterTest {
         w.initialiseEmpty(mem);
 
         long off1 = PostingIndexUtils.V2_ENTRY_REGION_BASE;
-        long off2 = off1 + PostingIndexChainEntry.entrySize(0);
+        long off2 = off1 + PostingIndexChainEntry.entrySize(1);
 
-        PostingIndexChainEntry.writeHeader(mem, off1, 1, 100, 0, 0, 0, 0, 64, 0, off2);
-        PostingIndexChainEntry.writeHeader(mem, off2, 2, 200, 0, 0, 0, 0, 64, 0, off1);
-        long limit = off2 + PostingIndexChainEntry.entrySize(0);
+        PostingIndexChainEntry.writeHeader(mem, off1, 1, 100, 0, 0, 0, 1, 64, 0, off2);
+        PostingIndexChainEntry.writeHeader(mem, off2, 2, 200, 0, 0, 0, 1, 64, 0, off1);
+        long limit = off2 + PostingIndexChainEntry.entrySize(1);
         PostingIndexChainHeader.publish(
                 mem, PostingIndexUtils.PAGE_A_OFFSET, off2, /* entryCount */ 2,
                 PostingIndexUtils.V2_ENTRY_REGION_BASE, limit, 2L
@@ -279,8 +279,8 @@ public class PostingIndexChainWriterTest {
     public void testOpenExistingPopulatesStateFromHead() {
         PostingIndexChainWriter writer = new PostingIndexChainWriter();
         writer.initialiseEmpty(mem);
-        writer.appendNewEntry(mem, 1, 10, 0, 0, 0, 0, 64, 0);
-        writer.appendNewEntry(mem, 2, 20, 0, 0, 0, 0, 64, 0);
+        writer.appendNewEntry(mem, 1, 10, 0, 0, 0, 1, 64, 0);
+        writer.appendNewEntry(mem, 2, 20, 0, 0, 0, 1, 64, 0);
 
         // Simulate writer reopen: a fresh instance reads from the same memory.
         PostingIndexChainWriter reopened = new PostingIndexChainWriter();
@@ -314,12 +314,12 @@ public class PostingIndexChainWriterTest {
         w.initialiseEmpty(mem);
 
         // Healthy entries — txnAtSeal at 10, 20, 30.
-        w.appendNewEntry(mem, 1, 10, 0, 0, 0, 0, 64, 0);
-        w.appendNewEntry(mem, 2, 20, 0, 0, 0, 0, 64, 0);
-        w.appendNewEntry(mem, 3, 30, 0, 0, 0, 0, 64, 0);
+        w.appendNewEntry(mem, 1, 10, 0, 0, 0, 1, 64, 0);
+        w.appendNewEntry(mem, 2, 20, 0, 0, 0, 1, 64, 0);
+        w.appendNewEntry(mem, 3, 30, 0, 0, 0, 1, 64, 0);
         // Two abandoned entries — txnAtSeal beyond what _txn ever committed.
-        long expectedRegionLimitAfter = w.appendNewEntry(mem, 4, 99, 0, 0, 0, 0, 64, 0);
-        w.appendNewEntry(mem, 5, 100, 0, 0, 0, 0, 64, 0);
+        long expectedRegionLimitAfter = w.appendNewEntry(mem, 4, 99, 0, 0, 0, 1, 64, 0);
+        w.appendNewEntry(mem, 5, 100, 0, 0, 0, 1, 64, 0);
 
         // entry #4's start
 
@@ -363,8 +363,8 @@ public class PostingIndexChainWriterTest {
     public void testRecoveryDropAbandonedNoOpWhenAllEntriesCommitted() {
         PostingIndexChainWriter w = new PostingIndexChainWriter();
         w.initialiseEmpty(mem);
-        w.appendNewEntry(mem, 1, 10, 0, 0, 0, 0, 64, 0);
-        w.appendNewEntry(mem, 2, 20, 0, 0, 0, 0, 64, 0);
+        w.appendNewEntry(mem, 1, 10, 0, 0, 0, 1, 64, 0);
+        w.appendNewEntry(mem, 2, 20, 0, 0, 0, 1, 64, 0);
         long headBefore = w.getHeadEntryOffset();
         long limitBefore = w.getRegionLimit();
         long counterBefore = w.getGenCounter();
@@ -381,7 +381,7 @@ public class PostingIndexChainWriterTest {
     public void testResetStateClearsInMemoryMirror() {
         PostingIndexChainWriter w = new PostingIndexChainWriter();
         w.initialiseEmpty(mem);
-        w.appendNewEntry(mem, 1, 10, 0, 0, 0, 0, 64, 0);
+        w.appendNewEntry(mem, 1, 10, 0, 0, 0, 1, 64, 0);
 
         w.resetState();
 

--- a/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainWriterTest.java
@@ -421,6 +421,8 @@ public class PostingIndexChainWriterTest {
         mem.putLong(slot2 + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET, 100L);
         mem.putLong(slot2 + PostingIndexUtils.GEN_DIR_OFFSET_SIZE, 50L);
 
+        long preRecoveryRegionLimit = w.getRegionLimit();
+
         LongList orphans = new LongList();
         int dropped = w.recoveryDropAbandoned(mem, /* currentTableTxn */ 10L, orphans);
 
@@ -429,33 +431,33 @@ public class PostingIndexChainWriterTest {
         Assert.assertTrue("head must be flagged as trimmed", w.isHeadTrimmedOnLastRecovery());
         Assert.assertEquals(1L, w.getEntryCount());
 
-        // Entry shrank to one gen + cover footer; LEN must match entrySize.
-        int newGenCount = mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
-        Assert.assertEquals(1, newGenCount);
+        // Copy-on-write: the source entry's bytes are untouched; a new
+        // trimmed entry sits at the post-recovery region tail.
+        Assert.assertEquals(3, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
+
+        long newHead = w.getHeadEntryOffset();
+        Assert.assertEquals(preRecoveryRegionLimit, newHead);
+        Assert.assertNotEquals(entryOffset, newHead);
+
         long expectedLen = PostingIndexChainEntry.entrySize(1, 2);
-        Assert.assertEquals(expectedLen, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN));
-        Assert.assertEquals(entryOffset + expectedLen, w.getRegionLimit());
+        Assert.assertEquals(1, mem.getInt(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
+        Assert.assertEquals(expectedLen, mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_LEN));
+        Assert.assertEquals(newHead + expectedLen, w.getRegionLimit());
+        Assert.assertEquals(100L, mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
+        Assert.assertEquals(50L, mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
 
-        // Entry-level MAX_VALUE / VALUE_MEM_SIZE / KEY_COUNT recovered from
-        // slot[0]'s recorded extents.
-        Assert.assertEquals(100L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
-        Assert.assertEquals(50L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
-
-        // Cover footer relocated from offset (header + 3*GEN_DIR_ENTRY_SIZE)
-        // to offset (header + 1*GEN_DIR_ENTRY_SIZE), preserving both cover
-        // end-offsets verbatim.
-        long newFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+        long newFooterOffset = newHead + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
                 + (long) PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
         Assert.assertEquals(7777L, mem.getLong(newFooterOffset));
         Assert.assertEquals(8888L, mem.getLong(newFooterOffset + PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE));
 
-        // Picker observes the trimmed entry through the chain header.
         PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
         PostingIndexChainEntry.Snapshot picked = new PostingIndexChainEntry.Snapshot();
         Assert.assertEquals(
                 PostingIndexChainPicker.RESULT_OK,
                 PostingIndexChainPicker.pick(mem, Long.MAX_VALUE, /* coverCount */ 2, header, picked)
         );
+        Assert.assertEquals(newHead, picked.offset);
         Assert.assertEquals(1, picked.genCount);
         Assert.assertEquals(2, picked.coverFileEndOffsets.size());
         Assert.assertEquals(7777L, picked.coverFileEndOffsets.getQuick(0));
@@ -482,18 +484,24 @@ public class PostingIndexChainWriterTest {
         mem.putLong(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE, 42L);
         mem.putInt(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY, 4);
 
+        long preRecoveryRegionLimit = w.getRegionLimit();
         int dropped = w.recoveryDropAbandoned(mem, /* currentTableTxn */ 10L, new LongList());
 
         Assert.assertEquals(0, dropped);
         Assert.assertTrue(w.isHeadTrimmedOnLastRecovery());
-        Assert.assertEquals(1, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
+        // Source untouched, new head at region tail.
+        Assert.assertEquals(2, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
+
+        long newHead = w.getHeadEntryOffset();
+        Assert.assertEquals(preRecoveryRegionLimit, newHead);
+        Assert.assertEquals(1, mem.getInt(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
         Assert.assertEquals(
                 PostingIndexChainEntry.entrySize(1, 0),
-                mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN)
+                mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_LEN)
         );
-        Assert.assertEquals(42L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
-        Assert.assertEquals(64L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
-        Assert.assertEquals(5, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT));
+        Assert.assertEquals(42L, mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
+        Assert.assertEquals(64L, mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
+        Assert.assertEquals(5, mem.getInt(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT));
     }
 
     @Test
@@ -552,19 +560,24 @@ public class PostingIndexChainWriterTest {
             mem.putLong(slot + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 5L + g);
         }
 
+        long preRecoveryRegionLimit = w.getRegionLimit();
         int dropped = w.recoveryDropAbandoned(mem, /* currentTableTxn */ 5L, new LongList());
 
         Assert.assertEquals(0, dropped);
         Assert.assertTrue(w.isHeadTrimmedOnLastRecovery());
-        Assert.assertEquals(1, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
+        Assert.assertEquals(5, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
+
+        long newHead = w.getHeadEntryOffset();
+        Assert.assertEquals(preRecoveryRegionLimit, newHead);
+        Assert.assertEquals(1, mem.getInt(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
         Assert.assertEquals(
                 PostingIndexChainEntry.entrySize(1, 0),
-                mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN)
+                mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_LEN)
         );
-        Assert.assertEquals(7L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
-        Assert.assertEquals(80L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
-        Assert.assertEquals(3, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT));
-        Assert.assertEquals(entryOffset + PostingIndexChainEntry.entrySize(1, 0), w.getRegionLimit());
+        Assert.assertEquals(7L, mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
+        Assert.assertEquals(80L, mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
+        Assert.assertEquals(3, mem.getInt(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT));
+        Assert.assertEquals(newHead + PostingIndexChainEntry.entrySize(1, 0), w.getRegionLimit());
     }
 
     @Test
@@ -603,20 +616,25 @@ public class PostingIndexChainWriterTest {
         mem.putLong(slot3 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 11L);
         mem.putLong(slot4 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 12L);
 
+        long preRecoveryRegionLimit = w.getRegionLimit();
         int dropped = w.recoveryDropAbandoned(mem, /* currentTableTxn */ 10L, new LongList());
 
         Assert.assertEquals(0, dropped);
         Assert.assertTrue(w.isHeadTrimmedOnLastRecovery());
-        Assert.assertEquals(3, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
+        Assert.assertEquals(5, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
+
+        long newHead = w.getHeadEntryOffset();
+        Assert.assertEquals(preRecoveryRegionLimit, newHead);
+        Assert.assertEquals(3, mem.getInt(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
         Assert.assertEquals(
                 PostingIndexChainEntry.entrySize(3, 2),
-                mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN)
+                mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_LEN)
         );
-        Assert.assertEquals(150L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
-        Assert.assertEquals(300L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
-        Assert.assertEquals(3, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT));
+        Assert.assertEquals(150L, mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
+        Assert.assertEquals(300L, mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
+        Assert.assertEquals(3, mem.getInt(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT));
 
-        long newFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+        long newFooterOffset = newHead + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
                 + 3L * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
         Assert.assertEquals(1111L, mem.getLong(newFooterOffset));
         Assert.assertEquals(2222L, mem.getLong(newFooterOffset + PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE));
@@ -625,10 +643,79 @@ public class PostingIndexChainWriterTest {
         PostingIndexChainEntry.Snapshot picked = new PostingIndexChainEntry.Snapshot();
         Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
                 PostingIndexChainPicker.pick(mem, Long.MAX_VALUE, /* coverCount */ 2, header, picked));
+        Assert.assertEquals(newHead, picked.offset);
         Assert.assertEquals(3, picked.genCount);
         Assert.assertEquals(2, picked.coverFileEndOffsets.size());
         Assert.assertEquals(1111L, picked.coverFileEndOffsets.getQuick(0));
         Assert.assertEquals(2222L, picked.coverFileEndOffsets.getQuick(1));
+    }
+
+    @Test
+    public void testRecoveryHeadTrimLeavesSourceEntryBytesIntact() {
+        PostingIndexChainWriter w = new PostingIndexChainWriter();
+        w.initialiseEmpty(mem);
+
+        LongList coverEnds = new LongList();
+        coverEnds.add(5555L);
+        long sourceOffset = w.appendNewEntry(
+                mem, /* sealTxn */ 1, /* txnAtSeal */ 10,
+                /* valueMemSize */ 0, /* maxValue */ -1,
+                /* keyCount */ 0, /* genCount */ 3,
+                /* blockCapacity */ 64, /* coveringFormat */ 0,
+                coverEnds
+        );
+        long slot1 = sourceOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                + (long) PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        long slot2 = slot1 + PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        mem.putLong(slot1 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 11L);
+        mem.putLong(slot2 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 12L);
+
+        long sourceEntryLen = PostingIndexChainEntry.entrySize(3, 1);
+        long[] sourceBytes = new long[(int) (sourceEntryLen / Long.BYTES)];
+        for (int i = 0; i < sourceBytes.length; i++) {
+            sourceBytes[i] = mem.getLong(sourceOffset + (long) i * Long.BYTES);
+        }
+
+        int dropped = w.recoveryDropAbandoned(mem, /* currentTableTxn */ 10L, new LongList());
+
+        Assert.assertEquals(0, dropped);
+        Assert.assertTrue(w.isHeadTrimmedOnLastRecovery());
+        Assert.assertNotEquals(sourceOffset, w.getHeadEntryOffset());
+
+        // Source entry bytes must be byte-for-byte unchanged: a concurrent
+        // reader holding a cached head pointer = sourceOffset must observe
+        // the original consistent snapshot, not a half-mutated state.
+        for (int i = 0; i < sourceBytes.length; i++) {
+            Assert.assertEquals(
+                    "source byte at index " + i + " was mutated by applyHeadTrim",
+                    sourceBytes[i], mem.getLong(sourceOffset + (long) i * Long.BYTES)
+            );
+        }
+    }
+
+    @Test
+    public void testRecoveryHeadTrimPreservesPrevPointerChain() {
+        PostingIndexChainWriter w = new PostingIndexChainWriter();
+        w.initialiseEmpty(mem);
+
+        long olderOffset = w.appendNewEntry(mem, 1, 5, 0, 0, 0, 1, 64, 0);
+        long headOffset = w.appendNewEntry(mem, 2, 10, 0, 0, 0, 2, 64, 0);
+        long headSlot1 = headOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                + (long) PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        mem.putLong(headSlot1 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 11L);
+
+        int dropped = w.recoveryDropAbandoned(mem, /* currentTableTxn */ 10L, new LongList());
+
+        Assert.assertEquals(0, dropped);
+        Assert.assertTrue(w.isHeadTrimmedOnLastRecovery());
+        Assert.assertEquals(2L, w.getEntryCount());
+
+        long newHead = w.getHeadEntryOffset();
+        Assert.assertNotEquals(headOffset, newHead);
+        Assert.assertEquals(
+                "new head's prev must skip the source entry and point at the older entry",
+                olderOffset, mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_PREV_ENTRY_OFFSET)
+        );
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainWriterTest.java
@@ -719,6 +719,74 @@ public class PostingIndexChainWriterTest {
     }
 
     @Test
+    public void testRecoveryHeadTrimAfterDropsCopiesToVirginSpace() {
+        // Drop-then-trim: the head entry is abandoned (dropped), and the
+        // entry below it is visible but carries an in-flight tail gen
+        // (trimmed). The trimmed copy must land in virgin space past the
+        // ORIGINAL regionLimit, never on the just-dropped entry's bytes --
+        // that entry was a previously-published head and a concurrent
+        // reader may still have it cached; overwriting it before the
+        // header republish would expose torn bytes to a straddling reader.
+        PostingIndexChainWriter w = new PostingIndexChainWriter();
+        w.initialiseEmpty(mem);
+
+        // E1: visible (txnAtSeal=10), genCount=2 with an in-flight slot[1].
+        long trimmedOffset = w.appendNewEntry(mem, 1, 10, 0, 0, 0, 2, 64, 0);
+        long e1Slot0 = trimmedOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE;
+        long e1Slot1 = e1Slot0 + PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        mem.putLong(e1Slot0 + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET, 0L);
+        mem.putLong(e1Slot0 + PostingIndexUtils.GEN_DIR_OFFSET_SIZE, 64L);
+        mem.putLong(e1Slot0 + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE, 42L);
+        mem.putInt(e1Slot0 + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY, 4);
+        mem.putLong(e1Slot1 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 11L);
+
+        // E2: abandoned head (txnAtSeal=20 > committedTxn 10), gets dropped.
+        long droppedOffset = w.appendNewEntry(mem, 2, 20, 0, 0, 0, 1, 64, 0);
+        long preRecoveryRegionLimit = w.getRegionLimit();
+
+        // Snapshot E2's bytes: recovery must leave them byte-for-byte intact.
+        long droppedEntryLen = PostingIndexChainEntry.entrySize(1, 0);
+        long[] droppedBytes = new long[(int) (droppedEntryLen / Long.BYTES)];
+        for (int i = 0; i < droppedBytes.length; i++) {
+            droppedBytes[i] = mem.getLong(droppedOffset + (long) i * Long.BYTES);
+        }
+
+        LongList orphans = new LongList();
+        int dropped = w.recoveryDropAbandoned(mem, /* currentTableTxn */ 10L, orphans);
+
+        Assert.assertEquals(1, dropped);
+        Assert.assertEquals(1, orphans.size());
+        Assert.assertEquals(2L, orphans.getQuick(0));
+        Assert.assertTrue(w.isHeadTrimmedOnLastRecovery());
+        Assert.assertEquals(1L, w.getEntryCount());
+
+        // The trimmed copy lands past the original regionLimit, not on the
+        // dropped entry's bytes.
+        long newHead = w.getHeadEntryOffset();
+        Assert.assertEquals(preRecoveryRegionLimit, newHead);
+        Assert.assertNotEquals(droppedOffset, newHead);
+        Assert.assertEquals(1, mem.getInt(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
+        Assert.assertEquals(
+                PostingIndexChainEntry.entrySize(1, 0),
+                mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_LEN)
+        );
+        Assert.assertEquals(42L, mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
+        Assert.assertEquals(64L, mem.getLong(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
+        Assert.assertEquals(5, mem.getInt(newHead + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT));
+
+        // Regression guard: the dropped entry's bytes must be untouched. A
+        // concurrent reader with headEntryOffset == droppedOffset cached
+        // must keep observing a consistent snapshot until it re-reads the
+        // republished header.
+        for (int i = 0; i < droppedBytes.length; i++) {
+            Assert.assertEquals(
+                    "dropped entry byte at index " + i + " was overwritten by applyHeadTrim",
+                    droppedBytes[i], mem.getLong(droppedOffset + (long) i * Long.BYTES)
+            );
+        }
+    }
+
+    @Test
     public void testRecoveryWholeEntryDroppedWhenSlot0InFlight() {
         PostingIndexChainWriter w = new PostingIndexChainWriter();
         w.initialiseEmpty(mem);

--- a/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainWriterTest.java
@@ -378,6 +378,91 @@ public class PostingIndexChainWriterTest {
     }
 
     @Test
+    public void testRecoveryHeadTrimRelocatesCoverFooter() {
+        PostingIndexChainWriter w = new PostingIndexChainWriter();
+        w.initialiseEmpty(mem);
+
+        // Build a single covered entry with genCount=3 and coverCount=2.
+        // appendNewEntry only stamps slot[0].TXN_AT_SEAL; the remaining
+        // slots are written by hand so we can simulate an extendHead-style
+        // fast-path tail with in-flight txnAtSeals.
+        LongList coverEnds = new LongList();
+        coverEnds.add(7777L);
+        coverEnds.add(8888L);
+        long entryOffset = w.appendNewEntry(
+                mem,
+                /* sealTxn */ 1, /* txnAtSeal */ 10,
+                /* valueMemSize */ 0, /* maxValue */ -1,
+                /* keyCount */ 0, /* genCount */ 3,
+                /* blockCapacity */ 64, /* coveringFormat */ 0,
+                coverEnds
+        );
+        // Stamp the three slots so trimInFlightTailGens has data to work
+        // with: slot[0] visible, slot[1..2] in-flight.
+        long slot0 = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE;
+        long slot1 = slot0 + PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        long slot2 = slot1 + PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        // slot[0] already has TXN_AT_SEAL=10 via appendNewEntry; assert
+        // the precondition rather than re-write it.
+        Assert.assertEquals(10L, mem.getLong(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL));
+        mem.putLong(slot1 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 11L);
+        mem.putLong(slot2 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 12L);
+        // Per-slot MAX_VALUE: the trim restores entry.MAX_VALUE from the
+        // last surviving slot's value.
+        mem.putLong(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE, 100L);
+        mem.putLong(slot1 + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE, 200L);
+        mem.putLong(slot2 + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE, 300L);
+        // Per-slot file extent: the trim caps entry.VALUE_MEM_SIZE at
+        // slot[keep-1].FILE_OFFSET + slot[keep-1].SIZE.
+        mem.putLong(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET, 0L);
+        mem.putLong(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_SIZE, 50L);
+        mem.putLong(slot1 + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET, 50L);
+        mem.putLong(slot1 + PostingIndexUtils.GEN_DIR_OFFSET_SIZE, 50L);
+        mem.putLong(slot2 + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET, 100L);
+        mem.putLong(slot2 + PostingIndexUtils.GEN_DIR_OFFSET_SIZE, 50L);
+
+        LongList orphans = new LongList();
+        int dropped = w.recoveryDropAbandoned(mem, /* currentTableTxn */ 10L, orphans);
+
+        Assert.assertEquals("entry-level visible: nothing dropped", 0, dropped);
+        Assert.assertEquals(0, orphans.size());
+        Assert.assertTrue("head must be flagged as trimmed", w.isHeadTrimmedOnLastRecovery());
+        Assert.assertEquals(1L, w.getEntryCount());
+
+        // Entry shrank to one gen + cover footer; LEN must match entrySize.
+        int newGenCount = mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
+        Assert.assertEquals(1, newGenCount);
+        long expectedLen = PostingIndexChainEntry.entrySize(1, 2);
+        Assert.assertEquals(expectedLen, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN));
+        Assert.assertEquals(entryOffset + expectedLen, w.getRegionLimit());
+
+        // Entry-level MAX_VALUE / VALUE_MEM_SIZE / KEY_COUNT recovered from
+        // slot[0]'s recorded extents.
+        Assert.assertEquals(100L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
+        Assert.assertEquals(50L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
+
+        // Cover footer relocated from offset (header + 3*GEN_DIR_ENTRY_SIZE)
+        // to offset (header + 1*GEN_DIR_ENTRY_SIZE), preserving both cover
+        // end-offsets verbatim.
+        long newFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                + (long) PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        Assert.assertEquals(7777L, mem.getLong(newFooterOffset));
+        Assert.assertEquals(8888L, mem.getLong(newFooterOffset + PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE));
+
+        // Picker observes the trimmed entry through the chain header.
+        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
+        PostingIndexChainEntry.Snapshot picked = new PostingIndexChainEntry.Snapshot();
+        Assert.assertEquals(
+                PostingIndexChainPicker.RESULT_OK,
+                PostingIndexChainPicker.pick(mem, Long.MAX_VALUE, /* coverCount */ 2, header, picked)
+        );
+        Assert.assertEquals(1, picked.genCount);
+        Assert.assertEquals(2, picked.coverFileEndOffsets.size());
+        Assert.assertEquals(7777L, picked.coverFileEndOffsets.getQuick(0));
+        Assert.assertEquals(8888L, picked.coverFileEndOffsets.getQuick(1));
+    }
+
+    @Test
     public void testResetStateClearsInMemoryMirror() {
         PostingIndexChainWriter w = new PostingIndexChainWriter();
         w.initialiseEmpty(mem);

--- a/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainWriterTest.java
@@ -463,6 +463,60 @@ public class PostingIndexChainWriterTest {
     }
 
     @Test
+    public void testRecoveryHeadTrimSingleTailGenNoCover() {
+        PostingIndexChainWriter w = new PostingIndexChainWriter();
+        w.initialiseEmpty(mem);
+
+        long entryOffset = w.appendNewEntry(
+                mem,
+                /* sealTxn */ 1, /* txnAtSeal */ 10,
+                /* valueMemSize */ 0, /* maxValue */ -1,
+                /* keyCount */ 0, /* genCount */ 2,
+                /* blockCapacity */ 64, /* coveringFormat */ 0
+        );
+        long slot0 = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE;
+        long slot1 = slot0 + PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        mem.putLong(slot1 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 11L);
+        mem.putLong(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET, 0L);
+        mem.putLong(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_SIZE, 64L);
+        mem.putLong(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE, 42L);
+        mem.putInt(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY, 4);
+
+        int dropped = w.recoveryDropAbandoned(mem, /* currentTableTxn */ 10L, new LongList());
+
+        Assert.assertEquals(0, dropped);
+        Assert.assertTrue(w.isHeadTrimmedOnLastRecovery());
+        Assert.assertEquals(1, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
+        Assert.assertEquals(
+                PostingIndexChainEntry.entrySize(1, 0),
+                mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN)
+        );
+        Assert.assertEquals(42L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
+        Assert.assertEquals(64L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
+        Assert.assertEquals(5, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT));
+    }
+
+    @Test
+    public void testRecoveryWholeEntryDroppedWhenSlot0InFlight() {
+        PostingIndexChainWriter w = new PostingIndexChainWriter();
+        w.initialiseEmpty(mem);
+
+        w.appendNewEntry(mem, 1, 10, 0, 0, 0, 1, 64, 0);
+        long inFlightOffset = w.appendNewEntry(mem, 2, 20, 0, 0, 0, 1, 64, 0);
+        long inFlightSlot0 = inFlightOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE;
+        mem.putLong(inFlightSlot0 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 20L);
+
+        LongList orphans = new LongList();
+        int dropped = w.recoveryDropAbandoned(mem, /* currentTableTxn */ 10L, orphans);
+
+        Assert.assertEquals(1, dropped);
+        Assert.assertFalse(w.isHeadTrimmedOnLastRecovery());
+        Assert.assertEquals(1, orphans.size());
+        Assert.assertEquals(2L, orphans.getQuick(0));
+        Assert.assertEquals(1L, w.getEntryCount());
+    }
+
+    @Test
     public void testResetStateClearsInMemoryMirror() {
         PostingIndexChainWriter w = new PostingIndexChainWriter();
         w.initialiseEmpty(mem);

--- a/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/idx/PostingIndexChainWriterTest.java
@@ -497,6 +497,141 @@ public class PostingIndexChainWriterTest {
     }
 
     @Test
+    public void testRecoveryDropsPartialSealEntryAtGetTxnPlusOne() {
+        // Models the SEAL branch in TableWriter.sealPostingIndexForPartition:
+        // a chain entry is published with txnAtSeal = txWriter.getTxn() + 1,
+        // then the surrounding O3 / parquet-rewrite path fails before
+        // txWriter.commit lands. The next writer-open runs recovery with
+        // currentTableTxn still at the pre-fail committed _txn; the
+        // (T+1 > T) predicate must drop the partial SEAL entry.
+        PostingIndexChainWriter w = new PostingIndexChainWriter();
+        w.initialiseEmpty(mem);
+
+        final long committedTxn = 42L;
+        long survivor = w.appendNewEntry(mem, 1, committedTxn, 0, 0, 0, 1, 64, 0);
+        w.appendNewEntry(mem, 2, committedTxn + 1L, 0, 0, 0, 1, 64, 0);
+
+        LongList orphans = new LongList();
+        int dropped = w.recoveryDropAbandoned(mem, committedTxn, orphans);
+
+        Assert.assertEquals(1, dropped);
+        Assert.assertEquals(1, orphans.size());
+        Assert.assertEquals(2L, orphans.getQuick(0));
+        Assert.assertEquals(1L, w.getEntryCount());
+        Assert.assertEquals(survivor, w.getHeadEntryOffset());
+        Assert.assertFalse(w.isHeadTrimmedOnLastRecovery());
+
+        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
+        PostingIndexChainEntry.Snapshot picked = new PostingIndexChainEntry.Snapshot();
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
+                PostingIndexChainPicker.pick(mem, Long.MAX_VALUE, header, picked));
+        Assert.assertEquals(1L, picked.sealTxn);
+        Assert.assertEquals(committedTxn, picked.txnAtSeal);
+    }
+
+    @Test
+    public void testRecoveryHeadTrimDropsAllTailGensKeepingSlot0Only() {
+        PostingIndexChainWriter w = new PostingIndexChainWriter();
+        w.initialiseEmpty(mem);
+
+        long entryOffset = w.appendNewEntry(
+                mem,
+                /* sealTxn */ 1, /* txnAtSeal */ 5,
+                /* valueMemSize */ 0, /* maxValue */ -1,
+                /* keyCount */ 0, /* genCount */ 5,
+                /* blockCapacity */ 64, /* coveringFormat */ 0
+        );
+        long slot0 = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE;
+        mem.putLong(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET, 0L);
+        mem.putLong(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_SIZE, 80L);
+        mem.putLong(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE, 7L);
+        mem.putInt(slot0 + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY, 2);
+        for (int g = 1; g < 5; g++) {
+            long slot = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                    + (long) g * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+            mem.putLong(slot + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 5L + g);
+        }
+
+        int dropped = w.recoveryDropAbandoned(mem, /* currentTableTxn */ 5L, new LongList());
+
+        Assert.assertEquals(0, dropped);
+        Assert.assertTrue(w.isHeadTrimmedOnLastRecovery());
+        Assert.assertEquals(1, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
+        Assert.assertEquals(
+                PostingIndexChainEntry.entrySize(1, 0),
+                mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN)
+        );
+        Assert.assertEquals(7L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
+        Assert.assertEquals(80L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
+        Assert.assertEquals(3, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT));
+        Assert.assertEquals(entryOffset + PostingIndexChainEntry.entrySize(1, 0), w.getRegionLimit());
+    }
+
+    @Test
+    public void testRecoveryHeadTrimKeepsMultipleGensWithCover() {
+        PostingIndexChainWriter w = new PostingIndexChainWriter();
+        w.initialiseEmpty(mem);
+
+        LongList coverEnds = new LongList();
+        coverEnds.add(1111L);
+        coverEnds.add(2222L);
+        long entryOffset = w.appendNewEntry(
+                mem,
+                /* sealTxn */ 1, /* txnAtSeal */ 10,
+                /* valueMemSize */ 0, /* maxValue */ -1,
+                /* keyCount */ 0, /* genCount */ 5,
+                /* blockCapacity */ 64, /* coveringFormat */ 0,
+                coverEnds
+        );
+        for (int g = 0; g < 5; g++) {
+            long slot = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                    + (long) g * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+            mem.putLong(slot + PostingIndexUtils.GEN_DIR_OFFSET_FILE_OFFSET, (long) g * 100);
+            mem.putLong(slot + PostingIndexUtils.GEN_DIR_OFFSET_SIZE, 100L);
+            mem.putLong(slot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_VALUE, (long) (g + 1) * 50);
+            mem.putInt(slot + PostingIndexUtils.GEN_DIR_OFFSET_MAX_KEY, g);
+        }
+        // slot[0] keeps TXN_AT_SEAL=10 from appendNewEntry; the rest mix
+        // visible (slot[1..2]) and in-flight (slot[3..4]).
+        long slot1 = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                + (long) PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        long slot2 = slot1 + PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        long slot3 = slot2 + PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        long slot4 = slot3 + PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        mem.putLong(slot1 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 10L);
+        mem.putLong(slot2 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 10L);
+        mem.putLong(slot3 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 11L);
+        mem.putLong(slot4 + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL, 12L);
+
+        int dropped = w.recoveryDropAbandoned(mem, /* currentTableTxn */ 10L, new LongList());
+
+        Assert.assertEquals(0, dropped);
+        Assert.assertTrue(w.isHeadTrimmedOnLastRecovery());
+        Assert.assertEquals(3, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT));
+        Assert.assertEquals(
+                PostingIndexChainEntry.entrySize(3, 2),
+                mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN)
+        );
+        Assert.assertEquals(150L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_MAX_VALUE));
+        Assert.assertEquals(300L, mem.getLong(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_VALUE_MEM_SIZE));
+        Assert.assertEquals(3, mem.getInt(entryOffset + PostingIndexUtils.V2_ENTRY_OFFSET_KEY_COUNT));
+
+        long newFooterOffset = entryOffset + PostingIndexUtils.V2_ENTRY_HEADER_SIZE
+                + 3L * PostingIndexUtils.GEN_DIR_ENTRY_SIZE;
+        Assert.assertEquals(1111L, mem.getLong(newFooterOffset));
+        Assert.assertEquals(2222L, mem.getLong(newFooterOffset + PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE));
+
+        PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
+        PostingIndexChainEntry.Snapshot picked = new PostingIndexChainEntry.Snapshot();
+        Assert.assertEquals(PostingIndexChainPicker.RESULT_OK,
+                PostingIndexChainPicker.pick(mem, Long.MAX_VALUE, /* coverCount */ 2, header, picked));
+        Assert.assertEquals(3, picked.genCount);
+        Assert.assertEquals(2, picked.coverFileEndOffsets.size());
+        Assert.assertEquals(1111L, picked.coverFileEndOffsets.getQuick(0));
+        Assert.assertEquals(2222L, picked.coverFileEndOffsets.getQuick(1));
+    }
+
+    @Test
     public void testRecoveryWholeEntryDroppedWhenSlot0InFlight() {
         PostingIndexChainWriter w = new PostingIndexChainWriter();
         w.initialiseEmpty(mem);


### PR DESCRIPTION
## Summary

- POSTING-indexed `WHERE col = v` against a WAL table occasionally returned a row whose `.d` value did not match `v`. Surfaced as a non-WAL vs WAL divergence in `WalWriterFuzzTest#testWalWriteRollbackHeavy` once writer distress (fuzz IO injection, very short `cairo.wal.apply.table.time.quota`) caused multiple commits to share a single chain entry via the canSkipRebuild fast-path.
- Root cause: PR #7087's `extendHead` mutates the chain entry header in place but never updates `TXN_AT_SEAL`. Recovery's `entry.TXN_AT_SEAL > committedTxn` predicate cannot identify partial-publish failures because the field stays pinned at the first commit's value while later tail gens carry uncommitted data. The reader picks the entry, walks the in-flight tail, and surfaces stale (key, rowId) pairs.

## Change

- Move `TXN_AT_SEAL` from entry header to per-slot. Each gen-dir slot tags itself with the anticipated table `_txn` at write time. Recovery does per-gen tail trim against `slot.TXN_AT_SEAL > committedTxn`; reader cursors skip in-flight tail gens for snapshot isolation. Per-slot `MAX_VALUE` lets recovery and per-gen read recompute the visible cumulative max in O(1).
- `applyHeadTrim` uses GEN_COUNT-first store order (inverse of `extendHead`'s GEN_COUNT-last). Trim is a shrink, so the latch field is written first to prevent a concurrent reader from seeing an old large GEN_COUNT with a new small VALUE_MEM_SIZE.
- `sealPostingIndexForPartition`'s `setNextTxnAtSeal` unified to `getTxn() + 1L` (matching `O3CopyJob`). The earlier `getTxn()` trade-off was tied to entry-header `TXN_AT_SEAL`; with the field moved to slot[0] and `publishPendingPurges` already clamping `toTableTxn` to `getTxn()`, the scoreboard concern no longer applies. Slot `TXN_AT_SEAL` is now monotonic within an entry.