### PR TITLE
Fix Line Protocol Comment Handling

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
@@ -329,6 +329,19 @@ public class LineTcpParser implements QuietCloseable {
                     appendByte = true;
                     nextValueCanBeOpenQuote = false;
                     break;
+
+                case '#':
+                    if (entityHandler == ENTITY_HANDLER_TABLE) {
+                        ParseResult skipResult = skipMeasurement(bufHi);
+                        if (skipResult == ParseResult.MEASUREMENT_COMPLETE) {
+                            startNextMeasurement();
+                            break;
+                        }
+                        return skipResult;
+                    }
+                    appendByte = true;
+                    nextValueCanBeOpenQuote = false;
+                    break;
             }
 
             if (appendByte) {
@@ -1042,7 +1055,7 @@ public class LineTcpParser implements QuietCloseable {
     }
 
     static {
-        char[] chars = new char[]{'\n', '\r', '=', ',', ' ', '\\', '"', '\0', '/'};
+        char[] chars = new char[]{'\n', '\r', '=', ',', ' ', '\\', '"', '\0', '/', '#'};
         controlBytes = new boolean[256];
         for (char ch : chars) {
             controlBytes[ch] = true;

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
@@ -801,12 +801,13 @@ public class LineTcpParser implements QuietCloseable {
             // System.err.println("LineTcpParser.ProtoEntity.parse :: " + ((char) last) + ", valueLen: " + valueLen);
             binaryFormat = false;
             switch (last) {
+                case 'u':
                 case 'i':
                     if (valueLen > 1 && value.byteAt(1) != 'x') {
                         return parseLong(ENTITY_TYPE_INTEGER);
                     }
                     if (valueLen > 3 && value.byteAt(0) == '0' && (value.byteAt(1) | 32) == 'x') {
-                        value.decHi(); // remove 'i'
+                        value.decHi(); // remove suffix ('i', 'u')
                         type = ENTITY_TYPE_LONG256;
                         return true;
                     }
@@ -1001,7 +1002,7 @@ public class LineTcpParser implements QuietCloseable {
             try {
                 charSeq.of(value.lo(), value.hi() - 1, true);
                 longValue = Numbers.parseLong(charSeq);
-                value.decHi(); // remove the suffix ('i', 'n', 't', 'm')
+                value.decHi(); // remove the suffix ('i', 'n', 't', 'm', 'u')
                 type = entityType;
             } catch (NumericException notANumber) {
                 unit = TIMESTAMP_UNIT_UNSET;

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpParserTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpParserTest.java
@@ -36,6 +36,30 @@ import org.junit.Test;
 public class LineTcpParserTest extends BaseLineTcpContextTest {
 
     @Test
+    public void testCommentsIgnored() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (LineTcpParser lineTcpParser = new LineTcpParser()) {
+                sink.clear();
+                sink.put("# This is a comment\n");
+                sink.put("t,v=k f=123i\n");
+                byte[] bytes = sink.toString().getBytes(Files.UTF_8);
+                final int len = bytes.length;
+                long mem = Unsafe.malloc(bytes.length, MemoryTag.NATIVE_DEFAULT);
+                try {
+                    for (int i = 0; i < bytes.length; i++) {
+                        Unsafe.putByte(mem + i, bytes[i]);
+                    }
+                    lineTcpParser.of(mem);
+                    Assert.assertEquals(LineTcpParser.ParseResult.MEASUREMENT_COMPLETE, lineTcpParser.parseMeasurement(mem + len));
+                    Assert.assertEquals("t", lineTcpParser.getMeasurementName().toString());
+                } finally {
+                    Unsafe.free(mem, bytes.length, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
     public void testGetValueType() throws Exception {
         assertType(LineTcpParser.ENTITY_TYPE_TAG, "null");
         assertType(LineTcpParser.ENTITY_TYPE_TAG, "NULL");

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpParserTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpParserTest.java
@@ -75,9 +75,11 @@ public class LineTcpParserTest extends BaseLineTcpContextTest {
 
         assertType(LineTcpParser.ENTITY_TYPE_LONG256, "0x123i");
         assertType(LineTcpParser.ENTITY_TYPE_LONG256, "0x1i");
+        assertType(LineTcpParser.ENTITY_TYPE_LONG256, "0x1234u");
 
         assertType(LineTcpParser.ENTITY_TYPE_INTEGER, "123i");
         assertType(LineTcpParser.ENTITY_TYPE_INTEGER, "1i");
+        assertType(LineTcpParser.ENTITY_TYPE_INTEGER, "1234u");
 
         assertType(LineTcpParser.ENTITY_TYPE_TIMESTAMP, CommonUtils.TIMESTAMP_UNIT_MICROS, "42t");
         assertType(LineTcpParser.ENTITY_TYPE_TIMESTAMP, CommonUtils.TIMESTAMP_UNIT_MICROS, "-42t");
@@ -157,7 +159,8 @@ public class LineTcpParserTest extends BaseLineTcpContextTest {
                                 break;
                             case LineTcpParser.ENTITY_TYPE_INTEGER:
                             case LineTcpParser.ENTITY_TYPE_LONG256:
-                                Assert.assertEquals(expectedValue, entity.getValue().toString() + "i");
+                                String suffix = expectedValue.endsWith("u") ? "u" : "i";
+                                Assert.assertEquals(expectedValue, entity.getValue().toString() + suffix);
                                 break;
                             case LineTcpParser.ENTITY_TYPE_TIMESTAMP:
                                 switch (unit) {


### PR DESCRIPTION
Fixes #6566

### Summary
The Line Protocol parser did not recognize comments, causing it to evaluate comment lines (lines starting with #) as normal input data and throw an ingestion syntax error.

### Approach

- Control Byte: Added ```#``` to the ```controlBytes``` array at the bottom of the file to ensure that the parser stops and processes ```#``` correctly.
- State Handling: Added a case for ```#``` in ```parseMeasurement```. If the parser sees a ```#``` while the state is set to ```ENTITY_HANDLER_TABLE``` (meaning the "#" is at the start of a newline), it will skip the rest of the line to discard the comment line up until the newline character.
- Context Awareness: If a ```#``` appears anywhere else in a line, the parser will skip the comment logic and append it as regular data.

### Testing
Added a new test in LineTcpParserTest.java to verify that comment lines are skipped correctly and subsequent valid lines are parsed correctly.

