### PR TITLE
fix(sql): prevent internal errors in symbol hash joins

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/DelegatingRecord.java
+++ b/core/src/main/java/io/questdb/cairo/sql/DelegatingRecord.java
@@ -26,6 +26,8 @@ package io.questdb.cairo.sql;
 
 import io.questdb.cairo.arr.ArrayView;
 import io.questdb.std.BinarySequence;
+import io.questdb.std.Decimal128;
+import io.questdb.std.Decimal256;
 import io.questdb.std.Interval;
 import io.questdb.std.Long256;
 import io.questdb.std.str.CharSink;
@@ -67,6 +69,36 @@ public class DelegatingRecord implements Record {
     @Override
     public long getDate(int col) {
         return base.getDate(col);
+    }
+
+    @Override
+    public void getDecimal128(int col, Decimal128 sink) {
+        base.getDecimal128(col, sink);
+    }
+
+    @Override
+    public short getDecimal16(int col) {
+        return base.getDecimal16(col);
+    }
+
+    @Override
+    public void getDecimal256(int col, Decimal256 sink) {
+        base.getDecimal256(col, sink);
+    }
+
+    @Override
+    public int getDecimal32(int col) {
+        return base.getDecimal32(col);
+    }
+
+    @Override
+    public long getDecimal64(int col) {
+        return base.getDecimal64(col);
+    }
+
+    @Override
+    public byte getDecimal8(int col) {
+        return base.getDecimal8(col);
     }
 
     @Override
@@ -120,6 +152,16 @@ public class DelegatingRecord implements Record {
     }
 
     @Override
+    public long getLong128Hi(int col) {
+        return base.getLong128Hi(col);
+    }
+
+    @Override
+    public long getLong128Lo(int col) {
+        return base.getLong128Lo(col);
+    }
+
+    @Override
     public void getLong256(int col, CharSink<?> sink) {
         base.getLong256(col, sink);
     }
@@ -137,6 +179,11 @@ public class DelegatingRecord implements Record {
     @Override
     public Record getRecord(int col) {
         return base.getRecord(col);
+    }
+
+    @Override
+    public long getRowId() {
+        return base.getRowId();
     }
 
     @Override
@@ -172,6 +219,11 @@ public class DelegatingRecord implements Record {
     @Override
     public long getTimestamp(int col) {
         return base.getTimestamp(col);
+    }
+
+    @Override
+    public long getUpdateRowId() {
+        return base.getUpdateRowId();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/sql/DelegatingRecord.java
+++ b/core/src/main/java/io/questdb/cairo/sql/DelegatingRecord.java
@@ -31,6 +31,7 @@ import io.questdb.std.Decimal256;
 import io.questdb.std.Interval;
 import io.questdb.std.Long256;
 import io.questdb.std.str.CharSink;
+import io.questdb.std.str.Utf16Sink;
 import io.questdb.std.str.Utf8Sequence;
 
 public class DelegatingRecord implements Record {
@@ -39,6 +40,11 @@ public class DelegatingRecord implements Record {
     @Override
     public ArrayView getArray(int col, int columnType) {
         return base.getArray(col, columnType);
+    }
+
+    @Override
+    public double getArrayDouble1d2d(int col, int columnType, int idx0, int idx1) {
+        return base.getArrayDouble1d2d(col, columnType, idx0, idx1);
     }
 
     @Override
@@ -177,6 +183,11 @@ public class DelegatingRecord implements Record {
     }
 
     @Override
+    public long getLongIPv4(int col) {
+        return base.getLongIPv4(col);
+    }
+
+    @Override
     public Record getRecord(int col) {
         return base.getRecord(col);
     }
@@ -224,6 +235,11 @@ public class DelegatingRecord implements Record {
     @Override
     public long getUpdateRowId() {
         return base.getUpdateRowId();
+    }
+
+    @Override
+    public void getVarchar(int col, Utf16Sink utf16Sink) {
+        base.getVarchar(col, utf16Sink);
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/sql/Record.java
+++ b/core/src/main/java/io/questdb/cairo/sql/Record.java
@@ -356,7 +356,6 @@ public interface Record {
      * @param col numeric index of the column
      * @return 64-bit integer
      */
-    @SuppressWarnings("unused")
     default long getLongIPv4(int col) {
         return Numbers.ipv4ToLong(getIPv4(col));
     }

--- a/core/src/test/java/io/questdb/test/cairo/sql/DelegatingRecordTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/sql/DelegatingRecordTest.java
@@ -1,0 +1,83 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.sql;
+
+import io.questdb.cairo.sql.DelegatingRecord;
+import io.questdb.cairo.sql.Record;
+import io.questdb.std.str.StringSink;
+import io.questdb.std.str.Utf16Sink;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DelegatingRecordTest {
+
+    @Test
+    public void testDelegatesArrayDouble1d2d() {
+        final DelegatingRecord record = new DelegatingRecord();
+        record.of(new Record() {
+            @Override
+            public double getArrayDouble1d2d(int col, int columnType, int idx0, int idx1) {
+                Assert.assertEquals(1, col);
+                Assert.assertEquals(2, columnType);
+                Assert.assertEquals(3, idx0);
+                Assert.assertEquals(4, idx1);
+                return 42.5;
+            }
+        });
+
+        Assert.assertEquals(42.5, record.getArrayDouble1d2d(1, 2, 3, 4), 0.0);
+    }
+
+    @Test
+    public void testDelegatesLongIPv4() {
+        final DelegatingRecord record = new DelegatingRecord();
+        record.of(new Record() {
+            @Override
+            public long getLongIPv4(int col) {
+                Assert.assertEquals(1, col);
+                return 0x01020304L;
+            }
+        });
+
+        Assert.assertEquals(0x01020304L, record.getLongIPv4(1));
+    }
+
+    @Test
+    public void testDelegatesVarcharUtf16Sink() {
+        final DelegatingRecord record = new DelegatingRecord();
+        record.of(new Record() {
+            @Override
+            public void getVarchar(int col, Utf16Sink utf16Sink) {
+                Assert.assertEquals(1, col);
+                utf16Sink.put("fast");
+            }
+        });
+        final StringSink sink = new StringSink();
+
+        record.getVarchar(1, sink);
+
+        Assert.assertEquals("fast", sink.toString());
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/sql/DelegatingRecordTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/sql/DelegatingRecordTest.java
@@ -26,58 +26,23 @@ package io.questdb.test.cairo.sql;
 
 import io.questdb.cairo.sql.DelegatingRecord;
 import io.questdb.cairo.sql.Record;
-import io.questdb.std.str.StringSink;
-import io.questdb.std.str.Utf16Sink;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 public class DelegatingRecordTest {
 
     @Test
-    public void testDelegatesArrayDouble1d2d() {
-        final DelegatingRecord record = new DelegatingRecord();
-        record.of(new Record() {
-            @Override
-            public double getArrayDouble1d2d(int col, int columnType, int idx0, int idx1) {
-                Assert.assertEquals(1, col);
-                Assert.assertEquals(2, columnType);
-                Assert.assertEquals(3, idx0);
-                Assert.assertEquals(4, idx1);
-                return 42.5;
+    public void testOverridesAllRecordMethods() throws Exception {
+        for (Method method : Record.class.getMethods()) {
+            if (method.getDeclaringClass() != Record.class || method.isSynthetic() || Modifier.isStatic(method.getModifiers())) {
+                continue;
             }
-        });
+            final Method delegatingMethod = DelegatingRecord.class.getMethod(method.getName(), method.getParameterTypes());
 
-        Assert.assertEquals(42.5, record.getArrayDouble1d2d(1, 2, 3, 4), 0.0);
-    }
-
-    @Test
-    public void testDelegatesLongIPv4() {
-        final DelegatingRecord record = new DelegatingRecord();
-        record.of(new Record() {
-            @Override
-            public long getLongIPv4(int col) {
-                Assert.assertEquals(1, col);
-                return 0x01020304L;
-            }
-        });
-
-        Assert.assertEquals(0x01020304L, record.getLongIPv4(1));
-    }
-
-    @Test
-    public void testDelegatesVarcharUtf16Sink() {
-        final DelegatingRecord record = new DelegatingRecord();
-        record.of(new Record() {
-            @Override
-            public void getVarchar(int col, Utf16Sink utf16Sink) {
-                Assert.assertEquals(1, col);
-                utf16Sink.put("fast");
-            }
-        });
-        final StringSink sink = new StringSink();
-
-        record.getVarchar(1, sink);
-
-        Assert.assertEquals("fast", sink.toString());
+            Assert.assertNotEquals(method.toGenericString(), Record.class, delegatingMethod.getDeclaringClass());
+        }
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/AsOfJoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/AsOfJoinTest.java
@@ -5561,6 +5561,24 @@ public class AsOfJoinTest extends AbstractCairoTest {
         assertAlgoAndResult(queryBody, hint, expectedAlgo, expectedResult, false);
     }
 
+    private void assertAlgoAndResult(String queryBody, String hint, String expectedAlgo, String expectedResult, boolean expectSymbolKeyJoin) throws SqlException {
+        String hintedQuery;
+        if (!hint.isEmpty()) {
+            hintedQuery = "SELECT /*+ " + hint + "*/ " + queryBody;
+        } else {
+            hintedQuery = "SELECT " + queryBody;
+        }
+        printSql("EXPLAIN " + hintedQuery);
+        TestUtils.assertContains(sink, "AsOf Join " + expectedAlgo);
+        if (hint.contains("asof_driveby_cache(t q)")) {
+            TestUtils.assertContains(sink, "driveByCache: true");
+        }
+        if (expectSymbolKeyJoin) {
+            TestUtils.assertContains(sink, "symbolKeyJoin: true");
+        }
+        assertSql(expectedResult, hintedQuery);
+    }
+
     private void assertAsOfJoinSymbolAndDecimalKey(String tableSuffix, String decimalType, String id1, String id2) throws Exception {
         final String masterTableName = "master_" + tableSuffix;
         final String slaveTableName = "slave_" + tableSuffix;
@@ -5617,24 +5635,6 @@ public class AsOfJoinTest extends AbstractCairoTest {
         assertAlgoAndResult(queryBody, "", "Fast", expected, true);
         assertAlgoAndResult(queryBody, "asof_dense(m s)", "Dense", expected, true);
         assertAlgoAndResult(queryBody, "asof_linear(m s)", "Light", expected, true);
-    }
-
-    private void assertAlgoAndResult(String queryBody, String hint, String expectedAlgo, String expectedResult, boolean expectSymbolKeyJoin) throws SqlException {
-        String hintedQuery;
-        if (!hint.isEmpty()) {
-            hintedQuery = "SELECT /*+ " + hint + "*/ " + queryBody;
-        } else {
-            hintedQuery = "SELECT " + queryBody;
-        }
-        printSql("EXPLAIN " + hintedQuery);
-        TestUtils.assertContains(sink, "AsOf Join " + expectedAlgo);
-        if (hint.contains("asof_driveby_cache(t q)")) {
-            TestUtils.assertContains(sink, "driveByCache: true");
-        }
-        if (expectSymbolKeyJoin) {
-            TestUtils.assertContains(sink, "symbolKeyJoin: true");
-        }
-        assertSql(expectedResult, hintedQuery);
     }
 
     private void assertResultSetsMatch(String leftTable, String rightTable) throws Exception {

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/AsOfJoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/AsOfJoinTest.java
@@ -1344,6 +1344,28 @@ public class AsOfJoinTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAsOfJoinSymbolAndDecimalKeys() throws Exception {
+        assertMemoryLeak(() -> {
+            assertAsOfJoinSymbolAndDecimalKey("dec8", "DECIMAL(2,1)", "1.2", "2.3");
+            assertAsOfJoinSymbolAndDecimalKey("dec16", "DECIMAL(4,2)", "12.34", "23.45");
+            assertAsOfJoinSymbolAndDecimalKey("dec32", "DECIMAL(9,4)", "12345.6789", "23456.7890");
+            assertAsOfJoinSymbolAndDecimalKey("dec64", "DECIMAL(18,6)", "123456789012.345678", "234567890123.456789");
+            assertAsOfJoinSymbolAndDecimalKey(
+                    "dec128",
+                    "DECIMAL(38,10)",
+                    "1234567890123456789012345678.9012345678",
+                    "2345678901234567890123456789.0123456789"
+            );
+            assertAsOfJoinSymbolAndDecimalKey(
+                    "dec256",
+                    "DECIMAL(76,20)",
+                    "12345678901234567890123456789012345678901234567890123456.78901234567890123456",
+                    "23456789012345678901234567890123456789012345678901234567.89012345678901234567"
+            );
+        });
+    }
+
+    @Test
     public void testAsOfJoinSymbolAndIntKeys() throws Exception {
         assertMemoryLeak(() -> {
             executeWithRewriteTimestamp(
@@ -1391,6 +1413,59 @@ public class AsOfJoinTest extends AbstractCairoTest {
                     """;
 
             String queryBody = "m.sym, m.id, m.val, s.price FROM master m ASOF JOIN slave s ON (m.sym = s.sym AND m.id = s.id)";
+            assertAlgoAndResult(queryBody, "", "Fast", expected, true);
+            assertAlgoAndResult(queryBody, "asof_dense(m s)", "Dense", expected, true);
+            assertAlgoAndResult(queryBody, "asof_linear(m s)", "Light", expected, true);
+        });
+    }
+
+    @Test
+    public void testAsOfJoinSymbolAndUuidKeys() throws Exception {
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp(
+                    """
+                            CREATE TABLE master (
+                                sym SYMBOL,
+                                id UUID,
+                                val DOUBLE,
+                                ts #TIMESTAMP
+                            ) TIMESTAMP(ts) PARTITION BY DAY""",
+                    leftTableTimestampType.getTypeName()
+            );
+
+            executeWithRewriteTimestamp(
+                    """
+                            CREATE TABLE slave (
+                                sym SYMBOL,
+                                id UUID,
+                                price DOUBLE,
+                                ts #TIMESTAMP
+                            ) TIMESTAMP(ts) PARTITION BY DAY""",
+                    rightTableTimestampType.getTypeName()
+            );
+
+            execute("""
+                    INSERT INTO master VALUES
+                        ('A', '11111111-1111-1111-1111-111111111111', 1.0, '2024-01-01T10:00:00.000000Z'),
+                        ('A', '22222222-2222-2222-2222-222222222222', 2.0, '2024-01-01T10:01:00.000000Z'),
+                        ('B', '11111111-1111-1111-1111-111111111111', 3.0, '2024-01-01T10:02:00.000000Z')
+                    """);
+
+            execute("""
+                    INSERT INTO slave VALUES
+                        ('A', '11111111-1111-1111-1111-111111111111', 10.0, '2024-01-01T09:00:00.000000Z'),
+                        ('A', '22222222-2222-2222-2222-222222222222', 20.0, '2024-01-01T09:30:00.000000Z'),
+                        ('B', '22222222-2222-2222-2222-222222222222', 30.0, '2024-01-01T09:45:00.000000Z')
+                    """);
+
+            String expected = """
+                    val\tprice
+                    1.0\t10.0
+                    2.0\t20.0
+                    3.0\tnull
+                    """;
+
+            String queryBody = "m.val, s.price FROM master m ASOF JOIN slave s ON (m.sym = s.sym AND m.id = s.id)";
             assertAlgoAndResult(queryBody, "", "Fast", expected, true);
             assertAlgoAndResult(queryBody, "asof_dense(m s)", "Dense", expected, true);
             assertAlgoAndResult(queryBody, "asof_linear(m s)", "Light", expected, true);
@@ -5478,6 +5553,58 @@ public class AsOfJoinTest extends AbstractCairoTest {
 
     private void assertAlgoAndResult(String queryBody, String hint, String expectedAlgo, String expectedResult) throws SqlException {
         assertAlgoAndResult(queryBody, hint, expectedAlgo, expectedResult, false);
+    }
+
+    private void assertAsOfJoinSymbolAndDecimalKey(String tableSuffix, String decimalType, String id1, String id2) throws Exception {
+        final String masterTableName = "master_" + tableSuffix;
+        final String slaveTableName = "slave_" + tableSuffix;
+        executeWithRewriteTimestamp(
+                """
+                        CREATE TABLE %s (
+                            sym SYMBOL,
+                            id %s,
+                            val DOUBLE,
+                            ts #TIMESTAMP
+                        ) TIMESTAMP(ts) PARTITION BY DAY""".formatted(masterTableName, decimalType),
+                leftTableTimestampType.getTypeName()
+        );
+
+        executeWithRewriteTimestamp(
+                """
+                        CREATE TABLE %s (
+                            sym SYMBOL,
+                            id %s,
+                            price DOUBLE,
+                            ts #TIMESTAMP
+                        ) TIMESTAMP(ts) PARTITION BY DAY""".formatted(slaveTableName, decimalType),
+                rightTableTimestampType.getTypeName()
+        );
+
+        execute("""
+                INSERT INTO %s VALUES
+                    ('A', %s::%s, 1.0, '2024-01-01T10:00:00.000000Z'),
+                    ('A', %s::%s, 2.0, '2024-01-01T10:01:00.000000Z'),
+                    ('B', %s::%s, 3.0, '2024-01-01T10:02:00.000000Z')
+                """.formatted(masterTableName, id1, decimalType, id2, decimalType, id1, decimalType));
+
+        execute("""
+                INSERT INTO %s VALUES
+                    ('A', %s::%s, 10.0, '2024-01-01T09:00:00.000000Z'),
+                    ('A', %s::%s, 20.0, '2024-01-01T09:30:00.000000Z'),
+                    ('B', %s::%s, 30.0, '2024-01-01T09:45:00.000000Z')
+                """.formatted(slaveTableName, id1, decimalType, id2, decimalType, id2, decimalType));
+
+        String expected = """
+                val\tprice
+                1.0\t10.0
+                2.0\t20.0
+                3.0\tnull
+                """;
+
+        String queryBody = "m.val, s.price FROM " + masterTableName + " m ASOF JOIN " + slaveTableName + " s ON (m.sym = s.sym AND m.id = s.id)";
+        assertAlgoAndResult(queryBody, "", "Fast", expected, true);
+        assertAlgoAndResult(queryBody, "asof_dense(m s)", "Dense", expected, true);
+        assertAlgoAndResult(queryBody, "asof_linear(m s)", "Light", expected, true);
     }
 
     private void assertAlgoAndResult(String queryBody, String hint, String expectedAlgo, String expectedResult, boolean expectSymbolKeyJoin) throws SqlException {

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/AsOfJoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/AsOfJoinTest.java
@@ -1448,14 +1448,18 @@ public class AsOfJoinTest extends AbstractCairoTest {
                     INSERT INTO master VALUES
                         ('A', '11111111-1111-1111-1111-111111111111', 1.0, '2024-01-01T10:00:00.000000Z'),
                         ('A', '22222222-2222-2222-2222-222222222222', 2.0, '2024-01-01T10:01:00.000000Z'),
-                        ('B', '11111111-1111-1111-1111-111111111111', 3.0, '2024-01-01T10:02:00.000000Z')
+                        ('B', '11111111-1111-1111-1111-111111111111', 3.0, '2024-01-01T10:02:00.000000Z'),
+                        ('N', cast(null as UUID), 4.0, '2024-01-01T10:03:00.000000Z'),
+                        (null, '11111111-1111-1111-1111-111111111111', 5.0, '2024-01-01T10:04:00.000000Z')
                     """);
 
             execute("""
                     INSERT INTO slave VALUES
                         ('A', '11111111-1111-1111-1111-111111111111', 10.0, '2024-01-01T09:00:00.000000Z'),
                         ('A', '22222222-2222-2222-2222-222222222222', 20.0, '2024-01-01T09:30:00.000000Z'),
-                        ('B', '22222222-2222-2222-2222-222222222222', 30.0, '2024-01-01T09:45:00.000000Z')
+                        ('B', '22222222-2222-2222-2222-222222222222', 30.0, '2024-01-01T09:45:00.000000Z'),
+                        ('N', cast(null as UUID), 40.0, '2024-01-01T09:40:00.000000Z'),
+                        (null, '11111111-1111-1111-1111-111111111111', 50.0, '2024-01-01T09:50:00.000000Z')
                     """);
 
             String expected = """
@@ -1463,6 +1467,8 @@ public class AsOfJoinTest extends AbstractCairoTest {
                     1.0\t10.0
                     2.0\t20.0
                     3.0\tnull
+                    4.0\t40.0
+                    5.0\t50.0
                     """;
 
             String queryBody = "m.val, s.price FROM master m ASOF JOIN slave s ON (m.sym = s.sym AND m.id = s.id)";
@@ -5584,21 +5590,27 @@ public class AsOfJoinTest extends AbstractCairoTest {
                 INSERT INTO %s VALUES
                     ('A', %s::%s, 1.0, '2024-01-01T10:00:00.000000Z'),
                     ('A', %s::%s, 2.0, '2024-01-01T10:01:00.000000Z'),
-                    ('B', %s::%s, 3.0, '2024-01-01T10:02:00.000000Z')
-                """.formatted(masterTableName, id1, decimalType, id2, decimalType, id1, decimalType));
+                    ('B', %s::%s, 3.0, '2024-01-01T10:02:00.000000Z'),
+                    ('N', cast(null as %s), 4.0, '2024-01-01T10:03:00.000000Z'),
+                    (null, %s::%s, 5.0, '2024-01-01T10:04:00.000000Z')
+                """.formatted(masterTableName, id1, decimalType, id2, decimalType, id1, decimalType, decimalType, id1, decimalType));
 
         execute("""
                 INSERT INTO %s VALUES
                     ('A', %s::%s, 10.0, '2024-01-01T09:00:00.000000Z'),
                     ('A', %s::%s, 20.0, '2024-01-01T09:30:00.000000Z'),
-                    ('B', %s::%s, 30.0, '2024-01-01T09:45:00.000000Z')
-                """.formatted(slaveTableName, id1, decimalType, id2, decimalType, id2, decimalType));
+                    ('B', %s::%s, 30.0, '2024-01-01T09:45:00.000000Z'),
+                    ('N', cast(null as %s), 40.0, '2024-01-01T09:40:00.000000Z'),
+                    (null, %s::%s, 50.0, '2024-01-01T09:50:00.000000Z')
+                """.formatted(slaveTableName, id1, decimalType, id2, decimalType, id2, decimalType, decimalType, id1, decimalType));
 
         String expected = """
                 val\tprice
                 1.0\t10.0
                 2.0\t20.0
                 3.0\tnull
+                4.0\t40.0
+                5.0\t50.0
                 """;
 
         String queryBody = "m.val, s.price FROM " + masterTableName + " m ASOF JOIN " + slaveTableName + " s ON (m.sym = s.sym AND m.id = s.id)";

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/HashJoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/HashJoinTest.java
@@ -255,6 +255,107 @@ public class HashJoinTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testHashOuterJoinSymbolAndDecimalKeys() throws Exception {
+        assertMemoryLeak(() -> {
+            assertHashOuterJoinSymbolAndDecimalKey("dec8", "DECIMAL(2,1)", "1.2", "2.3", "3.4");
+            assertHashOuterJoinSymbolAndDecimalKey("dec16", "DECIMAL(4,2)", "12.34", "23.45", "34.56");
+            assertHashOuterJoinSymbolAndDecimalKey("dec32", "DECIMAL(9,4)", "12345.6789", "23456.7890", "34567.8901");
+            assertHashOuterJoinSymbolAndDecimalKey("dec64", "DECIMAL(18,6)", "123456789012.345678", "234567890123.456789", "345678901234.567890");
+            assertHashOuterJoinSymbolAndDecimalKey(
+                    "dec128",
+                    "DECIMAL(38,10)",
+                    "1234567890123456789012345678.9012345678",
+                    "2345678901234567890123456789.0123456789",
+                    "3456789012345678901234567890.1234567890"
+            );
+            assertHashOuterJoinSymbolAndDecimalKey(
+                    "dec256",
+                    "DECIMAL(76,20)",
+                    "12345678901234567890123456789012345678901234567890123456.78901234567890123456",
+                    "23456789012345678901234567890123456789012345678901234567.89012345678901234567",
+                    "34567890123456789012345678901234567890123456789012345678.90123456789012345678"
+            );
+        });
+    }
+
+    @Test
+    public void testHashOuterJoinSymbolAndUuidKeys() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE m (id UUID, sym SYMBOL, v INT)");
+            execute("CREATE TABLE s (id UUID, sym SYMBOL, v INT)");
+            execute("""
+                    INSERT INTO m VALUES
+                        ('11111111-1111-1111-1111-111111111111', 'A', 1),
+                        ('22222222-2222-2222-2222-222222222222', 'B', 2),
+                        ('33333333-3333-3333-3333-333333333333', 'C', 3)""");
+            execute("""
+                    INSERT INTO s VALUES
+                        ('11111111-1111-1111-1111-111111111111', 'A', 10),
+                        ('22222222-2222-2222-2222-222222222222', 'X', 20),
+                        ('33333333-3333-3333-3333-333333333333', 'C', 30)""");
+
+            assertQueryNoLeakCheck(
+                    """
+                            id\tsym\tv\tv1
+                            11111111-1111-1111-1111-111111111111\tA\t1\t10
+                            22222222-2222-2222-2222-222222222222\tB\t2\tnull
+                            33333333-3333-3333-3333-333333333333\tC\t3\t30
+                            """,
+                    "SELECT m.id, m.sym, m.v, s.v FROM m LEFT JOIN s ON m.id = s.id AND m.sym = s.sym ORDER BY m.v",
+                    null,
+                    true,
+                    false
+            );
+        });
+    }
+
+    private void assertHashOuterJoinSymbolAndDecimalKey(String tableSuffix, String decimalType, String id1, String id2, String id3) throws Exception {
+        final String mTableName = "m_" + tableSuffix;
+        final String sTableName = "s_" + tableSuffix;
+        execute("CREATE TABLE " + mTableName + " (id " + decimalType + ", sym SYMBOL, v INT)");
+        execute("CREATE TABLE " + sTableName + " (id " + decimalType + ", sym SYMBOL, v INT)");
+        execute("""
+                INSERT INTO %s VALUES
+                    (%s::%s, 'A', 1),
+                    (%s::%s, 'B', 2),
+                    (%s::%s, 'C', 3)""".formatted(mTableName, id1, decimalType, id2, decimalType, id3, decimalType));
+        execute("""
+                INSERT INTO %s VALUES
+                    (%s::%s, 'A', 10),
+                    (%s::%s, 'X', 20),
+                    (%s::%s, 'C', 30)""".formatted(sTableName, id1, decimalType, id2, decimalType, id3, decimalType));
+        final String query = """
+                SELECT %s.v, %s.v
+                FROM %s
+                LEFT JOIN %s ON %s.id = %s.id AND %s.sym = %s.sym
+                ORDER BY %s.v
+                """.formatted(
+                mTableName,
+                sTableName,
+                mTableName,
+                sTableName,
+                mTableName,
+                sTableName,
+                mTableName,
+                sTableName,
+                mTableName
+        );
+
+        assertQueryNoLeakCheck(
+                """
+                        v\tv1
+                        1\t10
+                        2\tnull
+                        3\t30
+                        """,
+                query,
+                null,
+                true,
+                false
+        );
+    }
+
+    @Test
     public void testHashOuterJoinSymbolKeysSwapFullOuter() throws Exception {
         assertMemoryLeak(() -> {
             execute("CREATE TABLE m (sym1 SYMBOL, sym2 SYMBOL, v INT)");

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/HashJoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/HashJoinTest.java
@@ -287,18 +287,24 @@ public class HashJoinTest extends AbstractCairoTest {
                     INSERT INTO m VALUES
                         ('11111111-1111-1111-1111-111111111111', 'A', 1),
                         ('22222222-2222-2222-2222-222222222222', 'B', 2),
-                        ('33333333-3333-3333-3333-333333333333', 'C', 3)""");
+                        ('33333333-3333-3333-3333-333333333333', 'C', 3),
+                        (cast(null as UUID), 'N', 4),
+                        ('44444444-4444-4444-4444-444444444444', null, 5)""");
             execute("""
                     INSERT INTO s VALUES
                         ('11111111-1111-1111-1111-111111111111', 'A', 10),
                         ('22222222-2222-2222-2222-222222222222', 'X', 20),
-                        ('33333333-3333-3333-3333-333333333333', 'C', 30)""");
+                        ('33333333-3333-3333-3333-333333333333', 'C', 30),
+                        (cast(null as UUID), 'N', 40),
+                        ('44444444-4444-4444-4444-444444444444', null, 50)""");
 
             assertQueryNoLeakCheck(
                     """
                             id\tsym\tv\tv1
                             11111111-1111-1111-1111-111111111111\tA\t1\t10
                             33333333-3333-3333-3333-333333333333\tC\t3\t30
+                            \tN\t4\t40
+                            44444444-4444-4444-4444-444444444444\t\t5\t50
                             """,
                     "SELECT m.id, m.sym, m.v, s.v FROM m JOIN s ON m.id = s.id AND m.sym = s.sym ORDER BY m.v",
                     null,
@@ -341,12 +347,16 @@ public class HashJoinTest extends AbstractCairoTest {
                     INSERT INTO m VALUES
                         ('11111111-1111-1111-1111-111111111111', 'A', 1),
                         ('22222222-2222-2222-2222-222222222222', 'B', 2),
-                        ('33333333-3333-3333-3333-333333333333', 'C', 3)""");
+                        ('33333333-3333-3333-3333-333333333333', 'C', 3),
+                        (cast(null as UUID), 'N', 4),
+                        ('44444444-4444-4444-4444-444444444444', null, 5)""");
             execute("""
                     INSERT INTO s VALUES
                         ('11111111-1111-1111-1111-111111111111', 'A', 10),
                         ('22222222-2222-2222-2222-222222222222', 'X', 20),
-                        ('33333333-3333-3333-3333-333333333333', 'C', 30)""");
+                        ('33333333-3333-3333-3333-333333333333', 'C', 30),
+                        (cast(null as UUID), 'N', 40),
+                        ('44444444-4444-4444-4444-444444444444', null, 50)""");
 
             assertQueryNoLeakCheck(
                     """
@@ -354,6 +364,8 @@ public class HashJoinTest extends AbstractCairoTest {
                             11111111-1111-1111-1111-111111111111\tA\t1\t10
                             22222222-2222-2222-2222-222222222222\tB\t2\tnull
                             33333333-3333-3333-3333-333333333333\tC\t3\t30
+                            \tN\t4\t40
+                            44444444-4444-4444-4444-444444444444\t\t5\t50
                             """,
                     "SELECT m.id, m.sym, m.v, s.v FROM m LEFT JOIN s ON m.id = s.id AND m.sym = s.sym ORDER BY m.v",
                     null,
@@ -372,12 +384,16 @@ public class HashJoinTest extends AbstractCairoTest {
                 INSERT INTO %s VALUES
                     (%s::%s, 'A', 1),
                     (%s::%s, 'B', 2),
-                    (%s::%s, 'C', 3)""".formatted(mTableName, id1, decimalType, id2, decimalType, id3, decimalType));
+                    (%s::%s, 'C', 3),
+                    (cast(null as %s), 'N', 4),
+                    (%s::%s, null, 5)""".formatted(mTableName, id1, decimalType, id2, decimalType, id3, decimalType, decimalType, id1, decimalType));
         execute("""
                 INSERT INTO %s VALUES
                     (%s::%s, 'A', 10),
                     (%s::%s, 'X', 20),
-                    (%s::%s, 'C', 30)""".formatted(sTableName, id1, decimalType, id2, decimalType, id3, decimalType));
+                    (%s::%s, 'C', 30),
+                    (cast(null as %s), 'N', 40),
+                    (%s::%s, null, 50)""".formatted(sTableName, id1, decimalType, id2, decimalType, id3, decimalType, decimalType, id1, decimalType));
         final String query = """
                 SELECT %s.v, %s.v
                 FROM %s
@@ -400,6 +416,8 @@ public class HashJoinTest extends AbstractCairoTest {
                         v\tv1
                         1\t10
                         3\t30
+                        4\t40
+                        5\t50
                         """,
                 query,
                 null,
@@ -417,12 +435,16 @@ public class HashJoinTest extends AbstractCairoTest {
                 INSERT INTO %s VALUES
                     (%s::%s, 'A', 1),
                     (%s::%s, 'B', 2),
-                    (%s::%s, 'C', 3)""".formatted(mTableName, id1, decimalType, id2, decimalType, id3, decimalType));
+                    (%s::%s, 'C', 3),
+                    (cast(null as %s), 'N', 4),
+                    (%s::%s, null, 5)""".formatted(mTableName, id1, decimalType, id2, decimalType, id3, decimalType, decimalType, id1, decimalType));
         execute("""
                 INSERT INTO %s VALUES
                     (%s::%s, 'A', 10),
                     (%s::%s, 'X', 20),
-                    (%s::%s, 'C', 30)""".formatted(sTableName, id1, decimalType, id2, decimalType, id3, decimalType));
+                    (%s::%s, 'C', 30),
+                    (cast(null as %s), 'N', 40),
+                    (%s::%s, null, 50)""".formatted(sTableName, id1, decimalType, id2, decimalType, id3, decimalType, decimalType, id1, decimalType));
         final String query = """
                 SELECT %s.v, %s.v
                 FROM %s
@@ -446,6 +468,8 @@ public class HashJoinTest extends AbstractCairoTest {
                         1\t10
                         2\tnull
                         3\t30
+                        4\t40
+                        5\t50
                         """,
                 query,
                 null,

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/HashJoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/HashJoinTest.java
@@ -123,6 +123,66 @@ public class HashJoinTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testHashJoinSymbolAndDecimalKeys() throws Exception {
+        assertMemoryLeak(() -> {
+            assertHashJoinSymbolAndDecimalKey("dec8", "DECIMAL(2,1)", "1.2", "2.3", "3.4");
+            assertHashJoinSymbolAndDecimalKey("dec16", "DECIMAL(4,2)", "12.34", "23.45", "34.56");
+            assertHashJoinSymbolAndDecimalKey("dec32", "DECIMAL(9,4)", "12345.6789", "23456.7890", "34567.8901");
+            assertHashJoinSymbolAndDecimalKey("dec64", "DECIMAL(18,6)", "123456789012.345678", "234567890123.456789", "345678901234.567890");
+            assertHashJoinSymbolAndDecimalKey(
+                    "dec128",
+                    "DECIMAL(38,10)",
+                    "1234567890123456789012345678.9012345678",
+                    "2345678901234567890123456789.0123456789",
+                    "3456789012345678901234567890.1234567890"
+            );
+            assertHashJoinSymbolAndDecimalKey(
+                    "dec256",
+                    "DECIMAL(76,20)",
+                    "12345678901234567890123456789012345678901234567890123456.78901234567890123456",
+                    "23456789012345678901234567890123456789012345678901234567.89012345678901234567",
+                    "34567890123456789012345678901234567890123456789012345678.90123456789012345678"
+            );
+        });
+    }
+
+    @Test
+    public void testHashJoinSymbolAndUuidKeys() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE m (id UUID, sym SYMBOL, v INT)");
+            execute("CREATE TABLE s (id UUID, sym SYMBOL, v INT)");
+            execute("""
+                    INSERT INTO m VALUES
+                        ('11111111-1111-1111-1111-111111111111', 'A', 1),
+                        ('22222222-2222-2222-2222-222222222222', 'B', 2),
+                        ('33333333-3333-3333-3333-333333333333', 'C', 3),
+                        (cast(null as UUID), 'N', 4),
+                        ('44444444-4444-4444-4444-444444444444', null, 5)""");
+            execute("""
+                    INSERT INTO s VALUES
+                        ('11111111-1111-1111-1111-111111111111', 'A', 10),
+                        ('22222222-2222-2222-2222-222222222222', 'X', 20),
+                        ('33333333-3333-3333-3333-333333333333', 'C', 30),
+                        (cast(null as UUID), 'N', 40),
+                        ('44444444-4444-4444-4444-444444444444', null, 50)""");
+
+            assertQueryNoLeakCheck(
+                    """
+                            id\tsym\tv\tv1
+                            11111111-1111-1111-1111-111111111111\tA\t1\t10
+                            33333333-3333-3333-3333-333333333333\tC\t3\t30
+                            \tN\t4\t40
+                            44444444-4444-4444-4444-444444444444\t\t5\t50
+                            """,
+                    "SELECT m.id, m.sym, m.v, s.v FROM m JOIN s ON m.id = s.id AND m.sym = s.sym ORDER BY m.v",
+                    null,
+                    true,
+                    false
+            );
+        });
+    }
+
+    @Test
     public void testHashJoinSymbolKeysSwap() throws Exception {
         assertMemoryLeak(() -> {
             execute("CREATE TABLE m (sym1 SYMBOL, sym2 SYMBOL, v INT)");
@@ -255,66 +315,6 @@ public class HashJoinTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testHashJoinSymbolAndDecimalKeys() throws Exception {
-        assertMemoryLeak(() -> {
-            assertHashJoinSymbolAndDecimalKey("dec8", "DECIMAL(2,1)", "1.2", "2.3", "3.4");
-            assertHashJoinSymbolAndDecimalKey("dec16", "DECIMAL(4,2)", "12.34", "23.45", "34.56");
-            assertHashJoinSymbolAndDecimalKey("dec32", "DECIMAL(9,4)", "12345.6789", "23456.7890", "34567.8901");
-            assertHashJoinSymbolAndDecimalKey("dec64", "DECIMAL(18,6)", "123456789012.345678", "234567890123.456789", "345678901234.567890");
-            assertHashJoinSymbolAndDecimalKey(
-                    "dec128",
-                    "DECIMAL(38,10)",
-                    "1234567890123456789012345678.9012345678",
-                    "2345678901234567890123456789.0123456789",
-                    "3456789012345678901234567890.1234567890"
-            );
-            assertHashJoinSymbolAndDecimalKey(
-                    "dec256",
-                    "DECIMAL(76,20)",
-                    "12345678901234567890123456789012345678901234567890123456.78901234567890123456",
-                    "23456789012345678901234567890123456789012345678901234567.89012345678901234567",
-                    "34567890123456789012345678901234567890123456789012345678.90123456789012345678"
-            );
-        });
-    }
-
-    @Test
-    public void testHashJoinSymbolAndUuidKeys() throws Exception {
-        assertMemoryLeak(() -> {
-            execute("CREATE TABLE m (id UUID, sym SYMBOL, v INT)");
-            execute("CREATE TABLE s (id UUID, sym SYMBOL, v INT)");
-            execute("""
-                    INSERT INTO m VALUES
-                        ('11111111-1111-1111-1111-111111111111', 'A', 1),
-                        ('22222222-2222-2222-2222-222222222222', 'B', 2),
-                        ('33333333-3333-3333-3333-333333333333', 'C', 3),
-                        (cast(null as UUID), 'N', 4),
-                        ('44444444-4444-4444-4444-444444444444', null, 5)""");
-            execute("""
-                    INSERT INTO s VALUES
-                        ('11111111-1111-1111-1111-111111111111', 'A', 10),
-                        ('22222222-2222-2222-2222-222222222222', 'X', 20),
-                        ('33333333-3333-3333-3333-333333333333', 'C', 30),
-                        (cast(null as UUID), 'N', 40),
-                        ('44444444-4444-4444-4444-444444444444', null, 50)""");
-
-            assertQueryNoLeakCheck(
-                    """
-                            id\tsym\tv\tv1
-                            11111111-1111-1111-1111-111111111111\tA\t1\t10
-                            33333333-3333-3333-3333-333333333333\tC\t3\t30
-                            \tN\t4\t40
-                            44444444-4444-4444-4444-444444444444\t\t5\t50
-                            """,
-                    "SELECT m.id, m.sym, m.v, s.v FROM m JOIN s ON m.id = s.id AND m.sym = s.sym ORDER BY m.v",
-                    null,
-                    true,
-                    false
-            );
-        });
-    }
-
-    @Test
     public void testHashOuterJoinSymbolAndDecimalKeys() throws Exception {
         assertMemoryLeak(() -> {
             assertHashOuterJoinSymbolAndDecimalKey("dec8", "DECIMAL(2,1)", "1.2", "2.3", "3.4");
@@ -372,6 +372,67 @@ public class HashJoinTest extends AbstractCairoTest {
                     true,
                     false
             );
+        });
+    }
+
+    @Test
+    public void testHashOuterJoinSymbolKeysSwapFullOuter() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE m (sym1 SYMBOL, sym2 SYMBOL, v INT)");
+            execute("CREATE TABLE s (sym1 SYMBOL, sym2 SYMBOL, v INT)");
+            execute("""
+                    INSERT INTO m VALUES
+                        ('A', 'X', 1),
+                        ('C', 'Z', 3)""");
+            execute("""
+                    INSERT INTO s VALUES
+                        ('A', 'X', 10),
+                        ('B', 'Y', 20),
+                        ('D', 'W', 30),
+                        ('E', 'V', 40),
+                        ('F', 'U', 50)""");
+
+            assertQueryNoLeakCheck(
+                    """
+                            sym1	sym2	v	sym11	sym21	v1
+                            		null	B	Y	20
+                            		null	D	W	30
+                            		null	E	V	40
+                            		null	F	U	50
+                            A	X	1	A	X	10
+                            C	Z	3			null
+                            """,
+                    "SELECT * FROM m FULL JOIN s ON m.sym1 = s.sym1 AND m.sym2 = s.sym2 ORDER BY m.v, s.v",
+                    null,
+                    true,
+                    false
+            );
+        });
+    }
+
+    @Test
+    public void testHashOuterJoinWithFilter() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table taba (i long, locale_name symbol )");
+            execute("create table tabb (i long, state symbol, city symbol)");
+            execute("insert into taba values (1, 'pl')");
+            execute("insert into tabb values (1, 'a', 'pl')");
+            execute("insert into tabb values (1, 'b', 'b')");
+
+            assertQueryNoLeakCheck("""
+                    i\tlocale_name\ti1\tstate\tcity
+                    1\tpl\t1\ta\tpl
+                    """, "select * from taba left join tabb on taba.i = tabb.i and (locale_name = state OR locale_name=city)", null);
+            assertQueryNoLeakCheck("""
+                    i\tlocale_name\ti1\tstate\tcity
+                    1\tpl\t1\ta\tpl
+                    null\t\t1\tb\tb
+                    """, "select * from taba right join tabb on taba.i = tabb.i and (locale_name = state OR locale_name=city)", null);
+            assertQueryNoLeakCheck("""
+                    i\tlocale_name\ti1\tstate\tcity
+                    1\tpl\t1\ta\tpl
+                    null\t\t1\tb\tb
+                    """, "select * from taba full join tabb on taba.i = tabb.i and (locale_name = state OR locale_name=city)", null);
         });
     }
 
@@ -476,67 +537,6 @@ public class HashJoinTest extends AbstractCairoTest {
                 true,
                 false
         );
-    }
-
-    @Test
-    public void testHashOuterJoinSymbolKeysSwapFullOuter() throws Exception {
-        assertMemoryLeak(() -> {
-            execute("CREATE TABLE m (sym1 SYMBOL, sym2 SYMBOL, v INT)");
-            execute("CREATE TABLE s (sym1 SYMBOL, sym2 SYMBOL, v INT)");
-            execute("""
-                    INSERT INTO m VALUES
-                        ('A', 'X', 1),
-                        ('C', 'Z', 3)""");
-            execute("""
-                    INSERT INTO s VALUES
-                        ('A', 'X', 10),
-                        ('B', 'Y', 20),
-                        ('D', 'W', 30),
-                        ('E', 'V', 40),
-                        ('F', 'U', 50)""");
-
-            assertQueryNoLeakCheck(
-                    """
-                            sym1	sym2	v	sym11	sym21	v1
-                            		null	B	Y	20
-                            		null	D	W	30
-                            		null	E	V	40
-                            		null	F	U	50
-                            A	X	1	A	X	10
-                            C	Z	3			null
-                            """,
-                    "SELECT * FROM m FULL JOIN s ON m.sym1 = s.sym1 AND m.sym2 = s.sym2 ORDER BY m.v, s.v",
-                    null,
-                    true,
-                    false
-            );
-        });
-    }
-
-    @Test
-    public void testHashOuterJoinWithFilter() throws Exception {
-        assertMemoryLeak(() -> {
-            execute("create table taba (i long, locale_name symbol )");
-            execute("create table tabb (i long, state symbol, city symbol)");
-            execute("insert into taba values (1, 'pl')");
-            execute("insert into tabb values (1, 'a', 'pl')");
-            execute("insert into tabb values (1, 'b', 'b')");
-
-            assertQueryNoLeakCheck("""
-                    i\tlocale_name\ti1\tstate\tcity
-                    1\tpl\t1\ta\tpl
-                    """, "select * from taba left join tabb on taba.i = tabb.i and (locale_name = state OR locale_name=city)", null);
-            assertQueryNoLeakCheck("""
-                    i\tlocale_name\ti1\tstate\tcity
-                    1\tpl\t1\ta\tpl
-                    null\t\t1\tb\tb
-                    """, "select * from taba right join tabb on taba.i = tabb.i and (locale_name = state OR locale_name=city)", null);
-            assertQueryNoLeakCheck("""
-                    i\tlocale_name\ti1\tstate\tcity
-                    1\tpl\t1\ta\tpl
-                    null\t\t1\tb\tb
-                    """, "select * from taba full join tabb on taba.i = tabb.i and (locale_name = state OR locale_name=city)", null);
-        });
     }
 
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/HashJoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/HashJoinTest.java
@@ -255,6 +255,60 @@ public class HashJoinTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testHashJoinSymbolAndDecimalKeys() throws Exception {
+        assertMemoryLeak(() -> {
+            assertHashJoinSymbolAndDecimalKey("dec8", "DECIMAL(2,1)", "1.2", "2.3", "3.4");
+            assertHashJoinSymbolAndDecimalKey("dec16", "DECIMAL(4,2)", "12.34", "23.45", "34.56");
+            assertHashJoinSymbolAndDecimalKey("dec32", "DECIMAL(9,4)", "12345.6789", "23456.7890", "34567.8901");
+            assertHashJoinSymbolAndDecimalKey("dec64", "DECIMAL(18,6)", "123456789012.345678", "234567890123.456789", "345678901234.567890");
+            assertHashJoinSymbolAndDecimalKey(
+                    "dec128",
+                    "DECIMAL(38,10)",
+                    "1234567890123456789012345678.9012345678",
+                    "2345678901234567890123456789.0123456789",
+                    "3456789012345678901234567890.1234567890"
+            );
+            assertHashJoinSymbolAndDecimalKey(
+                    "dec256",
+                    "DECIMAL(76,20)",
+                    "12345678901234567890123456789012345678901234567890123456.78901234567890123456",
+                    "23456789012345678901234567890123456789012345678901234567.89012345678901234567",
+                    "34567890123456789012345678901234567890123456789012345678.90123456789012345678"
+            );
+        });
+    }
+
+    @Test
+    public void testHashJoinSymbolAndUuidKeys() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE m (id UUID, sym SYMBOL, v INT)");
+            execute("CREATE TABLE s (id UUID, sym SYMBOL, v INT)");
+            execute("""
+                    INSERT INTO m VALUES
+                        ('11111111-1111-1111-1111-111111111111', 'A', 1),
+                        ('22222222-2222-2222-2222-222222222222', 'B', 2),
+                        ('33333333-3333-3333-3333-333333333333', 'C', 3)""");
+            execute("""
+                    INSERT INTO s VALUES
+                        ('11111111-1111-1111-1111-111111111111', 'A', 10),
+                        ('22222222-2222-2222-2222-222222222222', 'X', 20),
+                        ('33333333-3333-3333-3333-333333333333', 'C', 30)""");
+
+            assertQueryNoLeakCheck(
+                    """
+                            id\tsym\tv\tv1
+                            11111111-1111-1111-1111-111111111111\tA\t1\t10
+                            33333333-3333-3333-3333-333333333333\tC\t3\t30
+                            """,
+                    "SELECT m.id, m.sym, m.v, s.v FROM m JOIN s ON m.id = s.id AND m.sym = s.sym ORDER BY m.v",
+                    null,
+                    true,
+                    false
+            );
+        });
+    }
+
+    @Test
     public void testHashOuterJoinSymbolAndDecimalKeys() throws Exception {
         assertMemoryLeak(() -> {
             assertHashOuterJoinSymbolAndDecimalKey("dec8", "DECIMAL(2,1)", "1.2", "2.3", "3.4");
@@ -307,6 +361,51 @@ public class HashJoinTest extends AbstractCairoTest {
                     false
             );
         });
+    }
+
+    private void assertHashJoinSymbolAndDecimalKey(String tableSuffix, String decimalType, String id1, String id2, String id3) throws Exception {
+        final String mTableName = "m_" + tableSuffix;
+        final String sTableName = "s_" + tableSuffix;
+        execute("CREATE TABLE " + mTableName + " (id " + decimalType + ", sym SYMBOL, v INT)");
+        execute("CREATE TABLE " + sTableName + " (id " + decimalType + ", sym SYMBOL, v INT)");
+        execute("""
+                INSERT INTO %s VALUES
+                    (%s::%s, 'A', 1),
+                    (%s::%s, 'B', 2),
+                    (%s::%s, 'C', 3)""".formatted(mTableName, id1, decimalType, id2, decimalType, id3, decimalType));
+        execute("""
+                INSERT INTO %s VALUES
+                    (%s::%s, 'A', 10),
+                    (%s::%s, 'X', 20),
+                    (%s::%s, 'C', 30)""".formatted(sTableName, id1, decimalType, id2, decimalType, id3, decimalType));
+        final String query = """
+                SELECT %s.v, %s.v
+                FROM %s
+                JOIN %s ON %s.id = %s.id AND %s.sym = %s.sym
+                ORDER BY %s.v
+                """.formatted(
+                mTableName,
+                sTableName,
+                mTableName,
+                sTableName,
+                mTableName,
+                sTableName,
+                mTableName,
+                sTableName,
+                mTableName
+        );
+
+        assertQueryNoLeakCheck(
+                """
+                        v\tv1
+                        1\t10
+                        3\t30
+                        """,
+                query,
+                null,
+                true,
+                false
+        );
     }
 
     private void assertHashOuterJoinSymbolAndDecimalKey(String tableSuffix, String decimalType, String id1, String id2, String id3) throws Exception {


### PR DESCRIPTION
Queries joining on SYMBOL plus UUID or DECIMAL keys could fail with an UnsupportedOperationException instead of returning results. Delegate the missing record accessors so these joins work correctly.