### PR TITLE
Fix Line Protocol Comment Handling

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/LineTcpParser.java
@@ -329,6 +329,19 @@ public class LineTcpParser implements QuietCloseable {
                     appendByte = true;
                     nextValueCanBeOpenQuote = false;
                     break;
+
+                case '#':
+                    if (entityHandler == ENTITY_HANDLER_TABLE) {
+                        ParseResult skipResult = skipMeasurement(bufHi);
+                        if (skipResult == ParseResult.MEASUREMENT_COMPLETE) {
+                            startNextMeasurement();
+                            break;
+                        }
+                        return skipResult;
+                    }
+                    appendByte = true;
+                    nextValueCanBeOpenQuote = false;
+                    break;
             }
 
             if (appendByte) {
@@ -1041,7 +1054,7 @@ public class LineTcpParser implements QuietCloseable {
     }
 
     static {
-        char[] chars = new char[]{'\n', '\r', '=', ',', ' ', '\\', '"', '\0', '/'};
+        char[] chars = new char[]{'\n', '\r', '=', ',', ' ', '\\', '"', '\0', '/', '#'};
         controlBytes = new boolean[256];
         for (char ch : chars) {
             controlBytes[ch] = true;

--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpParserTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpParserTest.java
@@ -36,6 +36,30 @@ import org.junit.Test;
 public class LineTcpParserTest extends BaseLineTcpContextTest {
 
     @Test
+    public void testCommentsIgnored() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (LineTcpParser lineTcpParser = new LineTcpParser()) {
+                sink.clear();
+                sink.put("# This is a comment\n");
+                sink.put("t,v=k f=123i\n");
+                byte[] bytes = sink.toString().getBytes(Files.UTF_8);
+                final int len = bytes.length;
+                long mem = Unsafe.malloc(bytes.length, MemoryTag.NATIVE_DEFAULT);
+                try {
+                    for (int i = 0; i < bytes.length; i++) {
+                        Unsafe.putByte(mem + i, bytes[i]);
+                    }
+                    lineTcpParser.of(mem);
+                    Assert.assertEquals(LineTcpParser.ParseResult.MEASUREMENT_COMPLETE, lineTcpParser.parseMeasurement(mem + len));
+                    Assert.assertEquals("t", lineTcpParser.getMeasurementName().toString());
+                } finally {
+                    Unsafe.free(mem, bytes.length, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
     public void testGetValueType() throws Exception {
         assertType(LineTcpParser.ENTITY_TYPE_TAG, "null");
         assertType(LineTcpParser.ENTITY_TYPE_TAG, "NULL");


### PR DESCRIPTION
Fixes #6566

### Summary
The Line Protocol parser did not recognize comments, causing it to evaluate comment lines (lines starting with #) as normal input data and throw an ingestion syntax error.

### Approach

- Control Byte: Added ```#``` to the ```controlBytes``` array at the bottom of the file to ensure that the parser stops and processes ```#``` correctly.
- State Handling: Added a case for ```#``` in ```parseMeasurement```. If the parser sees a ```#``` while the state is set to ```ENTITY_HANDLER_TABLE``` (meaning the "#" is at the start of a newline), it will skip the rest of the line to discard the comment line up until the newline character.
- Context Awareness: If a ```#``` appears anywhere else in a line, the parser will skip the comment logic and append it as regular data.

### Testing
Added a new test in LineTcpParserTest.java to verify that comment lines are skipped correctly and subsequent valid lines are parsed correctly.

Fix Line Protocol Comment Handling