### PR TITLE
fix(sql): allow multi-character separator in string_agg

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggGroupByFunction.java
@@ -43,7 +43,7 @@ class StringAggGroupByFunction extends StrFunction implements UnaryFunction, Gro
     private static final int INITIAL_SINK_CAPACITY = 512;
     private static final int LIST_CLEAR_THRESHOLD = 64;
     private final Function arg;
-    private final char delimiter;
+    private final CharSequence delimiter;
     private final int functionPosition;
     private final int maxBytes;
     private ObjList<DirectUtf16Sink> sinks = new ObjList<>();
@@ -52,7 +52,7 @@ class StringAggGroupByFunction extends StrFunction implements UnaryFunction, Gro
     private int touchedMemorySize;
     private int valueIndex;
 
-    public StringAggGroupByFunction(Function arg, int functionPosition, char delimiter, int maxBytes) {
+    public StringAggGroupByFunction(Function arg, int functionPosition, CharSequence delimiter, int maxBytes) {
         this.arg = arg;
         this.delimiter = delimiter;
         this.maxBytes = maxBytes;
@@ -117,8 +117,8 @@ class StringAggGroupByFunction extends StrFunction implements UnaryFunction, Gro
         if (str != null) {
             final int hi = sink.size();
             final boolean nullValue = mapValue.getBool(valueIndex + 1);
-            if (!nullValue) {
-                sink.putAscii(delimiter);
+            if (!nullValue && delimiter != null) {
+                sink.put(delimiter);
             }
             sink.put(str);
             mapValue.putBool(valueIndex + 1, false);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggStrSepGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggStrSepGroupByFunctionFactory.java
@@ -31,11 +31,11 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
 
-public class StringAggGroupByFunctionFactory implements FunctionFactory {
+public class StringAggStrSepGroupByFunctionFactory implements FunctionFactory {
 
     @Override
     public String getSignature() {
-        return "string_agg(Sa)";
+        return "string_agg(Ss)";
     }
 
     @Override
@@ -51,10 +51,11 @@ public class StringAggGroupByFunctionFactory implements FunctionFactory {
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) {
+        final CharSequence delimiter = args.getQuick(1).getStrA(null);
         return new StringAggGroupByFunction(
                 args.getQuick(0),
                 argPositions.getQuick(0),
-                String.valueOf(args.getQuick(1).getChar(null)),
+                delimiter == null ? null : delimiter.toString(),
                 configuration.getStrFunctionMaxBufferLength()
         );
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggVarcharGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggVarcharGroupByFunction.java
@@ -44,13 +44,13 @@ class StringAggVarcharGroupByFunction extends VarcharFunction implements UnaryFu
     private static final int INITIAL_SINK_CAPACITY = 512;
     private static final int LIST_CLEAR_THRESHOLD = 64;
     private final Function arg;
-    private final char delimiter;
+    private final Utf8Sequence delimiter;
     private boolean isShared;
     private int sinkIndex = 0;
     private ObjList<DirectUtf8Sink> sinks = new ObjList<>();
     private int valueIndex;
 
-    public StringAggVarcharGroupByFunction(Function arg, char delimiter) {
+    public StringAggVarcharGroupByFunction(Function arg, Utf8Sequence delimiter) {
         this.arg = arg;
         this.delimiter = delimiter;
     }
@@ -108,8 +108,8 @@ class StringAggVarcharGroupByFunction extends VarcharFunction implements UnaryFu
         final Utf8Sequence str = arg.getVarcharA(record);
         if (str != null) {
             final boolean nullValue = mapValue.getBool(valueIndex + 1);
-            if (!nullValue) {
-                sink.putAscii(delimiter);
+            if (!nullValue && delimiter != null) {
+                sink.put(delimiter);
             }
             sink.put(str);
             mapValue.putBool(valueIndex + 1, false);

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggVarcharGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggVarcharGroupByFunctionFactory.java
@@ -30,6 +30,7 @@ import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
+import io.questdb.std.str.Utf8String;
 
 public class StringAggVarcharGroupByFunctionFactory implements FunctionFactory {
 
@@ -51,6 +52,6 @@ public class StringAggVarcharGroupByFunctionFactory implements FunctionFactory {
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) {
-        return new StringAggVarcharGroupByFunction(args.getQuick(0), args.getQuick(1).getChar(null));
+        return new StringAggVarcharGroupByFunction(args.getQuick(0), new Utf8String(args.getQuick(1).getChar(null)));
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggVarcharStrSepGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/StringAggVarcharStrSepGroupByFunctionFactory.java
@@ -30,12 +30,14 @@ import io.questdb.griffin.FunctionFactory;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
+import io.questdb.std.str.Utf8Sequence;
+import io.questdb.std.str.Utf8String;
 
-public class StringAggGroupByFunctionFactory implements FunctionFactory {
+public class StringAggVarcharStrSepGroupByFunctionFactory implements FunctionFactory {
 
     @Override
     public String getSignature() {
-        return "string_agg(Sa)";
+        return "string_agg(Øø)";
     }
 
     @Override
@@ -51,11 +53,10 @@ public class StringAggGroupByFunctionFactory implements FunctionFactory {
             CairoConfiguration configuration,
             SqlExecutionContext sqlExecutionContext
     ) {
-        return new StringAggGroupByFunction(
+        final Utf8Sequence delimiter = args.getQuick(1).getVarcharA(null);
+        return new StringAggVarcharGroupByFunction(
                 args.getQuick(0),
-                argPositions.getQuick(0),
-                String.valueOf(args.getQuick(1).getChar(null)),
-                configuration.getStrFunctionMaxBufferLength()
+                delimiter == null ? null : Utf8String.newInstance(delimiter)
         );
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StringAggGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StringAggGroupByFunctionFactoryTest.java
@@ -234,6 +234,90 @@ public class StringAggGroupByFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testMultiCharStringSeparator() throws Exception {
+        assertQuery(
+                """
+                        string_agg
+                        abc -> bbb -> aaa -> ccc -> aaa
+                        """,
+                "select string_agg(s, ' -> ') from x",
+                "create table x as (select * from (select rnd_str('abc', 'aaa', 'bbb', 'ccc') s, timestamp_sequence(0, 100000) ts from long_sequence(5)) timestamp(ts))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testMultiCharStringSeparatorGroupKeyed() throws Exception {
+        assertQuery(
+                """
+                        a\tstring_agg
+                        a\tbbb // abc // aaa
+                        b\tccc // abc
+                        c\tccc
+                        d\tbbb
+                        e\tabc // ccc
+                        f\tccc
+                        """,
+                "select a, string_agg(s, ' // ') from x order by a",
+                "create table x as (" +
+                        "select * from (" +
+                        "   select " +
+                        "       rnd_symbol('a','b','c','d','e','f') a," +
+                        "       rnd_str('abc', 'aaa', 'bbb', 'ccc') s, " +
+                        "       timestamp_sequence(0, 100000) ts " +
+                        "   from long_sequence(10)" +
+                        ") timestamp(ts))",
+                null,
+                true,
+                true
+        );
+    }
+
+    @Test
+    public void testMultiCharStringSeparatorVarchar() throws Exception {
+        assertQuery(
+                """
+                        string_agg
+                        abc -> bbb -> aaa -> ccc -> aaa
+                        """,
+                "select string_agg(s::varchar, ' -> ') from x",
+                "create table x as (select * from (select rnd_str('abc', 'aaa', 'bbb', 'ccc') s, timestamp_sequence(0, 100000) ts from long_sequence(5)) timestamp(ts))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testNewlineStringSeparator() throws Exception {
+        assertQuery(
+                "string_agg\nCREATE TABLE foo_1 LIKE (foo);\nCREATE TABLE foo_2 LIKE (foo);\nCREATE TABLE foo_3 LIKE (foo);\n",
+                "SELECT string_agg('CREATE TABLE foo_' || x || ' LIKE (foo);', (10::char)::string) FROM long_sequence(3)",
+                null,
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
+    public void testNullStringSeparator() throws Exception {
+        assertQuery(
+                """
+                        string_agg
+                        abcbbbaaacccaaa
+                        """,
+                "select string_agg(s, cast(null as string)) from x",
+                "create table x as (select * from (select rnd_str('abc', 'aaa', 'bbb', 'ccc') s, timestamp_sequence(0, 100000) ts from long_sequence(5)) timestamp(ts))",
+                null,
+                false,
+                true
+        );
+    }
+
+    @Test
     public void testSkipNull() throws Exception {
         assertQuery(
                 """


### PR DESCRIPTION
Fixes #6500

## Summary

`string_agg` previously required the separator argument to be a single `CHAR` constant. Multi-character separators (e.g. `' -> '`, a newline+tab combination, or any user-provided text) were rejected with `there is no matching function string_agg with the argument types: (STRING, STRING)`, forcing workarounds like `10::char` or `chr_int::char`.

This change adds `STRING` and `VARCHAR` constant separators alongside the existing `CHAR` overloads, so the following queries all work:

```sql
SELECT string_agg(s, ',')      FROM t;   -- existing CHAR overload
SELECT string_agg(s, ' -> ')   FROM t;   -- new STRING overload
SELECT string_agg(s::varchar, concat('|', '|')) FROM t;  -- new VARCHAR overload
```

The reported example from #6500 now produces the expected output:

```sql
SELECT string_agg('CREATE TABLE foo_' || x || ' LIKE (foo);', (10::char)::string)
FROM long_sequence(3);
```

A `NULL` separator is treated as the empty string, matching how the function already silently skips null input rows.

## Implementation notes

- `StringAggGroupByFunction` and `StringAggVarcharGroupByFunction` now hold the delimiter as a `CharSequence` / `Utf8Sequence` instead of a primitive `char`.
- The existing `string_agg(Sa)` and `string_agg(Øa)` factories wrap the `CHAR` constant into a single-character `String` / `Utf8String` on construction, so plan output and runtime behavior for those overloads are unchanged.
- Two new factories `string_agg(Ss)` and `string_agg(Øø)` register the multi-character overloads.
- This is purely additive — no signature was removed and no overload that previously matched changes behavior.

This intentionally does not add backslash escape interpretation to SQL string literals (`'\n'` is still two characters); doing so would be a much wider language change and is unrelated to `string_agg`.

## Test plan

- New tests in `StringAggGroupByFunctionFactoryTest`:
  - `testMultiCharStringSeparator` and `testMultiCharStringSeparatorGroupKeyed` — multi-character separator on STRING column, both un-keyed and keyed
  - `testMultiCharStringSeparatorVarchar` — same against a VARCHAR column
  - `testNewlineStringSeparator` — reproduces the example from #6500
  - `testNullStringSeparator` — null separator behaves as no separator
- All pre-existing tests in the same class (16 total) pass unchanged
- `SqlOptimiserTest#testSampleByFromToCheckingColumnTypes` and `testSampleByFromToNotEnoughFillValues` (the SAMPLE BY tests that exercise `string_agg`) pass unchanged
- `StringDistinctAggGroupByFunctionFactoryTest` and `StringDistinctAggSymbolGroupByFunctionFactoryTest` pass unchanged
- `ExpressionParserTest` (295 tests, including the `string_agg` parser cases) pass unchanged