### PR TITLE
feat(qwp): expand ingest wire-type coverage and advertise batch cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,22 @@ offending character, not the start of the expression.
 
 ## Git & PR Conventions
 
+- **PRs are squash-merged. Commit history on a PR branch is throwaway** — only
+  the squashed commit message that lands on `master` is preserved. Do not
+  spend effort tidying the branch's history: no soft resets to "commit all at
+  once", no rewording prior commits, no force pushes to clean up. Adding a
+  fix-up commit on top is always fine. The squash flow folds the lot at merge
+  time anyway.
+
+## Investigating failures
+
+- **Never dismiss a failure as "pre-existing", "flaky", "unrelated", or "a
+  known issue" without actually proving it.** That label is a hypothesis,
+  not a conclusion. Treat any red test, red CI job, or surprising log line
+  as a live bug to investigate until the evidence — git log, reproduction
+  on master, a real timing constraint, an upstream report — forces a
+  different conclusion. Only after that proof can the issue be set aside,
+  and the proof itself should be reported back so it can be verified.
 - **`java-questdb-client/` is a separate git repo** (a git submodule). Always
   `cd` into it and commit there independently. Never commit it from the parent
   repo as a submodule pointer update without also committing inside it first.

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -117,7 +117,7 @@
           -->
         <uberjar.name>benchmarks</uberjar.name>
 
-        <questdb.client.version>1.2.1</questdb.client.version>
+        <questdb.client.version>1.2.2</questdb.client.version>
     </properties>
 
     <build>

--- a/benchmarks/src/main/java/org/questdb/QwpTotalBufferedBytesBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/QwpTotalBufferedBytesBenchmark.java
@@ -1,0 +1,194 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.questdb;
+
+import io.questdb.client.cutlass.qwp.protocol.QwpConstants;
+import io.questdb.client.cutlass.qwp.protocol.QwpTableBuffer;
+import io.questdb.client.std.CharSequenceObjHashMap;
+import io.questdb.client.std.Misc;
+import io.questdb.client.std.ObjList;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Microbench for the per-row bytes-tracking step inside
+ * {@code QwpWebSocketSender.sendRow()}.
+ * <p>
+ * Today {@code sendRow()} sets {@code pendingBytes = totalBufferedBytes()} on
+ * every call. {@code totalBufferedBytes()} walks {@code tableBuffers.keys()},
+ * does a hashmap {@code get()} for each table, and sums per-column
+ * {@code getBufferedBytes()} values. We want a number on what that walk
+ * actually costs, since the two consumers of {@code pendingBytes} are guarded:
+ * <ul>
+ *   <li>the byte-based auto-flush check, gated by
+ *       {@code effectiveAutoFlushBytes > 0};</li>
+ *   <li>the server-cap pre-flight, only checked when
+ *       {@code pendingRowCount == 1 && serverMaxBatchSize > 0}.</li>
+ * </ul>
+ * When neither gate is active the walk is dead work.
+ * <p>
+ * Three variants:
+ * <ul>
+ *   <li>{@link #walkAllTables} -- current behaviour.</li>
+ *   <li>{@link #currentTableOnly} -- alternative: track the active table only
+ *       (requires upstream delta bookkeeping to be correct).</li>
+ *   <li>{@link #shortCircuit} -- proposed fix's cheap path: skip the walk when
+ *       no gate is active.</li>
+ * </ul>
+ * Params sweep {@code numTables} and {@code numColumns} so the O(N{*}K)
+ * scaling is visible.
+ * <p>
+ * Run from the benchmarks module:
+ * <pre>
+ *   mvn -pl benchmarks -P local-client -DskipTests package
+ *   java -jar benchmarks/target/benchmarks.jar QwpTotalBufferedBytesBenchmark
+ * </pre>
+ * The {@code local-client} profile rebuilds the client from source so the
+ * bench measures the {@code QwpTableBuffer} version sitting in this tree
+ * rather than the Maven-cached release.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class QwpTotalBufferedBytesBenchmark {
+
+    @Param({"1", "4", "16"})
+    private int numTables;
+
+    @Param({"1", "8"})
+    private int numColumns;
+
+    @Param({"100"})
+    private int rowsPrePopulated;
+
+    private QwpTableBuffer currentTableBuffer;
+    private CharSequenceObjHashMap<QwpTableBuffer> tableBuffers;
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(QwpTotalBufferedBytesBenchmark.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+
+    /**
+     * Alternative B: only the currently-active table's bytes are summed.
+     * The sender would need to maintain {@code pendingBytes} as a running
+     * delta updated by column setters and {@code nextRow()} for this to be
+     * correct across multi-table interleaving; the bench just measures the
+     * single-table {@code getBufferedBytes()} cost in isolation.
+     */
+    @Benchmark
+    public long currentTableOnly() {
+        return currentTableBuffer.getBufferedBytes();
+    }
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        tableBuffers = new CharSequenceObjHashMap<>();
+        for (int t = 0; t < numTables; t++) {
+            String name = "tbl_" + t;
+            QwpTableBuffer tb = new QwpTableBuffer(name);
+            for (int r = 0; r < rowsPrePopulated; r++) {
+                for (int c = 0; c < numColumns; c++) {
+                    QwpTableBuffer.ColumnBuffer col =
+                            tb.getOrCreateColumn("c" + c, QwpConstants.TYPE_LONG, true);
+                    col.addLong((long) r * 31L + c);
+                }
+                tb.nextRow();
+            }
+            tableBuffers.put(name, tb);
+        }
+        currentTableBuffer = tableBuffers.get("tbl_0");
+    }
+
+    /**
+     * Proposed cheap path: when neither byte-based auto-flush nor server cap
+     * are active, {@code pendingBytes} is never read, so skip the walk.
+     * Returns a constant; JMH still has to call the method.
+     */
+    @Benchmark
+    public long shortCircuit() {
+        return 0L;
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        if (tableBuffers != null) {
+            ObjList<CharSequence> keys = tableBuffers.keys();
+            for (int i = 0, n = keys.size(); i < n; i++) {
+                CharSequence k = keys.getQuick(i);
+                if (k != null) {
+                    Misc.free(tableBuffers.get(k));
+                }
+            }
+            tableBuffers.clear();
+            tableBuffers = null;
+        }
+        currentTableBuffer = null;
+    }
+
+    /**
+     * Baseline: replicates {@code QwpWebSocketSender.totalBufferedBytes()}
+     * exactly so the bench measures the same map walk + per-table column
+     * loop the sender pays on every row.
+     */
+    @Benchmark
+    public long walkAllTables() {
+        long total = 0;
+        ObjList<CharSequence> keys = tableBuffers.keys();
+        for (int i = 0, n = keys.size(); i < n; i++) {
+            CharSequence name = keys.getQuick(i);
+            if (name == null) {
+                continue;
+            }
+            QwpTableBuffer tb = tableBuffers.get(name);
+            if (tb != null) {
+                total += tb.getBufferedBytes();
+            }
+        }
+        return total;
+    }
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,7 +46,7 @@
         -->
         <qdbr.rustflags>-D warnings</qdbr.rustflags>
 
-        <questdb.client.version>1.2.1</questdb.client.version>
+        <questdb.client.version>1.2.2-SNAPSHOT</questdb.client.version>
     </properties>
 
     <version>9.3.6-SNAPSHOT</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -45,7 +45,7 @@
         -->
         <qdbr.rustflags>-D warnings</qdbr.rustflags>
 
-        <questdb.client.version>1.2.2-SNAPSHOT</questdb.client.version>
+        <questdb.client.version>1.2.2</questdb.client.version>
     </properties>
 
     <version>9.4.1-SNAPSHOT</version>

--- a/core/src/main/java/io/questdb/DynamicPropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/DynamicPropServerConfiguration.java
@@ -99,7 +99,8 @@ public class DynamicPropServerConfiguration implements ServerConfiguration, Conf
             PropertyKey.CAIRO_SQL_JIT_MAX_IN_LIST_SIZE_THRESHOLD,
             PropertyKey.CAIRO_PARQUET_EXPORT_COPY_REPORT_FREQUENCY_LINES,
             PropertyKey.CAIRO_SQL_COPY_EXPORT_ROOT,
-            PropertyKey.CAIRO_SQL_COPIER_CHUNKED
+            PropertyKey.CAIRO_SQL_COPIER_CHUNKED,
+            PropertyKey.QWP_EGRESS_COMPRESSION_FORCE_LEVEL
     ));
     private static final Function<String, ? extends ConfigPropertyKey> keyResolver = (k) -> {
         Optional<PropertyKey> prop = PropertyKey.getByString(k);

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -415,6 +415,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final PublicPassthroughConfiguration publicPassthroughConfiguration = new PropPublicPassthroughConfiguration();
     private final int queryCacheEventQueueCapacity;
     private final boolean queryWithinLatestByOptimisationEnabled;
+    private final int qwpEgressForcedZstdLevel;
     private final int qwpMaxRowsPerTable;
     private final int qwpMaxSchemasPerConnection;
     private final int qwpMaxTablesPerConnection;
@@ -1817,6 +1818,22 @@ public class PropServerConfiguration implements ServerConfiguration {
                 throw new ServerConfigurationException(
                         PropertyKey.QWP_MAX_SCHEMAS_PER_CONNECTION.getPropertyPath()
                                 + " must be at least 1"
+                );
+            }
+            this.qwpEgressForcedZstdLevel = getInt(
+                    properties,
+                    env,
+                    PropertyKey.QWP_EGRESS_COMPRESSION_FORCE_LEVEL,
+                    0
+            );
+            if (qwpEgressForcedZstdLevel != 0
+                    && (qwpEgressForcedZstdLevel < QwpConstants.COMPRESSION_ZSTD_MIN_LEVEL
+                    || qwpEgressForcedZstdLevel > QwpConstants.COMPRESSION_ZSTD_MAX_LEVEL)) {
+                throw new ServerConfigurationException(
+                        PropertyKey.QWP_EGRESS_COMPRESSION_FORCE_LEVEL.getPropertyPath()
+                                + " must be 0 (off) or in ["
+                                + QwpConstants.COMPRESSION_ZSTD_MIN_LEVEL + ", "
+                                + QwpConstants.COMPRESSION_ZSTD_MAX_LEVEL + "]"
                 );
             }
             this.qwpMaxRowsPerTable = getInt(properties, env, PropertyKey.QWP_MAX_ROWS_PER_TABLE, QwpConstants.DEFAULT_MAX_ROWS_PER_TABLE);
@@ -4212,6 +4229,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public int getQueryRegistryPoolSize() {
             return sqlQueryRegistryPoolSize;
+        }
+
+        @Override
+        public int getQwpEgressForcedZstdLevel() {
+            return qwpEgressForcedZstdLevel;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -597,6 +597,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     CAIRO_DEFAULT_SEQ_PART_TXN_COUNT("cairo.default.sequencer.part.txn.count"),
     POSTHOG_API_KEY("posthog.api.key"),
     POSTHOG_ENABLED("posthog.enabled"),
+    QWP_EGRESS_COMPRESSION_FORCE_LEVEL("qwp.egress.compression.force.level"),
     QWP_MAX_SCHEMAS_PER_CONNECTION("qwp.max.schemas.per.connection"),
     QWP_MAX_ROWS_PER_TABLE("qwp.max.rows.per.table"),
     QWP_MAX_TABLES_PER_CONNECTION("qwp.max.tables.per.connection"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -562,6 +562,31 @@ public interface CairoConfiguration {
     int getQueryRegistryPoolSize();
 
     /**
+     * Operator override for the zstd compression level used on QWP egress
+     * {@code RESULT_BATCH} frames. Default {@code 0} means "honor the
+     * client-negotiated level" -- the server uses whatever the client
+     * advertised via {@code X-QWP-Accept-Encoding}, clamped to the wire
+     * range {@code [COMPRESSION_ZSTD_MIN_LEVEL, COMPRESSION_ZSTD_MAX_LEVEL]}.
+     * <p>
+     * A value in {@code [1, 9]} forces every ZSTD-negotiated connection on
+     * this server to use that level regardless of what the client asked
+     * for; out-of-range values are clamped at the override site. A misbehaving
+     * client cannot raise the server's CPU spend above the operator's chosen
+     * ceiling. The {@code X-QWP-Content-Encoding} response header echoes
+     * the effective (post-override) level so the client can observe what was
+     * actually used.
+     * <p>
+     * Read from the configuration object on every handshake (not cached at
+     * processor construction), so a live config reload takes effect on the
+     * next new connection. Connections already established keep their
+     * already-built ZSTD contexts -- runtime mutation of an in-flight cctx
+     * level is not safe.
+     */
+    default int getQwpEgressForcedZstdLevel() {
+        return 0;
+    }
+
+    /**
      * Source of the role / cluster / node identity emitted in the QWP egress
      * {@code SERVER_INFO} frame. Default is the standalone OSS provider; the
      * Enterprise configuration overrides this with a provider backed by the

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -838,6 +838,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public int getQwpEgressForcedZstdLevel() {
+        return getDelegate().getQwpEgressForcedZstdLevel();
+    }
+
+    @Override
     public @NotNull QwpServerInfoProvider getQwpServerInfoProvider() {
         return getDelegate().getQwpServerInfoProvider();
     }

--- a/core/src/main/java/io/questdb/cairo/wal/ColumnarRowAppender.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ColumnarRowAppender.java
@@ -386,6 +386,23 @@ public interface ColumnarRowAppender {
     void putFixedToVarcharColumn(int columnIndex, QwpFixedWidthColumnCursor cursor, int rowCount);
 
     /**
+     * Writes a TYPE_INT wire column to an IPv4 column with NULL-sentinel translation.
+     * <p>
+     * INT and IPv4 share the 4-byte wire encoding but disagree on the NULL bit pattern
+     * ({@code Integer.MIN_VALUE} vs {@code 0}). The IPv4 ingress arm accepts TYPE_INT
+     * as a legacy-client migration path; this method walks the cursor per row and
+     * writes {@link Numbers#IPv4_NULL} (0) for {@code cursor.isNull()} rows, the int
+     * verbatim otherwise. Without this translation the no-bitmap memcpy fast path in
+     * {@code putFixedColumn} would land the INT_NULL bit pattern verbatim and the
+     * value would read back as the address {@code 128.0.0.0}.
+     *
+     * @param columnIndex the column index in the table
+     * @param cursor      the fixed-width column cursor (TYPE_INT wire type)
+     * @param rowCount    total number of rows
+     */
+    void putIntToIPv4Column(int columnIndex, QwpFixedWidthColumnCursor cursor, int rowCount);
+
+    /**
      * Writes a fixed-width float/double column to any DECIMAL column with scale conversion.
      * <p>
      * Reads floating-point values from the cursor via getDouble() and converts to

--- a/core/src/main/java/io/questdb/cairo/wal/ColumnarRowAppender.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ColumnarRowAppender.java
@@ -117,6 +117,16 @@ public interface ColumnarRowAppender {
                         int rowCount, int columnType) throws QwpParseException;
 
     /**
+     * Writes a BINARY column from raw byte slices delivered by the streaming string
+     * cursor (BINARY shares the VARCHAR wire layout).
+     *
+     * @param columnIndex the column index in the table
+     * @param cursor      the string column cursor (used as raw byte source)
+     * @param rowCount    total number of rows
+     */
+    void putBinaryColumn(int columnIndex, QwpStringColumnCursor cursor, int rowCount) throws QwpParseException;
+
+    /**
      * Writes a BOOLEAN column.
      * <p>
      * Boolean values are bit-packed in QWP v1 wire format but stored as bytes in WAL.

--- a/core/src/main/java/io/questdb/cairo/wal/ColumnarRowAppender.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ColumnarRowAppender.java
@@ -391,7 +391,7 @@ public interface ColumnarRowAppender {
      * INT and IPv4 share the 4-byte wire encoding but disagree on the NULL bit pattern
      * ({@code Integer.MIN_VALUE} vs {@code 0}). The IPv4 ingress arm accepts TYPE_INT
      * as a legacy-client migration path; this method walks the cursor per row and
-     * writes {@link Numbers#IPv4_NULL} (0) for {@code cursor.isNull()} rows, the int
+     * writes {@link io.questdb.std.Numbers#IPv4_NULL} (0) for {@code cursor.isNull()} rows, the int
      * verbatim otherwise. Without this translation the no-bitmap memcpy fast path in
      * {@code putFixedColumn} would land the INT_NULL bit pattern verbatim and the
      * value would read back as the address {@code 128.0.0.0}.

--- a/core/src/main/java/io/questdb/cairo/wal/WalColumnarRowAppender.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalColumnarRowAppender.java
@@ -204,6 +204,27 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
     }
 
     @Override
+    public void putBinaryColumn(int columnIndex, QwpStringColumnCursor cursor, int rowCount) throws QwpParseException {
+        checkInColumnarWrite();
+
+        MemoryMA dataMem = walWriter.getDataColumn(columnIndex);
+        MemoryMA auxMem = walWriter.getAuxColumn(columnIndex);
+
+        cursor.resetRowPosition();
+        for (int row = 0; row < rowCount; row++) {
+            cursor.advanceRow();
+            if (cursor.isNull()) {
+                auxMem.putLong(dataMem.putNullBin());
+            } else {
+                DirectUtf8Sequence value = cursor.getUtf8Value();
+                auxMem.putLong(dataMem.putBin(value.ptr(), value.size()));
+            }
+        }
+
+        walWriter.setRowValueNotNullColumnar(columnIndex, startRowId + rowCount - 1);
+    }
+
+    @Override
     public void putBooleanColumn(int columnIndex, QwpBooleanColumnCursor cursor, int rowCount) {
         checkInColumnarWrite();
 

--- a/core/src/main/java/io/questdb/cairo/wal/WalColumnarRowAppender.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalColumnarRowAppender.java
@@ -541,6 +541,16 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
                         }
                     }
                 }
+                case ColumnType.IPv4 -> {
+                    for (int row = 0; row < rowCount; row++) {
+                        if (QwpNullBitmap.isNull(nullBitmapAddress, row)) {
+                            dataMem.putInt(Numbers.IPv4_NULL);
+                        } else {
+                            dataMem.putInt(Unsafe.getInt(valuesAddress + (long) valueIdx * 4));
+                            valueIdx++;
+                        }
+                    }
+                }
                 case ColumnType.FLOAT -> {
                     for (int row = 0; row < rowCount; row++) {
                         if (QwpNullBitmap.isNull(nullBitmapAddress, row)) {

--- a/core/src/main/java/io/questdb/cairo/wal/WalColumnarRowAppender.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalColumnarRowAppender.java
@@ -849,6 +849,22 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
     }
 
     @Override
+    public void putIntToIPv4Column(int columnIndex, QwpFixedWidthColumnCursor cursor, int rowCount) {
+        checkInColumnarWrite();
+        MemoryMA dataMem = walWriter.getDataColumn(columnIndex);
+        cursor.resetRowPosition();
+        for (int row = 0; row < rowCount; row++) {
+            cursor.advanceRow();
+            if (cursor.isNull()) {
+                dataMem.putInt(Numbers.IPv4_NULL);
+            } else {
+                dataMem.putInt((int) cursor.getLong());
+            }
+        }
+        walWriter.setRowValueNotNullColumnar(columnIndex, startRowId + rowCount - 1);
+    }
+
+    @Override
     public void putFloatToDecimalColumn(
             int columnIndex,
             QwpFixedWidthColumnCursor cursor,
@@ -1928,6 +1944,13 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
             case TYPE_TIMESTAMP -> MicrosFormatUtils.appendDateTime(sink, cursor.getTimestamp());
             case TYPE_TIMESTAMP_NANOS -> MicrosFormatUtils.appendDateTime(sink, cursor.getTimestamp() / 1000);
             case TYPE_CHAR -> sink.putAscii((char) cursor.getShort());
+            // The IPv4 NULL sentinel (bit pattern 0) is filtered upstream by
+            // cursor.isNull() in the calling per-row loop (added together
+            // with the IPv4 arm in isCurrentValueSentinelNull); this arm
+            // only fires for non-null IPv4 values. Numbers.intToIPv4Sink
+            // would render 0 as "0.0.0.0" if called for a NULL row, but
+            // that path is unreachable here.
+            case TYPE_IPV4 -> Numbers.intToIPv4Sink(sink, (int) cursor.getLong());
             default -> throw CairoException.nonCritical()
                     .put("unsupported wire type for string conversion: ").put(ilpType);
         }

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
@@ -243,6 +243,19 @@ public class QwpWalAppender implements QuietCloseable {
      * Only types within the same family are allowed (e.g., integer↔integer, float↔float),
      * plus integer→float/double cross-family coercion.
      * Other cross-family coercions (e.g., UUID→SHORT) are rejected to prevent silent data corruption.
+     * <p>
+     * TYPE_IPV4 is intentionally absent from every arm. The IPv4 column type has its
+     * own dedicated arm in {@code appendToWalColumnar} that accepts TYPE_IPV4 and
+     * TYPE_INT sources (the latter as a legacy-client migration path with NULL
+     * sentinel translation). The reverse direction -- TYPE_IPV4 wire into a BYTE /
+     * SHORT / INT / LONG column -- is deliberately rejected: while the wire layout
+     * is bit-identical to TYPE_INT, the two NULL sentinels disagree (INT_NULL =
+     * Integer.MIN_VALUE, IPv4_NULL = 0). A valid IPv4 address with bit pattern
+     * Integer.MIN_VALUE (i.e. 128.0.0.0) would land as INT_NULL on the integer side
+     * and surface as SQL NULL on read -- a valid IP silently turning into NULL is
+     * a worse surprise than rejecting the coercion. Clients that hold int bits and
+     * want to ingest into an IPv4 column should send TYPE_INT and rely on the
+     * IPv4-arm migration path; nothing supports the reverse direction.
      */
     private static boolean isFixedTypeCoercionAllowed(byte qwpType, int columnType) {
         int colTag = ColumnType.tagOf(columnType);
@@ -510,15 +523,31 @@ public class QwpWalAppender implements QuietCloseable {
                     case ColumnType.IPv4 -> {
                         // IPv4 wire is 4 LE bytes, identical to INT. QuestDB stores IPv4 as
                         // a 4-byte int column with the bit pattern 0 reserved as NULL, so a
-                        // direct copy plus the standard null bitmap is correct. Clients that
-                        // start with a string IP literal should parse it on the client side
-                        // (Numbers.parseIPv4) and send the int via ipv4Column().
+                        // direct copy plus the standard null bitmap is correct for TYPE_IPV4
+                        // sources. Clients that start with a string IP literal should parse it
+                        // on the client side (Numbers.parseIPv4) and send the int via
+                        // ipv4Column().
+                        //
+                        // TYPE_INT is also accepted as a legacy-client migration path, but the
+                        // two types disagree on the NULL bit pattern (INT_NULL = MIN_VALUE
+                        // vs IPv4_NULL = 0). Route TYPE_INT through putIntToIPv4Column so the
+                        // per-row sentinel translation fires; the fast-path memcpy in
+                        // putFixedColumn would otherwise land MIN_VALUE verbatim and the value
+                        // would read back as 128.0.0.0 instead of NULL.
+                        //
+                        // The reverse direction (TYPE_IPV4 wire into a BYTE/SHORT/INT/LONG
+                        // column) is intentionally not symmetric -- see the Javadoc on
+                        // isFixedTypeCoercionAllowed for the NULL-sentinel reasoning.
                         if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor
                                 && (qwpType == TYPE_IPV4 || qwpType == TYPE_INT)
                                 && fixedCursor.getValueSize() == 4) {
-                            appender.putFixedColumn(columnIndex, fixedCursor.getValuesAddress(),
-                                    fixedCursor.getValueCount(), fixedCursor.getValueSize(),
-                                    fixedCursor.getNullBitmapAddress(), rowCount);
+                            if (qwpType == TYPE_INT) {
+                                appender.putIntToIPv4Column(columnIndex, fixedCursor, rowCount);
+                            } else {
+                                appender.putFixedColumn(columnIndex, fixedCursor.getValuesAddress(),
+                                        fixedCursor.getValueCount(), fixedCursor.getValueSize(),
+                                        fixedCursor.getNullBitmapAddress(), rowCount);
+                            }
                         } else {
                             throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
                         }
@@ -660,6 +689,18 @@ public class QwpWalAppender implements QuietCloseable {
                         }
                     }
                     case ColumnType.VARCHAR -> {
+                        // The BINARY arm above accepts both TYPE_BINARY and
+                        // TYPE_VARCHAR sources because their wire layouts match.
+                        // The reverse -- TYPE_BINARY into a VARCHAR target --
+                        // must be rejected: raw opaque bytes (possibly non-UTF-8)
+                        // landing in a column QuestDB treats as UTF-8 silently
+                        // breaks the VARCHAR invariant. Without this guard, the
+                        // QwpStringColumnCursor arm below pattern-matches by
+                        // class only and routes BINARY bytes through
+                        // putVarcharColumn unchecked.
+                        if (qwpType == TYPE_BINARY) {
+                            throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
+                        }
                         switch (cursor) {
                             case QwpStringColumnCursor strCursor ->
                                     appender.putVarcharColumn(columnIndex, strCursor, rowCount);

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
@@ -663,6 +663,13 @@ public class QwpWalAppender implements QuietCloseable {
                         }
                     }
                     case ColumnType.CHAR -> {
+                        // Same reasoning as the VARCHAR arm below: TYPE_BINARY
+                        // bytes must not silently land in a text-typed column
+                        // (the QwpStringColumnCursor branch would treat the
+                        // first byte(s) as a CHAR otherwise).
+                        if (qwpType == TYPE_BINARY) {
+                            throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
+                        }
                         if (cursor instanceof QwpStringColumnCursor strCursor) {
                             appender.putCharColumn(columnIndex, strCursor, rowCount);
                         } else if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor
@@ -727,6 +734,13 @@ public class QwpWalAppender implements QuietCloseable {
                         }
                     }
                     case ColumnType.STRING -> {
+                        // Symmetric to the VARCHAR guard above: TYPE_BINARY
+                        // bytes (possibly non-UTF-8) must not be reinterpreted
+                        // as text by putStringColumn, which feeds them through
+                        // Utf8s.directUtf8ToUtf16.
+                        if (qwpType == TYPE_BINARY) {
+                            throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
+                        }
                         switch (cursor) {
                             case QwpStringColumnCursor strCursor ->
                                     appender.putStringColumn(columnIndex, strCursor, rowCount);
@@ -753,6 +767,12 @@ public class QwpWalAppender implements QuietCloseable {
                         }
                     }
                     case ColumnType.SYMBOL -> {
+                        // Symmetric to the VARCHAR guard above: TYPE_BINARY
+                        // bytes (possibly non-UTF-8) must not be interned as a
+                        // symbol via putStringToSymbolColumn.
+                        if (qwpType == TYPE_BINARY) {
+                            throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
+                        }
                         switch (cursor) {
                             case QwpSymbolColumnCursor symCursor -> {
                                 if (symbolCache != null && symCursor.isDeltaMode()) {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
@@ -112,6 +112,7 @@ public class QwpWalAppender implements QuietCloseable {
             case TYPE_FLOAT -> ColumnType.FLOAT;
             case TYPE_DOUBLE -> ColumnType.DOUBLE;
             case TYPE_VARCHAR -> ColumnType.VARCHAR;
+            case TYPE_BINARY -> ColumnType.BINARY;
             case TYPE_SYMBOL -> ColumnType.SYMBOL;
             case TYPE_TIMESTAMP -> ColumnType.TIMESTAMP;
             case TYPE_TIMESTAMP_NANOS -> ColumnType.TIMESTAMP_NANO;
@@ -643,6 +644,19 @@ public class QwpWalAppender implements QuietCloseable {
                                     fixedCursor.getNullBitmapAddress(), rowCount);
                         } else {
                             throw typeMismatchException(qwpType, columnType, tableBlock, col);
+                        }
+                    }
+                    case ColumnType.BINARY -> {
+                        // BINARY accepts opaque byte payloads only -- TYPE_BINARY on the wire,
+                        // or TYPE_VARCHAR if the client routed bytes through the string layout
+                        // (the two share an identical offset+bytes encoding). Any other source
+                        // cursor would mean reinterpreting numeric or structured data as raw
+                        // bytes, which is almost always a user error, so reject it.
+                        if (cursor instanceof QwpStringColumnCursor strCursor
+                                && (qwpType == TYPE_BINARY || qwpType == TYPE_VARCHAR)) {
+                            appender.putBinaryColumn(columnIndex, strCursor, rowCount);
+                        } else {
+                            throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
                         }
                     }
                     case ColumnType.VARCHAR -> {

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
@@ -107,6 +107,7 @@ public class QwpWalAppender implements QuietCloseable {
             case TYPE_SHORT -> ColumnType.SHORT;
             case TYPE_CHAR -> ColumnType.CHAR;
             case TYPE_INT -> ColumnType.INT;
+            case TYPE_IPV4 -> ColumnType.IPv4;
             case TYPE_LONG -> ColumnType.LONG;
             case TYPE_FLOAT -> ColumnType.FLOAT;
             case TYPE_DOUBLE -> ColumnType.DOUBLE;
@@ -485,6 +486,22 @@ public class QwpWalAppender implements QuietCloseable {
 
                 // Regular columns
                 switch (ColumnType.tagOf(columnType)) {
+                    case ColumnType.IPv4 -> {
+                        // IPv4 wire is 4 LE bytes, identical to INT. QuestDB stores IPv4 as
+                        // a 4-byte int column with the bit pattern 0 reserved as NULL, so a
+                        // direct copy plus the standard null bitmap is correct. Clients that
+                        // start with a string IP literal should parse it on the client side
+                        // (Numbers.parseIPv4) and send the int via ipv4Column().
+                        if (cursor instanceof QwpFixedWidthColumnCursor fixedCursor
+                                && (qwpType == TYPE_IPV4 || qwpType == TYPE_INT)
+                                && fixedCursor.getValueSize() == 4) {
+                            appender.putFixedColumn(columnIndex, fixedCursor.getValuesAddress(),
+                                    fixedCursor.getValueCount(), fixedCursor.getValueSize(),
+                                    fixedCursor.getNullBitmapAddress(), rowCount);
+                        } else {
+                            throw coercionNotSupportedException(qwpType, columnType, tableBlock, col);
+                        }
+                    }
                     case ColumnType.BOOLEAN -> {
                         if (cursor instanceof QwpBooleanColumnCursor boolCursor) {
                             appender.putBooleanColumn(columnIndex, boolCursor, rowCount);

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpColumnDef.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpColumnDef.java
@@ -27,7 +27,27 @@ package io.questdb.cutlass.qwp.protocol;
 import java.nio.charset.StandardCharsets;
 
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_BOOLEAN;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_BYTE;
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_CHAR;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_DATE;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_DECIMAL128;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_DECIMAL256;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_DECIMAL64;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_DOUBLE;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_DOUBLE_ARRAY;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_FLOAT;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_GEOHASH;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_INT;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_IPV4;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_LONG;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_LONG256;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_LONG_ARRAY;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_SHORT;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_SYMBOL;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_TIMESTAMP;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_TIMESTAMP_NANOS;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_UUID;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_VARCHAR;
 
 /**
  * Represents a column definition in a QWP v1 schema.
@@ -138,14 +158,37 @@ public final class QwpColumnDef {
      * @throws QwpParseException if type code is invalid
      */
     public void validate() throws QwpParseException {
-        // Valid type codes: TYPE_BOOLEAN (0x01) through TYPE_CHAR (0x16)
-        // This includes all basic types, arrays, decimals, and char
-        boolean valid = (typeCode >= TYPE_BOOLEAN && typeCode <= TYPE_CHAR);
-        if (!valid) {
-            throw QwpParseException.create(
-                    QwpParseException.ErrorCode.INVALID_COLUMN_TYPE,
-                    "invalid column type code: 0x" + Integer.toHexString(typeCode)
-            );
+        // Explicit allowlist of ingest-supported wire types. BINARY (0x17) is defined
+        // by the egress codec but has no ingest decoder yet, so it stays rejected.
+        switch (typeCode) {
+            case TYPE_BOOLEAN:
+            case TYPE_BYTE:
+            case TYPE_SHORT:
+            case TYPE_INT:
+            case TYPE_LONG:
+            case TYPE_FLOAT:
+            case TYPE_DOUBLE:
+            case TYPE_SYMBOL:
+            case TYPE_TIMESTAMP:
+            case TYPE_DATE:
+            case TYPE_UUID:
+            case TYPE_LONG256:
+            case TYPE_GEOHASH:
+            case TYPE_VARCHAR:
+            case TYPE_TIMESTAMP_NANOS:
+            case TYPE_DOUBLE_ARRAY:
+            case TYPE_LONG_ARRAY:
+            case TYPE_DECIMAL64:
+            case TYPE_DECIMAL128:
+            case TYPE_DECIMAL256:
+            case TYPE_CHAR:
+            case TYPE_IPV4:
+                return;
+            default:
+                throw QwpParseException.create(
+                        QwpParseException.ErrorCode.INVALID_COLUMN_TYPE,
+                        "invalid column type code: 0x" + Integer.toHexString(typeCode & 0xFF)
+                );
         }
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpColumnDef.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpColumnDef.java
@@ -26,6 +26,7 @@ package io.questdb.cutlass.qwp.protocol;
 
 import java.nio.charset.StandardCharsets;
 
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_BINARY;
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_BOOLEAN;
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_BYTE;
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_CHAR;
@@ -158,8 +159,7 @@ public final class QwpColumnDef {
      * @throws QwpParseException if type code is invalid
      */
     public void validate() throws QwpParseException {
-        // Explicit allowlist of ingest-supported wire types. BINARY (0x17) is defined
-        // by the egress codec but has no ingest decoder yet, so it stays rejected.
+        // Explicit allowlist of ingest-supported wire types.
         switch (typeCode) {
             case TYPE_BOOLEAN:
             case TYPE_BYTE:
@@ -175,6 +175,7 @@ public final class QwpColumnDef {
             case TYPE_LONG256:
             case TYPE_GEOHASH:
             case TYPE_VARCHAR:
+            case TYPE_BINARY:
             case TYPE_TIMESTAMP_NANOS:
             case TYPE_DOUBLE_ARRAY:
             case TYPE_LONG_ARRAY:

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpConstants.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpConstants.java
@@ -339,7 +339,7 @@ public final class QwpConstants {
             case TYPE_BOOLEAN -> 0; // Special: bit-packed
             case TYPE_BYTE -> 1;
             case TYPE_SHORT, TYPE_CHAR -> 2;
-            case TYPE_INT, TYPE_FLOAT -> 4;
+            case TYPE_INT, TYPE_IPV4, TYPE_FLOAT -> 4;
             case TYPE_LONG, TYPE_DOUBLE, TYPE_TIMESTAMP, TYPE_TIMESTAMP_NANOS, TYPE_DATE, TYPE_DECIMAL64 -> 8;
             case TYPE_UUID, TYPE_DECIMAL128 -> 16;
             case TYPE_LONG256, TYPE_DECIMAL256 -> 32;
@@ -392,7 +392,7 @@ public final class QwpConstants {
     public static boolean isFixedWidthType(byte typeCode) {
         return switch (typeCode) {
             case TYPE_BOOLEAN, TYPE_BYTE, TYPE_SHORT, TYPE_CHAR,
-                 TYPE_INT, TYPE_LONG, TYPE_FLOAT, TYPE_DOUBLE,
+                 TYPE_INT, TYPE_IPV4, TYPE_LONG, TYPE_FLOAT, TYPE_DOUBLE,
                  TYPE_TIMESTAMP, TYPE_TIMESTAMP_NANOS, TYPE_DATE,
                  TYPE_UUID, TYPE_LONG256,
                  TYPE_DECIMAL64, TYPE_DECIMAL128, TYPE_DECIMAL256 -> true;

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpFixedWidthColumnCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpFixedWidthColumnCursor.java
@@ -31,7 +31,7 @@ import static io.questdb.cutlass.qwp.protocol.QwpConstants.*;
 /**
  * Streaming cursor for fixed-width column types.
  * <p>
- * Supports: BYTE, SHORT, INT, LONG, FLOAT, DOUBLE, DATE, UUID, LONG256.
+ * Supports: BYTE, SHORT, INT, IPv4, LONG, FLOAT, DOUBLE, DATE, UUID, LONG256.
  * <p>
  * Wire format:
  * <pre>
@@ -297,7 +297,7 @@ public final class QwpFixedWidthColumnCursor implements QwpColumnCursor {
         switch (typeCode) {
             case TYPE_BYTE -> currentLong = Unsafe.getByte(address);
             case TYPE_SHORT, TYPE_CHAR -> currentLong = Unsafe.getShort(address);
-            case TYPE_INT -> currentLong = Unsafe.getInt(address);
+            case TYPE_INT, TYPE_IPV4 -> currentLong = Unsafe.getInt(address);
             case TYPE_LONG, TYPE_DATE, TYPE_TIMESTAMP, TYPE_TIMESTAMP_NANOS -> currentLong = Unsafe.getLong(address);
             case TYPE_FLOAT -> currentDouble = Unsafe.getFloat(address);
             case TYPE_DOUBLE -> currentDouble = Unsafe.getDouble(address);

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpFixedWidthColumnCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpFixedWidthColumnCursor.java
@@ -301,8 +301,14 @@ public final class QwpFixedWidthColumnCursor implements QwpColumnCursor {
     private boolean isCurrentValueSentinelNull() {
         return switch (typeCode) {
             case TYPE_INT -> (int) currentLong == Numbers.INT_NULL;
+            case TYPE_IPV4 -> (int) currentLong == Numbers.IPv4_NULL;
             case TYPE_LONG, TYPE_DATE, TYPE_TIMESTAMP, TYPE_TIMESTAMP_NANOS -> currentLong == Numbers.LONG_NULL;
             case TYPE_FLOAT, TYPE_DOUBLE -> Double.isNaN(currentDouble);
+            case TYPE_UUID -> currentUuidLo == Numbers.LONG_NULL && currentUuidHi == Numbers.LONG_NULL;
+            case TYPE_LONG256 -> currentLong256_0 == Numbers.LONG_NULL
+                    && currentLong256_1 == Numbers.LONG_NULL
+                    && currentLong256_2 == Numbers.LONG_NULL
+                    && currentLong256_3 == Numbers.LONG_NULL;
             default -> false;
         };
     }

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpTableBlockCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpTableBlockCursor.java
@@ -480,7 +480,10 @@ public class QwpTableBlockCursor implements Mutable {
                 timestampColumnIndices[timestampColumnCount++] = colIndex;
                 yield tsCursor.of(dataAddress, dataLength, rowCount, typeCode, gorillaEnabled);
             }
-            case TYPE_VARCHAR -> {
+            case TYPE_VARCHAR, TYPE_BINARY -> {
+                // BINARY shares VARCHAR's wire layout (offsets + concatenated bytes),
+                // so the same streaming cursor decodes both. Callers branch on the
+                // column's declared type code when interpreting the byte payload.
                 QwpStringColumnCursor strCursor;
                 if (cursor instanceof QwpStringColumnCursor c) {
                     strCursor = c;

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpTableBlockCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpTableBlockCursor.java
@@ -457,7 +457,7 @@ public class QwpTableBlockCursor implements Mutable {
                 booleanColumnIndices[booleanColumnCount++] = colIndex;
                 yield boolCursor.of(dataAddress, dataLength, rowCount);
             }
-            case TYPE_BYTE, TYPE_SHORT, TYPE_CHAR, TYPE_INT, TYPE_LONG,
+            case TYPE_BYTE, TYPE_SHORT, TYPE_CHAR, TYPE_INT, TYPE_IPV4, TYPE_LONG,
                  TYPE_FLOAT, TYPE_DOUBLE, TYPE_DATE, TYPE_UUID, TYPE_LONG256 -> {
                 QwpFixedWidthColumnCursor fixedCursor;
                 if (cursor instanceof QwpFixedWidthColumnCursor c) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketHttpProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketHttpProcessor.java
@@ -29,6 +29,7 @@ import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpRequestHandler;
 import io.questdb.cutlass.http.HttpRequestHeader;
 import io.questdb.cutlass.http.HttpRequestProcessor;
+import io.questdb.cutlass.qwp.protocol.QwpConstants;
 import io.questdb.std.Numbers;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.Utf8Sequence;
@@ -134,6 +135,11 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
     // is not, so one '=' padding byte lands in slot 27). The exact 28 matches both.
     private static final int SHA1_DIGEST_SIZE = 20;
     private static final ThreadLocal<byte[]> HASH_SCRATCH = ThreadLocal.withInitial(() -> new byte[SHA1_DIGEST_SIZE]);
+    // Precomputed X-QWP-Version digit bytes indexed by version number. Lets the
+    // handshake response writer skip per-call Integer.toString + getBytes
+    // allocations since the negotiated version is always inside the closed set
+    // [VERSION_1, MAX_SUPPORTED_VERSION] the server itself defines.
+    private static final byte[][] VERSION_BYTES = buildVersionBytes();
     private static final byte[] WEBSOCKET_GUID_BYTES = WEBSOCKET_GUID.getBytes(StandardCharsets.US_ASCII);
     private final QwpWebSocketUpgradeProcessor processor;
 
@@ -281,15 +287,11 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
      * @return the total response size in bytes
      */
     public static int responseSize(String acceptKey, int qwpVersion) {
-        return responseSize(acceptKey, qwpVersion, null, false, null);
+        return responseSize(acceptKey, qwpVersion, null, false, null, null);
     }
 
-    public static int responseSize(String acceptKey, int qwpVersion, String contentEncoding) {
-        return responseSize(acceptKey, qwpVersion, contentEncoding, false, null);
-    }
-
-    public static int responseSize(String acceptKey, int qwpVersion, String contentEncoding, boolean durableAckEnabled, byte[] roleBytes) {
-        return responseSize(acceptKey, qwpVersion, contentEncoding, durableAckEnabled, roleBytes, 0);
+    public static int responseSize(String acceptKey, int qwpVersion, byte[] contentEncodingBytes, boolean durableAckEnabled, byte[] roleBytes) {
+        return responseSize(acceptKey, qwpVersion, contentEncodingBytes, durableAckEnabled, roleBytes, null);
     }
 
     /**
@@ -299,14 +301,16 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
      * header, an optional {@code X-QuestDB-Role} header advertising the
      * server role, and an optional {@code X-QWP-Max-Batch-Size} header
      * advertising the server's ingest payload cap in bytes. Pass {@code null}
-     * / {@code false} / {@code 0} to skip any of them.
+     * / {@code false} to skip any of them. All byte[] arguments are written
+     * verbatim, so callers are expected to cache them on the hot path rather
+     * than allocating per handshake.
      */
-    public static int responseSize(String acceptKey, int qwpVersion, String contentEncoding, boolean durableAckEnabled, byte[] roleBytes, int maxBatchSize) {
+    public static int responseSize(String acceptKey, int qwpVersion, byte[] contentEncodingBytes, boolean durableAckEnabled, byte[] roleBytes, byte[] maxBatchSizeBytes) {
         int size = RESPONSE_PREFIX.length + acceptKey.length()
-                + RESPONSE_AFTER_ACCEPT.length + digitCount(qwpVersion)
+                + RESPONSE_AFTER_ACCEPT.length + VERSION_BYTES[qwpVersion].length
                 + RESPONSE_SUFFIX.length;
-        if (contentEncoding != null) {
-            size += RESPONSE_CONTENT_ENCODING_PREFIX.length + contentEncoding.length();
+        if (contentEncodingBytes != null) {
+            size += RESPONSE_CONTENT_ENCODING_PREFIX.length + contentEncodingBytes.length;
         }
         if (durableAckEnabled) {
             size += RESPONSE_DURABLE_ACK_ENABLED.length;
@@ -314,8 +318,8 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         if (roleBytes != null) {
             size += RESPONSE_ROLE_PREFIX.length + roleBytes.length;
         }
-        if (maxBatchSize > 0) {
-            size += RESPONSE_MAX_BATCH_SIZE_PREFIX.length + intDigitCount(maxBatchSize);
+        if (maxBatchSizeBytes != null) {
+            size += RESPONSE_MAX_BATCH_SIZE_PREFIX.length + maxBatchSizeBytes.length;
         }
         return size;
     }
@@ -400,15 +404,11 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
      * @return the number of bytes written
      */
     public static int writeResponse(long buf, String acceptKey, int qwpVersion) {
-        return writeResponse(buf, acceptKey, qwpVersion, null, false, null);
+        return writeResponse(buf, acceptKey, qwpVersion, null, false, null, null);
     }
 
-    public static int writeResponse(long buf, String acceptKey, int qwpVersion, String contentEncoding) {
-        return writeResponse(buf, acceptKey, qwpVersion, contentEncoding, false, null);
-    }
-
-    public static int writeResponse(long buf, String acceptKey, int qwpVersion, String contentEncoding, boolean durableAckEnabled, byte[] roleBytes) {
-        return writeResponse(buf, acceptKey, qwpVersion, contentEncoding, durableAckEnabled, roleBytes, 0);
+    public static int writeResponse(long buf, String acceptKey, int qwpVersion, byte[] contentEncodingBytes, boolean durableAckEnabled, byte[] roleBytes) {
+        return writeResponse(buf, acceptKey, qwpVersion, contentEncodingBytes, durableAckEnabled, roleBytes, null);
     }
 
     /**
@@ -419,10 +419,12 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
      * will receive {@code STATUS_DURABLE_ACK} frames, an optional
      * {@code X-QuestDB-Role} header advertising the server role, and an
      * optional {@code X-QWP-Max-Batch-Size} header advertising the server's
-     * ingest payload cap in bytes. Pass {@code null} / {@code false} /
-     * {@code 0} to skip any of them.
+     * ingest payload cap in bytes. Pass {@code null} / {@code false} to skip
+     * any of them. All byte[] arguments are written verbatim, so callers are
+     * expected to cache them on the hot path rather than allocating per
+     * handshake.
      */
-    public static int writeResponse(long buf, String acceptKey, int qwpVersion, String contentEncoding, boolean durableAckEnabled, byte[] roleBytes, int maxBatchSize) {
+    public static int writeResponse(long buf, String acceptKey, int qwpVersion, byte[] contentEncodingBytes, boolean durableAckEnabled, byte[] roleBytes, byte[] maxBatchSizeBytes) {
         int offset = 0;
 
         for (byte b : RESPONSE_PREFIX) {
@@ -437,17 +439,15 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         for (byte b : RESPONSE_AFTER_ACCEPT) {
             Unsafe.putByte(buf + offset++, b);
         }
-        byte[] versionBytes = Integer.toString(qwpVersion).getBytes(StandardCharsets.US_ASCII);
-        for (byte b : versionBytes) {
+        for (byte b : VERSION_BYTES[qwpVersion]) {
             Unsafe.putByte(buf + offset++, b);
         }
 
-        if (contentEncoding != null) {
+        if (contentEncodingBytes != null) {
             for (byte b : RESPONSE_CONTENT_ENCODING_PREFIX) {
                 Unsafe.putByte(buf + offset++, b);
             }
-            byte[] encBytes = contentEncoding.getBytes(StandardCharsets.US_ASCII);
-            for (byte b : encBytes) {
+            for (byte b : contentEncodingBytes) {
                 Unsafe.putByte(buf + offset++, b);
             }
         }
@@ -472,12 +472,11 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
             }
         }
 
-        if (maxBatchSize > 0) {
+        if (maxBatchSizeBytes != null) {
             for (byte b : RESPONSE_MAX_BATCH_SIZE_PREFIX) {
                 Unsafe.putByte(buf + offset++, b);
             }
-            byte[] maxBatchBytes = Integer.toString(maxBatchSize).getBytes(StandardCharsets.US_ASCII);
-            for (byte b : maxBatchBytes) {
+            for (byte b : maxBatchSizeBytes) {
                 Unsafe.putByte(buf + offset++, b);
             }
         }
@@ -496,6 +495,14 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         // is required because resolveProcessorById() calls this after headers are
         // cleared (post-protocol-switch).
         return processor;
+    }
+
+    private static byte[][] buildVersionBytes() {
+        byte[][] table = new byte[QwpConstants.MAX_SUPPORTED_VERSION + 1][];
+        for (int v = QwpConstants.VERSION_1; v <= QwpConstants.MAX_SUPPORTED_VERSION; v++) {
+            table[v] = Integer.toString(v).getBytes(StandardCharsets.US_ASCII);
+        }
+        return table;
     }
 
     private static boolean containsUpgrade(Utf8Sequence seq) {
@@ -517,27 +524,5 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
             }
         }
         return false;
-    }
-
-    private static int digitCount(int value) {
-        if (value < 10) return 1;
-        if (value < 100) return 2;
-        return 3; // QWP version will not exceed 255
-    }
-
-    private static int intDigitCount(int value) {
-        if (value < 0) {
-            return Integer.toString(value).length();
-        }
-        if (value < 10) return 1;
-        if (value < 100) return 2;
-        if (value < 1_000) return 3;
-        if (value < 10_000) return 4;
-        if (value < 100_000) return 5;
-        if (value < 1_000_000) return 6;
-        if (value < 10_000_000) return 7;
-        if (value < 100_000_000) return 8;
-        if (value < 1_000_000_000) return 9;
-        return 10;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketHttpProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketHttpProcessor.java
@@ -414,7 +414,7 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
     /**
      * Same as {@link #writeResponse(long, String, int)} but appends an optional
      * {@code X-QWP-Content-Encoding} header echoing the negotiated compression
-     * codec (e.g. {@code zstd;level=3}), an optional
+     * codec (e.g. {@code zstd;level=1}), an optional
      * {@code X-QWP-Durable-Ack: enabled} confirmation that this connection
      * will receive {@code STATUS_DURABLE_ACK} frames, an optional
      * {@code X-QuestDB-Role} header advertising the server role, and an

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketHttpProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketHttpProcessor.java
@@ -108,6 +108,12 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
     // frames, so the client must fail at handshake rather than wait forever.
     private static final byte[] RESPONSE_DURABLE_ACK_ENABLED =
             "\r\nX-QWP-Durable-Ack: enabled".getBytes(StandardCharsets.US_ASCII);
+    // Advertises the server's hard cap on QWP message payload bytes so the
+    // ingest client can size its batches without trial-and-error. Without this
+    // hint a wide-row sender would have to discover the cap by sending an
+    // oversized batch and reacting to STATUS_PARSE_ERROR.
+    private static final byte[] RESPONSE_MAX_BATCH_SIZE_PREFIX =
+            "\r\nX-QWP-Max-Batch-Size: ".getBytes(StandardCharsets.US_ASCII);
     // Response template
     private static final byte[] RESPONSE_PREFIX =
             "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ".getBytes(StandardCharsets.US_ASCII);
@@ -282,14 +288,20 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         return responseSize(acceptKey, qwpVersion, contentEncoding, false, null);
     }
 
+    public static int responseSize(String acceptKey, int qwpVersion, String contentEncoding, boolean durableAckEnabled, byte[] roleBytes) {
+        return responseSize(acceptKey, qwpVersion, contentEncoding, durableAckEnabled, roleBytes, 0);
+    }
+
     /**
      * Same as {@link #responseSize(String, int)} but accounts for an optional
      * {@code X-QWP-Content-Encoding} header echoing the negotiated compression
      * codec, an optional {@code X-QWP-Durable-Ack: enabled} confirmation
-     * header, and an optional {@code X-QuestDB-Role} header advertising the
-     * server role. Pass {@code null} / {@code false} to skip any of them.
+     * header, an optional {@code X-QuestDB-Role} header advertising the
+     * server role, and an optional {@code X-QWP-Max-Batch-Size} header
+     * advertising the server's ingest payload cap in bytes. Pass {@code null}
+     * / {@code false} / {@code 0} to skip any of them.
      */
-    public static int responseSize(String acceptKey, int qwpVersion, String contentEncoding, boolean durableAckEnabled, byte[] roleBytes) {
+    public static int responseSize(String acceptKey, int qwpVersion, String contentEncoding, boolean durableAckEnabled, byte[] roleBytes, int maxBatchSize) {
         int size = RESPONSE_PREFIX.length + acceptKey.length()
                 + RESPONSE_AFTER_ACCEPT.length + digitCount(qwpVersion)
                 + RESPONSE_SUFFIX.length;
@@ -301,6 +313,9 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         }
         if (roleBytes != null) {
             size += RESPONSE_ROLE_PREFIX.length + roleBytes.length;
+        }
+        if (maxBatchSize > 0) {
+            size += RESPONSE_MAX_BATCH_SIZE_PREFIX.length + intDigitCount(maxBatchSize);
         }
         return size;
     }
@@ -392,16 +407,22 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         return writeResponse(buf, acceptKey, qwpVersion, contentEncoding, false, null);
     }
 
+    public static int writeResponse(long buf, String acceptKey, int qwpVersion, String contentEncoding, boolean durableAckEnabled, byte[] roleBytes) {
+        return writeResponse(buf, acceptKey, qwpVersion, contentEncoding, durableAckEnabled, roleBytes, 0);
+    }
+
     /**
      * Same as {@link #writeResponse(long, String, int)} but appends an optional
      * {@code X-QWP-Content-Encoding} header echoing the negotiated compression
      * codec (e.g. {@code zstd;level=3}), an optional
      * {@code X-QWP-Durable-Ack: enabled} confirmation that this connection
-     * will receive {@code STATUS_DURABLE_ACK} frames, and an optional
-     * {@code X-QuestDB-Role} header advertising the server role.
-     * Pass {@code null} / {@code false} to skip any of them.
+     * will receive {@code STATUS_DURABLE_ACK} frames, an optional
+     * {@code X-QuestDB-Role} header advertising the server role, and an
+     * optional {@code X-QWP-Max-Batch-Size} header advertising the server's
+     * ingest payload cap in bytes. Pass {@code null} / {@code false} /
+     * {@code 0} to skip any of them.
      */
-    public static int writeResponse(long buf, String acceptKey, int qwpVersion, String contentEncoding, boolean durableAckEnabled, byte[] roleBytes) {
+    public static int writeResponse(long buf, String acceptKey, int qwpVersion, String contentEncoding, boolean durableAckEnabled, byte[] roleBytes, int maxBatchSize) {
         int offset = 0;
 
         for (byte b : RESPONSE_PREFIX) {
@@ -451,6 +472,16 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
             }
         }
 
+        if (maxBatchSize > 0) {
+            for (byte b : RESPONSE_MAX_BATCH_SIZE_PREFIX) {
+                Unsafe.putByte(buf + offset++, b);
+            }
+            byte[] maxBatchBytes = Integer.toString(maxBatchSize).getBytes(StandardCharsets.US_ASCII);
+            for (byte b : maxBatchBytes) {
+                Unsafe.putByte(buf + offset++, b);
+            }
+        }
+
         for (byte b : RESPONSE_SUFFIX) {
             Unsafe.putByte(buf + offset++, b);
         }
@@ -492,5 +523,21 @@ public class QwpWebSocketHttpProcessor implements HttpRequestHandler {
         if (value < 10) return 1;
         if (value < 100) return 2;
         return 3; // QWP version will not exceed 255
+    }
+
+    private static int intDigitCount(int value) {
+        if (value < 0) {
+            return Integer.toString(value).length();
+        }
+        if (value < 10) return 1;
+        if (value < 100) return 2;
+        if (value < 1_000) return 3;
+        if (value < 10_000) return 4;
+        if (value < 100_000) return 5;
+        if (value < 1_000_000) return 6;
+        if (value < 10_000_000) return 7;
+        if (value < 100_000_000) return 8;
+        if (value < 1_000_000_000) return 9;
+        return 10;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
@@ -92,6 +92,12 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
                     \r
                     """).getBytes(StandardCharsets.US_ASCII);
     // Dependencies for ILP processing (safe as instance fields — config only)
+    // Precomputed X-QWP-Max-Batch-Size header bytes, cached because the
+    // effective cap is derived from recvBufferSize (config-fixed for the
+    // lifetime of this processor) and would otherwise allocate a String and
+    // a byte[] on every handshake. Null when the cap collapses to zero,
+    // which omits the header entirely.
+    private final byte[] effectiveMaxBatchSizeBytes;
     private final CairoEngine engine;
     private final int forceRecvFragmentationChunkSize;
     // WebSocket frame parser (scratchpad — fully reset within each processWebSocketFrames call)
@@ -106,6 +112,18 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
                 .getForceRecvFragmentationChunkSize();
         this.httpConfiguration = httpConfiguration;
         this.recvBufferSize = httpConfiguration.getRecvBufferSize();
+        // Advertise the effective batch cap, not the QWP protocol ceiling. The
+        // HTTP recv buffer is the actual binding constraint on inbound
+        // WebSocket frame size, and it is checked before the QWP parser ever
+        // sees the payload -- a frame larger than recv-buffer minus the
+        // worst-case WebSocket frame header gets closed with code 1009 long
+        // before STATUS_PARSE_ERROR can fire.
+        int effectiveMaxBatchSize = Math.min(
+                Math.max(0, recvBufferSize - MAX_WS_FRAME_HEADER_BYTES),
+                QwpConstants.DEFAULT_MAX_BATCH_SIZE);
+        this.effectiveMaxBatchSizeBytes = effectiveMaxBatchSize > 0
+                ? Integer.toString(effectiveMaxBatchSize).getBytes(StandardCharsets.US_ASCII)
+                : null;
         this.maxResponseContentLength = httpConfiguration.getSendBufferSize();
     }
 
@@ -296,18 +314,9 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
                 && Utf8s.equalsIgnoreCaseAscii(durableAckHeader, QwpWebSocketHttpProcessor.HEADER_VALUE_DURABLE_ACK_ENABLED);
         boolean durableAckEnabled = durableAckRequested && engine.getDurableAckRegistry().isEnabled();
 
-        // Advertise the *effective* batch cap, not the QWP protocol ceiling.
-        // The HTTP recv buffer is the actual binding constraint on inbound
-        // WebSocket frame size, and it is checked before the QWP parser ever
-        // sees the payload; a frame larger than recv-buffer minus the
-        // worst-case WebSocket frame header gets closed with code 1009 long
-        // before STATUS_PARSE_ERROR can fire.
-        int effectiveMaxBatchSize = Math.min(
-                Math.max(0, recvBufferSize - MAX_WS_FRAME_HEADER_BYTES),
-                QwpConstants.DEFAULT_MAX_BATCH_SIZE);
         int requiredHandshakeSize = QwpWebSocketHttpProcessor.responseSize(
                 acceptKey, negotiatedVersion, null, durableAckEnabled, roleBytes,
-                effectiveMaxBatchSize);
+                effectiveMaxBatchSizeBytes);
         if (requiredHandshakeSize > bufferSize) {
             throw responseDoesNotFitSendBuffer(context.getFd(), "101 handshake response", bufferSize, requiredHandshakeSize);
         }
@@ -333,7 +342,7 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
         // Write the 101 Switching Protocols response (reuse the pre-computed accept key)
         int bytesWritten = QwpWebSocketHttpProcessor.writeResponse(
                 bufferAddr, acceptKey, negotiatedVersion, null, durableAckEnabled, roleBytes,
-                effectiveMaxBatchSize);
+                effectiveMaxBatchSizeBytes);
         if (bytesWritten <= 0) {
             throw responseDoesNotFitSendBuffer(context.getFd(), "101 handshake response", bufferSize, requiredHandshakeSize);
         }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
@@ -71,6 +71,11 @@ import static io.questdb.cutlass.qwp.protocol.QwpConstants.*;
 public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
     // Cumulative ACK batch size
     private static final int ACK_BATCH_SIZE = 8;
+    // Worst-case WebSocket frame header size (2-byte base + 8-byte 64-bit
+    // extended length + 4-byte mask for client->server frames). Subtracted
+    // from the recv buffer when computing the effective batch cap so the
+    // advertised value still leaves room for the frame header on the wire.
+    private static final int MAX_WS_FRAME_HEADER_BYTES = 14;
     // HTTP response templates
     private static final byte[] BAD_REQUEST_PREFIX =
             "HTTP/1.1 400 Bad Request\r\nContent-Type: text/plain\r\nContent-Length: ".getBytes(StandardCharsets.US_ASCII);
@@ -291,9 +296,18 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
                 && Utf8s.equalsIgnoreCaseAscii(durableAckHeader, QwpWebSocketHttpProcessor.HEADER_VALUE_DURABLE_ACK_ENABLED);
         boolean durableAckEnabled = durableAckRequested && engine.getDurableAckRegistry().isEnabled();
 
+        // Advertise the *effective* batch cap, not the QWP protocol ceiling.
+        // The HTTP recv buffer is the actual binding constraint on inbound
+        // WebSocket frame size, and it is checked before the QWP parser ever
+        // sees the payload; a frame larger than recv-buffer minus the
+        // worst-case WebSocket frame header gets closed with code 1009 long
+        // before STATUS_PARSE_ERROR can fire.
+        int effectiveMaxBatchSize = Math.min(
+                Math.max(0, recvBufferSize - MAX_WS_FRAME_HEADER_BYTES),
+                QwpConstants.DEFAULT_MAX_BATCH_SIZE);
         int requiredHandshakeSize = QwpWebSocketHttpProcessor.responseSize(
                 acceptKey, negotiatedVersion, null, durableAckEnabled, roleBytes,
-                QwpConstants.DEFAULT_MAX_BATCH_SIZE);
+                effectiveMaxBatchSize);
         if (requiredHandshakeSize > bufferSize) {
             throw responseDoesNotFitSendBuffer(context.getFd(), "101 handshake response", bufferSize, requiredHandshakeSize);
         }
@@ -319,7 +333,7 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
         // Write the 101 Switching Protocols response (reuse the pre-computed accept key)
         int bytesWritten = QwpWebSocketHttpProcessor.writeResponse(
                 bufferAddr, acceptKey, negotiatedVersion, null, durableAckEnabled, roleBytes,
-                QwpConstants.DEFAULT_MAX_BATCH_SIZE);
+                effectiveMaxBatchSize);
         if (bytesWritten <= 0) {
             throw responseDoesNotFitSendBuffer(context.getFd(), "101 handshake response", bufferSize, requiredHandshakeSize);
         }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
@@ -291,7 +291,9 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
                 && Utf8s.equalsIgnoreCaseAscii(durableAckHeader, QwpWebSocketHttpProcessor.HEADER_VALUE_DURABLE_ACK_ENABLED);
         boolean durableAckEnabled = durableAckRequested && engine.getDurableAckRegistry().isEnabled();
 
-        int requiredHandshakeSize = QwpWebSocketHttpProcessor.responseSize(acceptKey, negotiatedVersion, null, durableAckEnabled, roleBytes);
+        int requiredHandshakeSize = QwpWebSocketHttpProcessor.responseSize(
+                acceptKey, negotiatedVersion, null, durableAckEnabled, roleBytes,
+                QwpConstants.DEFAULT_MAX_BATCH_SIZE);
         if (requiredHandshakeSize > bufferSize) {
             throw responseDoesNotFitSendBuffer(context.getFd(), "101 handshake response", bufferSize, requiredHandshakeSize);
         }
@@ -315,7 +317,9 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
         state.setDurableAckEnabled(durableAckEnabled);
 
         // Write the 101 Switching Protocols response (reuse the pre-computed accept key)
-        int bytesWritten = QwpWebSocketHttpProcessor.writeResponse(bufferAddr, acceptKey, negotiatedVersion, null, durableAckEnabled, roleBytes);
+        int bytesWritten = QwpWebSocketHttpProcessor.writeResponse(
+                bufferAddr, acceptKey, negotiatedVersion, null, durableAckEnabled, roleBytes,
+                QwpConstants.DEFAULT_MAX_BATCH_SIZE);
         if (bytesWritten <= 0) {
             throw responseDoesNotFitSendBuffer(context.getFd(), "101 handshake response", bufferSize, requiredHandshakeSize);
         }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressCompressionNegotiator.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressCompressionNegotiator.java
@@ -34,7 +34,7 @@ import java.nio.charset.StandardCharsets;
  * first codec the server supports. The header follows HTTP's
  * {@code Accept-Encoding} grammar loosely:
  * <pre>
- *     X-QWP-Accept-Encoding: zstd;level=3, raw
+ *     X-QWP-Accept-Encoding: zstd;level=1, raw
  * </pre>
  * Tokens are matched case-insensitively and separated by commas. Parameters
  * (the {@code ;level=N} segment) are recognised only for {@code zstd}. The
@@ -126,6 +126,38 @@ public final class QwpEgressCompressionNegotiator {
     }
 
     /**
+     * Applies the operator-side forced-level override, if any, on top of the
+     * client-negotiated zstd level. Returns the level the server should
+     * actually use for the connection's encoder and echo back in the
+     * {@code X-QWP-Content-Encoding} response header.
+     * <ul>
+     *   <li>{@code forcedLevel == 0} -- no override; honor the client's
+     *       choice verbatim.</li>
+     *   <li>{@code negotiatedCodec != COMPRESSION_ZSTD} -- override is a
+     *       no-op; raw transport stays raw.</li>
+     *   <li>Otherwise the forced level wins, clamped into
+     *       {@code [COMPRESSION_ZSTD_MIN_LEVEL, COMPRESSION_ZSTD_MAX_LEVEL]}
+     *       as defense-in-depth so a misconfigured property can't escape the
+     *       wire-allowed range.</li>
+     * </ul>
+     * The operator override deliberately ignores the client's request: an
+     * operator capping a misbehaving client at level 1 must beat a client
+     * that asks for level 9.
+     */
+    public static byte resolveEffectiveZstdLevel(byte negotiatedCodec, byte negotiatedLevel, int forcedLevel) {
+        if (forcedLevel == 0 || negotiatedCodec != QwpConstants.COMPRESSION_ZSTD) {
+            return negotiatedLevel;
+        }
+        if (forcedLevel < QwpConstants.COMPRESSION_ZSTD_MIN_LEVEL) {
+            return (byte) QwpConstants.COMPRESSION_ZSTD_MIN_LEVEL;
+        }
+        if (forcedLevel > QwpConstants.COMPRESSION_ZSTD_MAX_LEVEL) {
+            return (byte) QwpConstants.COMPRESSION_ZSTD_MAX_LEVEL;
+        }
+        return (byte) forcedLevel;
+    }
+
+    /**
      * Returns the precomputed {@code X-QWP-Content-Encoding} response header
      * bytes for the negotiated codec, or {@code null} when the server chose
      * raw transport (the header is then omitted entirely). The returned array
@@ -170,13 +202,14 @@ public final class QwpEgressCompressionNegotiator {
     }
 
     /**
-     * Accepts either {@code level=N} or {@code N} (bare integer). Returns 3 as
-     * the default when the parameter is missing or unparseable so behaviour
-     * stays well-defined on malformed input.
+     * Accepts either {@code level=N} or {@code N} (bare integer). Returns 1 as
+     * the default when the parameter is missing or unparseable -- the cheapest
+     * zstd level, picked so a client that opts in to compression without
+     * naming a level doesn't pay surprise server-side CPU.
      */
     private static int parseLevel(Utf8Sequence seq, int start, int end) {
         if (start < 0 || end <= start) {
-            return 3;
+            return 1;
         }
         while (start < end && isAsciiWhitespace(seq.byteAt(start))) {
             start++;
@@ -215,7 +248,7 @@ public final class QwpEgressCompressionNegotiator {
             }
             start++;
         }
-        return anyDigit ? value : 3;
+        return anyDigit ? value : 1;
     }
 
     private static byte toLowerAscii(byte b) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressCompressionNegotiator.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressCompressionNegotiator.java
@@ -27,6 +27,8 @@ package io.questdb.cutlass.qwp.server.egress;
 import io.questdb.cutlass.qwp.protocol.QwpConstants;
 import io.questdb.std.str.Utf8Sequence;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Parses the {@code X-QWP-Accept-Encoding} handshake header and picks the
  * first codec the server supports. The header follows HTTP's
@@ -50,6 +52,13 @@ public final class QwpEgressCompressionNegotiator {
      * Sentinel returned when the header is absent or no supported codec is listed.
      */
     public static final long RESULT_NONE = 0L;
+    // Precomputed X-QWP-Content-Encoding header bytes per zstd level so the
+    // handshake response writer avoids a per-call String concatenation +
+    // getBytes allocation. Levels outside [COMPRESSION_ZSTD_MIN_LEVEL,
+    // COMPRESSION_ZSTD_MAX_LEVEL] are never produced by negotiate() and any
+    // out-of-band lookup will trip ArrayIndexOutOfBoundsException -- a loud
+    // failure is preferred over silently returning a wrong/raw header value.
+    private static final byte[][] ZSTD_LEVEL_BYTES = buildZstdLevelBytes();
 
     private QwpEgressCompressionNegotiator() {
     }
@@ -117,15 +126,24 @@ public final class QwpEgressCompressionNegotiator {
     }
 
     /**
-     * Renders the negotiated codec as a value for the
-     * {@code X-QWP-Content-Encoding} response header, or {@code null} when the
-     * server chose raw transport (the header is then omitted entirely).
+     * Returns the precomputed {@code X-QWP-Content-Encoding} response header
+     * bytes for the negotiated codec, or {@code null} when the server chose
+     * raw transport (the header is then omitted entirely). The returned array
+     * is interned in a static table -- callers must not mutate it.
      */
-    public static String responseHeaderValue(byte codec, byte level) {
+    public static byte[] responseHeaderValue(byte codec, byte level) {
         if (codec == QwpConstants.COMPRESSION_ZSTD) {
-            return "zstd;level=" + (level & 0xFF);
+            return ZSTD_LEVEL_BYTES[level & 0xFF];
         }
         return null;
+    }
+
+    private static byte[][] buildZstdLevelBytes() {
+        byte[][] table = new byte[QwpConstants.COMPRESSION_ZSTD_MAX_LEVEL + 1][];
+        for (int level = QwpConstants.COMPRESSION_ZSTD_MIN_LEVEL; level <= QwpConstants.COMPRESSION_ZSTD_MAX_LEVEL; level++) {
+            table[level] = ("zstd;level=" + level).getBytes(StandardCharsets.US_ASCII);
+        }
+        return table;
     }
 
     private static boolean isAsciiWhitespace(byte b) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressUpgradeProcessor.java
@@ -308,8 +308,16 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
         long negotiatedCompression = QwpEgressCompressionNegotiator.negotiate(acceptEncoding);
         byte negotiatedCodec = QwpEgressCompressionNegotiator.codec(negotiatedCompression);
         byte negotiatedLevel = QwpEgressCompressionNegotiator.level(negotiatedCompression);
+        // Apply the operator's force-level override (if any). Read from the
+        // live configuration on every handshake -- a hot config reload picks
+        // up the new value on the next new connection. Already-established
+        // connections keep their negotiated level since the ZSTD context is
+        // built once and mutating its level mid-stream is not safe.
+        byte effectiveLevel = QwpEgressCompressionNegotiator.resolveEffectiveZstdLevel(
+                negotiatedCodec, negotiatedLevel,
+                engine.getConfiguration().getQwpEgressForcedZstdLevel());
         byte[] contentEncodingHeaderBytes = QwpEgressCompressionNegotiator.responseHeaderValue(
-                negotiatedCodec, negotiatedLevel);
+                negotiatedCodec, effectiveLevel);
 
         String acceptKey = QwpWebSocketHttpProcessor.computeAcceptKey(wsKey);
         int requiredHandshakeSize = QwpWebSocketHttpProcessor.responseSize(
@@ -337,7 +345,7 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
         }
         state.of(context.getFd(), context.getSecurityContext());
         state.setNegotiatedVersion((byte) negotiatedVersion);
-        state.setCompression(negotiatedCodec, negotiatedLevel);
+        state.setCompression(negotiatedCodec, effectiveLevel);
         // Optional client preference for per-batch row cap. Absent or malformed
         // header falls back to the server's hard cap. Values outside [1, MAX]
         // are clamped rather than rejected so one buggy client doesn't break

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressUpgradeProcessor.java
@@ -308,12 +308,12 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
         long negotiatedCompression = QwpEgressCompressionNegotiator.negotiate(acceptEncoding);
         byte negotiatedCodec = QwpEgressCompressionNegotiator.codec(negotiatedCompression);
         byte negotiatedLevel = QwpEgressCompressionNegotiator.level(negotiatedCompression);
-        String contentEncodingHeader = QwpEgressCompressionNegotiator.responseHeaderValue(
+        byte[] contentEncodingHeaderBytes = QwpEgressCompressionNegotiator.responseHeaderValue(
                 negotiatedCodec, negotiatedLevel);
 
         String acceptKey = QwpWebSocketHttpProcessor.computeAcceptKey(wsKey);
         int requiredHandshakeSize = QwpWebSocketHttpProcessor.responseSize(
-                acceptKey, negotiatedVersion, contentEncodingHeader, false, null);
+                acceptKey, negotiatedVersion, contentEncodingHeaderBytes, false, null);
         // v2 appends a SERVER_INFO WebSocket frame right after the 101 response
         // bytes, in the same send buffer. Reserve an upper-bound for the frame so
         // a tiny send buffer that would fit the 101 response alone but not the
@@ -354,7 +354,7 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
         state.setMaxBatchRows(effectiveMaxBatchRows);
 
         int bytesWritten = QwpWebSocketHttpProcessor.writeResponse(
-                bufferAddr, acceptKey, negotiatedVersion, contentEncodingHeader, false, null);
+                bufferAddr, acceptKey, negotiatedVersion, contentEncodingHeaderBytes, false, null);
         // For v2 and above, append an unsolicited SERVER_INFO WebSocket frame to
         // the same send buffer. The client reads it as the first frame after the
         // upgrade handshake completes, which lets it route reads to primary vs

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -981,6 +981,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "posthog.enabled\tQDB_POSTHOG_ENABLED\tfalse\tdefault\tfalse\tfalse\n" +
                                     "posthog.api.key\tQDB_POSTHOG_API_KEY\t\tdefault\tfalse\tfalse\n" +
                                     "query.timeout.sec\tQDB_QUERY_TIMEOUT_SEC\t60\tdefault\tfalse\tfalse\n" +
+                                    "qwp.egress.compression.force.level\tQDB_QWP_EGRESS_COMPRESSION_FORCE_LEVEL\t0\tdefault\tfalse\ttrue\n" +
                                     "qwp.max.rows.per.table\tQDB_QWP_MAX_ROWS_PER_TABLE\t1000000\tdefault\tfalse\tfalse\n" +
                                     "qwp.max.schemas.per.connection\tQDB_QWP_MAX_SCHEMAS_PER_CONNECTION\t65535\tdefault\tfalse\tfalse\n" +
                                     "qwp.max.tables.per.connection\tQDB_QWP_MAX_TABLES_PER_CONNECTION\t10000\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderTest.java
@@ -847,8 +847,20 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
             // large batch's first row triggers newRow(), it rolls to a new segment,
             // opening new column files via ff.openRW(). We intercept that to know
             // the server has started processing and then trigger the rename.
+            //
+            // We also need to pause the batch on the first matching openRW until
+            // the rename has committed its structural change to the sequencer.
+            // Otherwise the batch's sequencer.nextTxn (commit) can win the race
+            // against the rename's sequencer.nextStructureTxn — both serialize
+            // through the same sequencer WRITE lock, and the test depends on the
+            // rename arriving first so the batch commit sees a token mismatch and
+            // is rejected via TableReferenceOutOfDateException -> 503. Only the
+            // first matching openRW is blocked, so the rename's own openRW for
+            // its wal2/0 segment is not blocked and cannot deadlock.
             CountDownLatch walSegmentRolled = new CountDownLatch(1);
+            CountDownLatch renameRegistered = new CountDownLatch(1);
             AtomicBoolean trackOpens = new AtomicBoolean(false);
+            AtomicBoolean batchPausedOnce = new AtomicBoolean(false);
 
             FilesFacade ff = new TestFilesFacadeImpl() {
                 @Override
@@ -859,6 +871,13 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
                             && Utf8s.containsAscii(name, "wal")
                             && Utf8s.endsWithAscii(name, ".d")) {
                         walSegmentRolled.countDown();
+                        if (batchPausedOnce.compareAndSet(false, true)) {
+                            try {
+                                renameRegistered.await(60, TimeUnit.SECONDS);
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                            }
+                        }
                     }
                     return fd;
                 }
@@ -947,8 +966,16 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
                 Assert.assertTrue("Timed out waiting for WAL segment roll",
                         walSegmentRolled.await(60, TimeUnit.SECONDS));
 
-                // Rename the table while the server is processing the large batch
+                // Rename the table while the server is processing the large batch.
+                // The batch's first column-file openRW is parked, so this RENAME
+                // is guaranteed to register its structural change on the sequencer
+                // before the batch can call sequencer.nextTxn at commit time.
                 serverMain.execute("RENAME TABLE " + tableName + " TO " + renamedTableName);
+
+                // Unblock the batch now that the rename's structural change is on
+                // the sequencer. The batch's commit will see the new table token
+                // and the sequencer will throw TableReferenceOutOfDateException.
+                renameRegistered.countDown();
 
                 // Create a new table with the original name
                 serverMain.execute("CREATE TABLE " + tableName + " (" +

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpColumnDefTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpColumnDefTest.java
@@ -49,6 +49,7 @@ public class QwpColumnDefTest {
                 QwpConstants.TYPE_LONG256,
                 QwpConstants.TYPE_GEOHASH,
                 QwpConstants.TYPE_VARCHAR,
+                QwpConstants.TYPE_BINARY,
                 QwpConstants.TYPE_TIMESTAMP_NANOS,
                 QwpConstants.TYPE_DOUBLE_ARRAY,
                 QwpConstants.TYPE_LONG_ARRAY,
@@ -83,7 +84,10 @@ public class QwpColumnDefTest {
 
     @Test(expected = QwpParseException.class)
     public void testValidateRejectsInvalidType() throws QwpParseException {
-        QwpColumnDef col = new QwpColumnDef("bad", (byte) 0x17);
+        // 0x19 sits just past TYPE_IPv4 (0x18) and is not currently assigned
+        // to any QWP wire type. If a new type lands at 0x19, pick another
+        // unassigned byte to keep this rejection coverage meaningful.
+        QwpColumnDef col = new QwpColumnDef("bad", (byte) 0x19);
         col.validate();
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpColumnDefTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpColumnDefTest.java
@@ -56,6 +56,7 @@ public class QwpColumnDefTest {
                 QwpConstants.TYPE_DECIMAL128,
                 QwpConstants.TYPE_DECIMAL256,
                 QwpConstants.TYPE_CHAR,
+                QwpConstants.TYPE_IPV4,
         };
         for (byte type : validTypes) {
             QwpColumnDef col = new QwpColumnDef("col", type);

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpCursorBoundsCheckTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpCursorBoundsCheckTest.java
@@ -479,6 +479,7 @@ public class QwpCursorBoundsCheckTest {
             case TYPE_SHORT:
             case TYPE_CHAR:
             case TYPE_INT:
+            case TYPE_IPV4:
             case TYPE_LONG:
             case TYPE_DATE:
                 acc = table.getFixedWidthColumn(col).getLong();
@@ -644,6 +645,7 @@ public class QwpCursorBoundsCheckTest {
         QwpTableBuffer.ColumnBuffer uuidCol = buffer.getOrCreateColumn("b_uuid", TYPE_UUID, true);
         QwpTableBuffer.ColumnBuffer long256Col = buffer.getOrCreateColumn("b_l256", TYPE_LONG256, true);
         QwpTableBuffer.ColumnBuffer geoCol = buffer.getOrCreateColumn("b_geo", TYPE_GEOHASH, true);
+        QwpTableBuffer.ColumnBuffer ipv4Col = buffer.getOrCreateColumn("b_ipv4", TYPE_IPV4, true);
         QwpTableBuffer.ColumnBuffer dec64Col = buffer.getOrCreateColumn("b_dec64", TYPE_DECIMAL64, true);
         QwpTableBuffer.ColumnBuffer dec128Col = buffer.getOrCreateColumn("b_dec128", TYPE_DECIMAL128, true);
         QwpTableBuffer.ColumnBuffer dec256Col = buffer.getOrCreateColumn("b_dec256", TYPE_DECIMAL256, true);
@@ -695,6 +697,8 @@ public class QwpCursorBoundsCheckTest {
                 uuidCol.addUuid(rnd.nextLong(), rnd.nextLong());
                 long256Col.addLong256(rnd.nextLong(), rnd.nextLong(), rnd.nextLong(), rnd.nextLong());
                 geoCol.addGeoHash(rnd.nextGeoHashLong(30), 30);
+                // OR a high bit to keep the address out of the 0.0.0.0 NULL sentinel.
+                ipv4Col.addIPv4(rnd.nextInt() | 0x01000000);
                 dec64Col.addDecimal64(new Decimal64((long) rnd.nextInt(100_000) - 50_000L, 2));
                 dec128Col.addDecimal128(Decimal128.fromLong((long) rnd.nextInt(1_000_000) - 500_000L, 4));
                 dec256Col.addDecimal256(Decimal256.fromLong((long) rnd.nextInt(10_000_000) - 5_000_000L, 5));
@@ -706,6 +710,7 @@ public class QwpCursorBoundsCheckTest {
                 uuidCol.addNull();
                 long256Col.addNull();
                 geoCol.addNull();
+                ipv4Col.addNull();
                 dec64Col.addNull();
                 dec128Col.addNull();
                 dec256Col.addNull();

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpCursorBoundsCheckTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpCursorBoundsCheckTest.java
@@ -500,6 +500,9 @@ public class QwpCursorBoundsCheckTest {
                 break;
             }
             case TYPE_VARCHAR:
+            case TYPE_BINARY:
+                // BINARY shares VARCHAR's wire layout, so the string cursor decodes
+                // both. We only sample the byte length to fold into the checksum.
                 acc = table.getStringColumn(col).getUtf8Value().size();
                 break;
             case TYPE_SYMBOL: {
@@ -540,6 +543,14 @@ public class QwpCursorBoundsCheckTest {
                 throw new AssertionError("unsupported fuzz column type: " + typeCode);
         }
         return acc;
+    }
+
+    private static byte[] randomBytes(Rnd rnd, int len) {
+        byte[] b = new byte[len];
+        for (int i = 0; i < len; i++) {
+            b[i] = (byte) rnd.nextInt(256);
+        }
+        return b;
     }
 
     private static byte[] copyFromNative(long address, int length) {
@@ -646,6 +657,7 @@ public class QwpCursorBoundsCheckTest {
         QwpTableBuffer.ColumnBuffer long256Col = buffer.getOrCreateColumn("b_l256", TYPE_LONG256, true);
         QwpTableBuffer.ColumnBuffer geoCol = buffer.getOrCreateColumn("b_geo", TYPE_GEOHASH, true);
         QwpTableBuffer.ColumnBuffer ipv4Col = buffer.getOrCreateColumn("b_ipv4", TYPE_IPV4, true);
+        QwpTableBuffer.ColumnBuffer binCol = buffer.getOrCreateColumn("b_bin", TYPE_BINARY, true);
         QwpTableBuffer.ColumnBuffer dec64Col = buffer.getOrCreateColumn("b_dec64", TYPE_DECIMAL64, true);
         QwpTableBuffer.ColumnBuffer dec128Col = buffer.getOrCreateColumn("b_dec128", TYPE_DECIMAL128, true);
         QwpTableBuffer.ColumnBuffer dec256Col = buffer.getOrCreateColumn("b_dec256", TYPE_DECIMAL256, true);
@@ -699,6 +711,7 @@ public class QwpCursorBoundsCheckTest {
                 geoCol.addGeoHash(rnd.nextGeoHashLong(30), 30);
                 // OR a high bit to keep the address out of the 0.0.0.0 NULL sentinel.
                 ipv4Col.addIPv4(rnd.nextInt() | 0x01000000);
+                binCol.addBinary(randomBytes(rnd, 1 + rnd.nextInt(8)));
                 dec64Col.addDecimal64(new Decimal64((long) rnd.nextInt(100_000) - 50_000L, 2));
                 dec128Col.addDecimal128(Decimal128.fromLong((long) rnd.nextInt(1_000_000) - 500_000L, 4));
                 dec256Col.addDecimal256(Decimal256.fromLong((long) rnd.nextInt(10_000_000) - 5_000_000L, 5));
@@ -711,6 +724,7 @@ public class QwpCursorBoundsCheckTest {
                 long256Col.addNull();
                 geoCol.addNull();
                 ipv4Col.addNull();
+                binCol.addNull();
                 dec64Col.addNull();
                 dec128Col.addNull();
                 dec256Col.addNull();

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressCompressionNegotiatorTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressCompressionNegotiatorTest.java
@@ -1,0 +1,167 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.qwp;
+
+import io.questdb.cutlass.qwp.protocol.QwpConstants;
+import io.questdb.cutlass.qwp.server.egress.QwpEgressCompressionNegotiator;
+import io.questdb.std.str.Utf8String;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Pure unit tests for {@link QwpEgressCompressionNegotiator}. These pin the
+ * server-side defaults and clamp ranges so a future bump (e.g., changing the
+ * default level back to 3, or moving the clamp ceiling) fails loudly here
+ * before it ships to clients on the wire.
+ */
+public class QwpEgressCompressionNegotiatorTest {
+
+    @Test
+    public void testBareZstdDefaultsToLevelOne() {
+        // "zstd" with no parameter -- the level must default to 1, the
+        // cheapest server-side CPU. Bumping this default silently would
+        // double or more the per-connection CPU cost for opt-in clients
+        // that don't pin a level explicitly.
+        long result = QwpEgressCompressionNegotiator.negotiate(new Utf8String("zstd"));
+        Assert.assertEquals("codec must be ZSTD",
+                QwpConstants.COMPRESSION_ZSTD, QwpEgressCompressionNegotiator.codec(result));
+        Assert.assertEquals("bare 'zstd' must default to level 1",
+                1, QwpEgressCompressionNegotiator.level(result));
+    }
+
+    @Test
+    public void testEmptyLevelParameterDefaultsToLevelOne() {
+        // "zstd;level=" with an empty value -- same default path as bare
+        // "zstd". Pinned separately because the parser's two unparseable
+        // branches converge on the same default and we want either drift
+        // to fail loudly.
+        long result = QwpEgressCompressionNegotiator.negotiate(new Utf8String("zstd;level="));
+        Assert.assertEquals("codec must be ZSTD",
+                QwpConstants.COMPRESSION_ZSTD, QwpEgressCompressionNegotiator.codec(result));
+        Assert.assertEquals("empty level value must default to level 1",
+                1, QwpEgressCompressionNegotiator.level(result));
+    }
+
+    @Test
+    public void testUnparseableLevelDefaultsToLevelOne() {
+        // "zstd;level=foo" -- the parser falls through to the same default
+        // as the empty / bare cases. Drift here would mean a typo'd client
+        // header silently lands on a different level than the documented
+        // default.
+        long result = QwpEgressCompressionNegotiator.negotiate(new Utf8String("zstd;level=foo"));
+        Assert.assertEquals("codec must be ZSTD",
+                QwpConstants.COMPRESSION_ZSTD, QwpEgressCompressionNegotiator.codec(result));
+        Assert.assertEquals("unparseable level value must default to level 1",
+                1, QwpEgressCompressionNegotiator.level(result));
+    }
+
+    @Test
+    public void testExplicitClientLevelIsHonoredWithinClampRange() {
+        // Sanity-check the happy path so the default tests above can't
+        // accidentally pass by always returning 1 regardless of input.
+        long result = QwpEgressCompressionNegotiator.negotiate(new Utf8String("zstd;level=5"));
+        Assert.assertEquals(5, QwpEgressCompressionNegotiator.level(result));
+    }
+
+    @Test
+    public void testLevelAboveMaxClampedDown() {
+        // Levels above COMPRESSION_ZSTD_MAX_LEVEL must be clamped down --
+        // pins the upper bound at 9.
+        long result = QwpEgressCompressionNegotiator.negotiate(new Utf8String("zstd;level=22"));
+        Assert.assertEquals("level above max must clamp to COMPRESSION_ZSTD_MAX_LEVEL",
+                QwpConstants.COMPRESSION_ZSTD_MAX_LEVEL,
+                QwpEgressCompressionNegotiator.level(result));
+    }
+
+    @Test
+    public void testLevelBelowMinClampedUp() {
+        // Levels below COMPRESSION_ZSTD_MIN_LEVEL must be clamped up --
+        // pins the lower bound at 1. zstd accepts negative levels, but
+        // they are disallowed on the QWP wire to bound the codec's worst
+        // case behavior.
+        long result = QwpEgressCompressionNegotiator.negotiate(new Utf8String("zstd;level=0"));
+        Assert.assertEquals("level below min must clamp to COMPRESSION_ZSTD_MIN_LEVEL",
+                QwpConstants.COMPRESSION_ZSTD_MIN_LEVEL,
+                QwpEgressCompressionNegotiator.level(result));
+    }
+
+    // --- resolveEffectiveZstdLevel (operator force-level override) ---
+
+    @Test
+    public void testForceLevelZeroIsNoOp() {
+        // Default config (forced=0): the client-negotiated level passes
+        // through unchanged. Pins the "off" sentinel so a future refactor
+        // can't silently flip the default behavior.
+        byte effective = QwpEgressCompressionNegotiator.resolveEffectiveZstdLevel(
+                QwpConstants.COMPRESSION_ZSTD, (byte) 5, 0);
+        Assert.assertEquals(5, effective);
+    }
+
+    @Test
+    public void testForceLevelIgnoredWhenCodecIsNotZstd() {
+        // The override only governs ZSTD-negotiated connections. If the
+        // server picked raw transport, forcing a zstd level must not flip
+        // the codec or write a misleading content-encoding header.
+        byte effective = QwpEgressCompressionNegotiator.resolveEffectiveZstdLevel(
+                QwpConstants.COMPRESSION_NONE, (byte) 0, 9);
+        Assert.assertEquals(0, effective);
+    }
+
+    @Test
+    public void testForceLevelOverridesClientChoiceWhenZstdNegotiated() {
+        // The operator override deliberately ignores the client's request:
+        // a client asking for level 9 from a server forced at level 1 lands
+        // on level 1. That's the whole point of the knob -- bound server
+        // CPU regardless of what clients ask for.
+        byte effective = QwpEgressCompressionNegotiator.resolveEffectiveZstdLevel(
+                QwpConstants.COMPRESSION_ZSTD, (byte) 9, 1);
+        Assert.assertEquals(1, effective);
+    }
+
+    @Test
+    public void testForceLevelCanRaiseLevelToo() {
+        // Symmetric: operator forcing level 9 must override a client that
+        // asked for level 1. Less useful in practice (operators usually
+        // want a ceiling not a floor) but the contract is "force, not cap".
+        byte effective = QwpEgressCompressionNegotiator.resolveEffectiveZstdLevel(
+                QwpConstants.COMPRESSION_ZSTD, (byte) 1, 9);
+        Assert.assertEquals(9, effective);
+    }
+
+    @Test
+    public void testForceLevelOutOfRangeClampedAtOverrideSite() {
+        // Defense-in-depth: even if a future caller bypasses the config
+        // parser's [1, 9] validation, the resolver must clamp into the
+        // wire-allowed range so a malformed forced value can't produce a
+        // header value the static byte[][] table can't render.
+        byte high = QwpEgressCompressionNegotiator.resolveEffectiveZstdLevel(
+                QwpConstants.COMPRESSION_ZSTD, (byte) 3, 22);
+        Assert.assertEquals(QwpConstants.COMPRESSION_ZSTD_MAX_LEVEL, high);
+
+        byte low = QwpEgressCompressionNegotiator.resolveEffectiveZstdLevel(
+                QwpConstants.COMPRESSION_ZSTD, (byte) 3, -1);
+        Assert.assertEquals(QwpConstants.COMPRESSION_ZSTD_MIN_LEVEL, low);
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressCompressionTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressCompressionTest.java
@@ -207,38 +207,61 @@ public class QwpEgressCompressionTest extends AbstractBootstrapTest {
     }
 
     @Test
-    public void testForceLevelPropertyIsExposedAndConnectionsWorkWithOverrideActive() throws Exception {
-        // Pins the end-to-end wiring of qwp.egress.compression.force.level:
-        //   PropertyKey -> PropServerConfiguration parser -> PropCairoConfiguration
-        //   -> CairoConfigurationWrapper -> engine.getConfiguration().
-        // Reading via the engine's configuration (the wrapper) is what makes
-        // the value reload-safe -- every handshake re-reads through this path.
-        // The runtime override behavior itself is unit-tested on
-        // QwpEgressCompressionNegotiator.resolveEffectiveZstdLevel; this test
-        // only proves the property reaches the resolver call site and that a
-        // ZSTD-negotiated connection round-trips data while the override is
-        // active.
+    public void testForceLevelEnforcedOnWireAndHotReloadable() throws Exception {
+        // True end-to-end pin of qwp.egress.compression.force.level:
+        //   1. Set force=3 on disk, start the server, open a client requesting
+        //      level=1 -- the server must override to 3 on the wire, observable
+        //      via QwpQueryClient.getNegotiatedZstdLevel().
+        //   2. Rewrite the server.conf to force=9, call
+        //      engine.getConfigReloader().reload(), then open a NEW client.
+        //      The new connection must see level=9 -- proving the override is
+        //      reloadable without restart.
+        // Already-open connections explicitly do NOT mutate mid-stream; the
+        // ZSTD encoder context is built once on handshake and not safe to
+        // re-level later. The "fresh connection picks up the change" is the
+        // promise.
         TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables(
-                    PropertyKey.QWP_EGRESS_COMPRESSION_FORCE_LEVEL.getEnvVarName(), "7"
-            )) {
+            createDummyConfiguration(
+                    PropertyKey.QWP_EGRESS_COMPRESSION_FORCE_LEVEL.getPropertyPath() + "=3");
+            try (final TestServerMain serverMain = startWithEnvVariables()) {
                 Assert.assertEquals(
                         "force-level property must surface on the engine's configuration",
-                        7, serverMain.getEngine().getConfiguration().getQwpEgressForcedZstdLevel());
+                        3, serverMain.getEngine().getConfiguration().getQwpEgressForcedZstdLevel());
                 serverMain.execute("CREATE TABLE fl(id LONG, ts TIMESTAMP) "
                         + "TIMESTAMP(ts) PARTITION BY DAY WAL");
                 serverMain.execute(
-                        "INSERT INTO fl SELECT x, x::TIMESTAMP FROM long_sequence(2000)");
+                        "INSERT INTO fl SELECT x, x::TIMESTAMP FROM long_sequence(500)");
                 serverMain.awaitTable("fl");
-                // Client asks for level 1; server's force=7 must win on the
-                // wire. The connection still establishes and decodes -- if
-                // the override broke the encoder selection or the response
-                // header, the upgrade would fail or the decoder would barf.
+
                 try (QwpQueryClient client = QwpQueryClient.fromConfig(
                         "ws::addr=127.0.0.1:" + HTTP_PORT
                                 + ";compression=zstd;compression_level=1;")) {
                     client.connect();
-                    assertLongSum(client, "SELECT * FROM fl", 2000, 2000L * 2001L / 2L);
+                    Assert.assertEquals(
+                            "server's forced level must beat the client's level=1 request",
+                            3, client.getNegotiatedZstdLevel());
+                    assertLongSum(client, "SELECT * FROM fl", 500, 500L * 501L / 2L);
+                }
+
+                // Hot reload: rewrite the server.conf with a different forced
+                // level and trigger reload synchronously. Direct reload API
+                // (vs. file-watch + assertReloadConfigEventually) is
+                // deterministic and avoids timing flake.
+                createDummyConfiguration(
+                        PropertyKey.QWP_EGRESS_COMPRESSION_FORCE_LEVEL.getPropertyPath() + "=9");
+                serverMain.getEngine().getConfigReloader().reload();
+                Assert.assertEquals(
+                        "config wrapper must surface the new value after reload",
+                        9, serverMain.getEngine().getConfiguration().getQwpEgressForcedZstdLevel());
+
+                try (QwpQueryClient client = QwpQueryClient.fromConfig(
+                        "ws::addr=127.0.0.1:" + HTTP_PORT
+                                + ";compression=zstd;compression_level=1;")) {
+                    client.connect();
+                    Assert.assertEquals(
+                            "hot-reloaded force level must win on the next new connection",
+                            9, client.getNegotiatedZstdLevel());
+                    assertLongSum(client, "SELECT * FROM fl", 500, 500L * 501L / 2L);
                 }
             }
         });

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressCompressionTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressCompressionTest.java
@@ -46,7 +46,7 @@ import org.junit.Test;
  * <p>
  * Coverage:
  * <ul>
- *   <li>{@code compression=zstd} at default level 3 round-trips correctly
+ *   <li>{@code compression=zstd} at default level 1 round-trips correctly
  *       across a highly compressible column (rotating symbols).</li>
  *   <li>Explicit {@code compression_level} values at the ends of the clamp
  *       range ({@code 1} and {@code 22}) still decode correctly. The server
@@ -204,6 +204,44 @@ public class QwpEgressCompressionTest extends AbstractBootstrapTest {
         // The client must decode correctly regardless of the level the
         // server actually used.
         runLevelSmoke(22);
+    }
+
+    @Test
+    public void testForceLevelPropertyIsExposedAndConnectionsWorkWithOverrideActive() throws Exception {
+        // Pins the end-to-end wiring of qwp.egress.compression.force.level:
+        //   PropertyKey -> PropServerConfiguration parser -> PropCairoConfiguration
+        //   -> CairoConfigurationWrapper -> engine.getConfiguration().
+        // Reading via the engine's configuration (the wrapper) is what makes
+        // the value reload-safe -- every handshake re-reads through this path.
+        // The runtime override behavior itself is unit-tested on
+        // QwpEgressCompressionNegotiator.resolveEffectiveZstdLevel; this test
+        // only proves the property reaches the resolver call site and that a
+        // ZSTD-negotiated connection round-trips data while the override is
+        // active.
+        TestUtils.assertMemoryLeak(() -> {
+            try (final TestServerMain serverMain = startWithEnvVariables(
+                    PropertyKey.QWP_EGRESS_COMPRESSION_FORCE_LEVEL.getEnvVarName(), "7"
+            )) {
+                Assert.assertEquals(
+                        "force-level property must surface on the engine's configuration",
+                        7, serverMain.getEngine().getConfiguration().getQwpEgressForcedZstdLevel());
+                serverMain.execute("CREATE TABLE fl(id LONG, ts TIMESTAMP) "
+                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+                serverMain.execute(
+                        "INSERT INTO fl SELECT x, x::TIMESTAMP FROM long_sequence(2000)");
+                serverMain.awaitTable("fl");
+                // Client asks for level 1; server's force=7 must win on the
+                // wire. The connection still establishes and decodes -- if
+                // the override broke the encoder selection or the response
+                // header, the upgrade would fail or the decoder would barf.
+                try (QwpQueryClient client = QwpQueryClient.fromConfig(
+                        "ws::addr=127.0.0.1:" + HTTP_PORT
+                                + ";compression=zstd;compression_level=1;")) {
+                    client.connect();
+                    assertLongSum(client, "SELECT * FROM fl", 2000, 2000L * 2001L / 2L);
+                }
+            }
+        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpFixedWidthDecoderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpFixedWidthDecoderTest.java
@@ -920,6 +920,41 @@ public class QwpFixedWidthDecoderTest {
     }
 
     @Test
+    public void testDecodeIPv4ColumnSentinelNullNoBitmap() throws QwpParseException {
+        // QwpTableBuffer.addIPv4 javadoc: "The bit pattern 0 (i.e. 0.0.0.0) is
+        // reserved by QuestDB as the IPv4 NULL sentinel and surfaces as NULL
+        // on read regardless of the null bitmap." The encoder writes 0 inline
+        // as a value when there are no bitmap-tagged nulls; the cursor's
+        // sentinel switch is the protocol-intended null detector for this case.
+        int[] values = {0x0A000001, Numbers.IPv4_NULL, 0xFFFFFFFF};
+        int rowCount = values.length;
+        int size = 1 + rowCount * 4;
+        long address = Unsafe.malloc(size, MemoryTag.NATIVE_DEFAULT);
+        try {
+            Unsafe.putByte(address, (byte) 0); // no null bitmap
+            for (int i = 0; i < rowCount; i++) {
+                Unsafe.putInt(address + 1 + (long) i * 4, values[i]);
+            }
+
+            QwpFixedWidthColumnCursor cursor = new QwpFixedWidthColumnCursor();
+            cursor.of(address, size, rowCount, TYPE_IPV4);
+
+            cursor.advanceRow();
+            Assert.assertFalse(cursor.isNull());
+            Assert.assertEquals(0x0A000001, (int) cursor.getLong());
+
+            cursor.advanceRow();
+            Assert.assertTrue("IPv4_NULL must be reported as NULL when no bitmap is present", cursor.isNull());
+
+            cursor.advanceRow();
+            Assert.assertFalse(cursor.isNull());
+            Assert.assertEquals(0xFFFFFFFF, (int) cursor.getLong());
+        } finally {
+            Unsafe.free(address, size, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
     public void testDecodeIntColumnSentinelNullNoBitmap() throws QwpParseException {
         int[] values = {42, Numbers.INT_NULL, -1};
         int rowCount = values.length;
@@ -950,6 +985,48 @@ public class QwpFixedWidthDecoderTest {
     }
 
     @Test
+    public void testDecodeLong256ColumnSentinelNullNoBitmap() throws QwpParseException {
+        // LONG256 NULL = (LONG_NULL, LONG_NULL, LONG_NULL, LONG_NULL) per
+        // Long256Impl.NULL_LONG256. With no bitmap the cursor must classify
+        // that bit pattern as NULL or downstream consumers (e.g. the
+        // LONG256->String type-conversion path) will format it as a
+        // non-null Long256 value.
+        long[][] values = {
+                {0x1L, 0x2L, 0x3L, 0x4L},
+                {Numbers.LONG_NULL, Numbers.LONG_NULL, Numbers.LONG_NULL, Numbers.LONG_NULL},
+                {-1L, -1L, -1L, -1L}
+        };
+        int rowCount = values.length;
+        int size = 1 + rowCount * 32;
+        long address = Unsafe.malloc(size, MemoryTag.NATIVE_DEFAULT);
+        try {
+            Unsafe.putByte(address, (byte) 0); // no null bitmap
+            for (int i = 0; i < rowCount; i++) {
+                long base = address + 1 + (long) i * 32;
+                Unsafe.putLong(base, values[i][0]);
+                Unsafe.putLong(base + 8, values[i][1]);
+                Unsafe.putLong(base + 16, values[i][2]);
+                Unsafe.putLong(base + 24, values[i][3]);
+            }
+
+            QwpFixedWidthColumnCursor cursor = new QwpFixedWidthColumnCursor();
+            cursor.of(address, size, rowCount, TYPE_LONG256);
+
+            cursor.advanceRow();
+            Assert.assertFalse(cursor.isNull());
+
+            cursor.advanceRow();
+            Assert.assertTrue("LONG256 NULL_LONG256 must be reported as NULL when no bitmap is present",
+                    cursor.isNull());
+
+            cursor.advanceRow();
+            Assert.assertFalse(cursor.isNull());
+        } finally {
+            Unsafe.free(address, size, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
     public void testDecodeLongColumnSentinelNullNoBitmap() throws QwpParseException {
         long[] values = {42L, Numbers.LONG_NULL, -1L};
         assertLongSentinelNull(values, TYPE_LONG);
@@ -965,6 +1042,48 @@ public class QwpFixedWidthDecoderTest {
     public void testDecodeTimestampNanosColumnSentinelNullNoBitmap() throws QwpParseException {
         long[] values = {1_000_000_000L, Numbers.LONG_NULL, -1L};
         assertLongSentinelNull(values, TYPE_TIMESTAMP_NANOS);
+    }
+
+    @Test
+    public void testDecodeUuidColumnSentinelNullNoBitmap() throws QwpParseException {
+        // UUID NULL = (LONG_NULL, LONG_NULL) per Uuid.isNull(lo, hi). With no
+        // bitmap the cursor must classify that bit pattern as NULL or the
+        // UUID->String type-conversion path (WalColumnarRowAppender
+        // putFixedOtherToStringColumn / putFixedOtherToVarcharColumn ->
+        // formatFixedOtherValue) formats it as a non-null Uuid value.
+        // Layout per QwpFixedWidthColumnCursor.readCurrentValue: lo first,
+        // hi second.
+        long[][] values = {
+                {0x1234L, 0x5678L},
+                {Numbers.LONG_NULL, Numbers.LONG_NULL},
+                {-1L, -1L}
+        };
+        int rowCount = values.length;
+        int size = 1 + rowCount * 16;
+        long address = Unsafe.malloc(size, MemoryTag.NATIVE_DEFAULT);
+        try {
+            Unsafe.putByte(address, (byte) 0); // no null bitmap
+            for (int i = 0; i < rowCount; i++) {
+                long base = address + 1 + (long) i * 16;
+                Unsafe.putLong(base, values[i][0]);       // lo
+                Unsafe.putLong(base + 8, values[i][1]);   // hi
+            }
+
+            QwpFixedWidthColumnCursor cursor = new QwpFixedWidthColumnCursor();
+            cursor.of(address, size, rowCount, TYPE_UUID);
+
+            cursor.advanceRow();
+            Assert.assertFalse(cursor.isNull());
+
+            cursor.advanceRow();
+            Assert.assertTrue("UUID NULL must be reported as NULL when no bitmap is present",
+                    cursor.isNull());
+
+            cursor.advanceRow();
+            Assert.assertFalse(cursor.isNull());
+        } finally {
+            Unsafe.free(address, size, MemoryTag.NATIVE_DEFAULT);
+        }
     }
 
     private static void assertLongSentinelNull(long[] values, byte typeCode) throws QwpParseException {

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpGeoHashDecoderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpGeoHashDecoderTest.java
@@ -694,26 +694,46 @@ public class QwpGeoHashDecoderTest {
     }
 
     @Test
-    public void testResetAllowsNewPrecision() throws Exception {
+    public void testResetPreservesGeoHashPrecisionAcrossBatches() throws Exception {
+        // Precision is a schema property locked on first write: the server
+        // auto-creates the column type from the first batch's precision and
+        // the wire varint must keep matching it across every subsequent
+        // batch. QwpTableBuffer.ColumnBuffer.reset() (called between batches)
+        // therefore preserves geohashPrecision, the same way it preserves the
+        // column's type byte. A producer that tries a different precision
+        // after a reset gets a synchronous LineSenderException from
+        // addGeoHash, well before anything reaches the wire.
         assertMemoryLeak(() -> {
             try (QwpWebSocketEncoder encoder = new QwpWebSocketEncoder()) {
                 QwpTableBuffer buffer = new QwpTableBuffer("test_table");
 
-                // First batch: 5-bit precision
+                // Batch 1: lock the column at 5-bit precision and flush.
                 QwpTableBuffer.ColumnBuffer col = buffer.getOrCreateColumn("geo", TYPE_GEOHASH, false);
                 col.addGeoHash(0b10110, 5);
                 buffer.nextRow();
-
                 encoder.encode(buffer, false);
                 buffer.reset();
 
-                // After reset: 20-bit precision works fine
+                // Batch 2: same precision must still work (sanity check that
+                // the lock isn't accidentally rejecting matching precisions).
                 col = buffer.getOrCreateColumn("geo", TYPE_GEOHASH, false);
-                col.addGeoHash(0xABCDE, 20);
+                col.addGeoHash(0b11010, 5);
                 buffer.nextRow();
-
                 int size = encoder.encode(buffer, false);
                 Assert.assertTrue(size > 12);
+                buffer.reset();
+
+                // Batch 3: different precision after reset must throw -- the
+                // schema is locked at 5 bits and a 20-bit write would diverge
+                // from the server's auto-created GEOHASH(1c) on the next flush.
+                col = buffer.getOrCreateColumn("geo", TYPE_GEOHASH, false);
+                try {
+                    col.addGeoHash(0xABCDE, 20);
+                    Assert.fail("expected LineSenderException for precision mismatch across reset");
+                } catch (LineSenderException e) {
+                    Assert.assertTrue("got: " + e.getMessage(),
+                            e.getMessage().contains("GeoHash precision mismatch"));
+                }
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
@@ -771,6 +771,16 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
         };
     }
 
+    /**
+     * Map an id (or any long seed) to a packed IPv4 address that is guaranteed
+     * non-zero. QuestDB reserves the bit pattern 0 as the IPv4 NULL sentinel,
+     * so we OR a high bit into the derived address; this keeps the oracle's
+     * non-null assertions unambiguous while still spanning the full 32-bit space.
+     */
+    private static int deriveIPv4(long seed) {
+        return (int) (seed * 2_654_435_761L) | 0x01_00_00_01;
+    }
+
     private static long directorySizeBytes(File dir) {
         if (!dir.exists()) {
             return 0;
@@ -799,6 +809,11 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setDouble("d", maybeNegate(rnd, id * 1.5));
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setString("s", "s_" + id + maybeNonAscii(rnd));
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setSymbol("sym", "sym_" + (id & 0xFL) + maybeNonAscii(rnd));
+        // IPv4: derive a 4-byte address from id; bit pattern 0 is the QuestDB IPv4
+        // NULL sentinel, so we OR in a constant high bit to guarantee a non-null
+        // value across the full id range. Skippable like the other base columns to
+        // exercise the explicit-NULL bitmap path through SF replay.
+        if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setIPv4("ip", deriveIPv4(id));
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR))
             row.setDoubleArray1d("da", deriveDoubleArr1d(id, rnd.nextBoolean() ? -1.0 : 1.0));
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR))
@@ -851,7 +866,7 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
         // write the extra expect type-default NULL at assertion time.
         // Numeric extras get the same independent sign-flip treatment as
         // base columns.
-        switch (rnd.nextInt(14)) {
+        switch (rnd.nextInt(15)) {
             case 0:
                 row.setLong("ex_l_0", maybeNegate(rnd, id * 7L));
                 break;
@@ -922,6 +937,11 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                         rnd.nextBoolean());
                 break;
             }
+            case 14:
+                // Auto-created IPv4 extra. Two distinct columns spread the per-id values
+                // out so neither column degenerates into a single repeated address.
+                row.setIPv4("ex_ip_" + (id & 1L), deriveIPv4(id + 0x9E37_79B9L));
+                break;
         }
     }
 
@@ -1028,6 +1048,7 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                             + "d DOUBLE, "
                             + "s STRING, "
                             + "sym SYMBOL, "
+                            + "ip IPv4, "
                             + "da DOUBLE[], "
                             + "da2 DOUBLE[][], "
                             + "da3 DOUBLE[][][], "

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
@@ -773,6 +773,36 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
     }
 
     /**
+     * Map an id (or any long seed) to a GEOHASH bit pattern in the low
+     * {@code precisionBits} bits. Top bits are masked off so the value fits
+     * the declared precision; the server-side GEOHASH NULL sentinel (-1
+     * truncated to storage width) is unreachable for {@code precisionBits < 60}
+     * because the high bit of the storage word is never set.
+     */
+    private static String base32GeoHashFromId(long id, int chars) {
+        // QuestDB's base32 alphabet (matches io.questdb.cairo.GeoHashes#base32):
+        // skips 'a', 'i', 'l', 'o' versus straight 0-9a-z.
+        final char[] alphabet = {
+                '0', '1', '2', '3', '4', '5', '6', '7',
+                '8', '9', 'b', 'c', 'd', 'e', 'f', 'g',
+                'h', 'j', 'k', 'm', 'n', 'p', 'q', 'r',
+                's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+        };
+        long mixed = id * 0x9E37_79B9_7F4A_7C15L + 0x0123_4567_89AB_CDEFL;
+        char[] out = new char[chars];
+        for (int i = chars - 1; i >= 0; i--) {
+            out[i] = alphabet[(int) (mixed & 0x1F)];
+            mixed >>>= 5;
+        }
+        return new String(out);
+    }
+
+    private static long deriveGeoHash(long seed, int precisionBits) {
+        long mixed = seed * 0x9E37_79B9_7F4A_7C15L + 0x0123_4567_89AB_CDEFL;
+        return precisionBits >= 64 ? mixed : mixed & ((1L << precisionBits) - 1L);
+    }
+
+    /**
      * Map an id (or any long seed) to a packed IPv4 address that is guaranteed
      * non-zero. QuestDB reserves the bit pattern 0 as the IPv4 NULL sentinel,
      * so we OR a high bit into the derived address; this keeps the oracle's
@@ -838,6 +868,14 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
         // value across the full id range. Skippable like the other base columns to
         // exercise the explicit-NULL bitmap path through SF replay.
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setIPv4("ip", deriveIPv4(id));
+        // GEOHASH at four precisions, one per storage class (GEOBYTE/SHORT/INT/LONG)
+        // plus a non-multiple-of-5 precision (g7) so the server's bit-precise
+        // encoding path is exercised alongside the base32-aligned ones.
+        if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setGeoHash("g5", deriveGeoHash(id, 5), 5);
+        if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setGeoHash("g7", deriveGeoHash(id, 7), 7);
+        if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setGeoHash("g15", deriveGeoHash(id, 15), 15);
+        if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setGeoHash("g20", deriveGeoHash(id, 20), 20);
+        if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setGeoHash("g35", deriveGeoHash(id, 35), 35);
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR))
             row.setDoubleArray1d("da", deriveDoubleArr1d(id, rnd.nextBoolean() ? -1.0 : 1.0));
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR))
@@ -890,7 +928,7 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
         // write the extra expect type-default NULL at assertion time.
         // Numeric extras get the same independent sign-flip treatment as
         // base columns.
-        switch (rnd.nextInt(20)) {
+        switch (rnd.nextInt(24)) {
             case 0:
                 row.setLong("ex_l_0", maybeNegate(rnd, id * 7L));
                 break;
@@ -986,6 +1024,24 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                 // Auto-created IPv4 extra. Two distinct columns spread the per-id values
                 // out so neither column degenerates into a single repeated address.
                 row.setIPv4("ex_ip_" + (id & 1L), deriveIPv4(id + 0x9E37_79B9L));
+                break;
+            case 20:
+                // Auto-created GEOHASH(5b) extra -> GEOBYTE storage.
+                row.setGeoHash("ex_g5", deriveGeoHash(id + 0x1111_1111L, 5), 5);
+                break;
+            case 21:
+                // Auto-created GEOHASH(15b) extra -> GEOSHORT storage.
+                row.setGeoHash("ex_g15", deriveGeoHash(id + 0x2222_2222L, 15), 15);
+                break;
+            case 22:
+                // Auto-created GEOHASH(20b) extra -> GEOINT storage; takes the
+                // base32-string overload so the client-side base32 decoder is
+                // exercised on the auto-create path too.
+                row.setGeoHash("ex_g20", base32GeoHashFromId(id, 4));
+                break;
+            case 23:
+                // Auto-created GEOHASH(35b) extra -> GEOLONG storage.
+                row.setGeoHash("ex_g35", deriveGeoHash(id + 0x4444_4444L, 35), 35);
                 break;
         }
     }
@@ -1109,6 +1165,11 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                             + "l256 LONG256, "
                             + "tn TIMESTAMP_NS, "
                             + "ip IPv4, "
+                            + "g5 GEOHASH(5b), "
+                            + "g7 GEOHASH(7b), "
+                            + "g15 GEOHASH(15b), "
+                            + "g20 GEOHASH(20b), "
+                            + "g35 GEOHASH(35b), "
                             + "da DOUBLE[], "
                             + "da2 DOUBLE[][], "
                             + "da3 DOUBLE[][][], "

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
@@ -797,6 +797,25 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
         return new String(out);
     }
 
+    /**
+     * Map an id (or any long seed) to a deterministic byte array. The bytes are
+     * derived from a splitmix-style mixer of {@code seed} so identical seeds
+     * yield identical payloads, which is what the oracle's deferred assertion
+     * compares against on read.
+     */
+    private static byte[] deriveBinary(long seed, int len) {
+        byte[] out = new byte[len];
+        long state = seed * 0xBF58_476D_1CE4_E5B9L + 0x94D0_49BB_1331_11EBL;
+        for (int i = 0; i < len; i++) {
+            // splitmix64 step: keeps successive bytes well-mixed without ever
+            // hitting the cold-pattern degenerate case len==0 .. len==1 hit.
+            state = (state ^ (state >>> 30)) * 0xBF58_476D_1CE4_E5B9L;
+            state = (state ^ (state >>> 27)) * 0x94D0_49BB_1331_11EBL;
+            out[i] = (byte) (state ^ (state >>> 31));
+        }
+        return out;
+    }
+
     private static long deriveGeoHash(long seed, int precisionBits) {
         long mixed = seed * 0x9E37_79B9_7F4A_7C15L + 0x0123_4567_89AB_CDEFL;
         return precisionBits >= 64 ? mixed : mixed & ((1L << precisionBits) - 1L);
@@ -876,6 +895,11 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setGeoHash("g15", deriveGeoHash(id, 15), 15);
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setGeoHash("g20", deriveGeoHash(id, 20), 20);
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setGeoHash("g35", deriveGeoHash(id, 35), 35);
+        // BINARY: derive a small byte slice from id; capped at 32 bytes to keep
+        // batch sizes manageable and to ensure variable-length offset arithmetic
+        // is exercised. Skippable like the other base columns, so the explicit-
+        // NULL bitmap path goes through SF replay too.
+        if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) row.setBinary("bin", deriveBinary(id, 1 + (int) (id & 0x1FL)));
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR))
             row.setDoubleArray1d("da", deriveDoubleArr1d(id, rnd.nextBoolean() ? -1.0 : 1.0));
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR))
@@ -928,7 +952,7 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
         // write the extra expect type-default NULL at assertion time.
         // Numeric extras get the same independent sign-flip treatment as
         // base columns.
-        switch (rnd.nextInt(24)) {
+        switch (rnd.nextInt(25)) {
             case 0:
                 row.setLong("ex_l_0", maybeNegate(rnd, id * 7L));
                 break;
@@ -1033,15 +1057,28 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                 // Auto-created GEOHASH(15b) extra -> GEOSHORT storage.
                 row.setGeoHash("ex_g15", deriveGeoHash(id + 0x2222_2222L, 15), 15);
                 break;
-            case 22:
-                // Auto-created GEOHASH(20b) extra -> GEOINT storage; takes the
-                // base32-string overload so the client-side base32 decoder is
-                // exercised on the auto-create path too.
-                row.setGeoHash("ex_g20", base32GeoHashFromId(id, 4));
+            case 22: {
+                // Auto-created GEOHASH extra via the base32-string overload, so
+                // the client-side base32 decoder gets coverage on the
+                // auto-create path too. Length is randomized in [1, 11] so all
+                // four storage classes (GEOBYTE/SHORT/INT/LONG) get exercised
+                // across runs. Each length gets its own column name --
+                // GEOHASH precision is schema-locked on first write, so a
+                // shared name would conflict across rows of different lengths.
+                int chars = rnd.nextInt(11) + 1;
+                row.setGeoHash("ex_g_b32_" + chars + "c", base32GeoHashFromId(id, chars));
                 break;
+            }
             case 23:
                 // Auto-created GEOHASH(35b) extra -> GEOLONG storage.
                 row.setGeoHash("ex_g35", deriveGeoHash(id + 0x4444_4444L, 35), 35);
+                break;
+            case 24:
+                // Auto-created BINARY extra. Two distinct columns (ex_bin_0 /
+                // ex_bin_1) spread the per-id values out so neither column
+                // degenerates into a single repeated payload.
+                row.setBinary("ex_bin_" + (id & 1L),
+                        deriveBinary(id + 0x5555_5555L, 1 + (int) (id & 0x0FL)));
                 break;
         }
     }
@@ -1170,6 +1207,7 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                             + "g15 GEOHASH(15b), "
                             + "g20 GEOHASH(20b), "
                             + "g35 GEOHASH(35b), "
+                            + "bin BINARY, "
                             + "da DOUBLE[], "
                             + "da2 DOUBLE[][], "
                             + "da3 DOUBLE[][][], "

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -267,6 +267,71 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
     }
 
     @Test
+    public void testAutoCreateGeoHashColumns() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_auto_geohash";
+            // Pre-create the table without geohash columns so QwpWalAppender
+            // auto-creates them at each declared precision -- the wire-side
+            // precision drives the chosen storage class:
+            //   5b  -> GEOBYTE  (GEOHASH(1c))
+            //   15b -> GEOSHORT (GEOHASH(3c))
+            //   20b -> GEOINT   (GEOHASH(4c))
+            //   35b -> GEOLONG  (GEOHASH(7c))
+            execute("CREATE TABLE " + table + " (ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                // Row 1: long+precision overload, hitting all four storage classes.
+                // High bits set in the long are masked by the sender; the row
+                // should round-trip the low precisionBits intact.
+                sender.table(table)
+                        .geoHashColumn("g5", 0x1FL, 5)
+                        .geoHashColumn("g15", 0x7FFFL, 15)
+                        .geoHashColumn("g20", 0xF_FFFFL, 20)
+                        .geoHashColumn("g35", 0x7_FFFF_FFFFL, 35)
+                        .at(1_000_000, ChronoUnit.MICROS);
+                // Row 2: base32 string overload; lengths derive precision as len*5.
+                // "s24se0g" lands inside GEOHASH(35b)/GEOLONG storage.
+                sender.table(table)
+                        .geoHashColumn("g5", "u")
+                        .geoHashColumn("g15", "u33")
+                        .geoHashColumn("g20", "u33d")
+                        .geoHashColumn("g35", "s24se0g")
+                        .at(2_000_000, ChronoUnit.MICROS);
+                // Row 3: skip all geohash columns -> writes implicit NULLs via the
+                // null bitmap, exercising the sparse path.
+                sender.table(table)
+                        .at(3_000_000, ChronoUnit.MICROS);
+                sender.flush();
+            }
+
+            drainWalQueue();
+            // Verify auto-created column types match the declared precisions.
+            assertSql(
+                    "SELECT \"column\", type FROM table_columns('" + table + "') WHERE \"column\" LIKE 'g%' ORDER BY \"column\"",
+                    """
+                            column\ttype
+                            g15\tGEOHASH(3c)
+                            g20\tGEOHASH(4c)
+                            g35\tGEOHASH(7c)
+                            g5\tGEOHASH(1c)
+                            """
+            );
+            // Round-trip values. Row 1 was bit-packed: 0x1F renders as 'z' (the
+            // last base32 digit), 0x7FFF / 0xFFFFF / 0x7FFFFFFFF are the all-ones
+            // payload for each precision and render to the top base32 chars.
+            assertSql(
+                    "SELECT g5, g15, g20, g35 FROM " + table + " ORDER BY ts",
+                    """
+                            g5\tg15\tg20\tg35
+                            z\tzzz\tzzzz\tzzzzzzz
+                            u\tu33\tu33d\ts24se0g
+                            \t\t\t
+                            """
+            );
+        });
+    }
+
+    @Test
     public void testAutoCreateIPv4Column() throws Exception {
         runInContext((port) -> {
             String table = "test_qwp_auto_ipv4";
@@ -2200,6 +2265,104 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
         });
     }
 
+    /**
+     * Regression check for the between-batch GEOHASH precision lock. When a
+     * column has zero values in a batch (every row leaves it null), the wire
+     * encoder must still emit the schema-locked precision varint rather than
+     * the writer's {@code precision = 1} fallback -- otherwise the strict
+     * server-side check added in {@code 91c0824b0d} rejects the batch as
+     * <pre>
+     *   GeoHash precision mismatch [column=g, columnType=GEOHASH(4c), wireBits=1]
+     * </pre>
+     * once the column has been auto-created at a real precision. The fix lives
+     * in {@code ColumnBuffer.reset()}, which now preserves
+     * {@code geohashPrecision} across batches.
+     */
+    @Test
+    public void testGeoHashColumnPrecisionPersistsAcrossBatches() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_geohash_persists_precision";
+            execute("CREATE TABLE " + table + " (ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                // Batch 1: write "g" with 20-bit precision. Server auto-creates
+                // GEOHASH(4c).
+                sender.table(table)
+                        .geoHashColumn("g", "u33d")
+                        .at(1_000_000, ChronoUnit.MICROS);
+                sender.flush();
+                drainWalQueue();
+
+                // Batch 2: no row writes "g". The column persists in the
+                // sender's buffer schema (reset() keeps column defs) but its
+                // geohashPrecision was reset to -1. The encoder writes
+                // precision varint = 1, which the server rejects.
+                sender.table(table)
+                        .longColumn("other", 1L)
+                        .at(2_000_000, ChronoUnit.MICROS);
+                sender.flush();
+            }
+
+            drainWalQueue();
+            // Expected once fixed: both rows ingested.
+            assertSql("SELECT count() FROM " + table, "count\n2\n");
+        });
+    }
+
+    @Test
+    public void testGeoHashColumnValidation() throws Exception {
+        // Client-side validation of the public geoHashColumn API: precision out
+        // of range, null/empty/too-long/invalid base32 string, and precision
+        // mismatch within a single column over multiple rows. None of these
+        // should reach the wire; the sender raises LineSenderException before
+        // anything is encoded.
+        runInContext((port) -> {
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                sender.table("dummy");
+                assertThrowsContains(() -> sender.geoHashColumn("g", 0L, 0),
+                        "invalid GEOHASH precision");
+                sender.cancelRow();
+
+                sender.table("dummy");
+                assertThrowsContains(() -> sender.geoHashColumn("g", 0L, 61),
+                        "invalid GEOHASH precision");
+                sender.cancelRow();
+
+                sender.table("dummy");
+                assertThrowsContains(() -> sender.geoHashColumn("g", (CharSequence) null),
+                        "GEOHASH string cannot be null");
+                sender.cancelRow();
+
+                sender.table("dummy");
+                assertThrowsContains(() -> sender.geoHashColumn("g", ""),
+                        "GEOHASH string cannot be empty");
+                sender.cancelRow();
+
+                sender.table("dummy");
+                assertThrowsContains(() -> sender.geoHashColumn("g", "0123456789abc"),
+                        "GEOHASH string exceeds 12 characters");
+                sender.cancelRow();
+
+                sender.table("dummy");
+                // 'a' is reserved (not in geohash base32 alphabet); the decoder
+                // rejects it as an invalid character.
+                assertThrowsContains(() -> sender.geoHashColumn("g", "ua"),
+                        "invalid GEOHASH string");
+                sender.cancelRow();
+
+                // Precision is locked on first value; a subsequent row at a
+                // different precision must throw before reaching the wire.
+                sender.table("dummy")
+                        .geoHashColumn("g", 0L, 20)
+                        .at(1_000_000, ChronoUnit.MICROS);
+                sender.table("dummy");
+                assertThrowsContains(() -> sender.geoHashColumn("g", 0L, 25),
+                        "GeoHash precision mismatch");
+                sender.cancelRow();
+            }
+        });
+    }
+
     @Test
     public void testGeoHashWirePrecisionMismatchRejected() throws Exception {
         runInContext((port) -> {
@@ -3561,6 +3724,17 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             drainWalQueue();
             assertSql("SELECT count() FROM " + table, "count\n1\n");
         });
+    }
+
+    private static void assertThrowsContains(Runnable action, String expectedMsgPart) {
+        try {
+            action.run();
+            Assert.fail("Expected LineSenderException containing '" + expectedMsgPart + "'");
+        } catch (LineSenderException e) {
+            String msg = e.getMessage();
+            Assert.assertTrue("Expected LineSenderException containing '" + expectedMsgPart
+                    + "' but got: " + msg, msg != null && msg.contains(expectedMsgPart));
+        }
     }
 
     private static void assertCoercionError(

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -602,6 +602,98 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
     }
 
     @Test
+    public void testBinarySourceRejectedByCharTarget() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_char_rejects_binary";
+            // Symmetric pin to testBinarySourceRejectedByVarcharTarget: a
+            // TYPE_BINARY wire payload must not be silently reinterpreted
+            // as text when the target column is CHAR. Without the guard
+            // QwpStringColumnCursor would route through putCharColumn and
+            // pick a CHAR from the leading byte(s).
+            execute("CREATE TABLE " + table + " (v CHAR, ts TIMESTAMP) "
+                    + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            byte[] payload = {(byte) 0x80, (byte) 0xFF, 0x00, 0x7F};
+
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                sender.table(table)
+                        .binaryColumn("v", payload)
+                        .at(1_000_000, ChronoUnit.MICROS);
+                try {
+                    sender.flush();
+                } catch (LineSenderException ignored) {
+                }
+            }
+
+            drainWalQueue();
+            assertSql(
+                    "SELECT count() FROM " + table,
+                    "count\n0\n"
+            );
+        });
+    }
+
+    @Test
+    public void testBinarySourceRejectedByStringTarget() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_string_rejects_binary";
+            // Symmetric pin to testBinarySourceRejectedByVarcharTarget: raw
+            // binary bytes must not land in a STRING column where
+            // Utf8s.directUtf8ToUtf16 would reinterpret them as text.
+            execute("CREATE TABLE " + table + " (v STRING, ts TIMESTAMP) "
+                    + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            byte[] payload = {(byte) 0x80, (byte) 0xFF, 0x00, 0x7F};
+
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                sender.table(table)
+                        .binaryColumn("v", payload)
+                        .at(1_000_000, ChronoUnit.MICROS);
+                try {
+                    sender.flush();
+                } catch (LineSenderException ignored) {
+                }
+            }
+
+            drainWalQueue();
+            assertSql(
+                    "SELECT count() FROM " + table,
+                    "count\n0\n"
+            );
+        });
+    }
+
+    @Test
+    public void testBinarySourceRejectedBySymbolTarget() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_symbol_rejects_binary";
+            // Symmetric pin to testBinarySourceRejectedByVarcharTarget: raw
+            // binary bytes must not be interned as a symbol via
+            // putStringToSymbolColumn.
+            execute("CREATE TABLE " + table + " (v SYMBOL, ts TIMESTAMP) "
+                    + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            byte[] payload = {(byte) 0x80, (byte) 0xFF, 0x00, 0x7F};
+
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                sender.table(table)
+                        .binaryColumn("v", payload)
+                        .at(1_000_000, ChronoUnit.MICROS);
+                try {
+                    sender.flush();
+                } catch (LineSenderException ignored) {
+                }
+            }
+
+            drainWalQueue();
+            assertSql(
+                    "SELECT count() FROM " + table,
+                    "count\n0\n"
+            );
+        });
+    }
+
+    @Test
     public void testBinarySourceRejectedByVarcharTarget() throws Exception {
         runInContext((port) -> {
             String table = "test_qwp_varchar_rejects_binary";

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -398,10 +398,14 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
      */
     @Test
     public void testCloseRethrowsLatchedTerminalError() throws Exception {
-        // Tight server recv buffer + no client-side row cap forces the
-        // 1000-row default batch to overflow on flush.
+        // Tight server recv buffer + a client configured to bypass the byte
+        // auto-flush (so it cannot self-clamp to the server-advertised cap)
+        // forces the 1000-row default batch to overflow on flush. When the
+        // server advertises X-QWP-Max-Batch-Size at handshake the default
+        // sender clamps to it -- this test explicitly disables that path by
+        // setting auto_flush_bytes=off so the rejection branch still fires.
         runInContext((port) -> {
-            try (QwpWebSocketSender sender = connectWs(port)) {
+            try (QwpWebSocketSender sender = connectWs(port, /*rows*/ 0, /*bytes*/ 0, /*intervalNanos*/ 0L)) {
                 for (int i = 0; i < 1500; i++) {
                     sender.table("close_rethrow")
                             .stringColumn("payload", "x".repeat(64))

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -32,6 +32,9 @@ import io.questdb.client.cutlass.qwp.protocol.QwpTableBuffer;
 import io.questdb.client.std.Decimal128;
 import io.questdb.client.std.Decimal256;
 import io.questdb.client.std.Decimal64;
+import io.questdb.client.std.bytes.DirectByteSlice;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Unsafe;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -214,6 +217,54 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
 
             drainWalQueue();
             assertSql("SELECT count() FROM test_at_now", "count\n1\n");
+        });
+    }
+
+    @Test
+    public void testAutoCreateBinaryColumn() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_auto_binary";
+            // Pre-create without the binary column so QwpWalAppender promotes
+            // TYPE_BINARY on first ingest to a BINARY column.
+            execute("CREATE TABLE " + table + " (ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            byte[] payload = {0x00, 0x7F, (byte) 0x80, (byte) 0xFF, 0x10, 0x20};
+
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                sender.table(table)
+                        .binaryColumn("b", payload)
+                        .at(1_000_000, ChronoUnit.MICROS);
+                // Row 2 omits the column -- implicit NULL via the null bitmap.
+                sender.table(table)
+                        .at(2_000_000, ChronoUnit.MICROS);
+                // Row 3 ships a zero-length value. QuestDB's BINARY storage
+                // layer (MemoryPARWImpl.putBin) writes the NULL_LEN sentinel
+                // when len == 0, so an empty byte[] round-trips as NULL on
+                // read -- there is no length-0 non-null BINARY in the storage
+                // contract. We send it anyway to pin that quirk in case it
+                // ever changes.
+                sender.table(table)
+                        .binaryColumn("b", new byte[0])
+                        .at(3_000_000, ChronoUnit.MICROS);
+                sender.flush();
+            }
+
+            drainWalQueue();
+            assertSql(
+                    "SELECT \"column\", type FROM table_columns('" + table + "') WHERE \"column\" = 'b'",
+                    "column\ttype\nb\tBINARY\n"
+            );
+            // length() returns -1 for NULL and the byte count otherwise.
+            // Rows 2 and 3 both surface as -1 (see comment on row 3 above).
+            assertSql(
+                    "SELECT length(b) AS len FROM " + table + " ORDER BY ts",
+                    """
+                            len
+                            6
+                            -1
+                            -1
+                            """
+            );
         });
     }
 
@@ -414,6 +465,97 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             assertSql(
                     "SELECT \"column\", type FROM table_columns('" + table + "') WHERE \"column\" = 'msg'",
                     "column\ttype\nmsg\tVARCHAR\n"
+            );
+        });
+    }
+
+    @Test
+    public void testBinaryColumnFromNativePointer() throws Exception {
+        // Exercises the zero-allocation overloads binaryColumn(name, ptr, len)
+        // and binaryColumn(name, DirectByteSlice). Both must land the same
+        // bytes as the byte[] form.
+        runInContext((port) -> {
+            String table = "test_qwp_binary_ptr";
+            execute("CREATE TABLE " + table + " (b BINARY, ts TIMESTAMP) "
+                    + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            byte[] payload = {(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF};
+            long ptr = Unsafe.malloc(payload.length, MemoryTag.NATIVE_DEFAULT);
+            try {
+                for (int i = 0; i < payload.length; i++) {
+                    Unsafe.putByte(ptr + i, payload[i]);
+                }
+
+                try (QwpWebSocketSender sender = connectWs(port)) {
+                    sender.table(table)
+                            .binaryColumn("b", ptr, payload.length)
+                            .at(1_000_000, ChronoUnit.MICROS);
+                    DirectByteSlice slice = new DirectByteSlice().of(ptr, payload.length);
+                    sender.table(table)
+                            .binaryColumn("b", slice)
+                            .at(2_000_000, ChronoUnit.MICROS);
+                    sender.flush();
+                }
+            } finally {
+                Unsafe.free(ptr, payload.length, MemoryTag.NATIVE_DEFAULT);
+            }
+
+            drainWalQueue();
+            assertSql(
+                    "SELECT length(b) AS len FROM " + table + " ORDER BY ts",
+                    """
+                            len
+                            4
+                            4
+                            """
+            );
+        });
+    }
+
+    @Test
+    public void testBinaryColumnValidation() throws Exception {
+        // Client-side validation of the binaryColumn API. A null reference is
+        // rejected so the NULL contract stays explicit (callers must omit the
+        // column instead, which routes through the null bitmap). Nothing here
+        // should reach the wire.
+        runInContext((port) -> {
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                sender.table("dummy");
+                assertThrowsContains(() -> sender.binaryColumn("b", (byte[]) null),
+                        "BINARY value cannot be null");
+                sender.cancelRow();
+                sender.table("dummy");
+                assertThrowsContains(() ->
+                                sender.binaryColumn("b", (io.questdb.client.std.bytes.DirectByteSlice) null),
+                        "BINARY slice cannot be null");
+                sender.cancelRow();
+            }
+        });
+    }
+
+    @Test
+    public void testBinaryColumnVarcharSourceCoercesToBinary() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_binary_from_varchar";
+            // Pre-create the table with a BINARY column. The client only has a
+            // stringColumn(...) helper, which sends TYPE_VARCHAR; QwpWalAppender's
+            // BINARY arm accepts both TYPE_BINARY and TYPE_VARCHAR sources because
+            // their wire layouts are identical, so the raw UTF-8 bytes land as
+            // BINARY without any reinterpretation step.
+            execute("CREATE TABLE " + table + " (b BINARY, ts TIMESTAMP) "
+                    + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                sender.table(table)
+                        .stringColumn("b", "hello") // 5 UTF-8 bytes
+                        .at(1_000_000, ChronoUnit.MICROS);
+                sender.flush();
+            }
+
+            drainWalQueue();
+            assertSql(
+                    "SELECT length(b) AS len FROM " + table,
+                    "len\n5\n"
             );
         });
     }
@@ -2329,7 +2471,7 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
                 sender.cancelRow();
 
                 sender.table("dummy");
-                assertThrowsContains(() -> sender.geoHashColumn("g", (CharSequence) null),
+                assertThrowsContains(() -> sender.geoHashColumn("g", null),
                         "GEOHASH string cannot be null");
                 sender.cancelRow();
 
@@ -3726,17 +3868,6 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
         });
     }
 
-    private static void assertThrowsContains(Runnable action, String expectedMsgPart) {
-        try {
-            action.run();
-            Assert.fail("Expected LineSenderException containing '" + expectedMsgPart + "'");
-        } catch (LineSenderException e) {
-            String msg = e.getMessage();
-            Assert.assertTrue("Expected LineSenderException containing '" + expectedMsgPart
-                    + "' but got: " + msg, msg != null && msg.contains(expectedMsgPart));
-        }
-    }
-
     private static void assertCoercionError(
             int port, String table,
             java.util.function.BiConsumer<QwpWebSocketSender, String> sendAction,
@@ -3765,6 +3896,17 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             Assert.assertTrue("Expected error containing '" + expectedMsgPart1 +
                             "' and '" + expectedMsgPart2 + "' but got: " + msg,
                     msg != null && msg.contains(expectedMsgPart1) && msg.contains(expectedMsgPart2));
+        }
+    }
+
+    private static void assertThrowsContains(Runnable action, String expectedMsgPart) {
+        try {
+            action.run();
+            Assert.fail("Expected LineSenderException containing '" + expectedMsgPart + "'");
+        } catch (LineSenderException e) {
+            String msg = e.getMessage();
+            Assert.assertTrue("Expected LineSenderException containing '" + expectedMsgPart
+                    + "' but got: " + msg, msg != null && msg.contains(expectedMsgPart));
         }
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -383,6 +383,47 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
     }
 
     @Test
+    public void testIntColumnIntoIPv4TranslatesNullSentinel() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_int_to_ipv4_null";
+            // The IPv4 arm of QwpWalAppender.appendToWalColumnar accepts
+            // qwpType == TYPE_INT as a legacy-client migration path (a
+            // client that predates TYPE_IPV4 can still ingest into an
+            // IPv4 column by sending int bits). But INT's NULL sentinel
+            // (Integer.MIN_VALUE = 0x80000000) is not IPv4's NULL
+            // sentinel (0 = 0.0.0.0). Without translation the bit
+            // pattern lands verbatim through putFixedColumn's no-bitmap
+            // memcpy fast path, and reads back as the valid address
+            // 128.0.0.0 -- silently changing what the user wrote (a
+            // NULL on the INT side) into a non-null IPv4 value.
+            execute("CREATE TABLE " + table + " (addr IPv4, ts TIMESTAMP) "
+                    + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                sender.table(table)
+                        .intColumn("addr", Integer.MIN_VALUE)   // INT_NULL
+                        .at(1_000_000, ChronoUnit.MICROS);
+                // Sanity row to confirm the TYPE_INT migration path
+                // still ingests real values correctly after the fix.
+                sender.table(table)
+                        .intColumn("addr", 0x0A000001)          // 10.0.0.1
+                        .at(2_000_000, ChronoUnit.MICROS);
+                sender.flush();
+            }
+
+            drainWalQueue();
+            assertSql(
+                    "SELECT coalesce(addr::string, 'null') v FROM " + table + " ORDER BY ts",
+                    """
+                            v
+                            null
+                            10.0.0.1
+                            """
+            );
+        });
+    }
+
+    @Test
     public void testAutoCreateIPv4Column() throws Exception {
         runInContext((port) -> {
             String table = "test_qwp_auto_ipv4";
@@ -556,6 +597,52 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             assertSql(
                     "SELECT length(b) AS len FROM " + table,
                     "len\n5\n"
+            );
+        });
+    }
+
+    @Test
+    public void testBinarySourceRejectedByVarcharTarget() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_varchar_rejects_binary";
+            // Pre-create the table with a VARCHAR column. The client sends
+            // TYPE_BINARY via binaryColumn(...), targeting that existing
+            // VARCHAR column. QwpWalAppender's VARCHAR arm pattern-matches
+            // the cursor by class (QwpStringColumnCursor handles both
+            // BINARY and VARCHAR wire layouts since they share the same
+            // offsets + bytes encoding) without checking qwpType, so today
+            // TYPE_BINARY bytes pass through putVarcharColumn unchecked and
+            // raw (possibly non-UTF-8) bytes land in a column QuestDB
+            // treats as UTF-8. The asymmetric BINARY arm has the symmetric
+            // qwpType guard (testBinaryColumnVarcharSourceCoercesToBinary
+            // pins the accepted direction); this test pins that the
+            // opposite direction is rejected.
+            execute("CREATE TABLE " + table + " (v VARCHAR, ts TIMESTAMP) "
+                    + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            // Non-UTF-8 bytes: 0x80 is a continuation byte without a lead,
+            // 0xFF is never valid UTF-8. If these land in a VARCHAR column
+            // they break the UTF-8 invariant the rest of QuestDB assumes.
+            byte[] payload = {(byte) 0x80, (byte) 0xFF, 0x00, 0x7F};
+
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                sender.table(table)
+                        .binaryColumn("v", payload)
+                        .at(1_000_000, ChronoUnit.MICROS);
+                try {
+                    sender.flush();
+                } catch (LineSenderException ignored) {
+                    // After the fix the server may surface the coercion
+                    // failure synchronously; before the fix it silently
+                    // accepts the row. Either way the count check below
+                    // is the definitive assertion.
+                }
+            }
+
+            drainWalQueue();
+            assertSql(
+                    "SELECT count() FROM " + table,
+                    "count\n0\n"
             );
         });
     }
@@ -1768,6 +1855,106 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
                     """
                             from_uuid\tfrom_timestamp
                             a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11\t2022-02-25T00:00:00.000Z
+                            """);
+        });
+    }
+
+    @Test
+    public void testCoercionToStringAndVarcharFromIPv4() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_ipv4_to_string_varchar";
+            // QwpFixedWidthColumnCursor reads TYPE_IPV4 wire data (4-byte
+            // int). When a client targets a pre-existing STRING or VARCHAR
+            // column with ipv4Column(...), appendToWalColumnar dispatches
+            // through the QwpFixedWidthColumnCursor arm of the STRING /
+            // VARCHAR switch. isIntegerWireType(qwpType) returns false for
+            // TYPE_IPV4 (the helper only covers BYTE/SHORT/INT/LONG), so
+            // the cursor falls into putFixedOtherToStringColumn /
+            // putFixedOtherToVarcharColumn, whose per-row formatter
+            // (formatFixedOtherValue) had no TYPE_IPV4 arm and threw
+            // "unsupported wire type for string conversion: 24" mid-row.
+            //
+            // After the fix, TYPE_IPV4 is formatted as a dotted-quad via
+            // Numbers.intToIPv4Sink and round-trips cleanly through both
+            // STRING and VARCHAR target columns. The IPv4 NULL sentinel
+            // (0) also round-trips as SQL NULL: the cursor's sentinel-null
+            // arm (added in the same series of fixes) classifies bit
+            // pattern 0 as null, so the per-row formatter is never called
+            // for that row.
+            execute("CREATE TABLE " + table + " ("
+                    + "addr_str STRING, addr_vc VARCHAR, ts TIMESTAMP"
+                    + ") TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                sender.table(table)
+                        .ipv4Column("addr_str", 0xC0A80101)         // 192.168.1.1
+                        .ipv4Column("addr_vc", 0xC0A80101)
+                        .at(1_000_000, ChronoUnit.MICROS);
+                // Sentinel row: bit pattern 0 must surface as SQL NULL on
+                // both targets, not as "0.0.0.0".
+                sender.table(table)
+                        .ipv4Column("addr_str", 0)
+                        .ipv4Column("addr_vc", 0)
+                        .at(2_000_000, ChronoUnit.MICROS);
+                sender.flush();
+            }
+
+            drainWalQueue();
+            assertSql(
+                    "SELECT coalesce(addr_str, 'null') s, coalesce(addr_vc, 'null') v"
+                            + " FROM " + table + " ORDER BY ts",
+                    """
+                            s\tv
+                            192.168.1.1\t192.168.1.1
+                            null\tnull
+                            """);
+        });
+    }
+
+    @Test
+    public void testCoercionToStringPreservesUuidAndLong256NullSentinels() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_uuid_long256_null_to_string";
+            // The cursor's isCurrentValueSentinelNull arms for TYPE_UUID and
+            // TYPE_LONG256 (added alongside the IPv4 sentinel arm) flow
+            // through cursor.isNull() consumed by the per-row loops in
+            // WalColumnarRowAppender.putFixedOtherToStringColumn and
+            // putFixedOtherToVarcharColumn. testCoercionToString /
+            // testCoercionToVarchar already exercise the happy path for
+            // UUID and LONG256 with random non-sentinel values, but neither
+            // pins what happens when the NULL bit pattern reaches the
+            // formatter: it must round-trip as SQL NULL, not as the
+            // literal "00000000-0000-0000-0000-000000000000" /
+            // "0x000...000" hex render. This test pins all four cells of
+            // the {UUID, LONG256} x {STRING, VARCHAR} matrix for the
+            // type-specific NULL sentinel.
+            execute("CREATE TABLE " + table + " (" +
+                    "uuid_str STRING, uuid_vc VARCHAR, " +
+                    "l256_str STRING, l256_vc VARCHAR, " +
+                    "ts TIMESTAMP" +
+                    ") TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                sender.table(table)
+                        // UUID NULL is (LONG_NULL, LONG_NULL) per Uuid.isNull.
+                        .uuidColumn("uuid_str", Long.MIN_VALUE, Long.MIN_VALUE)
+                        .uuidColumn("uuid_vc", Long.MIN_VALUE, Long.MIN_VALUE)
+                        // LONG256 NULL is all four longs == LONG_NULL per
+                        // Long256Impl.NULL_LONG256 static init.
+                        .long256Column("l256_str", Long.MIN_VALUE, Long.MIN_VALUE, Long.MIN_VALUE, Long.MIN_VALUE)
+                        .long256Column("l256_vc", Long.MIN_VALUE, Long.MIN_VALUE, Long.MIN_VALUE, Long.MIN_VALUE)
+                        .at(1_000_000, ChronoUnit.MICROS);
+                sender.flush();
+            }
+
+            drainWalQueue();
+            assertSql("SELECT count() FROM " + table, "count\n1\n");
+            assertSql(
+                    "SELECT uuid_str IS NULL AS u_s, uuid_vc IS NULL AS u_v,"
+                            + " l256_str IS NULL AS l_s, l256_vc IS NULL AS l_v FROM " + table,
+                    """
+                            u_s\tu_v\tl_s\tl_v
+                            true\ttrue\ttrue\ttrue
                             """);
         });
     }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -264,6 +264,49 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
     }
 
     @Test
+    public void testAutoCreateIPv4Column() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_auto_ipv4";
+            // Pre-create the table without the IPv4 column so QwpWalAppender
+            // auto-creates it, exercising the TYPE_IPV4 branch in
+            // mapQwpTypeToQuestDB plus the IPv4 null-aware arm in
+            // WalColumnarRowAppender.putFixedColumn (a null row forces the
+            // sparse path; 0.0.0.0 is QuestDB's IPv4 NULL sentinel).
+            execute("CREATE TABLE " + table + " (ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                sender.table(table)
+                        .ipv4Column("addr", 0xC0A80101) // 192.168.1.1
+                        .at(1_000_000, ChronoUnit.MICROS);
+                // Same column omitted on row 2 -> auto-NULL via the writer's null-aware path.
+                sender.table(table)
+                        .at(2_000_000, ChronoUnit.MICROS);
+                // String-overload parses the dotted-quad client-side.
+                sender.table(table)
+                        .ipv4Column("addr", "10.0.0.1")
+                        .at(3_000_000, ChronoUnit.MICROS);
+                sender.flush();
+            }
+
+            drainWalQueue();
+            // Verify the column was auto-created with the right QuestDB type.
+            assertSql(
+                    "SELECT type FROM table_columns('" + table + "') WHERE column = 'addr'",
+                    "type\nIPv4\n"
+            );
+            assertSql(
+                    "SELECT coalesce(addr::string, 'null') v FROM " + table + " ORDER BY ts",
+                    """
+                            v
+                            192.168.1.1
+                            null
+                            10.0.0.1
+                            """
+            );
+        });
+    }
+
+    @Test
     public void testAutoCreateNewColumnsDisabled() throws Exception {
         runInContextNoAutoCreate((port) -> {
             String table = "test_qwp_no_auto_col";

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFailoverBatchSizeTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFailoverBatchSizeTest.java
@@ -1,0 +1,344 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.qwp.e2e;
+
+import io.questdb.client.Sender;
+import io.questdb.client.SenderConnectionEvent;
+import io.questdb.client.SenderConnectionListener;
+import io.questdb.client.cutlass.line.LineSenderException;
+import io.questdb.cutlass.http.DefaultHttpContextConfiguration;
+import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
+import io.questdb.cutlass.http.HttpRequestHandlerFactory;
+import io.questdb.cutlass.http.HttpServer;
+import io.questdb.cutlass.qwp.server.QwpWebSocketHttpProcessor;
+import io.questdb.griffin.SqlException;
+import io.questdb.log.Log;
+import io.questdb.log.LogFactory;
+import io.questdb.network.PlainSocketFactory;
+import io.questdb.std.ObjHashSet;
+import io.questdb.std.Os;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.mp.TestWorkerPool;
+import io.questdb.test.tools.TestUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.ServerSocket;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * End-to-end coverage for the QWP ingress client's handling of the server's
+ * advertised {@code X-QWP-Max-Batch-Size} across a mid-stream failover to a
+ * peer with a tighter cap -- the rolling-upgrade scenario the
+ * {@code QwpWebSocketSender.applyServerBatchSizeLimit} Javadoc explicitly
+ * promises to handle.
+ *
+ * <p>The server formula in {@code QwpWebSocketUpgradeProcessor} is
+ * {@code advertised = min(http.recv.buffer.size - 14, 16 MB)}. Standing up
+ * two minimal QWP {@link HttpServer}s on the same {@code engine}, one with a
+ * roomy recv buffer and one with a tight recv buffer, gives them
+ * deterministically different advertised caps. The test then:
+ *
+ * <ol>
+ *   <li>Points a single {@link Sender} at the address list {@code A,B},
+ *       lets the initial connect land on A, and proves the wire is healthy
+ *       with a small row.</li>
+ *   <li>Stops A so the I/O thread observes the wire failure and the
+ *       reconnect loop walks to B -- a real mid-stream failover.</li>
+ *   <li>Pushes a single row whose raw bytes sit between the two caps:
+ *       safe under A's, oversize under B's.</li>
+ * </ol>
+ *
+ * <p>With the bug (current client code), the sender never refreshes its
+ * cached {@code serverMaxBatchSize} on reconnect, so the post-failover
+ * state still reflects A's roomy cap. The producer-thread "row too large"
+ * guard in {@code QwpWebSocketSender.sendRow} therefore does NOT fire, and
+ * the oversize row travels to B's wire only to be rejected downstream as
+ * a {@code ws-close[1009 Message Too Big]} -- a fuzzy error path
+ * unrelated to the cap.
+ *
+ * <p>With the fix, the cap is refreshed by the time the I/O thread
+ * installs the new client, so the producer guard fires synchronously with
+ * a clear {@code "row too large for server batch cap"} message citing
+ * B's tight cap. This test asserts that precise message, so it is red
+ * today and turns green when the fix lands.
+ */
+public class QwpSenderFailoverBatchSizeTest extends AbstractCairoTest {
+
+    private static final Log LOG = LogFactory.getLog(QwpSenderFailoverBatchSizeTest.class);
+    // 2 MB recv buffer  -> advertised cap = 2 * 1024 * 1024 - 14 = 2097138 bytes.
+    private static final int RECV_BUFFER_LARGE_BYTES = 2 * 1024 * 1024;
+    // 128 KB recv buffer -> advertised cap = 128 * 1024 - 14 = 131058 bytes.
+    private static final int RECV_BUFFER_SMALL_BYTES = 128 * 1024;
+    // 600 KB payload comfortably exceeds B's 131058 cap and fits under A's
+    // 2097138 cap, with margin for per-column metadata.
+    private static final int ROW_PAYLOAD_SIZE_BYTES = 600_000;
+
+    @Test
+    public void testReconnectToTighterCapRefreshesServerMaxBatchSize() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            int portA = pickFreePort();
+            int portB = pickFreePort();
+
+            QwpSidecar serverA = new QwpSidecar(portA, RECV_BUFFER_LARGE_BYTES);
+            QwpSidecar serverB = new QwpSidecar(portB, RECV_BUFFER_SMALL_BYTES);
+            try {
+                serverA.start();
+                serverB.start();
+
+                CapturingListener listener = new CapturingListener();
+                String config = "ws::addr=127.0.0.1:" + portA + ",127.0.0.1:" + portB
+                        + ";reconnect_max_duration_millis=15000"
+                        + ";reconnect_initial_backoff_millis=50"
+                        + ";reconnect_max_backoff_millis=200"
+                        + ";auto_flush_rows=1;";
+
+                try (Sender sender = Sender.builder(config)
+                        .connectionListener(listener)
+                        .build()) {
+                    Assert.assertTrue("CONNECTED must fire on initial connect",
+                            listener.awaitKind(SenderConnectionEvent.Kind.CONNECTED, 5_000));
+                    SenderConnectionEvent connected = listener.firstOf(SenderConnectionEvent.Kind.CONNECTED);
+                    Assert.assertNotNull(connected);
+                    Assert.assertEquals("initial CONNECTED must land on server A (first endpoint)",
+                            portA, connected.getPort());
+
+                    // Confirm A's wire works end-to-end before we kill it.
+                    sender.table("failover_cap_t")
+                            .longColumn("v", 1L)
+                            .at(1_000L, ChronoUnit.MICROS);
+                    sender.flush();
+
+                    // Stop A. The I/O thread surfaces the wire failure on its
+                    // next send/poll; the reconnect loop then walks to B.
+                    serverA.stop();
+
+                    // Drive producer-side traffic until FAILED_OVER lands.
+                    // Wire glitches during reconnect are expected and ignored.
+                    long deadlineNanos = System.nanoTime() + 15_000L * 1_000_000L;
+                    long row = 2;
+                    while (listener.countOf() == 0
+                            && System.nanoTime() < deadlineNanos) {
+                        try {
+                            sender.table("failover_cap_t")
+                                    .longColumn("v", row)
+                                    .at(1_000L * row, ChronoUnit.MICROS);
+                        } catch (LineSenderException ignored) {
+                            // mid-reconnect surface error; keep trying
+                        }
+                        row++;
+                        Os.sleep(20);
+                    }
+                    Assert.assertTrue("FAILED_OVER must fire after server A is stopped",
+                            listener.awaitKind(SenderConnectionEvent.Kind.FAILED_OVER, 1_000));
+                    SenderConnectionEvent failedOver = listener.firstOf(SenderConnectionEvent.Kind.FAILED_OVER);
+                    Assert.assertNotNull(failedOver);
+                    Assert.assertEquals("FAILED_OVER must land on server B (the only remaining endpoint)",
+                            portB, failedOver.getPort());
+
+                    // Now push a single row whose raw column bytes sit between
+                    // the two endpoint caps. The "row too large" guard in
+                    // sendRow must fire IFF serverMaxBatchSize was refreshed
+                    // to B's tight cap on the mid-stream reconnect.
+                    char[] payloadChars = new char[ROW_PAYLOAD_SIZE_BYTES];
+                    Arrays.fill(payloadChars, 'x');
+                    String payload = new String(payloadChars);
+
+                    LineSenderException thrown = null;
+                    try {
+                        sender.table("failover_cap_t")
+                                .stringColumn("payload", payload)
+                                .at(2_000_000L, ChronoUnit.MICROS);
+                        sender.flush();
+                    } catch (LineSenderException e) {
+                        thrown = e;
+                    }
+                    Assert.assertNotNull(
+                            "client must reject a row whose raw bytes exceed the new endpoint's serverMaxBatchSize",
+                            thrown);
+                    String msg = thrown.getMessage();
+                    Assert.assertNotNull(msg);
+                    Assert.assertTrue(
+                            "expected the producer-side 'row too large for server batch cap' guard message"
+                                    + " citing server B's tight cap, got: " + msg,
+                            msg.contains("row too large for server batch cap"));
+                }
+                // The QWP processor on each sidecar acquired WAL writers to
+                // ingest the warm-up / failover-driving rows. Without a WAL
+                // apply job those segments stay un-drained and the pooled
+                // writers keep file descriptors open. Drain explicitly and
+                // release inactive pool entries so assertMemoryLeak doesn't
+                // see them as a leak.
+                drainWalQueue();
+                engine.releaseInactive();
+            } finally {
+                serverA.stop();
+                serverB.stop();
+            }
+        });
+    }
+
+    private static int pickFreePort() throws Exception {
+        try (ServerSocket s = new ServerSocket(0)) {
+            s.setReuseAddress(true);
+            return s.getLocalPort();
+        }
+    }
+
+    /**
+     * Minimal QWP-only {@link HttpServer} wrapper modeled on
+     * {@link RestartableQwpServer}, but with a configurable HTTP recv buffer
+     * size so the test can stand up two peers that advertise distinct
+     * {@code X-QWP-Max-Batch-Size} caps. Shares the test's {@code engine}.
+     */
+    private static final class QwpSidecar {
+        private final int port;
+        private final int recvBufferSize;
+        private TestWorkerPool pool;
+        private boolean running;
+        private HttpServer server;
+
+        QwpSidecar(int port, int recvBufferSize) {
+            this.port = port;
+            this.recvBufferSize = recvBufferSize;
+        }
+
+        void start() throws SqlException {
+            final HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(
+                    configuration,
+                    new DefaultHttpContextConfiguration()
+            ) {
+                @Override
+                public int getBindPort() {
+                    return port;
+                }
+
+                @Override
+                public int getRecvBufferSize() {
+                    return recvBufferSize;
+                }
+            };
+            pool = new TestWorkerPool(1);
+            server = new HttpServer(httpConfig, pool, PlainSocketFactory.INSTANCE);
+            server.bind(new HttpRequestHandlerFactory() {
+                @Override
+                public ObjHashSet<String> getUrls() {
+                    return httpConfig.getContextPathQWP();
+                }
+
+                @Override
+                public QwpWebSocketHttpProcessor newInstance() {
+                    return new QwpWebSocketHttpProcessor(engine, httpConfig);
+                }
+            });
+            // Intentionally skip setupWriterJobs: this test only exercises the
+            // wire layer (handshake cap advertisement + client-side guard), and
+            // two co-existing sidecars on the same engine would collide on the
+            // singleton column-purge writer acquisition.
+            pool.start(LOG);
+            running = true;
+        }
+
+        void stop() {
+            if (!running) {
+                return;
+            }
+            running = false;
+            try {
+                pool.halt();
+            } catch (Throwable t) {
+                LOG.error().$("worker pool halt failed").$(t).$();
+            }
+            try {
+                server.close();
+            } catch (Throwable t) {
+                LOG.error().$("server close failed").$(t).$();
+            }
+            server = null;
+            pool = null;
+        }
+    }
+
+    /**
+     * Thread-safe collector of {@link SenderConnectionEvent}. The QWP
+     * dispatcher invokes the listener on its dedicated thread, so the
+     * collection must be concurrency-safe; events are sparse enough that
+     * {@link CopyOnWriteArrayList} is the right shape.
+     */
+    private static final class CapturingListener implements SenderConnectionListener {
+        private final List<SenderConnectionEvent> events = new CopyOnWriteArrayList<>();
+        private final Set<SenderConnectionEvent.Kind> seen = EnumSet.noneOf(SenderConnectionEvent.Kind.class);
+        private final Object seenLock = new Object();
+
+        @Override
+        public void onEvent(@NotNull SenderConnectionEvent event) {
+            events.add(event);
+            synchronized (seenLock) {
+                seen.add(event.getKind());
+                seenLock.notifyAll();
+            }
+        }
+
+        boolean awaitKind(SenderConnectionEvent.Kind kind, long timeoutMillis) throws InterruptedException {
+            long deadline = System.nanoTime() + timeoutMillis * 1_000_000L;
+            synchronized (seenLock) {
+                while (!seen.contains(kind)) {
+                    long remainingMs = (deadline - System.nanoTime()) / 1_000_000L;
+                    if (remainingMs <= 0) {
+                        return false;
+                    }
+                    seenLock.wait(remainingMs);
+                }
+                return true;
+            }
+        }
+
+        int countOf() {
+            int n = 0;
+            for (SenderConnectionEvent e : events) {
+                if (e.getKind() == SenderConnectionEvent.Kind.FAILED_OVER) {
+                    n++;
+                }
+            }
+            return n;
+        }
+
+        SenderConnectionEvent firstOf(SenderConnectionEvent.Kind kind) {
+            for (SenderConnectionEvent e : events) {
+                if (e.getKind() == kind) {
+                    return e;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFuzzTest.java
@@ -68,13 +68,21 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
     // colNameBases / colTypes / colValueBases are partitioned: the first
     // LEGACY_COLUMN_COUNT entries are STRING/DOUBLE columns and participate
     // in the full skip / new-column-injection fuzz; the rest are typed
-    // columns (BYTE, SHORT, INT, FLOAT, CHAR, UUID, LONG256, TIMESTAMP_NANO)
-    // that are always set on every row and never auto-injected as extras.
-    // Reason: typed columns whose unset cells render differently from their
-    // type-default (e.g. BYTE 0 vs INT NULL) would clash with the oracle's
-    // single-default-per-column model once startAlterTableThread converts
-    // them across the integer family.
+    // columns (BYTE, SHORT, INT, FLOAT, CHAR, UUID, LONG256, TIMESTAMP_NANO,
+    // GEOHASH at four precisions) that are always set on every row and never
+    // auto-injected as extras. Reason: typed columns whose unset cells render
+    // differently from their type-default (e.g. BYTE 0 vs INT NULL) would
+    // clash with the oracle's single-default-per-column model once
+    // startAlterTableThread converts them across the integer family.
     private static final int LEGACY_COLUMN_COUNT = 6;
+    // QuestDB's base32 alphabet (matches io.questdb.cairo.GeoHashes#base32):
+    // skips 'a', 'i', 'l', 'o' versus straight 0-9a-z.
+    private static final char[] GEO_HASH_BASE32 = {
+            '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'b', 'c', 'd', 'e', 'f', 'g',
+            'h', 'j', 'k', 'm', 'n', 'p', 'q', 'r',
+            's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+    };
     private static final Log LOG = LogFactory.getLog(QwpSenderFuzzTest.class);
     private static final int MAX_NUM_OF_SKIPPED_COLS = 2;
     private static final int NEW_COLUMN_RANDOMIZE_FACTOR = 2;
@@ -96,23 +104,34 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
             {"flag_c", "FLAG_C", "Flag_C"},
             {"sensor_id_u", "SENSOR_ID_U", "Sensor_Id_U"},
             {"token_l256", "TOKEN_L256", "Token_L256"},
-            {"event_at_ns", "EVENT_AT_NS", "Event_At_Ns"}
+            {"event_at_ns", "EVENT_AT_NS", "Event_At_Ns"},
+            {"loc_g5", "LOC_G5", "Loc_G5"},
+            {"loc_g15", "LOC_G15", "Loc_G15"},
+            {"loc_g20", "LOC_G20", "Loc_G20"},
+            {"loc_g35", "LOC_G35", "Loc_G35"}
     };
     // New non-string/non-double types added to fuzz native wire-type emission
     // through the QWP sender. Their addColumnValue cases yield exactly the
     // text representation that CursorPrinter writes for each type so the
     // TableData oracle's two-pass assertion matches.
     // int[] (not short[]) because TIMESTAMP_NANO is an int sentinel
-    // (1 << 18 | TIMESTAMP) outside the short range.
+    // (1 << 18 | TIMESTAMP) outside the short range. GEOBYTE/GEOSHORT/GEOINT/
+    // GEOLONG act as storage-class discriminants; addColumnValue maps each to
+    // a fixed precision (5b / 15b / 20b / 35b — all multiples of 5 so the
+    // cursor renders bare base32, matching the yielded string verbatim).
     private final int[] colTypes = new int[]{STRING, DOUBLE, DOUBLE, DOUBLE, STRING, DOUBLE,
-            BYTE, SHORT, INT, FLOAT, CHAR, UUID, LONG256, TIMESTAMP_NANO};
+            BYTE, SHORT, INT, FLOAT, CHAR, UUID, LONG256, TIMESTAMP_NANO,
+            GEOBYTE, GEOSHORT, GEOINT, GEOLONG};
     // Integer-family value bases (indices 6..9, for BYTE/SHORT/INT/FLOAT) are
     // capped so the *10 + d arithmetic stays within byte range. When the
     // alter-table thread narrows a column across the integer family (e.g.
     // INT -> BYTE), each previously-written value casts losslessly and the
     // oracle's stored yield still matches what the cursor renders.
+    // GEOHASH value bases are unused; the geohash cases generate random base32
+    // strings independent of valueBase.
     private final String[] colValueBases = new String[]{"europe", "8", "2", "1", "note", "6",
-            "5", "9", "11", "7", "M", "u", "l", "1700000000000000000"};
+            "5", "9", "11", "7", "M", "u", "l", "1700000000000000000",
+            "", "", "", ""};
     private final char[] nonAsciiChars = {'ó', 'í', 'Á', 'ч', 'Ъ', 'Ж', 'ю', 0x3000, 0x3080, 0x3a55};
     private final String[][] symbolNameBases = new String[][]{
             {"location", "Location", "LOCATION", "loCATion", "LocATioN"},
@@ -498,6 +517,10 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
                 NanosFormatUtils.appendDateTimeNSec(sink, nanos);
                 yield sink.toString();
             }
+            case GEOBYTE -> randomGeoHash(sender, colName, 1, rnd);   // GEOHASH(5b)
+            case GEOSHORT -> randomGeoHash(sender, colName, 3, rnd);  // GEOHASH(15b)
+            case GEOINT -> randomGeoHash(sender, colName, 4, rnd);    // GEOHASH(20b)
+            case GEOLONG -> randomGeoHash(sender, colName, 7, rnd);   // GEOHASH(35b)
             default -> {
                 sender.stringColumn(colName, valueBase);
                 yield valueBase;
@@ -548,6 +571,22 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
 
     private String addSymbolValue(int index, CharSequence colName, QwpWebSocketSender sender, Rnd rnd) {
         return addColumnValue(SYMBOL, symbolValueBases[index], colName, sender, rnd);
+    }
+
+    /**
+     * Emit a GEOHASH column from a random {@code chars}-char base32 string and
+     * yield the same string back. With precisions that are multiples of 5
+     * CursorPrinter renders the stored value as bare base32 (no '#' prefix),
+     * so the yield matches what the oracle reads back verbatim.
+     */
+    private String randomGeoHash(QwpWebSocketSender sender, CharSequence colName, int chars, Rnd rnd) {
+        char[] buf = new char[chars];
+        for (int i = 0; i < chars; i++) {
+            buf[i] = GEO_HASH_BASE32[rnd.nextInt(GEO_HASH_BASE32.length)];
+        }
+        String hash = new String(buf);
+        sender.geoHashColumn(colName, hash);
+        return hash;
     }
 
     private void assertTable(TableData table, String tableName) {

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFuzzTest.java
@@ -65,6 +65,14 @@ import static io.questdb.cairo.ColumnType.*;
 
 public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
 
+    // QuestDB's base32 alphabet (matches io.questdb.cairo.GeoHashes#base32):
+    // skips 'a', 'i', 'l', 'o' versus straight 0-9a-z.
+    private static final char[] GEO_HASH_BASE32 = {
+            '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'b', 'c', 'd', 'e', 'f', 'g',
+            'h', 'j', 'k', 'm', 'n', 'p', 'q', 'r',
+            's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+    };
     // colNameBases / colTypes / colValueBases are partitioned: the first
     // LEGACY_COLUMN_COUNT entries are STRING/DOUBLE columns and participate
     // in the full skip / new-column-injection fuzz; the rest are typed
@@ -75,14 +83,6 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
     // clash with the oracle's single-default-per-column model once
     // startAlterTableThread converts them across the integer family.
     private static final int LEGACY_COLUMN_COUNT = 6;
-    // QuestDB's base32 alphabet (matches io.questdb.cairo.GeoHashes#base32):
-    // skips 'a', 'i', 'l', 'o' versus straight 0-9a-z.
-    private static final char[] GEO_HASH_BASE32 = {
-            '0', '1', '2', '3', '4', '5', '6', '7',
-            '8', '9', 'b', 'c', 'd', 'e', 'f', 'g',
-            'h', 'j', 'k', 'm', 'n', 'p', 'q', 'r',
-            's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
-    };
     private static final Log LOG = LogFactory.getLog(QwpSenderFuzzTest.class);
     private static final int MAX_NUM_OF_SKIPPED_COLS = 2;
     private static final int NEW_COLUMN_RANDOMIZE_FACTOR = 2;
@@ -108,7 +108,8 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
             {"loc_g5", "LOC_G5", "Loc_G5"},
             {"loc_g15", "LOC_G15", "Loc_G15"},
             {"loc_g20", "LOC_G20", "Loc_G20"},
-            {"loc_g35", "LOC_G35", "Loc_G35"}
+            {"loc_g35", "LOC_G35", "Loc_G35"},
+            {"payload_bin", "PAYLOAD_BIN", "Payload_Bin"}
     };
     // New non-string/non-double types added to fuzz native wire-type emission
     // through the QWP sender. Their addColumnValue cases yield exactly the
@@ -121,7 +122,7 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
     // cursor renders bare base32, matching the yielded string verbatim).
     private final int[] colTypes = new int[]{STRING, DOUBLE, DOUBLE, DOUBLE, STRING, DOUBLE,
             BYTE, SHORT, INT, FLOAT, CHAR, UUID, LONG256, TIMESTAMP_NANO,
-            GEOBYTE, GEOSHORT, GEOINT, GEOLONG};
+            GEOBYTE, GEOSHORT, GEOINT, GEOLONG, BINARY};
     // Integer-family value bases (indices 6..9, for BYTE/SHORT/INT/FLOAT) are
     // capped so the *10 + d arithmetic stays within byte range. When the
     // alter-table thread narrows a column across the integer family (e.g.
@@ -131,7 +132,7 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
     // strings independent of valueBase.
     private final String[] colValueBases = new String[]{"europe", "8", "2", "1", "note", "6",
             "5", "9", "11", "7", "M", "u", "l", "1700000000000000000",
-            "", "", "", ""};
+            "", "", "", "", ""};
     private final char[] nonAsciiChars = {'ó', 'í', 'Á', 'ч', 'Ъ', 'Ж', 'ю', 0x3000, 0x3080, 0x3a55};
     private final String[][] symbolNameBases = new String[][]{
             {"location", "Location", "LOCATION", "loCATion", "LocATioN"},
@@ -521,6 +522,7 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
             case GEOSHORT -> randomGeoHash(sender, colName, 3, rnd);  // GEOHASH(15b)
             case GEOINT -> randomGeoHash(sender, colName, 4, rnd);    // GEOHASH(20b)
             case GEOLONG -> randomGeoHash(sender, colName, 7, rnd);   // GEOHASH(35b)
+            case BINARY -> randomBinaryOneByte(sender, colName, rnd);
             default -> {
                 sender.stringColumn(colName, valueBase);
                 yield valueBase;
@@ -571,22 +573,6 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
 
     private String addSymbolValue(int index, CharSequence colName, QwpWebSocketSender sender, Rnd rnd) {
         return addColumnValue(SYMBOL, symbolValueBases[index], colName, sender, rnd);
-    }
-
-    /**
-     * Emit a GEOHASH column from a random {@code chars}-char base32 string and
-     * yield the same string back. With precisions that are multiples of 5
-     * CursorPrinter renders the stored value as bare base32 (no '#' prefix),
-     * so the yield matches what the oracle reads back verbatim.
-     */
-    private String randomGeoHash(QwpWebSocketSender sender, CharSequence colName, int chars, Rnd rnd) {
-        char[] buf = new char[chars];
-        for (int i = 0; i < chars; i++) {
-            buf[i] = GEO_HASH_BASE32[rnd.nextInt(GEO_HASH_BASE32.length)];
-        }
-        String hash = new String(buf);
-        sender.geoHashColumn(colName, hash);
-        return hash;
     }
 
     private void assertTable(TableData table, String tableName) {
@@ -753,6 +739,37 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
     private CharSequence pickTableName(Rnd rnd) {
         String tableName = rnd.nextInt(UPPERCASE_TABLE_RANDOMIZE_FACTOR) == 0 ? "WEATHER" : "weather";
         return tableName + rnd.nextInt(numOfTables);
+    }
+
+    /**
+     * Emit a BINARY column with a random 1-byte payload and yield the exact
+     * text that {@code CursorPrinter} -> {@code Chars.toSink(BinarySequence,...)}
+     * produces for that payload: an 8-digit hex offset, a space, then the
+     * lowercase hex of the byte. Single-byte payloads keep the render to one
+     * line; multi-byte payloads would need to reproduce the 16-byte wrap rule.
+     */
+    private String randomBinaryOneByte(QwpWebSocketSender sender, CharSequence colName, Rnd rnd) {
+        byte b = (byte) rnd.nextInt(256);
+        sender.binaryColumn(colName, new byte[]{b});
+        char[] hex = io.questdb.std.Numbers.hexDigits;
+        int v = b & 0xFF;
+        return "00000000 " + hex[v >>> 4] + hex[v & 0xF];
+    }
+
+    /**
+     * Emit a GEOHASH column from a random {@code chars}-char base32 string and
+     * yield the same string back. With precisions that are multiples of 5
+     * CursorPrinter renders the stored value as bare base32 (no '#' prefix),
+     * so the yield matches what the oracle reads back verbatim.
+     */
+    private String randomGeoHash(QwpWebSocketSender sender, CharSequence colName, int chars, Rnd rnd) {
+        char[] buf = new char[chars];
+        for (int i = 0; i < chars; i++) {
+            buf[i] = GEO_HASH_BASE32[rnd.nextInt(GEO_HASH_BASE32.length)];
+        }
+        String hash = new String(buf);
+        sender.geoHashColumn(colName, hash);
+        return hash;
     }
 
     private void runTest() throws Exception {

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderOversizeRowInBatchTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderOversizeRowInBatchTest.java
@@ -1,0 +1,296 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.qwp.e2e;
+
+import io.questdb.client.Sender;
+import io.questdb.client.cutlass.line.LineSenderException;
+import io.questdb.cutlass.http.DefaultHttpContextConfiguration;
+import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
+import io.questdb.cutlass.http.HttpRequestHandlerFactory;
+import io.questdb.cutlass.http.HttpServer;
+import io.questdb.cutlass.qwp.server.QwpWebSocketHttpProcessor;
+import io.questdb.griffin.SqlException;
+import io.questdb.log.Log;
+import io.questdb.log.LogFactory;
+import io.questdb.network.PlainSocketFactory;
+import io.questdb.std.ObjHashSet;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.mp.TestWorkerPool;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.ServerSocket;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+
+/**
+ * End-to-end red test for the "row too large" producer-side guard inside
+ * {@code QwpWebSocketSender.sendRow}. The current guard is conditioned on
+ * {@code pendingRowCount == 1}, so it inspects only the very first row of
+ * a batch. Once a small row has accumulated, every subsequent row -- no
+ * matter how large -- escapes the guard and is silently appended to the
+ * pending batch. The auto-flush threshold then enqueues an oversize WS
+ * frame that the server closes with {@code ws-close[1009 Message Too Big]},
+ * surfacing the failure asynchronously rather than as the clean
+ * {@code "row too large for server batch cap"} pre-flight exception the
+ * guard was designed to produce.
+ *
+ * <p>This test:
+ * <ol>
+ *   <li>Stands up one QWP server with a tight HTTP recv buffer (128 KB),
+ *       so the advertised {@code X-QWP-Max-Batch-Size} is ~131 KB.</li>
+ *   <li>Sends a small row (raw bytes well under the cap), then a 600 KB
+ *       row (raw bytes well over the cap) to the same table.</li>
+ *   <li>Asserts the producer thread throws
+ *       {@code "row too large for server batch cap"} on the oversize row's
+ *       {@code at()} call.</li>
+ * </ol>
+ *
+ * <p>With the bug, the producer guard does not fire on row 2, so the
+ * {@code at()} call returns normally; the assertion that an exception
+ * with that message was thrown fails. With a per-row delta guard the
+ * exception fires synchronously and the test turns green.
+ */
+public class QwpSenderOversizeRowInBatchTest extends AbstractCairoTest {
+
+    private static final Log LOG = LogFactory.getLog(QwpSenderOversizeRowInBatchTest.class);
+    // 5 rows x 30 KB raw column data = 150 KB, comfortably above the
+    // 131058 cap while each individual row stays far below it.
+    private static final int BATCH_ROW_COUNT = 5;
+    // 128 KB recv buffer  -> advertised cap = 128 * 1024 - 14 = 131058 bytes.
+    private static final int RECV_BUFFER_SMALL_BYTES = 128 * 1024;
+    private static final int ROW_CHUNK_BYTES = 30 * 1024;
+    // 600 KB payload comfortably exceeds the 131058 cap with margin for
+    // per-column metadata.
+    private static final int ROW_PAYLOAD_SIZE_BYTES = 600_000;
+
+    @Test
+    public void testOversizeBatchFlushTripsProducerGuard() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            int port = pickFreePort();
+            QwpSidecar server = new QwpSidecar(port, RECV_BUFFER_SMALL_BYTES);
+            try {
+                server.start();
+
+                // Disable byte-based auto-flush so the user-driven batch
+                // grows past the server cap before the explicit flush().
+                // High row/interval thresholds keep the row-count and
+                // interval triggers out of the way. Each row's raw bytes
+                // are well under the per-row guard, so the only protection
+                // left is a flush-time wire-size check -- which today's
+                // flushPendingRows does not have.
+                String config = "ws::addr=127.0.0.1:" + port
+                        + ";auto_flush_rows=10000"
+                        + ";auto_flush_bytes=off"
+                        + ";auto_flush_interval=60000;";
+
+                try (Sender sender = Sender.builder(config).build()) {
+                    char[] chunkChars = new char[ROW_CHUNK_BYTES];
+                    Arrays.fill(chunkChars, 'x');
+                    String chunk = new String(chunkChars);
+
+                    // 5 rows x 30 KB = 150 KB raw, comfortably over the
+                    // sidecar's ~131 KB cap. Each individual row is far
+                    // below the cap so the per-row guard cannot help.
+                    for (int i = 0; i < BATCH_ROW_COUNT; i++) {
+                        sender.table("oversize_batch_t")
+                                .stringColumn("payload", chunk)
+                                .at(1_000L * (i + 1), ChronoUnit.MICROS);
+                    }
+
+                    LineSenderException thrown = null;
+                    try {
+                        sender.flush();
+                    } catch (LineSenderException e) {
+                        thrown = e;
+                    }
+
+                    Assert.assertNotNull(
+                            "expected flush() to refuse a batch whose wire size exceeds"
+                                    + " serverMaxBatchSize",
+                            thrown);
+                    String msg = thrown.getMessage();
+                    Assert.assertNotNull(msg);
+                    Assert.assertTrue(
+                            "expected 'batch too large for server batch cap' message,"
+                                    + " got: " + msg,
+                            msg.contains("batch too large for server batch cap"));
+                }
+                drainWalQueue();
+                engine.releaseInactive();
+            } finally {
+                server.stop();
+            }
+        });
+    }
+
+    @Test
+    public void testOversizeRowInsideBatchTripsProducerGuard() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            int port = pickFreePort();
+            QwpSidecar server = new QwpSidecar(port, RECV_BUFFER_SMALL_BYTES);
+            try {
+                server.start();
+
+                // High auto_flush_rows and auto_flush_bytes so the two
+                // rows accumulate into a single batch on the client. The
+                // producer guard is the only thing standing between the
+                // oversize row and a wire-level rejection -- exactly the
+                // condition the test is targeting.
+                String config = "ws::addr=127.0.0.1:" + port
+                        + ";auto_flush_rows=10000"
+                        + ";auto_flush_bytes=" + (ROW_PAYLOAD_SIZE_BYTES * 2)
+                        + ";auto_flush_interval=60000;";
+
+                try (Sender sender = Sender.builder(config).build()) {
+                    // Row 1: tiny. pendingRowCount becomes 1, the existing
+                    // pendingRowCount==1 guard inspects this row and
+                    // (correctly) lets it through.
+                    sender.table("oversize_in_batch_t")
+                            .longColumn("v", 1L)
+                            .at(1_000L, ChronoUnit.MICROS);
+
+                    // Row 2: a 600 KB string payload, well above the
+                    // sidecar's ~131 KB cap. A per-row delta guard MUST
+                    // fire on this row's at() call. Today, the guard is
+                    // gated on pendingRowCount==1 (now 2), so the row
+                    // commits silently and the test sees no exception.
+                    char[] payloadChars = new char[ROW_PAYLOAD_SIZE_BYTES];
+                    Arrays.fill(payloadChars, 'x');
+                    String payload = new String(payloadChars);
+
+                    LineSenderException thrown = null;
+                    try {
+                        sender.table("oversize_in_batch_t")
+                                .stringColumn("payload", payload)
+                                .at(2_000L, ChronoUnit.MICROS);
+                    } catch (LineSenderException e) {
+                        thrown = e;
+                    }
+
+                    Assert.assertNotNull(
+                            "expected producer-side guard to reject the oversize second row of the batch",
+                            thrown);
+                    String msg = thrown.getMessage();
+                    Assert.assertNotNull(msg);
+                    Assert.assertTrue(
+                            "expected 'row too large for server batch cap' message,"
+                                    + " got: " + msg,
+                            msg.contains("row too large for server batch cap"));
+                }
+                // The QWP processor on the sidecar may have acquired WAL
+                // writers to ingest the small row. Drain explicitly and
+                // release inactive pool entries so assertMemoryLeak
+                // doesn't see them as a leak.
+                drainWalQueue();
+                engine.releaseInactive();
+            } finally {
+                server.stop();
+            }
+        });
+    }
+
+    private static int pickFreePort() throws Exception {
+        try (ServerSocket s = new ServerSocket(0)) {
+            s.setReuseAddress(true);
+            return s.getLocalPort();
+        }
+    }
+
+    /**
+     * Minimal QWP-only {@link HttpServer} with a configurable HTTP recv
+     * buffer size so the test can stand up a peer whose advertised
+     * {@code X-QWP-Max-Batch-Size} is deterministically tight. Shares the
+     * test's {@code engine}.
+     */
+    private static final class QwpSidecar {
+        private final int port;
+        private final int recvBufferSize;
+        private TestWorkerPool pool;
+        private boolean running;
+        private HttpServer server;
+
+        QwpSidecar(int port, int recvBufferSize) {
+            this.port = port;
+            this.recvBufferSize = recvBufferSize;
+        }
+
+        void start() throws SqlException {
+            final HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(
+                    configuration,
+                    new DefaultHttpContextConfiguration()
+            ) {
+                @Override
+                public int getBindPort() {
+                    return port;
+                }
+
+                @Override
+                public int getRecvBufferSize() {
+                    return recvBufferSize;
+                }
+            };
+            pool = new TestWorkerPool(1);
+            server = new HttpServer(httpConfig, pool, PlainSocketFactory.INSTANCE);
+            server.bind(new HttpRequestHandlerFactory() {
+                @Override
+                public ObjHashSet<String> getUrls() {
+                    return httpConfig.getContextPathQWP();
+                }
+
+                @Override
+                public QwpWebSocketHttpProcessor newInstance() {
+                    return new QwpWebSocketHttpProcessor(engine, httpConfig);
+                }
+            });
+            // Intentionally skip setupWriterJobs: the test only exercises
+            // the wire layer (handshake cap advertisement + client-side
+            // guard) and does not need WAL apply behind it.
+            pool.start(LOG);
+            running = true;
+        }
+
+        void stop() {
+            if (!running) {
+                return;
+            }
+            running = false;
+            try {
+                pool.halt();
+            } catch (Throwable t) {
+                LOG.error().$("worker pool halt failed").$(t).$();
+            }
+            try {
+                server.close();
+            } catch (Throwable t) {
+                LOG.error().$("server close failed").$(t).$();
+            }
+            server = null;
+            pool = null;
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/load/QwpRow.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/load/QwpRow.java
@@ -194,12 +194,27 @@ public class QwpRow {
                     // auto-creates GEOHASH(Nb) sized to fit the declared precision.
                     qwp.geoHashColumn(name, v.geoHash, v.geoHashBits);
                     break;
+                case BINARY:
+                    sender.binaryColumn(name, v.bin);
+                    break;
                 case SYMBOL:
                     // already emitted
                     break;
             }
         }
         qwp.at(tsMicros, ChronoUnit.MICROS);
+    }
+
+    /**
+     * Records a BINARY value as a byte slice. Pass a non-null array (use
+     * {@code new byte[0]} for empty); omit the column entirely to model an
+     * explicit NULL through the bitmap path.
+     */
+    public QwpRow setBinary(String name, byte[] value) {
+        TypedValue v = put(name);
+        v.type = ValueType.BINARY;
+        v.bin = value;
+        return this;
     }
 
     public void setBool(String name, boolean value) {
@@ -609,6 +624,23 @@ public class QwpRow {
                 }
                 break;
             }
+            case ColumnType.BINARY: {
+                io.questdb.std.BinarySequence actual = record.getBin(columnIndex);
+                if (tv == null) {
+                    Assert.assertNull(name + " expected NULL row=" + rowOrdinal, actual);
+                } else {
+                    Assert.assertNotNull(name + " unexpectedly NULL row=" + rowOrdinal, actual);
+                    Assert.assertEquals(name + " length row=" + rowOrdinal, tv.bin.length, actual.length());
+                    for (int i = 0; i < tv.bin.length; i++) {
+                        Assert.assertEquals(
+                                name + " byte[" + i + "] row=" + rowOrdinal,
+                                tv.bin[i],
+                                actual.byteAt(i)
+                        );
+                    }
+                }
+                break;
+            }
             case ColumnType.SYMBOL: {
                 CharSequence actual = record.getSymA(columnIndex);
                 if (tv == null) {
@@ -691,7 +723,7 @@ public class QwpRow {
 
     public enum ValueType {
         BOOLEAN, BYTE, SHORT, INT, LONG, FLOAT, DOUBLE, CHAR, STRING, SYMBOL,
-        UUID, LONG256, TIMESTAMP_NANO, IPV4, GEOHASH,
+        UUID, LONG256, TIMESTAMP_NANO, IPV4, GEOHASH, BINARY,
         DOUBLE_ARRAY_1D, DOUBLE_ARRAY_2D, DOUBLE_ARRAY_3D,
         DECIMAL64, DECIMAL128, DECIMAL256
     }
@@ -699,6 +731,7 @@ public class QwpRow {
     public static final class TypedValue {
         public boolean b;
         public byte b8;
+        public byte[] bin;
         public char c;
         public double d;
         public double[] da1;

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/load/QwpRow.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/load/QwpRow.java
@@ -206,11 +206,23 @@ public class QwpRow {
     }
 
     /**
-     * Records a BINARY value as a byte slice. Pass a non-null array (use
-     * {@code new byte[0]} for empty); omit the column entirely to model an
-     * explicit NULL through the bitmap path.
+     * Records a BINARY value as a byte slice. The array must be non-null
+     * and non-empty: QuestDB's BINARY storage layer
+     * ({@code MemoryPARWImpl.putBin}) writes the {@code NULL_LEN} sentinel
+     * when {@code len == 0}, so an empty {@code byte[]} round-trips as SQL
+     * NULL on read and would diverge from this oracle's
+     * "expected-non-null, length 0" read assertion. To model an explicit
+     * NULL omit the column from the row entirely; the WAL writer marks it
+     * via the null bitmap.
+     *
+     * @throws IllegalArgumentException if {@code value} is null or empty
      */
     public QwpRow setBinary(String name, byte[] value) {
+        if (value == null || value.length == 0) {
+            throw new IllegalArgumentException(
+                    "setBinary requires a non-null, non-empty array (storage treats len=0 as NULL);"
+                            + " omit the column to model SQL NULL");
+        }
         TypedValue v = put(name);
         v.type = ValueType.BINARY;
         v.bin = value;

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/load/QwpRow.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/load/QwpRow.java
@@ -153,6 +153,9 @@ public class QwpRow {
                 case DECIMAL256:
                     sender.decimalColumn(name, new Decimal256(v.dec256Hh, v.dec256Hl, v.dec256Lh, v.dec256Ll, v.decScale));
                     break;
+                case IPV4:
+                    sender.ipv4Column(name, v.i);
+                    break;
                 case SYMBOL:
                     // already emitted
                     break;
@@ -190,6 +193,18 @@ public class QwpRow {
         v.type = ValueType.DECIMAL64;
         v.dec64Value = unscaledValue;
         v.decScale = scale;
+    }
+
+    /**
+     * Records a packed IPv4 address. The bit pattern 0 is reserved as QuestDB's
+     * IPv4 NULL sentinel; pass a non-zero address (or skip the column to model
+     * an explicit NULL) to keep the oracle's expectations unambiguous.
+     */
+    public QwpRow setIPv4(String name, int address) {
+        TypedValue v = put(name);
+        v.type = ValueType.IPV4;
+        v.i = address;
+        return this;
     }
 
     public QwpRow setDouble(String name, double value) {
@@ -319,6 +334,15 @@ public class QwpRow {
                 }
                 break;
             }
+            case ColumnType.IPv4: {
+                int actual = record.getIPv4(columnIndex);
+                if (tv == null) {
+                    Assert.assertEquals(name + " expected NULL row=" + rowOrdinal, Numbers.IPv4_NULL, actual);
+                } else {
+                    Assert.assertEquals(name + " row=" + rowOrdinal, tv.i, actual);
+                }
+                break;
+            }
             case ColumnType.DOUBLE: {
                 double actual = record.getDouble(columnIndex);
                 if (tv == null) {
@@ -431,7 +455,7 @@ public class QwpRow {
     }
 
     public enum ValueType {
-        BOOLEAN, LONG, DOUBLE, STRING, SYMBOL,
+        BOOLEAN, LONG, DOUBLE, STRING, SYMBOL, IPV4,
         DOUBLE_ARRAY_1D, DOUBLE_ARRAY_2D, DOUBLE_ARRAY_3D,
         DECIMAL64, DECIMAL128, DECIMAL256
     }
@@ -450,6 +474,7 @@ public class QwpRow {
         public long dec256Ll;
         public long dec64Value;
         public int decScale;
+        public int i;
         public long l;
         public String s;
         public ValueType type;

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/load/QwpRow.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/load/QwpRow.java
@@ -25,6 +25,7 @@
 package io.questdb.test.cutlass.qwp.load;
 
 import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.GeoHashes;
 import io.questdb.cairo.arr.ArrayView;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordMetadata;
@@ -188,6 +189,11 @@ public class QwpRow {
                 case IPV4:
                     sender.ipv4Column(name, v.ipv4);
                     break;
+                case GEOHASH:
+                    // QWP wire form carries the bits + precision pair; the server
+                    // auto-creates GEOHASH(Nb) sized to fit the declared precision.
+                    qwp.geoHashColumn(name, v.geoHash, v.geoHashBits);
+                    break;
                 case SYMBOL:
                     // already emitted
                     break;
@@ -280,6 +286,39 @@ public class QwpRow {
         TypedValue v = put(name);
         v.type = ValueType.FLOAT;
         v.f = value;
+    }
+
+    /**
+     * Records a GEOHASH value with explicit bit precision. {@code precisionBits}
+     * must be in {@code [1, 60]} and is locked at the column on the first row
+     * (the server auto-creates {@code GEOHASH(Nb)} sized to fit).
+     */
+    public QwpRow setGeoHash(String name, long bits, int precisionBits) {
+        TypedValue v = put(name);
+        v.type = ValueType.GEOHASH;
+        // Mask high bits so the stored expectation matches what the wire encoder
+        // and server-side null bitmap interpret (low precisionBits significant).
+        v.geoHash = precisionBits >= 64 ? bits : bits & ((1L << precisionBits) - 1L);
+        v.geoHashBits = precisionBits;
+        return this;
+    }
+
+    /**
+     * Records a GEOHASH from a base32 string (one char = 5 bits). Convenience
+     * for tests that want to read back exactly the string they wrote: the
+     * server stores the bits and renders them back as the same base32 string.
+     */
+    public QwpRow setGeoHash(String name, String base32) {
+        long bits = 0;
+        int len = base32.length();
+        for (int i = 0; i < len; i++) {
+            byte b = GeoHashes.encodeChar(base32.charAt(i));
+            if (b < 0) {
+                throw new IllegalArgumentException("invalid GEOHASH character '" + base32.charAt(i) + "' in: " + base32);
+            }
+            bits = (bits << 5) | b;
+        }
+        return setGeoHash(name, bits, len * 5);
     }
 
     public void setInt(String name, int value) {
@@ -459,6 +498,44 @@ public class QwpRow {
                 }
                 break;
             }
+            case ColumnType.GEOBYTE: {
+                // Server auto-creates GEOHASH(<=8b) as GEOBYTE storage; tv.geoHash
+                // already holds the low precisionBits, sign-narrow to byte to match.
+                byte actual = record.getGeoByte(columnIndex);
+                if (tv == null) {
+                    Assert.assertEquals(name + " expected NULL row=" + rowOrdinal, GeoHashes.BYTE_NULL, actual);
+                } else {
+                    Assert.assertEquals(name + " row=" + rowOrdinal, (byte) tv.geoHash, actual);
+                }
+                break;
+            }
+            case ColumnType.GEOSHORT: {
+                short actual = record.getGeoShort(columnIndex);
+                if (tv == null) {
+                    Assert.assertEquals(name + " expected NULL row=" + rowOrdinal, GeoHashes.SHORT_NULL, actual);
+                } else {
+                    Assert.assertEquals(name + " row=" + rowOrdinal, (short) tv.geoHash, actual);
+                }
+                break;
+            }
+            case ColumnType.GEOINT: {
+                int actual = record.getGeoInt(columnIndex);
+                if (tv == null) {
+                    Assert.assertEquals(name + " expected NULL row=" + rowOrdinal, GeoHashes.INT_NULL, actual);
+                } else {
+                    Assert.assertEquals(name + " row=" + rowOrdinal, (int) tv.geoHash, actual);
+                }
+                break;
+            }
+            case ColumnType.GEOLONG: {
+                long actual = record.getGeoLong(columnIndex);
+                if (tv == null) {
+                    Assert.assertEquals(name + " expected NULL row=" + rowOrdinal, GeoHashes.NULL, actual);
+                } else {
+                    Assert.assertEquals(name + " row=" + rowOrdinal, tv.geoHash, actual);
+                }
+                break;
+            }
             case ColumnType.FLOAT: {
                 float actual = record.getFloat(columnIndex);
                 if (tv == null) {
@@ -614,7 +691,7 @@ public class QwpRow {
 
     public enum ValueType {
         BOOLEAN, BYTE, SHORT, INT, LONG, FLOAT, DOUBLE, CHAR, STRING, SYMBOL,
-        UUID, LONG256, TIMESTAMP_NANO, IPV4,
+        UUID, LONG256, TIMESTAMP_NANO, IPV4, GEOHASH,
         DOUBLE_ARRAY_1D, DOUBLE_ARRAY_2D, DOUBLE_ARRAY_3D,
         DECIMAL64, DECIMAL128, DECIMAL256
     }
@@ -636,6 +713,8 @@ public class QwpRow {
         public long dec64Value;
         public int decScale;
         public float f;
+        public long geoHash;
+        public int geoHashBits;
         public int i32;
         public int ipv4;
         public long l;

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpAllTypesTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpAllTypesTest.java
@@ -128,6 +128,7 @@ public class QwpUdpAllTypesTest extends AbstractCairoTest {
                         b_short SHORT,
                         b_char CHAR,
                         b_int INT,
+                        b_ipv4 IPv4,
                         b_float FLOAT,
                         b_long LONG,
                         b_date DATE,
@@ -154,6 +155,8 @@ public class QwpUdpAllTypesTest extends AbstractCairoTest {
                     tb.getOrCreateColumn("b_short", TYPE_SHORT, false).addShort((short) 1234);
                     tb.getOrCreateColumn("b_char", TYPE_CHAR, false).addShort((short) 'X');
                     tb.getOrCreateColumn("b_int", TYPE_INT, false).addInt(56_789);
+                    // 192.168.1.1 packed
+                    tb.getOrCreateColumn("b_ipv4", TYPE_IPv4, true).addIPv4(0xC0A80101);
                     tb.getOrCreateColumn("b_float", TYPE_FLOAT, false).addFloat(3.14f);
                     tb.getOrCreateColumn("b_long", TYPE_LONG, false).addLong(99_999L);
                     tb.getOrCreateColumn("b_date", TYPE_DATE, true).addLong(1_705_276_800_000L);
@@ -181,14 +184,14 @@ public class QwpUdpAllTypesTest extends AbstractCairoTest {
             drainWalQueue();
             assertSql(
                     """
-                            b_bool\tb_byte\tb_short\tb_char\tb_int\tb_float\tb_long\tb_date\tb_double\tb_sym\tb_str\tb_uuid\tb_l256\tb_geo\tb_dec64\tb_dec128\tb_dec256\tb_darr\tb_ts\tb_tsns
-                            true\t42\t1234\tX\t56789\t3.14\t99999\t2024-01-15T00:00:00.000Z\t2.718\tabc\thello\t\
+                            b_bool\tb_byte\tb_short\tb_char\tb_int\tb_ipv4\tb_float\tb_long\tb_date\tb_double\tb_sym\tb_str\tb_uuid\tb_l256\tb_geo\tb_dec64\tb_dec128\tb_dec256\tb_darr\tb_ts\tb_tsns
+                            true\t42\t1234\tX\t56789\t192.168.1.1\t3.14\t99999\t2024-01-15T00:00:00.000Z\t2.718\tabc\thello\t\
                             550e8400-e29b-41d4-a716-446655440000\t\
                             0x4444444444444444333333333333333322222222222222221111111111111111\t\
                             s24se0\t123.45\t12345.6789\t99999.12345\t[1.0,2.0,3.0]\t\
                             2024-01-15T00:00:00.000000Z\t2024-01-15T00:00:00.000000123Z
                             """,
-                    "SELECT b_bool, b_byte, b_short, b_char, b_int, b_float, b_long, b_date, b_double, " +
+                    "SELECT b_bool, b_byte, b_short, b_char, b_int, b_ipv4, b_float, b_long, b_date, b_double, " +
                             "b_sym, b_str, b_uuid, b_l256, b_geo, b_dec64, b_dec128, b_dec256, b_darr, b_ts, b_tsns FROM t_all"
             );
         });
@@ -493,6 +496,63 @@ public class QwpUdpAllTypesTest extends AbstractCairoTest {
             assertSql(
                     "val\ns24se0\n",
                     "SELECT val FROM t_geo"
+            );
+        });
+    }
+
+    @Test
+    public void testIPv4Direct() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t_ipv4 (addr IPv4, timestamp TIMESTAMP) "
+                    + "TIMESTAMP(timestamp) PARTITION BY DAY WAL");
+
+            try (QwpUdpReceiver receiver = receiverFactory.create(LOW_COMMIT_RATE_CONF, engine)) {
+                // Concrete addresses round-trip via the wire (each datagram carries one row
+                // because the direct helper sends per call).
+                sendDirectRow("t_ipv4", tb -> {
+                    tb.getOrCreateColumn("addr", TYPE_IPv4, true).addIPv4(0xC0A80101); // 192.168.1.1
+                    tb.getOrCreateDesignatedTimestampColumn(TYPE_TIMESTAMP).addLong(1_000_000L);
+                    tb.nextRow();
+                });
+                sendDirectRow("t_ipv4", tb -> {
+                    tb.getOrCreateColumn("addr", TYPE_IPv4, true).addIPv4(0xFFFFFFFF); // 255.255.255.255
+                    tb.getOrCreateDesignatedTimestampColumn(TYPE_TIMESTAMP).addLong(2_000_000L);
+                    tb.nextRow();
+                });
+                sendDirectRow("t_ipv4", tb -> {
+                    tb.getOrCreateColumn("addr", TYPE_IPv4, true).addIPv4(0x0A000001); // 10.0.0.1
+                    tb.getOrCreateDesignatedTimestampColumn(TYPE_TIMESTAMP).addLong(3_000_000L);
+                    tb.nextRow();
+                });
+                // Row that does not mention addr at all: the table writer should fill the
+                // missing IPv4 cell with NULL on read.
+                sendDirectRow("t_ipv4", tb -> {
+                    tb.getOrCreateDesignatedTimestampColumn(TYPE_TIMESTAMP).addLong(4_000_000L);
+                    tb.nextRow();
+                });
+                // Explicit 0.0.0.0 -- QuestDB's IPv4 NULL sentinel; should also surface NULL.
+                sendDirectRow("t_ipv4", tb -> {
+                    tb.getOrCreateColumn("addr", TYPE_IPv4, true).addIPv4(0);
+                    tb.getOrCreateDesignatedTimestampColumn(TYPE_TIMESTAMP).addLong(5_000_000L);
+                    tb.nextRow();
+                });
+                drainReceiver(receiver);
+            }
+
+            drainWalQueue();
+            // Render through CAST to STRING so the NULL/0 rows surface as the literal token
+            // "null". This avoids depending on the implicit-cast rules of the IPv4 IN
+            // operator and matches QuestDB's IPv4 NULL convention.
+            assertSql(
+                    """
+                            v
+                            192.168.1.1
+                            255.255.255.255
+                            10.0.0.1
+                            null
+                            null
+                            """,
+                    "SELECT coalesce(addr::string, 'null') v FROM t_ipv4 ORDER BY timestamp"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/QwpWebSocketUpgradeProcessorOnHeadersReadyTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/QwpWebSocketUpgradeProcessorOnHeadersReadyTest.java
@@ -35,6 +35,7 @@ import io.questdb.cutlass.http.HttpRequestHeader;
 import io.questdb.cutlass.http.LocalValue;
 import io.questdb.cutlass.qwp.codec.QwpEgressMsgKind;
 import io.questdb.cutlass.qwp.codec.QwpServerInfoProvider;
+import io.questdb.cutlass.qwp.protocol.QwpConstants;
 import io.questdb.cutlass.qwp.server.QwpProcessorState;
 import io.questdb.cutlass.qwp.server.QwpWebSocketUpgradeProcessor;
 import io.questdb.network.PeerDisconnectedException;
@@ -67,6 +68,46 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
     @Test
     public void testOnHeadersReadyAcceptsStandaloneRole() throws Exception {
         assertMemoryLeak(() -> assertHandshakeAcceptedForRole(QwpEgressMsgKind.ROLE_STANDALONE, "STANDALONE"));
+    }
+
+    @Test
+    public void testOnHeadersReadyAdvertisesEffectiveBatchSize() throws Exception {
+        // The handshake response must carry X-QWP-Max-Batch-Size with the
+        // *effective* cap -- min(recvBufferSize - frame_overhead, MAX_BATCH_SIZE)
+        // -- so a wide-row client clamps to the value the server will actually
+        // accept on the wire rather than the QWP protocol ceiling. Advertising
+        // the protocol ceiling alone leaves clients hitting 1009 close on
+        // default deployments where recvBufferSize is well below 16 MB.
+        assertMemoryLeak(() -> {
+            HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+            QwpWebSocketUpgradeProcessor processor = new QwpWebSocketUpgradeProcessor(engine, httpConfig);
+
+            long bufferAddr = Unsafe.malloc(HANDSHAKE_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+            try (
+                    MockHttpRequestHeader header = new MockHttpRequestHeader();
+                    TestableContext context = new TestableContext(httpConfig, header, new MockRawSocket(bufferAddr, HANDSHAKE_BUFFER_SIZE))
+            ) {
+                header.setHeader("Upgrade", "websocket");
+                header.setHeader("Connection", "Upgrade");
+                header.setHeader("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
+                header.setHeader("Sec-WebSocket-Version", "13");
+
+                processor.onHeadersReady(context);
+
+                String response = readResponse(bufferAddr, context.getMockRawSocket().sentSize);
+                int expected = Math.min(
+                        Math.max(0, httpConfig.getRecvBufferSize() - 14),
+                        QwpConstants.DEFAULT_MAX_BATCH_SIZE);
+                String expectedHeader = "\r\nX-QWP-Max-Batch-Size: " + expected + "\r\n";
+                Assert.assertTrue(
+                        "response must carry X-QWP-Max-Batch-Size = " + expected + ", got: " + response,
+                        response.contains(expectedHeader));
+                Assert.assertTrue("advertised value must not exceed QWP protocol ceiling",
+                        expected <= QwpConstants.DEFAULT_MAX_BATCH_SIZE);
+            } finally {
+                Unsafe.free(bufferAddr, HANDSHAKE_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/QwpWebSocketUpgradeProcessorOnHeadersReadyTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/QwpWebSocketUpgradeProcessorOnHeadersReadyTest.java
@@ -78,8 +78,27 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
         // accept on the wire rather than the QWP protocol ceiling. Advertising
         // the protocol ceiling alone leaves clients hitting 1009 close on
         // default deployments where recvBufferSize is well below 16 MB.
+        //
+        // Pin the advertised value against a fixed recvBufferSize so a drift
+        // in MAX_WS_FRAME_HEADER_BYTES (currently 14; if it changed to 10 a
+        // re-derived expected would silently track it and the wire contract
+        // could regress unobserved) fails this test instead of passing.
         assertMemoryLeak(() -> {
-            HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+            // 128 KiB recv buffer; chosen well under DEFAULT_MAX_BATCH_SIZE so
+            // the test exercises the recv-buffer-minus-frame-overhead branch
+            // of the cap formula rather than the protocol ceiling branch.
+            final int recvBufferSize = 128 * 1024;
+            // Derivation: min(131072 - 14, 16 MiB) = min(131058, 16 MiB) = 131058.
+            // Updating MAX_WS_FRAME_HEADER_BYTES on the server side must be
+            // accompanied by updating this literal.
+            final int expectedAdvertisedCap = 131058;
+
+            HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration) {
+                @Override
+                public int getRecvBufferSize() {
+                    return recvBufferSize;
+                }
+            };
             QwpWebSocketUpgradeProcessor processor = new QwpWebSocketUpgradeProcessor(engine, httpConfig);
 
             long bufferAddr = Unsafe.malloc(HANDSHAKE_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
@@ -95,15 +114,14 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
                 processor.onHeadersReady(context);
 
                 String response = readResponse(bufferAddr, context.getMockRawSocket().sentSize);
-                int expected = Math.min(
-                        Math.max(0, httpConfig.getRecvBufferSize() - 14),
-                        QwpConstants.DEFAULT_MAX_BATCH_SIZE);
-                String expectedHeader = "\r\nX-QWP-Max-Batch-Size: " + expected + "\r\n";
+                String expectedHeader = "\r\nX-QWP-Max-Batch-Size: " + expectedAdvertisedCap + "\r\n";
                 Assert.assertTrue(
-                        "response must carry X-QWP-Max-Batch-Size = " + expected + ", got: " + response,
+                        "response must carry X-QWP-Max-Batch-Size = " + expectedAdvertisedCap
+                                + ", got: " + response,
                         response.contains(expectedHeader));
-                Assert.assertTrue("advertised value must not exceed QWP protocol ceiling",
-                        expected <= QwpConstants.DEFAULT_MAX_BATCH_SIZE);
+                Assert.assertTrue(
+                        "advertised value must not exceed QWP protocol ceiling",
+                        expectedAdvertisedCap <= QwpConstants.DEFAULT_MAX_BATCH_SIZE);
             } finally {
                 Unsafe.free(bufferAddr, HANDSHAKE_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
             }

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/WebSocketHandshakeTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/WebSocketHandshakeTest.java
@@ -226,13 +226,14 @@ public class WebSocketHandshakeTest extends AbstractWebSocketTest {
         assertMemoryLeak(() -> {
             String acceptKey = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
             int maxBatchSize = 16 * 1024 * 1024;
+            byte[] maxBatchSizeBytes = Integer.toString(maxBatchSize).getBytes(StandardCharsets.US_ASCII);
             int expectedSize = QwpWebSocketHttpProcessor.responseSize(
-                    acceptKey, 1, null, false, null, maxBatchSize);
+                    acceptKey, 1, null, false, null, maxBatchSizeBytes);
 
             long buf = allocateBuffer(512);
             try {
                 int written = QwpWebSocketHttpProcessor.writeResponse(
-                        buf, acceptKey, 1, null, false, null, maxBatchSize);
+                        buf, acceptKey, 1, null, false, null, maxBatchSizeBytes);
                 Assert.assertEquals(expectedSize, written);
 
                 String response = new String(readBytes(buf, written), StandardCharsets.US_ASCII);
@@ -246,14 +247,14 @@ public class WebSocketHandshakeTest extends AbstractWebSocketTest {
     }
 
     @Test
-    public void testWriteResponseOmitsMaxBatchSizeWhenZero() throws Exception {
+    public void testWriteResponseOmitsMaxBatchSizeWhenAbsent() throws Exception {
         assertMemoryLeak(() -> {
             String acceptKey = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
 
             long buf = allocateBuffer(256);
             try {
                 int written = QwpWebSocketHttpProcessor.writeResponse(
-                        buf, acceptKey, 1, null, false, null, 0);
+                        buf, acceptKey, 1, null, false, null, null);
 
                 String response = new String(readBytes(buf, written), StandardCharsets.US_ASCII);
                 Assert.assertFalse("did not expect X-QWP-Max-Batch-Size header, got: " + response,

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/WebSocketHandshakeTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/WebSocketHandshakeTest.java
@@ -222,6 +222,49 @@ public class WebSocketHandshakeTest extends AbstractWebSocketTest {
     }
 
     @Test
+    public void testResponseSizeWithMaxBatchSize() throws Exception {
+        assertMemoryLeak(() -> {
+            String acceptKey = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+            int maxBatchSize = 16 * 1024 * 1024;
+            int expectedSize = QwpWebSocketHttpProcessor.responseSize(
+                    acceptKey, 1, null, false, null, maxBatchSize);
+
+            long buf = allocateBuffer(512);
+            try {
+                int written = QwpWebSocketHttpProcessor.writeResponse(
+                        buf, acceptKey, 1, null, false, null, maxBatchSize);
+                Assert.assertEquals(expectedSize, written);
+
+                String response = new String(readBytes(buf, written), StandardCharsets.US_ASCII);
+                Assert.assertTrue("expected X-QWP-Max-Batch-Size header, got: " + response,
+                        response.contains("X-QWP-Max-Batch-Size: " + maxBatchSize + "\r\n"));
+                Assert.assertTrue(response.endsWith("\r\n\r\n"));
+            } finally {
+                freeBuffer(buf, 512);
+            }
+        });
+    }
+
+    @Test
+    public void testWriteResponseOmitsMaxBatchSizeWhenZero() throws Exception {
+        assertMemoryLeak(() -> {
+            String acceptKey = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+
+            long buf = allocateBuffer(256);
+            try {
+                int written = QwpWebSocketHttpProcessor.writeResponse(
+                        buf, acceptKey, 1, null, false, null, 0);
+
+                String response = new String(readBytes(buf, written), StandardCharsets.US_ASCII);
+                Assert.assertFalse("did not expect X-QWP-Max-Batch-Size header, got: " + response,
+                        response.contains("X-QWP-Max-Batch-Size"));
+            } finally {
+                freeBuffer(buf, 256);
+            }
+        });
+    }
+
+    @Test
     public void testThreadSafety() throws InterruptedException {
         // Test that accept key computation is thread-safe
         String clientKey = "dGhlIHNhbXBsZSBub25jZQ==";

--- a/docs/qwp/wire-egress.md
+++ b/docs/qwp/wire-egress.md
@@ -108,10 +108,12 @@ mismatches with a parse error and closes the WebSocket.
 - `raw` (or `identity`) - no compression.
 - `zstd` - whole-`RESULT_BATCH`-body zstd compression. Optional parameter
   `level=N` is a client-side hint; the server clamps to `[1, 9]` because
-  levels 10+ drop to `<20 MB/s` compress throughput. The default level is 3.
+  levels 10+ drop to `<20 MB/s` compress throughput. The default level is 1
+  -- the cheapest server-side CPU; raise it only when you measure a real
+  ratio improvement on your payload and have the headroom.
 
 The server echoes its choice in `X-QWP-Content-Encoding` (e.g.
-`zstd;level=3`). When `zstd` is negotiated, individual `RESULT_BATCH` frames
+`zstd;level=1`). When `zstd` is negotiated, individual `RESULT_BATCH` frames
 set `FLAG_ZSTD` (§7) on a per-batch basis; a batch whose compressed form is
 larger than its raw form ships raw. The region before the payload (msg_kind +
 request_id + batch_seq) is never compressed so the client dispatcher can

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -40,7 +40,7 @@
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
 
-        <questdb.client.version>1.2.1</questdb.client.version>
+        <questdb.client.version>1.2.2</questdb.client.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Tandem: https://github.com/questdb/questdb-enterprise/pull/1010

## Summary

This PR bundles several QWP ingest improvements that landed on the same branch:

### 1. Server advertises max batch size on handshake

- QWP ingest senders previously had no way to discover the server's payload cap. They learned it by sending a batch larger than 16 MB and reading `STATUS_PARSE_ERROR`. The 101 upgrade response on `/write/v4` now carries an `X-QWP-Max-Batch-Size` header with the server's effective payload cap (clamped to the smaller of the protocol ceiling and the HTTP recv buffer minus WebSocket framing overhead).
- The header is additive — older clients ignore it. The paired client-side parsing and budget clamping land in questdb/java-questdb-client#26.

### 2. IPv4 ingest support

- QWP egress had advertised `TYPE_IPV4` (0x18) since v1 cut, but ingress rejected it: `QwpColumnDef.validate()` range-checked `0x01..0x16 (CHAR)`, so any sender pushing an IPv4 column failed with `INVALID_COLUMN_TYPE` before the batch reached the table writer.
- `validate()` switches from a range check to an explicit allowlist that admits `TYPE_IPV4`. `BINARY` (0x17) stays rejected — no ingest decoder exists yet, but the explicit list now surfaces that gap rather than hiding it behind a range.
- `QwpConstants.getFixedTypeSize` / `isFixedWidthType`, `QwpFixedWidthColumnCursor`, and `QwpTableBlockCursor` treat IPv4 as a 4-byte fixed-width type, identical to INT on the wire.
- `QwpWalAppender` gains `TYPE_IPV4 -> ColumnType.IPv4` in `mapQwpTypeToQuestDB` (enables auto-create) and a dedicated IPv4 dispatch arm in `appendToWalColumnar` that accepts `TYPE_IPV4` or `TYPE_INT` wire input. Other coercions are rejected — IPv4 stays distinct from INT on read.
- `WalColumnarRowAppender.putFixedColumn` previously threw `unsupported column type for direct copy: IPv4` whenever any row in a batch was null (the fast path is a raw memcpy and worked without a switch). The null-aware switch now writes `Numbers.IPv4_NULL` (0) for null-bitmap positions and copies the int otherwise — matching QuestDB's IPv4 NULL convention.

The paired client-side IPv4 sender API lands in questdb/java-questdb-client#26.

### 3. GEOHASH end-to-end and fuzz coverage

The companion client adds the public `geoHashColumn(...)` API; this PR adds the end-to-end test coverage that proves GEOHASH round-trips through the server across all four storage classes, plus the bit-precise (non-multiple-of-5) wire path.

- `QwpSenderE2ETest` gains three GEOHASH tests:
  - `testAutoCreateGeoHashColumns` drives the new sender API in both overloads across GEOHASH(5b) / (15b) / (20b) / (35b), exercising the four storage classes (GEOBYTE / SHORT / INT / LONG) and the implicit-NULL bitmap path.
  - `testGeoHashColumnValidation` covers precision out of range, null / empty / over-12-char / invalid-base32 / cross-row precision mismatch — client-side `LineSenderException` paths that never reach the wire.
  - `testGeoHashColumnPrecisionPersistsAcrossBatches` pins the between-batch precision lock: a batch with no values for a previously-flushed GEOHASH column must still encode the schema-locked precision varint. Without the matching client fix, the server rejects the batch as `wireBits=1` vs the auto-created `GEOHASH(Nc)`.
- `QwpIngressOracleFuzzTest` adds five base GEOHASH columns at precisions 5 / 7 / 15 / 20 / 35 bits (covering the four storage classes plus one non-multiple-of-5 to exercise the bit-precise wire path), and four auto-create GEOHASH extras in `injectExtra` — `ex_g20` routes through the base32-string overload so the client-side decoder gets coverage on the auto-create path too.
- `QwpSenderFuzzTest` adds four typed GEOHASH columns to the always-written typed block, using `ColumnType.GEOBYTE / GEOSHORT / GEOINT / GEOLONG` as switch discriminants with fixed precision per case (multiples of 5 only so CursorPrinter's base32 render matches the yielded oracle string verbatim).
- `QwpRow` (the oracle row model) gains `ValueType.GEOHASH`, `setGeoHash(name, bits, precision)` plus a base32-string overload, dispatch through `qwp.geoHashColumn(...)`, and four storage-class-specific `assertCell` arms. `TypedValue`'s leftover IPv4 `i` field is renamed to `ipv4` to live cleanly next to `i32`.
- `QwpCursorBoundsCheckTest` had a gap that surfaced on CI: random-byte corruption that flipped a column-type byte to `TYPE_IPV4` (0x18) made the test's value consumer assert `unsupported fuzz column type: 24`. `TYPE_IPV4` is now in the consumer's `TYPE_INT` group, and an `ipv4` column is populated in `populateFuzzTable` so the non-corruption path exercises it too.

`questdb.client.version` default bumped to `1.2.2-SNAPSHOT` so e2e tests exercise the new client APIs. Pin back with `-Dquestdb.client.version=1.2.1` if you need to reproduce against the released client.

### 4. Cursor sentinel-null for IPv4 / UUID / LONG256

`QwpFixedWidthColumnCursor.readCurrentValue` handles `TYPE_IPV4`, `TYPE_UUID`, and `TYPE_LONG256`, but the matching `isCurrentValueSentinelNull` switch only handled `TYPE_INT` / `TYPE_LONG` / `TYPE_FLOAT` / `TYPE_DOUBLE`. The wire protocol omits the null bitmap whenever `nullCount == 0` (see `QwpColumnWriter.writeNullHeader`), so the sentinel switch is the protocol's intended null detector for those columns. The gap meant any consumer reading these types through `cursor.isNull()` saw the NULL bit-pattern as a real value.

- The bulk WAL ingest path (`WalColumnarRowAppender.putFixedColumn`) bypasses the cursor with a `nullBitmapAddress == 0 → bulk memcpy` fast path, so existing same-type ingest is unaffected.
- The type-conversion paths `putFixedOtherToStringColumn` / `putFixedOtherToVarcharColumn` dispatch UUID and LONG256 through `formatFixedOtherValue` and call `cursor.isNull()` per row, so the gap was live for those two types. After the fix, the NULL bit-pattern is correctly written as NULL into the target STRING / VARCHAR column rather than the literal `"00000000-0000-0000-0000-000000000000"` or `"0x000...000"`.
- IPv4 was latent (no `formatFixedOtherValue` arm dispatches to it today), but the asymmetry is closed for consistency with `readCurrentValue` and to harden against the next consumer that hits the cursor.

Three regression tests added to `QwpFixedWidthDecoderTest` mirror the existing `testDecodeIntColumnSentinelNullNoBitmap` pattern: `testDecodeIPv4ColumnSentinelNullNoBitmap`, `testDecodeUuidColumnSentinelNullNoBitmap`, `testDecodeLong256ColumnSentinelNullNoBitmap`.

### 5. End-to-end batch-cap regression tests

`QwpSenderOversizeRowInBatchTest` stands up a single QwpSidecar with a tight 128 KB recv buffer (advertised cap ~131 KB) and drives two scenarios that pin the producer-side guards added in the paired client PR:

- `testOversizeRowInsideBatchTripsProducerGuard`: a small row followed by a 600 KB row to the same table. Asserts the per-row guard throws `"row too large for server batch cap"` on row 2's `at()`, not just on row 1.
- `testOversizeBatchFlushTripsProducerGuard`: five 30 KB rows with byte-based auto-flush disabled, then a manual `flush()`. Asserts the flush-time guard throws `"batch too large for server batch cap"` rather than letting the oversize WS frame reach the wire (where the server would close the connection with `ws-close[1009]` asynchronously).

Both tests fail with "expected exception not thrown" against an unfixed client and pass against the matching client commit — true regression tests, not smoke tests.

Plus a minor tidy of `QwpSenderFailoverBatchSizeTest`: `countOf` signature simplified, sidecar made `static`, and a `drainWalQueue() + engine.releaseInactive()` block added to the teardown to satisfy `assertMemoryLeak`.

### 6. JMH micro-bench for the `pendingBytes` hot path

`QwpTotalBufferedBytesBenchmark` in the `benchmarks` module compares three implementations of the per-row `pendingBytes` update:

- `walkAllTables` — the pre-fix behaviour (walk every table per row).
- `currentTableOnly` — what the new delta-based code does (look at the active table only).
- `shortCircuit` — what a no-op would cost (lower bound for reference).

Parametrized on `numTables ∈ {1, 4, 16}` and `numColumns ∈ {1, 8}`. Confirms the `O(numTables)` shape of the old code (12.8 ns/row at 1 table, 264 ns/row at 16 tables on the dev machine) and the flat per-table cost of the new approach (~9 ns/row regardless of table count). Not a CI gate; ship-and-keep as documentation for the hot path.

### 7. Cross-type ingest hardening and test pins

Seven follow-ups that close asymmetric type-routing and test-coverage gaps surfaced by the new `TYPE_IPV4` / `TYPE_BINARY` allowlist additions and the cursor sentinel-null fix.

- **INT_NULL → IPv4_NULL translation.** The IPv4 arm of `appendToWalColumnar` accepts `qwpType == TYPE_INT` as a legacy-client migration path, but INT and IPv4 disagree on the NULL bit pattern (`INT_NULL = Integer.MIN_VALUE` vs `IPv4_NULL = 0`). Without translation, the fast-path memcpy in `WalColumnarRowAppender.putFixedColumn` would land `MIN_VALUE` verbatim and the value would read back as `128.0.0.0` instead of NULL. New `putIntToIPv4Column` method (added to both the `ColumnarRowAppender` interface and the WAL impl) uses the sentinel-aware `cursor.isNull()` to translate per row. Pinned by `testIntColumnIntoIPv4TranslatesNullSentinel`.
- **BINARY → VARCHAR coercion guard.** The VARCHAR arm of `appendToWalColumnar` pattern-matched the cursor by class only, so `TYPE_BINARY` wire data (newly valid after the allowlist refactor) routed through `putVarcharColumn` unchecked — raw possibly-non-UTF-8 bytes landing in a column QuestDB treats as UTF-8. A guard now rejects `qwpType == TYPE_BINARY` into a VARCHAR target with `coercionNotSupportedException`. Symmetric to the existing guard in the BINARY arm. Pinned by `testBinarySourceRejectedByVarcharTarget`.
- **UUID / LONG256 sentinel-null E2E pin.** The cursor sentinel-null arms for `TYPE_UUID` and `TYPE_LONG256` (section 4) flow through `cursor.isNull()` consumed by `putFixedOtherToStringColumn` / `putFixedOtherToVarcharColumn`, but existing `testCoercionToString` / `testCoercionToVarchar` only exercised random non-sentinel values. New `testCoercionToStringPreservesUuidAndLong256NullSentinels` sends `(LONG_NULL, LONG_NULL)` UUIDs and all-`LONG_NULL` LONG256 values into STRING and VARCHAR targets and asserts SQL NULL on read.
- **IPv4 → STRING / VARCHAR formatter arm.** `formatFixedOtherValue` had no `TYPE_IPV4` case, so a client sending `TYPE_IPV4` into a pre-existing STRING / VARCHAR column threw `"unsupported wire type for string conversion: 24"` mid-row and aborted the whole batch. Added a `TYPE_IPV4` arm that calls `Numbers.intToIPv4Sink` for dotted-quad rendering; the upstream `cursor.isNull()` filter already short-circuits the IPv4 NULL sentinel so this arm only fires for real addresses. Pinned by `testCoercionToStringAndVarcharFromIPv4`.
- **`setBinary` precondition tightened** (`QwpRow.java`, fuzz oracle helper). The Javadoc said "pass `new byte[0]` for empty", but `MemoryPARWImpl.putBin` writes `NULL_LEN` when `len == 0` so the column reads back as SQL NULL while `assertCell`'s BINARY arm asserts non-null + length match. Fuzz tests never emit length-0 today; the contract is tightened so future scenarios fail at the `setBinary` call site rather than at read-back assertion time.
- **Handshake cap test pin.** `testOnHeadersReadyAdvertisesEffectiveBatchSize` re-derived the "expected" value with the same `Math.min(Math.max(0, recvBufferSize - 14), DEFAULT_MAX_BATCH_SIZE)` formula the production code uses, so a drift in `MAX_WS_FRAME_HEADER_BYTES` (currently 14) would silently track on both sides. The test now pins the literal `131058` for a fixed `recvBufferSize` of 128 KiB — a future drift on either side fails this assertion.
- **`isFixedTypeCoercionAllowed` documentation.** The reverse direction `TYPE_IPV4` wire into a `BYTE` / `SHORT` / `INT` / `LONG` column is intentionally rejected (a valid IPv4 with bit pattern `Integer.MIN_VALUE` would land as `INT_NULL` and surface as SQL NULL on read — a worse surprise than rejecting). Javadoc on `isFixedTypeCoercionAllowed` and a cross-reference comment in the IPv4 arm now make this asymmetry and its NULL-sentinel reasoning explicit. No behaviour change.

### 8. Cache QWP handshake response header bytes (zero-GC)

Three response header values (`X-QWP-Version`, `X-QWP-Content-Encoding`,
`X-QWP-Max-Batch-Size`) were being built via
`Integer.toString().getBytes(US_ASCII)` and `String` concatenation on
every handshake. None of those values comes from client input — they
come from closed sets the server itself defines.

`QwpEgressCompressionNegotiator` now returns precomputed `byte[]`
instances from a per-zstd-level static table;
`QwpWebSocketHttpProcessor.VERSION_BYTES` is a static lookup by
version; `QwpWebSocketUpgradeProcessor` caches the max-batch-size
bytes at construction since the effective cap is derived from
`recvBufferSize` (per-instance config-fixed). Per-handshake
allocations for these three header values drop to zero. Wire format
byte-identical.

### 9. Default zstd compression level to 1 + operator force-level

Two related changes that give operators bounded CPU control over the
QWP egress compression path.

**Default**. The negotiator now picks level 1 (was 3) when a client
sends `zstd` without a level, or with an empty / unparseable level
value. Level 1 is the cheapest CPU; ratio gain at higher levels is
small for typical columnar payloads. Wire format unchanged.

**Force-level config**. New `qwp.egress.compression.force.level`
property (`PropertyKey.QWP_EGRESS_COMPRESSION_FORCE_LEVEL`).
- Value `0` (default) honors the client-negotiated level.
- Value in `[1, 9]` forces every ZSTD-negotiated connection on this
  server to that level regardless of what the client asked. Operators
  capping a misbehaving client at level 1 must beat clients that ask
  for level 9.

Reloadable: the property belongs to
`DynamicPropServerConfiguration.dynamicProps`, and
`QwpEgressUpgradeProcessor` reads
`engine.getConfiguration().getQwpEgressForcedZstdLevel()` on every
handshake (no caching at construction). Already-established
connections keep their negotiated level — mutating an in-flight ZSTD
context is not safe; the next new connection picks up the new value.

Out-of-range property values are rejected at startup; the override
site clamps as defense-in-depth.

New `QwpEgressCompressionNegotiatorTest` pins 11 cases between the
default-level (bare zstd, empty level, unparseable level), the
[1, 9] wire clamp at the negotiation site, and the operator override
semantics (no-op when off, no-op when codec != ZSTD, overrides client
choice in both directions, out-of-range clamp at the override site).

### 10. End-to-end test for force-level + hot reload

`QwpEgressCompressionTest.testForceLevelEnforcedOnWireAndHotReloadable`
writes `force.level=3` to `server.conf`, opens a client requesting
`compression_level=1`, asserts `client.getNegotiatedZstdLevel() == 3`
— proves the server's forced level beats the client request on the
wire. Then it rewrites the file with `force.level=9`, calls
`engine.getConfigReloader().reload()` synchronously, opens a fresh
client, and asserts `getNegotiatedZstdLevel() == 9` — proves hot
reload picks up on the next new connection without restart.

Uses the direct reload API (vs. file-watcher +
`assertReloadConfigEventually`) for determinism, matching
`DynamicPropServerConfigurationTest`'s convention.

Depends on the paired client-side accessor for
`X-QWP-Content-Encoding` (java-questdb-client #26 section 13).
Without that the test would have no observability for the wire-level
outcome.

## Tradeoffs

- Handshake header: 101 response body is ~30 bytes longer per upgrade. Negligible.
- The advertised batch cap is the protocol constant / recv-buffer-derived value — there is no per-server config knob to override it. Adding one is a separate change.
- Bumping `questdb.client.version` to `1.2.2-SNAPSHOT` means contributors on this branch must either `cd java-questdb-client && mvn clean install -DskipTests` once, or pass `-P local-client` to every build, until 1.2.2 ships. Without that, a stale local cache surfaces as a Maven resolution error.
- IPv4 ingest only accepts `TYPE_IPV4` and `TYPE_INT` wire data into IPv4 columns. Senders that previously crammed IPv4 addresses into INT columns and expected the server to interpret them as IPv4 still need an explicit IPv4 column type.
- The `QwpColumnDef.validate()` refactor swaps a single comparison for a switch. Cost is one extra branch per column-def parse — irrelevant in the noise.
- The GEOHASH coverage additions widen the oracle fuzz row by five columns and the non-oracle fuzz by four columns. Per-row wire payload grows by roughly 30-50 bytes; existing per-frame size budgets accommodate this without auto-flush behaviour changes.
- Forward-compatible: a 1.2.1 client connecting to this server ignores the unknown handshake header and behaves identically to before. Older clients that don't know about IPv4 / GEOHASH ingest simply never send those wire types.
- The cursor sentinel-null fix is a visible behaviour change for any consumer that today reads the NULL bit-pattern as a non-null value. UUID and LONG256 conversion-to-string paths are the live ones affected; their stored values now correctly read as SQL NULL rather than the literal all-zeros string. Bulk WAL ingest is unaffected (cursor bypassed).
- The new e2e tests in `QwpSenderOversizeRowInBatchTest` rely on the matching client-side guards landing. Without them the assertions fail with "expected exception not thrown".
- `QwpTotalBufferedBytesBenchmark` lives in the `benchmarks` module and is not run by CI. The numbers it reports are dev-machine-specific.
- The `INT_NULL → IPv4_NULL` translation changes observable behaviour for any caller today sending `Integer.MIN_VALUE` via `intColumn` into an IPv4 column. Before: stored as `128.0.0.0` silently. After: surfaces as SQL NULL. Strictly an improvement but a behaviour change for code relying on the old quirk.
- The `BINARY → VARCHAR` rejection breaks any caller today writing `TYPE_BINARY` into a pre-existing VARCHAR column. The only "working" use case was "VARCHAR happens to be UTF-8-safe random bytes" which is by definition fragile; a clear coercion error is the right surface.
- The `IPv4 → STRING/VARCHAR` formatter is purely additive: a code path that throws mid-row today succeeds and produces dotted-quad output. No caller relied on the mid-row throw.

## Cross-repo

- Client side: questdb/java-questdb-client#26 — parses `X-QWP-Max-Batch-Size`, clamps batches accordingly, exposes `sender.ipv4Column(...)` and `sender.geoHashColumn(...)` on the public `Sender` interface, ships the matching client-side GEOHASH precision-persistence fix, adds the producer-side batch-cap guards pinned by the e2e tests in this PR, and fixes the closed-sender check precedence across every column setter that null-short-circuits before the close check.
- Build pin: questdb/questdb-enterprise#1010 — bumps the enterprise client default to 1.2.2-SNAPSHOT.

## Test plan

- mvn test -pl core -Dtest="WebSocketHandshakeTest" — covers the header emission (positive value emits, zero omits).
- mvn test -pl core -Dtest="QwpSenderE2ETest" — end-to-end tests pass against the SNAPSHOT client, including IPv4 auto-create + the three new GEOHASH tests (auto-create across storage classes, validation paths, between-batch precision lock).
- mvn test -pl core -Dtest="QwpUdpAllTypesTest" — adds `testIPv4Direct` (three concrete addresses + explicit-bitmap-null + explicit 0.0.0.0 -> both NULL on read) and grows `testAllTypesInOneRow` with an IPv4 column.
- mvn test -pl core -Dtest="QwpIngressOracleFuzzTest" — oracle fuzz now generates `ip` + five base GEOHASH columns and per-id IPv4 / GEOHASH extras in `injectExtra`, exercising SF replay and the server-side auto-add-column path under randomized load.
- mvn test -pl core -Dtest="QwpSenderFuzzTest" — non-oracle fuzz writes IPv4 and four GEOHASH columns per row across 28 test scenarios.
- mvn test -pl core -Dtest="QwpCursorBoundsCheckTest" — payload-corruption fuzz no longer trips on `TYPE_IPV4` and exercises IPv4 in the clean path.
- mvn test -pl core -Dtest="QwpColumnDefTest" — `TYPE_IPV4` is in the valid-types fixture; 0x17 (BINARY) and 0x00 stay rejected.
- mvn test -pl core -Dtest="QwpFixedWidthDecoderTest" — 34 tests including the three new sentinel-null cases (`testDecodeIPv4ColumnSentinelNullNoBitmap`, `testDecodeUuidColumnSentinelNullNoBitmap`, `testDecodeLong256ColumnSentinelNullNoBitmap`).
- mvn test -pl core -Dtest="QwpSenderOversizeRowInBatchTest" — 2 tests, both pass against the paired client commit.
- mvn test -pl core -Dtest="QwpSenderE2ETest" — full E2E pass, including the four new tests added in section 7: `testIntColumnIntoIPv4TranslatesNullSentinel`, `testBinarySourceRejectedByVarcharTarget`, `testCoercionToStringPreservesUuidAndLong256NullSentinels`, `testCoercionToStringAndVarcharFromIPv4`.
- mvn test -pl core -Dtest="QwpWebSocketUpgradeProcessorOnHeadersReadyTest" — 15 tests, including the now-pinned `testOnHeadersReadyAdvertisesEffectiveBatchSize`.
- mvn test -pl core -Dtest.include="%regex[.*[Qq]wp.*]" — full core QWP regression: 1285 tests pass.



