### PR TITLE
fix(http): JSON-escape CHAR column values in /exec and /query responses

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessorState.java
@@ -454,9 +454,22 @@ public class JsonQueryProcessorState implements Mutable, Closeable {
         char c = rec.getChar(col);
         if (c == 0) {
             response.putAscii("\"\"");
-        } else {
-            response.putAscii('"').put(c).putAscii('"');
+            return;
         }
+        // Emit the char as a JSON string literal. Mirrors Utf8Sink.escapeJsonStr
+        // for a single char: control chars (< 0x20) get a backslash-u escape
+        // (or short \b/\f/\n/\r/\t form); double quote and backslash get a
+        // backslash prefix; everything else is forwarded verbatim through
+        // put(char), which handles UTF-8 for the non-ASCII range.
+        response.putAscii('"');
+        if (c < 0x20) {
+            response.escapeJsonStrChar(c);
+        } else if (c == '"' || c == '\\') {
+            response.putAscii('\\').putAscii(c);
+        } else {
+            response.put(c);
+        }
+        response.putAscii('"');
     }
 
     private static void putDateValue(HttpChunkedResponse response, Record rec, int col) {

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -440,13 +440,13 @@ public class IODispatcherTest extends AbstractTest {
                     }
 
                     @Override
-                    public HttpRequestProcessor select(HttpRequestHeader requestHeader) {
-                        return null;
+                    public HttpRequestProcessor resolveProcessorById(int handlerId, HttpRequestHeader header) {
+                        return select(header);
                     }
 
                     @Override
-                    public HttpRequestProcessor resolveProcessorById(int handlerId, HttpRequestHeader header) {
-                        return select(header);
+                    public HttpRequestProcessor select(HttpRequestHeader requestHeader) {
+                        return null;
                     }
                 };
 
@@ -3076,6 +3076,43 @@ public class IODispatcherTest extends AbstractTest {
     }
 
     @Test
+    public void testJsonQueryCharBackslashIsJsonEscaped() throws Exception {
+        getSimpleTester().run((engine, _) -> {
+            engine.execute("create table x (c char)");
+            engine.execute("insert into x values ('\\')");
+            testHttpClient.assertGet(
+                    "{\"query\":\"select c from x\",\"columns\":[{\"name\":\"c\",\"type\":\"CHAR\"}],\"timestamp\":-1,\"dataset\":[[\"\\\\\"]],\"count\":1}",
+                    "select c from x"
+            );
+        });
+    }
+
+    @Test
+    public void testJsonQueryCharControlCharIsJsonEscaped() throws Exception {
+        getSimpleTester().run((engine, _) -> {
+            engine.execute("create table x (c char)");
+            // cast(1 as char) yields the C0 control character at codepoint 1.
+            engine.execute("insert into x values (cast(1 as char))");
+            testHttpClient.assertGet(
+                    "{\"query\":\"select c from x\",\"columns\":[{\"name\":\"c\",\"type\":\"CHAR\"}],\"timestamp\":-1,\"dataset\":[[\"\\u0001\"]],\"count\":1}",
+                    "select c from x"
+            );
+        });
+    }
+
+    @Test
+    public void testJsonQueryCharDoubleQuoteIsJsonEscaped() throws Exception {
+        getSimpleTester().run((engine, _) -> {
+            engine.execute("create table x (c char)");
+            engine.execute("insert into x values ('\"')");
+            testHttpClient.assertGet(
+                    "{\"query\":\"select c from x\",\"columns\":[{\"name\":\"c\",\"type\":\"CHAR\"}],\"timestamp\":-1,\"dataset\":[[\"\\\"\"]],\"count\":1}",
+                    "select c from x"
+            );
+        });
+    }
+
+    @Test
     public void testJsonQueryCommentOnlyMultiline_apiV2() throws Exception {
         String expectedErrorResponse = """
                 HTTP/1.1 200 OK\r
@@ -4999,13 +5036,13 @@ public class IODispatcherTest extends AbstractTest {
                     }
 
                     @Override
-                    public HttpRequestProcessor select(HttpRequestHeader requestHeader) {
-                        return null;
+                    public HttpRequestProcessor resolveProcessorById(int handlerId, HttpRequestHeader header) {
+                        return select(header);
                     }
 
                     @Override
-                    public HttpRequestProcessor resolveProcessorById(int handlerId, HttpRequestHeader header) {
-                        return select(header);
+                    public HttpRequestProcessor select(HttpRequestHeader requestHeader) {
+                        return null;
                     }
                 }) {
 
@@ -5795,6 +5832,11 @@ public class IODispatcherTest extends AbstractTest {
                     }
 
                     @Override
+                    public HttpRequestProcessor resolveProcessorById(int handlerId, HttpRequestHeader header) {
+                        return select(header);
+                    }
+
+                    @Override
                     public HttpRequestProcessor select(HttpRequestHeader requestHeader) {
                         return new HttpRequestProcessor() {
                             @Override
@@ -5812,11 +5854,6 @@ public class IODispatcherTest extends AbstractTest {
                                 requestReceivedLatch.countDown();
                             }
                         };
-                    }
-
-                    @Override
-                    public HttpRequestProcessor resolveProcessorById(int handlerId, HttpRequestHeader header) {
-                        return select(header);
                     }
                 };
 
@@ -5967,6 +6004,11 @@ public class IODispatcherTest extends AbstractTest {
                     }
 
                     @Override
+                    public HttpRequestProcessor resolveProcessorById(int handlerId, HttpRequestHeader header) {
+                        return select(header);
+                    }
+
+                    @Override
                     public HttpRequestProcessor select(HttpRequestHeader requestHeader) {
                         return new HttpRequestProcessor() {
                             @Override
@@ -5988,11 +6030,6 @@ public class IODispatcherTest extends AbstractTest {
                                 context.simpleResponse().sendStatusTextContent(200);
                             }
                         };
-                    }
-
-                    @Override
-                    public HttpRequestProcessor resolveProcessorById(int handlerId, HttpRequestHeader header) {
-                        return select(header);
                     }
                 };
 
@@ -6125,6 +6162,11 @@ public class IODispatcherTest extends AbstractTest {
                     }
 
                     @Override
+                    public HttpRequestProcessor resolveProcessorById(int handlerId, HttpRequestHeader header) {
+                        return select(header);
+                    }
+
+                    @Override
                     public HttpRequestProcessor select(HttpRequestHeader requestHeader) {
                         return new HttpRequestProcessor() {
                             @Override
@@ -6141,11 +6183,6 @@ public class IODispatcherTest extends AbstractTest {
                                 sink.put("\r\n");
                             }
                         };
-                    }
-
-                    @Override
-                    public HttpRequestProcessor resolveProcessorById(int handlerId, HttpRequestHeader header) {
-                        return select(header);
                     }
                 };
 
@@ -6832,12 +6869,12 @@ public class IODispatcherTest extends AbstractTest {
                                 }
 
                                 @Override
-                                public HttpRequestProcessor select(HttpRequestHeader requestHeader) {
+                                public HttpRequestProcessor resolveProcessorById(int handlerId, HttpRequestHeader header) {
                                     return processor;
                                 }
 
                                 @Override
-                                public HttpRequestProcessor resolveProcessorById(int handlerId, HttpRequestHeader header) {
+                                public HttpRequestProcessor select(HttpRequestHeader requestHeader) {
                                     return processor;
                                 }
                             }) {

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -3113,6 +3113,18 @@ public class IODispatcherTest extends AbstractTest {
     }
 
     @Test
+    public void testJsonQueryCharNullIsEmptyString() throws Exception {
+        getSimpleTester().run((engine, _) -> {
+            engine.execute("create table x (c char)");
+            engine.execute("insert into x values (null)");
+            testHttpClient.assertGet(
+                    "{\"query\":\"select c from x\",\"columns\":[{\"name\":\"c\",\"type\":\"CHAR\"}],\"timestamp\":-1,\"dataset\":[[\"\"]],\"count\":1}",
+                    "select c from x"
+            );
+        });
+    }
+
+    @Test
     public void testJsonQueryCommentOnlyMultiline_apiV2() throws Exception {
         String expectedErrorResponse = """
                 HTTP/1.1 200 OK\r


### PR DESCRIPTION
The JSON query endpoints emitted CHAR values as a raw char between two ASCII quotes with no escaping. When a CHAR row contained " (0x22), the response carried three literal quotes ("""); for \ (0x5C) the closing quote was escaped away, leaving the JSON object unterminated; for any C0 control byte the raw byte was inlined verbatim. In every case strict JSON parsers fail mid-response, so any client doing a SELECT over a table with such values would see a parser error instead of data -- typically only after the table had already grown enough to randomly produce one of those chars.

putCharValue now escapes the value with the same rules as Utf8Sink.escapeJsonStr: backslash-prefix for " and \, the short \b/\f/\n/\r/\t form for the usual control chars, \uXXXX for the rest, and pass-through (UTF-8) for everything from U+0020 upward.