### PR TITLE
chore(core): fix flaky testConcurrentQueryRejectedInPhaseOne()

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressBootstrapTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressBootstrapTest.java
@@ -385,24 +385,29 @@ public class QwpEgressBootstrapTest extends AbstractReusedServerQwpEgressTest {
      * connection; this regression test instead asserts the state guard directly.
      */
     @Test
-    public void testConcurrentQueryRejectedInPhaseOne() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            io.questdb.cairo.CairoConfiguration cfg = new DefaultTestCairoConfiguration(root);
-            try (QwpEgressProcessorState state = new QwpEgressProcessorState(cfg)) {
-                Assert.assertFalse("state starts inactive", state.isStreamingActive());
-                // Simulate a streaming-active state without actual native resources by
-                // calling beginStreaming with null factory/cursor. The defensive endStreaming
-                // inside beginStreaming is idempotent for null.
-                state.beginStreaming(1L, null, null, 0, 0, false, 0L, null);
-                Assert.assertTrue(state.isStreamingActive());
-                // A second beginStreaming must not double-free (endStreaming handles nulls)
-                // and must transition to the new requestId cleanly.
-                state.beginStreaming(2L, null, null, 0, 0, false, 0L, null);
-                Assert.assertTrue(state.isStreamingActive());
-                state.endStreaming();
-                Assert.assertFalse(state.isStreamingActive());
-            }
-        });
+    public void testConcurrentQueryRejectedInPhaseOne() {
+        // No assertMemoryLeak here: this test drives QwpEgressProcessorState purely in memory
+        // (beginStreaming/endStreaming with null factory/cursor) and opens no files of its own.
+        // A per-test FD snapshot would race the shared server's background threads (e.g. async WAL
+        // purge of tables dropped by the previous test's resetState), flagging a phantom leak when
+        // an unrelated server-owned descriptor is closed mid-test. The state object is closed via
+        // try-with-resources, and AbstractReusedServerQwpEgressTest's class-level bracket already
+        // verifies FD and native-memory baselines across the whole class.
+        io.questdb.cairo.CairoConfiguration cfg = new DefaultTestCairoConfiguration(root);
+        try (QwpEgressProcessorState state = new QwpEgressProcessorState(cfg)) {
+            Assert.assertFalse("state starts inactive", state.isStreamingActive());
+            // Simulate a streaming-active state without actual native resources by
+            // calling beginStreaming with null factory/cursor. The defensive endStreaming
+            // inside beginStreaming is idempotent for null.
+            state.beginStreaming(1L, null, null, 0, 0, false, 0L, null);
+            Assert.assertTrue(state.isStreamingActive());
+            // A second beginStreaming must not double-free (endStreaming handles nulls)
+            // and must transition to the new requestId cleanly.
+            state.beginStreaming(2L, null, null, 0, 0, false, 0L, null);
+            Assert.assertTrue(state.isStreamingActive());
+            state.endStreaming();
+            Assert.assertFalse(state.isStreamingActive());
+        }
     }
 
     @Test
@@ -577,7 +582,6 @@ public class QwpEgressBootstrapTest extends AbstractReusedServerQwpEgressTest {
                 final String createSql = "CREATE TABLE " + table
                         + "(v LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL";
                 final String insertSql = "INSERT INTO " + table + " VALUES (1, 1::TIMESTAMP)";
-                final String selectSql = "SELECT v FROM " + table;
 
                 // Seed: create the table and run the SELECT once so the
                 // server compiles a RecordCursorFactory and parks it in
@@ -587,7 +591,7 @@ public class QwpEgressBootstrapTest extends AbstractReusedServerQwpEgressTest {
                 serverMain.awaitTable(table);
                 try (QwpQueryClient seed = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
                     seed.connect();
-                    assertSelectReturnsOneRow(seed, selectSql, "seed");
+                    assertSelectReturnsOneRow(seed, "seed");
                 }
 
                 // Trigger: DROP+CREATE (same name + shape -> new internal table
@@ -602,7 +606,7 @@ public class QwpEgressBootstrapTest extends AbstractReusedServerQwpEgressTest {
                     serverMain.awaitTable(table);
                     try (QwpQueryClient trigger = QwpQueryClient.newPlainText("127.0.0.1", HTTP_PORT)) {
                         trigger.connect();
-                        assertSelectReturnsOneRow(trigger, selectSql, "trigger-" + i);
+                        assertSelectReturnsOneRow(trigger, "trigger-" + i);
                     }
                 }
             }
@@ -735,8 +739,10 @@ public class QwpEgressBootstrapTest extends AbstractReusedServerQwpEgressTest {
     /**
      * Regression / defense-in-depth for C1: many queries that fail at various stages
      * of the server-side handle path (compile error, table-not-found, non-SELECT)
-     * must not leak native resources. assertMemoryLeak catches any leaked factory,
-     * cursor, or buffer scratch.
+     * must not leak native resources. This runs against the shared server, so it relies
+     * on AbstractReusedServerQwpEgressTest's class-level FD/native-memory bracket to catch
+     * any leaked factory, cursor, or buffer scratch rather than a per-test assertMemoryLeak
+     * (whose FD snapshot would race the shared server's background threads).
      */
     @Test
     public void testFailedQueriesDoNotLeak() throws Exception {
@@ -1777,10 +1783,10 @@ public class QwpEgressBootstrapTest extends AbstractReusedServerQwpEgressTest {
         Assert.assertNull(rows[1][1]);
     }
 
-    private static void assertSelectReturnsOneRow(QwpQueryClient client, String sql, String label) {
+    private static void assertSelectReturnsOneRow(QwpQueryClient client, String label) {
         final long[] sum = {0};
         final long[] rows = {0};
-        client.execute(sql, new QwpColumnBatchHandler() {
+        client.execute("SELECT v FROM schema_cache_retry_t", new QwpColumnBatchHandler() {
             @Override
             public void onBatch(QwpColumnBatch batch) {
                 int n = batch.getRowCount();


### PR DESCRIPTION
## What

`QwpEgressBootstrapTest.testConcurrentQueryRejectedInPhaseOne` fails intermittently in CI with a spurious file-descriptor leak, e.g.:

```
expected: cached file descriptors: 96 ... actual: cached file descriptors: 95
```

## Root cause

The test wraps its body in a per-test `TestUtils.assertMemoryLeak(...)`, which snapshots the global open-FD count before the body and asserts it returns to that baseline afterwards. But the test runs in `QwpEgressBootstrapTest`, which extends `AbstractReusedServerQwpEgressTest` — a base that boots a single long-lived server for the whole class and, between tests, runs `DROP ALL TABLES` + WAL drain in `resetState()`. That base class deliberately disables per-test FD/memory checks and brackets the whole class instead, precisely because the persistent server's background threads (async WAL purge of dropped tables) keep opening and closing descriptors that never return to a per-test baseline.

`testConcurrentQueryRejectedInPhaseOne` drives `QwpEgressProcessorState` purely in memory (`beginStreaming`/`endStreaming` with null factory/cursor) and opens no files of its own. Diffing the FD lists from a failing run confirms it: zero descriptors were opened during the test, and exactly one server-owned descriptor was closed mid-test — the async purge of a table the previous test dropped. The per-test snapshot races that background close and reports a phantom leak.

## Change

- Drop the per-test `assertMemoryLeak` wrapper from `testConcurrentQueryRejectedInPhaseOne`. The state object is still closed via try-with-resources, and the class-level bracket in `AbstractReusedServerQwpEgressTest` still verifies FD and native-memory baselines across the whole class, so a genuine leak from this state object is still caught.
- Fix the stale javadoc on `testFailedQueriesDoNotLeak`: it claimed an `assertMemoryLeak` the body never used. It runs against the shared server and relies on the class-level bracket; the comment now says so.
- Minor cleanup in `testDropRecreateDoesNotPoisonSchemaCache` / `assertSelectReturnsOneRow`: the helper always queries the same table, so the redundant `sql` parameter is removed.

## Tradeoffs

- `testConcurrentQueryRejectedInPhaseOne` loses its own per-test leak assertion. This is intentional: that assertion was not meaningful here (the test allocates no native file resources) and was the source of the flakiness. Leak coverage for this state object now comes only from the class-level bracket, which is coarser but not racy.
- The two other leak-checked tests in this class (`testDropAfterSelectReleasesReaderInTime`, `testDropRecreateDoesNotPoisonSchemaCache`) keep their `assertMemoryLeak`: both call `freeSharedServer()` first and boot their own server entirely inside the bracket, so they are self-contained and not exposed to the shared-server race.

## Test plan

- Ran `testConcurrentQueryRejectedInPhaseOne` locally on Java 25 — passes.
- Test-only change; no production code touched.
