### PR TITLE
fix(sql): WINDOW JOIN crash when master projects a symbol column

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -5701,7 +5701,11 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                                                         final boolean rightIsMaster = rightColumnIndex < columnSplit;
                                                         isLeft = parent != null && parent.lhs == nn;
 
-                                                        if (leftIsSymbol && rightIsSymbol && leftIsMaster != rightIsMaster) {
+                                                        // Both sides must expose a static symbol table; the fast path
+                                                        // enumerates master symbols up front to build the slave lookup map.
+                                                        if (leftIsSymbol && rightIsSymbol && leftIsMaster != rightIsMaster
+                                                                && joinMetadata.isSymbolTableStatic(leftColumnIndex)
+                                                                && joinMetadata.isSymbolTableStatic(rightColumnIndex)) {
                                                             leftSymbolIndex = leftIsMaster ? leftColumnIndex : rightColumnIndex;
                                                             rightSymbolIndex = leftIsMaster ? rightColumnIndex : leftColumnIndex;
                                                             rightSymbolIndex = rightSymbolIndex - columnSplit;

--- a/core/src/main/java/io/questdb/griffin/engine/join/AsyncWindowJoinFastAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/AsyncWindowJoinFastAtom.java
@@ -29,13 +29,11 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cairo.sql.StaticSymbolTable;
-import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.cairo.sql.SymbolTableSource;
 import io.questdb.cairo.vm.api.MemoryCARW;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.GroupByFunction;
-import io.questdb.griffin.engine.functions.SymbolFunction;
 import io.questdb.griffin.engine.table.ConcurrentTimeFrameState;
 import io.questdb.griffin.engine.table.TablePageFrameCursor;
 import io.questdb.jit.CompiledFilter;
@@ -259,9 +257,8 @@ public class AsyncWindowJoinFastAtom extends AsyncWindowJoinAtom {
         }
 
         final SymbolTableSource slaveSymbolTableSource = ownerSlaveTimeFrameHelper.getSymbolTableSource();
-        // Master may project the symbol through a SymbolColumn (e.g. CTE / sub-select), so unwrap.
-        StaticSymbolTable masterSymbolTable = asStaticSymbolTable(masterSymbolTableSource.getSymbolTable(masterSymbolIndex));
-        StaticSymbolTable slaveSymbolTable = asStaticSymbolTable(slaveSymbolTableSource.getSymbolTable(slaveSymbolIndex));
+        StaticSymbolTable masterSymbolTable = (StaticSymbolTable) masterSymbolTableSource.getSymbolTable(masterSymbolIndex);
+        StaticSymbolTable slaveSymbolTable = (StaticSymbolTable) slaveSymbolTableSource.getSymbolTable(slaveSymbolIndex);
         for (int masterKey = 0, n = masterSymbolTable.getSymbolCount(); masterKey < n; masterKey++) {
             final CharSequence masterSym = masterSymbolTable.valueOf(masterKey);
             final int slaveKey = slaveSymbolTable.keyOf(masterSym);
@@ -272,16 +269,6 @@ public class AsyncWindowJoinFastAtom extends AsyncWindowJoinAtom {
         if (masterSymbolTable.containsNullValue() && slaveSymbolTable.containsNullValue()) {
             slaveSymbolLookupMap.put(NULL_KEY, StaticSymbolTable.VALUE_IS_NULL);
         }
-    }
-
-    static StaticSymbolTable asStaticSymbolTable(SymbolTable symbolTable) {
-        if (symbolTable instanceof StaticSymbolTable) {
-            return (StaticSymbolTable) symbolTable;
-        }
-        if (symbolTable instanceof SymbolFunction) {
-            return ((SymbolFunction) symbolTable).getStaticSymbolTable();
-        }
-        return null;
     }
 
     static int toSymbolMapKey(int key) {

--- a/core/src/main/java/io/questdb/griffin/engine/join/AsyncWindowJoinFastAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/AsyncWindowJoinFastAtom.java
@@ -29,11 +29,13 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cairo.sql.StaticSymbolTable;
+import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.cairo.sql.SymbolTableSource;
 import io.questdb.cairo.vm.api.MemoryCARW;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.SymbolFunction;
 import io.questdb.griffin.engine.table.ConcurrentTimeFrameState;
 import io.questdb.griffin.engine.table.TablePageFrameCursor;
 import io.questdb.jit.CompiledFilter;
@@ -257,8 +259,9 @@ public class AsyncWindowJoinFastAtom extends AsyncWindowJoinAtom {
         }
 
         final SymbolTableSource slaveSymbolTableSource = ownerSlaveTimeFrameHelper.getSymbolTableSource();
-        StaticSymbolTable masterSymbolTable = (StaticSymbolTable) masterSymbolTableSource.getSymbolTable(masterSymbolIndex);
-        StaticSymbolTable slaveSymbolTable = (StaticSymbolTable) slaveSymbolTableSource.getSymbolTable(slaveSymbolIndex);
+        // Master may project the symbol through a SymbolColumn (e.g. CTE / sub-select), so unwrap.
+        StaticSymbolTable masterSymbolTable = asStaticSymbolTable(masterSymbolTableSource.getSymbolTable(masterSymbolIndex));
+        StaticSymbolTable slaveSymbolTable = asStaticSymbolTable(slaveSymbolTableSource.getSymbolTable(slaveSymbolIndex));
         for (int masterKey = 0, n = masterSymbolTable.getSymbolCount(); masterKey < n; masterKey++) {
             final CharSequence masterSym = masterSymbolTable.valueOf(masterKey);
             final int slaveKey = slaveSymbolTable.keyOf(masterSym);
@@ -269,6 +272,16 @@ public class AsyncWindowJoinFastAtom extends AsyncWindowJoinAtom {
         if (masterSymbolTable.containsNullValue() && slaveSymbolTable.containsNullValue()) {
             slaveSymbolLookupMap.put(NULL_KEY, StaticSymbolTable.VALUE_IS_NULL);
         }
+    }
+
+    static StaticSymbolTable asStaticSymbolTable(SymbolTable symbolTable) {
+        if (symbolTable instanceof StaticSymbolTable) {
+            return (StaticSymbolTable) symbolTable;
+        }
+        if (symbolTable instanceof SymbolFunction) {
+            return ((SymbolFunction) symbolTable).getStaticSymbolTable();
+        }
+        return null;
     }
 
     static int toSymbolMapKey(int key) {

--- a/core/src/main/java/io/questdb/griffin/engine/join/WindowJoinFastRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/WindowJoinFastRecordCursorFactory.java
@@ -351,7 +351,8 @@ public class WindowJoinFastRecordCursorFactory extends AbstractRecordCursorFacto
 
         protected void setupSlaveLookupMap(RecordCursor masterCursor, TimeFrameCursor slaveCursor) {
             slaveSymbolLookupMap.reopen();
-            StaticSymbolTable masterSymbolTable = (StaticSymbolTable) masterCursor.getSymbolTable(masterSymbolIndex);
+            // Master may project the symbol through a SymbolColumn (e.g. CTE / sub-select), so unwrap.
+            StaticSymbolTable masterSymbolTable = asStaticSymbolTable(masterCursor.getSymbolTable(masterSymbolIndex));
             StaticSymbolTable slaveSymbolTable = slaveCursor.getSymbolTable(slaveSymbolIndex);
             for (int masterKey = 0, n = masterSymbolTable.getSymbolCount(); masterKey < n; masterKey++) {
                 final CharSequence masterSym = masterSymbolTable.valueOf(masterKey);

--- a/core/src/main/java/io/questdb/griffin/engine/join/WindowJoinFastRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/WindowJoinFastRecordCursorFactory.java
@@ -305,6 +305,19 @@ public class WindowJoinFastRecordCursorFactory extends AbstractRecordCursorFacto
         Misc.free(value);
     }
 
+    private static StaticSymbolTable asStaticSymbolTable(SymbolTable symbolTable) {
+        if (symbolTable instanceof StaticSymbolTable sst) {
+            return sst;
+        }
+        if (symbolTable instanceof SymbolFunction sf) {
+            StaticSymbolTable sst = sf.getStaticSymbolTable();
+            if (sst != null) {
+                return sst;
+            }
+        }
+        throw new AssertionError("Failed to get static symbol table from " + symbolTable);
+    }
+
     private abstract class AbstractWindowJoinFastRecordCursor implements NoRandomAccessRecordCursor {
         protected final GroupByFunctionsUpdater groupByFunctionsUpdater;
         // Stores metadata about storage of slave underlying records

--- a/core/src/test/java/io/questdb/test/griffin/WindowJoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WindowJoinTest.java
@@ -6811,6 +6811,176 @@ public class WindowJoinTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testWithProjectedMasterSymbol() throws Exception {
+        // https://github.com/questdb/questdb/issues/7097
+        // The master is a sub-select with a virtual column, which forces the master
+        // factory to wrap and expose the SYMBOL column through a SymbolColumn rather
+        // than a StaticSymbolTable. The fast path must unwrap to the underlying static
+        // symbol table instead of crashing with a ClassCastException.
+        Assume.assumeTrue(leftTableTimestampType == TestTimestampType.MICRO);
+        Assume.assumeTrue(rightTableTimestampType == TestTimestampType.MICRO);
+        assertMemoryLeak(() -> {
+            execute(
+                    "create table trades (" +
+                            "  sym symbol," +
+                            "  price double," +
+                            "  ts timestamp" +
+                            ") timestamp(ts) partition by day;"
+            );
+            execute(
+                    "create table prices (" +
+                            "  sym symbol," +
+                            "  bid double," +
+                            "  ts timestamp" +
+                            ") timestamp(ts) partition by day;"
+            );
+
+            execute(
+                    "insert into trades values " +
+                            "('A', 1.0, '2023-01-01T09:00:00.000000Z')," +
+                            "('A', 2.0, '2023-01-01T09:01:00.000000Z')," +
+                            "('B', 3.0, '2023-01-01T09:00:00.000000Z')," +
+                            "('B', 4.0, '2023-01-01T09:02:00.000000Z');"
+            );
+            execute(
+                    "insert into prices values " +
+                            "('A', 10.0, '2023-01-01T08:59:30.000000Z')," +
+                            "('A', 20.0, '2023-01-01T09:00:30.000000Z')," +
+                            "('A', 30.0, '2023-01-01T09:01:30.000000Z')," +
+                            "('B', 40.0, '2023-01-01T09:00:00.000000Z')," +
+                            "('B', 50.0, '2023-01-01T09:02:30.000000Z');"
+            );
+
+            // The virtual `p2` column wraps the master in a VirtualRecordCursorFactory,
+            // which does not support page frames, so the single-threaded fast path is used.
+            final String query = "SELECT a.sym, a.ts, sum(p.bid) AS s " +
+                    "FROM (SELECT sym, ts, price + 0 AS p2 FROM trades) a " +
+                    "WINDOW JOIN prices p " +
+                    "ON (a.sym = p.sym) " +
+                    "RANGE BETWEEN 1 MINUTE PRECEDING AND 1 MINUTE FOLLOWING EXCLUDE PREVAILING " +
+                    "ORDER BY a.ts, a.sym";
+
+            assertPlanNoLeakCheck(
+                    query,
+                    """
+                            Encode sort
+                              keys: [ts, sym]
+                                Window Fast Join
+                                  vectorized: true
+                                  symbol: sym=sym
+                                  window lo: 60000000 preceding (exclude prevailing)
+                                  window hi: 60000000 following
+                                    VirtualRecord
+                                      functions: [sym,ts]
+                                        PageFrame
+                                            Row forward scan
+                                            Frame forward scan on: trades
+                                    PageFrame
+                                        Row forward scan
+                                        Frame forward scan on: prices
+                            """
+            );
+
+            assertQueryNoLeakCheck(
+                    """
+                            sym\tts\ts
+                            A\t2023-01-01T09:00:00.000000Z\t30.0
+                            B\t2023-01-01T09:00:00.000000Z\t40.0
+                            A\t2023-01-01T09:01:00.000000Z\t50.0
+                            B\t2023-01-01T09:02:00.000000Z\t50.0
+                            """,
+                    query,
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testWithProjectedMasterSymbolAsync() throws Exception {
+        // Smoke test for the async fast path counterpart of testWithProjectedMasterSymbol.
+        // The bug as reported only triggers in the single-threaded path because async
+        // requires page frame support on the master (which masks the SymbolColumn wrap),
+        // but AsyncWindowJoinFastAtom carries the same defensive unwrap.
+        Assume.assumeTrue(leftTableTimestampType == TestTimestampType.MICRO);
+        Assume.assumeTrue(rightTableTimestampType == TestTimestampType.MICRO);
+        assertMemoryLeak(() -> {
+            execute(
+                    "create table trades (" +
+                            "  sym symbol," +
+                            "  price double," +
+                            "  ts timestamp" +
+                            ") timestamp(ts) partition by day;"
+            );
+            execute(
+                    "create table prices (" +
+                            "  sym symbol," +
+                            "  bid double," +
+                            "  ts timestamp" +
+                            ") timestamp(ts) partition by day;"
+            );
+
+            execute(
+                    "insert into trades values " +
+                            "('A', 1.0, '2023-01-01T09:00:00.000000Z')," +
+                            "('A', 2.0, '2023-01-01T09:01:00.000000Z')," +
+                            "('B', 3.0, '2023-01-01T09:00:00.000000Z')," +
+                            "('B', 4.0, '2023-01-01T09:02:00.000000Z');"
+            );
+            execute(
+                    "insert into prices values " +
+                            "('A', 10.0, '2023-01-01T08:59:30.000000Z')," +
+                            "('A', 20.0, '2023-01-01T09:00:30.000000Z')," +
+                            "('A', 30.0, '2023-01-01T09:01:30.000000Z')," +
+                            "('B', 40.0, '2023-01-01T09:00:00.000000Z')," +
+                            "('B', 50.0, '2023-01-01T09:02:30.000000Z');"
+            );
+
+            // Column-only sub-select keeps page frame support, so the async fast path is used.
+            final String query = "SELECT a.sym, a.ts, sum(p.bid) AS s " +
+                    "FROM (SELECT sym, ts FROM trades) a " +
+                    "WINDOW JOIN prices p " +
+                    "ON (a.sym = p.sym) " +
+                    "RANGE BETWEEN 1 MINUTE PRECEDING AND 1 MINUTE FOLLOWING EXCLUDE PREVAILING " +
+                    "ORDER BY a.ts, a.sym";
+
+            assertPlanNoLeakCheck(
+                    query,
+                    """
+                            Encode sort
+                              keys: [ts, sym]
+                                Async Window Fast Join workers: 1
+                                  vectorized: true
+                                  symbol: sym=sym
+                                  window lo: 60000000 preceding (exclude prevailing)
+                                  window hi: 60000000 following
+                                    PageFrame
+                                        Row forward scan
+                                        Frame forward scan on: trades
+                                    PageFrame
+                                        Row forward scan
+                                        Frame forward scan on: prices
+                            """
+            );
+
+            assertQueryNoLeakCheck(
+                    """
+                            sym\tts\ts
+                            A\t2023-01-01T09:00:00.000000Z\t30.0
+                            B\t2023-01-01T09:00:00.000000Z\t40.0
+                            A\t2023-01-01T09:01:00.000000Z\t50.0
+                            B\t2023-01-01T09:02:00.000000Z\t50.0
+                            """,
+                    query,
+                    "ts",
+                    true,
+                    false
+            );
+        });
+    }
+
+    @Test
     public void testWithSymbolEqualConditionInSameTable() throws Exception {
         // timestamp types don't matter for this test
         Assume.assumeTrue(leftTableTimestampType == TestTimestampType.MICRO);

--- a/core/src/test/java/io/questdb/test/griffin/WindowJoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WindowJoinTest.java
@@ -6898,11 +6898,11 @@ public class WindowJoinTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testWithProjectedMasterSymbolAsync() throws Exception {
-        // Smoke test for the async fast path counterpart of testWithProjectedMasterSymbol.
-        // The bug as reported only triggers in the single-threaded path because async
-        // requires page frame support on the master (which masks the SymbolColumn wrap),
-        // but AsyncWindowJoinFastAtom carries the same defensive unwrap.
+    public void testWithProjectedMasterSymbolAndJoinFilter() throws Exception {
+        // Same projected-master scenario as testWithProjectedMasterSymbol but with an
+        // extra predicate on the slave column. The symbol equality is still extracted
+        // for the fast-path lookup map, while the remaining predicate is compiled as
+        // a join filter that runs against the projected master.
         Assume.assumeTrue(leftTableTimestampType == TestTimestampType.MICRO);
         Assume.assumeTrue(rightTableTimestampType == TestTimestampType.MICRO);
         assertMemoryLeak(() -> {
@@ -6937,11 +6937,10 @@ public class WindowJoinTest extends AbstractCairoTest {
                             "('B', 50.0, '2023-01-01T09:02:30.000000Z');"
             );
 
-            // Column-only sub-select keeps page frame support, so the async fast path is used.
             final String query = "SELECT a.sym, a.ts, sum(p.bid) AS s " +
-                    "FROM (SELECT sym, ts FROM trades) a " +
+                    "FROM (SELECT sym, ts, price + 0 AS p2 FROM trades) a " +
                     "WINDOW JOIN prices p " +
-                    "ON (a.sym = p.sym) " +
+                    "ON (a.sym = p.sym AND p.bid > 15) " +
                     "RANGE BETWEEN 1 MINUTE PRECEDING AND 1 MINUTE FOLLOWING EXCLUDE PREVAILING " +
                     "ORDER BY a.ts, a.sym";
 
@@ -6950,14 +6949,184 @@ public class WindowJoinTest extends AbstractCairoTest {
                     """
                             Encode sort
                               keys: [ts, sym]
-                                Async Window Fast Join workers: 1
-                                  vectorized: true
+                                Window Fast Join
+                                  vectorized: false
                                   symbol: sym=sym
                                   window lo: 60000000 preceding (exclude prevailing)
                                   window hi: 60000000 following
+                                  join filter: 15<p.bid
+                                    VirtualRecord
+                                      functions: [sym,ts]
+                                        PageFrame
+                                            Row forward scan
+                                            Frame forward scan on: trades
                                     PageFrame
                                         Row forward scan
-                                        Frame forward scan on: trades
+                                        Frame forward scan on: prices
+                            """
+            );
+
+            assertQueryNoLeakCheck(
+                    """
+                            sym\tts\ts
+                            A\t2023-01-01T09:00:00.000000Z\t20.0
+                            B\t2023-01-01T09:00:00.000000Z\t40.0
+                            A\t2023-01-01T09:01:00.000000Z\t50.0
+                            B\t2023-01-01T09:02:00.000000Z\t50.0
+                            """,
+                    query,
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testWithProjectedMasterSymbolIncludePrevailing() throws Exception {
+        // INCLUDE PREVAILING variant of testWithProjectedMasterSymbol. Exercises the
+        // WindowJoinWithPrevailingFastRecordCursor path, which shares setupSlaveLookupMap
+        // with the EXCLUDE PREVAILING cursor and therefore relies on the same symbol-table
+        // unwrap.
+        Assume.assumeTrue(leftTableTimestampType == TestTimestampType.MICRO);
+        Assume.assumeTrue(rightTableTimestampType == TestTimestampType.MICRO);
+        assertMemoryLeak(() -> {
+            execute(
+                    "create table trades (" +
+                            "  sym symbol," +
+                            "  price double," +
+                            "  ts timestamp" +
+                            ") timestamp(ts) partition by day;"
+            );
+            execute(
+                    "create table prices (" +
+                            "  sym symbol," +
+                            "  bid double," +
+                            "  ts timestamp" +
+                            ") timestamp(ts) partition by day;"
+            );
+
+            execute(
+                    "insert into trades values " +
+                            "('A', 1.0, '2023-01-01T09:00:00.000000Z')," +
+                            "('A', 2.0, '2023-01-01T09:01:00.000000Z')," +
+                            "('B', 3.0, '2023-01-01T09:00:00.000000Z')," +
+                            "('B', 4.0, '2023-01-01T09:02:00.000000Z');"
+            );
+            execute(
+                    "insert into prices values " +
+                            "('A', 10.0, '2023-01-01T08:59:30.000000Z')," +
+                            "('A', 20.0, '2023-01-01T09:00:30.000000Z')," +
+                            "('A', 30.0, '2023-01-01T09:01:30.000000Z')," +
+                            "('B', 40.0, '2023-01-01T09:00:00.000000Z')," +
+                            "('B', 50.0, '2023-01-01T09:02:30.000000Z');"
+            );
+
+            final String query = "SELECT a.sym, a.ts, sum(p.bid) AS s " +
+                    "FROM (SELECT sym, ts, price + 0 AS p2 FROM trades) a " +
+                    "WINDOW JOIN prices p " +
+                    "ON (a.sym = p.sym) " +
+                    "RANGE BETWEEN 1 MINUTE PRECEDING AND 1 MINUTE FOLLOWING INCLUDE PREVAILING " +
+                    "ORDER BY a.ts, a.sym";
+
+            assertPlanNoLeakCheck(
+                    query,
+                    """
+                            Encode sort
+                              keys: [ts, sym]
+                                Window Fast Join
+                                  vectorized: true
+                                  symbol: sym=sym
+                                  window lo: 60000000 preceding (include prevailing)
+                                  window hi: 60000000 following
+                                    VirtualRecord
+                                      functions: [sym,ts]
+                                        PageFrame
+                                            Row forward scan
+                                            Frame forward scan on: trades
+                                    PageFrame
+                                        Row forward scan
+                                        Frame forward scan on: prices
+                            """
+            );
+
+            assertQueryNoLeakCheck(
+                    """
+                            sym\tts\ts
+                            A\t2023-01-01T09:00:00.000000Z\t30.0
+                            B\t2023-01-01T09:00:00.000000Z\t40.0
+                            A\t2023-01-01T09:01:00.000000Z\t60.0
+                            B\t2023-01-01T09:02:00.000000Z\t90.0
+                            """,
+                    query,
+                    "ts",
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testWithProjectedNonStaticSymbolFallsBackToWindowJoin() throws Exception {
+        // Negative path of the SqlCodeGenerator gate added for issue #7097. When the
+        // master projects a non-static SYMBOL (here via varchar -> symbol cast), the
+        // planner must NOT pick the symbol-keyed fast path; the entire ON expression
+        // becomes a join filter on the generic Window Join factory.
+        Assume.assumeTrue(leftTableTimestampType == TestTimestampType.MICRO);
+        Assume.assumeTrue(rightTableTimestampType == TestTimestampType.MICRO);
+        assertMemoryLeak(() -> {
+            execute(
+                    "create table quotes (" +
+                            "  s varchar," +
+                            "  price double," +
+                            "  ts timestamp" +
+                            ") timestamp(ts) partition by day;"
+            );
+            execute(
+                    "create table prices (" +
+                            "  sym symbol," +
+                            "  bid double," +
+                            "  ts timestamp" +
+                            ") timestamp(ts) partition by day;"
+            );
+
+            execute(
+                    "insert into quotes values " +
+                            "('A', 1.0, '2023-01-01T09:00:00.000000Z')," +
+                            "('A', 2.0, '2023-01-01T09:01:00.000000Z')," +
+                            "('B', 3.0, '2023-01-01T09:00:00.000000Z')," +
+                            "('B', 4.0, '2023-01-01T09:02:00.000000Z');"
+            );
+            execute(
+                    "insert into prices values " +
+                            "('A', 10.0, '2023-01-01T08:59:30.000000Z')," +
+                            "('A', 20.0, '2023-01-01T09:00:30.000000Z')," +
+                            "('A', 30.0, '2023-01-01T09:01:30.000000Z')," +
+                            "('B', 40.0, '2023-01-01T09:00:00.000000Z')," +
+                            "('B', 50.0, '2023-01-01T09:02:30.000000Z');"
+            );
+
+            final String query = "SELECT a.sym, a.ts, sum(p.bid) AS s " +
+                    "FROM (SELECT s::symbol AS sym, ts FROM quotes) a " +
+                    "WINDOW JOIN prices p " +
+                    "ON (a.sym = p.sym) " +
+                    "RANGE BETWEEN 1 MINUTE PRECEDING AND 1 MINUTE FOLLOWING EXCLUDE PREVAILING " +
+                    "ORDER BY a.ts, a.sym";
+
+            assertPlanNoLeakCheck(
+                    query,
+                    """
+                            Sort
+                              keys: [ts, sym]
+                                Window Join
+                                  window lo: 60000000 preceding (exclude prevailing)
+                                  window hi: 60000000 following
+                                  join filter: a.sym=p.sym
+                                    VirtualRecord
+                                      functions: [s::symbol,ts]
+                                        PageFrame
+                                            Row forward scan
+                                            Frame forward scan on: quotes
                                     PageFrame
                                         Row forward scan
                                         Frame forward scan on: prices
@@ -6975,7 +7144,7 @@ public class WindowJoinTest extends AbstractCairoTest {
                     query,
                     "ts",
                     true,
-                    false
+                    true
             );
         });
     }


### PR DESCRIPTION
Fixes #7097

The fast symbol-keyed path in `WindowJoinFastRecordCursorFactory` blindly cast the master cursor's `getSymbolTable()` result to `StaticSymbolTable`. When the master factory wraps the symbol through a `SymbolColumn` (e.g. a CTE or sub-select that projects the symbol through a `VirtualRecord`), the cursor returns the `SymbolColumn` function itself, which is not a `StaticSymbolTable`, and the join fails with a `ClassCastException`.

Unwrap the projected `SymbolFunction` down to its underlying `StaticSymbolTable` in the single-threaded `WindowJoinFastRecordCursorFactory.setupSlaveLookupMap`. Also tighten the plan-time gate in `SqlCodeGenerator` so the symbol-keyed fast path is selected only when both columns expose a static symbol table.