### PR TITLE
Add support for unsigned integers in Line Protocol

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
@@ -801,12 +801,13 @@ public class LineTcpParser implements QuietCloseable {
             // System.err.println("LineTcpParser.ProtoEntity.parse :: " + ((char) last) + ", valueLen: " + valueLen);
             binaryFormat = false;
             switch (last) {
+                case 'u':
                 case 'i':
                     if (valueLen > 1 && value.byteAt(1) != 'x') {
                         return parseLong(ENTITY_TYPE_INTEGER);
                     }
                     if (valueLen > 3 && value.byteAt(0) == '0' && (value.byteAt(1) | 32) == 'x') {
-                        value.decHi(); // remove 'i'
+                        value.decHi(); // remove suffix ('i', 'u')
                         type = ENTITY_TYPE_LONG256;
                         return true;
                     }
@@ -1001,7 +1002,7 @@ public class LineTcpParser implements QuietCloseable {
             try {
                 charSeq.of(value.lo(), value.hi() - 1, true);
                 longValue = Numbers.parseLong(charSeq);
-                value.decHi(); // remove the suffix ('i', 'n', 't', 'm')
+                value.decHi(); // remove the suffix ('i', 'n', 't', 'm', 'u')
                 type = entityType;
             } catch (NumericException notANumber) {
                 unit = TIMESTAMP_UNIT_UNSET;

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpParserTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpParserTest.java
@@ -75,9 +75,11 @@ public class LineTcpParserTest extends BaseLineTcpContextTest {
 
         assertType(LineTcpParser.ENTITY_TYPE_LONG256, "0x123i");
         assertType(LineTcpParser.ENTITY_TYPE_LONG256, "0x1i");
+        assertType(LineTcpParser.ENTITY_TYPE_LONG256, "0x1234u");
 
         assertType(LineTcpParser.ENTITY_TYPE_INTEGER, "123i");
         assertType(LineTcpParser.ENTITY_TYPE_INTEGER, "1i");
+        assertType(LineTcpParser.ENTITY_TYPE_INTEGER, "1234u");
 
         assertType(LineTcpParser.ENTITY_TYPE_TIMESTAMP, CommonUtils.TIMESTAMP_UNIT_MICROS, "42t");
         assertType(LineTcpParser.ENTITY_TYPE_TIMESTAMP, CommonUtils.TIMESTAMP_UNIT_MICROS, "-42t");
@@ -157,7 +159,8 @@ public class LineTcpParserTest extends BaseLineTcpContextTest {
                                 break;
                             case LineTcpParser.ENTITY_TYPE_INTEGER:
                             case LineTcpParser.ENTITY_TYPE_LONG256:
-                                Assert.assertEquals(expectedValue, entity.getValue().toString() + "i");
+                                String suffix = expectedValue.endsWith("u") ? "u" : "i";
+                                Assert.assertEquals(expectedValue, entity.getValue().toString() + suffix);
                                 break;
                             case LineTcpParser.ENTITY_TYPE_TIMESTAMP:
                                 switch (unit) {


### PR DESCRIPTION
Hi, I saw #6567 was open for a while so I thought I would take a crack at it. This is my first contribution for questdb.

This PR adds support for the unsigned integer suffix (u) in the Line Protocol parser (LineTcpParser.java) to fix a "400 Bad Request" ingestion error.

By letting case 'u' fall through to case 'i', unsigned numbers are now routed through the standard ENTITY_TYPE_INTEGER pathway. Is this the acceptable and preferred behavior, or is there a different preferred architectural approach? Also added tests in LineTcpParserTest.java and updated the validation logic to dynamically accept both "i" and "u" suffixes.

Fixes #6567 