### PR TITLE
test(ilp): fix flaky rename-during-large-batch race

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/line/LineHttpSenderTest.java
@@ -851,27 +851,42 @@ public class LineHttpSenderTest extends AbstractBootstrapTest {
             // We also need to pause the batch on the first matching openRW until
             // the rename has committed its structural change to the sequencer.
             // Otherwise the batch's sequencer.nextTxn (commit) can win the race
-            // against the rename's sequencer.nextStructureTxn — both serialize
+            // against the rename's sequencer.nextStructureTxn -- both serialize
             // through the same sequencer WRITE lock, and the test depends on the
             // rename arriving first so the batch commit sees a token mismatch and
-            // is rejected via TableReferenceOutOfDateException -> 503. Only the
-            // first matching openRW is blocked, so the rename's own openRW for
-            // its wal2/0 segment is not blocked and cannot deadlock.
+            // is rejected via TableReferenceOutOfDateException -> 503.
+            //
+            // The RENAME runs synchronously on the test thread and also opens
+            // matching wal*/0 column files (its own structural-change segment).
+            // If the intercept allowed the test thread in, the test thread could
+            // win the race for the first match and park itself in execute(),
+            // letting the batch commit unhindered. Exclude the test thread so
+            // only the batch's HTTP worker can be parked.
             CountDownLatch walSegmentRolled = new CountDownLatch(1);
             CountDownLatch renameRegistered = new CountDownLatch(1);
             AtomicBoolean trackOpens = new AtomicBoolean(false);
             AtomicBoolean batchPausedOnce = new AtomicBoolean(false);
+            final Thread testThread = Thread.currentThread();
 
             FilesFacade ff = new TestFilesFacadeImpl() {
                 @Override
                 public long openRW(LPSZ name, int opts) {
                     long fd = super.openRW(name, opts);
+                    // Skip the test thread entirely: it runs the RENAME, and we must never park
+                    // it. If allowed in, the test thread's own openRW for wal*/0 column files
+                    // could win the parker CAS and deadlock the rename for 60 seconds.
                     if (trackOpens.get()
+                            && Thread.currentThread() != testThread
                             && Utf8s.containsAscii(name, tableName)
                             && Utf8s.containsAscii(name, "wal")
                             && Utf8s.endsWithAscii(name, ".d")) {
+                        // Decide who parks BEFORE counting down walSegmentRolled. If we counted
+                        // down first and then got preempted, the main thread could wake, issue
+                        // the RENAME, and a second matching openRW could win the CAS before
+                        // this one reaches it -- letting the batch commit unhindered.
+                        boolean parker = batchPausedOnce.compareAndSet(false, true);
                         walSegmentRolled.countDown();
-                        if (batchPausedOnce.compareAndSet(false, true)) {
+                        if (parker) {
                             try {
                                 renameRegistered.await(60, TimeUnit.SECONDS);
                             } catch (InterruptedException e) {


### PR DESCRIPTION
## Summary

`LineHttpSenderTest.testConcurrentRenameWhileProcessingLargeBatch` fails intermittently on slower runners ([Azure DevOps build 234875](https://dev.azure.com/questdb/questdb/_build/results?buildId=234875)). The failure is in the test's coordination logic, not in QuestDB itself.

The test installs an `openRW` intercept that does two things on the first matching file open:

```java
walSegmentRolled.countDown();                            // wake main thread
if (batchPausedOnce.compareAndSet(false, true)) { park } // pick the parker
```

If the batch's HTTP worker is preempted between the two, the main thread wakes, runs `RENAME` synchronously on the test thread, the rename's own openRW for its `wal2/0` column files reaches the CAS first, and the **test thread** parks itself inside `execute()`. The rename then stalls for the 60-second timeout while the batch — which never parked — commits via `sequencer.nextTxn` before any structural change is registered. No `TableReferenceOutOfDateException` is raised, and the assertion fires.

Reproduced locally by inserting `Thread.sleep(500)` between `countDown` and the CAS — same error, same ~60s duration as CI.

Two changes make the intercept deterministic:

- **Exclude the test thread**. The rename always runs synchronously on the test thread and must never be parked. Only the batch's HTTP worker is eligible to be the parker.
- **CAS before countDown**. The parker is committed atomically before the main thread is released, so a preemption window cannot let a second matcher win the CAS.

No production code is touched; this is a test-only fix.

## Test plan

- Reproduced the original failure locally with an injected `Thread.sleep(500)` between `countDown` and CAS — failed with the same `Expected LineSenderException due to table rename` and ~60s duration as CI.
- Re-ran with the same artificial delay after the fix — passes.
- 15/15 stress runs of `testConcurrentRenameWhileProcessingLargeBatch` pass.
- Full `LineHttpSenderTest` class (74 tests, 1 skipped) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)