### PR TITLE
chore(core): fix flaky LineHttpSender and QWP failover tests

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderTest.java
@@ -861,6 +861,7 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
             CountDownLatch renameRegistered = new CountDownLatch(1);
             AtomicBoolean trackOpens = new AtomicBoolean(false);
             AtomicBoolean batchPausedOnce = new AtomicBoolean(false);
+            AtomicBoolean renameRegisteredTimedOut = new AtomicBoolean(false);
 
             FilesFacade ff = new TestFilesFacadeImpl() {
                 @Override
@@ -870,10 +871,18 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
                             && Utf8s.containsAscii(name, tableName)
                             && Utf8s.containsAscii(name, "wal")
                             && Utf8s.endsWithAscii(name, ".d")) {
-                        walSegmentRolled.countDown();
+                        // Claim the pause slot BEFORE releasing the main thread.
+                        // The RENAME executed by the main thread also initializes
+                        // its own WAL segment, which opens matching .d column files.
+                        // If we counted down walSegmentRolled first, the main thread
+                        // could run RENAME and have its openRW win this slot, parking
+                        // the rename itself (deadlock) while the batch commits unparked.
                         if (batchPausedOnce.compareAndSet(false, true)) {
+                            walSegmentRolled.countDown();
                             try {
-                                renameRegistered.await(60, TimeUnit.SECONDS);
+                                if (!renameRegistered.await(60, TimeUnit.SECONDS)) {
+                                    renameRegisteredTimedOut.set(true);
+                                }
                             } catch (InterruptedException e) {
                                 Thread.currentThread().interrupt();
                             }
@@ -987,6 +996,7 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
                 // Wait for sender thread to complete
                 senderThread.join(60_000);
                 Assert.assertFalse("Sender thread timed out", senderThread.isAlive());
+                Assert.assertFalse("Batch timed out waiting for the rename to register", renameRegisteredTimedOut.get());
 
                 // Check for errors
                 Throwable error = senderError.get();

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFailoverBatchSizeTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFailoverBatchSizeTest.java
@@ -195,9 +195,14 @@ public class QwpSenderFailoverBatchSizeTest extends AbstractCairoTest {
                 // The QWP processor on each sidecar acquired WAL writers to
                 // ingest the warm-up / failover-driving rows. Without a WAL
                 // apply job those segments stay un-drained and the pooled
-                // writers keep file descriptors open. Drain explicitly and
-                // release inactive pool entries so assertMemoryLeak doesn't
-                // see them as a leak.
+                // writers keep file descriptors open. Stop the sidecars first
+                // so their worker pools halt and return the WAL writers to the
+                // pool; otherwise releaseInactive() races serverB's worker
+                // thread and may skip a still-checked-out writer, leaking fds.
+                // Then drain explicitly and release inactive pool entries so
+                // assertMemoryLeak doesn't see them as a leak.
+                serverA.stop();
+                serverB.stop();
                 drainWalQueue();
                 engine.releaseInactive();
             } finally {

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFailoverBatchSizeTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderFailoverBatchSizeTest.java
@@ -195,13 +195,14 @@ public class QwpSenderFailoverBatchSizeTest extends AbstractCairoTest {
                 // The QWP processor on each sidecar acquired WAL writers to
                 // ingest the warm-up / failover-driving rows. Without a WAL
                 // apply job those segments stay un-drained and the pooled
-                // writers keep file descriptors open. Stop the sidecars first
-                // so their worker pools halt and return the WAL writers to the
-                // pool; otherwise releaseInactive() races serverB's worker
-                // thread and may skip a still-checked-out writer, leaking fds.
-                // Then drain explicitly and release inactive pool entries so
-                // assertMemoryLeak doesn't see them as a leak.
-                serverA.stop();
+                // writers keep file descriptors open. serverB's sidecar is
+                // still running here (serverA was already stopped above), so
+                // stop it first to halt its worker pool and return the WAL
+                // writer to the pool; otherwise releaseInactive() races
+                // serverB's worker thread and may skip a still-checked-out
+                // writer, leaking fds. Then drain explicitly and release
+                // inactive pool entries so assertMemoryLeak doesn't see them
+                // as a leak.
                 serverB.stop();
                 drainWalQueue();
                 engine.releaseInactive();


### PR DESCRIPTION
## Summary

Two test-only fixes for intermittent failures in the ingestion test harness.
Neither touches production code or changes ingestion/rename behaviour.

- `LineHttpSenderTest.testConcurrentRenameWhileProcessingLargeBatch`
- `QwpSenderFailoverBatchSizeTest.testReconnectToTighterCapRefreshesServerMaxBatchSize`

Note: the core rename race in the first test (claiming the `batchPausedOnce`
slot before counting down `walSegmentRolled`, plus excluding the test thread
from the `openRW` interceptor) already landed on master via #7131, which this
branch merged in. The remaining net-new change to that test here is only the
timeout surfacing described below.

## testConcurrentRenameWhileProcessingLargeBatch

The parked `openRW` interceptor previously swallowed a timed-out
`renameRegistered.await(60, SECONDS)`. If the rename ever failed to register
within 60s, the batch committed unparked, no 503 was produced, and the test
failed with the misleading `AssertionError: Expected LineSenderException due to
table rename` rather than pointing at the real cause.

Change:

- Record the `await` timeout in `renameRegisteredTimedOut` instead of
  discarding it, and assert on it on the main thread after the sender joins.
  A rename that fails to register within 60s now fails the test with an
  accurate message.

## testReconnectToTighterCapRefreshesServerMaxBatchSize

Failed intermittently inside `assertMemoryLeak()` with a leaked file descriptor
count (e.g. 5 extra OS fds), not on the assertion the test was written to check.

Each sidecar's QWP processor acquires a pooled WAL writer to ingest the
warm-up/failover rows. The cleanup called `engine.releaseInactive()` while
serverB's sidecar worker pool was still running. `releaseInactive()` only frees
pool entries that are not currently checked out, so it raced serverB's worker
thread returning its WAL writer to the pool. When the test thread won the race,
the still-checked-out writer was skipped and its file descriptors leaked; when
serverB returned the writer first, the test passed. serverA was unaffected
because it is stopped earlier in the test body.

Change:

- Stop serverB before draining the WAL queue and calling `releaseInactive()`,
  so its worker pool halts and returns the WAL writer to the pool first.
  `QwpSidecar.stop()` is idempotent, so the existing `finally` block remains
  safe.

## Test plan

- Ran `testConcurrentRenameWhileProcessingLargeBatch` repeatedly (6 consecutive
  runs); all pass in ~2s.
- Ran `testReconnectToTighterCapRefreshesServerMaxBatchSize` repeatedly to
  confirm the fd leak no longer reproduces.
