### PR TITLE
fix(core): WAL metaFile drift across mid-alter crash

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerImpl.java
@@ -124,6 +124,15 @@ public class TableSequencerImpl implements TableSequencer {
             walIdGenerator.open(path);
             metadata.open(path, rootLen, tableToken);
             tableTransactionLog.open(path);
+            // Replay any structure changes that were committed to the txn
+            // log but had not yet been written to the metaFile mmap before
+            // the previous shutdown. nextStructureTxn writes txnLog first
+            // and metaFile second, so a crash between the two leaves the
+            // metaFile lagging; without this catch-up the next structure
+            // change would observe metadata.getMetadataVersion() <
+            // tableTransactionLog.maxMetadataVersion and trip
+            // beginMetadataChangeEntry's invariant.
+            catchUpMetadataFromTxnLog();
         } catch (CairoException ex) {
             closeLocked();
             if (ex.isTableDropped()) {
@@ -327,7 +336,26 @@ public class TableSequencerImpl implements TableSequencer {
                 AlterOperation deserializedAlter = tableTransactionLog.readTableMetadataChangeLog(
                         expectedStructureVersion, alterCommandWalFormatter);
 
-                applyToMetadata(deserializedAlter);
+                // Apply the (round-tripped) change to the in-memory metadata
+                // so the bumped metadata.getMetadataVersion() is visible to
+                // the invariant check below, but defer writing the metaFile
+                // mmap until AFTER endMetadataChangeEntry commits the txn
+                // log. mmap writes survive a process restart through the
+                // kernel page cache regardless of msync, so what matters
+                // here is the ORDER in which the two files receive their
+                // writes. If the metaFile mmap is written first (structure
+                // version bumped) and we crash before MAX_TXN_OFFSET is
+                // bumped, on restart metadata.getMetadataVersion() reads
+                // the new version while txnLog reports the old, and the
+                // next nextStructureTxn fails beginMetadataChangeEntry's
+                // invariant with
+                //   "possible corruption in transaction metadata
+                //    [offset=..., newVersion=...]"
+                // Writing the txn-log commit first leaves only the inverse
+                // window (metaFile behind txnLog) which
+                // catchUpMetadataFromTxnLog resolves on open by replaying
+                // pending alters.
+                deserializedAlter.apply(metadataSvc, true);
                 if (metadata.getMetadataVersion() != expectedStructureVersion + 1) {
                     throw CairoException.critical(0)
                             .put("applying structure change to WAL table failed [table=").put(tableToken)
@@ -335,10 +363,11 @@ public class TableSequencerImpl implements TableSequencer {
                             .put(", newVersion: ").put(metadata.getMetadataVersion())
                             .put(']');
                 }
-                metadata.sync();
                 // TableToken can become updated as a result of alter.
                 tableToken = metadata.getTableToken();
                 txn = tableTransactionLog.endMetadataChangeEntry();
+                metadata.syncToMetaFile();
+                metadata.sync();
 
                 if (!seqTxnTracker.isSuspended()) {
                     notifyTxnCommitted(txn);
@@ -408,19 +437,7 @@ public class TableSequencerImpl implements TableSequencer {
             return null;
         }
 
-        try (TableMetadataChangeLog metaChangeCursor = tableTransactionLog.getTableMetadataChangeLog(
-                metadata.getMetadataVersion(), alterCommandWalFormatter)
-        ) {
-            boolean updated = false;
-            while (metaChangeCursor.hasNext()) {
-                TableMetadataChange change = metaChangeCursor.next();
-                change.apply(metadataSvc, true);
-                updated = true;
-            }
-            if (updated) {
-                metadata.syncToMetaFile();
-            }
-        }
+        catchUpMetadataFromTxnLog();
         long lastTxn = tableTransactionLog.lastTxn();
         LOG.info()
                 .$("reloaded table sequencer [table=").$(tableToken)
@@ -441,9 +458,31 @@ public class TableSequencerImpl implements TableSequencer {
         this.distressed = true;
     }
 
-    private void applyToMetadata(TableMetadataChange change) {
-        change.apply(metadataSvc, true);
-        metadata.syncToMetaFile();
+    /**
+     * Bring the metaFile forward to match any structure changes that were
+     * committed to the txn log but had not yet propagated into the metaFile
+     * mmap before a crash. nextStructureTxn now writes the metaFile mmap
+     * AFTER endMetadataChangeEntry commits the txn log, so the only
+     * post-crash inconsistency window is metaFile lagging txnLog. This
+     * replays the missing alters from txnMetaMem into the metaFile mmap
+     * (which the kernel page cache then exposes to the next reader),
+     * so subsequent calls into nextStructureTxn see a consistent
+     * metadata.getMetadataVersion().
+     */
+    private void catchUpMetadataFromTxnLog() {
+        try (TableMetadataChangeLog metaChangeCursor = tableTransactionLog.getTableMetadataChangeLog(
+                metadata.getMetadataVersion(), alterCommandWalFormatter)
+        ) {
+            boolean updated = false;
+            while (metaChangeCursor.hasNext()) {
+                TableMetadataChange change = metaChangeCursor.next();
+                change.apply(metadataSvc, true);
+                updated = true;
+            }
+            if (updated) {
+                metadata.syncToMetaFile();
+            }
+        }
     }
 
     private void checkDropped() {


### PR DESCRIPTION
## Summary

Fixes a server-side WAL transaction-log invariant violation that triggers on process restart between an in-progress structure change's metaFile write and its txn-log commit. The next column-add after the restart fails with:

```
possible corruption in transaction metadata [table=..., offset=..., newVersion=...]
```

surfaced repeatedly by the QuestDB c-client QWP/WS bounce-sweep fuzz suite (seed `0x646fe2971b68a028`, CI build [234113](https://dev.azure.com/questdb/questdb/_build/results?buildId=234113)).

## Root cause

`TableSequencerImpl.nextStructureTxn` issued writes in this order:

1. `beginMetadataChangeEntry(v+1, ...)` — writes the alter record into `txnMem` mmap; bumps `txnMetaMem` + `txnMetaMemIndex`.
2. `applyToMetadata(...)` — `change.apply` updates in-memory metadata; `metadata.syncToMetaFile()` **writes the new structure version into the metaFile mmap**.
3. `metadata.sync()` — msync metaFile (cosmetic; mmap-page-cache persistence makes it not load-bearing for crash recovery).
4. `endMetadataChangeEntry()` — `fullSync()` then `txnLogFile.endMetadataChangeEntry()` — **bumps `MAX_TXN_OFFSET` in txnMem mmap**.

mmap writes survive process restart through the kernel page cache irrespective of msync, so what matters for crash consistency is the order of the *mmap writes themselves* — not the msyncs. A kill between (2) and (4) leaves the metaFile mmap durably ahead of the txn-log commit pointer. On restart:

- `metadata.open()` reads `structureVersion=v+1` from the metaFile.
- `tableTransactionLog.open()` reads `MAX_TXN_OFFSET=T` (unchanged → `maxStructureVersion=v`), positions `txnMetaMemIndex.appendOffset = (v+1) * 8`.

The next ingest-side column-add then satisfies the gate `metadata.getMetadataVersion() == expectedStructureVersion` (both `v+1`) and calls `beginMetadataChangeEntry(v+2, ...)`, which trips:

```java
if (newStructureVersion != txnMetaMemIndex.getAppendOffset() / Long.BYTES) {
    throw CairoException.critical(0).put("possible corruption in transaction metadata ...");
}
```

— with `newStructureVersion = v+2` (e.g. 90) and `appendOffset/8 = v+1` (89, hence the `offset=712` in the CI failure).

## Fix

Reorder the *writes* in `nextStructureTxn` so the txn-log commit lands before the metaFile mmap update:

- Split `applyToMetadata` into its two components: keep `deserializedAlter.apply(metadataSvc, true)` (in-memory state — still needed before the post-commit invariant check), but defer `metadata.syncToMetaFile()` until after `endMetadataChangeEntry()`.
- The reorder leaves only the inverse crash window (metaFile lagging txnLog). The existing `reload()` already had a catch-up loop that replays pending alters from `txnMetaMem` into the metaFile — factor it into `catchUpMetadataFromTxnLog()` and call it from `open()` as well as `reload()`.
- `applyToMetadata` is now unused; remove it.

After the fix, all crash windows are either consistent (both files at same version) or fixable on next open (metaFile behind txnLog → catch-up replays missing alters).

## Test plan

- [x] `TableSequencerImplTest` — 9 tests pass
- [x] `TableTransactionLogFuzzTest` — passes
- [x] `WalAlterTableSqlTest`, `WalTableFailureTest`, `AlterTableWalEnabledTest` — 83 tests, 0 failures
- [x] `WalTableWriterFuzzTest`, `WalWriterTest`, `WalWriterReplaceRangeTest` — 142 tests, 0 failures
- [ ] Re-run the QWP/WS bounce-sweep fuzz suite against a QuestDB build that includes this fix (seed `0x646fe2971b68a028` from CI build 234113) and confirm `test_n_bounce_sweep` is green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)