### PR TITLE
fix(qwp): fix WebSocket ingest disconnects during fragmented 101 handshake

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpProcessorState.java
@@ -93,10 +93,12 @@ public class QwpProcessorState implements QuietCloseable, ConnectionAware {
     private byte deferredErrorStatus;
     private boolean durableAckEnabled;
     private long fd = -1;
+    private boolean handshakeFlushPending;
     private long highestProcessedSequence = -1;
     private long lastAckedSequence = -1;
     private long messageSequence;
     private byte negotiatedVersion = QwpConstants.VERSION_1;
+    private int pendingHandshakeBytes;
     private int recvBufferLen;
     private long resumeAckSequence = -1;
     private SecurityContext securityContext;
@@ -275,6 +277,10 @@ public class QwpProcessorState implements QuietCloseable, ConnectionAware {
         return pendingAckSeqTxns;
     }
 
+    public int getPendingHandshakeBytes() {
+        return pendingHandshakeBytes;
+    }
+
     public int getRecvBufferLen() {
         return recvBufferLen;
     }
@@ -297,6 +303,10 @@ public class QwpProcessorState implements QuietCloseable, ConnectionAware {
 
     public boolean isDurableAckEnabled() {
         return durableAckEnabled;
+    }
+
+    public boolean isHandshakeFlushPending() {
+        return handshakeFlushPending;
     }
 
     public boolean isOk() {
@@ -415,6 +425,8 @@ public class QwpProcessorState implements QuietCloseable, ConnectionAware {
         sendState = SEND_STATE_READY;
         clearDeferredError();
         clearDeferredClose();
+        handshakeFlushPending = false;
+        pendingHandshakeBytes = 0;
         wsHandshakeSent = false;
 
         // Drop any durable-ack state; the connection is going away, so even if
@@ -614,12 +626,20 @@ public class QwpProcessorState implements QuietCloseable, ConnectionAware {
         this.durableAckEnabled = durableAckEnabled;
     }
 
+    public void setHandshakeFlushPending(boolean handshakeFlushPending) {
+        this.handshakeFlushPending = handshakeFlushPending;
+    }
+
     public void setHighestProcessedSequence(long highestProcessedSequence) {
         this.highestProcessedSequence = highestProcessedSequence;
     }
 
     public void setNegotiatedVersion(byte negotiatedVersion) {
         this.negotiatedVersion = negotiatedVersion;
+    }
+
+    public void setPendingHandshakeBytes(int pendingHandshakeBytes) {
+        this.pendingHandshakeBytes = pendingHandshakeBytes;
     }
 
     public void setRecvBufferLen(int recvBufferLen) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpWebSocketUpgradeProcessor.java
@@ -346,32 +346,37 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
         if (bytesWritten <= 0) {
             throw responseDoesNotFitSendBuffer(context.getFd(), "101 handshake response", bufferSize, requiredHandshakeSize);
         }
-        try {
-            rawSocket.send(bytesWritten);
-        } catch (PeerIsSlowToReadException e) {
-            // Handshake blocked — shouldn't happen on a fresh connection.
-            // Throw HttpException so handleClientRecv disconnects the connection
-            // rather than leaving the buffer in an inconsistent state.
-            throw HttpException.instance("WebSocket 101 handshake blocked");
-        }
-        // PeerDisconnectedException propagates to handleClientRecv → disconnectHttp()
-        state.setWsHandshakeSent(true);
-        LOG.info().$("WebSocket handshake sent [fd=").$(context.getFd()).I$();
-
-        // Switch to WebSocket protocol - this tells the framework to bypass HTTP parsing
-        context.switchProtocol();
+        // The HttpRequestProcessor contract forbids PeerIsSlowToReadException
+        // from onHeadersReady, so defer the raw-socket send to onRequestComplete
+        // where PISR propagates cleanly into the framework's park-on-write path.
+        // State carries the byte count across the two calls; finalizeHandshake
+        // performs the protocol switch only after the bytes are on the wire so
+        // we don't start parsing WebSocket frames while the 101 is still in
+        // flight.
+        state.setPendingHandshakeBytes(bytesWritten);
+        state.setHandshakeFlushPending(true);
     }
 
     @Override
-    public void onRequestComplete(HttpConnectionContext context) {
-        // For WebSocket, after the handshake is sent, we just return normally.
-        // The framework will call reset() and then loop back to handleClientRecv().
-        // Since we called switchProtocol() in onHeadersReady, the framework will
-        // delegate to resumeRecv instead of parsing more HTTP requests.
+    public void onRequestComplete(HttpConnectionContext context)
+            throws PeerDisconnectedException, PeerIsSlowToReadException, ServerDisconnectException {
         QwpProcessorState state = LV.get(context);
-        if (state != null && state.isWsHandshakeSent()) {
-            LOG.debug().$("WebSocket handshake complete, ready for frames [fd=").$(context.getFd()).I$();
+        if (state == null || !state.isHandshakeFlushPending()) {
+            // Either the handshake never made it past validation, or it has
+            // already been flushed and the protocol switch completed.
+            if (state != null && state.isWsHandshakeSent()) {
+                LOG.debug().$("WebSocket handshake complete, ready for frames [fd=").$(context.getFd()).I$();
+            }
+            return;
         }
+        // rawSocket.send may park us (small force-fragmentation chunk or a real
+        // slow peer's kernel buffer filling up). PISR propagates to
+        // handleClientRecv which parks the connection for write and schedules
+        // resumeSend; resumeSend finishes the flush and finalises the protocol
+        // switch.
+        HttpRawSocket rawSocket = context.getRawResponseSocket();
+        rawSocket.send(state.getPendingHandshakeBytes());
+        finalizeHandshake(context, state);
     }
 
     @Override
@@ -456,6 +461,18 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
         QwpProcessorState state = LV.get(context);
         if (state == null) {
             throw ServerDisconnectException.INSTANCE;
+        }
+
+        if (state.isHandshakeFlushPending()) {
+            // The deferred 101 send parked mid-flight. Drain the rest of the
+            // response from the framework buffer; PISR propagates so the
+            // dispatcher re-parks and re-enters here until the buffer is empty.
+            // Only after the flush completes do we finalise the protocol switch,
+            // so the connection never starts parsing WebSocket frames while the
+            // 101 response is still on the wire.
+            context.resumeResponseSend();
+            finalizeHandshake(context, state);
+            return;
         }
 
         switch (state.getSendState()) {
@@ -585,6 +602,17 @@ public class QwpWebSocketUpgradeProcessor implements HttpRequestProcessor {
                 throw PeerDisconnectedException.INSTANCE;
             }
         }
+    }
+
+    private void finalizeHandshake(HttpConnectionContext context, QwpProcessorState state) {
+        state.setWsHandshakeSent(true);
+        state.setHandshakeFlushPending(false);
+        state.setPendingHandshakeBytes(0);
+        LOG.info().$("WebSocket handshake sent [fd=").$(context.getFd()).I$();
+        // Switch to WebSocket protocol so subsequent reads bypass HTTP parsing.
+        // Done here, not in onHeadersReady, so the switch happens only after
+        // the 101 response has fully flushed.
+        context.switchProtocol();
     }
 
     private void flushPendingAck(HttpConnectionContext context, QwpProcessorState state)

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/AbstractQwpWebSocketTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/AbstractQwpWebSocketTest.java
@@ -183,20 +183,40 @@ public class AbstractQwpWebSocketTest extends AbstractCairoTest {
     }
 
     protected void runInContext(QwpTestContext r, int recvBufferSize, int forceRecvFragmentationChunkSize) throws Exception {
-        runInContext(r, recvBufferSize, forceRecvFragmentationChunkSize, true);
+        runInContext(r, recvBufferSize, forceRecvFragmentationChunkSize, Integer.MAX_VALUE, true);
+    }
+
+    protected void runInContext(
+            QwpTestContext r,
+            int recvBufferSize,
+            int forceRecvFragmentationChunkSize,
+            int forceSendFragmentationChunkSize
+    ) throws Exception {
+        runInContext(r, recvBufferSize, forceRecvFragmentationChunkSize, forceSendFragmentationChunkSize, true);
     }
 
     protected void runInContextNoAutoCreate(QwpTestContext r) throws Exception {
-        runInContext(r, 65_536, Integer.MAX_VALUE, false);
+        runInContext(r, 65_536, Integer.MAX_VALUE, Integer.MAX_VALUE, false);
     }
 
-    private void runInContext(QwpTestContext r, int recvBufferSize, int forceRecvFragmentationChunkSize, boolean autoCreateNewColumns) throws Exception {
+    private void runInContext(
+            QwpTestContext r,
+            int recvBufferSize,
+            int forceRecvFragmentationChunkSize,
+            int forceSendFragmentationChunkSize,
+            boolean autoCreateNewColumns
+    ) throws Exception {
         final HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(
                 configuration,
                 new DefaultHttpContextConfiguration() {
                     @Override
                     public int getForceRecvFragmentationChunkSize() {
                         return forceRecvFragmentationChunkSize;
+                    }
+
+                    @Override
+                    public int getForceSendFragmentationChunkSize() {
+                        return forceSendFragmentationChunkSize;
                     }
                 }
         ) {

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketProtocolTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketProtocolTest.java
@@ -120,6 +120,25 @@ public class QwpWebSocketProtocolTest extends AbstractQwpWebSocketTest {
     }
 
     @Test
+    public void testHandshakeSurvivesSmallSendChunkSize() throws Exception {
+        // Regression test: with forceSendFragmentationChunkSize=7, the ~200-byte
+        // 101 response gets fragmented and HttpResponseSink.sendBuffer throws
+        // PeerIsSlowToReadException after the first chunk to hand control back
+        // to the dispatcher's park-on-write loop. The ingress upgrade processor
+        // must defer the raw send to onRequestComplete and let PISR propagate
+        // into the framework, not catch it and treat it as a fatal handshake
+        // failure. performWebSocketHandshake reads byte-by-byte until
+        // \r\n\r\n and asserts a 101 status line, so a mid-handshake disconnect
+        // surfaces as "Unexpected end of stream during handshake".
+        runInContext((port) -> {
+            try (Socket socket = new Socket("localhost", port)) {
+                socket.setSoTimeout(5_000);
+                performWebSocketHandshake(socket, port);
+            }
+        }, 65_536, Integer.MAX_VALUE, 7);
+    }
+
+    @Test
     public void testStatusCodesSynchronizedBetweenServerAndClient() {
         assertClientDecodesStatus(QwpConstants.STATUS_OK, "OK");
         assertClientDecodesStatus(QwpConstants.STATUS_PARSE_ERROR, "PARSE_ERROR");

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/QwpWebSocketUpgradeProcessorOnHeadersReadyTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/QwpWebSocketUpgradeProcessorOnHeadersReadyTest.java
@@ -112,6 +112,9 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
                 header.setHeader("Sec-WebSocket-Version", "13");
 
                 processor.onHeadersReady(context);
+                // onHeadersReady now defers the raw-socket send to onRequestComplete;
+                // drive both to populate sentSize and trigger the protocol switch.
+                processor.onRequestComplete(context);
 
                 String response = readResponse(bufferAddr, context.getMockRawSocket().sentSize);
                 String expectedHeader = "\r\nX-QWP-Max-Batch-Size: " + expectedAdvertisedCap + "\r\n";
@@ -351,6 +354,7 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
             }
 
             processor.onHeadersReady(context);
+            processor.onRequestComplete(context);
 
             Assert.assertTrue("handshake must have switched protocol", context.isSwitchProtocolCalled());
             QwpProcessorState state = lv.get(context);
@@ -379,6 +383,7 @@ public class QwpWebSocketUpgradeProcessorOnHeadersReadyTest extends AbstractCair
             header.setHeader("Sec-WebSocket-Version", "13");
 
             processor.onHeadersReady(context);
+            processor.onRequestComplete(context);
 
             Assert.assertTrue("handshake must have switched protocol", context.isSwitchProtocolCalled());
             Assert.assertNotNull("state must be populated after successful handshake", lv.get(context));

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/QwpWebSocketUpgradeProcessorResumeRecvTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/QwpWebSocketUpgradeProcessorResumeRecvTest.java
@@ -563,6 +563,12 @@ public class QwpWebSocketUpgradeProcessorResumeRecvTest extends AbstractCairoTes
 
     @Test
     public void testHandshakeSendSlowToRead() throws Exception {
+        // onHeadersReady defers the raw-socket send to onRequestComplete so that
+        // PeerIsSlowToReadException can propagate cleanly into the framework's
+        // park-on-write path. Verify onHeadersReady returns without throwing and
+        // that the deferred send in onRequestComplete surfaces PISR for the
+        // framework to handle (rather than the upgrade processor swallowing it
+        // and disconnecting mid-handshake).
         assertMemoryLeak(() -> {
             HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
             QwpWebSocketUpgradeProcessor processor = new QwpWebSocketUpgradeProcessor(engine, httpConfig);
@@ -582,11 +588,15 @@ public class QwpWebSocketUpgradeProcessorResumeRecvTest extends AbstractCairoTes
                 header.setHeader("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
                 header.setHeader("Sec-WebSocket-Version", "13");
 
+                processor.onHeadersReady(context);
+                Assert.assertEquals("onHeadersReady must not send", 0, mockRawSocket.sendCallCount);
+
                 try {
-                    processor.onHeadersReady(context);
-                    Assert.fail("Expected HttpException");
-                } catch (HttpException e) {
-                    TestUtils.assertContains(e.getFlyweightMessage(), "blocked");
+                    processor.onRequestComplete(context);
+                    Assert.fail("Expected PeerIsSlowToReadException");
+                } catch (PeerIsSlowToReadException expected) {
+                    // PISR propagates so the dispatcher parks the connection and
+                    // schedules resumeSend to finish the flush.
                 }
             } finally {
                 Unsafe.free(sendBuf, SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
@@ -1139,8 +1149,10 @@ public class QwpWebSocketUpgradeProcessorResumeRecvTest extends AbstractCairoTes
                 header.setHeader("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
                 header.setHeader("Sec-WebSocket-Version", "13");
 
-                // First call creates state
+                // First call creates state; the protocol switch is finalised
+                // after the deferred 101 send completes in onRequestComplete.
                 processor.onHeadersReady(context);
+                processor.onRequestComplete(context);
                 Assert.assertTrue(context.isSwitchProtocolCalled());
 
                 LocalValue<QwpProcessorState> lv = getLV();
@@ -1153,6 +1165,7 @@ public class QwpWebSocketUpgradeProcessorResumeRecvTest extends AbstractCairoTes
 
                 // Second call reuses (clears) existing state
                 processor.onHeadersReady(context);
+                processor.onRequestComplete(context);
                 Assert.assertTrue(context.isSwitchProtocolCalled());
 
                 QwpProcessorState state2 = lv.get(context);


### PR DESCRIPTION
## Summary

The QWP/WebSocket ingress upgrade processor sent the 101 Switching
Protocols response synchronously from `onHeadersReady` and caught
`PeerIsSlowToReadException` as a fatal "handshake blocked" error.
`HttpResponseSink.sendBuffer` deliberately throws PISR after a chunk
when `forceSendFragmentationChunkSize` is smaller than the response,
and also throws on the `n == 0` branch when a real slow peer's kernel
send window cannot accept the whole 101 in one shot. In both cases
the processor converted the signal into an `HttpException` and
disconnected mid-handshake. A client connecting via QWP/WebSocket
ingest then saw exactly `chunkSize` bytes followed by EOF before the
`\r\n\r\n` header terminator arrived.

In production with the default `forceSendFragmentationChunkSize =
Integer.MAX_VALUE`, the fragmentation branch never trips. The
`n == 0` branch can still fire when the kernel send buffer is small
or a proxy / TCP-window quirk fragments the 101 response, so the bug
is rare in default deployments but possible in practice. The
egress upgrade processor on the same code path already handles this
correctly; this PR brings the ingress processor in line.

The fix mirrors `QwpEgressUpgradeProcessor`: `onHeadersReady` writes
the response into the send buffer and records the byte count on the
per-connection state; `onRequestComplete` performs `rawSocket.send`
and finalises the protocol switch; `resumeSend` drains any parked
bytes via `context.resumeResponseSend()` before finalising. PISR
propagates into the framework's park-on-write path and the dispatcher
resumes the flush until the buffer is empty. The protocol switch
happens only after the 101 response is fully on the wire, so the
connection never starts parsing WebSocket frames while the handshake
is still in flight.

## Tradeoffs and notes

- `QwpProcessorState` gains two fields (`handshakeFlushPending`,
  `pendingHandshakeBytes`) and getters/setters, paralleling
  `QwpEgressProcessorState`. `onDisconnected()` resets them.
- `onRequestComplete`'s declared exceptions widen to match the
  `HttpRequestProcessor` contract (`PeerDisconnectedException`,
  `PeerIsSlowToReadException`, `ServerDisconnectException`) since
  it now performs network I/O. Callers in the framework already
  expect these.
- The protocol switch shifts from `onHeadersReady` to a new private
  `finalizeHandshake` helper invoked once the send completes. The
  framework invokes `onHeadersReady` and `onRequestComplete`
  back-to-back inside `handleClientRecv`, so the synchronous fast
  path for callers that never park is observationally identical to
  before.
- The buffer-too-small failure paths (400 / 426 / 421) keep their
  existing synchronous send. Those responses fit in one chunk and
  the failure semantics there are unchanged.
- Three white-box unit tests that asserted the old in-`onHeadersReady`
  send semantics now also drive `onRequestComplete`; no assertion
  intent changed. `testHandshakeSendSlowToRead` was flipped from
  asserting an `HttpException` to asserting PISR propagation, since
  PISR is now the correct outward signal of a parked handshake send.

## Test plan

- Added `QwpWebSocketProtocolTest#testHandshakeSurvivesSmallSendChunkSize`,
  which boots the server with `forceSendFragmentationChunkSize = 7`
  and performs a WebSocket upgrade. On master this fails with
  `Unexpected end of stream during handshake` after exactly 7 bytes;
  with this change it passes.
- Ran the full `Qwp*Test, *WebSocket*` test set (1391 tests): all
  pass with no skips beyond the two pre-existing skipped tests.
- Ran adjacent suites (`LineHttp*Test`, `*HttpServer*Test`,
  `*HttpProcessor*Test`, 164 tests): all pass.
- Updated white-box unit tests
  (`QwpWebSocketUpgradeProcessorOnHeadersReadyTest`,
  `QwpWebSocketUpgradeProcessorResumeRecvTest`) to drive
  `onRequestComplete` where they previously relied on
  `onHeadersReady` having already sent the response. The c-questdb-client
  Rust fuzz test `binary_qwp_ws_random_fuzz` referenced in the
  original bug report exercises the same path and should start
  passing without further change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)