### PR TITLE
chore(qwp): egress keeps partitions open

### DIFF
--- a/core/src/main/java/io/questdb/cairo/ReaderScanProfile.java
+++ b/core/src/main/java/io/questdb/cairo/ReaderScanProfile.java
@@ -1,0 +1,76 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.cairo;
+
+/**
+ * Per-checkout scan profile that a {@link TableReader} adopts while a caller
+ * holds it from the pool. Controls two orthogonal concerns that used to be
+ * tangled in a single {@code streamingMode} boolean:
+ * <ul>
+ *   <li><b>Kernel page-cache hints</b>: whether partition columns are mapped
+ *       with {@code MADV_SEQUENTIAL} and unmapped with {@code MADV_DONTNEED},
+ *       useful for large sequential scans that should not evict the server's
+ *       working set.</li>
+ *   <li><b>Partition retention on pool return</b>: whether
+ *       {@link TableReader#closeExcessPartitions()} (called from
+ *       {@code goPassive()} when the reader returns to the pool) keeps the
+ *       cached partition mmaps or releases all of them. Releasing is the
+ *       right cleanup backstop for one-shot multi-partition exports;
+ *       retaining is required for high-frequency small-query workloads that
+ *       reuse the same reader's FdCache entries query after query.</li>
+ * </ul>
+ * <p>
+ * Only the three combinations callers actually need are exposed, so there is
+ * no way to ask for nonsensical combinations like "evict partitions on return
+ * but skip the kernel hints". The profile is set per checkout (typically via
+ * {@link io.questdb.cairo.sql.PageFrameCursor#setScanProfile}) and reset to
+ * {@link #DEFAULT} by {@code goPassive()} on every pool return.
+ */
+public enum ReaderScanProfile {
+    /**
+     * Normal interactive query workload. No kernel hints; partition mmaps
+     * are kept cached up to {@code cairo.inactive.reader.max.open.partitions}.
+     */
+    DEFAULT,
+
+    /**
+     * Sequential streaming scan where the caller will reuse the same reader
+     * for many subsequent queries. Partition columns are mapped with
+     * {@code MADV_SEQUENTIAL}; any partition that is closed during this
+     * checkout is hinted with {@code MADV_DONTNEED} before unmap. Partitions
+     * stay cached on pool return so the next checkout finds the FdCache and
+     * page cache warm. Used by QWP egress.
+     */
+    SEQUENTIAL_CACHED,
+
+    /**
+     * Sequential streaming scan that may touch many partitions in a single
+     * pass. Same kernel hints as {@link #SEQUENTIAL_CACHED}, plus a hard
+     * cleanup backstop: every partition opened by this checkout is closed
+     * when the reader returns to the pool, so a pool-resident reader does not
+     * accumulate thousands of mmaps across exports. Used by Parquet export.
+     */
+    SEQUENTIAL_EVICT
+}

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -96,6 +96,14 @@ public class TableReader implements Closeable, SymbolTableSource {
     private int columnCountShl;
     private LongList columnTops;
     private ObjList<MemoryCMR> columns;
+    // When true, closeExcessPartitions() (called from goPassive() on pool return)
+    // uses keepOpen=0 instead of maxOpenPartitions, so every partition opened by
+    // the current checkout is released back to the pool. Used by Parquet export
+    // workloads that may touch thousands of partitions in a single scan and need
+    // a hard cleanup backstop. High-frequency small-query workloads (e.g. QWP
+    // egress) must leave this false so the partition stays mapped across
+    // queries and the FdCache stays warm.
+    private boolean evictPartitionsOnReturn = false;
     private boolean hasActiveColumns;
     private ObjList<IndexReader> indexes;
     private int openPartitionCount;
@@ -105,8 +113,10 @@ public class TableReader implements Closeable, SymbolTableSource {
     private ObjList<MemoryCMR> parquetPartitions;
     private int partitionCount;
     private long rowCount;
-    // When streaming mode is enabled, partitions are opened with MADV_DONTNEED hint
-    // to release page cache after reading. Used by Parquet export to avoid page cache exhaustion.
+    // When true, partitions are opened with MADV_SEQUENTIAL and closed with
+    // MADV_DONTNEED so large sequential scans don't evict the server's working
+    // set. Independent of evictPartitionsOnReturn -- the two flags can be set
+    // separately depending on what the caller actually needs.
     private boolean streamingMode = false;
     private TableToken tableToken;
     private long tempMem8b = Unsafe.malloc(8, MemoryTag.NATIVE_TABLE_READER);
@@ -269,7 +279,7 @@ public class TableReader implements Closeable, SymbolTableSource {
 
     public void closeExcessPartitions() {
         // close all but N latest partitions
-        int keepOpen = streamingMode ? 0 : maxOpenPartitions;
+        int keepOpen = evictPartitionsOnReturn ? 0 : maxOpenPartitions;
         if (PartitionBy.isPartitioned(partitionBy) && openPartitionCount > keepOpen) {
             final int originallyOpen = openPartitionCount;
             int openCount = 0;
@@ -656,6 +666,7 @@ public class TableReader implements Closeable, SymbolTableSource {
         closeExcessPartitions();
         hasActiveColumns = false;
         resetAllColumnsOpenFlag();
+        evictPartitionsOnReturn = false;
         streamingMode = false;
     }
 
@@ -750,12 +761,38 @@ public class TableReader implements Closeable, SymbolTableSource {
     }
 
     /**
-     * Enables or disables streaming mode for this reader.
-     * When streaming mode is enabled, partitions are opened with MADV_DONTNEED hint
-     * to release page cache after reading. This is useful for large sequential scans
-     * like Parquet export to avoid page cache exhaustion under memory pressure.
+     * Enables the aggressive partition-eviction backstop for the current reader
+     * checkout. When enabled, returning the reader to the pool closes every
+     * partition opened during the checkout (via {@link #closeExcessPartitions()}
+     * with {@code keepOpen=0}), so the pool never accumulates thousands of
+     * partition mmaps from a single export pass.
+     * <p>
+     * Callers running many short queries on the same table (for example QWP
+     * egress) must leave this {@code false} -- otherwise every checkout closes
+     * and re-opens the same partition, defeating the {@link io.questdb.std.FdCache}
+     * and incurring per-query allocations on the open path.
+     * <p>
+     * Reset to {@code false} by {@link #goPassive()} on every pool return.
+     * Orthogonal to {@link #setStreamingMode(boolean)}.
      *
-     * @param enabled true to enable streaming mode, false to disable
+     * @param enabled true to close all partitions on the next pool return
+     */
+    public void setEvictPartitionsOnReturn(boolean enabled) {
+        this.evictPartitionsOnReturn = enabled;
+    }
+
+    /**
+     * Enables sequential-scan kernel hints for the current reader checkout.
+     * When enabled, partition columns are opened with {@code MADV_SEQUENTIAL}
+     * and any partition closed during this checkout has its mappings hinted
+     * with {@code MADV_DONTNEED} before unmap, so a large scan doesn't evict
+     * the server's working set.
+     * <p>
+     * Reset to {@code false} by {@link #goPassive()} on every pool return.
+     * Orthogonal to {@link #setEvictPartitionsOnReturn(boolean)} -- enabling
+     * one does not enable the other.
+     *
+     * @param enabled true to enable sequential-scan hints, false to disable
      */
     public void setStreamingMode(boolean enabled) {
         this.streamingMode = enabled;

--- a/core/src/main/java/io/questdb/cairo/TableReader.java
+++ b/core/src/main/java/io/questdb/cairo/TableReader.java
@@ -96,14 +96,6 @@ public class TableReader implements Closeable, SymbolTableSource {
     private int columnCountShl;
     private LongList columnTops;
     private ObjList<MemoryCMR> columns;
-    // When true, closeExcessPartitions() (called from goPassive() on pool return)
-    // uses keepOpen=0 instead of maxOpenPartitions, so every partition opened by
-    // the current checkout is released back to the pool. Used by Parquet export
-    // workloads that may touch thousands of partitions in a single scan and need
-    // a hard cleanup backstop. High-frequency small-query workloads (e.g. QWP
-    // egress) must leave this false so the partition stays mapped across
-    // queries and the FdCache stays warm.
-    private boolean evictPartitionsOnReturn = false;
     private boolean hasActiveColumns;
     private ObjList<IndexReader> indexes;
     private int openPartitionCount;
@@ -113,11 +105,10 @@ public class TableReader implements Closeable, SymbolTableSource {
     private ObjList<MemoryCMR> parquetPartitions;
     private int partitionCount;
     private long rowCount;
-    // When true, partitions are opened with MADV_SEQUENTIAL and closed with
-    // MADV_DONTNEED so large sequential scans don't evict the server's working
-    // set. Independent of evictPartitionsOnReturn -- the two flags can be set
-    // separately depending on what the caller actually needs.
-    private boolean streamingMode = false;
+    // Per-checkout scan profile -- controls kernel page-cache hints and
+    // post-checkout partition retention. Reset to DEFAULT by goPassive() on
+    // every pool return so cross-checkout leaks are impossible.
+    private ReaderScanProfile scanProfile = ReaderScanProfile.DEFAULT;
     private TableToken tableToken;
     private long tempMem8b = Unsafe.malloc(8, MemoryTag.NATIVE_TABLE_READER);
     private long txColumnVersion;
@@ -279,7 +270,7 @@ public class TableReader implements Closeable, SymbolTableSource {
 
     public void closeExcessPartitions() {
         // close all but N latest partitions
-        int keepOpen = evictPartitionsOnReturn ? 0 : maxOpenPartitions;
+        int keepOpen = scanProfile == ReaderScanProfile.SEQUENTIAL_EVICT ? 0 : maxOpenPartitions;
         if (PartitionBy.isPartitioned(partitionBy) && openPartitionCount > keepOpen) {
             final int originallyOpen = openPartitionCount;
             int openCount = 0;
@@ -666,8 +657,7 @@ public class TableReader implements Closeable, SymbolTableSource {
         closeExcessPartitions();
         hasActiveColumns = false;
         resetAllColumnsOpenFlag();
-        evictPartitionsOnReturn = false;
-        streamingMode = false;
+        scanProfile = ReaderScanProfile.DEFAULT;
     }
 
     public boolean hasParquetPartitions() {
@@ -761,41 +751,15 @@ public class TableReader implements Closeable, SymbolTableSource {
     }
 
     /**
-     * Enables the aggressive partition-eviction backstop for the current reader
-     * checkout. When enabled, returning the reader to the pool closes every
-     * partition opened during the checkout (via {@link #closeExcessPartitions()}
-     * with {@code keepOpen=0}), so the pool never accumulates thousands of
-     * partition mmaps from a single export pass.
-     * <p>
-     * Callers running many short queries on the same table (for example QWP
-     * egress) must leave this {@code false} -- otherwise every checkout closes
-     * and re-opens the same partition, defeating the {@link io.questdb.std.FdCache}
-     * and incurring per-query allocations on the open path.
-     * <p>
-     * Reset to {@code false} by {@link #goPassive()} on every pool return.
-     * Orthogonal to {@link #setStreamingMode(boolean)}.
+     * Sets the scan profile for the current checkout. See {@link ReaderScanProfile}
+     * for the meaning of each value. Reset to {@link ReaderScanProfile#DEFAULT}
+     * by {@link #goPassive()} on every pool return, so the profile is always
+     * a per-checkout decision.
      *
-     * @param enabled true to close all partitions on the next pool return
+     * @param profile the profile to adopt for the current checkout (non-null)
      */
-    public void setEvictPartitionsOnReturn(boolean enabled) {
-        this.evictPartitionsOnReturn = enabled;
-    }
-
-    /**
-     * Enables sequential-scan kernel hints for the current reader checkout.
-     * When enabled, partition columns are opened with {@code MADV_SEQUENTIAL}
-     * and any partition closed during this checkout has its mappings hinted
-     * with {@code MADV_DONTNEED} before unmap, so a large scan doesn't evict
-     * the server's working set.
-     * <p>
-     * Reset to {@code false} by {@link #goPassive()} on every pool return.
-     * Orthogonal to {@link #setEvictPartitionsOnReturn(boolean)} -- enabling
-     * one does not enable the other.
-     *
-     * @param enabled true to enable sequential-scan hints, false to disable
-     */
-    public void setStreamingMode(boolean enabled) {
-        this.streamingMode = enabled;
+    public void setScanProfile(ReaderScanProfile profile) {
+        this.scanProfile = profile;
     }
 
     public long size() {
@@ -962,7 +926,7 @@ public class TableReader implements Closeable, SymbolTableSource {
 
     private void closePartitionColumn(int base, int columnIndex) {
         int index = getPrimaryColumnIndex(base, columnIndex);
-        if (streamingMode) {
+        if (scanProfile != ReaderScanProfile.DEFAULT) {
             MemoryCMR mem = columns.get(index);
             if (mem != null) {
                 ff.madvise(mem.addressOf(0), mem.size(), Files.POSIX_MADV_DONTNEED);
@@ -1386,9 +1350,11 @@ public class TableReader implements Closeable, SymbolTableSource {
             long columnSize,
             boolean keepFdOpen
     ) {
-        // When streaming mode is enabled, use MADV_DONTNEED to hint the kernel
-        // to release page cache after reading, avoiding memory pressure during large scans
-        final int madviseOpts = streamingMode ? Files.POSIX_MADV_SEQUENTIAL : -1;
+        // Sequential scan profiles hint the kernel to read ahead and to
+        // release page cache after reading, avoiding memory pressure during
+        // large scans. closePartitionColumn() applies the matching DONTNEED
+        // hint at unmap time.
+        final int madviseOpts = scanProfile != ReaderScanProfile.DEFAULT ? Files.POSIX_MADV_SEQUENTIAL : -1;
         MemoryCMRDetachedImpl memory;
         if (mem != null && mem != NullMemoryCMR.INSTANCE) {
             memory = (MemoryCMRDetachedImpl) mem;

--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameCursor.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameCursor.java
@@ -147,15 +147,32 @@ public interface PageFrameCursor extends QuietCloseable, SymbolTableSource {
     }
 
     /**
-     * Enables or disables streaming mode for the cursor.
-     * When streaming mode is enabled, underlying resources (e.g., partitions) are opened
-     * with hints to release page cache after reading. This is useful for large sequential
-     * scans like Parquet export to avoid page cache exhaustion under memory pressure.
+     * Asks the cursor to close every partition it opened when the underlying
+     * reader is next returned to the pool. Useful for workloads that may touch
+     * many partitions in one pass (e.g. Parquet export) and want a hard
+     * cleanup backstop.
      * <p>
-     * Default implementation is a no-op. Subclasses backed by TableReader should override
-     * this method to delegate to the TableReader's streaming mode setting.
+     * Default implementation is a no-op. Subclasses backed by TableReader
+     * delegate to {@link io.questdb.cairo.TableReader#setEvictPartitionsOnReturn(boolean)}.
+     * Orthogonal to {@link #setStreamingMode(boolean)}.
      *
-     * @param enabled true to enable streaming mode, false to disable
+     * @param enabled true to evict all partitions on the next pool return
+     */
+    default void setEvictPartitionsOnReturn(boolean enabled) {
+        // no-op by default
+    }
+
+    /**
+     * Enables sequential-scan kernel hints (MADV_SEQUENTIAL on open,
+     * MADV_DONTNEED on close) for the underlying resources. Useful for large
+     * sequential scans like Parquet export to avoid evicting the server's
+     * working set from the page cache.
+     * <p>
+     * Default implementation is a no-op. Subclasses backed by TableReader
+     * delegate to {@link io.questdb.cairo.TableReader#setStreamingMode(boolean)}.
+     * Orthogonal to {@link #setEvictPartitionsOnReturn(boolean)}.
+     *
+     * @param enabled true to enable sequential-scan hints, false to disable
      */
     default void setStreamingMode(boolean enabled) {
         // no-op by default

--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameCursor.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameCursor.java
@@ -24,6 +24,7 @@
 
 package io.questdb.cairo.sql;
 
+import io.questdb.cairo.ReaderScanProfile;
 import io.questdb.std.QuietCloseable;
 import org.jetbrains.annotations.Nullable;
 
@@ -147,34 +148,18 @@ public interface PageFrameCursor extends QuietCloseable, SymbolTableSource {
     }
 
     /**
-     * Asks the cursor to close every partition it opened when the underlying
-     * reader is next returned to the pool. Useful for workloads that may touch
-     * many partitions in one pass (e.g. Parquet export) and want a hard
-     * cleanup backstop.
+     * Sets the scan profile of the underlying reader (kernel page-cache
+     * hints, partition retention on pool return). See
+     * {@link io.questdb.cairo.ReaderScanProfile} for the meaning of each
+     * value.
      * <p>
-     * Default implementation is a no-op. Subclasses backed by TableReader
-     * delegate to {@link io.questdb.cairo.TableReader#setEvictPartitionsOnReturn(boolean)}.
-     * Orthogonal to {@link #setStreamingMode(boolean)}.
+     * Default implementation is a no-op for cursors that are not backed by a
+     * {@link io.questdb.cairo.TableReader}; backed cursors delegate to
+     * {@link io.questdb.cairo.TableReader#setScanProfile}.
      *
-     * @param enabled true to evict all partitions on the next pool return
+     * @param profile the profile to adopt (non-null)
      */
-    default void setEvictPartitionsOnReturn(boolean enabled) {
-        // no-op by default
-    }
-
-    /**
-     * Enables sequential-scan kernel hints (MADV_SEQUENTIAL on open,
-     * MADV_DONTNEED on close) for the underlying resources. Useful for large
-     * sequential scans like Parquet export to avoid evicting the server's
-     * working set from the page cache.
-     * <p>
-     * Default implementation is a no-op. Subclasses backed by TableReader
-     * delegate to {@link io.questdb.cairo.TableReader#setStreamingMode(boolean)}.
-     * Orthogonal to {@link #setEvictPartitionsOnReturn(boolean)}.
-     *
-     * @param enabled true to enable sequential-scan hints, false to disable
-     */
-    default void setStreamingMode(boolean enabled) {
+    default void setScanProfile(ReaderScanProfile profile) {
         // no-op by default
     }
 

--- a/core/src/main/java/io/questdb/cutlass/http/processors/ExportQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/ExportQueryProcessor.java
@@ -33,6 +33,7 @@ import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.GeoHashes;
 import io.questdb.cairo.ImplicitCastException;
 import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.ReaderScanProfile;
 import io.questdb.cairo.arr.ArrayTypeDriver;
 import io.questdb.cairo.sql.NetworkSqlExecutionCircuitBreaker;
 import io.questdb.cairo.sql.PageFrameCursor;
@@ -249,8 +250,7 @@ public class ExportQueryProcessor implements HttpRequestProcessor, HttpRequestHa
                         // when unwrapped instanceof VirtualRecordCursorFactory.
                         RecordCursorFactory unwrapped = ParquetExportMode.unwrapFactory(state.recordCursorFactory);
                         VirtualRecordCursorFactory vf = (VirtualRecordCursorFactory) unwrapped;
-                        state.pageFrameCursor.setStreamingMode(true);
-                        state.pageFrameCursor.setEvictPartitionsOnReturn(true);
+                        state.pageFrameCursor.setScanProfile(ReaderScanProfile.SEQUENTIAL_EVICT);
                         state.materializer.setUpPageFrameBacked(vf, state.pageFrameCursor, sqlExecutionContext);
                     } else if (isParquet && state.parquetExportMode == ParquetExportMode.CURSOR_BASED) {
                         RecordCursorFactory unwrapped = ParquetExportMode.unwrapFactory(state.recordCursorFactory);

--- a/core/src/main/java/io/questdb/cutlass/http/processors/ExportQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/ExportQueryProcessor.java
@@ -250,6 +250,7 @@ public class ExportQueryProcessor implements HttpRequestProcessor, HttpRequestHa
                         RecordCursorFactory unwrapped = ParquetExportMode.unwrapFactory(state.recordCursorFactory);
                         VirtualRecordCursorFactory vf = (VirtualRecordCursorFactory) unwrapped;
                         state.pageFrameCursor.setStreamingMode(true);
+                        state.pageFrameCursor.setEvictPartitionsOnReturn(true);
                         state.materializer.setUpPageFrameBacked(vf, state.pageFrameCursor, sqlExecutionContext);
                     } else if (isParquet && state.parquetExportMode == ParquetExportMode.CURSOR_BASED) {
                         RecordCursorFactory unwrapped = ParquetExportMode.unwrapFactory(state.recordCursorFactory);

--- a/core/src/main/java/io/questdb/cutlass/parquet/CopyExportRequestTask.java
+++ b/core/src/main/java/io/questdb/cutlass/parquet/CopyExportRequestTask.java
@@ -332,8 +332,11 @@ public class CopyExportRequestTask implements Mutable, QuietCloseable {
 
     public void setUpStreamPartitionParquetExporter() {
         if (pageFrameCursor != null) {
-            // Enable streaming mode to use MADV_DONTNEED on mmap, avoiding page cache exhaustion
+            // Enable streaming mode for MADV_SEQUENTIAL/DONTNEED hints, plus
+            // eviction-on-return so the pooled reader doesn't accumulate
+            // mappings from a multi-partition export.
             pageFrameCursor.setStreamingMode(true);
+            pageFrameCursor.setEvictPartitionsOnReturn(true);
             streamPartitionParquetExporter.setUp();
         }
     }
@@ -344,8 +347,11 @@ public class CopyExportRequestTask implements Mutable, QuietCloseable {
         this.pageFrameCursor = pageFrameCursor;
         this.metadata = metadata;
         this.descending = descending;
-        // Enable streaming mode to use MADV_DONTNEED on mmap, avoiding page cache exhaustion
+        // Enable streaming mode for MADV_SEQUENTIAL/DONTNEED hints, plus
+        // eviction-on-return so the pooled reader doesn't accumulate
+        // mappings from a multi-partition export.
         pageFrameCursor.setStreamingMode(true);
+        pageFrameCursor.setEvictPartitionsOnReturn(true);
         streamPartitionParquetExporter.setUp();
     }
 

--- a/core/src/main/java/io/questdb/cutlass/parquet/CopyExportRequestTask.java
+++ b/core/src/main/java/io/questdb/cutlass/parquet/CopyExportRequestTask.java
@@ -27,6 +27,7 @@ package io.questdb.cutlass.parquet;
 
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.ReaderScanProfile;
 import io.questdb.cairo.SecurityContext;
 import io.questdb.cairo.SymbolMapReader;
 import io.questdb.cairo.sql.BindVariableService;
@@ -332,11 +333,10 @@ public class CopyExportRequestTask implements Mutable, QuietCloseable {
 
     public void setUpStreamPartitionParquetExporter() {
         if (pageFrameCursor != null) {
-            // Enable streaming mode for MADV_SEQUENTIAL/DONTNEED hints, plus
-            // eviction-on-return so the pooled reader doesn't accumulate
-            // mappings from a multi-partition export.
-            pageFrameCursor.setStreamingMode(true);
-            pageFrameCursor.setEvictPartitionsOnReturn(true);
+            // SEQUENTIAL_EVICT: MADV_SEQUENTIAL/DONTNEED hints plus a hard
+            // cleanup backstop on pool return so the pooled reader doesn't
+            // accumulate mappings from a multi-partition export.
+            pageFrameCursor.setScanProfile(ReaderScanProfile.SEQUENTIAL_EVICT);
             streamPartitionParquetExporter.setUp();
         }
     }
@@ -347,11 +347,10 @@ public class CopyExportRequestTask implements Mutable, QuietCloseable {
         this.pageFrameCursor = pageFrameCursor;
         this.metadata = metadata;
         this.descending = descending;
-        // Enable streaming mode for MADV_SEQUENTIAL/DONTNEED hints, plus
-        // eviction-on-return so the pooled reader doesn't accumulate
-        // mappings from a multi-partition export.
-        pageFrameCursor.setStreamingMode(true);
-        pageFrameCursor.setEvictPartitionsOnReturn(true);
+        // SEQUENTIAL_EVICT: MADV_SEQUENTIAL/DONTNEED hints plus a hard
+        // cleanup backstop on pool return so the pooled reader doesn't
+        // accumulate mappings from a multi-partition export.
+        pageFrameCursor.setScanProfile(ReaderScanProfile.SEQUENTIAL_EVICT);
         streamPartitionParquetExporter.setUp();
     }
 

--- a/core/src/main/java/io/questdb/cutlass/parquet/SQLSerialParquetExporter.java
+++ b/core/src/main/java/io/questdb/cutlass/parquet/SQLSerialParquetExporter.java
@@ -173,8 +173,13 @@ public class SQLSerialParquetExporter extends BaseParquetExporter implements Clo
 
             try (TableReader reader = cairoEngine.getReader(tableToken)) {
                 // Enable streaming mode to use MADV_SEQUENTIAL/DONTNEED hints,
-                // releasing page cache after each partition is processed
+                // releasing page cache after each partition is processed. Also
+                // enable eviction-on-return so the pooled reader is fully
+                // closed down after the export -- TABLE_READER/TEMP_TABLE
+                // paths close partitions one-at-a-time in the loop below, but
+                // this is the cleanup backstop for the pool-return path.
                 reader.setStreamingMode(true);
+                reader.setEvictPartitionsOnReturn(true);
                 final int timestampType = reader.getMetadata().getTimestampType();
                 final int partitionCount = reader.getPartitionCount();
                 final int partitionBy = reader.getPartitionedBy();
@@ -434,6 +439,7 @@ public class SQLSerialParquetExporter extends BaseParquetExporter implements Clo
                 VirtualRecordCursorFactory vf = (VirtualRecordCursorFactory) factory;
                 pfc = vf.getBaseFactory().getPageFrameCursor(sqlExecutionContext, ORDER_ASC);
                 pfc.setStreamingMode(true);
+                pfc.setEvictPartitionsOnReturn(true);
                 streamBuffers.setUpPageFrameBacked(vf, pfc, sqlExecutionContext);
                 exporter.setUp(streamBuffers.getAdjustedMetadata(), pfc, streamBuffers.getBaseColumnMap());
             } else {
@@ -501,6 +507,7 @@ public class SQLSerialParquetExporter extends BaseParquetExporter implements Clo
                 case DIRECT_PAGE_FRAME -> {
                     try (PageFrameCursor pfc = baseFactory.getPageFrameCursor(sqlExecutionContext, ORDER_ASC)) {
                         pfc.setStreamingMode(true);
+                        pfc.setEvictPartitionsOnReturn(true);
                         RecordMetadata meta = baseFactory.getMetadata();
                         int colCount = meta.getColumnCount();
                         if (identityColumnMap.size() != colCount) {

--- a/core/src/main/java/io/questdb/cutlass/parquet/SQLSerialParquetExporter.java
+++ b/core/src/main/java/io/questdb/cutlass/parquet/SQLSerialParquetExporter.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.ReaderScanProfile;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.TableUtils;
@@ -172,14 +173,12 @@ public class SQLSerialParquetExporter extends BaseParquetExporter implements Clo
             }
 
             try (TableReader reader = cairoEngine.getReader(tableToken)) {
-                // Enable streaming mode to use MADV_SEQUENTIAL/DONTNEED hints,
-                // releasing page cache after each partition is processed. Also
-                // enable eviction-on-return so the pooled reader is fully
-                // closed down after the export -- TABLE_READER/TEMP_TABLE
-                // paths close partitions one-at-a-time in the loop below, but
-                // this is the cleanup backstop for the pool-return path.
-                reader.setStreamingMode(true);
-                reader.setEvictPartitionsOnReturn(true);
+                // SEQUENTIAL_EVICT: MADV_SEQUENTIAL/DONTNEED hints to release
+                // page cache after each partition, plus a hard cleanup
+                // backstop -- closeExcessPartitions(keepOpen=0) on pool
+                // return ensures the pooled reader doesn't accumulate
+                // mappings across exports.
+                reader.setScanProfile(ReaderScanProfile.SEQUENTIAL_EVICT);
                 final int timestampType = reader.getMetadata().getTimestampType();
                 final int partitionCount = reader.getPartitionCount();
                 final int partitionBy = reader.getPartitionedBy();
@@ -438,8 +437,7 @@ public class SQLSerialParquetExporter extends BaseParquetExporter implements Clo
             if (isPageFrameBacked) {
                 VirtualRecordCursorFactory vf = (VirtualRecordCursorFactory) factory;
                 pfc = vf.getBaseFactory().getPageFrameCursor(sqlExecutionContext, ORDER_ASC);
-                pfc.setStreamingMode(true);
-                pfc.setEvictPartitionsOnReturn(true);
+                pfc.setScanProfile(ReaderScanProfile.SEQUENTIAL_EVICT);
                 streamBuffers.setUpPageFrameBacked(vf, pfc, sqlExecutionContext);
                 exporter.setUp(streamBuffers.getAdjustedMetadata(), pfc, streamBuffers.getBaseColumnMap());
             } else {
@@ -506,8 +504,7 @@ public class SQLSerialParquetExporter extends BaseParquetExporter implements Clo
             switch (mode) {
                 case DIRECT_PAGE_FRAME -> {
                     try (PageFrameCursor pfc = baseFactory.getPageFrameCursor(sqlExecutionContext, ORDER_ASC)) {
-                        pfc.setStreamingMode(true);
-                        pfc.setEvictPartitionsOnReturn(true);
+                        pfc.setScanProfile(ReaderScanProfile.SEQUENTIAL_EVICT);
                         RecordMetadata meta = baseFactory.getMetadata();
                         int colCount = meta.getColumnCount();
                         if (identityColumnMap.size() != colCount) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressUpgradeProcessor.java
@@ -26,6 +26,7 @@ package io.questdb.cutlass.qwp.server.egress;
 
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ReaderScanProfile;
 import io.questdb.cairo.sql.InsertOperation;
 import io.questdb.cairo.sql.OperationFuture;
 import io.questdb.cairo.sql.PageFrame;
@@ -1092,10 +1093,12 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
             // heap copy, so the decoder's scratch is free to be overwritten
             // by the next request on this connection.
             if (pageFrameCursor != null) {
-                // Streaming mode asks the cursor to release page cache pages
-                // after reading, so a 10M-row scan doesn't evict the server's
-                // working set. Same hint used by the parquet exporter.
-                pageFrameCursor.setStreamingMode(true);
+                // SEQUENTIAL_CACHED hints the kernel to read ahead and to drop
+                // page cache after streaming, so a 10M-row scan doesn't evict
+                // the server's working set. Unlike SEQUENTIAL_EVICT (used by
+                // the parquet exporter), the partition stays mapped on pool
+                // return so the next QWP query reuses the FdCache.
+                pageFrameCursor.setScanProfile(ReaderScanProfile.SEQUENTIAL_CACHED);
                 state.beginStreamingPageFrame(requestId, factory, pageFrameCursor,
                         columnCount, schemaId, schemaAlreadyKnown, decoder.initialCredit, cacheKey);
             } else {

--- a/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
+++ b/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
@@ -28,6 +28,7 @@ import io.questdb.cairo.AbstractRecordCursorFactory;
 import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ReaderScanProfile;
 import io.questdb.cairo.SqlJitMode;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableToken;
@@ -506,16 +507,11 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
             baseCursor.releaseOpenPartitions();
         }
 
-        @Override
-        public void setEvictPartitionsOnReturn(boolean enabled) {
-            baseCursor.setEvictPartitionsOnReturn(enabled);
-        }
-
         // Qodana false positive
         @SuppressWarnings("unused")
         @Override
-        public void setStreamingMode(boolean enabled) {
-            baseCursor.setStreamingMode(enabled);
+        public void setScanProfile(ReaderScanProfile profile) {
+            baseCursor.setScanProfile(profile);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
+++ b/core/src/main/java/io/questdb/griffin/engine/QueryProgress.java
@@ -506,6 +506,11 @@ public class QueryProgress extends AbstractRecordCursorFactory implements Resour
             baseCursor.releaseOpenPartitions();
         }
 
+        @Override
+        public void setEvictPartitionsOnReturn(boolean enabled) {
+            baseCursor.setEvictPartitionsOnReturn(enabled);
+        }
+
         // Qodana false positive
         @SuppressWarnings("unused")
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/ExtraNullColumnCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/ExtraNullColumnCursorFactory.java
@@ -26,6 +26,7 @@ package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.AbstractRecordCursorFactory;
 import io.questdb.cairo.EmptySymbolMapReader;
+import io.questdb.cairo.ReaderScanProfile;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.idx.IndexReader;
@@ -471,8 +472,8 @@ public final class ExtraNullColumnCursorFactory extends AbstractRecordCursorFact
         }
 
         @Override
-        public void setStreamingMode(boolean enabled) {
-            baseCursor.setStreamingMode(enabled);
+        public void setScanProfile(ReaderScanProfile profile) {
+            baseCursor.setScanProfile(profile);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/SelectedRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/SelectedRecordCursorFactory.java
@@ -541,6 +541,11 @@ public final class SelectedRecordCursorFactory extends AbstractRecordCursorFacto
         }
 
         @Override
+        public void setEvictPartitionsOnReturn(boolean enabled) {
+            baseCursor.setEvictPartitionsOnReturn(enabled);
+        }
+
+        @Override
         public void setStreamingMode(boolean enabled) {
             baseCursor.setStreamingMode(enabled);
         }

--- a/core/src/main/java/io/questdb/griffin/engine/table/SelectedRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/SelectedRecordCursorFactory.java
@@ -25,6 +25,7 @@
 package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.AbstractRecordCursorFactory;
+import io.questdb.cairo.ReaderScanProfile;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.idx.IndexReader;
@@ -541,13 +542,8 @@ public final class SelectedRecordCursorFactory extends AbstractRecordCursorFacto
         }
 
         @Override
-        public void setEvictPartitionsOnReturn(boolean enabled) {
-            baseCursor.setEvictPartitionsOnReturn(enabled);
-        }
-
-        @Override
-        public void setStreamingMode(boolean enabled) {
-            baseCursor.setStreamingMode(enabled);
+        public void setScanProfile(ReaderScanProfile profile) {
+            baseCursor.setScanProfile(profile);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/TablePageFrameCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/TablePageFrameCursor.java
@@ -70,14 +70,13 @@ public interface TablePageFrameCursor extends PageFrameCursor {
         throw new UnsupportedOperationException();
     }
 
-    /**
-     * Enables or disables streaming mode for the underlying TableReader.
-     * When streaming mode is enabled, partitions are opened with MADV_DONTNEED hint
-     * to release page cache after reading. This is useful for large sequential scans
-     * like Parquet export to avoid page cache exhaustion under memory pressure.
-     *
-     * @param enabled true to enable streaming mode, false to disable
-     */
+    default void setEvictPartitionsOnReturn(boolean enabled) {
+        TableReader reader = getTableReader();
+        if (reader != null) {
+            reader.setEvictPartitionsOnReturn(enabled);
+        }
+    }
+
     default void setStreamingMode(boolean enabled) {
         TableReader reader = getTableReader();
         if (reader != null) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/TablePageFrameCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/TablePageFrameCursor.java
@@ -24,6 +24,7 @@
 
 package io.questdb.griffin.engine.table;
 
+import io.questdb.cairo.ReaderScanProfile;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.sql.ColumnMapping;
 import io.questdb.cairo.sql.PageFrameCursor;
@@ -70,17 +71,11 @@ public interface TablePageFrameCursor extends PageFrameCursor {
         throw new UnsupportedOperationException();
     }
 
-    default void setEvictPartitionsOnReturn(boolean enabled) {
+    @Override
+    default void setScanProfile(ReaderScanProfile profile) {
         TableReader reader = getTableReader();
         if (reader != null) {
-            reader.setEvictPartitionsOnReturn(enabled);
-        }
-    }
-
-    default void setStreamingMode(boolean enabled) {
-        TableReader reader = getTableReader();
-        if (reader != null) {
-            reader.setStreamingMode(enabled);
+            reader.setScanProfile(profile);
         }
     }
 }

--- a/core/src/main/java/io/questdb/std/FdCache.java
+++ b/core/src/main/java/io/questdb/std/FdCache.java
@@ -294,7 +294,9 @@ public class FdCache {
                 Utf8String path = Utf8String.newInstance(lpsz);
                 holder = createFdCacheRecord(path, mmapKeyGenerator.getAndIncrement());
                 holder.osFd = osFd;
-                openFdMapByPath.putAt(keyIndex, lpsz, holder);
+                // Reuse the same Utf8String for the map key so putAt picks the
+                // Utf8String overload and skips its own newInstance() copy.
+                openFdMapByPath.putAt(keyIndex, path, holder);
             }
         } else {
             holder = openFdMapByPath.valueAtQuick(keyIndex);


### PR DESCRIPTION
- Replace `TableReader`'s overloaded streaming-mode boolean with explicit `ReaderScanProfile` values.
- Keep Parquet exports on sequential/evict behavior to avoid retaining large partition mappings after exports.
- Move QWP egress to sequential/cached behavior so streaming scans still use page-cache hints without dropping reusable reader state.
- Thread the new scan-profile API through page-frame cursor wrappers and trim one `FdCache` string copy.


Result:
```
  Latency distribution — BEFORE (master 46c13d48c8) vs AFTER (enum refactor 5ef6b45287)

  All times microseconds, per-query end-to-end (client-side wall time including network).

  Full scan — SELECT * FROM egress_perf (500k rows)
  
  ┌─────────┬────────┬────────┬────────┐
  │         │ BEFORE │ AFTER  │   Δ    │
  ├─────────┼────────┼────────┼────────┤
  │ queries │  2,109 │  2,510 │ +19.0% │
  ├─────────┼────────┼────────┼────────┤
  │ mean    │ 14,225 │ 11,952 │ −16.0% │
  ├─────────┼────────┼────────┼────────┤
  │ p50     │ 14,057 │ 11,849 │ −15.7% │
  ├─────────┼────────┼────────┼────────┤
  │ p90     │ 15,349 │ 12,722 │ −17.1% │
  ├─────────┼────────┼────────┼────────┤
  │ p99     │ 17,010 │ 13,742 │ −19.2% │
  ├─────────┼────────┼────────┼────────┤
  │ p99.9   │ 18,276 │ 15,030 │ −17.8% │
  ├─────────┼────────┼────────┼────────┤
  │ max     │ 18,456 │ 15,757 │ −14.6% │
  └─────────┴────────┴────────┴────────┘
```