### PR TITLE
ci(core): speed up Mac and Windows test jobs

### DIFF
--- a/ci/templates/hosted-jobs.yml
+++ b/ci/templates/hosted-jobs.yml
@@ -46,6 +46,9 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         mac-other:
+          # No WEB_CONSOLE_PROFILE override: this group runs ServerMainTest, whose
+          # testServerUpgradeDoesNotOverrideWebConsoleConfig needs the bundled web
+          # console, so it inherits the default build-web-console profile.
           imageName: "macos-14"
           poolName: "Azure Pipelines"
           os: macOS
@@ -147,7 +150,9 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         windows-other-1:
-          WEB_CONSOLE_PROFILE: ""
+          # No WEB_CONSOLE_PROFILE override: this group runs ServerMainTest, whose
+          # testServerUpgradeDoesNotOverrideWebConsoleConfig needs the bundled web
+          # console, so it inherits the default build-web-console profile.
           imageName: "windows-latest"
           poolName: "Azure Pipelines"
           os: Windows

--- a/ci/templates/hosted-jobs.yml
+++ b/ci/templates/hosted-jobs.yml
@@ -162,10 +162,10 @@ jobs:
           # Exclude cairo: run in windows-cairo-1, windows-cairo-2, windows-fuzz1
           # Exclude compat/cliutil: run in Linux (JavaAndRustLint stage)
           # Exclude pgwire: run in windows-pgwire
-          # Exclude cutlass/http: run in windows-other-2
+          # Exclude cutlass/http, cutlass/qwp, cutlass/text: run in windows-other-2
           # Exclude Fuzz tests: run in windows-fuzz1 and windows-fuzz2
           # Exclude O3 tests: run in windows-other-2
-          excludeTests: "**/griffin/**,**/cairo/**,**/compat/**,**/cliutil/**,**/pgwire/**,**/cutlass/http/**,**/**Fuzz**,**/O3*Test**"
+          excludeTests: "**/griffin/**,**/cairo/**,**/compat/**,**/cliutil/**,**/pgwire/**,**/cutlass/http/**,**/cutlass/qwp/**,**/cutlass/text/**,**/**Fuzz**,**/O3*Test**"
           javadoc_step: ""
           javadoc_profile: ""
         windows-other-2:
@@ -174,7 +174,8 @@ jobs:
           os: Windows
           jdk: "1.25"
           testset: "all"
-          includeTests: "**/cutlass/http/**,**/O3*Test**"
+          # Heavier cutlass groups (http, qwp, text) plus O3 tests; balances wall-clock with windows-other-1
+          includeTests: "**/cutlass/http/**,**/cutlass/qwp/**,**/cutlass/text/**,**/O3*Test**"
           # Exclude Fuzz tests: run in windows-fuzz2
           # Exclude cairo/o3 and cairo/mv: run in windows-cairo-2
           excludeTests: "**/**Fuzz**,**/cairo/o3/**,**/cairo/mv/**"

--- a/ci/templates/hosted-jobs.yml
+++ b/ci/templates/hosted-jobs.yml
@@ -169,6 +169,9 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         windows-other-2:
+          # No test here needs the bundled web console (ServerMainTest runs in
+          # windows-other-1), so skip the build-web-console download.
+          WEB_CONSOLE_PROFILE: ""
           imageName: "windows-latest"
           poolName: "Azure Pipelines"
           os: Windows

--- a/ci/templates/hosted-jobs.yml
+++ b/ci/templates/hosted-jobs.yml
@@ -4,6 +4,7 @@ jobs:
     strategy:
       matrix:
         mac-griffin:
+          WEB_CONSOLE_PROFILE: ""
           imageName: "macos-14"
           poolName: "Azure Pipelines"
           os: macOS
@@ -13,6 +14,7 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         mac-cairo:
+          WEB_CONSOLE_PROFILE: ""
           imageName: "macos-14"
           poolName: "Azure Pipelines"
           os: macOS
@@ -24,6 +26,7 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         mac-cairo-fuzz:
+          WEB_CONSOLE_PROFILE: ""
           imageName: "macos-14"
           poolName: "Azure Pipelines"
           os: macOS
@@ -33,6 +36,7 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         mac-pgwire:
+          WEB_CONSOLE_PROFILE: ""
           imageName: "macos-14"
           poolName: "Azure Pipelines"
           os: macOS
@@ -55,6 +59,7 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         windows-griffin-base:
+          WEB_CONSOLE_PROFILE: ""
           imageName: "windows-latest"
           poolName: "Azure Pipelines"
           os: Windows
@@ -67,6 +72,7 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         windows-griffin-sub:
+          WEB_CONSOLE_PROFILE: ""
           imageName: "windows-latest"
           poolName: "Azure Pipelines"
           os: Windows
@@ -80,6 +86,7 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         windows-fuzz1:
+          WEB_CONSOLE_PROFILE: ""
           imageName: "windows-latest"
           poolName: "Azure Pipelines"
           os: Windows
@@ -89,6 +96,7 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         windows-fuzz2:
+          WEB_CONSOLE_PROFILE: ""
           imageName: "windows-latest"
           poolName: "Azure Pipelines"
           os: Windows
@@ -100,6 +108,7 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         windows-cairo-1:
+          WEB_CONSOLE_PROFILE: ""
           imageName: "windows-latest"
           poolName: "Azure Pipelines"
           os: Windows
@@ -113,6 +122,7 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         windows-cairo-2:
+          WEB_CONSOLE_PROFILE: ""
           imageName: "windows-latest"
           poolName: "Azure Pipelines"
           os: Windows
@@ -124,6 +134,7 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         windows-pgwire:
+          WEB_CONSOLE_PROFILE: ""
           imageName: "windows-latest"
           poolName: "Azure Pipelines"
           os: Windows
@@ -136,6 +147,7 @@ jobs:
           javadoc_step: ""
           javadoc_profile: ""
         windows-other-1:
+          WEB_CONSOLE_PROFILE: ""
           imageName: "windows-latest"
           poolName: "Azure Pipelines"
           os: Windows
@@ -176,5 +188,7 @@ jobs:
       DIFF_COVER_THRESHOLD_PCT: 50
       ARCHIVED_CRASH_LOG: "$(Build.ArtifactStagingDirectory)/questdb-crash-$(Build.SourceBranchName)-$(Build.SourceVersion)-$(System.StageAttempt)-$(Agent.OS)-$(jdk).log"
       MAVEN_OPTS: "-Xmx2g -XX:+UseParallelGC"
+      # Hosted groups only run core-module tests; compile just core and its deps.
+      TEST_REACTOR_ARGS: "-pl core -am"
     steps:
       - template: steps.yml

--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -154,12 +154,12 @@ steps:
       mavenPomFile: "pom.xml"
       mavenOptions: "-Xlog:gc -Dfile.encoding=UTF-8 $(MAVEN_OPTS)"
       goals: "clean test"
-      options: "--batch-mode --quiet -Dtest.include=$(includeTests)
+      options: "--batch-mode --quiet $(TEST_REACTOR_ARGS) -Dtest.include=$(includeTests)
         -Dtest.exclude=$(excludeTests)
         -Dout=$(Build.SourcesDirectory)/ci/qlog.conf
         -DfailIfNoTests=false
         -Dsurefire.failIfNoSpecifiedTests=false
-        -P build-web-console
+        $(WEB_CONSOLE_PROFILE)
         $(CLIENT_PROFILE) $(MAVEN_RUN_OPTS)"
       jdkVersionOption: $(jdk)
     env:

--- a/ci/test-fuzz.yml
+++ b/ci/test-fuzz.yml
@@ -20,6 +20,10 @@ variables:
   MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30"
   MAVEN_VERSION: "version"
   MAVEN_VERSION_OPTION: "Default"
+  # Full reactor (the fuzz regex spans core and compat), but no fuzz test serves the
+  # web console, so skip its download.
+  TEST_REACTOR_ARGS: ""
+  WEB_CONSOLE_PROFILE: ""
 
 stages:
   - stage: HostedRunTestsBranches

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -17,6 +17,10 @@ variables:
   MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 "
   MAVEN_VERSION: "version"
   MAVEN_VERSION_OPTION: "Default"
+  # Full-reactor defaults for the self-hosted Linux jobs. Hosted mac/windows jobs
+  # (hosted-jobs.yml) override these to "-pl core -am" and drop the unused web console.
+  TEST_REACTOR_ARGS: ""
+  WEB_CONSOLE_PROFILE: "-P build-web-console"
 
 stages:
   - stage: CheckChanges

--- a/core/src/test/java/io/questdb/test/FilesTest.java
+++ b/core/src/test/java/io/questdb/test/FilesTest.java
@@ -1176,61 +1176,56 @@ public class FilesTest {
 
                 long mem = Unsafe.malloc(8, MemoryTag.NATIVE_DEFAULT);
 
-                long testValue = 0x1234567890ABCDEFL;
-                Unsafe.putLong(mem, testValue);
-                long fileSize = (2L << 30) + 2 * 4096;
+                long sentinel = 0x1234567890ABCDEFL;
+                Unsafe.putLong(mem, sentinel);
+
+                // A copy whose offsets reach past 2 GiB exercises the 64-bit offset/length
+                // arithmetic in copyData/copyDataToOffset (offsets at or beyond 2 GiB exceed a
+                // signed 32-bit int). We only need to *cross* the boundary, not move 2 GiB: the
+                // source is truncated to just past 2 GiB but left unwritten, so the region beyond
+                // the 8-byte sentinel is a hole that reads as zeros with no physical fill. The
+                // copies below move a small window that straddles the boundary, so the test stays
+                // fast on every platform (writing 2 GiB on the hosted Windows runner took minutes).
+                // The returned byte count is what catches truncation: if any offset wrapped through
+                // a signed 32-bit int, the count would be short or negative. Each copy also reads
+                // back zeros, proving the read came from the >2 GiB hole and not from the offset-0
+                // sentinel that a truncated offset would alias back to.
+                final long chunk = 64 * 1024;            // matches the native copy buffer size
+                final long boundary = 2L << 30;          // first offset past signed 32-bit range
+                final long fileSize = boundary + chunk;
+                final long belowBoundary = boundary - chunk;
 
                 try {
                     Files.truncate(fd1, fileSize);
-
                     Files.write(fd1, mem, 8, 0);
-                    Files.write(fd1, mem, 8, fileSize - 8);
 
-                    // Check copy call works
-                    int offset = 2058;
-                    long copiedLen = Files.copyData(fd1, fd2, offset, -1);
+                    // (1) copy to EOF (length == -1): the loop offset advances past 2 GiB up to EOF
+                    long copiedLen = Files.copyData(fd1, fd2, belowBoundary, -1);
+                    Assert.assertEquals("errno: " + Os.errno(), fileSize - belowBoundary, copiedLen);
+                    Assert.assertEquals(0L, Files.readNonNegativeLong(fd2, 0));
 
-                    Assert.assertEquals("errno: " + Os.errno(), fileSize - offset, copiedLen);
-
-                    long long1 = Files.readNonNegativeLong(fd2, fileSize - offset - 8);
-                    Assert.assertEquals(testValue, long1);
-
-                    // Copy with set length
+                    // (2) copy with explicit length: hi = srcOffset + length crosses 2 GiB
                     Files.close(fd2);
                     TestUtils.remove(path2.$());
                     fd2 = Files.openRW(path2.$());
+                    long length = fileSize - belowBoundary;
+                    copiedLen = Files.copyData(fd1, fd2, belowBoundary, length);
+                    Assert.assertEquals("errno: " + Os.errno(), length, copiedLen);
+                    Assert.assertEquals(0L, Files.readNonNegativeLong(fd2, 0));
 
-                    // Check copy call works
-                    offset = 3051;
-                    copiedLen = Files.copyData(fd1, fd2, offset, fileSize - offset);
-                    Assert.assertEquals("errno: " + Os.errno(), fileSize - offset, copiedLen);
-
-                    long1 = Files.readNonNegativeLong(fd2, fileSize - offset - 8);
-                    Assert.assertEquals(testValue, long1);
-
-                    // Copy with destination offset
+                    // (3) source offset itself is past 2 GiB, plus a non-zero destination offset
                     Files.close(fd2);
                     TestUtils.remove(path2.$());
                     fd2 = Files.openRW(path2.$());
-
-                    // Check copy with offset call works
                     long destOffset = 1057;
-                    copiedLen = Files.copyDataToOffset(fd1, fd2, offset, destOffset, fileSize - offset);
-                    Assert.assertEquals(fileSize - offset, copiedLen);
+                    copiedLen = Files.copyDataToOffset(fd1, fd2, boundary, destOffset, chunk);
+                    Assert.assertEquals("errno: " + Os.errno(), chunk, copiedLen);
+                    Assert.assertEquals(0L, Files.readNonNegativeLong(fd2, destOffset));
 
-                    long1 = Files.readNonNegativeLong(fd2, destOffset + fileSize - offset - 8);
-                    Assert.assertEquals(testValue, long1);
-
-                    // Check subsequent copy call with zero offset works
-                    long anotherTestValue = 0x0987654321FEDCBAL;
-                    Unsafe.putLong(mem, anotherTestValue);
-                    Files.write(fd1, mem, 8, 0);
-
+                    // (4) a subsequent small copy from offset 0 still moves real data
                     copiedLen = Files.copyDataToOffset(fd1, fd2, 0, 0, 8);
                     Assert.assertEquals(8, copiedLen);
-
-                    long1 = Files.readNonNegativeLong(fd2, 0);
-                    Assert.assertEquals(anotherTestValue, long1);
+                    Assert.assertEquals(sentinel, Files.readNonNegativeLong(fd2, 0));
                 } finally {
                     // Release mem, fd
                     Files.close(fd1);

--- a/core/src/test/java/io/questdb/test/ServerMainQuerySmokeTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainQuerySmokeTest.java
@@ -28,6 +28,7 @@ import io.questdb.PropertyKey;
 import io.questdb.ServerMain;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.Numbers;
+import io.questdb.std.Os;
 import io.questdb.std.Rnd;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.StringSink;
@@ -502,7 +503,8 @@ public class ServerMainQuerySmokeTest extends AbstractBootstrapTest {
             }
 
             final int nThreads = 6;
-            final int nIterations = 80;
+            // Fewer iterations on slow CI runners; 6 oversubscribed threads still stress work stealing.
+            final int nIterations = Os.isLinux() ? 80 : 30;
 
             final CyclicBarrier startBarrier = new CyclicBarrier(nThreads);
             final SOCountDownLatch doneLatch = new SOCountDownLatch(nThreads);

--- a/core/src/test/java/io/questdb/test/cairo/ArrayTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/ArrayTest.java
@@ -35,6 +35,7 @@ import io.questdb.cairo.vm.api.MemoryA;
 import io.questdb.cutlass.line.tcp.ArrayBinaryFormatParser;
 import io.questdb.std.IntList;
 import io.questdb.std.MemoryTag;
+import io.questdb.std.Os;
 import io.questdb.std.Unsafe;
 import io.questdb.std.Vect;
 import io.questdb.std.str.DirectUtf8Sink;
@@ -2805,7 +2806,16 @@ public class ArrayTest extends AbstractCairoTest {
 
     @Test
     public void testShardedMapCursorArrayAccess() throws Exception {
-
+        // Smaller dataset on slow CI runners (Mac, Windows). Lower the parallel GROUP BY sharding
+        // threshold there so the query still takes the sharded map path this test exercises; the
+        // first five 1-minute groups are unchanged, so the asserted result is identical.
+        final int rowCount;
+        if (Os.isLinux()) {
+            rowCount = 3_000_000;
+        } else {
+            rowCount = 300_000;
+            setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_SHARDING_THRESHOLD, 100);
+        }
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE AAPL_orderbook (
@@ -2820,8 +2830,7 @@ public class ArrayTest extends AbstractCairoTest {
                       [26.0,400.0,7.0,15.0,10.0,5.0,2.0,0.0,0.0,0.0],
                       [1.0,1.0,1.0, 1.0,1.0,1.0,1.0,0.0,0.0,0.0]
                      ] as asks
-                    \tFROM long_sequence(3_000_000)
-                    ;""");
+                    \tFROM long_sequence(""" + rowCount + ");");
 
             drainWalQueue();
 

--- a/core/src/test/java/io/questdb/test/cairo/BitmapIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/BitmapIndexTest.java
@@ -505,8 +505,8 @@ public class BitmapIndexTest extends AbstractCairoTest {
     public void testConcurrentWriterAndBackwardReadHeight() throws Exception {
         final Rnd rnd = TestUtils.generateRandom(LOG);
         // randomize row count with a floor for meaningful coverage; smaller range on slow CI runners (Mac, Windows)
-        int n = Os.isLinux() ? 100_000 + rnd.nextInt(900_000) : 10_000 + rnd.nextInt(90_000);
-        testConcurrentBackwardRW(n, 100000);
+        int rowCount = Os.isLinux() ? 100_000 + rnd.nextInt(900_000) : 10_000 + rnd.nextInt(90_000);
+        testConcurrentBackwardRW(rowCount, 100000);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cairo/BitmapIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/BitmapIndexTest.java
@@ -61,6 +61,7 @@ import io.questdb.std.LongList;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
 import io.questdb.std.Numbers;
+import io.questdb.std.Os;
 import io.questdb.std.Rnd;
 import io.questdb.std.Rows;
 import io.questdb.std.Vect;
@@ -503,7 +504,9 @@ public class BitmapIndexTest extends AbstractCairoTest {
     @Test
     public void testConcurrentWriterAndBackwardReadHeight() throws Exception {
         final Rnd rnd = TestUtils.generateRandom(LOG);
-        testConcurrentBackwardRW(rnd.nextInt(1000000), 100000);
+        // randomize row count with a floor for meaningful coverage; smaller range on slow CI runners (Mac, Windows)
+        int n = Os.isLinux() ? 100_000 + rnd.nextInt(900_000) : 10_000 + rnd.nextInt(90_000);
+        testConcurrentBackwardRW(n, 100000);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cairo/RssMemoryLimitTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/RssMemoryLimitTest.java
@@ -81,7 +81,8 @@ public class RssMemoryLimitTest extends AbstractCairoTest {
     public void testLargeTxEventuallySucceeds() throws Exception {
         long limitMiB = 60;
         assertMemoryLeak(limitMiB, () -> {
-            // fewer transactions on slow CI runners (Mac, Windows); each batch still triggers memory pressure
+            // fewer transactions on slow CI runners (Mac, Windows); the workload below still triggers
+            // memory pressure during WAL apply, which the easing-up log assertion at the end verifies
             int batchCount = Os.isLinux() ? 10 : 4;
             int batchSize = 500_000;
 
@@ -114,6 +115,10 @@ public class RssMemoryLimitTest extends AbstractCairoTest {
                 }
             }, 600);
 
+            // The reduced workload must still exercise the memory pressure/recovery path; otherwise the
+            // test passes trivially. The apply job logs this line only after recovering from a pressure
+            // episode (onEnoughMemory() returns true), so its presence proves pressure was triggered.
+            capture.waitForRegex("table writing memory pressure is easing up \\[table=");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/RssMemoryLimitTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/RssMemoryLimitTest.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.TableToken;
 import io.questdb.griffin.engine.QueryProgress;
 import io.questdb.log.LogFactory;
 import io.questdb.std.MemoryTag;
+import io.questdb.std.Os;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.tools.LogCapture;
 import io.questdb.test.tools.TestUtils;
@@ -80,7 +81,8 @@ public class RssMemoryLimitTest extends AbstractCairoTest {
     public void testLargeTxEventuallySucceeds() throws Exception {
         long limitMiB = 60;
         assertMemoryLeak(limitMiB, () -> {
-            int batchCount = 10;
+            // fewer transactions on slow CI runners (Mac, Windows); each batch still triggers memory pressure
+            int batchCount = Os.isLinux() ? 10 : 4;
             int batchSize = 500_000;
 
             execute("create table x (ts timestamp, i int, l long, d double, vch varchar) timestamp(ts) partition by day wal;");

--- a/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableNameRegistryTest.java
@@ -336,7 +336,8 @@ public class TableNameRegistryTest extends AbstractCairoTest {
     public void testConcurrentReadWriteAndReload() throws Exception {
         assertMemoryLeak(() -> {
             int threadCount = 2;
-            int tableCount = 400;
+            // smaller workload on slow CI runners (Mac, Windows)
+            int tableCount = Os.isLinux() ? 200 : 100;
             AtomicReference<Throwable> ref = new AtomicReference<>();
             CyclicBarrier startBarrier = new CyclicBarrier(threadCount + 1);
             ObjList<Thread> threads = new ObjList<>(threadCount);

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderTailRecordCursorTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderTailRecordCursorTest.java
@@ -130,7 +130,8 @@ public class TableReaderTailRecordCursorTest extends AbstractCairoTest {
     public void testNonPartitioned() throws Exception {
         testBusyPoll(
                 10000,
-                3_000_000,
+                // smaller workload on slow CI runners (Mac, Windows)
+                Os.isLinux() ? 3_000_000 : 300_000,
                 "create table xyz (sequence INT, event BINARY, ts LONG, stamp TIMESTAMP) timestamp(stamp) partition by NONE"
         );
     }

--- a/core/src/test/java/io/questdb/test/cairo/TableReaderTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableReaderTest.java
@@ -1774,7 +1774,8 @@ public class TableReaderTest extends AbstractCairoTest {
             // model data
             LongList list = new LongList();
             final int N = 1024;
-            final int scale = 10000;
+            // smaller workload on slow CI runners (Mac, Windows)
+            final int scale = Os.isLinux() ? 10000 : 1000;
             for (int i = 0; i < N; i++) {
                 list.add(i);
             }
@@ -5456,8 +5457,10 @@ public class TableReaderTest extends AbstractCairoTest {
 
     private void testConcurrentReloadMultiplePartitions(int partitionBy, long stride1) throws Exception {
         assertMemoryLeak(() -> {
-            final int N = 1024_0000;
-            long stride = timestampDriver.fromMicros(stride1);
+            // smaller workload on slow CI runners (Mac, Windows); stride scales up to keep partition count constant
+            final int divisor = Os.isLinux() ? 1 : 10;
+            final int N = 1024_0000 / divisor;
+            long stride = timestampDriver.fromMicros(stride1 * divisor);
             // model table
             TableModel model = new TableModel(configuration, "w", partitionBy).col("l", ColumnType.LONG).timestamp(timestampType);
             AbstractCairoTest.create(model);

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewFuzzTest.java
@@ -441,9 +441,13 @@ public class MatViewFuzzTest extends AbstractFuzzTest {
         setProperty(PropertyKey.CAIRO_WAL_PURGE_INTERVAL, 10);
         assertMemoryLeak(() -> {
             final Rnd rnd = generateRandom(LOG);
-            setFuzzParams(rnd, 0, 0);
+            // Smaller workload on slow CI runners (Mac, Windows): fewer transactions, rows, and tables.
+            // Segment rollover stays at 10 rows and the purge interval at 10, so the test still
+            // generates many WAL segments and runs WalPurgeJob frequently to exercise the race.
+            final boolean isLinux = Os.isLinux();
+            setFuzzParams(rnd, isLinux ? 10_000 : 3_000, isLinux ? 100_000 : 30_000, 0, 0);
             setFuzzProperties(rnd);
-            runMvFuzz(rnd, getTestName(), 4, true);
+            runMvFuzz(rnd, getTestName(), isLinux ? 4 : 2, true);
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewFuzzTest.java
@@ -441,7 +441,7 @@ public class MatViewFuzzTest extends AbstractFuzzTest {
         setProperty(PropertyKey.CAIRO_WAL_PURGE_INTERVAL, 10);
         assertMemoryLeak(() -> {
             final Rnd rnd = generateRandom(LOG);
-            // Smaller workload on slow CI runners (Mac, Windows): fewer transactions, rows, and tables.
+            // Smaller workload on slow CI runners (Mac, Windows): fewer fuzz rows, initial rows, and tables.
             // Segment rollover stays at 10 rows and the purge interval at 10, so the test still
             // generates many WAL segments and runs WalPurgeJob frequently to exercise the race.
             final boolean isLinux = Os.isLinux();

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3FailureTest.java
@@ -3764,7 +3764,8 @@ public class O3FailureTest extends AbstractO3Test {
         int batchCountMin = batchCountMax / 2;
         int batchCount = batchCountMin + rnd.nextInt(batchCountMax - batchCountMin + 1);
 
-        // max timestamp should be 100_000
+        // bulk-load the initial dataset; the O3 batches below use timestamps in [0, 100_000)
+        // to force out-of-order inserts into the earliest partitions
         engine.execute("insert atomic into x select rnd_symbol('aa', 'bb', 'cc'), rnd_str(4,4,1), rnd_str(4,4,1), rnd_str(4,4,1), rnd_str(4,4,1), rnd_varchar(1,40,1), rnd_varchar(1,1,1), rnd_symbol('aa', 'bb', 'cc'), rnd_int(), timestamp_sequence(0, 100) from long_sequence(" + initialRows + ")", executionContext);
 
         String[] symbols = new String[]{"ppp", "wrre", "0ppd", "l22z", "wwe32", "pps", "oop2", "00kk"};

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3FailureTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3FailureTest.java
@@ -46,6 +46,7 @@ import io.questdb.mp.WorkerPool;
 import io.questdb.std.Chars;
 import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
+import io.questdb.std.Os;
 import io.questdb.std.Rnd;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
@@ -3753,16 +3754,23 @@ public class O3FailureTest extends AbstractO3Test {
     ) throws SqlException {
 
         engine.execute("create table x (f symbol index, a string, b string, c string, d string, vc1 varchar, vc2 varchar, e symbol index, g int, t " + timestampTypeName + ") timestamp (t) partition by DAY", executionContext);
+
+        // randomize workload; smaller ranges on slow CI runners (Mac, Windows)
+        Rnd rnd = TestUtils.generateRandom(LOG);
+        int initialRowsMax = Os.isLinux() ? 3_000_000 : 500_000;
+        int initialRowsMin = initialRowsMax / 3;
+        int initialRows = initialRowsMin + rnd.nextInt(initialRowsMax - initialRowsMin + 1);
+        int batchCountMax = Os.isLinux() ? 75 : 30;
+        int batchCountMin = batchCountMax / 2;
+        int batchCount = batchCountMin + rnd.nextInt(batchCountMax - batchCountMin + 1);
+
         // max timestamp should be 100_000
-        engine.execute("insert atomic into x select rnd_symbol('aa', 'bb', 'cc'), rnd_str(4,4,1), rnd_str(4,4,1), rnd_str(4,4,1), rnd_str(4,4,1), rnd_varchar(1,40,1), rnd_varchar(1,1,1), rnd_symbol('aa', 'bb', 'cc'), rnd_int(), timestamp_sequence(0, 100) from long_sequence(3000000)", executionContext);
+        engine.execute("insert atomic into x select rnd_symbol('aa', 'bb', 'cc'), rnd_str(4,4,1), rnd_str(4,4,1), rnd_str(4,4,1), rnd_str(4,4,1), rnd_varchar(1,40,1), rnd_varchar(1,1,1), rnd_symbol('aa', 'bb', 'cc'), rnd_int(), timestamp_sequence(0, 100) from long_sequence(" + initialRows + ")", executionContext);
 
         String[] symbols = new String[]{"ppp", "wrre", "0ppd", "l22z", "wwe32", "pps", "oop2", "00kk"};
         final int symbolLen = symbols.length;
 
-
-        Rnd rnd = TestUtils.generateRandom(LOG);
         int batches = 0;
-        int batchCount = 75;
 
         Utf8StringSink utf8Sink = new Utf8StringSink();
         while (batches < batchCount) {

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3MaxLagTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3MaxLagTest.java
@@ -279,9 +279,14 @@ public class O3MaxLagTest extends AbstractO3Test {
                     int initialCountLo = longsPerPage - 1;
                     int additionalCountLo = longsPerPage - 1;
 
-                    // sample a sliding window of the inner range; smaller on slow CI runners (Mac, Windows)
+                    // Sample a sliding window of the inner range; smaller on slow CI runners (Mac, Windows).
+                    // The window always covers the page boundary (longsPerPage * 2), the value this test
+                    // exists to exercise, so every run still hits the boundary while total iterations drop.
+                    int pageBoundary = longsPerPage * 2;
                     int innerWindow = Os.isLinux() ? 8 : 2;
-                    int innerStart = lo + rnd.nextInt(Math.max(1, hi - lo - innerWindow + 1));
+                    int startLo = Math.max(lo, pageBoundary - innerWindow + 1);
+                    int startHi = Math.min(pageBoundary, hi - innerWindow);
+                    int innerStart = startLo + rnd.nextInt(Math.max(1, startHi - startLo + 1));
                     int innerEnd = innerStart + innerWindow;
 
                     for (int initialCount = initialCountLo; initialCount < initialCountLo + 3; initialCount++) {

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3MaxLagTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3MaxLagTest.java
@@ -42,6 +42,7 @@ import io.questdb.std.Files;
 import io.questdb.std.IntList;
 import io.questdb.std.Numbers;
 import io.questdb.std.NumericException;
+import io.questdb.std.Os;
 import io.questdb.std.Rnd;
 import io.questdb.std.str.Utf8StringSink;
 import io.questdb.test.cairo.TableModel;
@@ -272,14 +273,20 @@ public class O3MaxLagTest extends AbstractO3Test {
                     int longsPerPage = dataAppendPageSize / 8;
                     int hi = (longsPerPage + 8) * 2;
                     int lo = (longsPerPage - 8) * 2;
-                    int maxUncommitted = TestUtils.generateRandom(null).nextInt(hi);
+                    Rnd rnd = TestUtils.generateRandom(LOG);
+                    int maxUncommitted = rnd.nextInt(hi);
 
                     int initialCountLo = longsPerPage - 1;
                     int additionalCountLo = longsPerPage - 1;
 
+                    // sample a sliding window of the inner range; smaller on slow CI runners (Mac, Windows)
+                    int innerWindow = Os.isLinux() ? 8 : 2;
+                    int innerStart = lo + rnd.nextInt(Math.max(1, hi - lo - innerWindow + 1));
+                    int innerEnd = innerStart + innerWindow;
+
                     for (int initialCount = initialCountLo; initialCount < initialCountLo + 3; initialCount++) {
                         for (int additionalCount = additionalCountLo; additionalCount < additionalCountLo + 3; additionalCount++) {
-                            for (int i = lo; i < hi; i++) {
+                            for (int i = innerStart; i < innerEnd; i++) {
                                 LOG.info().$("=========== count1 ").$(initialCount).$(" count2 = ").$(additionalCount).$("iteration ").$(i).$(", max uncommitted ").$(maxUncommitted).$(" ===================").$();
                                 testVarColumnMergeWithColumnTops(
                                         engine,

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3Test.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3Test.java
@@ -5116,13 +5116,19 @@ public class O3Test extends AbstractO3Test {
             SqlExecutionContext sqlExecutionContext,
             String timestampTypeName
     ) throws SqlException {
+        // randomize workload; smaller range on slow CI runners (Mac, Windows)
+        Rnd rnd = TestUtils.generateRandom(LOG);
+        int rowsMax = Os.isLinux() ? 1_000_000 : 250_000;
+        int rowsMin = rowsMax / 5;
+        int rows = rowsMin + rnd.nextInt(rowsMax - rowsMin + 1);
+        int batch = Math.max(1, rows / 10);
         assertLag(
                 engine,
                 compiler,
                 sqlExecutionContext,
                 "with maxUncommittedRows=400",
-                " from long_sequence(1000000)",
-                "insert batch 100000 o3MaxLag 180s into x select * from top",
+                " from long_sequence(" + rows + ")",
+                "insert batch " + batch + " o3MaxLag 180s into x select * from top",
                 timestampTypeName
         );
     }
@@ -8560,13 +8566,19 @@ public class O3Test extends AbstractO3Test {
             SqlExecutionContext sqlExecutionContext,
             String timestampTypeName
     ) throws SqlException {
+        // randomize workload; smaller range on slow CI runners (Mac, Windows)
+        Rnd rnd = TestUtils.generateRandom(LOG);
+        int rowsMax = Os.isLinux() ? 1_000_000 : 250_000;
+        int rowsMin = rowsMax / 5;
+        int rows = rowsMin + rnd.nextInt(rowsMax - rowsMin + 1);
+        int batch = Math.max(1, rows / 10);
         assertLag(
                 engine,
                 compiler,
                 sqlExecutionContext,
                 "",
-                " from long_sequence(1000000)",
-                "insert batch 100000 o3MaxLag 180s into x select * from top",
+                " from long_sequence(" + rows + ")",
+                "insert batch " + batch + " o3MaxLag 180s into x select * from top",
                 timestampTypeName
         );
     }

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3Test.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3Test.java
@@ -570,6 +570,9 @@ public class O3Test extends AbstractO3Test {
 
     @Test
     public void testLargeO3MaxLagContended() throws Exception {
+        // This large-dataset lag test exercises only platform-independent logic and the shared
+        // native sort path; it is slow on the hosted Mac and Windows runners, so run on Linux only.
+        Assume.assumeTrue(Os.isLinux());
         executeWithPool(0, O3Test::testLargeO3MaxLag0);
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/parquet/O3ParquetMergeStrategyFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/parquet/O3ParquetMergeStrategyFuzzTest.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.ParquetMetaFileReader;
 import io.questdb.griffin.engine.table.parquet.ParquetVersion;
 import io.questdb.std.Misc;
 import io.questdb.std.ObjList;
+import io.questdb.std.Os;
 import io.questdb.std.Rnd;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.cairo.fuzz.AbstractFuzzTest;
@@ -136,7 +137,8 @@ public class O3ParquetMergeStrategyFuzzTest extends AbstractFuzzTest {
 
             long dayEnd = partitionTs + DAY_MICROS;
 
-            int rounds = 3 + rnd.nextInt(8);
+            // fewer rounds on slow CI runners (Mac, Windows)
+            int rounds = Os.isLinux() ? 3 + rnd.nextInt(8) : 3 + rnd.nextInt(2);
             LOG.info()
                     .$("starting all-parquet fuzz: initialRowCount=").$(initialRowCount)
                     .$(", rounds=").$(rounds)
@@ -306,7 +308,8 @@ public class O3ParquetMergeStrategyFuzzTest extends AbstractFuzzTest {
             // Initial data starts at '2022-02-24' (see FuzzRunner.createInitialTable).
             long dayEnd = partitionTs + DAY_MICROS;
 
-            int rounds = 3 + rnd.nextInt(8);
+            // fewer rounds on slow CI runners (Mac, Windows)
+            int rounds = Os.isLinux() ? 3 + rnd.nextInt(8) : 3 + rnd.nextInt(2);
             LOG.info()
                     .$("starting fuzz: initialRowCount=").$(initialRowCount)
                     .$(", rounds=").$(rounds)
@@ -475,7 +478,8 @@ public class O3ParquetMergeStrategyFuzzTest extends AbstractFuzzTest {
             // Each round uses a non-overlapping window advancing through the second
             // half of the day, so every batch appends after the previous one.
             long dayEnd = partitionTs + DAY_MICROS;
-            int rounds = 5 + rnd.nextInt(6);
+            // fewer rounds on slow CI runners (Mac, Windows)
+            int rounds = Os.isLinux() ? 5 + rnd.nextInt(6) : 5 + rnd.nextInt(2);
             long windowSize = (dayEnd - partitionTs - DAY_MICROS / 2) / rounds;
 
             LOG.info()
@@ -600,7 +604,8 @@ public class O3ParquetMergeStrategyFuzzTest extends AbstractFuzzTest {
 
             long dayEnd = partitionTs + DAY_MICROS;
 
-            int rounds = 3 + rnd.nextInt(8);
+            // fewer rounds on slow CI runners (Mac, Windows)
+            int rounds = Os.isLinux() ? 3 + rnd.nextInt(8) : 3 + rnd.nextInt(2);
             LOG.info()
                     .$("starting io-failure fuzz: initialRowCount=").$(initialRowCount)
                     .$(", rounds=").$(rounds)
@@ -759,7 +764,8 @@ public class O3ParquetMergeStrategyFuzzTest extends AbstractFuzzTest {
 
             long dayEnd = partitionTs + DAY_MICROS;
 
-            int rounds = 3 + rnd.nextInt(8);
+            // fewer rounds on slow CI runners (Mac, Windows)
+            int rounds = Os.isLinux() ? 3 + rnd.nextInt(8) : 3 + rnd.nextInt(2);
             LOG.info()
                     .$("starting schema-change fuzz: initialRowCount=").$(initialRowCount)
                     .$(", rounds=").$(rounds)

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalLockerFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalLockerFuzzTest.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.TableToken;
 import io.questdb.cairo.wal.QdbrWalLocker;
 import io.questdb.cairo.wal.WalLocker;
 import io.questdb.cairo.wal.WalUtils;
+import io.questdb.std.Os;
 import io.questdb.std.Rnd;
 import io.questdb.test.tools.TestUtils;
 import org.junit.After;
@@ -63,7 +64,8 @@ public class WalLockerFuzzTest {
         final int numThreads = 8;
         final int numTables = 3;
         final int numWalsPerTable = 4;
-        final int operationsPerThread = 200000;
+        // fewer ops on slow CI runners (Mac, Windows)
+        final int operationsPerThread = Os.isLinux() ? 200000 : 50000;
 
         // Track state per (table, wal) pair
         // States: 0=unlocked, 1=writer, 2=purge, 3=writer+purge

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalWriterTest.java
@@ -111,6 +111,7 @@ import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.File;
@@ -337,6 +338,9 @@ public class WalWriterTest extends AbstractCairoTest {
 
     @Test
     public void testAddColumnsRollLargeSegment() throws Exception {
+        // The bug this guards is a Java int overflow (platform-independent); writing >2GB is
+        // very slow on the hosted Mac and Windows runners, so run on Linux only.
+        Assume.assumeTrue(Os.isLinux());
         assertMemoryLeak(() -> {
             // This test reproduces a bug where rolling a large segment file sized over 2GB
             // resulted in int overflow and commit exception.

--- a/core/src/test/java/io/questdb/test/cutlass/http/ExpParquetExportTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/ExpParquetExportTest.java
@@ -141,7 +141,9 @@ public class ExpParquetExportTest extends AbstractBootstrapTest {
                             "FROM long_sequence(1000)" +
                             ")", sqlExecutionContext);
 
-                    int threadCount = 15;
+                    // Single-worker server (see getExportTester()): a few concurrent clients already
+                    // exercise export connection handling; more just add scheduling overhead.
+                    int threadCount = Os.isLinux() ? 8 : 4;
                     CyclicBarrier barrier = new CyclicBarrier(threadCount);
                     AtomicInteger successCount = new AtomicInteger(0);
                     AtomicInteger errorCount = new AtomicInteger(0);
@@ -703,7 +705,10 @@ public class ExpParquetExportTest extends AbstractBootstrapTest {
                     testHttpClient.assertGetParquet("/exp", 104173, params, "test_table");
                     params.put("row_group_size", "10000");
                     testHttpClient.assertGetParquet("/exp", 101211, params, "test_table");
-                    assertParquetExportDataCorrectness(engine, sqlExecutionContext, new String[]{"test_table"}, 10, 10091);
+                    // Each round re-exports the full 10k-row table over the forced byte-level HTTP
+                    // fragmentation from getExportTester(), slow on Mac/Windows. The assertGetParquet
+                    // calls above already cover every row_group_size, so fewer rounds suffice.
+                    assertParquetExportDataCorrectness(engine, sqlExecutionContext, new String[]{"test_table"}, Os.isLinux() ? 10 : 3, 10091);
                 });
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/json/JsonLexerTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/json/JsonLexerTest.java
@@ -264,7 +264,13 @@ public class JsonLexerTest {
                 try {
                     Assert.assertEquals(l, Files.read(fd, buf, (int) l, 0));
 
-                    for (int i = 0; i < l; i++) {
+                    // Split the file at byte offset i and feed the two halves as separate chunks,
+                    // exercising the lexer's chunk-boundary state machine. Doing this at every offset
+                    // is O(l^2); on slow CI runners (Mac, Windows) sample every Nth split point, which
+                    // still spreads boundaries across the whole file. The prime stride avoids aligning
+                    // with the file's structure.
+                    final int stride = Os.isLinux() ? 1 : 7;
+                    for (int i = 0; i < l; i += stride) {
                         try {
                             LEXER.clear();
                             Unsafe.copyMemory(buf, bufA, i);

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/AbstractReusedServerQwpEgressTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/AbstractReusedServerQwpEgressTest.java
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.qwp;
+
+import io.questdb.cairo.CairoEngine;
+import io.questdb.network.NetworkError;
+import io.questdb.std.Chars;
+import io.questdb.std.Files;
+import io.questdb.std.Misc;
+import io.questdb.std.Os;
+import io.questdb.std.Unsafe;
+import io.questdb.std.str.Path;
+import io.questdb.test.AbstractBootstrapTest;
+import io.questdb.test.TestServerMain;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import static io.questdb.PropertyKey.HTTP_MIN_ENABLED;
+import static io.questdb.PropertyKey.LINE_TCP_ENABLED;
+import static io.questdb.PropertyKey.PG_ENABLED;
+
+/**
+ * Base for QWP egress tests that drive the server only through the engine and the QWP WebSocket
+ * endpoint. Such tests booted a fresh {@link TestServerMain} per test, which is dominated by
+ * on-disk database creation plus the recursive root wipe in {@code tearDown} - several hundred
+ * milliseconds per test. This base boots a single server once for the whole class and drops the
+ * user tables between tests instead.
+ * <p>
+ * Trade-offs and how they are handled:
+ * <ul>
+ *     <li>The shared server skips the PGWire, ILP and HTTP-min listeners. Egress tests only use the
+ *     HTTP/QWP WebSocket port, so dropping the rest cuts per-boot work and listener resources.</li>
+ *     <li>The per-test memory/FD leak check is disabled, because a persistent server's FDs and
+ *     native memory do not return to a per-test baseline (e.g. async WAL purge of dropped tables).
+ *     Instead a single class-level check brackets the whole class: it snapshots FD/native memory
+ *     before the server boots and asserts they return to that baseline after the server is freed.
+ *     FD counts must return exactly - a long-lived reused server leaking descriptors is the real
+ *     risk. Native memory is checked with a small tolerance, because the persistent worker threads
+ *     retain a bounded amount of thread-local {@link Path} memory that a byte-exact check would
+ *     flag; a genuine leak across dozens of tests would be far larger.</li>
+ *     <li>A test that needs a differently configured server calls {@link #freeSharedServer()} and
+ *     boots its own; {@link #setUp()} reboots the shared instance (resetting any state the test's
+ *     own server left under the same root) before the next test.</li>
+ * </ul>
+ */
+public abstract class AbstractReusedServerQwpEgressTest extends AbstractBootstrapTest {
+
+    private static final long NATIVE_MEM_TOLERANCE_BYTES = 256 * 1024;
+    protected static TestServerMain serverMain;
+    private static long cachedFdBaseline;
+    private static long fdBaseline;
+    private static long memBaseline;
+
+    @BeforeClass
+    public static void setUpSharedServer() throws Exception {
+        // Egress tests only use the HTTP/QWP WebSocket port; skip the listeners they never touch.
+        createDummyConfiguration(
+                PG_ENABLED + "=false",
+                LINE_TCP_ENABLED + "=false",
+                HTTP_MIN_ENABLED + "=false"
+        );
+        dbPath.parent().$();
+        Path.clearThreadLocals();
+        fdBaseline = Files.getOpenFileCount();
+        cachedFdBaseline = Files.getOpenCachedFileCount();
+        memBaseline = Unsafe.getMemUsed();
+    }
+
+    @AfterClass
+    public static void tearDownSharedServer() {
+        serverMain = Misc.free(serverMain);
+        Path.clearThreadLocals();
+        Assert.assertEquals("leaked OS file descriptors across the class", fdBaseline, Files.getOpenFileCount());
+        Assert.assertEquals("leaked cached file descriptors across the class", cachedFdBaseline, Files.getOpenCachedFileCount());
+        final long memGrowth = Unsafe.getMemUsed() - memBaseline;
+        Assert.assertTrue("native memory grew by " + memGrowth + " bytes across the class", memGrowth < NATIVE_MEM_TOLERANCE_BYTES);
+    }
+
+    @Override
+    @Before
+    public void setUp() {
+        super.setUp();
+        if (serverMain != null) {
+            return;
+        }
+        // First test, or a previous test closed the shared server to run against its own instance.
+        // Boot a fresh default-config server, then drop any tables that closed instance may have
+        // left under the same root.
+        serverMain = startServerWithRetry();
+        resetState();
+    }
+
+    @Override
+    @After
+    public void tearDown() {
+        // Drop the test's tables instead of tearing the server down (the server is freed in
+        // @AfterClass, and the root must stay around while it holds it open).
+        if (serverMain != null) {
+            resetState();
+        }
+    }
+
+    /**
+     * Frees the shared server so a single test can boot its own differently configured instance on
+     * the same ports. {@link #setUp()} reboots the shared instance before the next test.
+     */
+    protected static void freeSharedServer() {
+        serverMain = Misc.free(serverMain);
+    }
+
+    /**
+     * Boots a server, retrying on a bind failure. These tests use fixed ports, and closing a server
+     * does not release its listening port instantly, so a server booting right after another on the
+     * same ports closed (across a class boundary, or after {@link #freeSharedServer()}) can hit
+     * EADDRINUSE. Back off and retry until the port frees.
+     */
+    protected static TestServerMain startServerWithRetry(String... envs) {
+        NetworkError lastError = null;
+        for (int attempt = 0; attempt < 100; attempt++) {
+            try {
+                return startWithEnvVariables(envs);
+            } catch (NetworkError e) {
+                // startWithEnvVariables already closed the half-started server before rethrowing.
+                if (e.getMessage() == null || !Chars.contains(e.getMessage(), "could not bind socket")) {
+                    throw e;
+                }
+                lastError = e;
+                LOG.info().$("server port still in use, retrying boot [attempt=").$(attempt).$(']').$();
+                Os.sleep(100);
+            }
+        }
+        throw lastError;
+    }
+
+    protected void resetState() {
+        serverMain.execute("DROP ALL TABLES");
+        final CairoEngine engine = serverMain.getEngine();
+        engine.releaseInactive();
+        // Apply the enqueued WAL drops so the table names are free for the next test's CREATE.
+        drainWalQueue(engine);
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressBindRoundTripTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressBindRoundTripTest.java
@@ -30,11 +30,7 @@ import io.questdb.client.cutlass.qwp.client.QwpColumnBatchHandler;
 import io.questdb.client.cutlass.qwp.client.QwpQueryClient;
 import io.questdb.client.cutlass.qwp.client.WebSocketResponse;
 import io.questdb.client.cutlass.qwp.protocol.QwpConstants;
-import io.questdb.test.AbstractBootstrapTest;
-import io.questdb.test.TestServerMain;
-import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.UUID;
@@ -54,14 +50,7 @@ import java.util.UUID;
  * DECIMAL64 / DECIMAL128 / DECIMAL256. ARRAY, BINARY, and IPv4 are rejected
  * server-side and verified here via the client's setNull guard.
  */
-public class QwpEgressBindRoundTripTest extends AbstractBootstrapTest {
-
-    @Before
-    public void setUp() {
-        super.setUp();
-        TestUtils.unchecked(() -> createDummyConfiguration());
-        dbPath.parent().$();
-    }
+public class QwpEgressBindRoundTripTest extends AbstractReusedServerQwpEgressTest {
 
     @Test
     public void testBindBooleanFilter() throws Exception {
@@ -187,42 +176,38 @@ public class QwpEgressBindRoundTripTest extends AbstractBootstrapTest {
 
     @Test
     public void testBindErrorSurfacesViaOnError() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(c LONG, part_ts TIMESTAMP) TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(c LONG, part_ts TIMESTAMP) TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.awaitTable("t");
 
-                final byte[] status = {Byte.MIN_VALUE};
-                final String[] msg = {null};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute(
-                            "SELECT c FROM t WHERE c = $1",
-                            binds -> binds.setGeohash(0, 999, 0L),  // invalid precision
-                            new QwpColumnBatchHandler() {
-                                @Override
-                                public void onBatch(QwpColumnBatch batch) {
-                                    Assert.fail("unexpected batch: bind encode should have failed");
-                                }
+        final byte[] status = {Byte.MIN_VALUE};
+        final String[] msg = {null};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute(
+                    "SELECT c FROM t WHERE c = $1",
+                    binds -> binds.setGeohash(0, 999, 0L),  // invalid precision
+                    new QwpColumnBatchHandler() {
+                        @Override
+                        public void onBatch(QwpColumnBatch batch) {
+                            Assert.fail("unexpected batch: bind encode should have failed");
+                        }
 
-                                @Override
-                                public void onEnd(long totalRows) {
-                                    Assert.fail("unexpected onEnd: bind encode should have failed");
-                                }
+                        @Override
+                        public void onEnd(long totalRows) {
+                            Assert.fail("unexpected onEnd: bind encode should have failed");
+                        }
 
-                                @Override
-                                public void onError(byte s, String m) {
-                                    status[0] = s;
-                                    msg[0] = m;
-                                }
-                            }
-                    );
-                }
-                Assert.assertEquals(WebSocketResponse.STATUS_INTERNAL_ERROR, status[0]);
-                Assert.assertNotNull(msg[0]);
-                Assert.assertTrue("message: " + msg[0], msg[0].contains("bind encoding failed"));
-            }
-        });
+                        @Override
+                        public void onError(byte s, String m) {
+                            status[0] = s;
+                            msg[0] = m;
+                        }
+                    }
+            );
+        }
+        Assert.assertEquals(WebSocketResponse.STATUS_INTERNAL_ERROR, status[0]);
+        Assert.assertNotNull(msg[0]);
+        Assert.assertTrue("message: " + msg[0], msg[0].contains("bind encoding failed"));
     }
 
     @Test
@@ -300,24 +285,20 @@ public class QwpEgressBindRoundTripTest extends AbstractBootstrapTest {
     public void testBindNoBindsViaNullLambda() throws Exception {
         // Sanity: when the user passes the 3-arg form with no setter, the wire
         // still encodes bind_count=0. Identical to the 2-arg overload.
-        TestUtils.assertMemoryLeak(() -> {
-            try (TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(c LONG, part_ts TIMESTAMP) TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO t VALUES (42, 1::TIMESTAMP)");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(c LONG, part_ts TIMESTAMP) TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO t VALUES (42, 1::TIMESTAMP)");
+        serverMain.awaitTable("t");
 
-                final long[] value = {Long.MIN_VALUE};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute(
-                            "SELECT c FROM t",
-                            null,
-                            batchHandler(batch -> value[0] = batch.getLongValue(0, 0))
-                    );
-                }
-                Assert.assertEquals(42L, value[0]);
-            }
-        });
+        final long[] value = {Long.MIN_VALUE};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute(
+                    "SELECT c FROM t",
+                    null,
+                    batchHandler(batch -> value[0] = batch.getLongValue(0, 0))
+            );
+        }
+        Assert.assertEquals(42L, value[0]);
     }
 
     @Test
@@ -397,39 +378,35 @@ public class QwpEgressBindRoundTripTest extends AbstractBootstrapTest {
         // iterations. Asserts each result is the value just bound. The server's
         // SQL-text-keyed factory cache compiles once on the first call; every
         // subsequent call with the same text reuses the cached factory.
-        TestUtils.assertMemoryLeak(() -> {
-            try (TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(id LONG, part_ts TIMESTAMP) TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO t VALUES (1, 1::TIMESTAMP), (2, 2::TIMESTAMP), (3, 3::TIMESTAMP), (4, 4::TIMESTAMP), (5, 5::TIMESTAMP)");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(id LONG, part_ts TIMESTAMP) TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO t VALUES (1, 1::TIMESTAMP), (2, 2::TIMESTAMP), (3, 3::TIMESTAMP), (4, 4::TIMESTAMP), (5, 5::TIMESTAMP)");
+        serverMain.awaitTable("t");
 
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    String sql = "SELECT id FROM t WHERE id = $1";
-                    for (int i = 1; i <= 5; i++) {
-                        final long target = i;
-                        final long[] observed = {-1L};
-                        client.execute(sql, binds -> binds.setLong(0, target), new QwpColumnBatchHandler() {
-                            @Override
-                            public void onBatch(QwpColumnBatch batch) {
-                                Assert.assertEquals(1, batch.getRowCount());
-                                observed[0] = batch.getLongValue(0, 0);
-                            }
-
-                            @Override
-                            public void onEnd(long totalRows) {
-                            }
-
-                            @Override
-                            public void onError(byte status, String message) {
-                                Assert.fail("iteration " + target + ": " + message);
-                            }
-                        });
-                        Assert.assertEquals("iteration " + target, target, observed[0]);
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            String sql = "SELECT id FROM t WHERE id = $1";
+            for (int i = 1; i <= 5; i++) {
+                final long target = i;
+                final long[] observed = {-1L};
+                client.execute(sql, binds -> binds.setLong(0, target), new QwpColumnBatchHandler() {
+                    @Override
+                    public void onBatch(QwpColumnBatch batch) {
+                        Assert.assertEquals(1, batch.getRowCount());
+                        observed[0] = batch.getLongValue(0, 0);
                     }
-                }
+
+                    @Override
+                    public void onEnd(long totalRows) {
+                    }
+
+                    @Override
+                    public void onError(byte status, String message) {
+                        Assert.fail("iteration " + target + ": " + message);
+                    }
+                });
+                Assert.assertEquals("iteration " + target, target, observed[0]);
             }
-        });
+        }
     }
 
     @Test
@@ -537,36 +514,32 @@ public class QwpEgressBindRoundTripTest extends AbstractBootstrapTest {
         // Executes two distinct queries on the same client back-to-back: the
         // bindValues scratch must reset between calls so the second query's
         // binds don't leak state from the first.
-        TestUtils.assertMemoryLeak(() -> {
-            try (TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(id LONG, part_ts TIMESTAMP) TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO t VALUES (1, 1::TIMESTAMP), (2, 2::TIMESTAMP), (3, 3::TIMESTAMP)");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(id LONG, part_ts TIMESTAMP) TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO t VALUES (1, 1::TIMESTAMP), (2, 2::TIMESTAMP), (3, 3::TIMESTAMP)");
+        serverMain.awaitTable("t");
 
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
 
-                    // First: 3 binds.
-                    final long[] first = {-1L};
-                    client.execute(
-                            "SELECT id FROM t WHERE id IN ($1, $2, $3) ORDER BY id DESC LIMIT 1",
-                            binds -> binds.setLong(0, 1).setLong(1, 2).setLong(2, 3),
-                            batchHandler(batch -> first[0] = batch.getLongValue(0, 0))
-                    );
-                    Assert.assertEquals(3L, first[0]);
+            // First: 3 binds.
+            final long[] first = {-1L};
+            client.execute(
+                    "SELECT id FROM t WHERE id IN ($1, $2, $3) ORDER BY id DESC LIMIT 1",
+                    binds -> binds.setLong(0, 1).setLong(1, 2).setLong(2, 3),
+                    batchHandler(batch -> first[0] = batch.getLongValue(0, 0))
+            );
+            Assert.assertEquals(3L, first[0]);
 
-                    // Second: 1 bind. If the scratch didn't reset, bind_count
-                    // would be 4 on the wire and the server would read garbage.
-                    final long[] second = {-1L};
-                    client.execute(
-                            "SELECT id FROM t WHERE id = $1",
-                            binds -> binds.setLong(0, 2),
-                            batchHandler(batch -> second[0] = batch.getLongValue(0, 0))
-                    );
-                    Assert.assertEquals(2L, second[0]);
-                }
-            }
-        });
+            // Second: 1 bind. If the scratch didn't reset, bind_count
+            // would be 4 on the wire and the server would read garbage.
+            final long[] second = {-1L};
+            client.execute(
+                    "SELECT id FROM t WHERE id = $1",
+                    binds -> binds.setLong(0, 2),
+                    batchHandler(batch -> second[0] = batch.getLongValue(0, 0))
+            );
+            Assert.assertEquals(2L, second[0]);
+        }
     }
 
     private QwpColumnBatchHandler batchHandler(BatchConsumer body) {
@@ -594,35 +567,31 @@ public class QwpEgressBindRoundTripTest extends AbstractBootstrapTest {
             QwpBindSetter binds,
             BatchAsserter asserter
     ) throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute(createSql);
-                serverMain.execute(insertSql);
-                serverMain.awaitTable("t");
+        serverMain.execute(createSql);
+        serverMain.execute(insertSql);
+        serverMain.awaitTable("t");
 
-                final boolean[] observed = {false};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute(selectSql, binds, new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            asserter.run(batch);
-                            observed[0] = true;
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+        final boolean[] observed = {false};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute(selectSql, binds, new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    asserter.run(batch);
+                    observed[0] = true;
                 }
-                Assert.assertTrue("expected at least one batch", observed[0]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+        }
+        Assert.assertTrue("expected at least one batch", observed[0]);
     }
 
     private void runProjectionNonNull(
@@ -630,32 +599,28 @@ public class QwpEgressBindRoundTripTest extends AbstractBootstrapTest {
             QwpBindSetter binds,
             BatchAsserter asserter
     ) throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (TestServerMain ignored = startWithEnvVariables()) {
-                final boolean[] observed = {false};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute(selectSql, binds, new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            Assert.assertEquals(1, batch.getRowCount());
-                            asserter.run(batch);
-                            observed[0] = true;
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+        final boolean[] observed = {false};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute(selectSql, binds, new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    Assert.assertEquals(1, batch.getRowCount());
+                    asserter.run(batch);
+                    observed[0] = true;
                 }
-                Assert.assertTrue("expected exactly one batch", observed[0]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+        }
+        Assert.assertTrue("expected exactly one batch", observed[0]);
     }
 
     private void runProjectionNull(

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressBootstrapTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressBootstrapTest.java
@@ -34,12 +34,10 @@ import io.questdb.griffin.CompiledQuery;
 import io.questdb.std.IntList;
 import io.questdb.std.LongList;
 import io.questdb.std.ObjList;
-import io.questdb.test.AbstractBootstrapTest;
 import io.questdb.test.TestServerMain;
 import io.questdb.test.cairo.DefaultTestCairoConfiguration;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -50,101 +48,90 @@ import java.util.List;
  * populate a table via SQL, open {@link QwpQueryClient} against /read/v1,
  * issue a SELECT, and assert the decoded batches match.
  */
-public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
-
-    @Before
-    public void setUp() {
-        super.setUp();
-        TestUtils.unchecked(() -> createDummyConfiguration());
-        dbPath.parent().$();
-    }
+public class QwpEgressBootstrapTest extends AbstractReusedServerQwpEgressTest {
 
     @Test
     public void testAllPrimitiveTypes() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                // part_ts is a separate designated timestamp so the existing ts column can still
-                // round-trip a NULL (row 1) without violating WAL partition assignment.
-                serverMain.execute("""
-                        CREATE TABLE allp(
-                            b BOOLEAN,
-                            bt BYTE,
-                            sh SHORT,
-                            ch CHAR,
-                            i INT,
-                            l LONG,
-                            f FLOAT,
-                            d DOUBLE,
-                            dt DATE,
-                            ts TIMESTAMP,
-                            s STRING,
-                            v VARCHAR,
-                            sy SYMBOL,
-                            part_ts TIMESTAMP
-                        ) TIMESTAMP(part_ts) PARTITION BY DAY WAL
-                        """);
-                // Row 0: all set. Row 1: nulls (only types that can hold NULL).
-                serverMain.execute("""
-                        INSERT INTO allp VALUES
-                            (true,  127, 32767, 'A', 999,  999999999999L, 1.5f, 3.14,
-                             '2024-01-01'::DATE, '2024-01-01T00:00:00.000Z', 'hello', 'world', 'SYM1', 1::TIMESTAMP),
-                            (false, 0,   0,     'B', NULL, NULL,          NULL, NULL,
-                             NULL,               NULL,                       NULL,    NULL,    NULL,   2::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("allp");
+        // part_ts is a separate designated timestamp so the existing ts column can still
+        // round-trip a NULL (row 1) without violating WAL partition assignment.
+        serverMain.execute("""
+                CREATE TABLE allp(
+                    b BOOLEAN,
+                    bt BYTE,
+                    sh SHORT,
+                    ch CHAR,
+                    i INT,
+                    l LONG,
+                    f FLOAT,
+                    d DOUBLE,
+                    dt DATE,
+                    ts TIMESTAMP,
+                    s STRING,
+                    v VARCHAR,
+                    sy SYMBOL,
+                    part_ts TIMESTAMP
+                ) TIMESTAMP(part_ts) PARTITION BY DAY WAL
+                """);
+        // Row 0: all set. Row 1: nulls (only types that can hold NULL).
+        serverMain.execute("""
+                INSERT INTO allp VALUES
+                    (true,  127, 32767, 'A', 999,  999999999999L, 1.5f, 3.14,
+                     '2024-01-01'::DATE, '2024-01-01T00:00:00.000Z', 'hello', 'world', 'SYM1', 1::TIMESTAMP),
+                    (false, 0,   0,     'B', NULL, NULL,          NULL, NULL,
+                     NULL,               NULL,                       NULL,    NULL,    NULL,   2::TIMESTAMP)
+                """);
+        serverMain.awaitTable("allp");
 
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    // Explicit column list (not SELECT *) so the test still sees 13 columns and
-                    // the per-column assertions keep addressing the same logical columns.
-                    client.execute(
-                            "SELECT b, bt, sh, ch, i, l, f, d, dt, ts, s, v, sy FROM allp",
-                            new QwpColumnBatchHandler() {
-                                @Override
-                                public void onBatch(QwpColumnBatch batch) {
-                                    Assert.assertEquals(13, batch.getColumnCount());
-                                    Assert.assertEquals(2, batch.getRowCount());
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            // Explicit column list (not SELECT *) so the test still sees 13 columns and
+            // the per-column assertions keep addressing the same logical columns.
+            client.execute(
+                    "SELECT b, bt, sh, ch, i, l, f, d, dt, ts, s, v, sy FROM allp",
+                    new QwpColumnBatchHandler() {
+                        @Override
+                        public void onBatch(QwpColumnBatch batch) {
+                            Assert.assertEquals(13, batch.getColumnCount());
+                            Assert.assertEquals(2, batch.getRowCount());
 
-                                    // Row 0 assertions
-                                    Assert.assertTrue(batch.getBoolValue(0, 0));                       // BOOLEAN
-                                    Assert.assertEquals((byte) 127, batch.getByteValue(1, 0));         // BYTE
-                                    Assert.assertEquals((short) 32767, batch.getShortValue(2, 0));     // SHORT
-                                    Assert.assertEquals('A', batch.getCharValue(3, 0));                // CHAR
-                                    Assert.assertEquals(999, batch.getIntValue(4, 0));                 // INT
-                                    Assert.assertEquals(999_999_999_999L, batch.getLongValue(5, 0));   // LONG
-                                    Assert.assertEquals(1.5f, batch.getFloatValue(6, 0), 0.0f);        // FLOAT
-                                    Assert.assertEquals(3.14, batch.getDoubleValue(7, 0), 1e-9);       // DOUBLE
-                                    Assert.assertTrue(batch.getLongValue(8, 0) > 0);                   // DATE
-                                    Assert.assertTrue(batch.getLongValue(9, 0) > 0);                   // TIMESTAMP
-                                    Assert.assertEquals("hello", batch.getString(10, 0));         // STRING
-                                    Assert.assertEquals("world", batch.getString(11, 0));         // VARCHAR
-                                    Assert.assertEquals("SYM1", batch.getString(12, 0));          // SYMBOL
+                            // Row 0 assertions
+                            Assert.assertTrue(batch.getBoolValue(0, 0));                       // BOOLEAN
+                            Assert.assertEquals((byte) 127, batch.getByteValue(1, 0));         // BYTE
+                            Assert.assertEquals((short) 32767, batch.getShortValue(2, 0));     // SHORT
+                            Assert.assertEquals('A', batch.getCharValue(3, 0));                // CHAR
+                            Assert.assertEquals(999, batch.getIntValue(4, 0));                 // INT
+                            Assert.assertEquals(999_999_999_999L, batch.getLongValue(5, 0));   // LONG
+                            Assert.assertEquals(1.5f, batch.getFloatValue(6, 0), 0.0f);        // FLOAT
+                            Assert.assertEquals(3.14, batch.getDoubleValue(7, 0), 1e-9);       // DOUBLE
+                            Assert.assertTrue(batch.getLongValue(8, 0) > 0);                   // DATE
+                            Assert.assertTrue(batch.getLongValue(9, 0) > 0);                   // TIMESTAMP
+                            Assert.assertEquals("hello", batch.getString(10, 0));         // STRING
+                            Assert.assertEquals("world", batch.getString(11, 0));         // VARCHAR
+                            Assert.assertEquals("SYM1", batch.getString(12, 0));          // SYMBOL
 
-                                    // Row 1: NULL-capable types come back as null
-                                    Assert.assertTrue(batch.isNull(4, 1));   // INT
-                                    Assert.assertTrue(batch.isNull(5, 1));   // LONG
-                                    Assert.assertTrue(batch.isNull(6, 1));   // FLOAT
-                                    Assert.assertTrue(batch.isNull(7, 1));   // DOUBLE
-                                    Assert.assertTrue(batch.isNull(8, 1));   // DATE
-                                    Assert.assertTrue(batch.isNull(9, 1));   // TIMESTAMP
-                                    Assert.assertTrue(batch.isNull(10, 1));  // STRING
-                                    Assert.assertTrue(batch.isNull(11, 1));  // VARCHAR
-                                    Assert.assertTrue(batch.isNull(12, 1));  // SYMBOL
-                                    // BOOLEAN/BYTE/SHORT/CHAR cannot represent NULL in QuestDB -- stored values round-trip.
-                                }
+                            // Row 1: NULL-capable types come back as null
+                            Assert.assertTrue(batch.isNull(4, 1));   // INT
+                            Assert.assertTrue(batch.isNull(5, 1));   // LONG
+                            Assert.assertTrue(batch.isNull(6, 1));   // FLOAT
+                            Assert.assertTrue(batch.isNull(7, 1));   // DOUBLE
+                            Assert.assertTrue(batch.isNull(8, 1));   // DATE
+                            Assert.assertTrue(batch.isNull(9, 1));   // TIMESTAMP
+                            Assert.assertTrue(batch.isNull(10, 1));  // STRING
+                            Assert.assertTrue(batch.isNull(11, 1));  // VARCHAR
+                            Assert.assertTrue(batch.isNull(12, 1));  // SYMBOL
+                            // BOOLEAN/BYTE/SHORT/CHAR cannot represent NULL in QuestDB -- stored values round-trip.
+                        }
 
-                                @Override
-                                public void onEnd(long totalRows) {
-                                }
+                        @Override
+                        public void onEnd(long totalRows) {
+                        }
 
-                                @Override
-                                public void onError(byte status, String message) {
-                                    Assert.fail("egress query error: " + message);
-                                }
-                            });
-                }
-            }
-        });
+                        @Override
+                        public void onError(byte status, String message) {
+                            Assert.fail("egress query error: " + message);
+                        }
+                    });
+        }
     }
 
     /**
@@ -155,54 +142,50 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testArrayColumns() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                // QuestDB SQL only supports DOUBLE[] arrays today; LONG[] support exists in the
-                // wire format but isn't surfaced via SQL CREATE TABLE. Restrict to DOUBLE[] here.
-                serverMain.execute("CREATE TABLE arr_t(d DOUBLE[], ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO arr_t VALUES (ARRAY[1.0, 2.0, 3.0], 1::TIMESTAMP)");
-                serverMain.execute("INSERT INTO arr_t VALUES (ARRAY[4.0, 5.0], 2::TIMESTAMP)");
-                serverMain.awaitTable("arr_t");
+        // QuestDB SQL only supports DOUBLE[] arrays today; LONG[] support exists in the
+        // wire format but isn't surfaced via SQL CREATE TABLE. Restrict to DOUBLE[] here.
+        serverMain.execute("CREATE TABLE arr_t(d DOUBLE[], ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO arr_t VALUES (ARRAY[1.0, 2.0, 3.0], 1::TIMESTAMP)");
+        serverMain.execute("INSERT INTO arr_t VALUES (ARRAY[4.0, 5.0], 2::TIMESTAMP)");
+        serverMain.awaitTable("arr_t");
 
-                final int[] count = {0};
-                final byte[] dWireType = {0};
-                final ObjList<double[]> rowElements = new ObjList<>();
-                final IntList rowDims = new IntList();
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    // No ORDER BY -- QuestDB does not support ORDER BY on DOUBLE[] columns.
-                    // Monotonic designated timestamps keep WAL scan order aligned with insert order.
-                    client.execute("SELECT d FROM arr_t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            dWireType[0] = batch.getColumnWireType(0);
-                            for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
-                                Assert.assertFalse("array row " + r + " must be non-null", batch.isNull(0, r));
-                                rowDims.add(batch.getArrayNDims(0, r));
-                                rowElements.add(batch.getDoubleArrayElements(0, r));
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress error: " + message);
-                        }
-                    });
+        final int[] count = {0};
+        final byte[] dWireType = {0};
+        final ObjList<double[]> rowElements = new ObjList<>();
+        final IntList rowDims = new IntList();
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            // No ORDER BY -- QuestDB does not support ORDER BY on DOUBLE[] columns.
+            // Monotonic designated timestamps keep WAL scan order aligned with insert order.
+            client.execute("SELECT d FROM arr_t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    dWireType[0] = batch.getColumnWireType(0);
+                    for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
+                        Assert.assertFalse("array row " + r + " must be non-null", batch.isNull(0, r));
+                        rowDims.add(batch.getArrayNDims(0, r));
+                        rowElements.add(batch.getDoubleArrayElements(0, r));
+                    }
                 }
-                Assert.assertEquals(2, count[0]);
-                Assert.assertEquals(io.questdb.client.cutlass.qwp.protocol.QwpConstants.TYPE_DOUBLE_ARRAY, dWireType[0]);
-                // Both rows are 1-D arrays; element content must round-trip exactly.
-                Assert.assertEquals(1, rowDims.getQuick(0));
-                Assert.assertEquals(1, rowDims.getQuick(1));
-                Assert.assertArrayEquals(new double[]{1.0, 2.0, 3.0}, rowElements.getQuick(0), 0.0);
-                Assert.assertArrayEquals(new double[]{4.0, 5.0}, rowElements.getQuick(1), 0.0);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals(2, count[0]);
+        Assert.assertEquals(io.questdb.client.cutlass.qwp.protocol.QwpConstants.TYPE_DOUBLE_ARRAY, dWireType[0]);
+        // Both rows are 1-D arrays; element content must round-trip exactly.
+        Assert.assertEquals(1, rowDims.getQuick(0));
+        Assert.assertEquals(1, rowDims.getQuick(1));
+        Assert.assertArrayEquals(new double[]{1.0, 2.0, 3.0}, rowElements.getQuick(0), 0.0);
+        Assert.assertArrayEquals(new double[]{4.0, 5.0}, rowElements.getQuick(1), 0.0);
     }
 
     /**
@@ -211,36 +194,32 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testBackToBackQueriesOnOneConnection() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE cc(x LONG, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO cc VALUES (1, 1::TIMESTAMP)");
-                serverMain.awaitTable("cc");
-                final int[] rows = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    for (int i = 0; i < 2; i++) {
-                        client.execute("SELECT x FROM cc", new QwpColumnBatchHandler() {
-                            @Override
-                            public void onBatch(QwpColumnBatch batch) {
-                                for (int r = 0; r < batch.getRowCount(); r++) rows[0]++;
-                            }
-
-                            @Override
-                            public void onEnd(long totalRows) {
-                            }
-
-                            @Override
-                            public void onError(byte status, String message) {
-                                Assert.fail("egress error: " + message);
-                            }
-                        });
+        serverMain.execute("CREATE TABLE cc(x LONG, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO cc VALUES (1, 1::TIMESTAMP)");
+        serverMain.awaitTable("cc");
+        final int[] rows = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            for (int i = 0; i < 2; i++) {
+                client.execute("SELECT x FROM cc", new QwpColumnBatchHandler() {
+                    @Override
+                    public void onBatch(QwpColumnBatch batch) {
+                        for (int r = 0; r < batch.getRowCount(); r++) rows[0]++;
                     }
-                }
-                Assert.assertEquals(2, rows[0]);
+
+                    @Override
+                    public void onEnd(long totalRows) {
+                    }
+
+                    @Override
+                    public void onError(byte status, String message) {
+                        Assert.fail("egress error: " + message);
+                    }
+                });
             }
-        });
+        }
+        Assert.assertEquals(2, rows[0]);
     }
 
     /**
@@ -254,70 +233,66 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testBinaryColumn() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE bin_t(b BINARY, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                // Two non-null random binary values + one explicit NULL.
-                serverMain.execute("INSERT INTO bin_t SELECT rnd_bin(8, 8, 0), x::TIMESTAMP FROM long_sequence(2)");
-                serverMain.execute("INSERT INTO bin_t VALUES (CAST(NULL AS BINARY), 3::TIMESTAMP)");
-                serverMain.awaitTable("bin_t");
+        serverMain.execute("CREATE TABLE bin_t(b BINARY, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        // Two non-null random binary values + one explicit NULL.
+        serverMain.execute("INSERT INTO bin_t SELECT rnd_bin(8, 8, 0), x::TIMESTAMP FROM long_sequence(2)");
+        serverMain.execute("INSERT INTO bin_t VALUES (CAST(NULL AS BINARY), 3::TIMESTAMP)");
+        serverMain.awaitTable("bin_t");
 
-                final boolean[] nullFlags = new boolean[3];
-                final int[] sizes = new int[3];
-                final byte[][] heapCopies = new byte[3][];
-                final byte[][] viewCopies = new byte[3][];
-                final byte[] wireType = {0};
-                final int[] count = {0};
+        final boolean[] nullFlags = new boolean[3];
+        final int[] sizes = new int[3];
+        final byte[][] heapCopies = new byte[3][];
+        final byte[][] viewCopies = new byte[3][];
+        final byte[] wireType = {0};
+        final int[] count = {0};
 
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT b FROM bin_t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
-                                if (batch.isNull(0, r)) {
-                                    nullFlags[count[0]] = true;
-                                    continue;
-                                }
-                                // Zero-alloc native view
-                                io.questdb.client.std.bytes.DirectByteSequence view = batch.getBinaryA(0, r);
-                                int sz = view.size();
-                                sizes[count[0]] = sz;
-                                byte[] viaView = new byte[sz];
-                                for (int i = 0; i < sz; i++) viaView[i] = view.byteAt(i);
-                                viewCopies[count[0]] = viaView;
-                                // Heap-allocating convenience
-                                heapCopies[count[0]] = batch.getBinary(0, r);
-                            }
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT b FROM bin_t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
+                        if (batch.isNull(0, r)) {
+                            nullFlags[count[0]] = true;
+                            continue;
                         }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress error: " + message);
-                        }
-                    });
+                        // Zero-alloc native view
+                        io.questdb.client.std.bytes.DirectByteSequence view = batch.getBinaryA(0, r);
+                        int sz = view.size();
+                        sizes[count[0]] = sz;
+                        byte[] viaView = new byte[sz];
+                        for (int i = 0; i < sz; i++) viaView[i] = view.byteAt(i);
+                        viewCopies[count[0]] = viaView;
+                        // Heap-allocating convenience
+                        heapCopies[count[0]] = batch.getBinary(0, r);
+                    }
                 }
 
-                Assert.assertEquals(3, count[0]);
-                Assert.assertEquals(io.questdb.client.cutlass.qwp.protocol.QwpConstants.TYPE_BINARY, wireType[0]);
-                // Two non-nulls, one null
-                Assert.assertFalse(nullFlags[0]);
-                Assert.assertFalse(nullFlags[1]);
-                Assert.assertTrue("explicit NULL must surface as null", nullFlags[2]);
-                // rnd_bin(8, 8, 0) generates 8-byte values
-                Assert.assertEquals(8, sizes[0]);
-                Assert.assertEquals(8, sizes[1]);
-                // Native view and heap copy must agree
-                Assert.assertArrayEquals(viewCopies[0], heapCopies[0]);
-                Assert.assertArrayEquals(viewCopies[1], heapCopies[1]);
-            }
-        });
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress error: " + message);
+                }
+            });
+        }
+
+        Assert.assertEquals(3, count[0]);
+        Assert.assertEquals(io.questdb.client.cutlass.qwp.protocol.QwpConstants.TYPE_BINARY, wireType[0]);
+        // Two non-nulls, one null
+        Assert.assertFalse(nullFlags[0]);
+        Assert.assertFalse(nullFlags[1]);
+        Assert.assertTrue("explicit NULL must surface as null", nullFlags[2]);
+        // rnd_bin(8, 8, 0) generates 8-byte values
+        Assert.assertEquals(8, sizes[0]);
+        Assert.assertEquals(8, sizes[1]);
+        // Native view and heap copy must agree
+        Assert.assertArrayEquals(viewCopies[0], heapCopies[0]);
+        Assert.assertArrayEquals(viewCopies[1], heapCopies[1]);
     }
 
     /**
@@ -329,79 +304,75 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test(timeout = 30_000)
     public void testCloseWhileExecuteDoesNotHang() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE slow(x LONG, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO slow SELECT x, x::TIMESTAMP FROM long_sequence(50000)");
-                serverMain.awaitTable("slow");
+        serverMain.execute("CREATE TABLE slow(x LONG, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO slow SELECT x, x::TIMESTAMP FROM long_sequence(50000)");
+        serverMain.awaitTable("slow");
 
-                final java.util.concurrent.CountDownLatch firstBatchSeen = new java.util.concurrent.CountDownLatch(1);
-                final java.util.concurrent.CountDownLatch executeReturned = new java.util.concurrent.CountDownLatch(1);
-                final java.util.concurrent.atomic.AtomicReference<String> errorMessage = new java.util.concurrent.atomic.AtomicReference<>();
-                final java.util.concurrent.atomic.AtomicBoolean endSeen = new java.util.concurrent.atomic.AtomicBoolean();
+        final java.util.concurrent.CountDownLatch firstBatchSeen = new java.util.concurrent.CountDownLatch(1);
+        final java.util.concurrent.CountDownLatch executeReturned = new java.util.concurrent.CountDownLatch(1);
+        final java.util.concurrent.atomic.AtomicReference<String> errorMessage = new java.util.concurrent.atomic.AtomicReference<>();
+        final java.util.concurrent.atomic.AtomicBoolean endSeen = new java.util.concurrent.atomic.AtomicBoolean();
 
-                final QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT);
-                client.connect();
+        final QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT);
+        client.connect();
 
-                Thread queryThread = new Thread(() -> {
-                    try {
-                        client.execute("SELECT x FROM slow ORDER BY x", new QwpColumnBatchHandler() {
-                            @Override
-                            public void onBatch(QwpColumnBatch batch) {
-                                firstBatchSeen.countDown();
-                                // Sleep just long enough that close() lands while we're still
-                                // mid-onBatch (so the I/O thread is parked on pendingRelease.take()
-                                // when shutdown arrives). MUST NOT be interrupted by the test --
-                                // an interrupt would also pop the user thread out of any blocking
-                                // events.take() it later parks on, masking the C7 fix that this
-                                // test exists to regression-check (the I/O thread's finally-block
-                                // synthetic error is what must wake events.take, not an interrupt).
-                                try {
-                                    Thread.sleep(2_000);
-                                } catch (InterruptedException ie) {
-                                    Thread.currentThread().interrupt();
-                                }
-                            }
-
-                            @Override
-                            public void onEnd(long totalRows) {
-                                endSeen.set(true);
-                            }
-
-                            @Override
-                            public void onError(byte status, String message) {
-                                errorMessage.set(message);
-                            }
-                        });
-                    } finally {
-                        executeReturned.countDown();
+        Thread queryThread = new Thread(() -> {
+            try {
+                client.execute("SELECT x FROM slow ORDER BY x", new QwpColumnBatchHandler() {
+                    @Override
+                    public void onBatch(QwpColumnBatch batch) {
+                        firstBatchSeen.countDown();
+                        // Sleep just long enough that close() lands while we're still
+                        // mid-onBatch (so the I/O thread is parked on pendingRelease.take()
+                        // when shutdown arrives). MUST NOT be interrupted by the test --
+                        // an interrupt would also pop the user thread out of any blocking
+                        // events.take() it later parks on, masking the C7 fix that this
+                        // test exists to regression-check (the I/O thread's finally-block
+                        // synthetic error is what must wake events.take, not an interrupt).
+                        try {
+                            Thread.sleep(2_000);
+                        } catch (InterruptedException ie) {
+                            Thread.currentThread().interrupt();
+                        }
                     }
-                }, "qwp-execute-under-test");
-                queryThread.setDaemon(true);
-                queryThread.start();
 
-                // Wait for the query to actually be in-flight before we close.
-                Assert.assertTrue("first batch not received within 15s",
-                        firstBatchSeen.await(15, java.util.concurrent.TimeUnit.SECONDS));
+                    @Override
+                    public void onEnd(long totalRows) {
+                        endSeen.set(true);
+                    }
 
-                // Close from the main thread while the query thread is parked in onBatch.
-                // Without the C7 fix, the user thread would hang on events.take() forever
-                // after the I/O thread exited and the user returned from its in-handler
-                // sleep -- the I/O thread would be gone but no sentinel event would be
-                // there to unblock the next take().
-                client.close();
-
-                // No interrupt() here: the user thread must exit onBatch on its own and
-                // then wake from events.take() on the C7 sentinel error. 15s window
-                // covers the in-handler sleep + close + take + return.
-                Assert.assertTrue("execute() did not return within 15s after close()",
-                        executeReturned.await(15, java.util.concurrent.TimeUnit.SECONDS));
-                Assert.assertNotNull("expected a synthetic error notifying that the query was aborted",
-                        errorMessage.get());
-                Assert.assertFalse("RESULT_END must not have been delivered after close()", endSeen.get());
+                    @Override
+                    public void onError(byte status, String message) {
+                        errorMessage.set(message);
+                    }
+                });
+            } finally {
+                executeReturned.countDown();
             }
-        });
+        }, "qwp-execute-under-test");
+        queryThread.setDaemon(true);
+        queryThread.start();
+
+        // Wait for the query to actually be in-flight before we close.
+        Assert.assertTrue("first batch not received within 15s",
+                firstBatchSeen.await(15, java.util.concurrent.TimeUnit.SECONDS));
+
+        // Close from the main thread while the query thread is parked in onBatch.
+        // Without the C7 fix, the user thread would hang on events.take() forever
+        // after the I/O thread exited and the user returned from its in-handler
+        // sleep -- the I/O thread would be gone but no sentinel event would be
+        // there to unblock the next take().
+        client.close();
+
+        // No interrupt() here: the user thread must exit onBatch on its own and
+        // then wake from events.take() on the C7 sentinel error. 15s window
+        // covers the in-handler sleep + close + take + return.
+        Assert.assertTrue("execute() did not return within 15s after close()",
+                executeReturned.await(15, java.util.concurrent.TimeUnit.SECONDS));
+        Assert.assertNotNull("expected a synthetic error notifying that the query was aborted",
+                errorMessage.get());
+        Assert.assertFalse("RESULT_END must not have been delivered after close()", endSeen.get());
     }
 
     /**
@@ -436,47 +407,43 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
 
     @Test
     public void testDecimal() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE dec(d64 DECIMAL(18,4), d128 DECIMAL(38,6), ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO dec VALUES (1234.5678m, 987654321.123456m, 1::TIMESTAMP)");
-                serverMain.execute("INSERT INTO dec VALUES (CAST(NULL AS DECIMAL(18,4)), CAST(NULL AS DECIMAL(38,6)), 2::TIMESTAMP)");
-                serverMain.awaitTable("dec");
+        serverMain.execute("CREATE TABLE dec(d64 DECIMAL(18,4), d128 DECIMAL(38,6), ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO dec VALUES (1234.5678m, 987654321.123456m, 1::TIMESTAMP)");
+        serverMain.execute("INSERT INTO dec VALUES (CAST(NULL AS DECIMAL(18,4)), CAST(NULL AS DECIMAL(38,6)), 2::TIMESTAMP)");
+        serverMain.awaitTable("dec");
 
-                final Long[] d64 = new Long[2];
-                final long[][] d128 = new long[2][];
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    client.execute("SELECT d64, d128 FROM dec", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                d64[r] = batch.isNull(0, r) ? null : batch.getLongValue(0, r);
-                                d128[r] = batch.isNull(1, r) ? null : new long[]{
-                                        batch.getDecimal128Low(1, r),
-                                        batch.getDecimal128High(1, r)
-                                };
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+        final Long[] d64 = new Long[2];
+        final long[][] d128 = new long[2][];
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            client.execute("SELECT d64, d128 FROM dec", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        d64[r] = batch.isNull(0, r) ? null : batch.getLongValue(0, r);
+                        d128[r] = batch.isNull(1, r) ? null : new long[]{
+                                batch.getDecimal128Low(1, r),
+                                batch.getDecimal128High(1, r)
+                        };
+                    }
                 }
-                // 1234.5678 with scale 4 -> unscaled = 12345678
-                Assert.assertEquals(Long.valueOf(12_345_678L), d64[0]);
-                Assert.assertNull(d64[1]);
-                Assert.assertNotNull(d128[0]);
-                Assert.assertNull(d128[1]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+        }
+        // 1234.5678 with scale 4 -> unscaled = 12345678
+        Assert.assertEquals(Long.valueOf(12_345_678L), d64[0]);
+        Assert.assertNull(d64[1]);
+        Assert.assertNotNull(d128[0]);
+        Assert.assertNull(d128[1]);
     }
 
     /**
@@ -498,8 +465,11 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testDropAfterSelectReleasesReaderInTime() throws Exception {
+        // Needs forced HTTP fragmentation, so it boots its own server; free the shared one first to
+        // release the ports (setUp reboots the shared server for the next test).
+        freeSharedServer();
         TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables(
+            try (final TestServerMain serverMain = startServerWithRetry(
                     PropertyKey.DEBUG_HTTP_FORCE_RECV_FRAGMENTATION_CHUNK_SIZE.getEnvVarName(), "23",
                     PropertyKey.DEBUG_HTTP_FORCE_SEND_FRAGMENTATION_CHUNK_SIZE.getEnvVarName(), "23"
             )) {
@@ -596,8 +566,11 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testDropRecreateDoesNotPoisonSchemaCache() throws Exception {
+        // Needs the query cache enabled, so it boots its own server; free the shared one first to
+        // release the ports (setUp reboots the shared server for the next test).
+        freeSharedServer();
         TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables(
+            try (final TestServerMain serverMain = startServerWithRetry(
                     PropertyKey.HTTP_QUERY_CACHE_ENABLED.getEnvVarName(), "true"
             )) {
                 final String table = "schema_cache_retry_t";
@@ -643,43 +616,39 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testEmptyResultSet() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE empty_t(id LONG, name STRING, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                // No INSERT -- table is empty.
+        serverMain.execute("CREATE TABLE empty_t(id LONG, name STRING, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        // No INSERT -- table is empty.
 
-                final int[] batchCount = {0};
-                final int[] rowCount = {0};
-                final int[] schemaColCount = {-1};
-                final boolean[] endSeen = {false};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT id, name FROM empty_t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            batchCount[0]++;
-                            schemaColCount[0] = batch.getColumnCount();
-                            rowCount[0] += batch.getRowCount();
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                            endSeen[0] = true;
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress error: " + message);
-                        }
-                    });
+        final int[] batchCount = {0};
+        final int[] rowCount = {0};
+        final int[] schemaColCount = {-1};
+        final boolean[] endSeen = {false};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT id, name FROM empty_t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    batchCount[0]++;
+                    schemaColCount[0] = batch.getColumnCount();
+                    rowCount[0] += batch.getRowCount();
                 }
-                Assert.assertEquals("expected one batch (with the schema, zero rows)", 1, batchCount[0]);
-                Assert.assertEquals(0, rowCount[0]);
-                Assert.assertEquals("schema must surface even with no rows", 2, schemaColCount[0]);
-                Assert.assertTrue("RESULT_END must always fire", endSeen[0]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                    endSeen[0] = true;
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals("expected one batch (with the schema, zero rows)", 1, batchCount[0]);
+        Assert.assertEquals(0, rowCount[0]);
+        Assert.assertEquals("schema must surface even with no rows", 2, schemaColCount[0]);
+        Assert.assertTrue("RESULT_END must always fire", endSeen[0]);
     }
 
     /**
@@ -696,75 +665,71 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testEmptyResultSetOnReusedSchemaStillDeliversOneBatch() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE reuse_t(id LONG, name STRING, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO reuse_t VALUES (1, 'one', 1::TIMESTAMP), "
-                        + "(2, 'two', 2::TIMESTAMP), (3, 'three', 3::TIMESTAMP)");
-                serverMain.awaitTable("reuse_t");
+        serverMain.execute("CREATE TABLE reuse_t(id LONG, name STRING, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO reuse_t VALUES (1, 'one', 1::TIMESTAMP), "
+                + "(2, 'two', 2::TIMESTAMP), (3, 'three', 3::TIMESTAMP)");
+        serverMain.awaitTable("reuse_t");
 
-                final int[] q1Batches = {0};
-                final int[] q1Rows = {0};
-                final int[] q2Batches = {0};
-                final int[] q2Rows = {0};
-                final int[] q2SchemaCols = {-1};
-                final boolean[] q2EndSeen = {false};
+        final int[] q1Batches = {0};
+        final int[] q1Rows = {0};
+        final int[] q2Batches = {0};
+        final int[] q2Rows = {0};
+        final int[] q2SchemaCols = {-1};
+        final boolean[] q2EndSeen = {false};
 
-                try (QwpQueryClient client = QwpQueryClient.fromConfig(
-                        "ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
+        try (QwpQueryClient client = QwpQueryClient.fromConfig(
+                "ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
 
-                    // Query 1: populates the connection-scoped schema cache with a fresh id
-                    // for shape (id LONG, name STRING).
-                    client.execute("SELECT id, name FROM reuse_t WHERE id >= 0", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            q1Batches[0]++;
-                            q1Rows[0] += batch.getRowCount();
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress error on q1: " + message);
-                        }
-                    });
-
-                    // Query 2: identical column shape -> server hits schemaAlreadyKnown=true.
-                    // WHERE predicate filters everything out -> empty cursor.
-                    client.execute("SELECT id, name FROM reuse_t WHERE id < 0", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            q2Batches[0]++;
-                            q2SchemaCols[0] = batch.getColumnCount();
-                            q2Rows[0] += batch.getRowCount();
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                            q2EndSeen[0] = true;
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress error on q2: " + message);
-                        }
-                    });
+            // Query 1: populates the connection-scoped schema cache with a fresh id
+            // for shape (id LONG, name STRING).
+            client.execute("SELECT id, name FROM reuse_t WHERE id >= 0", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    q1Batches[0]++;
+                    q1Rows[0] += batch.getRowCount();
                 }
-                Assert.assertEquals("q1 must deliver at least one batch", 1, q1Batches[0]);
-                Assert.assertEquals(3, q1Rows[0]);
-                Assert.assertTrue("q2 RESULT_END must still fire", q2EndSeen[0]);
-                Assert.assertEquals(0, q2Rows[0]);
-                Assert.assertEquals("empty-result q2 on reused schema must still deliver one RESULT_BATCH (spec sec. 7)",
-                        1, q2Batches[0]);
-                Assert.assertEquals("schema must surface to the handler on q2 even with no rows",
-                        2, q2SchemaCols[0]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress error on q1: " + message);
+                }
+            });
+
+            // Query 2: identical column shape -> server hits schemaAlreadyKnown=true.
+            // WHERE predicate filters everything out -> empty cursor.
+            client.execute("SELECT id, name FROM reuse_t WHERE id < 0", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    q2Batches[0]++;
+                    q2SchemaCols[0] = batch.getColumnCount();
+                    q2Rows[0] += batch.getRowCount();
+                }
+
+                @Override
+                public void onEnd(long totalRows) {
+                    q2EndSeen[0] = true;
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress error on q2: " + message);
+                }
+            });
+        }
+        Assert.assertEquals("q1 must deliver at least one batch", 1, q1Batches[0]);
+        Assert.assertEquals(3, q1Rows[0]);
+        Assert.assertTrue("q2 RESULT_END must still fire", q2EndSeen[0]);
+        Assert.assertEquals(0, q2Rows[0]);
+        Assert.assertEquals("empty-result q2 on reused schema must still deliver one RESULT_BATCH (spec sec. 7)",
+                1, q2Batches[0]);
+        Assert.assertEquals("schema must surface to the handler on q2 even with no rows",
+                2, q2SchemaCols[0]);
     }
 
     /**
@@ -775,93 +740,85 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testFailedQueriesDoNotLeak() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE leakcheck(x LONG, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO leakcheck VALUES (1, 1::TIMESTAMP), (2, 2::TIMESTAMP), (3, 3::TIMESTAMP)");
-                serverMain.awaitTable("leakcheck");
+        serverMain.execute("CREATE TABLE leakcheck(x LONG, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO leakcheck VALUES (1, 1::TIMESTAMP), (2, 2::TIMESTAMP), (3, 3::TIMESTAMP)");
+        serverMain.awaitTable("leakcheck");
 
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    final int[] errorCount = {0};
-                    final int[] successCount = {0};
-                    final int[] execDoneCount = {0};
-                    QwpColumnBatchHandler handler = new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            successCount[0]++;
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            errorCount[0]++;
-                        }
-
-                        @Override
-                        public void onExecDone(short opType, long rowsAffected) {
-                            execDoneCount[0]++;
-                        }
-                    };
-                    // Mix of success and failure paths -- each failure exercises a different
-                    // catch arm in handleQueryRequest. With C1 unfixed, the
-                    // factory.getCursor() / metadata path leaks RecordCursorFactory
-                    // instances on any failure between getCursor and beginStreaming.
-                    for (int i = 0; i < 25; i++) {
-                        client.execute("SELECT x FROM leakcheck ORDER BY x", handler);    // ok (batch)
-                        client.execute("SELECT FROM leakcheck", handler);                  // syntax error
-                        client.execute("SELECT * FROM does_not_exist", handler);           // table not found
-                        client.execute("INSERT INTO leakcheck VALUES (4, 4::TIMESTAMP)", handler);       // DDL succeeds -> execDone
-                    }
-                    Assert.assertEquals(25, successCount[0]);
-                    Assert.assertEquals(50, errorCount[0]);
-                    Assert.assertEquals(25, execDoneCount[0]);
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            final int[] errorCount = {0};
+            final int[] successCount = {0};
+            final int[] execDoneCount = {0};
+            QwpColumnBatchHandler handler = new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    successCount[0]++;
                 }
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    errorCount[0]++;
+                }
+
+                @Override
+                public void onExecDone(short opType, long rowsAffected) {
+                    execDoneCount[0]++;
+                }
+            };
+            // Mix of success and failure paths -- each failure exercises a different
+            // catch arm in handleQueryRequest. With C1 unfixed, the
+            // factory.getCursor() / metadata path leaks RecordCursorFactory
+            // instances on any failure between getCursor and beginStreaming.
+            for (int i = 0; i < 25; i++) {
+                client.execute("SELECT x FROM leakcheck ORDER BY x", handler);    // ok (batch)
+                client.execute("SELECT FROM leakcheck", handler);                  // syntax error
+                client.execute("SELECT * FROM does_not_exist", handler);           // table not found
+                client.execute("INSERT INTO leakcheck VALUES (4, 4::TIMESTAMP)", handler);       // DDL succeeds -> execDone
             }
-        });
+            Assert.assertEquals(25, successCount[0]);
+            Assert.assertEquals(50, errorCount[0]);
+            Assert.assertEquals(25, execDoneCount[0]);
+        }
     }
 
     @Test
     public void testFromConfigConnectString() throws Exception {
         // The fromConfig(String) factory mirrors Sender.fromConfig: schema::key=value;...
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE cs(x LONG, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO cs VALUES (42, 1::TIMESTAMP), (43, 2::TIMESTAMP)");
-                serverMain.awaitTable("cs");
+        serverMain.execute("CREATE TABLE cs(x LONG, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO cs VALUES (42, 1::TIMESTAMP), (43, 2::TIMESTAMP)");
+        serverMain.awaitTable("cs");
 
-                LongList rows = new LongList();
-                String conf = "ws::addr=127.0.0.1:" + HTTP_PORT + ";path=/read/v1;client_id=conf-test/1.0;buffer_pool_size=2;";
-                try (QwpQueryClient client = QwpQueryClient.fromConfig(conf)) {
-                    client.connect();
-                    client.execute("SELECT x FROM cs ORDER BY x", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                rows.add(batch.getLongValue(0, r));
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+        LongList rows = new LongList();
+        String conf = "ws::addr=127.0.0.1:" + HTTP_PORT + ";path=/read/v1;client_id=conf-test/1.0;buffer_pool_size=2;";
+        try (QwpQueryClient client = QwpQueryClient.fromConfig(conf)) {
+            client.connect();
+            client.execute("SELECT x FROM cs ORDER BY x", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        rows.add(batch.getLongValue(0, r));
+                    }
                 }
-                Assert.assertEquals(2, rows.size());
-                Assert.assertEquals(42L, rows.getQuick(0));
-                Assert.assertEquals(43L, rows.getQuick(1));
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals(2, rows.size());
+        Assert.assertEquals(42L, rows.getQuick(0));
+        Assert.assertEquals(43L, rows.getQuick(1));
     }
 
     @Test
@@ -888,51 +845,47 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
 
     @Test
     public void testGeohash() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE geo(g20 GEOHASH(20b), g40 GEOHASH(40b), ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                // Geohash literal: #<base-32-chars>; 4 chars = 20 bits, 8 chars = 40 bits
-                serverMain.execute("INSERT INTO geo VALUES (#dr5r, #dr5rsjut, 1::TIMESTAMP)");
-                serverMain.execute(
-                        "INSERT INTO geo VALUES (CAST(NULL AS GEOHASH(20b)), CAST(NULL AS GEOHASH(40b)), 2::TIMESTAMP)"
-                );
-                serverMain.awaitTable("geo");
+        serverMain.execute("CREATE TABLE geo(g20 GEOHASH(20b), g40 GEOHASH(40b), ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        // Geohash literal: #<base-32-chars>; 4 chars = 20 bits, 8 chars = 40 bits
+        serverMain.execute("INSERT INTO geo VALUES (#dr5r, #dr5rsjut, 1::TIMESTAMP)");
+        serverMain.execute(
+                "INSERT INTO geo VALUES (CAST(NULL AS GEOHASH(20b)), CAST(NULL AS GEOHASH(40b)), 2::TIMESTAMP)"
+        );
+        serverMain.awaitTable("geo");
 
-                final Long[] g20Values = new Long[2];
-                final Long[] g40Values = new Long[2];
-                final int[] precisionBits = new int[2];
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    client.execute("SELECT g20, g40 FROM geo", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            precisionBits[0] = batch.getGeohashPrecisionBits(0);
-                            precisionBits[1] = batch.getGeohashPrecisionBits(1);
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                g20Values[r] = batch.isNull(0, r) ? null : batch.getGeohashValue(0, r);
-                                g40Values[r] = batch.isNull(1, r) ? null : batch.getGeohashValue(1, r);
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+        final Long[] g20Values = new Long[2];
+        final Long[] g40Values = new Long[2];
+        final int[] precisionBits = new int[2];
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            client.execute("SELECT g20, g40 FROM geo", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    precisionBits[0] = batch.getGeohashPrecisionBits(0);
+                    precisionBits[1] = batch.getGeohashPrecisionBits(1);
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        g20Values[r] = batch.isNull(0, r) ? null : batch.getGeohashValue(0, r);
+                        g40Values[r] = batch.isNull(1, r) ? null : batch.getGeohashValue(1, r);
+                    }
                 }
-                Assert.assertEquals(20, precisionBits[0]);
-                Assert.assertEquals(40, precisionBits[1]);
-                Assert.assertNotNull(g20Values[0]);
-                Assert.assertNotNull(g40Values[0]);
-                Assert.assertNull(g20Values[1]);
-                Assert.assertNull(g40Values[1]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals(20, precisionBits[0]);
+        Assert.assertEquals(40, precisionBits[1]);
+        Assert.assertNotNull(g20Values[0]);
+        Assert.assertNotNull(g40Values[0]);
+        Assert.assertNull(g20Values[1]);
+        Assert.assertNull(g40Values[1]);
     }
 
     /**
@@ -943,64 +896,60 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testGeohashNullAcrossAllWidths() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                // 4->GEOBYTE, 8->GEOSHORT, 16->GEOINT, 40/60->GEOLONG.
-                serverMain.execute("""
-                        CREATE TABLE geo_nulls(
-                            g4 GEOHASH(4b),
-                            g8 GEOHASH(8b),
-                            g16 GEOHASH(16b),
-                            g40 GEOHASH(40b),
-                            g60 GEOHASH(60b),
-                            ts TIMESTAMP
-                        ) TIMESTAMP(ts) PARTITION BY DAY WAL
-                        """);
-                serverMain.execute("""
-                        INSERT INTO geo_nulls VALUES (
-                            CAST(NULL AS GEOHASH(4b)),
-                            CAST(NULL AS GEOHASH(8b)),
-                            CAST(NULL AS GEOHASH(16b)),
-                            CAST(NULL AS GEOHASH(40b)),
-                            CAST(NULL AS GEOHASH(60b)),
-                            1::TIMESTAMP
-                        )
-                        """);
-                // A non-null row to ensure the column isn't always null.
-                serverMain.execute("INSERT INTO geo_nulls VALUES (#0, #00, #0000, #00000000, #000000000000, 2::TIMESTAMP)");
-                serverMain.awaitTable("geo_nulls");
+        // 4->GEOBYTE, 8->GEOSHORT, 16->GEOINT, 40/60->GEOLONG.
+        serverMain.execute("""
+                CREATE TABLE geo_nulls(
+                    g4 GEOHASH(4b),
+                    g8 GEOHASH(8b),
+                    g16 GEOHASH(16b),
+                    g40 GEOHASH(40b),
+                    g60 GEOHASH(60b),
+                    ts TIMESTAMP
+                ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                """);
+        serverMain.execute("""
+                INSERT INTO geo_nulls VALUES (
+                    CAST(NULL AS GEOHASH(4b)),
+                    CAST(NULL AS GEOHASH(8b)),
+                    CAST(NULL AS GEOHASH(16b)),
+                    CAST(NULL AS GEOHASH(40b)),
+                    CAST(NULL AS GEOHASH(60b)),
+                    1::TIMESTAMP
+                )
+                """);
+        // A non-null row to ensure the column isn't always null.
+        serverMain.execute("INSERT INTO geo_nulls VALUES (#0, #00, #0000, #00000000, #000000000000, 2::TIMESTAMP)");
+        serverMain.awaitTable("geo_nulls");
 
-                final boolean[][] isNull = new boolean[2][5];
-                final int[] count = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT g4, g8, g16, g40, g60 FROM geo_nulls", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
-                                for (int c = 0; c < 5; c++) isNull[count[0]][c] = batch.isNull(c, r);
-                            }
-                        }
+        final boolean[][] isNull = new boolean[2][5];
+        final int[] count = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT g4, g8, g16, g40, g60 FROM geo_nulls", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
+                        for (int c = 0; c < 5; c++) isNull[count[0]][c] = batch.isNull(c, r);
+                    }
+                }
 
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
+                @Override
+                public void onEnd(long totalRows) {
+                }
 
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
                 }
-                Assert.assertEquals(2, count[0]);
-                for (int c = 0; c < 5; c++) {
-                    Assert.assertTrue("NULL row, col " + c + " (width-class " + (c == 0 ? "byte" : c == 1 ? "short" : c == 2 ? "int" : "long") + ")", isNull[0][c]);
-                }
-                for (int c = 0; c < 5; c++) {
-                    Assert.assertFalse("non-null row, col " + c, isNull[1][c]);
-                }
-            }
-        });
+            });
+        }
+        Assert.assertEquals(2, count[0]);
+        for (int c = 0; c < 5; c++) {
+            Assert.assertTrue("NULL row, col " + c + " (width-class " + (c == 0 ? "byte" : c == 1 ? "short" : c == 2 ? "int" : "long") + ")", isNull[0][c]);
+        }
+        for (int c = 0; c < 5; c++) {
+            Assert.assertFalse("non-null row, col " + c, isNull[1][c]);
+        }
     }
 
     @Test
@@ -1012,56 +961,52 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
         // NULL. QuestDB itself treats 0.0.0.0 as NULL, so both '0.0.0.0' and explicit NULL
         // inserts come back as null. A non-zero address surfaces as non-null with the address
         // bits intact.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE ipx(addr IPv4, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO ipx VALUES
-                            ('0.0.0.0',     1::TIMESTAMP),
-                            (NULL,          2::TIMESTAMP),
-                            ('192.168.1.1', 3::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("ipx");
+        serverMain.execute("CREATE TABLE ipx(addr IPv4, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO ipx VALUES
+                    ('0.0.0.0',     1::TIMESTAMP),
+                    (NULL,          2::TIMESTAMP),
+                    ('192.168.1.1', 3::TIMESTAMP)
+                """);
+        serverMain.awaitTable("ipx");
 
-                final boolean[] nullSeen = new boolean[3];
-                final long[] valueSeen = new long[3];
-                final byte[] wireType = {0};
-                final int[] count = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT addr FROM ipx", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
-                                nullSeen[count[0]] = batch.isNull(0, r);
-                                if (!nullSeen[count[0]]) {
-                                    valueSeen[count[0]] = batch.getIntValue(0, r);
-                                }
-                            }
+        final boolean[] nullSeen = new boolean[3];
+        final long[] valueSeen = new long[3];
+        final byte[] wireType = {0};
+        final int[] count = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT addr FROM ipx", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
+                        nullSeen[count[0]] = batch.isNull(0, r);
+                        if (!nullSeen[count[0]]) {
+                            valueSeen[count[0]] = batch.getIntValue(0, r);
                         }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+                    }
                 }
-                Assert.assertEquals(3, count[0]);
-                Assert.assertEquals(io.questdb.client.cutlass.qwp.protocol.QwpConstants.TYPE_IPv4, wireType[0]);
-                Assert.assertTrue("'0.0.0.0' is the IPv4 NULL sentinel -- must surface as null", nullSeen[0]);
-                Assert.assertTrue("explicit NULL must surface as null", nullSeen[1]);
-                Assert.assertFalse("real address must surface as non-null", nullSeen[2]);
-                // 192.168.1.1 in network byte order = 0xC0A80101 = 3232235777. QuestDB stores IPv4 as int
-                // in big-endian order; verify the round-trip preserves the bit pattern.
-                Assert.assertEquals(0xC0A80101L, valueSeen[2] & 0xFFFFFFFFL);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals(3, count[0]);
+        Assert.assertEquals(io.questdb.client.cutlass.qwp.protocol.QwpConstants.TYPE_IPv4, wireType[0]);
+        Assert.assertTrue("'0.0.0.0' is the IPv4 NULL sentinel -- must surface as null", nullSeen[0]);
+        Assert.assertTrue("explicit NULL must surface as null", nullSeen[1]);
+        Assert.assertFalse("real address must surface as non-null", nullSeen[2]);
+        // 192.168.1.1 in network byte order = 0xC0A80101 = 3232235777. QuestDB stores IPv4 as int
+        // in big-endian order; verify the round-trip preserves the bit pattern.
+        Assert.assertEquals(0xC0A80101L, valueSeen[2] & 0xFFFFFFFFL);
     }
 
     @Test
@@ -1069,50 +1014,46 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
         // 20,000 rows -> spans at least 5 batches with MAX_ROWS_PER_BATCH=4096.
         // Exercises: schema-reference mode (mode 0x01) after the first batch,
         // client recv-buffer growth, multi-batch reassembly on decode loop.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE big(x LONG, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute(
-                        "INSERT INTO big SELECT x, x::TIMESTAMP FROM long_sequence(20000)"
-                );
-                serverMain.awaitTable("big");
+        serverMain.execute("CREATE TABLE big(x LONG, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute(
+                "INSERT INTO big SELECT x, x::TIMESTAMP FROM long_sequence(20000)"
+        );
+        serverMain.awaitTable("big");
 
-                int[] count = {0};
-                int[] batches = {0};
-                long[] sum = {0};
-                long[] serverTotalRows = {-1};
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    client.execute("SELECT x FROM big", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            batches[0]++;
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                sum[0] += batch.getLongValue(0, r);
-                                count[0]++;
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                            serverTotalRows[0] = totalRows;
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+        int[] count = {0};
+        int[] batches = {0};
+        long[] sum = {0};
+        long[] serverTotalRows = {-1};
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            client.execute("SELECT x FROM big", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    batches[0]++;
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        sum[0] += batch.getLongValue(0, r);
+                        count[0]++;
+                    }
                 }
-                Assert.assertEquals(20_000, count[0]);
-                Assert.assertTrue("expected multi-batch streaming, got " + batches[0] + " batches",
-                        batches[0] > 1);
-                // sum(1..20000) = n(n+1)/2 = 20000 * 20001 / 2
-                Assert.assertEquals(200_010_000L, sum[0]);
-                Assert.assertEquals("RESULT_END.total_rows must equal rows streamed", 20_000L, serverTotalRows[0]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                    serverTotalRows[0] = totalRows;
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals(20_000, count[0]);
+        Assert.assertTrue("expected multi-batch streaming, got " + batches[0] + " batches",
+                batches[0] > 1);
+        // sum(1..20000) = n(n+1)/2 = 20000 * 20001 / 2
+        Assert.assertEquals(200_010_000L, sum[0]);
+        Assert.assertEquals("RESULT_END.total_rows must equal rows streamed", 20_000L, serverTotalRows[0]);
     }
 
     /**
@@ -1121,48 +1062,44 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testManyUniqueSymbolsSchemaReference() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE sym_t(s SYMBOL, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                // Spans multiple batches by using 2 * MAX_ROWS_PER_BATCH rows with
-                // 1_000 unique symbols. Sized off the constant so a future bump to
-                // the batch cap still leaves this test meaningfully multi-batch.
-                int totalRows = 2 * QwpEgressUpgradeProcessor.MAX_ROWS_PER_BATCH;
-                serverMain.execute("INSERT INTO sym_t SELECT 'sym_' || (x % 1000)::STRING, x::TIMESTAMP FROM long_sequence("
-                        + totalRows + ")");
-                serverMain.awaitTable("sym_t");
+        serverMain.execute("CREATE TABLE sym_t(s SYMBOL, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        // Spans multiple batches by using 2 * MAX_ROWS_PER_BATCH rows with
+        // 1_000 unique symbols. Sized off the constant so a future bump to
+        // the batch cap still leaves this test meaningfully multi-batch.
+        int totalRows = 2 * QwpEgressUpgradeProcessor.MAX_ROWS_PER_BATCH;
+        serverMain.execute("INSERT INTO sym_t SELECT 'sym_' || (x % 1000)::STRING, x::TIMESTAMP FROM long_sequence("
+                + totalRows + ")");
+        serverMain.awaitTable("sym_t");
 
-                final int[] rows = {0};
-                final int[] batches = {0};
-                final java.util.Set<String> distinct = new java.util.HashSet<>();
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT s FROM sym_t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            batches[0]++;
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                distinct.add(batch.getString(0, r));
-                                rows[0]++;
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress error: " + message);
-                        }
-                    });
+        final int[] rows = {0};
+        final int[] batches = {0};
+        final java.util.Set<String> distinct = new java.util.HashSet<>();
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT s FROM sym_t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    batches[0]++;
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        distinct.add(batch.getString(0, r));
+                        rows[0]++;
+                    }
                 }
-                Assert.assertEquals(totalRows, rows[0]);
-                Assert.assertTrue("expected multi-batch streaming, got " + batches[0], batches[0] > 1);
-                Assert.assertEquals("1000 unique symbols expected", 1000, distinct.size());
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals(totalRows, rows[0]);
+        Assert.assertTrue("expected multi-batch streaming, got " + batches[0], batches[0] > 1);
+        Assert.assertEquals("1000 unique symbols expected", 1000, distinct.size());
     }
 
     /**
@@ -1175,54 +1112,50 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testMultiBatchSeqIsMonotonic() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE seqcheck(x LONG, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                // 20_000 rows across multiple batches (server caps batches at 4096 rows).
-                serverMain.execute(
-                        "INSERT INTO seqcheck SELECT x, x::TIMESTAMP FROM long_sequence(20000)");
-                serverMain.awaitTable("seqcheck");
+        serverMain.execute("CREATE TABLE seqcheck(x LONG, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        // 20_000 rows across multiple batches (server caps batches at 4096 rows).
+        serverMain.execute(
+                "INSERT INTO seqcheck SELECT x, x::TIMESTAMP FROM long_sequence(20000)");
+        serverMain.awaitTable("seqcheck");
 
-                final LongList seenSeqs = new LongList();
-                final long[] firstValuePerBatch = {-1};
-                final long[] totalRows = {0};
+        final LongList seenSeqs = new LongList();
+        final long[] firstValuePerBatch = {-1};
+        final long[] totalRows = {0};
 
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    client.execute("SELECT x FROM seqcheck ORDER BY x", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            seenSeqs.add(batch.batchSeq());
-                            // Capture the first value of each batch: must equal totalRows + 1
-                            // (rows are 1-indexed). Any duplicate batch with different rows
-                            // shows up here as a non-contiguous start value.
-                            if (batch.getRowCount() > 0 && firstValuePerBatch[0] == -1) {
-                                firstValuePerBatch[0] = batch.getLongValue(0, 0);
-                            }
-                            totalRows[0] += batch.getRowCount();
-                        }
-
-                        @Override
-                        public void onEnd(long rows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress error: " + message);
-                        }
-                    });
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            client.execute("SELECT x FROM seqcheck ORDER BY x", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    seenSeqs.add(batch.batchSeq());
+                    // Capture the first value of each batch: must equal totalRows + 1
+                    // (rows are 1-indexed). Any duplicate batch with different rows
+                    // shows up here as a non-contiguous start value.
+                    if (batch.getRowCount() > 0 && firstValuePerBatch[0] == -1) {
+                        firstValuePerBatch[0] = batch.getLongValue(0, 0);
+                    }
+                    totalRows[0] += batch.getRowCount();
                 }
 
-                Assert.assertEquals(20_000, totalRows[0]);
-                Assert.assertTrue("expected multiple batches, got " + seenSeqs.size(), seenSeqs.size() > 1);
-                Assert.assertEquals("first streamed row must be x=1", 1L, firstValuePerBatch[0]);
-                // Each seq must equal its index in the stream (no duplicates, no gaps).
-                for (int i = 0; i < seenSeqs.size(); i++) {
-                    Assert.assertEquals("batch index " + i + " expected seq=" + i, i, seenSeqs.getQuick(i));
+                @Override
+                public void onEnd(long rows) {
                 }
-            }
-        });
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress error: " + message);
+                }
+            });
+        }
+
+        Assert.assertEquals(20_000, totalRows[0]);
+        Assert.assertTrue("expected multiple batches, got " + seenSeqs.size(), seenSeqs.size() > 1);
+        Assert.assertEquals("first streamed row must be x=1", 1L, firstValuePerBatch[0]);
+        // Each seq must equal its index in the stream (no duplicates, no gaps).
+        for (int i = 0; i < seenSeqs.size(); i++) {
+            Assert.assertEquals("batch index " + i + " expected seq=" + i, i, seenSeqs.getQuick(i));
+        }
     }
 
     /**
@@ -1232,49 +1165,45 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testNaNMapsToNull() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE nans(d DOUBLE, f FLOAT, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO nans VALUES (1.5, 2.5, 1::TIMESTAMP)");
-                // 0/0 produces NaN at SQL level -- indistinguishable from explicit NULL on the wire.
-                serverMain.execute("INSERT INTO nans VALUES (0.0/0.0, CAST(0.0/0.0 AS FLOAT), 2::TIMESTAMP)");
-                serverMain.execute("INSERT INTO nans VALUES (NULL, NULL, 3::TIMESTAMP)");
-                serverMain.awaitTable("nans");
+        serverMain.execute("CREATE TABLE nans(d DOUBLE, f FLOAT, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO nans VALUES (1.5, 2.5, 1::TIMESTAMP)");
+        // 0/0 produces NaN at SQL level -- indistinguishable from explicit NULL on the wire.
+        serverMain.execute("INSERT INTO nans VALUES (0.0/0.0, CAST(0.0/0.0 AS FLOAT), 2::TIMESTAMP)");
+        serverMain.execute("INSERT INTO nans VALUES (NULL, NULL, 3::TIMESTAMP)");
+        serverMain.awaitTable("nans");
 
-                final boolean[] nullD = new boolean[3];
-                final boolean[] nullF = new boolean[3];
-                final int[] count = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT d, f FROM nans", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
-                                nullD[count[0]] = batch.isNull(0, r);
-                                nullF[count[0]] = batch.isNull(1, r);
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+        final boolean[] nullD = new boolean[3];
+        final boolean[] nullF = new boolean[3];
+        final int[] count = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT d, f FROM nans", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
+                        nullD[count[0]] = batch.isNull(0, r);
+                        nullF[count[0]] = batch.isNull(1, r);
+                    }
                 }
-                Assert.assertEquals(3, count[0]);
-                Assert.assertFalse("real value is non-null", nullD[0]);
-                Assert.assertFalse("real value is non-null", nullF[0]);
-                Assert.assertTrue("NaN must surface as null over the wire (QuestDB NaN = NULL convention)", nullD[1]);
-                Assert.assertTrue("NaN must surface as null over the wire (QuestDB NaN = NULL convention)", nullF[1]);
-                Assert.assertTrue("explicit NULL", nullD[2]);
-                Assert.assertTrue("explicit NULL", nullF[2]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals(3, count[0]);
+        Assert.assertFalse("real value is non-null", nullD[0]);
+        Assert.assertFalse("real value is non-null", nullF[0]);
+        Assert.assertTrue("NaN must surface as null over the wire (QuestDB NaN = NULL convention)", nullD[1]);
+        Assert.assertTrue("NaN must surface as null over the wire (QuestDB NaN = NULL convention)", nullF[1]);
+        Assert.assertTrue("explicit NULL", nullD[2]);
+        Assert.assertTrue("explicit NULL", nullF[2]);
     }
 
     @Test
@@ -1283,42 +1212,38 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
         // test asserted a PARSE_ERROR rejection; since the DDL / INSERT / UPDATE
         // execution landed, the same DROP now round-trips with a success ack
         // carrying the op type and zero rows affected.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE dummy(x LONG, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                final short[] opType = {-1};
-                final long[] rowsAffected = {-1L};
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    client.execute("DROP TABLE dummy", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            Assert.fail("unexpected batch");
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                            Assert.fail("unexpected end");
-                        }
-
-                        @Override
-                        public void onError(byte s, String m) {
-                            Assert.fail("unexpected error: " + m);
-                        }
-
-                        @Override
-                        public void onExecDone(short ot, long ra) {
-                            opType[0] = ot;
-                            rowsAffected[0] = ra;
-                        }
-                    });
+        serverMain.execute("CREATE TABLE dummy(x LONG, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        final short[] opType = {-1};
+        final long[] rowsAffected = {-1L};
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            client.execute("DROP TABLE dummy", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    Assert.fail("unexpected batch");
                 }
-                // CompiledQuery.DROP == 7 (see io.questdb.griffin.CompiledQuery).
-                Assert.assertEquals(7, opType[0]);
-                Assert.assertEquals(0L, rowsAffected[0]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                    Assert.fail("unexpected end");
+                }
+
+                @Override
+                public void onError(byte s, String m) {
+                    Assert.fail("unexpected error: " + m);
+                }
+
+                @Override
+                public void onExecDone(short ot, long ra) {
+                    opType[0] = ot;
+                    rowsAffected[0] = ra;
+                }
+            });
+        }
+        // CompiledQuery.DROP == 7 (see io.questdb.griffin.CompiledQuery).
+        Assert.assertEquals(7, opType[0]);
+        Assert.assertEquals(0L, rowsAffected[0]);
     }
 
     /**
@@ -1350,140 +1275,128 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
 
     @Test
     public void testSelectLong() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(x LONG, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO t VALUES (1, 1::TIMESTAMP), (2, 2::TIMESTAMP), (3, 3::TIMESTAMP)");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(x LONG, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO t VALUES (1, 1::TIMESTAMP), (2, 2::TIMESTAMP), (3, 3::TIMESTAMP)");
+        serverMain.awaitTable("t");
 
-                LongList collected = new LongList();
-                long[] totalRowsHolder = {-1L};
-                boolean[] errorSeen = {false};
+        LongList collected = new LongList();
+        long[] totalRowsHolder = {-1L};
+        boolean[] errorSeen = {false};
 
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    client.execute("SELECT x FROM t ORDER BY x", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            Assert.assertEquals(1, batch.getColumnCount());
-                            Assert.assertEquals("x", batch.getColumnName(0));
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                collected.add(batch.getLongValue(0, r));
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long rows) {
-                            totalRowsHolder[0] = rows;
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            errorSeen[0] = true;
-                            Assert.fail("egress query error: status=" + status + " msg=" + message);
-                        }
-                    });
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            client.execute("SELECT x FROM t ORDER BY x", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    Assert.assertEquals(1, batch.getColumnCount());
+                    Assert.assertEquals("x", batch.getColumnName(0));
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        collected.add(batch.getLongValue(0, r));
+                    }
                 }
 
-                Assert.assertFalse(errorSeen[0]);
-                Assert.assertEquals(3, collected.size());
-                Assert.assertEquals(1L, collected.getQuick(0));
-                Assert.assertEquals(2L, collected.getQuick(1));
-                Assert.assertEquals(3L, collected.getQuick(2));
-                Assert.assertEquals(3L, totalRowsHolder[0]);
-            }
-        });
+                @Override
+                public void onEnd(long rows) {
+                    totalRowsHolder[0] = rows;
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    errorSeen[0] = true;
+                    Assert.fail("egress query error: status=" + status + " msg=" + message);
+                }
+            });
+        }
+
+        Assert.assertFalse(errorSeen[0]);
+        Assert.assertEquals(3, collected.size());
+        Assert.assertEquals(1L, collected.getQuick(0));
+        Assert.assertEquals(2L, collected.getQuick(1));
+        Assert.assertEquals(3L, collected.getQuick(2));
+        Assert.assertEquals(3L, totalRowsHolder[0]);
     }
 
     @Test
     public void testSelectMixedTypes() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE mixed(id LONG, px DOUBLE, sym SYMBOL, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO mixed VALUES
-                            (1, 1.5, 'AAPL', '2024-01-01T00:00:00.000Z'),
-                            (2, 2.5, 'MSFT', '2024-01-01T00:00:01.000Z'),
-                            (3, 3.5, 'AAPL', '2024-01-01T00:00:02.000Z')
-                        """);
-                serverMain.awaitTxn("mixed", 1);
+        serverMain.execute("CREATE TABLE mixed(id LONG, px DOUBLE, sym SYMBOL, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO mixed VALUES
+                    (1, 1.5, 'AAPL', '2024-01-01T00:00:00.000Z'),
+                    (2, 2.5, 'MSFT', '2024-01-01T00:00:01.000Z'),
+                    (3, 3.5, 'AAPL', '2024-01-01T00:00:02.000Z')
+                """);
+        serverMain.awaitTxn("mixed", 1);
 
-                final int[] rows = {0};
-                final String[] expectedSym = {"AAPL", "MSFT", "AAPL"};
-                final double[] expectedPx = {1.5, 2.5, 3.5};
+        final int[] rows = {0};
+        final String[] expectedSym = {"AAPL", "MSFT", "AAPL"};
+        final double[] expectedPx = {1.5, 2.5, 3.5};
 
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    client.execute("SELECT id, px, sym, ts FROM mixed ORDER BY id", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            Assert.assertEquals(4, batch.getColumnCount());
-                            for (int r = 0; r < batch.getRowCount(); r++, rows[0]++) {
-                                Assert.assertEquals(rows[0] + 1, batch.getLongValue(0, r));
-                                Assert.assertEquals(expectedPx[rows[0]], batch.getDoubleValue(1, r), 1e-9);
-                                Assert.assertEquals(expectedSym[rows[0]], batch.getString(2, r));
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                            // reachable
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: status=" + status + " msg=" + message);
-                        }
-                    });
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            client.execute("SELECT id, px, sym, ts FROM mixed ORDER BY id", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    Assert.assertEquals(4, batch.getColumnCount());
+                    for (int r = 0; r < batch.getRowCount(); r++, rows[0]++) {
+                        Assert.assertEquals(rows[0] + 1, batch.getLongValue(0, r));
+                        Assert.assertEquals(expectedPx[rows[0]], batch.getDoubleValue(1, r), 1e-9);
+                        Assert.assertEquals(expectedSym[rows[0]], batch.getString(2, r));
+                    }
                 }
-                Assert.assertEquals(3, rows[0]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                    // reachable
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: status=" + status + " msg=" + message);
+                }
+            });
+        }
+        Assert.assertEquals(3, rows[0]);
     }
 
     @Test
     public void testSelectWithNulls() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE n(x LONG, s STRING, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO n VALUES (1, 'a', 1::TIMESTAMP), (NULL, NULL, 2::TIMESTAMP), (3, 'c', 3::TIMESTAMP)");
-                serverMain.awaitTable("n");
+        serverMain.execute("CREATE TABLE n(x LONG, s STRING, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO n VALUES (1, 'a', 1::TIMESTAMP), (NULL, NULL, 2::TIMESTAMP), (3, 'c', 3::TIMESTAMP)");
+        serverMain.awaitTable("n");
 
-                List<Object[]> rows = new ArrayList<>();
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    client.execute("SELECT x, s FROM n", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                rows.add(new Object[]{
-                                        batch.isNull(0, r) ? null : batch.getLongValue(0, r),
-                                        batch.getString(1, r)
-                                });
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: status=" + status + " msg=" + message);
-                        }
-                    });
+        List<Object[]> rows = new ArrayList<>();
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            client.execute("SELECT x, s FROM n", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        rows.add(new Object[]{
+                                batch.isNull(0, r) ? null : batch.getLongValue(0, r),
+                                batch.getString(1, r)
+                        });
+                    }
                 }
-                Assert.assertEquals(3, rows.size());
-                Assert.assertEquals(1L, rows.get(0)[0]);
-                Assert.assertEquals("a", rows.get(0)[1]);
-                Assert.assertNull(rows.get(1)[0]);
-                Assert.assertNull(rows.get(1)[1]);
-                Assert.assertEquals(3L, rows.get(2)[0]);
-                Assert.assertEquals("c", rows.get(2)[1]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: status=" + status + " msg=" + message);
+                }
+            });
+        }
+        Assert.assertEquals(3, rows.size());
+        Assert.assertEquals(1L, rows.get(0)[0]);
+        Assert.assertEquals("a", rows.get(0)[1]);
+        Assert.assertNull(rows.get(1)[0]);
+        Assert.assertNull(rows.get(1)[1]);
+        Assert.assertEquals(3L, rows.get(2)[0]);
+        Assert.assertEquals("c", rows.get(2)[1]);
     }
 
     /**
@@ -1499,60 +1412,56 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testSlowConsumerTriggersResumeSend() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                final int totalRows = 100_000;
-                serverMain.execute("CREATE TABLE slow_t(x LONG, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute(
-                        "INSERT INTO slow_t SELECT x, x::TIMESTAMP FROM long_sequence(" + totalRows + ")"
-                );
-                serverMain.awaitTable("slow_t");
+        final int totalRows = 100_000;
+        serverMain.execute("CREATE TABLE slow_t(x LONG, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute(
+                "INSERT INTO slow_t SELECT x, x::TIMESTAMP FROM long_sequence(" + totalRows + ")"
+        );
+        serverMain.awaitTable("slow_t");
 
-                final int[] rows = {0};
-                final int[] batches = {0};
-                final long[] sum = {0L};
-                final long[] serverTotalRows = {-1L};
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    client.execute("SELECT x FROM slow_t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            batches[0]++;
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                sum[0] += batch.getLongValue(0, r);
-                                rows[0]++;
-                            }
-                            if (batches[0] <= 3) {
-                                // Stall the first few callbacks so the server's send buffer fills
-                                // and it parks on PeerIsSlowToReadException. The client I/O thread
-                                // blocks on freeBuffers.take() while the user thread sleeps here.
-                                try {
-                                    Thread.sleep(50);
-                                } catch (InterruptedException e) {
-                                    Thread.currentThread().interrupt();
-                                }
-                            }
+        final int[] rows = {0};
+        final int[] batches = {0};
+        final long[] sum = {0L};
+        final long[] serverTotalRows = {-1L};
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            client.execute("SELECT x FROM slow_t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    batches[0]++;
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        sum[0] += batch.getLongValue(0, r);
+                        rows[0]++;
+                    }
+                    if (batches[0] <= 3) {
+                        // Stall the first few callbacks so the server's send buffer fills
+                        // and it parks on PeerIsSlowToReadException. The client I/O thread
+                        // blocks on freeBuffers.take() while the user thread sleeps here.
+                        try {
+                            Thread.sleep(50);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
                         }
-
-                        @Override
-                        public void onEnd(long trs) {
-                            serverTotalRows[0] = trs;
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress error: " + message);
-                        }
-                    });
+                    }
                 }
-                Assert.assertEquals(totalRows, rows[0]);
-                Assert.assertTrue("expected multi-batch streaming, got " + batches[0], batches[0] > 1);
-                Assert.assertEquals((long) totalRows * (totalRows + 1) / 2L, sum[0]);
-                Assert.assertEquals("RESULT_END.total_rows must equal rows streamed after resumeSend",
-                        totalRows, serverTotalRows[0]);
-            }
-        });
+
+                @Override
+                public void onEnd(long trs) {
+                    serverTotalRows[0] = trs;
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals(totalRows, rows[0]);
+        Assert.assertTrue("expected multi-batch streaming, got " + batches[0], batches[0] > 1);
+        Assert.assertEquals((long) totalRows * (totalRows + 1) / 2L, sum[0]);
+        Assert.assertEquals("RESULT_END.total_rows must equal rows streamed after resumeSend",
+                totalRows, serverTotalRows[0]);
     }
 
     // testTextFrameRejectsConnection deleted: it never sent a TEXT frame. The real
@@ -1562,40 +1471,36 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
 
     @Test
     public void testSqlSyntaxError() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain ignored = startWithEnvVariables()) {
-                final byte[] errorStatus = {(byte) 0xFF};
-                final String[] errorMsg = {null};
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    // Missing table name after FROM -> syntax error at a specific position.
-                    client.execute("SELECT * FROM", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            Assert.fail("unexpected batch on malformed SQL");
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                            Assert.fail("unexpected end on malformed SQL");
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            errorStatus[0] = status;
-                            errorMsg[0] = message;
-                        }
-                    });
+        final byte[] errorStatus = {(byte) 0xFF};
+        final String[] errorMsg = {null};
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            // Missing table name after FROM -> syntax error at a specific position.
+            client.execute("SELECT * FROM", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    Assert.fail("unexpected batch on malformed SQL");
                 }
-                Assert.assertNotNull("expected error message", errorMsg[0]);
-                Assert.assertEquals("PARSE_ERROR status expected", 0x05, errorStatus[0]);
-                // SqlException.getMessage() format: "[<position>] <text>"
-                Assert.assertTrue(
-                        "message should contain position marker, got: " + errorMsg[0],
-                        errorMsg[0].startsWith("[") && errorMsg[0].contains("]")
-                );
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                    Assert.fail("unexpected end on malformed SQL");
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    errorStatus[0] = status;
+                    errorMsg[0] = message;
+                }
+            });
+        }
+        Assert.assertNotNull("expected error message", errorMsg[0]);
+        Assert.assertEquals("PARSE_ERROR status expected", 0x05, errorStatus[0]);
+        // SqlException.getMessage() format: "[<position>] <text>"
+        Assert.assertTrue(
+                "message should contain position marker, got: " + errorMsg[0],
+                errorMsg[0].startsWith("[") && errorMsg[0].contains("]")
+        );
     }
 
     /**
@@ -1609,74 +1514,70 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testStaleCachedFactoryRetriesCompile() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(id LONG, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO t VALUES (1, 0::TIMESTAMP)");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(id LONG, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO t VALUES (1, 0::TIMESTAMP)");
+        serverMain.awaitTable("t");
 
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    // First query warms the per-server select cache.
-                    long[] firstRows = {0};
-                    client.execute("SELECT id FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            firstRows[0] += batch.getRowCount();
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("first query failed: " + message);
-                        }
-                    });
-                    Assert.assertEquals(1L, firstRows[0]);
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            // First query warms the per-server select cache.
+            long[] firstRows = {0};
+            client.execute("SELECT id FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    firstRows[0] += batch.getRowCount();
                 }
 
-                // Drop and recreate the table with an identical schema. The cached
-                // factory's TableReader now points at a dead tableId.
-                serverMain.execute("DROP TABLE t");
-                serverMain.execute("CREATE TABLE t(id LONG, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO t VALUES (42, 0::TIMESTAMP)");
-                serverMain.awaitTable("t");
-
-                // Second query (new connection, but the server-wide select cache
-                // still carries the stale factory). Server must detect + retry.
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    long[] secondRows = {0};
-                    long[] secondSum = {0};
-                    client.execute("SELECT id FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0, n = batch.getRowCount(); r < n; r++) {
-                                secondSum[0] += batch.getLongValue(0, r);
-                                secondRows[0]++;
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("stale-factory retry path failed to recover: " + message);
-                        }
-                    });
-                    Assert.assertEquals("retry must still produce the single row from the new table",
-                            1L, secondRows[0]);
-                    Assert.assertEquals("retry must read from the NEW table (id=42 from the re-inserted row)",
-                            42L, secondSum[0]);
+                @Override
+                public void onEnd(long totalRows) {
                 }
-            }
-        });
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("first query failed: " + message);
+                }
+            });
+            Assert.assertEquals(1L, firstRows[0]);
+        }
+
+        // Drop and recreate the table with an identical schema. The cached
+        // factory's TableReader now points at a dead tableId.
+        serverMain.execute("DROP TABLE t");
+        serverMain.execute("CREATE TABLE t(id LONG, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO t VALUES (42, 0::TIMESTAMP)");
+        serverMain.awaitTable("t");
+
+        // Second query (new connection, but the server-wide select cache
+        // still carries the stale factory). Server must detect + retry.
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            long[] secondRows = {0};
+            long[] secondSum = {0};
+            client.execute("SELECT id FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    for (int r = 0, n = batch.getRowCount(); r < n; r++) {
+                        secondSum[0] += batch.getLongValue(0, r);
+                        secondRows[0]++;
+                    }
+                }
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("stale-factory retry path failed to recover: " + message);
+                }
+            });
+            Assert.assertEquals("retry must still produce the single row from the new table",
+                    1L, secondRows[0]);
+            Assert.assertEquals("retry must read from the NEW table (id=42 from the re-inserted row)",
+                    42L, secondSum[0]);
+        }
     }
 
     /**
@@ -1687,94 +1588,86 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testSymbolDictResentEachQuery() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE syms(s SYMBOL, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO syms VALUES ('A', 1::TIMESTAMP), ('B', 2::TIMESTAMP), "
-                        + "('C', 3::TIMESTAMP), ('A', 4::TIMESTAMP), ('B', 5::TIMESTAMP)");
-                serverMain.awaitTable("syms");
+        serverMain.execute("CREATE TABLE syms(s SYMBOL, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO syms VALUES ('A', 1::TIMESTAMP), ('B', 2::TIMESTAMP), "
+                + "('C', 3::TIMESTAMP), ('A', 4::TIMESTAMP), ('B', 5::TIMESTAMP)");
+        serverMain.awaitTable("syms");
 
-                final List<String> firstRun = new ArrayList<>();
-                final List<String> secondRun = new ArrayList<>();
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT s FROM syms", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++) firstRun.add(batch.getString(0, r));
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
-                    // Second query on the SAME connection: under the published spec the dict
-                    // would be a connection-scoped delta (no entries to retransmit). Under the
-                    // current implementation the inline dict is sent again. Either way, the
-                    // string values must match -- and they do. The behavioral pin here is that
-                    // both runs succeed independently with the same string contents.
-                    client.execute("SELECT s FROM syms", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++) secondRun.add(batch.getString(0, r));
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+        final List<String> firstRun = new ArrayList<>();
+        final List<String> secondRun = new ArrayList<>();
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT s FROM syms", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    for (int r = 0; r < batch.getRowCount(); r++) firstRun.add(batch.getString(0, r));
                 }
-                Assert.assertEquals(List.of("A", "B", "C", "A", "B"), firstRun);
-                Assert.assertEquals(List.of("A", "B", "C", "A", "B"), secondRun);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+            // Second query on the SAME connection: under the published spec the dict
+            // would be a connection-scoped delta (no entries to retransmit). Under the
+            // current implementation the inline dict is sent again. Either way, the
+            // string values must match -- and they do. The behavioral pin here is that
+            // both runs succeed independently with the same string contents.
+            client.execute("SELECT s FROM syms", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    for (int r = 0; r < batch.getRowCount(); r++) secondRun.add(batch.getString(0, r));
+                }
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals(List.of("A", "B", "C", "A", "B"), firstRun);
+        Assert.assertEquals(List.of("A", "B", "C", "A", "B"), secondRun);
     }
 
     @Test
     public void testTableNotFound() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain ignored = startWithEnvVariables()) {
-                final String[] errorMsg = {null};
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    client.execute("SELECT * FROM no_such_table", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            Assert.fail("unexpected batch");
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                            Assert.fail("unexpected end");
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            errorMsg[0] = message;
-                        }
-                    });
+        final String[] errorMsg = {null};
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            client.execute("SELECT * FROM no_such_table", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    Assert.fail("unexpected batch");
                 }
-                Assert.assertNotNull(errorMsg[0]);
-                // Expect the message to reference the unknown table
-                Assert.assertTrue(
-                        "message should mention the unknown table, got: " + errorMsg[0],
-                        errorMsg[0].toLowerCase().contains("no_such_table")
-                                || errorMsg[0].toLowerCase().contains("table does not exist")
-                                || errorMsg[0].toLowerCase().contains("not found")
-                );
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                    Assert.fail("unexpected end");
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    errorMsg[0] = message;
+                }
+            });
+        }
+        Assert.assertNotNull(errorMsg[0]);
+        // Expect the message to reference the unknown table
+        Assert.assertTrue(
+                "message should mention the unknown table, got: " + errorMsg[0],
+                errorMsg[0].toLowerCase().contains("no_such_table")
+                        || errorMsg[0].toLowerCase().contains("table does not exist")
+                        || errorMsg[0].toLowerCase().contains("not found")
+        );
     }
 
     /**
@@ -1784,112 +1677,104 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
      */
     @Test
     public void testTimestampNanos() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE ts_n(ts TIMESTAMP_NS, v LONG) TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO ts_n VALUES
-                            ('2024-01-01T00:00:00.000000001Z', 1),
-                            ('2024-01-01T00:00:00.000000002Z', 2)
-                        """);
-                serverMain.awaitTxn("ts_n", 1);
+        serverMain.execute("CREATE TABLE ts_n(ts TIMESTAMP_NS, v LONG) TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO ts_n VALUES
+                    ('2024-01-01T00:00:00.000000001Z', 1),
+                    ('2024-01-01T00:00:00.000000002Z', 2)
+                """);
+        serverMain.awaitTxn("ts_n", 1);
 
-                final int[] count = {0};
-                final long[] firstTs = {0};
-                final long[] secondTs = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT ts, v FROM ts_n ORDER BY ts", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            Assert.assertEquals(io.questdb.client.cutlass.qwp.protocol.QwpConstants.TYPE_TIMESTAMP_NANOS,
-                                    batch.getColumnWireType(0));
-                            for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
-                                if (count[0] == 0) firstTs[0] = batch.getLongValue(0, r);
-                                if (count[0] == 1) secondTs[0] = batch.getLongValue(0, r);
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress error: " + message);
-                        }
-                    });
+        final int[] count = {0};
+        final long[] firstTs = {0};
+        final long[] secondTs = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT ts, v FROM ts_n ORDER BY ts", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    Assert.assertEquals(io.questdb.client.cutlass.qwp.protocol.QwpConstants.TYPE_TIMESTAMP_NANOS,
+                            batch.getColumnWireType(0));
+                    for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
+                        if (count[0] == 0) firstTs[0] = batch.getLongValue(0, r);
+                        if (count[0] == 1) secondTs[0] = batch.getLongValue(0, r);
+                    }
                 }
-                Assert.assertEquals(2, count[0]);
-                Assert.assertEquals(1L, secondTs[0] - firstTs[0]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals(2, count[0]);
+        Assert.assertEquals(1L, secondTs[0] - firstTs[0]);
     }
 
     @Test
     public void testUuidAndLong256() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE wide(u UUID, l256 LONG256, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute(
-                        "INSERT INTO wide VALUES ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', CAST('0x01' AS LONG256), 1::TIMESTAMP)"
-                );
-                serverMain.execute(
-                        "INSERT INTO wide VALUES (CAST(NULL AS UUID), CAST(NULL AS LONG256), 2::TIMESTAMP)"
-                );
-                serverMain.awaitTable("wide");
+        serverMain.execute("CREATE TABLE wide(u UUID, l256 LONG256, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute(
+                "INSERT INTO wide VALUES ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', CAST('0x01' AS LONG256), 1::TIMESTAMP)"
+        );
+        serverMain.execute(
+                "INSERT INTO wide VALUES (CAST(NULL AS UUID), CAST(NULL AS LONG256), 2::TIMESTAMP)"
+        );
+        serverMain.awaitTable("wide");
 
-                final Object[][] rows = new Object[2][];
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    // Explicit projection keeps the on-wire schema at 2 columns so the
-                    // assertions below keep indexing into [0]=u and [1]=l256.
-                    client.execute("SELECT u, l256 FROM wide", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            Assert.assertEquals(2, batch.getColumnCount());
-                            Assert.assertEquals(2, batch.getRowCount());
-                            for (int r = 0; r < 2; r++) {
-                                rows[r] = new Object[]{
-                                        batch.isNull(0, r) ? null : new long[]{
-                                                batch.getUuidLo(0, r),
-                                                batch.getUuidHi(0, r)
-                                        },
-                                        batch.isNull(1, r) ? null : new long[]{
-                                                batch.getLong256Word(1, r, 0),
-                                                batch.getLong256Word(1, r, 1),
-                                                batch.getLong256Word(1, r, 2),
-                                                batch.getLong256Word(1, r, 3)
-                                        }
-                                };
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+        final Object[][] rows = new Object[2][];
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            // Explicit projection keeps the on-wire schema at 2 columns so the
+            // assertions below keep indexing into [0]=u and [1]=l256.
+            client.execute("SELECT u, l256 FROM wide", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    Assert.assertEquals(2, batch.getColumnCount());
+                    Assert.assertEquals(2, batch.getRowCount());
+                    for (int r = 0; r < 2; r++) {
+                        rows[r] = new Object[]{
+                                batch.isNull(0, r) ? null : new long[]{
+                                        batch.getUuidLo(0, r),
+                                        batch.getUuidHi(0, r)
+                                },
+                                batch.isNull(1, r) ? null : new long[]{
+                                        batch.getLong256Word(1, r, 0),
+                                        batch.getLong256Word(1, r, 1),
+                                        batch.getLong256Word(1, r, 2),
+                                        batch.getLong256Word(1, r, 3)
+                                }
+                        };
+                    }
                 }
-                // UUID round-trip: 2 longs (lo, hi)
-                Assert.assertNotNull(rows[0][0]);
-                Assert.assertEquals(2, ((long[]) rows[0][0]).length);
-                // LONG256 round-trip: 4 longs, least significant first. 0x01 -> {1, 0, 0, 0}
-                long[] l256 = (long[]) rows[0][1];
-                Assert.assertEquals(1L, l256[0]);
-                Assert.assertEquals(0L, l256[1]);
-                Assert.assertEquals(0L, l256[2]);
-                Assert.assertEquals(0L, l256[3]);
-                // NULL rows
-                Assert.assertNull(rows[1][0]);
-                Assert.assertNull(rows[1][1]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+        }
+        // UUID round-trip: 2 longs (lo, hi)
+        Assert.assertNotNull(rows[0][0]);
+        Assert.assertEquals(2, ((long[]) rows[0][0]).length);
+        // LONG256 round-trip: 4 longs, least significant first. 0x01 -> {1, 0, 0, 0}
+        long[] l256 = (long[]) rows[0][1];
+        Assert.assertEquals(1L, l256[0]);
+        Assert.assertEquals(0L, l256[1]);
+        Assert.assertEquals(0L, l256[2]);
+        Assert.assertEquals(0L, l256[3]);
+        // NULL rows
+        Assert.assertNull(rows[1][0]);
+        Assert.assertNull(rows[1][1]);
     }
 
     private static void assertSelectReturnsOneRow(QwpQueryClient client, String sql, String label) {
@@ -1919,51 +1804,47 @@ public class QwpEgressBootstrapTest extends AbstractBootstrapTest {
     }
 
     private void runBatchBoundary(int totalRows) throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE boundary_t(x LONG, ts TIMESTAMP) "
-                        + "TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute(
-                        "INSERT INTO boundary_t SELECT x, x::TIMESTAMP FROM long_sequence(" + totalRows + ")"
-                );
-                serverMain.awaitTable("boundary_t");
+        serverMain.execute("CREATE TABLE boundary_t(x LONG, ts TIMESTAMP) "
+                + "TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute(
+                "INSERT INTO boundary_t SELECT x, x::TIMESTAMP FROM long_sequence(" + totalRows + ")"
+        );
+        serverMain.awaitTable("boundary_t");
 
-                final int[] count = {0};
-                final int[] batches = {0};
-                final long[] sum = {0L};
-                final long[] serverTotalRows = {-1L};
-                try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
-                    client.connect();
-                    client.execute("SELECT x FROM boundary_t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            batches[0]++;
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                sum[0] += batch.getLongValue(0, r);
-                                count[0]++;
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long trs) {
-                            serverTotalRows[0] = trs;
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+        final int[] count = {0};
+        final int[] batches = {0};
+        final long[] sum = {0L};
+        final long[] serverTotalRows = {-1L};
+        try (QwpQueryClient client = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
+            client.connect();
+            client.execute("SELECT x FROM boundary_t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    batches[0]++;
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        sum[0] += batch.getLongValue(0, r);
+                        count[0]++;
+                    }
                 }
-                Assert.assertEquals(totalRows, count[0]);
-                Assert.assertEquals((long) totalRows * (totalRows + 1) / 2L, sum[0]);
-                Assert.assertEquals(totalRows, serverTotalRows[0]);
-                if (totalRows <= QwpEgressUpgradeProcessor.MAX_ROWS_PER_BATCH) {
-                    Assert.assertEquals("expected exactly one batch", 1, batches[0]);
-                } else {
-                    Assert.assertTrue("expected > 1 batch, got " + batches[0], batches[0] > 1);
+
+                @Override
+                public void onEnd(long trs) {
+                    serverTotalRows[0] = trs;
                 }
-            }
-        });
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals(totalRows, count[0]);
+        Assert.assertEquals((long) totalRows * (totalRows + 1) / 2L, sum[0]);
+        Assert.assertEquals(totalRows, serverTotalRows[0]);
+        if (totalRows <= QwpEgressUpgradeProcessor.MAX_ROWS_PER_BATCH) {
+            Assert.assertEquals("expected exactly one batch", 1, batches[0]);
+        } else {
+            Assert.assertTrue("expected > 1 batch, got " + batches[0], batches[0] > 1);
+        }
     }
 }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressTypesExhaustiveTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressTypesExhaustiveTest.java
@@ -40,11 +40,7 @@ import io.questdb.client.std.str.Utf8s;
 import io.questdb.std.BoolList;
 import io.questdb.std.LongList;
 import io.questdb.std.Unsafe;
-import io.questdb.test.AbstractBootstrapTest;
-import io.questdb.test.TestServerMain;
-import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -62,153 +58,138 @@ import java.util.List;
  * Each test asserts the schema's wire-type code and the per-cell round-trip. Runs against a
  * locally booted QuestDB; share via {@code -P local-client} so the locally-built client is used.
  */
-public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
-
-    @Before
-    public void setUp() {
-        super.setUp();
-        TestUtils.unchecked(() -> createDummyConfiguration());
-        dbPath.parent().$();
-    }
+public class QwpEgressTypesExhaustiveTest extends AbstractReusedServerQwpEgressTest {
 
     @Test
     public void testAllNullColumn() throws Exception {
         // Edge case: every row in the column is NULL. Null bitmap fully set; no values
         // section. Pin that the per-column emit/decode handles the all-null path.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(s STRING, l LONG, d DOUBLE, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO t VALUES (NULL, NULL, NULL, 1::TIMESTAMP), "
-                        + "(NULL, NULL, NULL, 2::TIMESTAMP), (NULL, NULL, NULL, 3::TIMESTAMP)");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(s STRING, l LONG, d DOUBLE, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO t VALUES (NULL, NULL, NULL, 1::TIMESTAMP), "
+                + "(NULL, NULL, NULL, 2::TIMESTAMP), (NULL, NULL, NULL, 3::TIMESTAMP)");
+        serverMain.awaitTable("t");
 
-                final int[] nullCount = {0};
-                final int[] rows = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT s, l, d FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++, rows[0]++) {
-                                for (int c = 0; c < 3; c++) {
-                                    if (batch.isNull(c, r)) nullCount[0]++;
-                                }
-                            }
+        final int[] nullCount = {0};
+        final int[] rows = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT s, l, d FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    for (int r = 0; r < batch.getRowCount(); r++, rows[0]++) {
+                        for (int c = 0; c < 3; c++) {
+                            if (batch.isNull(c, r)) nullCount[0]++;
                         }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+                    }
                 }
-                Assert.assertEquals(3, rows[0]);
-                Assert.assertEquals(9, nullCount[0]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(3, rows[0]);
+        Assert.assertEquals(9, nullCount[0]);
     }
 
     @Test
     public void testBinaryExhaustive() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(b BINARY, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                // Mix of sizes via rnd_bin: small (1-2 bytes), medium (32 bytes), explicit NULL.
-                serverMain.execute("INSERT INTO t SELECT rnd_bin(1, 2, 0), x::TIMESTAMP FROM long_sequence(2)");
-                serverMain.execute("INSERT INTO t SELECT rnd_bin(32, 32, 0), (x + 10)::TIMESTAMP FROM long_sequence(2)");
-                serverMain.execute("INSERT INTO t VALUES (CAST(NULL AS BINARY), 100::TIMESTAMP)");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(b BINARY, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        // Mix of sizes via rnd_bin: small (1-2 bytes), medium (32 bytes), explicit NULL.
+        serverMain.execute("INSERT INTO t SELECT rnd_bin(1, 2, 0), x::TIMESTAMP FROM long_sequence(2)");
+        serverMain.execute("INSERT INTO t SELECT rnd_bin(32, 32, 0), (x + 10)::TIMESTAMP FROM long_sequence(2)");
+        serverMain.execute("INSERT INTO t VALUES (CAST(NULL AS BINARY), 100::TIMESTAMP)");
+        serverMain.awaitTable("t");
 
-                final List<byte[]> heapCopies = new ArrayList<>();
-                final List<byte[]> viewCopies = new ArrayList<>();
-                final List<byte[]> dualA = new ArrayList<>();
-                final List<byte[]> dualB = new ArrayList<>();
-                final byte[] wireType = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT b FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            int n = batch.getRowCount();
-                            for (int r = 0; r < n; r++) {
-                                if (batch.isNull(0, r)) {
-                                    heapCopies.add(null);
-                                    viewCopies.add(null);
-                                    continue;
-                                }
-                                // Heap copy (allocates)
-                                heapCopies.add(batch.getBinary(0, r));
-                                // Native zero-alloc view
-                                DirectByteSequence view = batch.getBinaryA(0, r);
-                                byte[] copy = new byte[view.size()];
-                                for (int i = 0; i < view.size(); i++) copy[i] = view.byteAt(i);
-                                viewCopies.add(copy);
-                            }
-                            // Dual-view: A and B point at different cells simultaneously.
-                            // Pick two non-null rows to confirm A doesn't clobber B.
-                            int firstNonNull = -1, secondNonNull = -1;
-                            for (int r = 0; r < n; r++) {
-                                if (!batch.isNull(0, r)) {
-                                    if (firstNonNull < 0) {
-                                        firstNonNull = r;
-                                    } else {
-                                        secondNonNull = r;
-                                        break;
-                                    }
-                                }
-                            }
-                            if (firstNonNull >= 0 && secondNonNull >= 0) {
-                                DirectByteSequence a = batch.getBinaryA(0, firstNonNull);
-                                DirectByteSequence b = batch.getBinaryB(0, secondNonNull);
-                                byte[] aCopy = new byte[a.size()];
-                                byte[] bCopy = new byte[b.size()];
-                                for (int i = 0; i < a.size(); i++) aCopy[i] = a.byteAt(i);
-                                for (int i = 0; i < b.size(); i++) bCopy[i] = b.byteAt(i);
-                                dualA.add(aCopy);
-                                dualB.add(bCopy);
+        final List<byte[]> heapCopies = new ArrayList<>();
+        final List<byte[]> viewCopies = new ArrayList<>();
+        final List<byte[]> dualA = new ArrayList<>();
+        final List<byte[]> dualB = new ArrayList<>();
+        final byte[] wireType = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT b FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    int n = batch.getRowCount();
+                    for (int r = 0; r < n; r++) {
+                        if (batch.isNull(0, r)) {
+                            heapCopies.add(null);
+                            viewCopies.add(null);
+                            continue;
+                        }
+                        // Heap copy (allocates)
+                        heapCopies.add(batch.getBinary(0, r));
+                        // Native zero-alloc view
+                        DirectByteSequence view = batch.getBinaryA(0, r);
+                        byte[] copy = new byte[view.size()];
+                        for (int i = 0; i < view.size(); i++) copy[i] = view.byteAt(i);
+                        viewCopies.add(copy);
+                    }
+                    // Dual-view: A and B point at different cells simultaneously.
+                    // Pick two non-null rows to confirm A doesn't clobber B.
+                    int firstNonNull = -1, secondNonNull = -1;
+                    for (int r = 0; r < n; r++) {
+                        if (!batch.isNull(0, r)) {
+                            if (firstNonNull < 0) {
+                                firstNonNull = r;
+                            } else {
+                                secondNonNull = r;
+                                break;
                             }
                         }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+                    }
+                    if (firstNonNull >= 0 && secondNonNull >= 0) {
+                        DirectByteSequence a = batch.getBinaryA(0, firstNonNull);
+                        DirectByteSequence b = batch.getBinaryB(0, secondNonNull);
+                        byte[] aCopy = new byte[a.size()];
+                        byte[] bCopy = new byte[b.size()];
+                        for (int i = 0; i < a.size(); i++) aCopy[i] = a.byteAt(i);
+                        for (int i = 0; i < b.size(); i++) bCopy[i] = b.byteAt(i);
+                        dualA.add(aCopy);
+                        dualB.add(bCopy);
+                    }
                 }
-                Assert.assertEquals(QwpConstants.TYPE_BINARY, wireType[0]);
-                Assert.assertEquals(5, heapCopies.size());
-                // First two are 1-2 bytes
-                Assert.assertNotNull(heapCopies.get(0));
-                Assert.assertTrue(heapCopies.get(0).length >= 1 && heapCopies.get(0).length <= 2);
-                Assert.assertNotNull(heapCopies.get(1));
-                Assert.assertTrue(heapCopies.get(1).length >= 1 && heapCopies.get(1).length <= 2);
-                // Next two are 32 bytes
-                Assert.assertEquals(32, heapCopies.get(2).length);
-                Assert.assertEquals(32, heapCopies.get(3).length);
-                // Last is NULL
-                Assert.assertNull(heapCopies.get(4));
-                // Native view matches heap copy byte-for-byte
-                for (int r = 0; r < 5; r++) {
-                    if (heapCopies.get(r) == null) Assert.assertNull(viewCopies.get(r));
-                    else Assert.assertArrayEquals("row " + r, heapCopies.get(r), viewCopies.get(r));
+
+                @Override
+                public void onEnd(long totalRows) {
                 }
-                // Dual-view holds two cells without clobber
-                Assert.assertFalse("dual-view A and B should have captured two non-null cells", dualA.isEmpty());
-                Assert.assertFalse(Arrays.equals(dualA.getFirst(), dualB.getFirst()) && dualA.getFirst().length == dualB.getFirst().length
-                        && (dualA.getFirst().length == 0));
-            }
-        });
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(QwpConstants.TYPE_BINARY, wireType[0]);
+        Assert.assertEquals(5, heapCopies.size());
+        // First two are 1-2 bytes
+        Assert.assertNotNull(heapCopies.get(0));
+        Assert.assertTrue(heapCopies.get(0).length >= 1 && heapCopies.get(0).length <= 2);
+        Assert.assertNotNull(heapCopies.get(1));
+        Assert.assertTrue(heapCopies.get(1).length >= 1 && heapCopies.get(1).length <= 2);
+        // Next two are 32 bytes
+        Assert.assertEquals(32, heapCopies.get(2).length);
+        Assert.assertEquals(32, heapCopies.get(3).length);
+        // Last is NULL
+        Assert.assertNull(heapCopies.get(4));
+        // Native view matches heap copy byte-for-byte
+        for (int r = 0; r < 5; r++) {
+            if (heapCopies.get(r) == null) Assert.assertNull(viewCopies.get(r));
+            else Assert.assertArrayEquals("row " + r, heapCopies.get(r), viewCopies.get(r));
+        }
+        // Dual-view holds two cells without clobber
+        Assert.assertFalse("dual-view A and B should have captured two non-null cells", dualA.isEmpty());
+        Assert.assertFalse(Arrays.equals(dualA.getFirst(), dualB.getFirst()) && dualA.getFirst().length == dualB.getFirst().length
+                && (dualA.getFirst().length == 0));
     }
 
     @Test
@@ -280,67 +261,63 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
         // Pins the column-pinned facade: column(c) returns a flyweight whose
         // single-arg accessors match the (col, row) primitives across types and
         // NULL rows. Two concurrent ColumnView instances must coexist.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(i INT, d DOUBLE, s SYMBOL, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            (1,    1.5,  'AAPL', 1::TIMESTAMP),
-                            (NULL, 2.5,  'MSFT', 2::TIMESTAMP),
-                            (3,    NULL, NULL,   3::TIMESTAMP),
-                            (4,    4.5,  'AAPL', 4::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(i INT, d DOUBLE, s SYMBOL, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    (1,    1.5,  'AAPL', 1::TIMESTAMP),
+                    (NULL, 2.5,  'MSFT', 2::TIMESTAMP),
+                    (3,    NULL, NULL,   3::TIMESTAMP),
+                    (4,    4.5,  'AAPL', 4::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final int[] intVals = new int[4];
-                final boolean[] intNulls = new boolean[4];
-                final double[] dblVals = new double[4];
-                final boolean[] dblNulls = new boolean[4];
-                final String[] symVals = new String[4];
-                final boolean[] sameInstance = {false};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT i, d, s FROM t ORDER BY part_ts", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            ColumnView ints = batch.column(0);
-                            ColumnView dbls = batch.column(1);
-                            ColumnView syms = batch.column(2);
-                            sameInstance[0] = batch.column(0) == ints;
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                intNulls[r] = ints.isNull(r);
-                                intVals[r] = ints.getIntValue(r);
-                                dblNulls[r] = dbls.isNull(r);
-                                dblVals[r] = dbls.getDoubleValue(r);
-                                symVals[r] = syms.getSymbol(r);
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final int[] intVals = new int[4];
+        final boolean[] intNulls = new boolean[4];
+        final double[] dblVals = new double[4];
+        final boolean[] dblNulls = new boolean[4];
+        final String[] symVals = new String[4];
+        final boolean[] sameInstance = {false};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT i, d, s FROM t ORDER BY part_ts", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    ColumnView ints = batch.column(0);
+                    ColumnView dbls = batch.column(1);
+                    ColumnView syms = batch.column(2);
+                    sameInstance[0] = batch.column(0) == ints;
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        intNulls[r] = ints.isNull(r);
+                        intVals[r] = ints.getIntValue(r);
+                        dblNulls[r] = dbls.isNull(r);
+                        dblVals[r] = dbls.getDoubleValue(r);
+                        symVals[r] = syms.getSymbol(r);
+                    }
                 }
-                Assert.assertTrue("repeated column(c) returns the same instance", sameInstance[0]);
-                Assert.assertArrayEquals(new int[]{1, 0, 3, 4}, intVals);
-                Assert.assertArrayEquals(new boolean[]{false, true, false, false}, intNulls);
-                Assert.assertArrayEquals(new boolean[]{false, false, true, false}, dblNulls);
-                Assert.assertEquals(1.5, dblVals[0], 0.0);
-                Assert.assertEquals(2.5, dblVals[1], 0.0);
-                Assert.assertTrue(Double.isNaN(dblVals[2]));
-                Assert.assertEquals(4.5, dblVals[3], 0.0);
-                Assert.assertEquals("AAPL", symVals[0]);
-                Assert.assertEquals("MSFT", symVals[1]);
-                Assert.assertNull(symVals[2]);
-                Assert.assertEquals("AAPL", symVals[3]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertTrue("repeated column(c) returns the same instance", sameInstance[0]);
+        Assert.assertArrayEquals(new int[]{1, 0, 3, 4}, intVals);
+        Assert.assertArrayEquals(new boolean[]{false, true, false, false}, intNulls);
+        Assert.assertArrayEquals(new boolean[]{false, false, true, false}, dblNulls);
+        Assert.assertEquals(1.5, dblVals[0], 0.0);
+        Assert.assertEquals(2.5, dblVals[1], 0.0);
+        Assert.assertTrue(Double.isNaN(dblVals[2]));
+        Assert.assertEquals(4.5, dblVals[3], 0.0);
+        Assert.assertEquals("AAPL", symVals[0]);
+        Assert.assertEquals("MSFT", symVals[1]);
+        Assert.assertNull(symVals[2]);
+        Assert.assertEquals("AAPL", symVals[3]);
     }
 
     @Test
@@ -348,62 +325,58 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
         // SIMD/JNI consumers iterate ColumnView.valuesAddr() directly. Assert
         // that the raw addresses, stride, and null bitmap line up with what
         // the typed accessors return.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(d DOUBLE, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            (1.5,  1::TIMESTAMP),
-                            (2.5,  2::TIMESTAMP),
-                            (NULL, 3::TIMESTAMP),
-                            (4.5,  4::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(d DOUBLE, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    (1.5,  1::TIMESTAMP),
+                    (2.5,  2::TIMESTAMP),
+                    (NULL, 3::TIMESTAMP),
+                    (4.5,  4::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final long[] valuesAddr = {0};
-                final long[] nullBitmapAddr = {0};
-                final int[] stride = {0};
-                final int[] nonNullCount = {0};
-                final boolean[] nullForRow2 = {false};
-                final double[] decoded = new double[3];
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT d FROM t ORDER BY part_ts", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            ColumnView col = batch.column(0);
-                            valuesAddr[0] = col.valuesAddr();
-                            nullBitmapAddr[0] = col.nullBitmapAddr();
-                            stride[0] = col.bytesPerValue();
-                            nonNullCount[0] = col.nonNullCount();
-                            // Null bitmap: row 2 NULL; LSB-first within byte 0 -> bit 2 set.
-                            byte bm = Unsafe.getByte(nullBitmapAddr[0]);
-                            nullForRow2[0] = (bm & (1 << 2)) != 0;
-                            // Walk the dense values array directly.
-                            for (int i = 0; i < nonNullCount[0]; i++) {
-                                decoded[i] = Unsafe.getDouble(valuesAddr[0] + (long) stride[0] * i);
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final long[] valuesAddr = {0};
+        final long[] nullBitmapAddr = {0};
+        final int[] stride = {0};
+        final int[] nonNullCount = {0};
+        final boolean[] nullForRow2 = {false};
+        final double[] decoded = new double[3];
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT d FROM t ORDER BY part_ts", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    ColumnView col = batch.column(0);
+                    valuesAddr[0] = col.valuesAddr();
+                    nullBitmapAddr[0] = col.nullBitmapAddr();
+                    stride[0] = col.bytesPerValue();
+                    nonNullCount[0] = col.nonNullCount();
+                    // Null bitmap: row 2 NULL; LSB-first within byte 0 -> bit 2 set.
+                    byte bm = Unsafe.getByte(nullBitmapAddr[0]);
+                    nullForRow2[0] = (bm & (1 << 2)) != 0;
+                    // Walk the dense values array directly.
+                    for (int i = 0; i < nonNullCount[0]; i++) {
+                        decoded[i] = Unsafe.getDouble(valuesAddr[0] + (long) stride[0] * i);
+                    }
                 }
-                Assert.assertEquals("DOUBLE stride", 8, stride[0]);
-                Assert.assertEquals("3 non-null rows out of 4", 3, nonNullCount[0]);
-                Assert.assertNotEquals("values address must be set", 0L, valuesAddr[0]);
-                Assert.assertNotEquals("null bitmap must be set when nulls are present", 0L, nullBitmapAddr[0]);
-                Assert.assertTrue("row 2 NULL bit must be set", nullForRow2[0]);
-                Assert.assertArrayEquals(new double[]{1.5, 2.5, 4.5}, decoded, 0.0);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals("DOUBLE stride", 8, stride[0]);
+        Assert.assertEquals("3 non-null rows out of 4", 3, nonNullCount[0]);
+        Assert.assertNotEquals("values address must be set", 0L, valuesAddr[0]);
+        Assert.assertNotEquals("null bitmap must be set when nulls are present", 0L, nullBitmapAddr[0]);
+        Assert.assertTrue("row 2 NULL bit must be set", nullForRow2[0]);
+        Assert.assertArrayEquals(new double[]{1.5, 2.5, 4.5}, decoded, 0.0);
     }
 
     @Test
@@ -433,151 +406,139 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
 
     @Test
     public void testDecimal128() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(d DECIMAL(38,6), part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO t VALUES (123456789.123456m, 1::TIMESTAMP), "
-                        + "(CAST(NULL AS DECIMAL(38,6)), 2::TIMESTAMP)");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(d DECIMAL(38,6), part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO t VALUES (123456789.123456m, 1::TIMESTAMP), "
+                + "(CAST(NULL AS DECIMAL(38,6)), 2::TIMESTAMP)");
+        serverMain.awaitTable("t");
 
-                final List<long[]> values = new ArrayList<>();
-                final byte[] wireType = {0};
-                final int[] scale = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT d FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            scale[0] = batch.getDecimalScale(0);
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                if (batch.isNull(0, r)) {
-                                    values.add(null);
-                                } else {
-                                    values.add(new long[]{batch.getDecimal128Low(0, r), batch.getDecimal128High(0, r)});
-                                }
-                            }
+        final List<long[]> values = new ArrayList<>();
+        final byte[] wireType = {0};
+        final int[] scale = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT d FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    scale[0] = batch.getDecimalScale(0);
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        if (batch.isNull(0, r)) {
+                            values.add(null);
+                        } else {
+                            values.add(new long[]{batch.getDecimal128Low(0, r), batch.getDecimal128High(0, r)});
                         }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+                    }
                 }
-                Assert.assertEquals(QwpConstants.TYPE_DECIMAL128, wireType[0]);
-                Assert.assertEquals(6, scale[0]);
-                Assert.assertNotNull(values.get(0));
-                Assert.assertEquals(2, values.get(0).length);
-                Assert.assertNull(values.get(1));
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(QwpConstants.TYPE_DECIMAL128, wireType[0]);
+        Assert.assertEquals(6, scale[0]);
+        Assert.assertNotNull(values.get(0));
+        Assert.assertEquals(2, values.get(0).length);
+        Assert.assertNull(values.get(1));
     }
 
     @Test
     public void testDecimal256() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(d DECIMAL(76,10), part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO t VALUES (123456789.1234567890m, 1::TIMESTAMP), "
-                        + "(CAST(NULL AS DECIMAL(76,10)), 2::TIMESTAMP)");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(d DECIMAL(76,10), part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO t VALUES (123456789.1234567890m, 1::TIMESTAMP), "
+                + "(CAST(NULL AS DECIMAL(76,10)), 2::TIMESTAMP)");
+        serverMain.awaitTable("t");
 
-                final List<long[]> values = new ArrayList<>();
-                final byte[] wireType = {0};
-                final int[] scale = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT d FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            scale[0] = batch.getDecimalScale(0);
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                if (batch.isNull(0, r)) {
-                                    values.add(null);
-                                } else {
-                                    values.add(new long[]{
-                                            batch.getLong256Word(0, r, 0),
-                                            batch.getLong256Word(0, r, 1),
-                                            batch.getLong256Word(0, r, 2),
-                                            batch.getLong256Word(0, r, 3)
-                                    });
-                                }
-                            }
+        final List<long[]> values = new ArrayList<>();
+        final byte[] wireType = {0};
+        final int[] scale = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT d FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    scale[0] = batch.getDecimalScale(0);
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        if (batch.isNull(0, r)) {
+                            values.add(null);
+                        } else {
+                            values.add(new long[]{
+                                    batch.getLong256Word(0, r, 0),
+                                    batch.getLong256Word(0, r, 1),
+                                    batch.getLong256Word(0, r, 2),
+                                    batch.getLong256Word(0, r, 3)
+                            });
                         }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+                    }
                 }
-                Assert.assertEquals(QwpConstants.TYPE_DECIMAL256, wireType[0]);
-                Assert.assertEquals(10, scale[0]);
-                Assert.assertNotNull(values.get(0));
-                Assert.assertNull(values.get(1));
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(QwpConstants.TYPE_DECIMAL256, wireType[0]);
+        Assert.assertEquals(10, scale[0]);
+        Assert.assertNotNull(values.get(0));
+        Assert.assertNull(values.get(1));
     }
 
     @Test
     public void testDecimal64() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(d DECIMAL(18,4), part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO t VALUES (1234.5678m, 1::TIMESTAMP), (-1234.5678m, 2::TIMESTAMP), "
-                        + "(0m, 3::TIMESTAMP), (CAST(NULL AS DECIMAL(18,4)), 4::TIMESTAMP)");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(d DECIMAL(18,4), part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO t VALUES (1234.5678m, 1::TIMESTAMP), (-1234.5678m, 2::TIMESTAMP), "
+                + "(0m, 3::TIMESTAMP), (CAST(NULL AS DECIMAL(18,4)), 4::TIMESTAMP)");
+        serverMain.awaitTable("t");
 
-                final LongList rawValues = new LongList();
-                final BoolList nulls = new BoolList();
-                final byte[] wireType = {0};
-                final int[] scale = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT d FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            scale[0] = batch.getDecimalScale(0);
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                boolean isNull = batch.isNull(0, r);
-                                nulls.add(isNull);
-                                rawValues.add(isNull ? 0L : batch.getLongValue(0, r));
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final LongList rawValues = new LongList();
+        final BoolList nulls = new BoolList();
+        final byte[] wireType = {0};
+        final int[] scale = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT d FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    scale[0] = batch.getDecimalScale(0);
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        boolean isNull = batch.isNull(0, r);
+                        nulls.add(isNull);
+                        rawValues.add(isNull ? 0L : batch.getLongValue(0, r));
+                    }
                 }
-                Assert.assertEquals(QwpConstants.TYPE_DECIMAL64, wireType[0]);
-                Assert.assertEquals(4, scale[0]);
-                // 1234.5678 with scale 4 -> unscaled 12_345_678
-                Assert.assertEquals(12_345_678L, rawValues.getQuick(0));
-                Assert.assertEquals(-12_345_678L, rawValues.getQuick(1));
-                Assert.assertEquals(0L, rawValues.getQuick(2));
-                Assert.assertTrue(nulls.get(3));
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(QwpConstants.TYPE_DECIMAL64, wireType[0]);
+        Assert.assertEquals(4, scale[0]);
+        // 1234.5678 with scale 4 -> unscaled 12_345_678
+        Assert.assertEquals(12_345_678L, rawValues.getQuick(0));
+        Assert.assertEquals(-12_345_678L, rawValues.getQuick(1));
+        Assert.assertEquals(0L, rawValues.getQuick(2));
+        Assert.assertTrue(nulls.get(3));
     }
 
     @Test
@@ -587,66 +548,62 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
         //    independently. One shared field in the decoder would collapse all
         //    scales to the last column's value.
         // 2. Scale=0 byte decodes correctly (not confused with "scale unset").
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("""
-                        CREATE TABLE t(
-                            d64_0   DECIMAL(18, 0),
-                            d64_4   DECIMAL(18, 4),
-                            d128_0  DECIMAL(38, 0),
-                            d128_20 DECIMAL(38, 20),
-                            d256_0  DECIMAL(76, 0),
-                            d256_38 DECIMAL(76, 38),
-                            part_ts TIMESTAMP
-                        ) TIMESTAMP(part_ts) PARTITION BY DAY WAL
-                        """);
-                serverMain.execute("""
-                        INSERT INTO t VALUES (
-                            42m,
-                            1.2345m,
-                            1000m,
-                            3.14159265358979323846m,
-                            9999999999999999999999999999999999999m,
-                            1.12345678901234567890123456789012345678m,
-                            1::TIMESTAMP
-                        )
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("""
+                CREATE TABLE t(
+                    d64_0   DECIMAL(18, 0),
+                    d64_4   DECIMAL(18, 4),
+                    d128_0  DECIMAL(38, 0),
+                    d128_20 DECIMAL(38, 20),
+                    d256_0  DECIMAL(76, 0),
+                    d256_38 DECIMAL(76, 38),
+                    part_ts TIMESTAMP
+                ) TIMESTAMP(part_ts) PARTITION BY DAY WAL
+                """);
+        serverMain.execute("""
+                INSERT INTO t VALUES (
+                    42m,
+                    1.2345m,
+                    1000m,
+                    3.14159265358979323846m,
+                    9999999999999999999999999999999999999m,
+                    1.12345678901234567890123456789012345678m,
+                    1::TIMESTAMP
+                )
+                """);
+        serverMain.awaitTable("t");
 
-                final byte[] wireTypes = new byte[6];
-                final int[] scales = new int[6];
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute(
-                            "SELECT d64_0, d64_4, d128_0, d128_20, d256_0, d256_38 FROM t",
-                            new QwpColumnBatchHandler() {
-                                @Override
-                                public void onBatch(QwpColumnBatch batch) {
-                                    for (int c = 0; c < 6; c++) {
-                                        wireTypes[c] = batch.getColumnWireType(c);
-                                        scales[c] = batch.getDecimalScale(c);
-                                    }
-                                }
+        final byte[] wireTypes = new byte[6];
+        final int[] scales = new int[6];
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute(
+                    "SELECT d64_0, d64_4, d128_0, d128_20, d256_0, d256_38 FROM t",
+                    new QwpColumnBatchHandler() {
+                        @Override
+                        public void onBatch(QwpColumnBatch batch) {
+                            for (int c = 0; c < 6; c++) {
+                                wireTypes[c] = batch.getColumnWireType(c);
+                                scales[c] = batch.getDecimalScale(c);
+                            }
+                        }
 
-                                @Override
-                                public void onEnd(long totalRows) {
-                                }
+                        @Override
+                        public void onEnd(long totalRows) {
+                        }
 
-                                @Override
-                                public void onError(byte status, String message) {
-                                    Assert.fail(message);
-                                }
-                            });
-                }
-                Assert.assertEquals(QwpConstants.TYPE_DECIMAL64, wireTypes[0]);
-                Assert.assertEquals(QwpConstants.TYPE_DECIMAL64, wireTypes[1]);
-                Assert.assertEquals(QwpConstants.TYPE_DECIMAL128, wireTypes[2]);
-                Assert.assertEquals(QwpConstants.TYPE_DECIMAL128, wireTypes[3]);
-                Assert.assertEquals(QwpConstants.TYPE_DECIMAL256, wireTypes[4]);
-                Assert.assertEquals(QwpConstants.TYPE_DECIMAL256, wireTypes[5]);
-                Assert.assertArrayEquals(new int[]{0, 4, 0, 20, 0, 38}, scales);
-            }
-        });
+                        @Override
+                        public void onError(byte status, String message) {
+                            Assert.fail(message);
+                        }
+                    });
+        }
+        Assert.assertEquals(QwpConstants.TYPE_DECIMAL64, wireTypes[0]);
+        Assert.assertEquals(QwpConstants.TYPE_DECIMAL64, wireTypes[1]);
+        Assert.assertEquals(QwpConstants.TYPE_DECIMAL128, wireTypes[2]);
+        Assert.assertEquals(QwpConstants.TYPE_DECIMAL128, wireTypes[3]);
+        Assert.assertEquals(QwpConstants.TYPE_DECIMAL256, wireTypes[4]);
+        Assert.assertEquals(QwpConstants.TYPE_DECIMAL256, wireTypes[5]);
+        Assert.assertArrayEquals(new int[]{0, 4, 0, 20, 0, 38}, scales);
     }
 
     @Test
@@ -673,45 +630,41 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
 
     @Test
     public void testDoubleArray1DAnd2D() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(a DOUBLE[], b DOUBLE[][], part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO t VALUES (ARRAY[1.0, 2.0, 3.0], ARRAY[[1.0, 2.0], [3.0, 4.0]], 1::TIMESTAMP)");
-                serverMain.execute("INSERT INTO t VALUES (ARRAY[10.0], ARRAY[[5.0, 6.0]], 2::TIMESTAMP)");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(a DOUBLE[], b DOUBLE[][], part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO t VALUES (ARRAY[1.0, 2.0, 3.0], ARRAY[[1.0, 2.0], [3.0, 4.0]], 1::TIMESTAMP)");
+        serverMain.execute("INSERT INTO t VALUES (ARRAY[10.0], ARRAY[[5.0, 6.0]], 2::TIMESTAMP)");
+        serverMain.awaitTable("t");
 
-                final byte[] wt1d = {0};
-                final byte[] wt2d = {0};
-                final int[] count = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT a, b FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wt1d[0] = batch.getColumnWireType(0);
-                            wt2d[0] = batch.getColumnWireType(1);
-                            for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
-                                Assert.assertFalse("col 0 row " + r + " must be non-null", batch.isNull(0, r));
-                                Assert.assertFalse("col 1 row " + r + " must be non-null", batch.isNull(1, r));
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final byte[] wt1d = {0};
+        final byte[] wt2d = {0};
+        final int[] count = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT a, b FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wt1d[0] = batch.getColumnWireType(0);
+                    wt2d[0] = batch.getColumnWireType(1);
+                    for (int r = 0; r < batch.getRowCount(); r++, count[0]++) {
+                        Assert.assertFalse("col 0 row " + r + " must be non-null", batch.isNull(0, r));
+                        Assert.assertFalse("col 1 row " + r + " must be non-null", batch.isNull(1, r));
+                    }
                 }
-                Assert.assertEquals(QwpConstants.TYPE_DOUBLE_ARRAY, wt1d[0]);
-                Assert.assertEquals(QwpConstants.TYPE_DOUBLE_ARRAY, wt2d[0]);
-                Assert.assertEquals(2, count[0]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(QwpConstants.TYPE_DOUBLE_ARRAY, wt1d[0]);
+        Assert.assertEquals(QwpConstants.TYPE_DOUBLE_ARRAY, wt2d[0]);
+        Assert.assertEquals(2, count[0]);
     }
 
     @Test
@@ -742,194 +695,182 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
         // Pins the row-pinned facade: forEachRow walks every row in order,
         // RowView#getRowIndex tracks position, single-arg accessors match the
         // (col, row) primitives, and the same flyweight instance is reused.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(i INT, d DOUBLE, s SYMBOL, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            (1,    1.5,  'AAPL', 1::TIMESTAMP),
-                            (NULL, 2.5,  'MSFT', 2::TIMESTAMP),
-                            (3,    NULL, NULL,   3::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(i INT, d DOUBLE, s SYMBOL, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    (1,    1.5,  'AAPL', 1::TIMESTAMP),
+                    (NULL, 2.5,  'MSFT', 2::TIMESTAMP),
+                    (3,    NULL, NULL,   3::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final List<Object[]> rows = new ArrayList<>();
-                final java.util.IdentityHashMap<RowView, Boolean> seenInstances = new java.util.IdentityHashMap<>();
-                final boolean[] sawBatchAccessor = {false};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT i, d, s FROM t ORDER BY part_ts", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            sawBatchAccessor[0] = batch.row(0).batch() == batch;
-                            batch.forEachRow(row -> {
-                                seenInstances.put(row, Boolean.TRUE);
-                                rows.add(new Object[]{
-                                        row.getRowIndex(),
-                                        row.isNull(0), row.getIntValue(0),
-                                        row.isNull(1), row.getDoubleValue(1),
-                                        row.getSymbol(2)
-                                });
-                            });
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
+        final List<Object[]> rows = new ArrayList<>();
+        final java.util.IdentityHashMap<RowView, Boolean> seenInstances = new java.util.IdentityHashMap<>();
+        final boolean[] sawBatchAccessor = {false};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT i, d, s FROM t ORDER BY part_ts", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    sawBatchAccessor[0] = batch.row(0).batch() == batch;
+                    batch.forEachRow(row -> {
+                        seenInstances.put(row, Boolean.TRUE);
+                        rows.add(new Object[]{
+                                row.getRowIndex(),
+                                row.isNull(0), row.getIntValue(0),
+                                row.isNull(1), row.getDoubleValue(1),
+                                row.getSymbol(2)
+                        });
                     });
                 }
-                Assert.assertTrue("row().batch() returns the parent batch", sawBatchAccessor[0]);
-                Assert.assertEquals("forEachRow reuses the same RowView", 1, seenInstances.size());
-                Assert.assertEquals(3, rows.size());
 
-                Object[] r0 = rows.getFirst();
-                Assert.assertEquals(0, r0[0]);
-                Assert.assertEquals(Boolean.FALSE, r0[1]);
-                Assert.assertEquals(1, r0[2]);
-                Assert.assertEquals(Boolean.FALSE, r0[3]);
-                Assert.assertEquals(1.5, (Double) r0[4], 0.0);
-                Assert.assertEquals("AAPL", r0[5]);
+                @Override
+                public void onEnd(long totalRows) {
+                }
 
-                Object[] r1 = rows.get(1);
-                Assert.assertEquals(1, r1[0]);
-                Assert.assertEquals(Boolean.TRUE, r1[1]);
-                Assert.assertEquals(0, r1[2]); // NULL INT -> 0
-                Assert.assertEquals(2.5, (Double) r1[4], 0.0);
-                Assert.assertEquals("MSFT", r1[5]);
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertTrue("row().batch() returns the parent batch", sawBatchAccessor[0]);
+        Assert.assertEquals("forEachRow reuses the same RowView", 1, seenInstances.size());
+        Assert.assertEquals(3, rows.size());
 
-                Object[] r2 = rows.get(2);
-                Assert.assertEquals(2, r2[0]);
-                Assert.assertEquals(3, r2[2]);
-                Assert.assertEquals(Boolean.TRUE, r2[3]);
-                Assert.assertTrue("NULL DOUBLE -> NaN", Double.isNaN((Double) r2[4]));
-                Assert.assertNull(r2[5]);
-            }
-        });
+        Object[] r0 = rows.getFirst();
+        Assert.assertEquals(0, r0[0]);
+        Assert.assertEquals(Boolean.FALSE, r0[1]);
+        Assert.assertEquals(1, r0[2]);
+        Assert.assertEquals(Boolean.FALSE, r0[3]);
+        Assert.assertEquals(1.5, (Double) r0[4], 0.0);
+        Assert.assertEquals("AAPL", r0[5]);
+
+        Object[] r1 = rows.get(1);
+        Assert.assertEquals(1, r1[0]);
+        Assert.assertEquals(Boolean.TRUE, r1[1]);
+        Assert.assertEquals(0, r1[2]); // NULL INT -> 0
+        Assert.assertEquals(2.5, (Double) r1[4], 0.0);
+        Assert.assertEquals("MSFT", r1[5]);
+
+        Object[] r2 = rows.get(2);
+        Assert.assertEquals(2, r2[0]);
+        Assert.assertEquals(3, r2[2]);
+        Assert.assertEquals(Boolean.TRUE, r2[3]);
+        Assert.assertTrue("NULL DOUBLE -> NaN", Double.isNaN((Double) r2[4]));
+        Assert.assertNull(r2[5]);
     }
 
     @Test
     public void testGeohashAllWidths() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                // 5 widths spanning all four storage classes (byte/short/int/long).
-                serverMain.execute("""
-                        CREATE TABLE t(
-                            g4 GEOHASH(4b),
-                            g8 GEOHASH(8b),
-                            g16 GEOHASH(16b),
-                            g40 GEOHASH(40b),
-                            g60 GEOHASH(60b),
-                            part_ts TIMESTAMP
-                        ) TIMESTAMP(part_ts) PARTITION BY DAY WAL
-                        """);
-                serverMain.execute("INSERT INTO t VALUES (#0, #00, #0000, #00000000, #000000000000, 1::TIMESTAMP)");
-                serverMain.execute("""
-                        INSERT INTO t VALUES (
-                            CAST(NULL AS GEOHASH(4b)),
-                            CAST(NULL AS GEOHASH(8b)),
-                            CAST(NULL AS GEOHASH(16b)),
-                            CAST(NULL AS GEOHASH(40b)),
-                            CAST(NULL AS GEOHASH(60b)),
-                            2::TIMESTAMP
-                        )
-                        """);
-                serverMain.awaitTable("t");
+        // 5 widths spanning all four storage classes (byte/short/int/long).
+        serverMain.execute("""
+                CREATE TABLE t(
+                    g4 GEOHASH(4b),
+                    g8 GEOHASH(8b),
+                    g16 GEOHASH(16b),
+                    g40 GEOHASH(40b),
+                    g60 GEOHASH(60b),
+                    part_ts TIMESTAMP
+                ) TIMESTAMP(part_ts) PARTITION BY DAY WAL
+                """);
+        serverMain.execute("INSERT INTO t VALUES (#0, #00, #0000, #00000000, #000000000000, 1::TIMESTAMP)");
+        serverMain.execute("""
+                INSERT INTO t VALUES (
+                    CAST(NULL AS GEOHASH(4b)),
+                    CAST(NULL AS GEOHASH(8b)),
+                    CAST(NULL AS GEOHASH(16b)),
+                    CAST(NULL AS GEOHASH(40b)),
+                    CAST(NULL AS GEOHASH(60b)),
+                    2::TIMESTAMP
+                )
+                """);
+        serverMain.awaitTable("t");
 
-                final boolean[][] isNull = new boolean[2][5];
-                final int[] precisionBits = new int[5];
-                final byte[] wireType = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT * FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            for (int c = 0; c < 5; c++) precisionBits[c] = batch.getGeohashPrecisionBits(c);
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                for (int c = 0; c < 5; c++) isNull[r][c] = batch.isNull(c, r);
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final boolean[][] isNull = new boolean[2][5];
+        final int[] precisionBits = new int[5];
+        final byte[] wireType = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT * FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    for (int c = 0; c < 5; c++) precisionBits[c] = batch.getGeohashPrecisionBits(c);
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        for (int c = 0; c < 5; c++) isNull[r][c] = batch.isNull(c, r);
+                    }
                 }
-                Assert.assertEquals(QwpConstants.TYPE_GEOHASH, wireType[0]);
-                Assert.assertArrayEquals(new int[]{4, 8, 16, 40, 60}, precisionBits);
-                for (int c = 0; c < 5; c++) {
-                    Assert.assertFalse("non-null row, col " + c, isNull[0][c]);
-                    Assert.assertTrue("null row, col " + c, isNull[1][c]);
+
+                @Override
+                public void onEnd(long totalRows) {
                 }
-            }
-        });
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(QwpConstants.TYPE_GEOHASH, wireType[0]);
+        Assert.assertArrayEquals(new int[]{4, 8, 16, 40, 60}, precisionBits);
+        for (int c = 0; c < 5; c++) {
+            Assert.assertFalse("non-null row, col " + c, isNull[0][c]);
+            Assert.assertTrue("null row, col " + c, isNull[1][c]);
+        }
     }
 
     @Test
     public void testIPv4() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(addr IPv4, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                // QuestDB convention: 0.0.0.0 == NULL for IPv4.
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            ('192.168.1.1',     1::TIMESTAMP),
-                            ('255.255.255.255', 2::TIMESTAMP),
-                            ('10.0.0.1',        3::TIMESTAMP),
-                            (NULL,              4::TIMESTAMP),
-                            ('0.0.0.0',         5::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(addr IPv4, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        // QuestDB convention: 0.0.0.0 == NULL for IPv4.
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    ('192.168.1.1',     1::TIMESTAMP),
+                    ('255.255.255.255', 2::TIMESTAMP),
+                    ('10.0.0.1',        3::TIMESTAMP),
+                    (NULL,              4::TIMESTAMP),
+                    ('0.0.0.0',         5::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final LongList values = new LongList();
-                final boolean[] nullSeen = new boolean[5];
-                final byte[] wireType = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT addr FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                nullSeen[r] = batch.isNull(0, r);
-                                values.add(nullSeen[r] ? 0L : batch.getIntValue(0, r));
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final LongList values = new LongList();
+        final boolean[] nullSeen = new boolean[5];
+        final byte[] wireType = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT addr FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        nullSeen[r] = batch.isNull(0, r);
+                        values.add(nullSeen[r] ? 0L : batch.getIntValue(0, r));
+                    }
                 }
-                Assert.assertEquals(QwpConstants.TYPE_IPv4, wireType[0]);
-                // 192.168.1.1 = 0xC0A80101
-                Assert.assertEquals(0xC0A80101L, values.getQuick(0) & 0xFFFFFFFFL);
-                // 255.255.255.255 = 0xFFFFFFFF
-                Assert.assertEquals(0xFFFFFFFFL, values.getQuick(1) & 0xFFFFFFFFL);
-                // 10.0.0.1
-                Assert.assertEquals(0x0A000001L, values.getQuick(2) & 0xFFFFFFFFL);
-                // explicit NULL and 0.0.0.0 both surface as null
-                Assert.assertTrue(nullSeen[3]);
-                Assert.assertTrue(nullSeen[4]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(QwpConstants.TYPE_IPv4, wireType[0]);
+        // 192.168.1.1 = 0xC0A80101
+        Assert.assertEquals(0xC0A80101L, values.getQuick(0) & 0xFFFFFFFFL);
+        // 255.255.255.255 = 0xFFFFFFFF
+        Assert.assertEquals(0xFFFFFFFFL, values.getQuick(1) & 0xFFFFFFFFL);
+        // 10.0.0.1
+        Assert.assertEquals(0x0A000001L, values.getQuick(2) & 0xFFFFFFFFL);
+        // explicit NULL and 0.0.0.0 both surface as null
+        Assert.assertTrue(nullSeen[3]);
+        Assert.assertTrue(nullSeen[4]);
     }
 
     @Test
@@ -978,59 +919,55 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
 
     @Test
     public void testLong256() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(l256 LONG256, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            (CAST('0x01' AS LONG256),               1::TIMESTAMP),
-                            (CAST('0xFFFFFFFFFFFFFFFF' AS LONG256), 2::TIMESTAMP),
-                            (CAST(NULL AS LONG256),                 3::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(l256 LONG256, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    (CAST('0x01' AS LONG256),               1::TIMESTAMP),
+                    (CAST('0xFFFFFFFFFFFFFFFF' AS LONG256), 2::TIMESTAMP),
+                    (CAST(NULL AS LONG256),                 3::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final List<long[]> words = new ArrayList<>();
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT l256 FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                if (batch.isNull(0, r)) {
-                                    words.add(null);
-                                } else {
-                                    words.add(new long[]{
-                                            batch.getLong256Word(0, r, 0),
-                                            batch.getLong256Word(0, r, 1),
-                                            batch.getLong256Word(0, r, 2),
-                                            batch.getLong256Word(0, r, 3)
-                                    });
-                                }
-                            }
+        final List<long[]> words = new ArrayList<>();
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT l256 FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        if (batch.isNull(0, r)) {
+                            words.add(null);
+                        } else {
+                            words.add(new long[]{
+                                    batch.getLong256Word(0, r, 0),
+                                    batch.getLong256Word(0, r, 1),
+                                    batch.getLong256Word(0, r, 2),
+                                    batch.getLong256Word(0, r, 3)
+                            });
                         }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+                    }
                 }
-                // 0x01 = {1, 0, 0, 0}
-                Assert.assertEquals(1L, words.getFirst()[0]);
-                Assert.assertEquals(0L, words.getFirst()[1]);
-                Assert.assertEquals(0L, words.get(0)[2]);
-                Assert.assertEquals(0L, words.get(0)[3]);
-                // 0xFFFF...FF in low word
-                Assert.assertEquals(-1L, words.get(1)[0]);
-                Assert.assertEquals(0L, words.get(1)[1]);
-                Assert.assertNull(words.get(2));
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        // 0x01 = {1, 0, 0, 0}
+        Assert.assertEquals(1L, words.getFirst()[0]);
+        Assert.assertEquals(0L, words.getFirst()[1]);
+        Assert.assertEquals(0L, words.get(0)[2]);
+        Assert.assertEquals(0L, words.get(0)[3]);
+        // 0xFFFF...FF in low word
+        Assert.assertEquals(-1L, words.get(1)[0]);
+        Assert.assertEquals(0L, words.get(1)[1]);
+        Assert.assertNull(words.get(2));
     }
 
     @Test
@@ -1038,53 +975,49 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
         // Same data as testLong256, but read via the single-call Long256Sink API.
         // A reusable Long256Impl is handed to the batch for every row; the
         // four-word copy happens inside getLong256 with one virtual dispatch.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(l256 LONG256, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            (CAST('0x01' AS LONG256),               1::TIMESTAMP),
-                            (CAST('0xFFFFFFFFFFFFFFFF' AS LONG256), 2::TIMESTAMP),
-                            (CAST(NULL AS LONG256),                 3::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(l256 LONG256, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    (CAST('0x01' AS LONG256),               1::TIMESTAMP),
+                    (CAST('0xFFFFFFFFFFFFFFFF' AS LONG256), 2::TIMESTAMP),
+                    (CAST(NULL AS LONG256),                 3::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final List<long[]> words = new ArrayList<>();
-                final boolean[] hits = new boolean[3];
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT l256 FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            // Reused across rows -- the whole point of the sink API.
-                            Long256Impl sink = new Long256Impl();
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                hits[r] = batch.getLong256(0, r, sink);
-                                words.add(hits[r]
-                                        ? new long[]{sink.getLong0(), sink.getLong1(), sink.getLong2(), sink.getLong3()}
-                                        : null);
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final List<long[]> words = new ArrayList<>();
+        final boolean[] hits = new boolean[3];
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT l256 FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    // Reused across rows -- the whole point of the sink API.
+                    Long256Impl sink = new Long256Impl();
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        hits[r] = batch.getLong256(0, r, sink);
+                        words.add(hits[r]
+                                ? new long[]{sink.getLong0(), sink.getLong1(), sink.getLong2(), sink.getLong3()}
+                                : null);
+                    }
                 }
-                Assert.assertArrayEquals(new long[]{1L, 0L, 0L, 0L}, words.get(0));
-                Assert.assertArrayEquals(new long[]{-1L, 0L, 0L, 0L}, words.get(1));
-                Assert.assertNull(words.get(2));
-                Assert.assertTrue(hits[0]);
-                Assert.assertTrue(hits[1]);
-                Assert.assertFalse("getLong256 must return false for NULL row", hits[2]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertArrayEquals(new long[]{1L, 0L, 0L, 0L}, words.get(0));
+        Assert.assertArrayEquals(new long[]{-1L, 0L, 0L, 0L}, words.get(1));
+        Assert.assertNull(words.get(2));
+        Assert.assertTrue(hits[0]);
+        Assert.assertTrue(hits[1]);
+        Assert.assertFalse("getLong256 must return false for NULL row", hits[2]);
     }
 
     @Test
@@ -1109,57 +1042,53 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
     @Test
     public void testString() throws Exception {
         // Cover: empty, ASCII, multi-byte UTF-8, large, NULL.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(s STRING, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            ('',     1::TIMESTAMP),
-                            ('hello', 2::TIMESTAMP),
-                            ('héllo wörld', 3::TIMESTAMP),
-                            ('日本語', 4::TIMESTAMP),
-                            ('a string of moderate length to exercise heap growth', 5::TIMESTAMP),
-                            (NULL,   6::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(s STRING, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    ('',     1::TIMESTAMP),
+                    ('hello', 2::TIMESTAMP),
+                    ('héllo wörld', 3::TIMESTAMP),
+                    ('日本語', 4::TIMESTAMP),
+                    ('a string of moderate length to exercise heap growth', 5::TIMESTAMP),
+                    (NULL,   6::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final List<String> values = new ArrayList<>();
-                final boolean[] nullSeen = new boolean[6];
-                final byte[] wireType = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT s FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                nullSeen[r] = batch.isNull(0, r);
-                                values.add(nullSeen[r] ? null : batch.getString(0, r));
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress error: " + message);
-                        }
-                    });
+        final List<String> values = new ArrayList<>();
+        final boolean[] nullSeen = new boolean[6];
+        final byte[] wireType = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT s FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        nullSeen[r] = batch.isNull(0, r);
+                        values.add(nullSeen[r] ? null : batch.getString(0, r));
+                    }
                 }
-                // Egress advertises VARCHAR for both QuestDB STRING and VARCHAR columns.
-                Assert.assertEquals(QwpConstants.TYPE_VARCHAR, wireType[0]);
-                Assert.assertEquals("", values.get(0));
-                Assert.assertEquals("hello", values.get(1));
-                Assert.assertEquals("héllo wörld", values.get(2));
-                Assert.assertEquals("日本語", values.get(3));
-                Assert.assertEquals("a string of moderate length to exercise heap growth", values.get(4));
-                Assert.assertNull(values.get(5));
-                Assert.assertTrue(nullSeen[5]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress error: " + message);
+                }
+            });
+        }
+        // Egress advertises VARCHAR for both QuestDB STRING and VARCHAR columns.
+        Assert.assertEquals(QwpConstants.TYPE_VARCHAR, wireType[0]);
+        Assert.assertEquals("", values.get(0));
+        Assert.assertEquals("hello", values.get(1));
+        Assert.assertEquals("héllo wörld", values.get(2));
+        Assert.assertEquals("日本語", values.get(3));
+        Assert.assertEquals("a string of moderate length to exercise heap growth", values.get(4));
+        Assert.assertNull(values.get(5));
+        Assert.assertTrue(nullSeen[5]);
     }
 
     @Test
@@ -1168,54 +1097,50 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
         // single batch. A single flyweight would be clobbered by the second call,
         // so the caller needs getStrA(current row) + getStrB(previous row) to hold
         // both bytes concurrently for the comparison.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(sym SYMBOL, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                // Expected transitions in designated-ts order:
-                //   A,A,B,B,B,C,A -> A->B at idx 2, B->C at idx 5, C->A at idx 6 = 3 transitions
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            ('A', 1::TIMESTAMP),
-                            ('A', 2::TIMESTAMP),
-                            ('B', 3::TIMESTAMP),
-                            ('B', 4::TIMESTAMP),
-                            ('B', 5::TIMESTAMP),
-                            ('C', 6::TIMESTAMP),
-                            ('A', 7::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(sym SYMBOL, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        // Expected transitions in designated-ts order:
+        //   A,A,B,B,B,C,A -> A->B at idx 2, B->C at idx 5, C->A at idx 6 = 3 transitions
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    ('A', 1::TIMESTAMP),
+                    ('A', 2::TIMESTAMP),
+                    ('B', 3::TIMESTAMP),
+                    ('B', 4::TIMESTAMP),
+                    ('B', 5::TIMESTAMP),
+                    ('C', 6::TIMESTAMP),
+                    ('A', 7::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final int[] transitions = {0};
-                final int[] rowsSeen = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT sym FROM t ORDER BY part_ts", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            int n = batch.getRowCount();
-                            for (int r = 1; r < n; r++) {
-                                Utf8Sequence cur = batch.getStrA(0, r);
-                                Utf8Sequence prev = batch.getStrB(0, r - 1);
-                                if (!Utf8s.equals(prev, cur)) transitions[0]++;
-                            }
-                            rowsSeen[0] += n;
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final int[] transitions = {0};
+        final int[] rowsSeen = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT sym FROM t ORDER BY part_ts", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    int n = batch.getRowCount();
+                    for (int r = 1; r < n; r++) {
+                        Utf8Sequence cur = batch.getStrA(0, r);
+                        Utf8Sequence prev = batch.getStrB(0, r - 1);
+                        if (!Utf8s.equals(prev, cur)) transitions[0]++;
+                    }
+                    rowsSeen[0] += n;
                 }
-                Assert.assertEquals(7, rowsSeen[0]);
-                Assert.assertEquals(3, transitions[0]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(7, rowsSeen[0]);
+        Assert.assertEquals(3, transitions[0]);
     }
 
     @Test
@@ -1223,118 +1148,110 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
         // Exercises the zero-allocation getString(col, row, CharSink) overload on
         // both Utf16Sink (transcodes to UTF-16) and Utf8Sink (pass-through).
         // Multi-byte UTF-8 input catches any single-byte-only transcoding bug.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(s STRING, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            ('hello',       1::TIMESTAMP),
-                            ('héllo wörld', 2::TIMESTAMP),
-                            (NULL,          3::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(s STRING, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    ('hello',       1::TIMESTAMP),
+                    ('héllo wörld', 2::TIMESTAMP),
+                    (NULL,          3::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final List<String> utf16Values = new ArrayList<>();
-                final List<byte[]> utf8Values = new ArrayList<>();
-                final boolean[] nullWrite = new boolean[3];
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT s FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            StringSink utf16 = new StringSink();
-                            Utf8StringSink utf8 = new Utf8StringSink();
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                utf16.clear();
-                                utf8.clear();
-                                boolean wrote16 = batch.getString(0, r, utf16);
-                                boolean wrote8 = batch.getString(0, r, utf8);
-                                // Must agree on null vs non-null
-                                Assert.assertEquals("utf16 vs utf8 null agreement at row " + r, wrote16, wrote8);
-                                if (wrote16) {
-                                    utf16Values.add(utf16.toString());
-                                    byte[] bytes = new byte[utf8.size()];
-                                    for (int i = 0; i < utf8.size(); i++) bytes[i] = utf8.byteAt(i);
-                                    utf8Values.add(bytes);
-                                } else {
-                                    utf16Values.add(null);
-                                    utf8Values.add(null);
-                                    nullWrite[r] = true;
-                                }
-                            }
+        final List<String> utf16Values = new ArrayList<>();
+        final List<byte[]> utf8Values = new ArrayList<>();
+        final boolean[] nullWrite = new boolean[3];
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT s FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    StringSink utf16 = new StringSink();
+                    Utf8StringSink utf8 = new Utf8StringSink();
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        utf16.clear();
+                        utf8.clear();
+                        boolean wrote16 = batch.getString(0, r, utf16);
+                        boolean wrote8 = batch.getString(0, r, utf8);
+                        // Must agree on null vs non-null
+                        Assert.assertEquals("utf16 vs utf8 null agreement at row " + r, wrote16, wrote8);
+                        if (wrote16) {
+                            utf16Values.add(utf16.toString());
+                            byte[] bytes = new byte[utf8.size()];
+                            for (int i = 0; i < utf8.size(); i++) bytes[i] = utf8.byteAt(i);
+                            utf8Values.add(bytes);
+                        } else {
+                            utf16Values.add(null);
+                            utf8Values.add(null);
+                            nullWrite[r] = true;
                         }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+                    }
                 }
-                Assert.assertEquals("hello", utf16Values.get(0));
-                Assert.assertEquals("héllo wörld", utf16Values.get(1));
-                Assert.assertNull(utf16Values.get(2));
-                Assert.assertArrayEquals("hello".getBytes(java.nio.charset.StandardCharsets.UTF_8), utf8Values.get(0));
-                Assert.assertArrayEquals("héllo wörld".getBytes(java.nio.charset.StandardCharsets.UTF_8), utf8Values.get(1));
-                Assert.assertNull(utf8Values.get(2));
-                Assert.assertTrue(nullWrite[2]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals("hello", utf16Values.get(0));
+        Assert.assertEquals("héllo wörld", utf16Values.get(1));
+        Assert.assertNull(utf16Values.get(2));
+        Assert.assertArrayEquals("hello".getBytes(java.nio.charset.StandardCharsets.UTF_8), utf8Values.get(0));
+        Assert.assertArrayEquals("héllo wörld".getBytes(java.nio.charset.StandardCharsets.UTF_8), utf8Values.get(1));
+        Assert.assertNull(utf8Values.get(2));
+        Assert.assertTrue(nullWrite[2]);
     }
 
     @Test
     public void testSymbol() throws Exception {
         // SYMBOL: dict dedup (repeated value -> same dict entry), NULL, empty string, multiple unique.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(s SYMBOL, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("INSERT INTO t VALUES ('A', 1::TIMESTAMP), ('B', 2::TIMESTAMP), "
-                        + "('A', 3::TIMESTAMP), ('B', 4::TIMESTAMP), ('', 5::TIMESTAMP), "
-                        + "('A', 6::TIMESTAMP), (NULL, 7::TIMESTAMP)");
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(s SYMBOL, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("INSERT INTO t VALUES ('A', 1::TIMESTAMP), ('B', 2::TIMESTAMP), "
+                + "('A', 3::TIMESTAMP), ('B', 4::TIMESTAMP), ('', 5::TIMESTAMP), "
+                + "('A', 6::TIMESTAMP), (NULL, 7::TIMESTAMP)");
+        serverMain.awaitTable("t");
 
-                final List<String> values = new ArrayList<>();
-                final byte[] wireType = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT s FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                values.add(batch.isNull(0, r) ? null : batch.getString(0, r));
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final List<String> values = new ArrayList<>();
+        final byte[] wireType = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT s FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        values.add(batch.isNull(0, r) ? null : batch.getString(0, r));
+                    }
                 }
-                Assert.assertEquals(QwpConstants.TYPE_SYMBOL, wireType[0]);
-                // QuestDB SYMBOL keeps '' and NULL distinct: '' is a valid zero-length
-                // symbol value, NULL is carried through the null bitmap. Assert the full
-                // seven rows.
-                Assert.assertEquals(7, values.size());
-                Assert.assertEquals("A", values.get(0));
-                Assert.assertEquals("B", values.get(1));
-                Assert.assertEquals("A", values.get(2));
-                Assert.assertEquals("B", values.get(3));
-                Assert.assertEquals("'' SYMBOL must surface as empty string, not null", "", values.get(4));
-                Assert.assertEquals("A", values.get(5));
-                Assert.assertNull("NULL SYMBOL must surface as null", values.get(6));
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(QwpConstants.TYPE_SYMBOL, wireType[0]);
+        // QuestDB SYMBOL keeps '' and NULL distinct: '' is a valid zero-length
+        // symbol value, NULL is carried through the null bitmap. Assert the full
+        // seven rows.
+        Assert.assertEquals(7, values.size());
+        Assert.assertEquals("A", values.get(0));
+        Assert.assertEquals("B", values.get(1));
+        Assert.assertEquals("A", values.get(2));
+        Assert.assertEquals("B", values.get(3));
+        Assert.assertEquals("'' SYMBOL must surface as empty string, not null", "", values.get(4));
+        Assert.assertEquals("A", values.get(5));
+        Assert.assertNull("NULL SYMBOL must surface as null", values.get(6));
     }
 
     @Test
@@ -1343,80 +1260,76 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
         // distinct symbols returns K String instances, not N. Also exercises
         // the id-based API (getSymbolId / getSymbolForId / getSymbolDictSize)
         // and verifies getString shares the same cache.
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(sym SYMBOL, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                // 3 distinct symbols repeated across 6 rows + 1 NULL.
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            ('AAPL', 1::TIMESTAMP),
-                            ('MSFT', 2::TIMESTAMP),
-                            ('AAPL', 3::TIMESTAMP),
-                            ('GOOG', 4::TIMESTAMP),
-                            ('MSFT', 5::TIMESTAMP),
-                            ('AAPL', 6::TIMESTAMP),
-                            (NULL,   7::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(sym SYMBOL, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        // 3 distinct symbols repeated across 6 rows + 1 NULL.
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    ('AAPL', 1::TIMESTAMP),
+                    ('MSFT', 2::TIMESTAMP),
+                    ('AAPL', 3::TIMESTAMP),
+                    ('GOOG', 4::TIMESTAMP),
+                    ('MSFT', 5::TIMESTAMP),
+                    ('AAPL', 6::TIMESTAMP),
+                    (NULL,   7::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final int[] dictSize = {-1};
-                final int[] rowIds = new int[7];
-                final String[] viaGetSymbol = new String[7];
-                final String[] viaGetString = new String[7];
-                final java.util.IdentityHashMap<String, Boolean> distinctInstances = new java.util.IdentityHashMap<>();
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT sym FROM t ORDER BY part_ts", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            dictSize[0] = batch.getSymbolDictSize(0);
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                rowIds[r] = batch.getSymbolId(0, r);
-                                viaGetSymbol[r] = batch.getSymbol(0, r);
-                                viaGetString[r] = batch.getString(0, r);
-                                if (viaGetSymbol[r] != null) distinctInstances.put(viaGetSymbol[r], Boolean.TRUE);
-                            }
-                            // getSymbolForId must resolve to the same cached instance as getSymbol(col, row).
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                if (rowIds[r] < 0) continue;
-                                Assert.assertSame("getSymbolForId must hit the per-dict cache",
-                                        viaGetSymbol[r], batch.getSymbolForId(0, rowIds[r]));
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final int[] dictSize = {-1};
+        final int[] rowIds = new int[7];
+        final String[] viaGetSymbol = new String[7];
+        final String[] viaGetString = new String[7];
+        final java.util.IdentityHashMap<String, Boolean> distinctInstances = new java.util.IdentityHashMap<>();
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT sym FROM t ORDER BY part_ts", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    dictSize[0] = batch.getSymbolDictSize(0);
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        rowIds[r] = batch.getSymbolId(0, r);
+                        viaGetSymbol[r] = batch.getSymbol(0, r);
+                        viaGetString[r] = batch.getString(0, r);
+                        if (viaGetSymbol[r] != null) distinctInstances.put(viaGetSymbol[r], Boolean.TRUE);
+                    }
+                    // getSymbolForId must resolve to the same cached instance as getSymbol(col, row).
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        if (rowIds[r] < 0) continue;
+                        Assert.assertSame("getSymbolForId must hit the per-dict cache",
+                                viaGetSymbol[r], batch.getSymbolForId(0, rowIds[r]));
+                    }
                 }
-                Assert.assertEquals(3, dictSize[0]);
-                Assert.assertEquals("AAPL", viaGetSymbol[0]);
-                Assert.assertEquals("MSFT", viaGetSymbol[1]);
-                Assert.assertEquals("AAPL", viaGetSymbol[2]);
-                Assert.assertEquals("GOOG", viaGetSymbol[3]);
-                Assert.assertEquals("MSFT", viaGetSymbol[4]);
-                Assert.assertEquals("AAPL", viaGetSymbol[5]);
-                Assert.assertNull(viaGetSymbol[6]);
-                Assert.assertEquals(-1, rowIds[6]);
-                // Identity: every row sharing a dict entry returns the SAME String instance.
-                Assert.assertSame("rows 0/2/5 share dict entry for 'AAPL'", viaGetSymbol[0], viaGetSymbol[2]);
-                Assert.assertSame(viaGetSymbol[0], viaGetSymbol[5]);
-                Assert.assertSame("rows 1/4 share dict entry for 'MSFT'", viaGetSymbol[1], viaGetSymbol[4]);
-                // getString on a SYMBOL column must hit the same cache as getSymbol.
-                for (int r = 0; r < 6; r++) {
-                    Assert.assertSame("getString must delegate to symbol cache at row " + r,
-                            viaGetSymbol[r], viaGetString[r]);
+
+                @Override
+                public void onEnd(long totalRows) {
                 }
-                // 6 non-null rows, 3 distinct dict entries, 3 cached String instances.
-                Assert.assertEquals(3, distinctInstances.size());
-            }
-        });
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(3, dictSize[0]);
+        Assert.assertEquals("AAPL", viaGetSymbol[0]);
+        Assert.assertEquals("MSFT", viaGetSymbol[1]);
+        Assert.assertEquals("AAPL", viaGetSymbol[2]);
+        Assert.assertEquals("GOOG", viaGetSymbol[3]);
+        Assert.assertEquals("MSFT", viaGetSymbol[4]);
+        Assert.assertEquals("AAPL", viaGetSymbol[5]);
+        Assert.assertNull(viaGetSymbol[6]);
+        Assert.assertEquals(-1, rowIds[6]);
+        // Identity: every row sharing a dict entry returns the SAME String instance.
+        Assert.assertSame("rows 0/2/5 share dict entry for 'AAPL'", viaGetSymbol[0], viaGetSymbol[2]);
+        Assert.assertSame(viaGetSymbol[0], viaGetSymbol[5]);
+        Assert.assertSame("rows 1/4 share dict entry for 'MSFT'", viaGetSymbol[1], viaGetSymbol[4]);
+        // getString on a SYMBOL column must hit the same cache as getSymbol.
+        for (int r = 0; r < 6; r++) {
+            Assert.assertSame("getString must delegate to symbol cache at row " + r,
+                    viaGetSymbol[r], viaGetString[r]);
+        }
+        // 6 non-null rows, 3 distinct dict entries, 3 cached String instances.
+        Assert.assertEquals(3, distinctInstances.size());
     }
 
     @Test
@@ -1449,101 +1362,93 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
 
     @Test
     public void testTimestampNanos() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(ts TIMESTAMP_NS) TIMESTAMP(ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            ('2024-01-01T00:00:00.000000001Z'),
-                            ('2024-01-01T00:00:00.000000002Z'),
-                            ('2024-01-01T00:00:00.000000999Z')
-                        """);
-                serverMain.awaitTxn("t", 1);
+        serverMain.execute("CREATE TABLE t(ts TIMESTAMP_NS) TIMESTAMP(ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    ('2024-01-01T00:00:00.000000001Z'),
+                    ('2024-01-01T00:00:00.000000002Z'),
+                    ('2024-01-01T00:00:00.000000999Z')
+                """);
+        serverMain.awaitTxn("t", 1);
 
-                final LongList values = new LongList();
-                final byte[] wireType = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT ts FROM t ORDER BY ts", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            for (int r = 0; r < batch.getRowCount(); r++) values.add(batch.getLongValue(0, r));
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final LongList values = new LongList();
+        final byte[] wireType = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT ts FROM t ORDER BY ts", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    for (int r = 0; r < batch.getRowCount(); r++) values.add(batch.getLongValue(0, r));
                 }
-                Assert.assertEquals(QwpConstants.TYPE_TIMESTAMP_NANOS, wireType[0]);
-                Assert.assertEquals(3, values.size());
-                Assert.assertEquals(1L, values.getQuick(1) - values.getQuick(0));
-                Assert.assertEquals(997L, values.getQuick(2) - values.getQuick(1));
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(QwpConstants.TYPE_TIMESTAMP_NANOS, wireType[0]);
+        Assert.assertEquals(3, values.size());
+        Assert.assertEquals(1L, values.getQuick(1) - values.getQuick(0));
+        Assert.assertEquals(997L, values.getQuick(2) - values.getQuick(1));
     }
 
     @Test
     public void testUuid() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(u UUID, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            ('00000000-0000-0000-0000-000000000000', 1::TIMESTAMP),
-                            ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 2::TIMESTAMP),
-                            ('ffffffff-ffff-ffff-ffff-fffffffffffe', 3::TIMESTAMP),
-                            (CAST(NULL AS UUID),                     4::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(u UUID, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    ('00000000-0000-0000-0000-000000000000', 1::TIMESTAMP),
+                    ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 2::TIMESTAMP),
+                    ('ffffffff-ffff-ffff-ffff-fffffffffffe', 3::TIMESTAMP),
+                    (CAST(NULL AS UUID),                     4::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final List<long[]> values = new ArrayList<>();
-                final byte[] wireType = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT u FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                if (batch.isNull(0, r)) {
-                                    values.add(null);
-                                } else {
-                                    values.add(new long[]{batch.getUuidLo(0, r), batch.getUuidHi(0, r)});
-                                }
-                            }
+        final List<long[]> values = new ArrayList<>();
+        final byte[] wireType = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT u FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        if (batch.isNull(0, r)) {
+                            values.add(null);
+                        } else {
+                            values.add(new long[]{batch.getUuidLo(0, r), batch.getUuidHi(0, r)});
                         }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+                    }
                 }
-                Assert.assertEquals(QwpConstants.TYPE_UUID, wireType[0]);
-                // 00000000-...0 = both halves zero (this *is* the all-zeros UUID, treated as non-null
-                // because QuestDB UUID NULL is both halves Long.MIN_VALUE, not zero).
-                Assert.assertNotNull(values.getFirst());
-                Assert.assertEquals(0L, values.get(0)[0]);
-                Assert.assertEquals(0L, values.get(0)[1]);
-                // mid-range UUID
-                Assert.assertNotNull(values.get(1));
-                // ffff...fe (avoid exact ffff...ff which might overlap with sentinel)
-                Assert.assertNotNull(values.get(2));
-                Assert.assertNull(values.get(3));
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(QwpConstants.TYPE_UUID, wireType[0]);
+        // 00000000-...0 = both halves zero (this *is* the all-zeros UUID, treated as non-null
+        // because QuestDB UUID NULL is both halves Long.MIN_VALUE, not zero).
+        Assert.assertNotNull(values.getFirst());
+        Assert.assertEquals(0L, values.get(0)[0]);
+        Assert.assertEquals(0L, values.get(0)[1]);
+        // mid-range UUID
+        Assert.assertNotNull(values.get(1));
+        // ffff...fe (avoid exact ffff...ff which might overlap with sentinel)
+        Assert.assertNotNull(values.get(2));
+        Assert.assertNull(values.get(3));
     }
 
     @Test
@@ -1551,104 +1456,96 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
         // Same data as testUuid, but read via the single-call Uuid sink API.
         // Pins that getUuid returns false for NULL rows and leaves the sink
         // untouched (the caller's previous value stays intact).
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(u UUID, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 1::TIMESTAMP),
-                            (CAST(NULL AS UUID),                     2::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(u UUID, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 1::TIMESTAMP),
+                    (CAST(NULL AS UUID),                     2::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final long[] loSeen = new long[2];
-                final long[] hiSeen = new long[2];
-                final boolean[] hits = new boolean[2];
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT u FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            Uuid sink = new Uuid();
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                // Re-seed with a sentinel before every call so "untouched on NULL"
-                                // is detectable independently of the previous row's contents.
-                                sink.setAll(0xDEADBEEFL, 0xCAFEBABEL);
-                                hits[r] = batch.getUuid(0, r, sink);
-                                loSeen[r] = sink.getLo();
-                                hiSeen[r] = sink.getHi();
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final long[] loSeen = new long[2];
+        final long[] hiSeen = new long[2];
+        final boolean[] hits = new boolean[2];
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT u FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    Uuid sink = new Uuid();
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        // Re-seed with a sentinel before every call so "untouched on NULL"
+                        // is detectable independently of the previous row's contents.
+                        sink.setAll(0xDEADBEEFL, 0xCAFEBABEL);
+                        hits[r] = batch.getUuid(0, r, sink);
+                        loSeen[r] = sink.getLo();
+                        hiSeen[r] = sink.getHi();
+                    }
                 }
-                Assert.assertTrue(hits[0]);
-                // Cross-check against the part-wise accessors via parsed literal:
-                // 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' -> hi=0xa0eebc999c0b4ef8, lo=0xbb6d6bb9bd380a11
-                Assert.assertEquals(0xa0eebc999c0b4ef8L, hiSeen[0]);
-                Assert.assertEquals(0xbb6d6bb9bd380a11L, loSeen[0]);
-                // NULL row: sink untouched, still holds the pre-seed values.
-                Assert.assertFalse("getUuid must return false for NULL row", hits[1]);
-                Assert.assertEquals(0xDEADBEEFL, loSeen[1]);
-                Assert.assertEquals(0xCAFEBABEL, hiSeen[1]);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertTrue(hits[0]);
+        // Cross-check against the part-wise accessors via parsed literal:
+        // 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11' -> hi=0xa0eebc999c0b4ef8, lo=0xbb6d6bb9bd380a11
+        Assert.assertEquals(0xa0eebc999c0b4ef8L, hiSeen[0]);
+        Assert.assertEquals(0xbb6d6bb9bd380a11L, loSeen[0]);
+        // NULL row: sink untouched, still holds the pre-seed values.
+        Assert.assertFalse("getUuid must return false for NULL row", hits[1]);
+        Assert.assertEquals(0xDEADBEEFL, loSeen[1]);
+        Assert.assertEquals(0xCAFEBABEL, hiSeen[1]);
     }
 
     @Test
     public void testVarchar() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute("CREATE TABLE t(v VARCHAR, part_ts TIMESTAMP) "
-                        + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
-                serverMain.execute("""
-                        INSERT INTO t VALUES
-                            ('',     1::TIMESTAMP),
-                            ('plain', 2::TIMESTAMP),
-                            ('héllo', 3::TIMESTAMP),
-                            (NULL,   4::TIMESTAMP)
-                        """);
-                serverMain.awaitTable("t");
+        serverMain.execute("CREATE TABLE t(v VARCHAR, part_ts TIMESTAMP) "
+                + "TIMESTAMP(part_ts) PARTITION BY DAY WAL");
+        serverMain.execute("""
+                INSERT INTO t VALUES
+                    ('',     1::TIMESTAMP),
+                    ('plain', 2::TIMESTAMP),
+                    ('héllo', 3::TIMESTAMP),
+                    (NULL,   4::TIMESTAMP)
+                """);
+        serverMain.awaitTable("t");
 
-                final List<String> values = new ArrayList<>();
-                final byte[] wireType = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    client.execute("SELECT v FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                values.add(batch.getString(0, r));
-                            }
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail(message);
-                        }
-                    });
+        final List<String> values = new ArrayList<>();
+        final byte[] wireType = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            client.execute("SELECT v FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    for (int r = 0; r < batch.getRowCount(); r++) {
+                        values.add(batch.getString(0, r));
+                    }
                 }
-                Assert.assertEquals(QwpConstants.TYPE_VARCHAR, wireType[0]);
-                Assert.assertEquals("", values.get(0));
-                Assert.assertEquals("plain", values.get(1));
-                Assert.assertEquals("héllo", values.get(2));
-                Assert.assertNull(values.get(3));
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        Assert.assertEquals(QwpConstants.TYPE_VARCHAR, wireType[0]);
+        Assert.assertEquals("", values.get(0));
+        Assert.assertEquals("plain", values.get(1));
+        Assert.assertEquals("héllo", values.get(2));
+        Assert.assertNull(values.get(3));
     }
 
     /**
@@ -1713,40 +1610,36 @@ public class QwpEgressTypesExhaustiveTest extends AbstractBootstrapTest {
             RowExtractor rowExtractor,
             Asserter asserter
     ) throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain serverMain = startWithEnvVariables()) {
-                serverMain.execute(walifyCreate(createSql));
-                serverMain.execute(walifyValuesInsert(insertSql));
-                serverMain.awaitTable("t");
+        serverMain.execute(walifyCreate(createSql));
+        serverMain.execute(walifyValuesInsert(insertSql));
+        serverMain.awaitTable("t");
 
-                final List<Object> rows = new ArrayList<>();
-                final byte[] wireType = {0};
-                try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
-                    client.connect();
-                    // Explicit column projection over SELECT * so the part_ts column added
-                    // by walifyCreate stays hidden from the test's row extractor.
-                    client.execute("SELECT " + extractColumnNames(createSql) + " FROM t", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            wireType[0] = batch.getColumnWireType(0);
-                            rowExtractor.extract(batch, rows);
-                        }
-
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
-
-                        @Override
-                        public void onError(byte status, String message) {
-                            Assert.fail("egress query error: " + message);
-                        }
-                    });
+        final List<Object> rows = new ArrayList<>();
+        final byte[] wireType = {0};
+        try (QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";")) {
+            client.connect();
+            // Explicit column projection over SELECT * so the part_ts column added
+            // by walifyCreate stays hidden from the test's row extractor.
+            client.execute("SELECT " + extractColumnNames(createSql) + " FROM t", new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    wireType[0] = batch.getColumnWireType(0);
+                    rowExtractor.extract(batch, rows);
                 }
-                Assert.assertEquals("wire type code", expectedWireType, wireType[0]);
-                Assert.assertEquals("row count", expectedRowCount, rows.size());
-                asserter.run(rows);
-            }
-        });
+
+                @Override
+                public void onEnd(long totalRows) {
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail("egress query error: " + message);
+                }
+            });
+        }
+        Assert.assertEquals("wire type code", expectedWireType, wireType[0]);
+        Assert.assertEquals("row count", expectedRowCount, rows.size());
+        asserter.run(rows);
     }
 
     /**

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFuzzTest.java
@@ -189,7 +189,7 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
     @Test
     public void testAddColumns() throws Exception {
         initLoadParameters(15 + random.nextInt(100), 5 + random.nextInt(5),
-                2 + random.nextInt(Os.isWindows() ? 5 : 20), 1 + random.nextInt(4),
+                2 + random.nextInt(Os.isLinux() ? 8 : 3), 1 + random.nextInt(4),
                 random.nextInt(75));
         initFuzzParameters(-1, 1, 1 + random.nextInt(3), 6, false, true, false, 0.1);
         runTest();
@@ -211,49 +211,49 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
 
     @Test
     public void testAllMixed() throws Exception {
-        initLoadParameters(50, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(50, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(3, 4, 5, 10, 5, true, true, true, 0.05);
         runTest();
     }
 
     @Test
     public void testAllMixedNoSymbols() throws Exception {
-        initLoadParameters(50, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(50, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(3, 4, 5, 10, 5, true, false, true, 0.05);
         runTest();
     }
 
     @Test
     public void testAllMixedSingleTable() throws Exception {
-        initLoadParameters(50, Os.isWindows() ? 3 : 5, 5, 1, 50);
+        initLoadParameters(50, Os.isLinux() ? 5 : 3, 5, 1, 50);
         initFuzzParameters(3, 4, 5, 10, 5, true, true, true, 0.05);
         runTest();
     }
 
     @Test
     public void testAllMixedSplitPart() throws Exception {
-        initLoadParameters(50, Os.isWindows() ? 3 : 5, 5, 1, 50);
+        initLoadParameters(50, Os.isLinux() ? 5 : 3, 5, 1, 50);
         initFuzzParameters(-1, -1, -1, 10, -1, false, true, false, 0.05);
         runTest();
     }
 
     @Test
     public void testCaseVariationReorderingColumns() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, -1, 2, -1, true, true, false);
         runTest();
     }
 
     @Test
     public void testCaseVariationReorderingColumnsNoSymbols() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, -1, -1, -1, true, false, false);
         runTest();
     }
 
     @Test
     public void testCaseVariationReorderingColumnsSendSymbolsWithSpace() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, -1, 3, -1, true, true, true);
         // Same wide-batch-vs-default-recv-buffer issue as testLoadSendSymbolsWithSpace.
         clientAutoFlushRows = 5;
@@ -262,47 +262,47 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
 
     @Test
     public void testDuplicatesReorderingColumns() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, 4, -1, -1, -1, true, true, false, 0.05);
         runTest();
     }
 
     @Test
     public void testDuplicatesReorderingColumnsNoSymbols() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, 4, -1, -1, -1, true, false, false, 0.05);
         runTest();
     }
 
     @Test
     public void testDuplicatesReorderingColumnsSendSymbolsWithSpace() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, 4, -1, -1, -1, true, true, true, 0.05);
         runTest();
     }
 
     @Test
     public void testLoad() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 7, 12, 20);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 7, 12, 20);
         runTest();
     }
 
     @Test
     public void testLoadLargePayload() throws Exception {
-        initLoadParameters(500, Os.isWindows() ? 3 : 5, 5, 5, 10);
+        initLoadParameters(500, Os.isLinux() ? 5 : 3, 5, 5, 10);
         runTest();
     }
 
     @Test
     public void testLoadNoSymbols() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 7, 12, 20);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 7, 12, 20);
         initFuzzParameters(-1, -1, -1, 5, true, false, false, 0.05);
         runTest();
     }
 
     @Test
     public void testLoadSendSymbolsWithSpace() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 4, 8, 20);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 4, 8, 20);
         initFuzzParameters(-1, -1, 2, -1, false, true, true);
         // Frequent new-column injection (newColumnFactor=2) plus 8
         // interleaved tables and symbols with embedded spaces inflates
@@ -321,34 +321,34 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
         // interleaved per batch and full schema headers, ~3 rows yields
         // a wire frame around 1KB, comfortably under 2048.
         clientAutoFlushRows = 3;
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 20);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 20);
         runTest();
     }
 
     @Test
     public void testNonAsciiValues() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(-1, -1, 3, 4, false, true, false);
         runTest();
     }
 
     @Test
     public void testNonAsciiValuesNoSymbols() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(-1, -1, -1, 4, false, false, false);
         runTest();
     }
 
     @Test
     public void testReorderingColumns() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, -1, -1, 8, false, true, true, 0.05);
         runTest();
     }
 
     @Test
     public void testReorderingColumnsNoSymbols() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, -1, -1, -1, true, false, false, 0.05);
         runTest();
     }
@@ -356,7 +356,7 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
     @Test
     public void testReorderingManyThreads() throws Exception {
         initLoadParameters(15 + random.nextInt(100), 5 + random.nextInt(5),
-                2 + random.nextInt(Os.isWindows() ? 5 : 20), 1 + random.nextInt(4),
+                2 + random.nextInt(Os.isLinux() ? 8 : 3), 1 + random.nextInt(4),
                 random.nextInt(75));
         initFuzzParameters(3, -1, 1 + random.nextInt(3), -1, false, true, false);
         runTest();
@@ -364,35 +364,35 @@ public class QwpSenderFuzzTest extends AbstractQwpWebSocketTest {
 
     @Test
     public void testReorderingNonAscii() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, -1, 2, 4, false, true, false);
         runTest();
     }
 
     @Test
     public void testReorderingSkipColumnsWithNonAscii() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, 4, 2, 4, true, true, false);
         runTest();
     }
 
     @Test
     public void testReorderingSkipColumnsWithNonAsciiNoSymbols() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, 4, -1, 4, true, false, false);
         runTest();
     }
 
     @Test
     public void testReorderingSkipDuplicateColumnsWithNonAscii() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, 4, 4, -1, 4, true, true, false, 0.05);
         runTest();
     }
 
     @Test
     public void testReorderingSkipDuplicateColumnsWithNonAsciiNoSymbols() throws Exception {
-        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initLoadParameters(100, Os.isLinux() ? 5 : 3, 5, 5, 50);
         initFuzzParameters(4, 4, 4, -1, 4, true, false, false, 0.05);
         runTest();
     }

--- a/core/src/test/java/io/questdb/test/cutlass/text/ParallelCsvFileImporterTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/text/ParallelCsvFileImporterTest.java
@@ -61,6 +61,7 @@ import io.questdb.std.LongList;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
 import io.questdb.std.ObjList;
+import io.questdb.std.Os;
 import io.questdb.std.Rnd;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
@@ -2759,6 +2760,10 @@ public class ParallelCsvFileImporterTest extends AbstractCairoTest {
 
         for (int workers = 2; workers < 3; workers++) {
             for (int queueSize = 1; queueSize < 9; queueSize <<= 1) {
+                // Only the extreme queue sizes (serialized vs. full parallelism) on slow CI runners.
+                if (!Os.isLinux() && queueSize != 1 && queueSize != 8) {
+                    continue;
+                }
                 LOG.info().$("run [no=").$(run++).$(",workers=").$(workers).$(",queueSize=").$(queueSize).I$();
 
                 int workerCount = workers;

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -1078,12 +1078,15 @@ public class CheckpointTest extends AbstractCairoTest {
             setProperty(PropertyKey.CAIRO_LEGACY_SNAPSHOT_INSTANCE_ID, snapshotId);
 
             final String tableName = getTestTableName();
+            // Fewer day partitions on slow CI runners; the index-rebuild assertions are computed
+            // from the data, so they hold at any size.
+            final int rowCount = Os.isLinux() ? 500 : 100;
             // Create table without indexed columns initially
             execute(
                     "create table " + tableName + " as (" +
                             "select x, " +
                             "timestamp_sequence(0, 100000000000) ts " +
-                            "from long_sequence(500)" +
+                            "from long_sequence(" + rowCount + ")" +
                             ") timestamp(ts) PARTITION BY DAY"
             );
 
@@ -1098,7 +1101,7 @@ public class CheckpointTest extends AbstractCairoTest {
                             "timestamp_sequence(50000000000000, 100000000000) ts, " +
                             "rnd_symbol('A','B','C') sym1, " +
                             "rnd_symbol('X','Y','Z') sym2 " +
-                            "from long_sequence(500)"
+                            "from long_sequence(" + rowCount + ")"
             );
 
             // Query using indexes before checkpoint to get expected counts
@@ -1189,13 +1192,16 @@ public class CheckpointTest extends AbstractCairoTest {
             setProperty(PropertyKey.CAIRO_LEGACY_SNAPSHOT_INSTANCE_ID, snapshotId);
 
             final String tableName = getTestTableName();
+            // Fewer day partitions on slow CI runners (each row lands in its own daily partition);
+            // the index-rebuild assertions are computed from the data, so they hold at any size.
+            final int rowCount = Os.isLinux() ? 1000 : 200;
             execute(
                     "create table " + tableName + " as (" +
                             "select rnd_symbol('A','B','C') sym1, " +
                             "rnd_symbol('X','Y','Z') sym2, " +
                             "x, " +
                             "timestamp_sequence(0, 100000000000) ts " +
-                            "from long_sequence(1000)" +
+                            "from long_sequence(" + rowCount + ")" +
                             "), index(sym1), index(sym2) timestamp(ts) PARTITION BY DAY"
             );
 
@@ -1217,7 +1223,7 @@ public class CheckpointTest extends AbstractCairoTest {
                             "rnd_symbol('X','Y','Z') sym2, " +
                             "x + 1000, " +
                             "timestamp_sequence(100000000000000, 100000000000) ts " +
-                            "from long_sequence(500)"
+                            "from long_sequence(" + (rowCount / 2) + ")"
             );
 
             // Release all readers and writers, but keep the snapshot dir around.
@@ -2822,7 +2828,8 @@ public class CheckpointTest extends AbstractCairoTest {
 
     @Test
     public void testRecoverCheckpointLargePartitionCount() throws Exception {
-        final int partitionCount = 2000;
+        // Fewer partitions on slow CI runners; still large enough to exercise the recovery path.
+        final int partitionCount = Os.isLinux() ? 2000 : 400;
         final String snapshotId = "id1";
         final String restartedId = "id2";
         assertMemoryLeak(() -> {

--- a/core/src/test/java/io/questdb/test/griffin/ParquetLateMaterializationFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParquetLateMaterializationFuzzTest.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.mp.WorkerPool;
+import io.questdb.std.Os;
 import io.questdb.std.Rnd;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractCairoTest;
@@ -736,6 +737,9 @@ public class ParquetLateMaterializationFuzzTest extends AbstractCairoTest {
     }
 
     private void testLateMaterializationAllTypesLowSelectivity(CharSequence query, boolean checkStrLen, boolean checkVarcharLen) throws Exception {
+        // Smaller table on slow CI runners; expected is computed from the same data pre-conversion,
+        // so the assertion holds at any size.
+        final int rowCount = Os.isLinux() ? 2000 : 500;
         WorkerPool pool = new WorkerPool(() -> 4);
         TestUtils.execute(
                 pool,
@@ -773,8 +777,7 @@ public class ParquetLateMaterializationFuzzTest extends AbstractCairoTest {
                                         rnd_decimal(76, 10, 0) a_decimal256,
                                         cast(timestamp_sequence(0,1000000) as date) a_date,
                                         timestamp_sequence(0, 60000000) as ts
-                                      from long_sequence(2000)
-                                    ) timestamp(ts) partition by day;""",
+                                      from long_sequence(""" + rowCount + ")) timestamp(ts) partition by day;",
                             sqlExecutionContext
                     );
 

--- a/core/src/test/java/io/questdb/test/std/ParseNanosFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/std/ParseNanosFuzzTest.java
@@ -30,13 +30,9 @@ import io.questdb.std.Rnd;
 import io.questdb.std.str.StringSink;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
-import java.util.Collection;
 
-@RunWith(Parameterized.class)
 public class ParseNanosFuzzTest {
     private static final char[] INVALID_CHARS = "abcdefgijklopqrtwxyz#$%^&*()+={}[]|\\:;\"'<>,.?/".toCharArray();
     private static final String[] INVALID_UNITS = {"d", "y", "w", "mo", "yr", "sec", "min", "hour", "HMS", "MSC"};
@@ -56,42 +52,21 @@ public class ParseNanosFuzzTest {
             3_600_000_000_000L    // hours
     };
     private static final Rnd rnd = new Rnd();
-    private final boolean expectError;
-    private final long expected;
-    private final String input;
-
-    public ParseNanosFuzzTest(String input, long expected, boolean expectError) {
-        this.input = input;
-        this.expected = expected;
-        this.expectError = expectError;
-    }
-
-    // Define the test data
-    @Parameterized.Parameters(name = "{0}")  // {0} refers to the first parameter (testName)
-    public static Collection<Object[]> testData() {
-        ArrayList<Object[]> testData = new ArrayList<>();
-        runFuzzTests(testData);
-        return testData;
-    }
 
     @Test
-    public void test() {
-        try {
-            long result = parseMicros(input);
-
-            if (expectError) {
-                Assert.fail("Failed: Expected exception for input: " + input);
-            }
-
-            if (expected != result) {
-                Assert.fail("Failed: Input: " + input +
-                        " Expected: " + expected +
-                        " Got: " + result);
-            }
-        } catch (NumericException e) {
-            if (!expectError) {
-                Assert.fail("Failed: Unexpected exception for input: " + input);
-            }
+    public void testFuzz() {
+        // Build the full fuzz corpus once, then exercise every case in a single test method.
+        // This was previously a @Parameterized test expanding to ~15,000 cases; each case
+        // carried JUnit's per-invocation overhead (listener callbacks, a logged line, name
+        // formatting) for microseconds of parsing, which dominated the class runtime. Looping
+        // keeps identical input coverage at a fraction of the cost.
+        ArrayList<Object[]> testData = new ArrayList<>();
+        runFuzzTests(testData);
+        for (int i = 0, n = testData.size(); i < n; i++) {
+            Object[] testCase = testData.get(i);
+            // expected is boxed as Integer or Long depending on the generator; Number.longValue()
+            // mirrors the unbox-then-widen the @Parameterized constructor used to do via reflection.
+            verify((String) testCase[0], ((Number) testCase[1]).longValue(), (Boolean) testCase[2]);
         }
     }
 
@@ -605,6 +580,24 @@ public class ParseNanosFuzzTest {
     private static void testSimpleNumber(ArrayList<Object[]> testData) {
         final int value = rnd.nextInt(MAX_VALUE);
         testData.add(new Object[]{String.valueOf(value), value, false});
+    }
+
+    private static void verify(String input, long expected, boolean expectError) {
+        try {
+            long result = parseMicros(input);
+            if (expectError) {
+                Assert.fail("Failed: Expected exception for input: " + input);
+            }
+            if (expected != result) {
+                Assert.fail("Failed: Input: " + input +
+                        " Expected: " + expected +
+                        " Got: " + result);
+            }
+        } catch (NumericException e) {
+            if (!expectError) {
+                Assert.fail("Failed: Unexpected exception for input: " + input);
+            }
+        }
     }
 
     static String insertMultipleUnderscores(String number) {

--- a/core/src/test/java/io/questdb/test/std/bytes/DirectByteSinkTest.java
+++ b/core/src/test/java/io/questdb/test/std/bytes/DirectByteSinkTest.java
@@ -26,16 +26,19 @@ package io.questdb.test.std.bytes;
 
 import io.questdb.cairo.CairoException;
 import io.questdb.std.MemoryTag;
+import io.questdb.std.Os;
 import io.questdb.std.Unsafe;
 import io.questdb.std.bytes.ByteSequence;
 import io.questdb.std.bytes.DirectByteSink;
 import io.questdb.std.bytes.NativeByteSink;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.function.Supplier;
 
 public class DirectByteSinkTest {
+
     @Test
     public void testBasics() {
         final long mallocCount0 = Unsafe.getMallocCount();
@@ -166,16 +169,17 @@ public class DirectByteSinkTest {
             Assert.assertEquals((byte) 'd', sink.byteAt(3));
             Assert.assertEquals(512, sink.allocatedCapacity());
         }
-
     }
 
     @Test
     public void testOver2GiB() {
+        // The 2GiB overflow boundary this guards is platform-independent, but filling >2GB of
+        // native memory is very slow on the hosted Mac and Windows runners, so run on Linux only.
+        Assume.assumeTrue(Os.isLinux());
         try (
                 DirectByteSink oneMegChunk = new DirectByteSink(32, MemoryTag.NATIVE_DIRECT_BYTE_SINK);
                 DirectByteSink dbs = new DirectByteSink(32, MemoryTag.NATIVE_DIRECT_BYTE_SINK)
         ) {
-
             final int oneMiB = 1024 * 1024;
             for (int i = 0; i < oneMiB; i++) {
                 oneMegChunk.put((byte) '0');

--- a/core/src/test/java/io/questdb/test/std/str/Utf8sTest.java
+++ b/core/src/test/java/io/questdb/test/std/str/Utf8sTest.java
@@ -36,6 +36,7 @@ import io.questdb.std.LongList;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
+import io.questdb.std.Os;
 import io.questdb.std.Rnd;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.DirectUtf8Sequence;
@@ -51,6 +52,7 @@ import io.questdb.std.str.Utf8StringSink;
 import io.questdb.std.str.Utf8s;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -1433,6 +1435,9 @@ public class Utf8sTest {
 
     @Test
     public void testReadWriteVarcharOver2GB() {
+        // The 2GB varchar offset boundary this guards is platform-independent, but writing and
+        // reading back >2GB is very slow on the hosted Mac and Windows runners, so run on Linux only.
+        Assume.assumeTrue(Os.isLinux());
         try (
                 MemoryCARW auxMem = Vm.getCARWInstance(16 * 1024 * 1024, Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT);
                 MemoryCARW dataMem = Vm.getCARWInstance(16 * 1024 * 1024, Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)


### PR DESCRIPTION
The mac-cairo CI job has been timing out at its 60-minute cap. A small number of heavy tests dominate the runtime, and most are substantially slower on the hosted Mac and Windows runners than on Linux due to slower I/O and fewer cores.

## Observed job runtimes

Per-job wall-clock times from the `New pull request` pipeline over 183 runs between 2026-04-29 and 2026-05-20 (the state before this PR), for the hosted Mac and Windows jobs, sorted by p90:

| Job | runs | median | p90 | max | cap timeouts |
|-----|-----:|-------:|----:|----:|-------------:|
| mac-cairo | 182 | 37m | 52m | 65m | 6 |
| mac-other | 182 | 30m | 41m | 58m | 0 |
| windows-other-1 | 182 | 34m | 40m | 58m | 0 |
| mac-griffin | 182 | 27m | 38m | 57m | 0 |
| windows-cairo-1 | 182 | 31m | 36m | 58m | 0 |
| windows-cairo-2 | 182 | 26m | 30m | 58m | 0 |
| windows-pgwire | 182 | 25m | 30m | 58m | 0 |
| windows-fuzz2 | 182 | 25m | 29m | 58m | 0 |
| windows-griffin-base | 182 | 24m | 29m | 58m | 0 |
| windows-griffin-sub | 182 | 25m | 29m | 58m | 0 |
| windows-fuzz1 | 182 | 18m | 23m | 48m | 0 |
| mac-pgwire | 182 | 15m | 21m | 57m | 0 |
| mac-cairo-fuzz | 182 | 13m | 18m | 27m | 0 |
| windows-other-2 | 182 | 13m | 14m | 57m | 0 |

In this window mac-cairo is the only job that reached the 60-minute cap because of its own runtime, doing so six times across six unrelated PRs. It also has the highest median and p90 of the group, so it runs closest to the cap on a passing run too. The two other cap hits in the window were infrastructure events rather than test runtime: one pipeline-wide agent slowdown that pushed roughly twenty jobs on a single PR's runs to 56-60 minutes, and one self-hosted linux-x64-zfs worker dropout. For the same reason, the `max` column is less representative here than median and p90. The self-hosted Linux jobs run faster and stay below the cap, which is why this PR leaves their coverage intact.

Only mac-cairo hits the cap, but mac-other (41m p90) and mac-griffin (38m p90) are the next closest, so this PR also trims the heaviest tests in those groups to add headroom. Two of those reductions lower Linux runtime as well, called out below.

This PR makes several kinds of change: most reduce test work on the slow runners, one removes build work those jobs never needed, one rebalances the two Windows other jobs against each other, one rewrites a 2GB file test so it no longer moves 2GB on any platform, one restructures a parameterized fuzz test to remove its per-case framework overhead, and one reuses a single server across the QWP egress test suites instead of booting one per test.

## 1. Reduce the workload on non-Linux platforms

Using the existing `Os.isLinux()` pattern, the workload is reduced on Mac and Windows while Linux coverage is left intact (and in a couple of cases Linux is trimmed too, where the test was needlessly slow there). Where it made sense, the workload is randomized within per-platform bounds so coverage still varies across runs while average runtime drops.

- `TableReaderTest.testConcurrentReload*` (single and multiple partitions): cut row/scale counts 10x on non-Linux; stride scales up so the partition-count assertion still holds.
- `O3Test` vanilla and lag-overflow `O3MaxLag` tests: randomized row and batch counts with smaller ranges on non-Linux.
- `O3FailureTest.testVarColumnStress`: randomized initial row count and batch count with smaller ranges on non-Linux.
- `O3MaxLagTest.testVarColumnPageBoundaries3`: sample a sliding window of the inner loop instead of the full range, anchored so every run still covers the page boundary the test targets (also faster on Linux).
- `O3ParquetMergeStrategyFuzzTest` (all five round-based tests): fewer fuzz rounds on non-Linux.
- `TableReaderTailRecordCursorTest.testNonPartitioned`: match the row count of its sibling tests on non-Linux.
- `BitmapIndexTest.testConcurrentWriterAndBackwardReadHeight`: add a row count floor for meaningful coverage and cap the range on non-Linux.
- `WalLockerFuzzTest.testFuzz`: fewer operations per thread on non-Linux.
- `TableNameRegistryTest.testConcurrentReadWriteAndReload`: fewer tables (also trimmed on Linux).
- `RssMemoryLimitTest.testLargeTxEventuallySucceeds`: fewer transactions on non-Linux while keeping batch size and the RSS limit unchanged so memory pressure is still triggered. The test now asserts that the WAL apply logs its memory-pressure easing-up message, so it fails loudly if a reduced workload ever stops triggering pressure (verified locally that the non-Linux 4-transaction path still does).
- `ArrayTest.testShardedMapCursorArrayAccess`: cut the inserted row count 10x on non-Linux and lower the parallel GROUP BY sharding threshold there, so the query still takes the sharded map path the test exercises. The assertion checks only the first five 1-minute buckets, whose data is unchanged, so the expected result is identical.
- `MatViewFuzzTest.testStressWalPurgeJob`: fewer fuzz rows and initial rows, and two tables instead of four, on non-Linux. The WAL segment rollover and purge interval are unchanged, so the test still generates many WAL segments and runs `WalPurgeJob` frequently to exercise the race against `MatViewRefreshJob`.

The same approach trims the heaviest tests in the mac-griffin and mac-other groups (and their Windows equivalents):

- `QwpSenderFuzzTest` (all load tests): extend the existing Windows-only reductions to Mac, and cap the concurrent sender thread count, previously up to 21 on Linux, to a 2-9 range on Linux and 2-4 on non-Linux. The thread count scales both contention and total data volume, so the lower cap also reduces Linux runtime; it still oversubscribes the 1-4 shared tables enough to exercise the concurrent-ingestion races the fuzz test targets.
- `ExpParquetExportTest`: cut the full-table parquet round-trip rounds in `testOnParquetPartition` from 10 to 3 on non-Linux. Each round re-exports the 10k-row table over the byte-level HTTP fragmentation the suite forces, and the explicit per-row-group export assertions above the loop are unchanged. Separately, lower `testConcurrentParquetExports` from 15 to 8 clients on Linux and 4 on non-Linux against its single-worker server.
- `ServerMainQuerySmokeTest` (parallel sharded GROUP BY load tests): reduce the concurrent query loop from 80 to 30 iterations on non-Linux. The dataset and asserted results are unchanged because they are exact; six oversubscribed threads still exercise the work-stealing path the test guards against deadlocking.
- `ParquetLateMaterializationFuzzTest`: shrink the shared all-types table from 2000 to 500 rows on non-Linux. The expected result is computed from the same data before the parquet conversion, so the assertion holds at any size.
- `CheckpointTest` (`testCheckpointRestoreRebuildsBitmapIndexes`, `testCheckpointRestoreIndexWithColumnTop`, `testRecoverCheckpointLargePartitionCount`): reduce the row count about 5x on non-Linux. Each row lands in its own daily partition, so the checkpoint creates and recovers far fewer partition directories; the index-rebuild assertions are computed from the data and the partition-count assertion uses the row-count variable directly.
- `ParallelCsvFileImporterTest.testRunManyImportsSequentially`: run only the extreme queue sizes (1 and 8) instead of 1, 2, 4, 8 on non-Linux.
- `JsonLexerTest.testParseLargeFile`: the test splits a 64KB JSON file at every byte offset and re-parses both halves, which is O(n^2). On non-Linux it samples every 7th split point (a prime stride, to avoid aligning with the file structure), still spreading chunk boundaries across the whole file; Linux keeps every offset.

## 2. Gate large 2GB-class tests to Linux only

Each materializes roughly 2GB of data, which is slow on the hosted Mac and Windows runners, and each guards platform-independent behavior, so Linux coverage is sufficient. They are gated with `Assume.assumeTrue(Os.isLinux())`.

- `WalWriterTest.testAddColumnsRollLargeSegment`: reproduces a Java int overflow (an int cast truncating a long file size at 2GB in `SegmentColumnRollSink`); the overflow is identical on every OS.
- `O3Test.testLargeO3MaxLagContended`: a large-dataset auto-lag feature test whose logic is Java and whose sort/merge runs the same cross-platform native code already exercised by other O3 tests on all platforms.
- `DirectByteSinkTest.testOver2GiB`: fills a `DirectByteSink` past `Integer.MAX_VALUE` to check the size overflow guard; the boundary is the same on every OS. The sparse-hole trick used in section 5 does not apply here, because the bytes are written into native memory and read back rather than left as a file hole.
- `Utf8sTest.testReadWriteVarcharOver2GB`: writes and reads back more than 2GB of varchar data to exercise the 2GB data-vector offset boundary, which is platform-independent.

`O3Test.testVarColumnCopyLargePrefix` is deliberately left running on Mac. It is already skipped on Windows (mixed I/O is disabled there) and asserts a single native write larger than 2GB, whose syscall behavior differs between Linux and macOS, so it provides genuine non-Linux coverage.

## 3. Trim build work in the hosted CI test jobs

Independently of the test workload, each hosted Mac and Windows test job ran `mvn clean test` over the full Maven reactor and downloaded the web console, regardless of which test slice it ran. Two parts of that are unnecessary for these jobs:

- The full reactor compiles `benchmarks` (JMH annotation processing), `compat`, and `utils`, but the hosted per-package groups run almost entirely `core`-module tests. The `utils`/`cliutil` tests are excluded on the relevant groups and run only on Linux. The `compat` tests are excluded on `mac-other` and `windows-other-1`, but the `windows-fuzz2` group's broad `**/**Fuzz**` include also matched `compat`'s one fuzz test, `LineOkHttpFuzzTest` (the only non-`core` fuzz test outside `cairo/fuzz`). Switching these jobs to `-pl core -am` drops `benchmarks`, `compat`, and `utils` from the reactor, which removes `LineOkHttpFuzzTest` from Windows; this is the one coverage change from the build-work trim, called out again under Impact. (The scheduled fuzz pipeline keeps the full reactor for the same reason, but runs Linux-only, so it does not restore Windows coverage for this test.) These jobs now build with `-pl core -am`.
- The web console is needed by exactly one test, `ServerMainTest.testServerUpgradeDoesNotOverrideWebConsoleConfig`, which reads the bundled `console-configuration.json` directly. It runs in the root `io.questdb.test` package, on `mac-other` and `windows-other-1`, so those two groups keep the `-P build-web-console` download. The `cutlass/http` static-content tests (`WebConsoleLoadingTest`, `HttpSecurityTest`) do not need the bundled console: `WebConsoleLoadingTest` builds its own dummy console and `HttpSecurityTest` expects 404/401 responses. Every other group, including `windows-other-2` (which runs `cutlass/http`, `cutlass/qwp`, `cutlass/text`, and O3 tests, but not `ServerMainTest`), now skips the download. The fuzz pipeline also skips it, since its http fuzz tests use `/exec` and ILP rather than the console.

The self-hosted Linux jobs run the full suite (including `compat` and `utils`) on faster hardware where the compile is cheap, so they keep the full reactor and the web console via the pipeline defaults. The change is implemented as per-job overrides in `ci/`; the web-console default is left on, so a missed override forgoes a saving rather than dropping the console where a test needs it.

## 4. Rebalance the windows-other-1 and windows-other-2 jobs

The two Windows "other" jobs split the non-griffin, non-cairo, non-pgwire `core` tests, but unevenly: windows-other-1 ran at a 34m median / 40m p90 while windows-other-2 ran at 13m / 14m (see the table above). Both jobs build the web console (windows-other-2 runs the `cutlass/http` console tests), so the fixed cost is the same on each and the gap is purely test distribution.

This PR moves the `cutlass/qwp` and `cutlass/text` packages from windows-other-1 to windows-other-2. By sequential test duration that shifts roughly 10 minutes of work, bringing both jobs to about 18 minutes of tests each. windows-other-2 becomes the job for the heavier cutlass groups (`http`, `qwp`, `text`) plus the O3 tests; windows-other-1 keeps everything else (`cutlass/line`, `std`, `log`, the server bootstrap tests, `FilesTest`, and so on). Fuzz tests in the moved packages still route to windows-fuzz2, `cutlass/line` stays in windows-other-1, and no test runs twice or zero times.

## 5. Rewrite FilesTest.testSendFileOver2GBWithOffset to avoid moving 2GB

`testSendFileOver2GBWithOffset` verifies that `copyData`/`copyDataToOffset` handle file offsets and lengths past the 2GB signed-int boundary. The old test built a 2GB+ file and ran three full ~2GB `copyData` calls. The native file layer has no sparse-file support and `truncate` only sets the file size, so on the hosted Windows runner the first write past 2GB also forced a physical zero-fill. The test took about 272s on windows-other-1, versus ~12s on Mac and Linux where the filesystem and disk are faster.

The rewrite leaves the region past 2GB as an unwritten hole that reads as zeros, and copies a small window that straddles the 2GB boundary instead of the whole file. The bug class it guards (a signed-32-bit truncation of an offset or length) is caught by the returned byte count, which would come back short or negative on truncation; a zero read-back confirms the copy read from the >2GB hole rather than aliasing back to a sentinel written at offset 0. It still covers the four paths the original did: the EOF sentinel (`length == -1`), an explicit length, a source offset past 2GB, and a non-zero destination offset.

Unlike the gated tests in section 2, this keeps full coverage on every platform, including the Windows-specific 64-bit offset handling in the native code, and runs in about 0.16s on Linux. The other 2GB-class FilesTest cases (`testWriteOver2GB`, `testReadOver2GB`, `testSendFileOver2GB`) are left unchanged: their cost is a single read or write larger than `INT_MAX` that genuinely needs the bulk transfer.

## 6. Restructure ParseNanosFuzzTest to remove per-case framework overhead

`ParseNanosFuzzTest` was a JUnit `@Parameterized` test whose data factory expanded into roughly 15,000 cases (10,000 random valid inputs, a handful of fixed edge and invalid cases, and 5,000 fuzzed invalid inputs). Each case ran a full JUnit lifecycle (listener callbacks, a logged line, parameter-name formatting, reflective construction) for microseconds of actual parsing, so framework overhead dominated: about 25s of wall-clock and 15,000 log lines on the hosted mac-other and windows-other-1 jobs, of which only about 9s was attributed to the test bodies and about 16s was per-case overhead.

The test now builds the same corpus once inside a single `@Test` and loops over every case. The generator methods are unchanged and the shared default-seeded `Rnd` is consumed in the same order, so the input coverage is identical; only the per-case framework cost is removed. The class runs in about 0.2s on every platform. The one behavioral change is that the loop stops at the first failing input rather than reporting each case independently; the failure message still names the offending input, and the fixed seed makes it reproducible.

## 7. Reuse one server across the QWP egress test suites

The three QWP egress suites - `QwpEgressBindRoundTripTest`, `QwpEgressTypesExhaustiveTest`, and `QwpEgressBootstrapTest` - each booted a fresh `TestServerMain` per test method, about 86 server boots in total. Each boot creates the on-disk database and starts every listener, and the per-test teardown then wipes the root recursively, so on the slow runners these suites spent most of their wall-clock starting and stopping servers rather than exercising egress.

A new base class, `AbstractReusedServerQwpEgressTest`, boots one server per class and drops the user tables between tests instead (`DROP ALL TABLES`, then a reader release and a WAL drain so the table names free up for the next test). It also disables the PGWire, ILP, and HTTP-min listeners, which these egress tests never use - they talk only to the HTTP/QWP WebSocket port. Three tests keep their own per-test server: the two that need a different server config (forced HTTP fragmentation; query cache enabled) free the shared server and boot their own, and one that drives the egress state object directly needs no server.

The per-test memory and file-descriptor leak check moves to the class level. A persistent server's descriptors and native memory do not return to a per-test baseline (async WAL purge of dropped tables, pooled readers), so the base class snapshots FD and native-memory counts before the server boots and asserts they return after it is freed at the end of the class - FD counts exactly, native memory within a small tolerance for the worker threads' thread-local buffers. This mirrors the reused-server pattern already used by the enterprise ACL suites.

Because these tests use fixed ports and closing a server does not release its listening port instantly, a server booting on the same port right after another closed (across a class boundary, or after a special-config test) can hit `EADDRINUSE`. This surfaced as a flaky bind failure during testing, so all boots go through a retry that backs off and re-binds, matching the existing approach in `AbstractSqllogicTestRunner`.

Local run times (median of three runs, surefire per-class):

| Suite | before | after |
|-------|-------:|------:|
| `QwpEgressBindRoundTripTest` | 12.0s | 2.0s |
| `QwpEgressTypesExhaustiveTest` | 14.8s | 3.7s |
| `QwpEgressBootstrapTest` | 17.5s | 7.2s |

Coverage of the egress behavior is unchanged; the large line diff in the three suites is mostly re-indentation from unwrapping each test out of its per-test server block (review with `git diff -w`).

## Impact and tradeoffs

On Linux, coverage is essentially unchanged, with two deliberate exceptions: the `QwpSenderFuzzTest` sender-thread cap (from up to 21 to 9) and the `ExpParquetExportTest` concurrent-export client cap (from 15 to 8) lower the concurrency level on Linux too. This trades some concurrency-stress coverage for shorter runtime on every platform; both counts still oversubscribe their workers. `testVarColumnPageBoundaries3` and `testConcurrentReadWriteAndReload` also run faster on Linux.

On Mac and Windows, coverage is reduced:
- The workload-reduced tests exercise smaller datasets and fewer iterations, so a defect that only manifests at larger scale or higher iteration counts may now be caught only on Linux.
- The four gated tests no longer run on Mac or Windows at all.
- `compat`'s `LineOkHttpFuzzTest` no longer runs on Windows. It had run on `windows-fuzz2` via the broad `**/**Fuzz**` include, and the `-pl core -am` reactor trim drops the `compat` module. It still runs on Linux, on both the self-hosted per-PR jobs and the scheduled Linux-only fuzz pipeline, so its coverage is preserved there.

Estimated mac-cairo wall-clock reduction is roughly 20 minutes (about 17 from the workload reductions and about 3 from the two gates), taking the ~51-minute run to ~31 minutes. The windows-cairo jobs benefit similarly. These figures are derived from the per-test durations in the timed-out run; actual numbers will vary per run, especially for the randomized tests.

The mac-other and mac-griffin reductions are smaller and rougher: on mac-other the `QwpSenderFuzzTest`, `ExpParquetExportTest`, and `ServerMainQuerySmokeTest` cuts, the `JsonLexerTest` split-point sampling, the `ParseNanosFuzzTest` restructure, and the two Linux-only gates (`DirectByteSinkTest.testOver2GiB`, `Utf8sTest.testReadWriteVarcharOver2GB`) together account for an estimated 3 to 4 minutes, and on mac-griffin the `CheckpointTest` and `ParquetLateMaterializationFuzzTest` cuts for roughly half a minute. The `ParseNanosFuzzTest` restructure (about 25s) also lands on windows-other-1, and unlike the gates it changes no coverage on any platform. These come from the same per-test `duration_ms` log values, which exclude per-test setup and teardown and so understate the wall-clock gain somewhat; both jobs are well under the cap to begin with, so this is headroom rather than a fix.

The QWP egress server-reuse (section 7) removes roughly 30 seconds of per-test server bootstrapping locally across the three suites, and more on the slower hosted runners; `cutlass/qwp` runs on mac-other and, after the rebalance, windows-other-2, so it adds headroom to both. Its tradeoff is the move from a per-test to a class-level leak check: a descriptor or native-memory leak isolated to a single egress test is no longer attributed to that test, only to the class. Coverage of the egress behavior itself is unchanged.

The Windows job rebalance moves tests between windows-other-1 and windows-other-2 without changing what runs, so coverage is unchanged; it lowers windows-other-1's wall-clock and raises windows-other-2's. The projected ~18 minutes per job comes from per-test durations that exclude per-test setup and teardown, which is non-trivial for the server bootstrap tests in `cutlass/qwp`, so the real split may drift and is worth confirming against a CI run. The `testSendFileOver2GBWithOffset` rewrite removes about 272s from windows-other-1 and a few seconds from mac-other, with no coverage loss on any platform.

The build-work change removes the compile of `benchmarks`, `compat`, and `utils`, plus the web-console download, from the hosted Mac and Windows test jobs. The estimated saving is roughly 1 to 1.5 minutes of compile per job; this was not measured precisely, since `--quiet` hides the per-phase timing. It changes test coverage in one place: `compat`'s `LineOkHttpFuzzTest` had been running on `windows-fuzz2` via the broad fuzz include, and dropping `compat` from the reactor removes it from Windows (it still runs on Linux). The other dropped modules, `benchmarks` and `utils`, have no tests that ran on these hosted jobs. The risk is in the per-job scoping itself: an over-broad reactor exclusion or web-console skip would drop a needed test or resource, which is why the web-console default stays on and the change needs a CI run to confirm.

## Test plan

- CI green on all platforms (Linux runs everything; Mac and Windows skip the four gated tests)
- mac-cairo completes within the 60-minute cap
- Each modified test verified passing locally on Linux, with Linux durations unchanged where intended
- `mac-other` and `windows-other-1` still build the web console for `ServerMainTest`, which still passes; `windows-other-2` now skips it and its `cutlass/http` tests (`WebConsoleLoadingTest`, `HttpSecurityTest`) still pass without the bundled console
- windows-other-1 and windows-other-2 finish closer in wall-clock, with the moved `cutlass/qwp` and `cutlass/text` packages running in windows-other-2
- `testSendFileOver2GBWithOffset` still passes and no longer transfers 2GB
- The self-hosted Linux jobs still run the `compat` and `utils` suites
- Hosted Mac and Windows jobs still run their `core` test slices unchanged
- mac-other and mac-griffin run faster, with `QwpSenderFuzzTest`, `ExpParquetExportTest`, `ServerMainQuerySmokeTest`, `ParallelCsvFileImporterTest`, `JsonLexerTest`, `CheckpointTest`, and `ParquetLateMaterializationFuzzTest` reduced on the slow runners
- The reduced non-Linux branches for `CheckpointTest` and `ParquetLateMaterializationFuzzTest` verified passing locally by temporarily forcing the non-Linux path
- The non-Linux `JsonLexerTest.testParseLargeFile` split-point sampling verified passing locally by forcing the stride branch; `DirectByteSinkTest.testOver2GiB` and `Utf8sTest.testReadWriteVarcharOver2GB` verified passing locally on Linux
- `ParseNanosFuzzTest` restructured from ~15,000 `@Parameterized` cases to one looped test; verified passing locally with identical coverage (about 0.2s versus about 25s)
- The Linux-affecting thread caps in `QwpSenderFuzzTest` and `ExpParquetExportTest` verified passing locally on Linux
- The three QWP egress suites (`QwpEgressBindRoundTripTest`, `QwpEgressTypesExhaustiveTest`, `QwpEgressBootstrapTest`) reuse one server per class; all 99 tests pass and the class-level FD/native-memory leak check holds, verified across repeated random-order runs including the fixed-port bind retry, with per-suite before/after times of 12.0s/2.0s, 14.8s/3.7s, and 17.5s/7.2s







