### PR TITLE
docs(qwp): warn about DATE ingress/egress encoding asymmetry

### DIFF
--- a/docs/qwp/design/egress-phase2-backlog.md
+++ b/docs/qwp/design/egress-phase2-backlog.md
@@ -63,6 +63,11 @@ All items in this list are net-new work; everything below is already landed on
   per-column native-keyed dedup map.
 - Gorilla delta-of-delta encoding (`FLAG_GORILLA`) for TIMESTAMP /
   TIMESTAMP_NANOS / DATE columns, with per-column raw-vs-encoded fallback.
+  **Note:** `DATE` is timestamp-ish (encoding discriminator + Gorilla) on
+  **egress only**; on the **ingress** wire `DATE` is a plain `int64`
+  column like `LONG`. This in/out asymmetry is deliberate and a known
+  implementor trap — see the prominent warnings in `wire-egress.md` and
+  `wire-ingress.md`.
 - Whole-batch-body zstd compression (`FLAG_ZSTD`) negotiated via
   `X-QWP-Accept-Encoding` / `X-QWP-Content-Encoding`, with a reused
   `ZSTD_CCtx` per connection and per-batch raw fallback when the compressed

--- a/docs/qwp/wire-egress.md
+++ b/docs/qwp/wire-egress.md
@@ -276,6 +276,24 @@ Gorilla when the column has at least three non-null values and the
 delta-of-delta bitstream is smaller than `nonNull * 8` bytes; unordered or
 jumpy columns fall back to raw.
 
+> **⚠️ `DATE` is timestamp-ish on EGRESS ONLY. Do NOT assume symmetry with
+> ingress — implementors get this wrong.**
+>
+> The rule above (encoding discriminator + optional Gorilla) applies to
+> `DATE` (`0x0B`) **only on the egress wire**. On the **ingress** wire
+> `DATE` is a plain `int64` column written exactly like `LONG`: no
+> discriminator byte, never Gorilla-encoded, even under `FLAG_GORILLA`
+> (see `wire-ingress.md` §10 Column Types — the DATE asymmetry warning,
+> and §"Timestamp Type (`0x0A`, `0x10`)" which excludes `DATE`).
+>
+> A codec that reuses its egress DATE path for ingress (or vice-versa)
+> shifts every DATE value one byte (a clean ×256) and breaks Gorilla
+> DATE entirely. Server: egress
+> `QwpResultBatchBuffer.emitTimestampColumn` groups `DATE` with the
+> timestamp types; ingress `QwpTableBlockCursor` /
+> `QwpFixedWidthColumnCursor` treat `DATE` as generic fixed-width
+> `int64`.
+
 The schema section inside the table block follows the standard rules:
 
 - **First batch for a query**: schema mode `0x00` (full), with a new

--- a/docs/qwp/wire-ingress.md
+++ b/docs/qwp/wire-ingress.md
@@ -347,6 +347,29 @@ senders should use VARCHAR (`0x0F`) for text columns.
 TIMESTAMP and TIMESTAMP_NANOS may use Gorilla encoding when `FLAG_GORILLA` is
 set (see [Column Data Encoding](#12-column-data-encoding)).
 
+> **⚠️ DATE is NOT a timestamp-ish column on ingress — and this is
+> DELIBERATELY ASYMMETRIC with egress. Implementors get this wrong.**
+>
+> On the **ingress** wire, `DATE` (`0x0B`) is a plain fixed-width `int64`
+> column: written exactly like `LONG`, with **no** per-column
+> encoding-discriminator byte and **never** Gorilla-encoded — even when
+> `FLAG_GORILLA` is set. Only `TIMESTAMP` (`0x0A`) and `TIMESTAMP_NANOS`
+> (`0x10`) carry the encoding flag on ingress.
+>
+> On the **egress** wire it is the opposite: `DATE` *is* grouped with
+> `TIMESTAMP`/`TIMESTAMP_NANOS` and *does* carry the 1-byte encoding
+> discriminator (+ optional Gorilla). See `wire-egress.md` (FLAG_GORILLA /
+> encoding-discriminator paragraph).
+>
+> Reusing one direction's DATE rule for the other shifts every DATE value
+> one byte (a clean ×256) and breaks Gorilla-encoded DATE entirely.
+> Server references — ingress: `QwpTableBlockCursor` puts `DATE` in the
+> generic fixed-width arm (`case … TYPE_DATE … `), distinct from the
+> `TYPE_TIMESTAMP, TYPE_TIMESTAMP_NANOS -> tsCursor` arm, and
+> `QwpFixedWidthColumnCursor` reads it with a plain `Unsafe.getLong`;
+> egress: `QwpResultBatchBuffer.emitTimestampColumn` includes `DATE`
+> alongside the timestamp types.
+
 ## 11. Null Handling
 
 Each column's data section begins with a 1-byte **null flag**. The flag tells
@@ -556,10 +579,20 @@ mode exclusively.
 
 ### Timestamp Type (`0x0A`, `0x10`)
 
-When `FLAG_GORILLA` (0x04) is set in the message header flags, timestamp columns
-include a 1-byte encoding flag after the null bitmap. When `FLAG_GORILLA` is
-**not** set, there is no encoding flag -- timestamps are written as plain
-uncompressed int64 arrays.
+> **⚠️ This section applies ONLY to `TIMESTAMP` (`0x0A`) and
+> `TIMESTAMP_NANOS` (`0x10`). `DATE` (`0x0B`) is EXCLUDED on ingress.**
+> Despite "milliseconds since epoch" looking timestamp-like, `DATE` is a
+> plain `int64` column on the ingress wire (written like `LONG`: no
+> encoding flag, never Gorilla), regardless of `FLAG_GORILLA`. Do **not**
+> apply the rule below to `DATE`. This is the opposite of the egress wire,
+> where `DATE` *is* timestamp-ish — see the prominent DATE asymmetry
+> warning in §10 (Column Types).
+
+When `FLAG_GORILLA` (0x04) is set in the message header flags, the
+`TIMESTAMP` (`0x0A`) and `TIMESTAMP_NANOS` (`0x10`) columns include a 1-byte
+encoding flag after the null bitmap. When `FLAG_GORILLA` is **not** set,
+there is no encoding flag -- they are written as plain uncompressed int64
+arrays. (`DATE`, `0x0B`, is never in scope here — see the warning above.)
 
 #### Without FLAG_GORILLA (no encoding flag)
 


### PR DESCRIPTION
## What

`DATE` (`0x0B`) is encoded differently on the two QWP wire directions, and this asymmetry is deliberate:

- **Egress**: `DATE` is grouped with `TIMESTAMP`/`TIMESTAMP_NANOS` — it carries the 1-byte encoding discriminator and can be Gorilla-encoded.
- **Ingress**: `DATE` is a plain fixed-width `int64` column written exactly like `LONG` — no encoding discriminator, never Gorilla-encoded, even under `FLAG_GORILLA`.

A codec that reuses one direction's DATE path for the other shifts every DATE value by one byte (a clean ×256) and breaks Gorilla-encoded DATE entirely. This is an easy trap for protocol implementors to fall into.

This change adds prominent warnings to the spec so the asymmetry is hard to miss:

- `docs/qwp/wire-egress.md` — note that the encoding-discriminator + Gorilla rule applies to `DATE` on egress only.
- `docs/qwp/wire-ingress.md` — §10 Column Types warning, and a scoped warning on the Timestamp Type section excluding `DATE`.
- `docs/qwp/design/egress-phase2-backlog.md` — cross-reference the asymmetry next to the Gorilla backlog item.

Each warning points at the relevant server code paths (`QwpResultBatchBuffer.emitTimestampColumn` on egress; `QwpTableBlockCursor` / `QwpFixedWidthColumnCursor` on ingress) so the spec and implementation stay tied together.

## Impact

Documentation only — no code changes, no behavior change. Reduces the risk of future codec implementations getting the DATE wire encoding wrong.

## Test plan

- Docs-only change; no tests required.
- Rendered the modified Markdown to confirm the warning callouts display correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)