### PR TITLE
chore(qwp): expand fuzz tests with full wire-type coverage

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/load/TableData.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/load/TableData.java
@@ -33,8 +33,12 @@ import io.questdb.std.Rnd;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import static io.questdb.cairo.ColumnType.BYTE;
 import static io.questdb.cairo.ColumnType.DOUBLE;
 import static io.questdb.cairo.ColumnType.FLOAT;
+import static io.questdb.cairo.ColumnType.INT;
+import static io.questdb.cairo.ColumnType.LONG;
+import static io.questdb.cairo.ColumnType.SHORT;
 
 public class TableData {
     private final IntLongSortedList index = new IntLongSortedList();
@@ -137,8 +141,14 @@ public class TableData {
     }
 
     private String getDefaultValue(short colType) {
+        // NULL renderings must match CursorPrinter.printColumn for each type:
+        // - DOUBLE/FLOAT NULL: "null"
+        // - INT/LONG NULL: Numbers.append() prints "null"
+        // - BYTE/SHORT: no NULL sentinel; cursor renders the stored 0 as "0"
+        // - CHAR/UUID/LONG256/TIMESTAMP and string-like types: empty
         return switch (colType) {
-            case DOUBLE, FLOAT -> "null";
+            case DOUBLE, FLOAT, INT, LONG -> "null";
+            case BYTE, SHORT -> "0";
             default -> "";
         };
     }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
@@ -53,12 +53,13 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 /**
  * QWP ingress fuzz tests that compare the actual table contents against an
  * in-memory oracle built up front. Every row that the test intends to publish
- * is materialized as a {@link QwpRow} (with all data types — booleans, longs,
- * doubles, strings, symbols, 1D/2D double and long arrays) and added to the
- * {@link QwpTable} oracle. Producer threads then call {@link QwpRow#publishTo}
- * to send the row through QWP. After ingestion completes, every cell of every
- * row in the table is asserted against the oracle's typed values via
- * {@link QwpTable#assertCursor}.
+ * is materialized as a {@link QwpRow} (covering booleans, all integer widths
+ * (byte/short/int/long), floats, doubles, chars, strings, symbols, UUIDs,
+ * LONG256, nanosecond timestamps, decimals, and 1D/2D/3D double arrays) and
+ * added to the {@link QwpTable} oracle. Producer threads then call
+ * {@link QwpRow#publishTo} to send the row through QWP. After ingestion
+ * completes, every cell of every row in the table is asserted against the
+ * oracle's typed values via {@link QwpTable#assertCursor}.
  *
  * <p>Two scenarios:
  * <ul>
@@ -788,17 +789,40 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
 
     private static QwpRow generateRow(Rnd rnd, long id, long tsMicros) {
         QwpRow row = new QwpRow(id, tsMicros);
-        // BOOLEAN is mandatory: it has no NULL representation, so an absent
-        // BOOLEAN cell would be indistinguishable from a stored 'false'.
+        // BOOLEAN, BYTE, SHORT and CHAR are mandatory: none of them have a NULL
+        // representation, so an absent cell would be indistinguishable from a
+        // stored 0/false/'\0'.
         row.setBool("b", (id & 1L) == 0L);
+        row.setByte("b8", (byte) ((id & 0x7FL) - (rnd.nextBoolean() ? 0 : 0x40)));
+        row.setShort("s16", (short) maybeNegate(rnd, (id * 31L) & 0x7FFFL));
+        row.setChar("c", (char) ('A' + (int) (id & 0x1FL)));
         // Sign flips are independent per column to maximize coverage of
         // sign-bit handling in the SF wire encoder. id stays positive
         // because it's the dedup key and sorting alongside ts gives a
         // single deterministic interpretation.
+        if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setInt("i", (int) maybeNegate(rnd, (id * 65537L) & 0x7FFF_FFFFL));
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setLong("l", maybeNegate(rnd, id * 1_000_003L));
+        if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setFloat("f", (float) maybeNegate(rnd, id * 0.125));
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setDouble("d", maybeNegate(rnd, id * 1.5));
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setString("s", "s_" + id + maybeNonAscii(rnd));
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setSymbol("sym", "sym_" + (id & 0xFL) + maybeNonAscii(rnd));
+        if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) {
+            // UUID limbs use distinct mixing so hi != lo, exercising both halves
+            // of the 128-bit wire payload independently.
+            row.setUuid("u", id * 0xCAFEBABEL + 17L, id * 0xDEADBEEFL - 13L);
+        }
+        if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) {
+            row.setLong256("l256",
+                    id * 0x11111111L + 1L,
+                    id * 0x22222222L + 2L,
+                    id * 0x33333333L + 3L,
+                    id * 0x44444444L + 4L);
+        }
+        if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) {
+            // TIMESTAMP_NANO: pick a value distinct from the designated ts to make
+            // sure assertions hit the nanos path, not the row's micros payload.
+            row.setTimestampNano("tn", tsMicros * 1_000L + (id & 0x3FFL));
+        }
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR))
             row.setDoubleArray1d("da", deriveDoubleArr1d(id, rnd.nextBoolean() ? -1.0 : 1.0));
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR))
@@ -851,7 +875,7 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
         // write the extra expect type-default NULL at assertion time.
         // Numeric extras get the same independent sign-flip treatment as
         // base columns.
-        switch (rnd.nextInt(14)) {
+        switch (rnd.nextInt(19)) {
             case 0:
                 row.setLong("ex_l_0", maybeNegate(rnd, id * 7L));
                 break;
@@ -922,6 +946,27 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                         rnd.nextBoolean());
                 break;
             }
+            case 14:
+                row.setInt("ex_i_0", (int) maybeNegate(rnd, (id * 65537L) & 0x7FFF_FFFFL));
+                break;
+            case 15:
+                row.setFloat("ex_f_0", (float) maybeNegate(rnd, id * 0.0625));
+                break;
+            case 16:
+                row.setUuid("ex_u_0",
+                        id * 0xABCD_1234L + 5L,
+                        id * 0x5678_FEDCL + 11L);
+                break;
+            case 17:
+                row.setLong256("ex_l256_0",
+                        id * 0x0F0F_0F0FL + 1L,
+                        id * 0x1E1E_1E1EL + 2L,
+                        id * 0x2D2D_2D2DL + 3L,
+                        id * 0x3C3C_3C3CL + 4L);
+                break;
+            case 18:
+                row.setTimestampNano("ex_tn_0", row.getTimestampMicros() * 1_000L + (id & 0x1FFL));
+                break;
         }
     }
 
@@ -947,7 +992,14 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
      * {@link #slotCapFor} so the post-close assertion scales accordingly.
      */
     private static long pickSfMaxBytes(Rnd rnd) {
-        long[] pool = {64L * 1024, 256L * 1024, 1024L * 1024, 4L * 1024 * 1024};
+        // Smallest segment must comfortably fit one max-chunk frame. With all
+        // the row's typed columns set (LONG256, UUID, three array dims,
+        // three decimal widths, etc.) a wide row's wire payload runs around
+        // 500 bytes, and testOracleSenderRestartReplaysAcrossBounces flushes
+        // up to ~230 rows in one shot. 64 KiB used to be enough back when
+        // rows were ~6 columns; with the current schema it overflows with
+        // MmapSegmentException("payload too large for segment").
+        long[] pool = {256L * 1024, 1024L * 1024, 4L * 1024 * 1024};
         return pool[rnd.nextInt(pool.length)];
     }
 
@@ -1024,10 +1076,18 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                     "CREATE TABLE " + TABLE_NAME + " ("
                             + "id LONG, "
                             + "b BOOLEAN, "
+                            + "b8 BYTE, "
+                            + "s16 SHORT, "
+                            + "c CHAR, "
+                            + "i INT, "
                             + "l LONG, "
+                            + "f FLOAT, "
                             + "d DOUBLE, "
                             + "s STRING, "
                             + "sym SYMBOL, "
+                            + "u UUID, "
+                            + "l256 LONG256, "
+                            + "tn TIMESTAMP_NS, "
                             + "da DOUBLE[], "
                             + "da2 DOUBLE[][], "
                             + "da3 DOUBLE[][][], "

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFuzzTest.java
@@ -41,7 +41,9 @@ import io.questdb.std.LowerCaseCharSequenceObjHashMap;
 import io.questdb.std.Numbers;
 import io.questdb.std.Os;
 import io.questdb.std.Rnd;
+import io.questdb.std.datetime.nanotime.NanosFormatUtils;
 import io.questdb.std.str.Path;
+import io.questdb.std.str.StringSink;
 import io.questdb.test.cairo.TestTableReaderRecordCursor;
 import io.questdb.test.cutlass.line.tcp.load.LineData;
 import io.questdb.test.cutlass.line.tcp.load.TableData;
@@ -63,6 +65,16 @@ import static io.questdb.cairo.ColumnType.*;
 
 public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
 
+    // colNameBases / colTypes / colValueBases are partitioned: the first
+    // LEGACY_COLUMN_COUNT entries are STRING/DOUBLE columns and participate
+    // in the full skip / new-column-injection fuzz; the rest are typed
+    // columns (BYTE, SHORT, INT, FLOAT, CHAR, UUID, LONG256, TIMESTAMP_NANO)
+    // that are always set on every row and never auto-injected as extras.
+    // Reason: typed columns whose unset cells render differently from their
+    // type-default (e.g. BYTE 0 vs INT NULL) would clash with the oracle's
+    // single-default-per-column model once startAlterTableThread converts
+    // them across the integer family.
+    private static final int LEGACY_COLUMN_COUNT = 6;
     private static final Log LOG = LogFactory.getLog(QwpSenderFuzzTest.class);
     private static final int MAX_NUM_OF_SKIPPED_COLS = 2;
     private static final int NEW_COLUMN_RANDOMIZE_FACTOR = 2;
@@ -76,10 +88,31 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
             {"humidity", "HUMIdity", "HumiditY", "HUmiDIty", "HUMIDITY", "Humidity"},
             {"hőmérséklet", "HŐMÉRSÉKLET", "HŐmérséKLEt", "hőMÉRséKlET"},
             {"notes", "NOTES", "NotEs", "noTeS"},
-            {"ветер", "Ветер", "ВЕТЕР", "вЕТЕр", "ВетЕР"}
+            {"ветер", "Ветер", "ВЕТЕР", "вЕТЕр", "ВетЕР"},
+            {"pressure_b", "PRESSURE_B", "Pressure_B"},
+            {"pressure_s", "PRESSURE_S", "Pressure_S"},
+            {"pressure_i", "PRESSURE_I", "Pressure_I"},
+            {"pressure_f", "PRESSURE_F", "Pressure_F"},
+            {"flag_c", "FLAG_C", "Flag_C"},
+            {"sensor_id_u", "SENSOR_ID_U", "Sensor_Id_U"},
+            {"token_l256", "TOKEN_L256", "Token_L256"},
+            {"event_at_ns", "EVENT_AT_NS", "Event_At_Ns"}
     };
-    private final short[] colTypes = new short[]{STRING, DOUBLE, DOUBLE, DOUBLE, STRING, DOUBLE};
-    private final String[] colValueBases = new String[]{"europe", "8", "2", "1", "note", "6"};
+    // New non-string/non-double types added to fuzz native wire-type emission
+    // through the QWP sender. Their addColumnValue cases yield exactly the
+    // text representation that CursorPrinter writes for each type so the
+    // TableData oracle's two-pass assertion matches.
+    // int[] (not short[]) because TIMESTAMP_NANO is an int sentinel
+    // (1 << 18 | TIMESTAMP) outside the short range.
+    private final int[] colTypes = new int[]{STRING, DOUBLE, DOUBLE, DOUBLE, STRING, DOUBLE,
+            BYTE, SHORT, INT, FLOAT, CHAR, UUID, LONG256, TIMESTAMP_NANO};
+    // Integer-family value bases (indices 6..9, for BYTE/SHORT/INT/FLOAT) are
+    // capped so the *10 + d arithmetic stays within byte range. When the
+    // alter-table thread narrows a column across the integer family (e.g.
+    // INT -> BYTE), each previously-written value casts losslessly and the
+    // oracle's stored yield still matches what the cursor renders.
+    private final String[] colValueBases = new String[]{"europe", "8", "2", "1", "note", "6",
+            "5", "9", "11", "7", "M", "u", "l", "1700000000000000000"};
     private final char[] nonAsciiChars = {'ó', 'í', 'Á', 'ч', 'Ъ', 'Ж', 'ю', 0x3000, 0x3080, 0x3a55};
     private final String[][] symbolNameBases = new String[][]{
             {"location", "Location", "LOCATION", "loCATion", "LocATioN"},
@@ -112,7 +145,12 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
     private int numOfTables;
     private int numOfThreads;
     private Rnd random;
-    private int recvBufferSize = 8192;
+    // 32 KiB default. With 14 column types and frequent auto-create of "ex_..."
+    // extras, full schema headers plus a global symbol-dict delta inflate
+    // each flushed frame well past the legacy 8 KiB default. Tests that need
+    // to assert behaviour around the recv-buffer limit override this
+    // explicitly (see testLoadSmallBuffer).
+    private int recvBufferSize = 32_768;
     private boolean sendSymbolsWithSpace = false;
     private LowerCaseCharSequenceObjHashMap<TableData> tables;
     private SOCountDownLatch threadPushFinished;
@@ -365,7 +403,7 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
         return colName;
     }
 
-    private String addColumnValue(short type, String valueBase, CharSequence colName, QwpWebSocketSender sender, Rnd rnd) {
+    private String addColumnValue(int type, String valueBase, CharSequence colName, QwpWebSocketSender sender, Rnd rnd) {
         return switch (type) {
             case DOUBLE -> {
                 int d = rnd.nextInt(9);
@@ -387,6 +425,78 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
                 String postfix = Character.toString(shouldFuzz(nonAsciiValueFactor, rnd) ? nonAsciiChars[rnd.nextInt(nonAsciiChars.length)] : rnd.nextChar());
                 sender.stringColumn(colName, valueBase + postfix);
                 yield "\"" + valueBase + postfix + "\"";
+            }
+            case BYTE -> {
+                // valueBase may belong to a column whose type was changed via DDL
+                // (e.g. an INT column with base "100" coerced to BYTE), so the
+                // raw int can exceed the byte range. Yield the truncated byte
+                // so the oracle matches what the cursor renders.
+                int d = rnd.nextInt(9);
+                byte v = (byte) (Numbers.parseInt(valueBase) * 10 + d);
+                sender.byteColumn(colName, v);
+                yield Integer.toString(v);
+            }
+            case SHORT -> {
+                int d = rnd.nextInt(9);
+                short v = (short) (Numbers.parseInt(valueBase) * 10 + d);
+                sender.shortColumn(colName, v);
+                yield Integer.toString(v);
+            }
+            case INT -> {
+                int d = rnd.nextInt(9);
+                int v = Numbers.parseInt(valueBase) * 10 + d;
+                sender.intColumn(colName, v);
+                yield Integer.toString(v);
+            }
+            case FLOAT -> {
+                // Integer-valued floats render identically via CursorPrinter and
+                // Float.toString, so the yielded "70.0".."79.0" matches.
+                int d = rnd.nextInt(9);
+                float v = (float) (Numbers.parseInt(valueBase) * 10 + d);
+                sender.floatColumn(colName, v);
+                yield ((int) v) + ".0";
+            }
+            case CHAR -> {
+                // CursorPrinter writes a CHAR via sink.put(char), no decoration.
+                // Offset random letter from the valueBase letter to vary per row.
+                char c = (char) (valueBase.charAt(0) + rnd.nextInt(10));
+                sender.charColumn(colName, c);
+                yield Character.toString(c);
+            }
+            case UUID -> {
+                // hi/lo crafted so neither limb hits LONG_NULL (which would render
+                // as empty per Uuid.isNull). Use Numbers.appendUuid to match the
+                // exact text format the cursor produces.
+                long hi = (long) (rnd.nextInt(0x7FFF_FFFF) + 1) << 32 | (rnd.nextInt() & 0xFFFFFFFFL);
+                long lo = (long) (rnd.nextInt(0x7FFF_FFFF) + 1) << 32 | (rnd.nextInt() & 0xFFFFFFFFL);
+                sender.uuidColumn(colName, lo, hi);
+                StringSink sink = new StringSink();
+                Numbers.appendUuid(lo, hi, sink);
+                yield sink.toString();
+            }
+            case LONG256 -> {
+                // Force the top limb non-zero so the four-limb hex render path
+                // fires deterministically; values stay positive to keep things
+                // simple.
+                long l0 = (rnd.nextLong() & 0x7FFF_FFFF_FFFF_FFFFL) | 1L;
+                long l1 = (rnd.nextLong() & 0x7FFF_FFFF_FFFF_FFFFL) | 1L;
+                long l2 = (rnd.nextLong() & 0x7FFF_FFFF_FFFF_FFFFL) | 1L;
+                long l3 = (rnd.nextLong() & 0x7FFF_FFFF_FFFF_FFFFL) | 1L;
+                sender.long256Column(colName, l0, l1, l2, l3);
+                StringSink sink = new StringSink();
+                Numbers.appendLong256(l0, l1, l2, l3, sink);
+                yield sink.toString();
+            }
+            case TIMESTAMP_NANO -> {
+                // Step in 1-microsecond units (1_000 nanos) off the base so nanos
+                // values stay distinct per row but always end in 000 — that keeps
+                // the rendered string stable to read.
+                long base = Numbers.parseLong(valueBase);
+                long nanos = base + (long) rnd.nextInt(1_000_000) * 1_000L;
+                sender.timestampColumn(colName, nanos, ChronoUnit.NANOS);
+                StringSink sink = new StringSink();
+                NanosFormatUtils.appendDateTimeNSec(sink, nanos);
+                yield sink.toString();
             }
             default -> {
                 sender.stringColumn(colName, valueBase);
@@ -411,7 +521,9 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
 
     private void addNewColumn(LineData line, QwpWebSocketSender sender, Rnd rnd) {
         if (shouldFuzz(newColumnFactor, rnd)) {
-            int extraColIndex = rnd.nextInt(colNameBases.length);
+            // Pick only from the legacy STRING/DOUBLE pool; typed columns are
+            // always set on every row, so they have no auto-create-only mode.
+            int extraColIndex = rnd.nextInt(LEGACY_COLUMN_COUNT);
             CharSequence colName = generateColumnName(extraColIndex, true, rnd);
             CharSequence colValue = addColumnValue(colTypes[extraColIndex], colValueBases[extraColIndex], colName, sender, rnd);
             line.addColumn(colName, colValue);
@@ -659,8 +771,30 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
             }
             int numOfSkippedCols = rnd.nextInt(MAX_NUM_OF_SKIPPED_COLS) + 1;
             for (int i = 0; i < numOfSkippedCols; i++) {
-                int skipIndex = rnd.nextInt(indexes.size());
-                indexes.remove(skipIndex);
+                // Only legacy STRING/DOUBLE columns are eligible to be skipped.
+                // Typed columns (BYTE/SHORT/INT/FLOAT/CHAR/UUID/LONG256/TIMESTAMP_NANO)
+                // must remain in every row so the oracle never falls back to a
+                // type default whose cursor rendering can drift after a DDL
+                // type conversion.
+                int legacyEligible = 0;
+                for (Integer idx : indexes) {
+                    if (idx < LEGACY_COLUMN_COUNT) {
+                        legacyEligible++;
+                    }
+                }
+                if (legacyEligible == 0) {
+                    break;
+                }
+                int target = rnd.nextInt(legacyEligible);
+                for (int j = 0; j < indexes.size(); j++) {
+                    if (indexes.get(j) < LEGACY_COLUMN_COUNT) {
+                        if (target == 0) {
+                            indexes.remove(j);
+                            break;
+                        }
+                        target--;
+                    }
+                }
             }
             int[] columnIndexes = new int[indexes.size()];
             for (int i = 0; i < columnIndexes.length; i++) {

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/load/QwpRow.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/load/QwpRow.java
@@ -29,10 +29,12 @@ import io.questdb.cairo.arr.ArrayView;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordMetadata;
 import io.questdb.client.Sender;
+import io.questdb.client.cutlass.qwp.client.QwpWebSocketSender;
 import io.questdb.client.std.Decimal128;
 import io.questdb.client.std.Decimal256;
 import io.questdb.client.std.Decimal64;
 import io.questdb.std.Decimals;
+import io.questdb.std.Long256;
 import io.questdb.std.LowerCaseCharSequenceObjHashMap;
 import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
@@ -110,61 +112,103 @@ public class QwpRow {
      * with {@code at(tsMicros, MICROS)}.
      */
     public void publishTo(Sender sender, String tableName, String idColumnName) {
-        sender.table(tableName);
+        // QWP WebSocket connection ("ws::") always returns a QwpWebSocketSender, which
+        // exposes per-wire-type setters (byte/short/int/float/char/uuid/long256) that
+        // the public Sender interface does not. We need the cast to fuzz those wire
+        // types end-to-end.
+        QwpWebSocketSender qwp = (QwpWebSocketSender) sender;
+        qwp.table(tableName);
         for (int i = 0, n = orderedNames.size(); i < n; i++) {
             CharSequence name = orderedNames.getQuick(i);
             TypedValue v = values.get(name);
             if (v.type == ValueType.SYMBOL) {
-                sender.symbol(name, v.s);
+                qwp.symbol(name, v.s);
             }
         }
-        sender.longColumn(idColumnName, id);
+        qwp.longColumn(idColumnName, id);
         for (int i = 0, n = orderedNames.size(); i < n; i++) {
             CharSequence name = orderedNames.getQuick(i);
             TypedValue v = values.get(name);
             switch (v.type) {
                 case BOOLEAN:
-                    sender.boolColumn(name, v.b);
+                    qwp.boolColumn(name, v.b);
+                    break;
+                case BYTE:
+                    qwp.byteColumn(name, v.b8);
+                    break;
+                case SHORT:
+                    qwp.shortColumn(name, v.s16);
+                    break;
+                case INT:
+                    qwp.intColumn(name, v.i32);
                     break;
                 case LONG:
-                    sender.longColumn(name, v.l);
+                    qwp.longColumn(name, v.l);
+                    break;
+                case FLOAT:
+                    qwp.floatColumn(name, v.f);
                     break;
                 case DOUBLE:
-                    sender.doubleColumn(name, v.d);
+                    qwp.doubleColumn(name, v.d);
+                    break;
+                case CHAR:
+                    qwp.charColumn(name, v.c);
                     break;
                 case STRING:
-                    sender.stringColumn(name, v.s);
+                    qwp.stringColumn(name, v.s);
+                    break;
+                case UUID:
+                    // QwpWebSocketSender.uuidColumn signature is (name, lo, hi).
+                    qwp.uuidColumn(name, v.uuidLo, v.uuidHi);
+                    break;
+                case LONG256:
+                    qwp.long256Column(name, v.l256_0, v.l256_1, v.l256_2, v.l256_3);
+                    break;
+                case TIMESTAMP_NANO:
+                    qwp.timestampColumn(name, v.tsNanos, ChronoUnit.NANOS);
                     break;
                 case DOUBLE_ARRAY_1D:
-                    sender.doubleArray(name, v.da1);
+                    qwp.doubleArray(name, v.da1);
                     break;
                 case DOUBLE_ARRAY_2D:
-                    sender.doubleArray(name, v.da2);
+                    qwp.doubleArray(name, v.da2);
                     break;
                 case DOUBLE_ARRAY_3D:
-                    sender.doubleArray(name, v.da3);
+                    qwp.doubleArray(name, v.da3);
                     break;
                 case DECIMAL64:
-                    sender.decimalColumn(name, Decimal64.fromLong(v.dec64Value, v.decScale));
+                    qwp.decimalColumn(name, Decimal64.fromLong(v.dec64Value, v.decScale));
                     break;
                 case DECIMAL128:
-                    sender.decimalColumn(name, new Decimal128(v.dec128Hi, v.dec128Lo, v.decScale));
+                    qwp.decimalColumn(name, new Decimal128(v.dec128Hi, v.dec128Lo, v.decScale));
                     break;
                 case DECIMAL256:
-                    sender.decimalColumn(name, new Decimal256(v.dec256Hh, v.dec256Hl, v.dec256Lh, v.dec256Ll, v.decScale));
+                    qwp.decimalColumn(name, new Decimal256(v.dec256Hh, v.dec256Hl, v.dec256Lh, v.dec256Ll, v.decScale));
                     break;
                 case SYMBOL:
                     // already emitted
                     break;
             }
         }
-        sender.at(tsMicros, ChronoUnit.MICROS);
+        qwp.at(tsMicros, ChronoUnit.MICROS);
     }
 
     public void setBool(String name, boolean value) {
         TypedValue v = put(name);
         v.type = ValueType.BOOLEAN;
         v.b = value;
+    }
+
+    public void setByte(String name, byte value) {
+        TypedValue v = put(name);
+        v.type = ValueType.BYTE;
+        v.b8 = value;
+    }
+
+    public void setChar(String name, char value) {
+        TypedValue v = put(name);
+        v.type = ValueType.CHAR;
+        v.c = value;
     }
 
     public void setDecimal128(String name, long hi, long lo, int scale) {
@@ -217,11 +261,38 @@ public class QwpRow {
         v.da3 = value;
     }
 
+    public void setFloat(String name, float value) {
+        TypedValue v = put(name);
+        v.type = ValueType.FLOAT;
+        v.f = value;
+    }
+
+    public void setInt(String name, int value) {
+        TypedValue v = put(name);
+        v.type = ValueType.INT;
+        v.i32 = value;
+    }
+
     public QwpRow setLong(String name, long value) {
         TypedValue v = put(name);
         v.type = ValueType.LONG;
         v.l = value;
         return this;
+    }
+
+    public void setLong256(String name, long l0, long l1, long l2, long l3) {
+        TypedValue v = put(name);
+        v.type = ValueType.LONG256;
+        v.l256_0 = l0;
+        v.l256_1 = l1;
+        v.l256_2 = l2;
+        v.l256_3 = l3;
+    }
+
+    public void setShort(String name, short value) {
+        TypedValue v = put(name);
+        v.type = ValueType.SHORT;
+        v.s16 = value;
     }
 
     public QwpRow setString(String name, String value) {
@@ -235,6 +306,19 @@ public class QwpRow {
         TypedValue v = put(name);
         v.type = ValueType.SYMBOL;
         v.s = value;
+    }
+
+    public void setTimestampNano(String name, long valueNanos) {
+        TypedValue v = put(name);
+        v.type = ValueType.TIMESTAMP_NANO;
+        v.tsNanos = valueNanos;
+    }
+
+    public void setUuid(String name, long hi, long lo) {
+        TypedValue v = put(name);
+        v.type = ValueType.UUID;
+        v.uuidHi = hi;
+        v.uuidLo = lo;
     }
 
     private static void assertArray1dDoubleEquals(String name, double[] expected, ArrayView actual, long rowOrdinal) {
@@ -301,6 +385,17 @@ public class QwpRow {
     }
 
     private static void assertCell(String name, int colType, TypedValue tv, Record record, int columnIndex, long rowOrdinal) {
+        // TIMESTAMP_NANO and TIMESTAMP share the same tag (TIMESTAMP); the high bit
+        // discriminates them. Handle TIMESTAMP_NANO before falling into the tag switch.
+        if (ColumnType.isTimestampNano(colType)) {
+            long actual = record.getTimestamp(columnIndex);
+            if (tv == null) {
+                Assert.assertEquals(name + " expected NULL row=" + rowOrdinal, Numbers.LONG_NULL, actual);
+            } else {
+                Assert.assertEquals(name + " row=" + rowOrdinal, tv.tsNanos, actual);
+            }
+            return;
+        }
         short tag = ColumnType.tagOf(colType);
         switch (tag) {
             case ColumnType.BOOLEAN: {
@@ -308,6 +403,27 @@ public class QwpRow {
                 // for the oracle MUST always set BOOLEAN columns.
                 boolean expected = tv != null && tv.b;
                 Assert.assertEquals(name + " row=" + rowOrdinal, expected, record.getBool(columnIndex));
+                break;
+            }
+            case ColumnType.BYTE: {
+                // BYTE has no NULL; absent column reads as 0. Producers must always set it.
+                byte expected = tv == null ? 0 : tv.b8;
+                Assert.assertEquals(name + " row=" + rowOrdinal, expected, record.getByte(columnIndex));
+                break;
+            }
+            case ColumnType.SHORT: {
+                // SHORT has no NULL; absent column reads as 0. Producers must always set it.
+                short expected = tv == null ? 0 : tv.s16;
+                Assert.assertEquals(name + " row=" + rowOrdinal, expected, record.getShort(columnIndex));
+                break;
+            }
+            case ColumnType.INT: {
+                int actual = record.getInt(columnIndex);
+                if (tv == null) {
+                    Assert.assertEquals(name + " expected NULL row=" + rowOrdinal, Numbers.INT_NULL, actual);
+                } else {
+                    Assert.assertEquals(name + " row=" + rowOrdinal, tv.i32, actual);
+                }
                 break;
             }
             case ColumnType.LONG: {
@@ -319,12 +435,54 @@ public class QwpRow {
                 }
                 break;
             }
+            case ColumnType.FLOAT: {
+                float actual = record.getFloat(columnIndex);
+                if (tv == null) {
+                    Assert.assertTrue(name + " expected NULL row=" + rowOrdinal, Float.isNaN(actual));
+                } else {
+                    Assert.assertEquals(name + " row=" + rowOrdinal, tv.f, actual, 0.0f);
+                }
+                break;
+            }
             case ColumnType.DOUBLE: {
                 double actual = record.getDouble(columnIndex);
                 if (tv == null) {
                     Assert.assertFalse(name + " expected NULL row=" + rowOrdinal, Numbers.isFinite(actual));
                 } else {
                     Assert.assertEquals(name + " row=" + rowOrdinal, tv.d, actual, 0.0);
+                }
+                break;
+            }
+            case ColumnType.CHAR: {
+                // CHAR NULL is '\0'; absent column reads as '\0'. Producers must always set it.
+                char expected = tv == null ? Numbers.CHAR_NULL : tv.c;
+                Assert.assertEquals(name + " row=" + rowOrdinal, expected, record.getChar(columnIndex));
+                break;
+            }
+            case ColumnType.UUID: {
+                long actualHi = record.getLong128Hi(columnIndex);
+                long actualLo = record.getLong128Lo(columnIndex);
+                if (tv == null) {
+                    Assert.assertEquals(name + ".hi expected NULL row=" + rowOrdinal, Numbers.LONG_NULL, actualHi);
+                    Assert.assertEquals(name + ".lo expected NULL row=" + rowOrdinal, Numbers.LONG_NULL, actualLo);
+                } else {
+                    Assert.assertEquals(name + ".hi row=" + rowOrdinal, tv.uuidHi, actualHi);
+                    Assert.assertEquals(name + ".lo row=" + rowOrdinal, tv.uuidLo, actualLo);
+                }
+                break;
+            }
+            case ColumnType.LONG256: {
+                Long256 actual = record.getLong256A(columnIndex);
+                if (tv == null) {
+                    Assert.assertEquals(name + ".l0 expected NULL row=" + rowOrdinal, Numbers.LONG_NULL, actual.getLong0());
+                    Assert.assertEquals(name + ".l1 expected NULL row=" + rowOrdinal, Numbers.LONG_NULL, actual.getLong1());
+                    Assert.assertEquals(name + ".l2 expected NULL row=" + rowOrdinal, Numbers.LONG_NULL, actual.getLong2());
+                    Assert.assertEquals(name + ".l3 expected NULL row=" + rowOrdinal, Numbers.LONG_NULL, actual.getLong3());
+                } else {
+                    Assert.assertEquals(name + ".l0 row=" + rowOrdinal, tv.l256_0, actual.getLong0());
+                    Assert.assertEquals(name + ".l1 row=" + rowOrdinal, tv.l256_1, actual.getLong1());
+                    Assert.assertEquals(name + ".l2 row=" + rowOrdinal, tv.l256_2, actual.getLong2());
+                    Assert.assertEquals(name + ".l3 row=" + rowOrdinal, tv.l256_3, actual.getLong3());
                 }
                 break;
             }
@@ -431,13 +589,16 @@ public class QwpRow {
     }
 
     public enum ValueType {
-        BOOLEAN, LONG, DOUBLE, STRING, SYMBOL,
+        BOOLEAN, BYTE, SHORT, INT, LONG, FLOAT, DOUBLE, CHAR, STRING, SYMBOL,
+        UUID, LONG256, TIMESTAMP_NANO,
         DOUBLE_ARRAY_1D, DOUBLE_ARRAY_2D, DOUBLE_ARRAY_3D,
         DECIMAL64, DECIMAL128, DECIMAL256
     }
 
     public static final class TypedValue {
         public boolean b;
+        public byte b8;
+        public char c;
         public double d;
         public double[] da1;
         public double[][] da2;
@@ -450,8 +611,18 @@ public class QwpRow {
         public long dec256Ll;
         public long dec64Value;
         public int decScale;
+        public float f;
+        public int i32;
         public long l;
+        public long l256_0;
+        public long l256_1;
+        public long l256_2;
+        public long l256_3;
         public String s;
+        public short s16;
+        public long tsNanos;
         public ValueType type;
+        public long uuidHi;
+        public long uuidLo;
     }
 }


### PR DESCRIPTION
## Summary

- `QwpIngressOracleFuzzTest` now drives BYTE, SHORT, INT, FLOAT, CHAR, UUID, LONG256, and TIMESTAMP_NANO through the oracle. Base columns are pre-declared in `createTargetTable` (pre-existing-column path); `injectExtra` adds five auto-create cases for the new types. The smallest `sf_max_bytes` pool entry is raised from 64 KiB to 256 KiB so a max-chunk frame fits the wider row.
- `QwpSenderFuzzTest` adds one column per new type to `colTypes` / `colNameBases` / `colValueBases`. New typed columns are always set on every row and excluded from the auto-create-extras pool; only the legacy STRING/DOUBLE slice is eligible for skipping or auto-create injection. Default `recvBufferSize` is raised from 8 KiB to 32 KiB so the wider per-flush frame fits.

## Type coverage added

| Wire type | Client setter used |
|-----------|--------------------|
| BYTE | `byteColumn` |
| SHORT | `shortColumn` |
| INT | `intColumn` |
| FLOAT | `floatColumn` |
| CHAR | `charColumn` |
| UUID | `uuidColumn` |
| LONG256 | `long256Column` |
| TIMESTAMP_NS | `timestampColumn(.., NANOS)` |

The non-public setters route through a `Sender` -> `QwpWebSocketSender` cast inside `QwpRow.publishTo`. The WS connection (`ws::`) always returns that impl, so the cast is safe.

Wire types still uncovered after this change: `DATE` and `GEOHASH`. No client setter exists at any layer for either.

## Notable design points

- `QwpRow.assertCell` handles `TIMESTAMP_NANO` ahead of the tag switch because `ColumnType.tagOf(TIMESTAMP_NANO) == TIMESTAMP`. BYTE/SHORT/CHAR mirror BOOLEAN's no-NULL semantics: the oracle requires producers to always set them.
- `QwpSenderFuzzTest.LEGACY_COLUMN_COUNT = 6` partitions the column-name array. Typed columns sit beyond that index, never skipped, never used as extras. This keeps the `LineData`/`TableData` single-default-per-column model intact when the alter-table thread converts a column across types with different NULL semantics (BYTE 0 renders as `0`; INT NULL renders as `null`).
- `addColumnValue`'s integer cases cap values to byte range. Narrowing conversions (INT -> BYTE) then preserve every stored value losslessly, and the oracle's yielded string still matches the cursor.
- `TableData.getDefaultValue` gains BYTE/SHORT -> `"0"` and INT/LONG -> `"null"` so that when the alter-table thread morphs a legacy column into an integer-family member, the oracle's default cell rendering matches the cursor's NULL/zero rendering.

## Tradeoffs

- Integer-family value bases stay <= 119 so narrowing conversions do not overflow. The numeric span the typed columns exercise is narrower than it could be in exchange for end-to-end test reliability.
- New typed columns in `QwpSenderFuzzTest` are always set on every row. Their wire emission, reordering, duplicate, and case-variation paths are exercised; their auto-create-only path is not.
- 32 KiB is more permissive than the old 8 KiB `recvBufferSize` default. Only `testLoadSmallBuffer` still pins a tight buffer to exercise the small-frame path explicitly.
- The new 256 KiB minimum `sf_max_bytes` is larger than the previous 64 KiB. Segment-rotation coverage is preserved by the remaining `{256 KiB, 1 MiB, 4 MiB}` entries.

## Test plan

- Run `mvn -pl core -Dtest=QwpIngressOracleFuzzTest test` across multiple seeds; 4/4 pass each time
- Run `mvn -pl core -Dtest=QwpSenderFuzzTest test` across multiple seeds; 28/28 pass each time
- Combined `mvn -pl core -Dtest='QwpIngressOracleFuzzTest,QwpSenderFuzzTest' test`; 32/32 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)