### PR TITLE
chore(qwp): fix geohash precision loss and sentinel null handling on ingest

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
@@ -519,93 +519,100 @@ public class QwpWalAppender implements QuietCloseable {
                          ColumnType.DATE,
                          ColumnType.UUID, ColumnType.LONG256,
                          ColumnType.GEOBYTE, ColumnType.GEOSHORT, ColumnType.GEOINT, ColumnType.GEOLONG -> {
-                        if (cursor instanceof QwpGeoHashColumnCursor geoHashCursor) {
-                            if (ColumnType.isGeoHash(columnType)) {
-                                int wireBits = geoHashCursor.getPrecision();
-                                if (wireBits != ColumnType.getGeoHashBits(columnType)) {
-                                    throw geoHashPrecisionMismatchException(columnType, wireBits, tableBlock, col);
+                        switch (cursor) {
+                            case QwpGeoHashColumnCursor geoHashCursor -> {
+                                if (ColumnType.isGeoHash(columnType)) {
+                                    int wireBits = geoHashCursor.getPrecision();
+                                    if (wireBits != ColumnType.getGeoHashBits(columnType)) {
+                                        throw geoHashPrecisionMismatchException(columnType, wireBits, tableBlock, col);
+                                    }
+                                }
+                                appender.putGeoHashColumn(columnIndex, geoHashCursor, rowCount, columnType);
+                            }
+                            case QwpFixedWidthColumnCursor fixedCursor -> {
+                                if (!isFixedTypeCoercionAllowed(qwpType, columnType)) {
+                                    throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
+                                }
+                                int wireSize = fixedCursor.getValueSize();
+                                int columnSize = ColumnType.sizeOf(columnType);
+                                int colTag = ColumnType.tagOf(columnType);
+                                boolean isIntegerWire = isIntegerWireType(qwpType);
+                                boolean isFloatWire = isFloatWireType(qwpType);
+                                boolean isFloatTarget = colTag == ColumnType.FLOAT || colTag == ColumnType.DOUBLE;
+                                boolean isIntegerTarget = colTag == ColumnType.BYTE || colTag == ColumnType.SHORT
+                                        || colTag == ColumnType.INT || colTag == ColumnType.LONG;
+                                if (isIntegerWire && (isFloatTarget || wireSize != columnSize)) {
+                                    // Integer → float/double, integer widening (INT → LONG), or
+                                    // integer narrowing with overflow check (INT → BYTE, INT → SHORT)
+                                    appender.putIntegerToNumericColumn(columnIndex, fixedCursor, rowCount, columnType);
+                                } else if (isFloatWire && (isIntegerTarget || wireSize != columnSize)) {
+                                    // Float → integer (with whole-number + range check),
+                                    // float widening (FLOAT → DOUBLE), or
+                                    // float narrowing (DOUBLE → FLOAT)
+                                    appender.putFloatToNumericColumn(columnIndex, fixedCursor, rowCount, columnType);
+                                } else if (wireSize == columnSize || columnSize <= 0) {
+                                    appender.putFixedColumn(columnIndex, fixedCursor.getValuesAddress(),
+                                            fixedCursor.getValueCount(), fixedCursor.getValueSize(),
+                                            fixedCursor.getNullBitmapAddress(), rowCount);
+                                } else {
+                                    throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
                                 }
                             }
-                            appender.putGeoHashColumn(columnIndex, geoHashCursor, rowCount, columnType);
-                        } else if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor) {
-                            if (!isFixedTypeCoercionAllowed(qwpType, columnType)) {
-                                throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
+                            case QwpBooleanColumnCursor boolCursor -> {
+                                int colTag = ColumnType.tagOf(columnType);
+                                if (colTag == ColumnType.BYTE || colTag == ColumnType.SHORT
+                                        || colTag == ColumnType.INT || colTag == ColumnType.LONG
+                                        || colTag == ColumnType.FLOAT || colTag == ColumnType.DOUBLE) {
+                                    appender.putBooleanToNumericColumn(columnIndex, boolCursor, rowCount, columnType);
+                                } else {
+                                    throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                                }
                             }
-                            int wireSize = fixedCursor.getValueSize();
-                            int columnSize = ColumnType.sizeOf(columnType);
-                            int colTag = ColumnType.tagOf(columnType);
-                            boolean isIntegerWire = isIntegerWireType(qwpType);
-                            boolean isFloatWire = isFloatWireType(qwpType);
-                            boolean isFloatTarget = colTag == ColumnType.FLOAT || colTag == ColumnType.DOUBLE;
-                            boolean isIntegerTarget = colTag == ColumnType.BYTE || colTag == ColumnType.SHORT
-                                    || colTag == ColumnType.INT || colTag == ColumnType.LONG;
-                            if (isIntegerWire && (isFloatTarget || wireSize != columnSize)) {
-                                // Integer → float/double, integer widening (INT → LONG), or
-                                // integer narrowing with overflow check (INT → BYTE, INT → SHORT)
-                                appender.putIntegerToNumericColumn(columnIndex, fixedCursor, rowCount, columnType);
-                            } else if (isFloatWire && (isIntegerTarget || wireSize != columnSize)) {
-                                // Float → integer (with whole-number + range check),
-                                // float widening (FLOAT → DOUBLE), or
-                                // float narrowing (DOUBLE → FLOAT)
-                                appender.putFloatToNumericColumn(columnIndex, fixedCursor, rowCount, columnType);
-                            } else if (wireSize == columnSize || columnSize <= 0) {
-                                appender.putFixedColumn(columnIndex, fixedCursor.getValuesAddress(),
-                                        fixedCursor.getValueCount(), fixedCursor.getValueSize(),
-                                        fixedCursor.getNullBitmapAddress(), rowCount);
-                            } else {
-                                throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
+                            case QwpStringColumnCursor strCursor -> {
+                                int colTag = ColumnType.tagOf(columnType);
+                                switch (colTag) {
+                                    case ColumnType.UUID ->
+                                            appender.putStringToUuidColumn(columnIndex, strCursor, rowCount);
+                                    case ColumnType.LONG256 ->
+                                            appender.putStringToLong256Column(columnIndex, strCursor, rowCount);
+                                    case ColumnType.GEOBYTE, ColumnType.GEOSHORT, ColumnType.GEOINT,
+                                         ColumnType.GEOLONG ->
+                                            appender.putStringToGeoHashColumn(columnIndex, strCursor, rowCount, columnType);
+                                    default ->
+                                            appender.putStringToNumericColumn(columnIndex, strCursor, rowCount, columnType);
+                                }
                             }
-                        } else if (cursor instanceof QwpBooleanColumnCursor boolCursor) {
-                            int colTag = ColumnType.tagOf(columnType);
-                            if (colTag == ColumnType.BYTE || colTag == ColumnType.SHORT
-                                    || colTag == ColumnType.INT || colTag == ColumnType.LONG
-                                    || colTag == ColumnType.FLOAT || colTag == ColumnType.DOUBLE) {
-                                appender.putBooleanToNumericColumn(columnIndex, boolCursor, rowCount, columnType);
-                            } else {
-                                throw typeMismatchException(qwpType, columnType, tableBlock, col);
-                            }
-                        } else if (cursor instanceof QwpStringColumnCursor strCursor) {
-                            int colTag = ColumnType.tagOf(columnType);
-                            switch (colTag) {
-                                case ColumnType.UUID ->
-                                        appender.putStringToUuidColumn(columnIndex, strCursor, rowCount);
-                                case ColumnType.LONG256 ->
-                                        appender.putStringToLong256Column(columnIndex, strCursor, rowCount);
-                                case ColumnType.GEOBYTE, ColumnType.GEOSHORT, ColumnType.GEOINT, ColumnType.GEOLONG ->
-                                        appender.putStringToGeoHashColumn(columnIndex, strCursor, rowCount, columnType);
-                                default ->
-                                        appender.putStringToNumericColumn(columnIndex, strCursor, rowCount, columnType);
-                            }
-                        } else {
-                            throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                            case null, default -> throw typeMismatchException(qwpType, columnType, tableBlock, col);
                         }
                     }
                     case ColumnType.TIMESTAMP -> {
                         // Non-designated timestamp (handles both micros and nanos precision via tagOf)
-                        if (cursor instanceof QwpTimestampColumnCursor tsCursor) {
-                            // Check for precision mismatch
-                            boolean wireIsNanos = (qwpType == TYPE_TIMESTAMP_NANOS);
-                            boolean columnIsNanos = (columnType == ColumnType.TIMESTAMP_NANO);
-                            if (wireIsNanos != columnIsNanos || !tsCursor.supportsDirectAccess()) {
-                                // Precision mismatch or Gorilla-encoded - must iterate with conversion
-                                appender.putTimestampColumnWithConversion(columnIndex, tsCursor, rowCount,
-                                        qwpType, columnType, false, Numbers.LONG_NULL);
-                            } else {
-                                // Direct access, no conversion needed
-                                appender.putFixedColumn(columnIndex, tsCursor.getValuesAddress(),
-                                        tsCursor.getValueCount(), 8, tsCursor.getNullBitmapAddress(), rowCount);
+                        switch (cursor) {
+                            case QwpTimestampColumnCursor tsCursor -> {
+                                // Check for precision mismatch
+                                boolean wireIsNanos = (qwpType == TYPE_TIMESTAMP_NANOS);
+                                boolean columnIsNanos = (columnType == ColumnType.TIMESTAMP_NANO);
+                                if (wireIsNanos != columnIsNanos || !tsCursor.supportsDirectAccess()) {
+                                    // Precision mismatch or Gorilla-encoded - must iterate with conversion
+                                    appender.putTimestampColumnWithConversion(columnIndex, tsCursor, rowCount,
+                                            qwpType, columnType, false, Numbers.LONG_NULL);
+                                } else {
+                                    // Direct access, no conversion needed
+                                    appender.putFixedColumn(columnIndex, tsCursor.getValuesAddress(),
+                                            tsCursor.getValueCount(), 8, tsCursor.getNullBitmapAddress(), rowCount);
+                                }
                             }
-                        } else if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor) {
-                            if (isIntegerWireType(qwpType)) {
-                                // Integer → timestamp: raw epoch offset
-                                appender.putIntegerToNumericColumn(columnIndex, fixedCursor, rowCount, columnType);
-                            } else {
-                                throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
+                            case QwpFixedWidthColumnCursor fixedCursor -> {
+                                if (isIntegerWireType(qwpType)) {
+                                    // Integer → timestamp: raw epoch offset
+                                    appender.putIntegerToNumericColumn(columnIndex, fixedCursor, rowCount, columnType);
+                                } else {
+                                    throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
+                                }
                             }
-                        } else if (cursor instanceof QwpStringColumnCursor strCursor) {
-                            appender.putStringToTimestampColumn(columnIndex, strCursor, rowCount, columnType);
-                        } else {
-                            throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                            case QwpStringColumnCursor strCursor ->
+                                    appender.putStringToTimestampColumn(columnIndex, strCursor, rowCount, columnType);
+                            case null, default -> throw typeMismatchException(qwpType, columnType, tableBlock, col);
                         }
                     }
                     case ColumnType.CHAR -> {
@@ -622,151 +629,159 @@ public class QwpWalAppender implements QuietCloseable {
                         }
                     }
                     case ColumnType.VARCHAR -> {
-                        if (cursor instanceof QwpStringColumnCursor strCursor) {
-                            appender.putVarcharColumn(columnIndex, strCursor, rowCount);
-                        } else if (cursor instanceof QwpBooleanColumnCursor boolCursor) {
-                            appender.putBooleanToVarcharColumn(columnIndex, boolCursor, rowCount);
-                        } else if (cursor instanceof QwpTimestampColumnCursor tsCursor) {
-                            appender.putTimestampToVarcharColumn(columnIndex, tsCursor, rowCount, qwpType);
-                        } else if (cursor instanceof QwpGeoHashColumnCursor geoCursor) {
-                            appender.putGeoHashToVarcharColumn(columnIndex, geoCursor, rowCount);
-                        } else if (cursor instanceof QwpDecimalColumnCursor decCursor) {
-                            appender.putDecimalToVarcharColumn(columnIndex, decCursor, rowCount);
-                        } else if (cursor instanceof QwpSymbolColumnCursor symCursor) {
-                            appender.putSymbolToVarcharColumn(columnIndex, symCursor, rowCount);
-                        } else if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor) {
-                            if (isIntegerWireType(qwpType)) {
-                                appender.putFixedToVarcharColumn(columnIndex, fixedCursor, rowCount);
-                            } else if (isFloatWireType(qwpType)) {
-                                appender.putFloatToVarcharColumn(columnIndex, fixedCursor, rowCount);
-                            } else {
-                                appender.putFixedOtherToVarcharColumn(columnIndex, fixedCursor, rowCount, qwpType);
+                        switch (cursor) {
+                            case QwpStringColumnCursor strCursor ->
+                                    appender.putVarcharColumn(columnIndex, strCursor, rowCount);
+                            case QwpBooleanColumnCursor boolCursor ->
+                                    appender.putBooleanToVarcharColumn(columnIndex, boolCursor, rowCount);
+                            case QwpTimestampColumnCursor tsCursor ->
+                                    appender.putTimestampToVarcharColumn(columnIndex, tsCursor, rowCount, qwpType);
+                            case QwpGeoHashColumnCursor geoCursor ->
+                                    appender.putGeoHashToVarcharColumn(columnIndex, geoCursor, rowCount);
+                            case QwpDecimalColumnCursor decCursor ->
+                                    appender.putDecimalToVarcharColumn(columnIndex, decCursor, rowCount);
+                            case QwpSymbolColumnCursor symCursor ->
+                                    appender.putSymbolToVarcharColumn(columnIndex, symCursor, rowCount);
+                            case QwpFixedWidthColumnCursor fixedCursor -> {
+                                if (isIntegerWireType(qwpType)) {
+                                    appender.putFixedToVarcharColumn(columnIndex, fixedCursor, rowCount);
+                                } else if (isFloatWireType(qwpType)) {
+                                    appender.putFloatToVarcharColumn(columnIndex, fixedCursor, rowCount);
+                                } else {
+                                    appender.putFixedOtherToVarcharColumn(columnIndex, fixedCursor, rowCount, qwpType);
+                                }
                             }
-                        } else {
-                            throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                            case null, default -> throw typeMismatchException(qwpType, columnType, tableBlock, col);
                         }
                     }
                     case ColumnType.STRING -> {
-                        if (cursor instanceof QwpStringColumnCursor strCursor) {
-                            appender.putStringColumn(columnIndex, strCursor, rowCount);
-                        } else if (cursor instanceof QwpBooleanColumnCursor boolCursor) {
-                            appender.putBooleanToStringColumn(columnIndex, boolCursor, rowCount);
-                        } else if (cursor instanceof QwpTimestampColumnCursor tsCursor) {
-                            appender.putTimestampToStringColumn(columnIndex, tsCursor, rowCount, qwpType);
-                        } else if (cursor instanceof QwpGeoHashColumnCursor geoCursor) {
-                            appender.putGeoHashToStringColumn(columnIndex, geoCursor, rowCount);
-                        } else if (cursor instanceof QwpDecimalColumnCursor decCursor) {
-                            appender.putDecimalToStringColumn(columnIndex, decCursor, rowCount);
-                        } else if (cursor instanceof QwpSymbolColumnCursor symCursor) {
-                            appender.putSymbolToStringColumn(columnIndex, symCursor, rowCount);
-                        } else if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor) {
-                            if (isIntegerWireType(qwpType)) {
-                                appender.putFixedToStringColumn(columnIndex, fixedCursor, rowCount);
-                            } else if (isFloatWireType(qwpType)) {
-                                appender.putFloatToStringColumn(columnIndex, fixedCursor, rowCount);
-                            } else {
-                                appender.putFixedOtherToStringColumn(columnIndex, fixedCursor, rowCount, qwpType);
+                        switch (cursor) {
+                            case QwpStringColumnCursor strCursor ->
+                                    appender.putStringColumn(columnIndex, strCursor, rowCount);
+                            case QwpBooleanColumnCursor boolCursor ->
+                                    appender.putBooleanToStringColumn(columnIndex, boolCursor, rowCount);
+                            case QwpTimestampColumnCursor tsCursor ->
+                                    appender.putTimestampToStringColumn(columnIndex, tsCursor, rowCount, qwpType);
+                            case QwpGeoHashColumnCursor geoCursor ->
+                                    appender.putGeoHashToStringColumn(columnIndex, geoCursor, rowCount);
+                            case QwpDecimalColumnCursor decCursor ->
+                                    appender.putDecimalToStringColumn(columnIndex, decCursor, rowCount);
+                            case QwpSymbolColumnCursor symCursor ->
+                                    appender.putSymbolToStringColumn(columnIndex, symCursor, rowCount);
+                            case QwpFixedWidthColumnCursor fixedCursor -> {
+                                if (isIntegerWireType(qwpType)) {
+                                    appender.putFixedToStringColumn(columnIndex, fixedCursor, rowCount);
+                                } else if (isFloatWireType(qwpType)) {
+                                    appender.putFloatToStringColumn(columnIndex, fixedCursor, rowCount);
+                                } else {
+                                    appender.putFixedOtherToStringColumn(columnIndex, fixedCursor, rowCount, qwpType);
+                                }
                             }
-                        } else {
-                            throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                            case null, default -> throw typeMismatchException(qwpType, columnType, tableBlock, col);
                         }
                     }
                     case ColumnType.SYMBOL -> {
-                        if (cursor instanceof QwpSymbolColumnCursor symCursor) {
-                            if (symbolCache != null && symCursor.isDeltaMode()) {
-                                long tableId = tud.getTableToken().getTableId();
-                                int initialSymbolCount = walWriter.getSymbolCountWatermark(columnIndex);
-                                appender.putSymbolColumn(
-                                        columnIndex,
-                                        symCursor,
-                                        rowCount,
-                                        symbolCache,
-                                        tableId,
-                                        initialSymbolCount
-                                );
-                            } else {
-                                appender.putSymbolColumn(columnIndex, symCursor, rowCount);
+                        switch (cursor) {
+                            case QwpSymbolColumnCursor symCursor -> {
+                                if (symbolCache != null && symCursor.isDeltaMode()) {
+                                    long tableId = tud.getTableToken().getTableId();
+                                    int initialSymbolCount = walWriter.getSymbolCountWatermark(columnIndex);
+                                    appender.putSymbolColumn(
+                                            columnIndex,
+                                            symCursor,
+                                            rowCount,
+                                            symbolCache,
+                                            tableId,
+                                            initialSymbolCount
+                                    );
+                                } else {
+                                    appender.putSymbolColumn(columnIndex, symCursor, rowCount);
+                                }
                             }
-                        } else if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor) {
-                            if (isIntegerWireType(qwpType)) {
-                                appender.putFixedToSymbolColumn(columnIndex, fixedCursor, rowCount);
-                            } else if (isFloatWireType(qwpType)) {
-                                appender.putFloatToSymbolColumn(columnIndex, fixedCursor, rowCount);
-                            } else {
-                                throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                            case QwpFixedWidthColumnCursor fixedCursor -> {
+                                if (isIntegerWireType(qwpType)) {
+                                    appender.putFixedToSymbolColumn(columnIndex, fixedCursor, rowCount);
+                                } else if (isFloatWireType(qwpType)) {
+                                    appender.putFloatToSymbolColumn(columnIndex, fixedCursor, rowCount);
+                                } else {
+                                    throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                                }
                             }
-                        } else if (cursor instanceof QwpStringColumnCursor strCursor) {
-                            appender.putStringToSymbolColumn(columnIndex, strCursor, rowCount);
-                        } else {
-                            throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                            case QwpStringColumnCursor strCursor ->
+                                    appender.putStringToSymbolColumn(columnIndex, strCursor, rowCount);
+                            case null, default -> throw typeMismatchException(qwpType, columnType, tableBlock, col);
                         }
                     }
                     case ColumnType.DECIMAL8, ColumnType.DECIMAL16, ColumnType.DECIMAL32 -> {
-                        if (cursor instanceof QwpDecimalColumnCursor decCursor) {
-                            appender.putDecimalToSmallDecimalColumn(columnIndex, decCursor, rowCount, columnType);
-                        } else if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor) {
-                            if (isFloatWireType(qwpType)) {
-                                appender.putFloatToDecimalColumn(columnIndex, fixedCursor, rowCount, columnType);
-                            } else if (isIntegerWireType(qwpType)) {
-                                appender.putFixedToSmallDecimalColumn(columnIndex, fixedCursor, rowCount, columnType);
-                            } else {
-                                throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                        switch (cursor) {
+                            case QwpDecimalColumnCursor decCursor ->
+                                    appender.putDecimalToSmallDecimalColumn(columnIndex, decCursor, rowCount, columnType);
+                            case QwpFixedWidthColumnCursor fixedCursor -> {
+                                if (isFloatWireType(qwpType)) {
+                                    appender.putFloatToDecimalColumn(columnIndex, fixedCursor, rowCount, columnType);
+                                } else if (isIntegerWireType(qwpType)) {
+                                    appender.putFixedToSmallDecimalColumn(columnIndex, fixedCursor, rowCount, columnType);
+                                } else {
+                                    throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                                }
                             }
-                        } else if (cursor instanceof QwpStringColumnCursor strCursor) {
-                            appender.putStringToDecimalColumn(columnIndex, strCursor, rowCount, columnType);
-                        } else {
-                            throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                            case QwpStringColumnCursor strCursor ->
+                                    appender.putStringToDecimalColumn(columnIndex, strCursor, rowCount, columnType);
+                            case null, default -> throw typeMismatchException(qwpType, columnType, tableBlock, col);
                         }
                     }
                     case ColumnType.DECIMAL64 -> {
-                        if (cursor instanceof QwpDecimalColumnCursor decCursor) {
-                            appender.putDecimal64Column(columnIndex, decCursor, rowCount, columnType);
-                        } else if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor) {
-                            if (isFloatWireType(qwpType)) {
-                                appender.putFloatToDecimalColumn(columnIndex, fixedCursor, rowCount, columnType);
-                            } else if (isIntegerWireType(qwpType)) {
-                                appender.putFixedToDecimal64Column(columnIndex, fixedCursor, rowCount, columnType);
-                            } else {
-                                throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                        switch (cursor) {
+                            case QwpDecimalColumnCursor decCursor ->
+                                    appender.putDecimal64Column(columnIndex, decCursor, rowCount, columnType);
+                            case QwpFixedWidthColumnCursor fixedCursor -> {
+                                if (isFloatWireType(qwpType)) {
+                                    appender.putFloatToDecimalColumn(columnIndex, fixedCursor, rowCount, columnType);
+                                } else if (isIntegerWireType(qwpType)) {
+                                    appender.putFixedToDecimal64Column(columnIndex, fixedCursor, rowCount, columnType);
+                                } else {
+                                    throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                                }
                             }
-                        } else if (cursor instanceof QwpStringColumnCursor strCursor) {
-                            appender.putStringToDecimalColumn(columnIndex, strCursor, rowCount, columnType);
-                        } else {
-                            throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                            case QwpStringColumnCursor strCursor ->
+                                    appender.putStringToDecimalColumn(columnIndex, strCursor, rowCount, columnType);
+                            case null, default -> throw typeMismatchException(qwpType, columnType, tableBlock, col);
                         }
                     }
                     case ColumnType.DECIMAL128 -> {
-                        if (cursor instanceof QwpDecimalColumnCursor decCursor) {
-                            appender.putDecimal128Column(columnIndex, decCursor, rowCount, columnType);
-                        } else if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor) {
-                            if (isFloatWireType(qwpType)) {
-                                appender.putFloatToDecimalColumn(columnIndex, fixedCursor, rowCount, columnType);
-                            } else if (isIntegerWireType(qwpType)) {
-                                appender.putFixedToDecimal128Column(columnIndex, fixedCursor, rowCount, columnType);
-                            } else {
-                                throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                        switch (cursor) {
+                            case QwpDecimalColumnCursor decCursor ->
+                                    appender.putDecimal128Column(columnIndex, decCursor, rowCount, columnType);
+                            case QwpFixedWidthColumnCursor fixedCursor -> {
+                                if (isFloatWireType(qwpType)) {
+                                    appender.putFloatToDecimalColumn(columnIndex, fixedCursor, rowCount, columnType);
+                                } else if (isIntegerWireType(qwpType)) {
+                                    appender.putFixedToDecimal128Column(columnIndex, fixedCursor, rowCount, columnType);
+                                } else {
+                                    throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                                }
                             }
-                        } else if (cursor instanceof QwpStringColumnCursor strCursor) {
-                            appender.putStringToDecimalColumn(columnIndex, strCursor, rowCount, columnType);
-                        } else {
-                            throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                            case QwpStringColumnCursor strCursor ->
+                                    appender.putStringToDecimalColumn(columnIndex, strCursor, rowCount, columnType);
+                            case null, default -> throw typeMismatchException(qwpType, columnType, tableBlock, col);
                         }
                     }
                     case ColumnType.DECIMAL256 -> {
-                        if (cursor instanceof QwpDecimalColumnCursor decCursor) {
-                            appender.putDecimal256Column(columnIndex, decCursor, rowCount, columnType);
-                        } else if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor) {
-                            if (isFloatWireType(qwpType)) {
-                                appender.putFloatToDecimalColumn(columnIndex, fixedCursor, rowCount, columnType);
-                            } else if (isIntegerWireType(qwpType)) {
-                                appender.putFixedToDecimal256Column(columnIndex, fixedCursor, rowCount, columnType);
-                            } else {
-                                throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                        switch (cursor) {
+                            case QwpDecimalColumnCursor decCursor ->
+                                    appender.putDecimal256Column(columnIndex, decCursor, rowCount, columnType);
+                            case QwpFixedWidthColumnCursor fixedCursor -> {
+                                if (isFloatWireType(qwpType)) {
+                                    appender.putFloatToDecimalColumn(columnIndex, fixedCursor, rowCount, columnType);
+                                } else if (isIntegerWireType(qwpType)) {
+                                    appender.putFixedToDecimal256Column(columnIndex, fixedCursor, rowCount, columnType);
+                                } else {
+                                    throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                                }
                             }
-                        } else if (cursor instanceof QwpStringColumnCursor strCursor) {
-                            appender.putStringToDecimalColumn(columnIndex, strCursor, rowCount, columnType);
-                        } else {
-                            throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                            case QwpStringColumnCursor strCursor ->
+                                    appender.putStringToDecimalColumn(columnIndex, strCursor, rowCount, columnType);
+                            case null, default -> throw typeMismatchException(qwpType, columnType, tableBlock, col);
                         }
                     }
                     default -> {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
@@ -191,6 +191,19 @@ public class QwpWalAppender implements QuietCloseable {
                 .put(']');
     }
 
+    private static CairoException geoHashPrecisionMismatchException(
+            int columnType, int wireBits, QwpTableBlockCursor tableBlock, int col
+    ) {
+        return CairoException.nonCritical()
+                .put("GeoHash precision mismatch [column=")
+                .put(tableBlock.getColumnDef(col).getName())
+                .put(", columnType=")
+                .put(ColumnType.nameOf(columnType))
+                .put(", wireBits=")
+                .put(wireBits)
+                .put(']');
+    }
+
     private static int getArrayBatchDimensionality(
             QwpArrayColumnCursor cursor,
             int rowCount,
@@ -507,6 +520,12 @@ public class QwpWalAppender implements QuietCloseable {
                          ColumnType.UUID, ColumnType.LONG256,
                          ColumnType.GEOBYTE, ColumnType.GEOSHORT, ColumnType.GEOINT, ColumnType.GEOLONG -> {
                         if (cursor instanceof QwpGeoHashColumnCursor geoHashCursor) {
+                            if (ColumnType.isGeoHash(columnType)) {
+                                int wireBits = geoHashCursor.getPrecision();
+                                if (wireBits != ColumnType.getGeoHashBits(columnType)) {
+                                    throw geoHashPrecisionMismatchException(columnType, wireBits, tableBlock, col);
+                                }
+                            }
                             appender.putGeoHashColumn(columnIndex, geoHashCursor, rowCount, columnType);
                         } else if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor) {
                             if (!isFixedTypeCoercionAllowed(qwpType, columnType)) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
@@ -262,14 +262,15 @@ public class QwpWalAppender implements QuietCloseable {
     }
 
     /**
-     * Maps a QWP v1 type code to QuestDB column type, with cursor access for decimal scale.
+     * Maps a QWP v1 type code to QuestDB column type, folding per-column metadata
+     * (decimal scale, geohash bit precision) from the cursor when needed.
      *
      * @param qwpType    QWP v1 type code
-     * @param tableBlock table block cursor for accessing decimal scale
+     * @param tableBlock table block cursor positioned on the column
      * @param colIndex   column index
-     * @return QuestDB column type
+     * @return QuestDB column type, or {@link ColumnType#UNDEFINED} if cursor metadata is out of range
      */
-    private static int mapQwpTypeToQuestDB(int qwpType, QwpTableBlockCursor tableBlock, int colIndex) {
+    public static int mapQwpTypeToQuestDB(int qwpType, QwpTableBlockCursor tableBlock, int colIndex) {
         switch (qwpType) {
             case TYPE_DECIMAL64 -> {
                 int scale = tableBlock.getDecimalColumn(colIndex).getScale() & 0xFF;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
@@ -270,7 +270,6 @@ public class QwpWalAppender implements QuietCloseable {
      * @return QuestDB column type
      */
     private static int mapQwpTypeToQuestDB(int qwpType, QwpTableBlockCursor tableBlock, int colIndex) {
-        // For decimal types, we need to get the scale from the cursor
         switch (qwpType) {
             case TYPE_DECIMAL64 -> {
                 int scale = tableBlock.getDecimalColumn(colIndex).getScale() & 0xFF;
@@ -286,6 +285,13 @@ public class QwpWalAppender implements QuietCloseable {
                 int scale = tableBlock.getDecimalColumn(colIndex).getScale() & 0xFF;
                 int precision = Decimals.getDecimalTagPrecision(ColumnType.DECIMAL256);
                 return ColumnType.getDecimalType(ColumnType.DECIMAL256, precision, scale);
+            }
+            case TYPE_GEOHASH -> {
+                int bits = tableBlock.getGeoHashColumn(colIndex).getPrecision();
+                if (bits < ColumnType.GEOBYTE_MIN_BITS || bits > ColumnType.GEOLONG_MAX_BITS) {
+                    return ColumnType.UNDEFINED;
+                }
+                return ColumnType.getGeoHashTypeWithBits(bits);
             }
             default -> {
                 return mapQwpTypeToQuestDB(qwpType);

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpFixedWidthColumnCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpFixedWidthColumnCursor.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cutlass.qwp.protocol;
 
+import io.questdb.std.Numbers;
 import io.questdb.std.Unsafe;
 
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.*;
@@ -79,7 +80,11 @@ public final class QwpFixedWidthColumnCursor implements QwpColumnCursor {
         long valueAddress = valuesAddress + (long) currentValueIndex * valueSize;
         readCurrentValue(valueAddress);
         currentValueIndex++;
-        return false;
+
+        if (nullBitmapAddress == 0) {
+            currentIsNull = isCurrentValueSentinelNull();
+        }
+        return currentIsNull;
     }
 
     @Override
@@ -291,6 +296,15 @@ public final class QwpFixedWidthColumnCursor implements QwpColumnCursor {
         currentRow = -1;
         currentValueIndex = 0;
         currentIsNull = false;
+    }
+
+    private boolean isCurrentValueSentinelNull() {
+        return switch (typeCode) {
+            case TYPE_INT -> (int) currentLong == Numbers.INT_NULL;
+            case TYPE_LONG, TYPE_DATE, TYPE_TIMESTAMP, TYPE_TIMESTAMP_NANOS -> currentLong == Numbers.LONG_NULL;
+            case TYPE_FLOAT, TYPE_DOUBLE -> Double.isNaN(currentDouble);
+            default -> false;
+        };
     }
 
     private void readCurrentValue(long address) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpGeoHashColumnCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpGeoHashColumnCursor.java
@@ -63,15 +63,18 @@ public final class QwpGeoHashColumnCursor implements QwpColumnCursor {
                 currentGeoHash = 0;
                 return true;
             }
-        } else {
-            currentIsNull = false;
         }
 
-        // Read geohash value from packed array (non-null values only)
         long valueAddress = valuesAddress + (long) currentValueIndex * valueSize;
         currentGeoHash = readValue(valueAddress, valueSize);
         currentValueIndex++;
-        return false;
+
+        if (nullBitmapAddress == 0) {
+            // Sentinel mode: all-ones truncated to valueSize bytes encodes null.
+            // readValue zero-extends, so the sentinel decodes as (-1L >>> ((8 - valueSize) * 8)).
+            currentIsNull = currentGeoHash == (-1L >>> ((8 - valueSize) * 8));
+        }
+        return currentIsNull;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpTudCache.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpTudCache.java
@@ -49,7 +49,6 @@ import io.questdb.cutlass.qwp.protocol.QwpConstants;
 import io.questdb.cutlass.qwp.protocol.QwpTableBlockCursor;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
-import io.questdb.std.Decimals;
 import io.questdb.std.IntList;
 import io.questdb.std.LowerCaseUtf8SequenceObjHashMap;
 import io.questdb.std.Misc;
@@ -598,14 +597,6 @@ public class QwpTudCache implements QuietCloseable {
 
         private int getSchemaColumnType(int schemaIndex) {
             final byte typeCode = schema.getQuick(schemaIndex).getTypeCode();
-            if (typeCode == QwpConstants.TYPE_DECIMAL64 ||
-                    typeCode == QwpConstants.TYPE_DECIMAL128 ||
-                    typeCode == QwpConstants.TYPE_DECIMAL256) {
-                final int scale = cursor.getDecimalColumn(schemaIndex).getScale() & 0xFF;
-                final int tag = QwpWalAppender.mapQwpTypeToQuestDB(typeCode);
-                final int precision = Decimals.getDecimalTagPrecision(tag);
-                return ColumnType.getDecimalType(tag, precision, scale);
-            }
             if (typeCode == QwpConstants.TYPE_DOUBLE_ARRAY) {
                 final int nDims = getArrayBatchDimensionality(
                         cursor.getArrayColumn(schemaIndex),
@@ -617,14 +608,7 @@ public class QwpTudCache implements QuietCloseable {
                 }
                 return ColumnType.encodeArrayType(ColumnType.DOUBLE, nDims);
             }
-            if (typeCode == QwpConstants.TYPE_GEOHASH) {
-                final int bits = cursor.getGeoHashColumn(schemaIndex).getPrecision();
-                if (bits < ColumnType.GEOBYTE_MIN_BITS || bits > ColumnType.GEOLONG_MAX_BITS) {
-                    return ColumnType.UNDEFINED;
-                }
-                return ColumnType.getGeoHashTypeWithBits(bits);
-            }
-            return QwpWalAppender.mapQwpTypeToQuestDB(typeCode);
+            return QwpWalAppender.mapQwpTypeToQuestDB(typeCode, cursor, schemaIndex);
         }
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpTudCache.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpTudCache.java
@@ -617,6 +617,13 @@ public class QwpTudCache implements QuietCloseable {
                 }
                 return ColumnType.encodeArrayType(ColumnType.DOUBLE, nDims);
             }
+            if (typeCode == QwpConstants.TYPE_GEOHASH) {
+                final int bits = cursor.getGeoHashColumn(schemaIndex).getPrecision();
+                if (bits < ColumnType.GEOBYTE_MIN_BITS || bits > ColumnType.GEOLONG_MAX_BITS) {
+                    return ColumnType.UNDEFINED;
+                }
+                return ColumnType.getGeoHashTypeWithBits(bits);
+            }
             return QwpWalAppender.mapQwpTypeToQuestDB(typeCode);
         }
     }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpFixedWidthDecoderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpFixedWidthDecoderTest.java
@@ -35,6 +35,7 @@ import io.questdb.cutlass.qwp.protocol.QwpTableBlockCursor;
 import io.questdb.cutlass.qwp.protocol.QwpTimestampColumnCursor;
 import io.questdb.cutlass.qwp.server.QwpStreamingDecoder;
 import io.questdb.std.MemoryTag;
+import io.questdb.std.Numbers;
 import io.questdb.std.Unsafe;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -433,7 +434,7 @@ public class QwpFixedWidthDecoderTest {
 
     @Test
     public void testDecodeIntColumn() throws QwpParseException {
-        int[] values = {1, 65_536, -1, Integer.MAX_VALUE, Integer.MIN_VALUE, 0};
+        int[] values = {1, 65_536, -1, Integer.MAX_VALUE, Integer.MIN_VALUE + 1, 0};
         int rowCount = values.length;
 
         int size = 1 + rowCount * 4; // flag byte + values
@@ -577,7 +578,7 @@ public class QwpFixedWidthDecoderTest {
 
     @Test
     public void testDecodeLongColumn() throws QwpParseException {
-        long[] values = {1L, 4_294_967_296L, -1L, Long.MAX_VALUE, Long.MIN_VALUE, 0L};
+        long[] values = {1L, 4_294_967_296L, -1L, Long.MAX_VALUE, Long.MIN_VALUE + 1, 0L};
         int rowCount = values.length;
 
         int size = 1 + rowCount * 8; // flag byte + values
@@ -829,6 +830,172 @@ public class QwpFixedWidthDecoderTest {
                 }
             }
         });
+    }
+
+    @Test
+    public void testDecodeDateColumnSentinelNullNoBitmap() throws QwpParseException {
+        long[] values = {1_000L, Numbers.LONG_NULL, -2_000L};
+        assertLongSentinelNull(values, TYPE_DATE);
+    }
+
+    @Test
+    public void testDecodeDoubleColumnSentinelNullNoBitmap() throws QwpParseException {
+        double[] values = {1.5, Double.NaN, -2.5};
+        int rowCount = values.length;
+        int size = 1 + rowCount * 8;
+        long address = Unsafe.malloc(size, MemoryTag.NATIVE_DEFAULT);
+        try {
+            Unsafe.putByte(address, (byte) 0); // no null bitmap
+            for (int i = 0; i < rowCount; i++) {
+                Unsafe.putDouble(address + 1 + (long) i * 8, values[i]);
+            }
+
+            QwpFixedWidthColumnCursor cursor = new QwpFixedWidthColumnCursor();
+            cursor.of(address, size, rowCount, TYPE_DOUBLE);
+
+            cursor.advanceRow();
+            Assert.assertFalse(cursor.isNull());
+            Assert.assertEquals(1.5, cursor.getDouble(), 0.0);
+
+            cursor.advanceRow();
+            Assert.assertTrue("NaN must be reported as NULL when no bitmap is present", cursor.isNull());
+
+            cursor.advanceRow();
+            Assert.assertFalse(cursor.isNull());
+            Assert.assertEquals(-2.5, cursor.getDouble(), 0.0);
+        } finally {
+            Unsafe.free(address, size, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
+    public void testDecodeFloatColumnSentinelNullNoBitmap() throws QwpParseException {
+        float[] values = {1.5f, Float.NaN, -2.5f};
+        int rowCount = values.length;
+        int size = 1 + rowCount * 4;
+        long address = Unsafe.malloc(size, MemoryTag.NATIVE_DEFAULT);
+        try {
+            Unsafe.putByte(address, (byte) 0); // no null bitmap
+            for (int i = 0; i < rowCount; i++) {
+                Unsafe.putFloat(address + 1 + (long) i * 4, values[i]);
+            }
+
+            QwpFixedWidthColumnCursor cursor = new QwpFixedWidthColumnCursor();
+            cursor.of(address, size, rowCount, TYPE_FLOAT);
+
+            cursor.advanceRow();
+            Assert.assertFalse(cursor.isNull());
+            Assert.assertEquals(1.5f, (float) cursor.getDouble(), 0.0f);
+
+            cursor.advanceRow();
+            Assert.assertTrue("NaN must be reported as NULL when no bitmap is present", cursor.isNull());
+
+            cursor.advanceRow();
+            Assert.assertFalse(cursor.isNull());
+            Assert.assertEquals(-2.5f, (float) cursor.getDouble(), 0.0f);
+        } finally {
+            Unsafe.free(address, size, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
+    public void testDecodeIntColumnExplicitSentinelWithBitmap() throws QwpParseException {
+        int rowCount = 1;
+        int size = 1 + 1 + 4;
+        long address = Unsafe.malloc(size, MemoryTag.NATIVE_DEFAULT);
+        try {
+            Unsafe.putByte(address, (byte) 1);          // bitmap present
+            Unsafe.putByte(address + 1, (byte) 0);      // bitmap: row 0 NOT null
+            Unsafe.putInt(address + 2, Numbers.INT_NULL);
+
+            QwpFixedWidthColumnCursor cursor = new QwpFixedWidthColumnCursor();
+            cursor.of(address, size, rowCount, TYPE_INT);
+
+            cursor.advanceRow();
+            Assert.assertFalse("bitmap-marked non-null must not be sentinel-detected", cursor.isNull());
+            Assert.assertEquals(Numbers.INT_NULL, (int) cursor.getLong());
+        } finally {
+            Unsafe.free(address, size, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
+    public void testDecodeIntColumnSentinelNullNoBitmap() throws QwpParseException {
+        int[] values = {42, Numbers.INT_NULL, -1};
+        int rowCount = values.length;
+        int size = 1 + rowCount * 4;
+        long address = Unsafe.malloc(size, MemoryTag.NATIVE_DEFAULT);
+        try {
+            Unsafe.putByte(address, (byte) 0); // no null bitmap
+            for (int i = 0; i < rowCount; i++) {
+                Unsafe.putInt(address + 1 + (long) i * 4, values[i]);
+            }
+
+            QwpFixedWidthColumnCursor cursor = new QwpFixedWidthColumnCursor();
+            cursor.of(address, size, rowCount, TYPE_INT);
+
+            cursor.advanceRow();
+            Assert.assertFalse(cursor.isNull());
+            Assert.assertEquals(42, (int) cursor.getLong());
+
+            cursor.advanceRow();
+            Assert.assertTrue("INT_NULL must be reported as NULL when no bitmap is present", cursor.isNull());
+
+            cursor.advanceRow();
+            Assert.assertFalse(cursor.isNull());
+            Assert.assertEquals(-1, (int) cursor.getLong());
+        } finally {
+            Unsafe.free(address, size, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
+    public void testDecodeLongColumnSentinelNullNoBitmap() throws QwpParseException {
+        long[] values = {42L, Numbers.LONG_NULL, -1L};
+        assertLongSentinelNull(values, TYPE_LONG);
+    }
+
+    @Test
+    public void testDecodeTimestampColumnSentinelNullNoBitmap() throws QwpParseException {
+        long[] values = {1_000_000L, Numbers.LONG_NULL, -1L};
+        assertLongSentinelNull(values, TYPE_TIMESTAMP);
+    }
+
+    @Test
+    public void testDecodeTimestampNanosColumnSentinelNullNoBitmap() throws QwpParseException {
+        long[] values = {1_000_000_000L, Numbers.LONG_NULL, -1L};
+        assertLongSentinelNull(values, TYPE_TIMESTAMP_NANOS);
+    }
+
+    private static void assertLongSentinelNull(long[] values, byte typeCode) throws QwpParseException {
+        int rowCount = values.length;
+        int size = 1 + rowCount * 8;
+        long address = Unsafe.malloc(size, MemoryTag.NATIVE_DEFAULT);
+        try {
+            Unsafe.putByte(address, (byte) 0); // no null bitmap
+            for (int i = 0; i < rowCount; i++) {
+                Unsafe.putLong(address + 1 + (long) i * 8, values[i]);
+            }
+
+            QwpFixedWidthColumnCursor cursor = new QwpFixedWidthColumnCursor();
+            cursor.of(address, size, rowCount, typeCode);
+
+            for (int i = 0; i < rowCount; i++) {
+                cursor.advanceRow();
+                if (values[i] == Numbers.LONG_NULL) {
+                    Assert.assertTrue(
+                            "row " + i + " (" + QwpConstants.getTypeName(typeCode)
+                                    + ") LONG_NULL must be reported as NULL when no bitmap is present",
+                            cursor.isNull()
+                    );
+                } else {
+                    Assert.assertFalse("row " + i + " must not be NULL", cursor.isNull());
+                    Assert.assertEquals(values[i], cursor.getLong());
+                }
+            }
+        } finally {
+            Unsafe.free(address, size, MemoryTag.NATIVE_DEFAULT);
+        }
     }
 
     private static int findColumnIndex(QwpTableBlockCursor table, byte typeCode) {

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpGeoHashDecoderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpGeoHashDecoderTest.java
@@ -284,8 +284,9 @@ public class QwpGeoHashDecoderTest {
     @Test
     public void testDecodeGeoHashLong() throws Exception {
         assertMemoryLeak(() -> {
-            // 40-bit precision (typical for 8 geohash characters)
-            long[] values = {0xABCDEF1234L, 0x123456789AL, 0xFFFFFFFFFFL, 0x0000000000L};
+            // 40-bit precision (typical for 8 geohash characters).
+            // Avoid 0xFFFFFFFFFFL: at valueSize=5 it is the all-ones null sentinel.
+            long[] values = {0xABCDEF1234L, 0x123456789AL, 0xFEFFFFFFFFL, 0x0000000000L};
             assertEncoderRoundTrip(values, 40);
         });
     }
@@ -301,6 +302,21 @@ public class QwpGeoHashDecoderTest {
                     0x0000000000000000L
             };
             assertEncoderRoundTrip(values, 60);
+        });
+    }
+
+    @Test
+    public void testDecodeGeoHashSentinelModeNull() throws Exception {
+        // Verifies that null rows survive the sentinel-mode (useNullBitmap=false)
+        // wire path for every GEOHASH storage width. The encoder writes -1L
+        // truncated to ceil(precision/8) bytes; the decoder must recognise the
+        // all-ones pattern as null instead of a junk value (e.g. precision 20 ->
+        // 3-byte read -> 0x00FFFFFF == 16_777_215, which is NOT GeoHashes.INT_NULL).
+        assertMemoryLeak(() -> {
+            int[] precisions = {5, 10, 20, 25, 40, 48, 56, 60};
+            for (int precision : precisions) {
+                assertSentinelNullRoundTrip(precision);
+            }
         });
     }
 
@@ -448,17 +464,20 @@ public class QwpGeoHashDecoderTest {
     @Test
     public void testDecodeVariablePrecision() throws Exception {
         assertMemoryLeak(() -> {
+            // Avoid all-ones bit patterns at the per-value byte width:
+            // those equal the null sentinel and cannot round-trip in sentinel mode.
+
             // GEOBYTE boundary
             assertEncoderRoundTrip(new long[]{0x7F}, 7);  // Max for GEOBYTE
-            assertEncoderRoundTrip(new long[]{0xFF}, 8);  // Min for GEOSHORT
+            assertEncoderRoundTrip(new long[]{0xFE}, 8);  // Min for GEOSHORT
 
             // GEOSHORT boundary
             assertEncoderRoundTrip(new long[]{0x7FFF}, 15);  // Max for GEOSHORT
-            assertEncoderRoundTrip(new long[]{0xFFFF}, 16);  // Min for GEOINT
+            assertEncoderRoundTrip(new long[]{0xFFFE}, 16);  // Min for GEOINT
 
             // GEOINT boundary
             assertEncoderRoundTrip(new long[]{0x7FFFFFFFL}, 31);  // Max for GEOINT
-            assertEncoderRoundTrip(new long[]{0xFFFFFFFFL}, 32);  // Min for GEOLONG
+            assertEncoderRoundTrip(new long[]{0xFFFFFFFEL}, 32);  // Min for GEOLONG
         });
     }
 
@@ -798,6 +817,49 @@ public class QwpGeoHashDecoderTest {
                     }
                 }
                 Assert.assertFalse(table.hasNextRow());
+            }
+        }
+    }
+
+    private void assertSentinelNullRoundTrip(int precision) throws QwpParseException {
+        long value = 1L << (precision - 1); // highest bit set, distinct from the all-ones null sentinel
+        try (QwpWebSocketEncoder encoder = new QwpWebSocketEncoder()) {
+            QwpTableBuffer buffer = new QwpTableBuffer("test_geohash");
+            // useNullBitmap=false forces the sender to encode nulls as the all-ones sentinel
+            QwpTableBuffer.ColumnBuffer col = buffer.getOrCreateColumn("geo", TYPE_GEOHASH, false);
+            QwpTableBuffer.ColumnBuffer tsCol = buffer.getOrCreateDesignatedTimestampColumn(TYPE_TIMESTAMP);
+
+            col.addGeoHash(value, precision);
+            tsCol.addLong(1_000_000_000_000L);
+            buffer.nextRow();
+
+            col.addNull();
+            tsCol.addLong(1_000_000_000_001L);
+            buffer.nextRow();
+
+            int size = encoder.encode(buffer, false);
+            QwpBufferWriter buf = encoder.getBuffer();
+            long ptr = buf.getBufferPtr();
+
+            try (QwpStreamingDecoder decoder = new QwpStreamingDecoder()) {
+                QwpMessageCursor msg = decoder.decode(ptr, size);
+                Assert.assertTrue(msg.hasNextTable());
+                QwpTableBlockCursor table = msg.nextTable();
+
+                int geoColIdx = findGeoHashColumnIndex(table);
+                Assert.assertNotEquals("GEOHASH column not found", -1, geoColIdx);
+
+                Assert.assertTrue(table.hasNextRow());
+                table.nextRow();
+                Assert.assertFalse("precision " + precision + ": row 0 must not be null",
+                        table.isColumnNull(geoColIdx));
+                Assert.assertEquals("precision " + precision + ": row 0 value mismatch",
+                        value, table.getGeoHashColumn(geoColIdx).getGeoHash());
+
+                Assert.assertTrue(table.hasNextRow());
+                table.nextRow();
+                Assert.assertTrue("precision " + precision + ": sentinel-encoded null must be reported null",
+                        table.isColumnNull(geoColIdx));
             }
         }
     }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -28,6 +28,7 @@ import io.questdb.client.Sender;
 import io.questdb.client.SenderError;
 import io.questdb.client.cutlass.line.LineSenderException;
 import io.questdb.client.cutlass.qwp.client.QwpWebSocketSender;
+import io.questdb.client.cutlass.qwp.protocol.QwpTableBuffer;
 import io.questdb.client.std.Decimal128;
 import io.questdb.client.std.Decimal256;
 import io.questdb.client.std.Decimal64;
@@ -41,6 +42,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static io.questdb.client.cutlass.qwp.protocol.QwpConstants.TYPE_GEOHASH;
 
 /**
  * End-to-end tests for the QWP (QuestDB Wire Protocol) WebSocket sender.
@@ -2147,6 +2150,26 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
                             -2.25
                             0.0
                             """);
+        });
+    }
+
+    @Test
+    public void testGeoHashWirePrecisionMismatchRejected() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_geohash_prec_mismatch";
+            execute("CREATE TABLE " + table + " (col GEOHASH(5b), ts TIMESTAMP) " +
+                    "TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            assertCoercionError(port, table,
+                    (s, t) -> {
+                        QwpTableBuffer buf = s.getTableBuffer(t);
+                        QwpTableBuffer.ColumnBuffer col = buf.getOrCreateColumn("col", TYPE_GEOHASH, true);
+                        // Wire precision is 35 bits (5-byte values); the column is 5 bits (1-byte storage).
+                        // The server must reject this batch instead of silently truncating.
+                        col.addGeoHash(0x123456789AL, 35);
+                        s.at(1_000_000_000L, ChronoUnit.MICROS);
+                    },
+                    "GeoHash precision mismatch", "GEOHASH");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpAllTypesTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpAllTypesTest.java
@@ -474,6 +474,26 @@ public class QwpUdpAllTypesTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testGeoHashAutoCreateGeoByte() throws Exception {
+        assertGeoHashAutoCreate("t_geo_auto_byte", "s", 5, "GEOHASH(1c)");
+    }
+
+    @Test
+    public void testGeoHashAutoCreateGeoInt() throws Exception {
+        assertGeoHashAutoCreate("t_geo_auto_int", "s24s", 20, "GEOHASH(4c)");
+    }
+
+    @Test
+    public void testGeoHashAutoCreateGeoLong() throws Exception {
+        assertGeoHashAutoCreate("t_geo_auto_long", "s24se0g", 35, "GEOHASH(7c)");
+    }
+
+    @Test
+    public void testGeoHashAutoCreateGeoShort() throws Exception {
+        assertGeoHashAutoCreate("t_geo_auto_short", "s24", 15, "GEOHASH(3c)");
+    }
+
+    @Test
     public void testGeoHashDirect() throws Exception {
         assertMemoryLeak(() -> {
             execute("CREATE TABLE t_geo (val GEOHASH(6c), timestamp TIMESTAMP) TIMESTAMP(timestamp) PARTITION BY DAY WAL");
@@ -874,6 +894,35 @@ public class QwpUdpAllTypesTest extends AbstractCairoTest {
             assertSql(
                     "val\nhello varchar\n",
                     "SELECT val FROM t_varchar"
+            );
+        });
+    }
+
+    private void assertGeoHashAutoCreate(
+            String tableName,
+            String hash,
+            int precisionBits,
+            String expectedColumnType
+    ) throws Exception {
+        assertMemoryLeak(() -> {
+            try (QwpUdpReceiver receiver = receiverFactory.create(LOW_COMMIT_RATE_CONF, engine)) {
+                sendDirectRow(tableName, tb -> {
+                    QwpTableBuffer.ColumnBuffer col = tb.getOrCreateColumn("val", TYPE_GEOHASH, true);
+                    col.addGeoHash(GeoHashes.fromString(hash), precisionBits);
+                    QwpTableBuffer.ColumnBuffer ts = tb.getOrCreateDesignatedTimestampColumn(TYPE_TIMESTAMP);
+                    ts.addLong(1_000_000L);
+                    tb.nextRow();
+                });
+                drainReceiver(receiver);
+            }
+            drainWalQueue();
+            assertSql(
+                    "type\n" + expectedColumnType + "\n",
+                    "SELECT type FROM (SHOW COLUMNS FROM " + tableName + ") WHERE column = 'val'"
+            );
+            assertSql(
+                    "val\n" + hash + "\n",
+                    "SELECT val FROM " + tableName
             );
         });
     }


### PR DESCRIPTION
## Summary

- Auto-creating a GEOHASH column from a QWP ingest batch now carries the correct bit precision. Previously the column type was inferred without per-column precision metadata from the wire cursor, producing an incorrect type.
- Fixed-width columns (INT, LONG, DATE, TIMESTAMP, TIMESTAMP_NS, FLOAT, DOUBLE) carrying sentinel NULL values (`INT_NULL`, `LONG_NULL`, `NaN`) without a null bitmap are now recognised as NULL. Without the fix, row-by-row conversion paths could throw on out-of-range coercions (e.g. INT to BYTE with `INT_NULL`) or write the raw sentinel value into storage instead of NULL.

## Test plan

- QwpFixedWidthDecoderTest covers sentinel-NULL detection across all supported types, plus the inverse case (bitmap-marked non-null preserves an explicit sentinel value).
- QwpUdpAllTypesTest covers GEOHASH auto-create end-to-end across all four storage widths (GEOBYTE, GEOSHORT, GEOINT, GEOLONG).