### PR TITLE
fix(sql): cap intervals rendered in EXPLAIN plan to keep large IN lists within the response buffer

### DIFF
--- a/core/src/main/java/io/questdb/griffin/model/RuntimeIntervalModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/RuntimeIntervalModel.java
@@ -47,6 +47,10 @@ import io.questdb.std.str.StringSink;
 import static io.questdb.griffin.model.IntervalUtils.STATIC_LONGS_PER_DYNAMIC_INTERVAL;
 
 public class RuntimeIntervalModel implements RuntimeIntrinsicIntervalModel {
+    // Cap on the number of intervals rendered into an EXPLAIN plan; further intervals are
+    // collapsed into a trailing "... N more" marker so a query like
+    // `timestamp IN '...;70000'` does not overflow the response buffer (see #5661).
+    static final int PLAN_MAX_INTERVALS = 64;
     private static final Log LOG = LogFactory.getLog(RuntimeIntervalModel.class);
     private final ObjList<Function> dynamicRangeList;
     // These 2 are incoming model
@@ -130,15 +134,20 @@ public class RuntimeIntervalModel implements RuntimeIntrinsicIntervalModel {
             sink.val('[');
             try {
                 LongList intervals = calculateIntervals(sink.getExecutionContext());
-                for (int i = 0, n = intervals.size(); i < n; i += 2) {
+                final int totalIntervals = intervals.size() / 2;
+                final int renderCount = Math.min(totalIntervals, PLAN_MAX_INTERVALS);
+                for (int i = 0; i < renderCount; i++) {
                     if (i > 0) {
                         sink.val(',');
                     }
                     sink.val("(\"");
-                    valTs(sink, timestampDriver, intervals.getQuick(i));
+                    valTs(sink, timestampDriver, intervals.getQuick(i * 2));
                     sink.val("\",\"");
-                    valTs(sink, timestampDriver, intervals.getQuick(i + 1));
+                    valTs(sink, timestampDriver, intervals.getQuick(i * 2 + 1));
                     sink.val("\")");
+                }
+                if (totalIntervals > renderCount) {
+                    sink.val(",...(").val(totalIntervals - renderCount).val(" more)");
                 }
             } catch (SqlException e) {
                 LOG.error().$("Can't calculate intervals: ").$safe(e.getFlyweightMessage()).$();

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -7981,6 +7981,41 @@ public class ExplainPlanTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testExplainTruncatesLargeIntervalLists() throws Exception {
+        // 65 intervals: 64 render verbatim then "...(1 more)" trails. Catches the
+        // response-buffer overflow on EXPLAIN of `IN '...;70000'` from issue #5661.
+        // The 64-interval companion check guards the off-by-one at the cap.
+        assertMemoryLeak(() -> {
+            execute("create table trades (timestamp timestamp) timestamp(timestamp)");
+            assertPlanNoLeakCheck(
+                    "select * from trades where timestamp in '2005-01-01T12:55:00;2m;1d;64'",
+                    "PageFrame\n    Row forward scan\n    Interval forward scan on: trades\n      intervals: " + buildIntervalPlanList(64, false) + "\n"
+            );
+            assertPlanNoLeakCheck(
+                    "select * from trades where timestamp in '2005-01-01T12:55:00;2m;1d;65'",
+                    "PageFrame\n    Row forward scan\n    Interval forward scan on: trades\n      intervals: " + buildIntervalPlanList(64, true) + "\n"
+            );
+        });
+    }
+
+    private static String buildIntervalPlanList(int firstN, boolean withOneMore) {
+        StringBuilder sb = new StringBuilder("[");
+        java.time.LocalDate start = java.time.LocalDate.of(2005, 1, 1);
+        for (int i = 0; i < firstN; i++) {
+            if (i > 0) sb.append(',');
+            java.time.LocalDate day = start.plusDays(i);
+            String ymd = day.toString();
+            sb.append("(\"").append(ymd).append("T12:55:00.000000Z\",\"")
+                    .append(ymd).append("T12:56:59.999999Z\")");
+        }
+        if (withOneMore) {
+            sb.append(",...(1 more)");
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+
+    @Test
     public void testSelectDynamicTsInterval3() throws Exception {
         assertPlan("create table tab ( l long, ts timestamp) timestamp(ts);", "select * from tab where ts > now()", """
                 PageFrame


### PR DESCRIPTION
Fixes #5661

## Summary

`RuntimeIntervalModel.toPlan` materializes every interval into the EXPLAIN plan column. Filters with very large interval lists (the issue reports `IN '2005-01-01T12:55:00;2m;1d;70000'`) push the plan past the HTTP response buffer and the request fails with `response buffer is too small for the column value [columnName=QUERY PLAN, columnIndex=0]`.

Render at most 64 intervals verbatim and replace the tail with `...(N more)`. `puzpuzpuz` suggested exactly this shape on the issue thread; the limit is module-private so it can be tuned later without API impact.

```sql
-- before: HTTP 400, response buffer is too small
explain select * from trades where timestamp IN '2005-01-01T12:55:00;2m;1d;70000';

-- after: plan completes, tail is collapsed
...
    Interval forward scan on: trades
      intervals: [("2005-01-01T12:55:00.000000Z","2005-01-01T12:56:59.999999Z"),
                  ...,
                  ("2005-03-05T12:55:00.000000Z","2005-03-05T12:56:59.999999Z"),
                  ...(69936 more)]
```

The runtime path (interval evaluation, scan ordering, cursor iteration) is unchanged — only the plan rendering is bounded. Plans whose interval lists already fit (the overwhelming majority of EXPLAIN output today) are unaffected.

## Tradeoffs

- Tools that scrape EXPLAIN output to enumerate intervals lose entries past 64. Anyone needing the full list can already get it deterministically from the IN expression itself, which the plan still prints upstream of the scan. Worth flagging if any internal tooling depends on the verbatim list.
- 64 is a heuristic. It is generous enough that real-world queries with hand-written IN lists are not affected, but small enough that worst-case plan size (a few KB) is well under the default response buffer. If the cap is the wrong shape, a `cairo.sql.explain.max.intervals` setting is a small follow-up.

## Test plan

- New `ExplainPlanTest#testExplainTruncatesLargeIntervalLists` asserts:
  - 64 intervals at the cap render verbatim with no `more)` marker
  - 65 intervals render 64 entries followed by `...(1 more)`
- All 535 existing `ExplainPlanTest` tests pass unchanged
- `SqlOptimiserTest`, `GroupByTest`, `WindowJoinTest`, `SampleByTest` (the four suites with the largest concentration of plan assertions touching `Interval forward scan`) pass — 946 tests total, 0 failures