### PR TITLE
fix(core): fix indexed NULL lookups against Parquet partitions

### DIFF
--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -25,9 +25,9 @@
 package io.questdb.cairo;
 
 import io.questdb.MessageBus;
+import io.questdb.cairo.idx.BitmapIndexUtils;
 import io.questdb.cairo.idx.IndexWriter;
 import io.questdb.cairo.sql.RecordMetadata;
-import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.cairo.sql.TableRecordMetadata;
 import io.questdb.cairo.vm.api.MemoryCR;
 import io.questdb.cairo.vm.api.MemoryMA;
@@ -3370,18 +3370,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                                 final long addr = rowGroupBuffers.getChunkDataPtr(0);
                                 final long size = rowGroupBuffers.getChunkDataSize(0);
                                 if (size == 0) {
-                                    // _pm-backed decode fast path: when the chunk's stats report
-                                    // null_count == num_values the Rust decoder skips
-                                    // materialising the buffer and returns size=0 (see
-                                    // RowGroupBuffers javadoc). The caller must emit null index
-                                    // entries for every row in the row group, otherwise indexed
-                                    // WHERE x = null on a rewritten parquet partition silently
-                                    // returns no rows.
-                                    final int nullKey = TableUtils.toIndexKey(SymbolTable.VALUE_IS_NULL);
-                                    final long rgEnd = rowCount + rowGroupSize;
-                                    for (; rowId < rgEnd; rowId++) {
-                                        indexWriter.add(nullKey, rowId);
-                                    }
+                                    BitmapIndexUtils.addNullEntries(indexWriter, rowId, rowCount + rowGroupSize);
                                 } else {
                                     for (long p = addr, lim = addr + size; p < lim; p += 4, rowId++) {
                                         indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -27,6 +27,7 @@ package io.questdb.cairo;
 import io.questdb.MessageBus;
 import io.questdb.cairo.idx.IndexWriter;
 import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.cairo.sql.TableRecordMetadata;
 import io.questdb.cairo.vm.api.MemoryCR;
 import io.questdb.cairo.vm.api.MemoryMA;
@@ -3368,8 +3369,23 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                                 long rowId = Math.max(rowCount, columnTop);
                                 final long addr = rowGroupBuffers.getChunkDataPtr(0);
                                 final long size = rowGroupBuffers.getChunkDataSize(0);
-                                for (long p = addr, lim = addr + size; p < lim; p += 4, rowId++) {
-                                    indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);
+                                if (size == 0) {
+                                    // _pm-backed decode fast path: when the chunk's stats report
+                                    // null_count == num_values the Rust decoder skips
+                                    // materialising the buffer and returns size=0 (see
+                                    // RowGroupBuffers javadoc). The caller must emit null index
+                                    // entries for every row in the row group, otherwise indexed
+                                    // WHERE x = null on a rewritten parquet partition silently
+                                    // returns no rows.
+                                    final int nullKey = TableUtils.toIndexKey(SymbolTable.VALUE_IS_NULL);
+                                    final long rgEnd = rowCount + rowGroupSize;
+                                    for (; rowId < rgEnd; rowId++) {
+                                        indexWriter.add(nullKey, rowId);
+                                    }
+                                } else {
+                                    for (long p = addr, lim = addr + size; p < lim; p += 4, rowId++) {
+                                        indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);
+                                    }
                                 }
 
                                 rowCount += rowGroupSize;

--- a/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
+++ b/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
@@ -24,13 +24,13 @@
 
 package io.questdb.cairo;
 
+import io.questdb.cairo.idx.BitmapIndexUtils;
 import io.questdb.cairo.idx.IndexFactory;
 import io.questdb.cairo.idx.IndexWriter;
 import io.questdb.cairo.idx.PostingIndexUtils;
 import io.questdb.cairo.mv.MatViewDefinition;
 import io.questdb.cairo.mv.MatViewState;
 import io.questdb.cairo.sql.RecordMetadata;
-import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.cairo.view.ViewDefinition;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryCMARW;
@@ -1252,20 +1252,7 @@ public class TableSnapshotRestore implements QuietCloseable {
                     final long addr = rowGroupBuffers.getChunkDataPtr(i);
                     final long size = rowGroupBuffers.getChunkDataSize(i);
                     if (size == 0) {
-                        // _pm-backed decode fast path: when the chunk's stats
-                        // report null_count == num_values the Rust decoder
-                        // skips materialising the buffer and returns size=0
-                        // (see RowGroupBuffers javadoc). The caller must
-                        // emit null index entries for every row covered by
-                        // the row group, otherwise the rebuilt index drops
-                        // every NULL and indexed WHERE col = null on a
-                        // restored parquet partition silently returns no
-                        // rows.
-                        final int nullKey = TableUtils.toIndexKey(SymbolTable.VALUE_IS_NULL);
-                        final long rgEnd = rowCount + rowGroupSize;
-                        for (; rowId < rgEnd; rowId++) {
-                            indexWriter.add(nullKey, rowId);
-                        }
+                        BitmapIndexUtils.addNullEntries(indexWriter, rowId, rowCount + rowGroupSize);
                     } else {
                         for (long p = addr + startOffset * 4, lim = addr + size; p < lim; p += 4, rowId++) {
                             indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);

--- a/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
+++ b/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.idx.PostingIndexUtils;
 import io.questdb.cairo.mv.MatViewDefinition;
 import io.questdb.cairo.mv.MatViewState;
 import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.cairo.view.ViewDefinition;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryCMARW;
@@ -1250,8 +1251,25 @@ public class TableSnapshotRestore implements QuietCloseable {
 
                     final long addr = rowGroupBuffers.getChunkDataPtr(i);
                     final long size = rowGroupBuffers.getChunkDataSize(i);
-                    for (long p = addr + startOffset * 4, lim = addr + size; p < lim; p += 4, rowId++) {
-                        indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);
+                    if (size == 0) {
+                        // _pm-backed decode fast path: when the chunk's stats
+                        // report null_count == num_values the Rust decoder
+                        // skips materialising the buffer and returns size=0
+                        // (see RowGroupBuffers javadoc). The caller must
+                        // emit null index entries for every row covered by
+                        // the row group, otherwise the rebuilt index drops
+                        // every NULL and indexed WHERE col = null on a
+                        // restored parquet partition silently returns no
+                        // rows.
+                        final int nullKey = TableUtils.toIndexKey(SymbolTable.VALUE_IS_NULL);
+                        final long rgEnd = rowCount + rowGroupSize;
+                        for (; rowId < rgEnd; rowId++) {
+                            indexWriter.add(nullKey, rowId);
+                        }
+                    } else {
+                        for (long p = addr + startOffset * 4, lim = addr + size; p < lim; p += 4, rowId++) {
+                            indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);
+                        }
                     }
                 }
 

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -6662,8 +6662,23 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     long rowId = Math.max(rowCount, columnTop);
                     final long addr = rowGroupBuffers.getChunkDataPtr(0);
                     final long size = rowGroupBuffers.getChunkDataSize(0);
-                    for (long p = addr, lim = addr + size; p < lim; p += 4, rowId++) {
-                        indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);
+                    if (size == 0) {
+                        // _pm-backed decode fast path: when the chunk's stats report
+                        // null_count == num_values the Rust decoder skips
+                        // materialising the buffer and returns size=0 (see
+                        // RowGroupBuffers javadoc). The caller must emit null index
+                        // entries for every row in the row group, otherwise indexed
+                        // WHERE x = null on a parquet partition (e.g. after ALTER
+                        // TABLE ADD INDEX) silently returns no rows.
+                        final int nullKey = TableUtils.toIndexKey(SymbolTable.VALUE_IS_NULL);
+                        final long rgEnd = rowCount + rowGroupSize;
+                        for (; rowId < rgEnd; rowId++) {
+                            indexWriter.add(nullKey, rowId);
+                        }
+                    } else {
+                        for (long p = addr, lim = addr + size; p < lim; p += 4, rowId++) {
+                            indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);
+                        }
                     }
 
                     rowCount += rowGroupSize;

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -6663,18 +6663,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     final long addr = rowGroupBuffers.getChunkDataPtr(0);
                     final long size = rowGroupBuffers.getChunkDataSize(0);
                     if (size == 0) {
-                        // _pm-backed decode fast path: when the chunk's stats report
-                        // null_count == num_values the Rust decoder skips
-                        // materialising the buffer and returns size=0 (see
-                        // RowGroupBuffers javadoc). The caller must emit null index
-                        // entries for every row in the row group, otherwise indexed
-                        // WHERE x = null on a parquet partition (e.g. after ALTER
-                        // TABLE ADD INDEX) silently returns no rows.
-                        final int nullKey = TableUtils.toIndexKey(SymbolTable.VALUE_IS_NULL);
-                        final long rgEnd = rowCount + rowGroupSize;
-                        for (; rowId < rgEnd; rowId++) {
-                            indexWriter.add(nullKey, rowId);
-                        }
+                        BitmapIndexUtils.addNullEntries(indexWriter, rowId, rowCount + rowGroupSize);
                     } else {
                         for (long p = addr, lim = addr + size; p < lim; p += 4, rowId++) {
                             indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);

--- a/core/src/main/java/io/questdb/cairo/idx/BitmapIndexUtils.java
+++ b/core/src/main/java/io/questdb/cairo/idx/BitmapIndexUtils.java
@@ -25,6 +25,8 @@
 package io.questdb.cairo.idx;
 
 import io.questdb.cairo.CairoException;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.sql.SymbolTable;
 import io.questdb.cairo.vm.api.MemoryR;
 import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.Path;
@@ -49,6 +51,24 @@ public final class BitmapIndexUtils {
     public static final int KEY_RESERVED_OFFSET_VALUE_MEM_SIZE = 9;
     public static final byte SIGNATURE = (byte) 0xfa;
     public static final int VALUE_BLOCK_FILE_RESERVED = 16;
+
+    /**
+     * Emits NULL-key index entries for rows {@code [startRowId, endRowIdExclusive)}
+     * into {@code writer}. Use this on the {@code size == 0} branch when rebuilding
+     * a covering index from a decoded parquet row group: the _pm-backed Rust decoder
+     * fast-paths a SYMBOL chunk whose stats report {@code null_count == num_values}
+     * by returning {@code size = 0} without materialising the chunk buffer (see
+     * {@code RowGroupBuffers} javadoc). Walking the empty buffer would emit no
+     * entries for the NULL key, so callers that rebuild a covering index over a
+     * parquet partition must instead invoke this helper to record one NULL entry
+     * per row covered by the row group.
+     */
+    public static void addNullEntries(IndexWriter writer, long startRowId, long endRowIdExclusive) {
+        final int nullKey = TableUtils.toIndexKey(SymbolTable.VALUE_IS_NULL);
+        for (long rowId = startRowId; rowId < endRowIdExclusive; rowId++) {
+            writer.add(nullKey, rowId);
+        }
+    }
 
     public static long getKeyEntryOffset(int key) {
         return key * KEY_ENTRY_SIZE + KEY_FILE_RESERVED;

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/WalWriterFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/WalWriterFuzzTest.java
@@ -188,6 +188,52 @@ public class WalWriterFuzzTest extends AbstractFuzzTest {
         runFuzz(rnd);
     }
 
+    // Regression for the O3 Parquet-rewrite covering-index bug where an indexed
+    // SYMBOL column added after the partition was first converted to Parquet
+    // could end up with no index entries at all. The rewrite's
+    // updateParquetIndexes walked the decoded chunk buffer to emit index
+    // entries, but the _pm-backed Rust decoder skips materialising the buffer
+    // when chunk stats report null_count == num_values (size=0, per the
+    // RowGroupBuffers javadoc). The walk iterated zero bytes and
+    // zeroColumnTopsAfterParquetRewrite then dropped columnTop to 0, so the
+    // PostingIndexFwdReader's implicit-null synthesis was disabled and
+    // WHERE col = null returned no rows on the WAL table while the non-WAL
+    // twin returned them correctly. Seeds captured from a CI failure of
+    // testConvertPartitionToParquet; the shared worker pool adds residual
+    // non-determinism, so this is not a fully deterministic reproducer; on
+    // master it fails reliably with these seeds and on the fix branch it
+    // passes consistently.
+    @Test
+    public void testConvertPartitionToParquetAllNullChunkIndex() throws Exception {
+        Rnd rnd = generateRandom(LOG, 8_858_563_550_353_991L, 1_779_599_486_943L);
+        setTestParams(rnd);
+
+        setFuzzProbabilities(
+                0.01,
+                0.01,
+                0.01,
+                0.1,
+                0.05,
+                0.05,
+                0.1,
+                0.0,
+                1.0,
+                0.01,
+                0.01,
+                0.5,
+                0.5,
+                0.1,
+                0.0,
+                0.8,
+                0.00,
+                0,
+                0.01,
+                0.1
+        );
+        setFuzzCounts(rnd.nextBoolean(), 10_000, 300, 20, 10, 1000, 100, 3);
+        runFuzz(rnd);
+    }
+
     // Regression for the non-WAL partition-squash + POSTING-index correctness bug
     // where squashSplitPartitions failed to reseal the target partition's chain,
     // causing indexed WHERE predicates to drop rows for columns whose columnTop

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -1335,6 +1335,56 @@ public class CheckpointTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCheckpointRestoreRebuildsBitmapIndexesOnParquetAllNullChunk() throws Exception {
+        // Red regression for the all-null chunk bug in TableSnapshotRestore.
+        // When the _pm decoder fast-paths an all-null SYMBOL chunk to
+        // size == 0 (per RowGroupBuffers javadoc), the bitmap rebuild loop
+        // walks zero bytes and emits no entries for the NULL key. Indexed
+        // WHERE sym = null on the restored parquet partition then silently
+        // returns no rows, even though the pre-rebuild index served the
+        // same query correctly.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t (
+                        sym SYMBOL INDEX,
+                        ts TIMESTAMP
+                    ) TIMESTAMP(ts) PARTITION BY DAY
+                    """);
+            // Entire '2024-01-01' partition has NULL symbols: the parquet
+            // row group stats report null_count == num_values, triggering
+            // the _pm decoder's size == 0 fast path.
+            execute("""
+                    INSERT INTO t VALUES
+                    (null, '2024-01-01T00:00:00.000000Z'),
+                    (null, '2024-01-01T06:00:00.000000Z'),
+                    (null, '2024-01-01T12:00:00.000000Z'),
+                    ('k1', '2024-01-05T00:00:00.000000Z')
+                    """);
+            execute("ALTER TABLE t CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+
+            TableToken tableToken = engine.verifyTableName("t");
+            String dbRoot = engine.getConfiguration().getDbRoot();
+
+            // Release all readers and writers before rebuilding files on
+            // disk; rebuildTableFiles is designed for checkpoint recovery
+            // where the engine restarts, so cached readers must be released.
+            engine.clear();
+
+            try (
+                    Path tablePath = new Path().of(dbRoot).concat(tableToken).slash();
+                    TableSnapshotRestore restoreAgent = new TableSnapshotRestore(configuration)
+            ) {
+                restoreAgent.rebuildTableFiles(tablePath, new AtomicInteger(), true);
+            }
+
+            assertSql(
+                    "count\n3\n",
+                    "SELECT count() FROM t WHERE sym = null"
+            );
+        });
+    }
+
+    @Test
     public void testCheckpointRestoreRebuildsBitmapIndexesOnParquetMultiColumn() throws Exception {
         // Reproduces the enterprise backup test setup: 9 columns with an
         // indexed SYMBOL, convert a partition to parquet, then rebuild.

--- a/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/CheckpointTest.java
@@ -1286,7 +1286,7 @@ public class CheckpointTest extends AbstractCairoTest {
             TableToken tableToken = engine.verifyTableName("t");
             String dbRoot = engine.getConfiguration().getDbRoot();
             File tableDir = new File(dbRoot, tableToken.getDirName());
-            File[] partDirs = tableDir.listFiles((dir, name) -> name.startsWith("2024-01-01"));
+            File[] partDirs = tableDir.listFiles((_, name) -> name.startsWith("2024-01-01"));
             Assert.assertNotNull(partDirs);
             Assert.assertTrue("partition directory not found", partDirs.length > 0);
             File partDir = partDirs[0];
@@ -1298,13 +1298,13 @@ public class CheckpointTest extends AbstractCairoTest {
 
             // Delete any existing bitmap index files for the parquet partition
             // so we can verify the rebuild actually creates them.
-            File[] oldKeyFiles = partDir.listFiles((dir, name) -> name.startsWith("sym.k"));
+            File[] oldKeyFiles = partDir.listFiles((_, name) -> name.startsWith("sym.k"));
             if (oldKeyFiles != null) {
                 for (File f : oldKeyFiles) {
                     Assert.assertTrue("failed to delete " + f, f.delete());
                 }
             }
-            File[] oldValFiles = partDir.listFiles((dir, name) -> name.startsWith("sym.v"));
+            File[] oldValFiles = partDir.listFiles((_, name) -> name.startsWith("sym.v"));
             if (oldValFiles != null) {
                 for (File f : oldValFiles) {
                     Assert.assertTrue("failed to delete " + f, f.delete());
@@ -1321,10 +1321,10 @@ public class CheckpointTest extends AbstractCairoTest {
             // Verify the bitmap index files were actually created by the rebuild.
             // Without both fixes, the rebuild is silently skipped (path doubling
             // makes ff.exists() return false) and these files would not exist.
-            File[] keyFiles = partDir.listFiles((dir, name) -> name.startsWith("sym.k"));
+            File[] keyFiles = partDir.listFiles((_, name) -> name.startsWith("sym.k"));
             Assert.assertNotNull("bitmap index .k file not created for sym column", keyFiles);
             Assert.assertTrue("bitmap index .k file not created for sym column", keyFiles.length > 0);
-            File[] valFiles = partDir.listFiles((dir, name) -> name.startsWith("sym.v"));
+            File[] valFiles = partDir.listFiles((_, name) -> name.startsWith("sym.v"));
             Assert.assertNotNull("bitmap index .v file not created for sym column", valFiles);
             Assert.assertTrue("bitmap index .v file not created for sym column", valFiles.length > 0);
 
@@ -1559,12 +1559,12 @@ public class CheckpointTest extends AbstractCairoTest {
             String dbRoot = engine.getConfiguration().getDbRoot();
             File tableDir = new File(dbRoot, tableToken.getDirName());
             for (String partitionPrefix : new String[]{"2024-01-01", "2024-01-02"}) {
-                File[] partDirs = tableDir.listFiles((d, n) -> n.startsWith(partitionPrefix));
+                File[] partDirs = tableDir.listFiles((_, n) -> n.startsWith(partitionPrefix));
                 Assert.assertNotNull("partition dir missing: " + partitionPrefix, partDirs);
                 Assert.assertTrue("partition dir missing: " + partitionPrefix, partDirs.length > 0);
                 File partDir = partDirs[0];
 
-                File[] sealedPv = partDir.listFiles((d, n) -> {
+                File[] sealedPv = partDir.listFiles((_, n) -> {
                     if (!n.startsWith("sym.pv")) return false;
                     int lastDot = n.lastIndexOf('.');
                     if (lastDot < 0) return false;
@@ -1579,7 +1579,7 @@ public class CheckpointTest extends AbstractCairoTest {
                 Assert.assertTrue(partitionPrefix + ": sealed .pv file missing (only unsealed sym.pv.0 exists)",
                         sealedPv.length > 0);
 
-                File[] pci = partDir.listFiles((d, n) -> n.startsWith("sym.pci"));
+                File[] pci = partDir.listFiles((_, n) -> n.startsWith("sym.pci"));
                 Assert.assertNotNull(partitionPrefix + ": sym.pci sidecar missing", pci);
                 Assert.assertTrue(partitionPrefix + ": sym.pci sidecar missing", pci.length > 0);
             }
@@ -1652,12 +1652,12 @@ public class CheckpointTest extends AbstractCairoTest {
 
             String dbRoot = engine.getConfiguration().getDbRoot();
             File tableDir = new File(dbRoot, tableToken.getDirName());
-            File[] partDirs = tableDir.listFiles((d, n) -> n.startsWith("2024-01-01"));
+            File[] partDirs = tableDir.listFiles((_, n) -> n.startsWith("2024-01-01"));
             Assert.assertNotNull("partition dir missing", partDirs);
             Assert.assertTrue("partition dir missing", partDirs.length > 0);
             File partDir = partDirs[0];
 
-            File[] pci = partDir.listFiles((d, n) -> n.startsWith("sym.pci"));
+            File[] pci = partDir.listFiles((_, n) -> n.startsWith("sym.pci"));
             Assert.assertNotNull("sym.pci sidecar missing", pci);
             Assert.assertTrue("sym.pci sidecar missing", pci.length > 0);
 
@@ -1722,12 +1722,12 @@ public class CheckpointTest extends AbstractCairoTest {
             TableToken tableToken = engine.verifyTableName("t_pi_parquet");
             String dbRoot = engine.getConfiguration().getDbRoot();
             File tableDir = new File(dbRoot, tableToken.getDirName());
-            File[] partDirs = tableDir.listFiles((d, n) -> n.startsWith("2024-01-01"));
+            File[] partDirs = tableDir.listFiles((_, n) -> n.startsWith("2024-01-01"));
             Assert.assertNotNull("parquet partition dir missing", partDirs);
             Assert.assertTrue("parquet partition dir missing", partDirs.length > 0);
             File partDir = partDirs[0];
 
-            File[] pciBefore = partDir.listFiles((d, n) -> n.startsWith("sym.pci"));
+            File[] pciBefore = partDir.listFiles((_, n) -> n.startsWith("sym.pci"));
             Assert.assertNotNull("setup: sym.pci must exist after parquet conversion", pciBefore);
             Assert.assertTrue("setup: sym.pci must exist after parquet conversion",
                     pciBefore.length > 0);
@@ -1748,14 +1748,14 @@ public class CheckpointTest extends AbstractCairoTest {
             // .pci must still exist after the rebuild. Without the fix,
             // removeIndexFiles wipes it and the parquet rebuild path never
             // recreates it.
-            File[] pciAfter = partDir.listFiles((d, n) -> n.startsWith("sym.pci"));
+            File[] pciAfter = partDir.listFiles((_, n) -> n.startsWith("sym.pci"));
             Assert.assertNotNull("sym.pci must exist after parquet partition rebuild", pciAfter);
             Assert.assertTrue("sym.pci must exist after parquet partition rebuild "
                             + "(parquet rebuild path is missing seal()/configureCovering)",
                     pciAfter.length > 0);
 
             // .pc0 must also exist (the actual covered column data file).
-            File[] pc0After = partDir.listFiles((d, n) -> n.startsWith("sym.pc0"));
+            File[] pc0After = partDir.listFiles((_, n) -> n.startsWith("sym.pc0"));
             Assert.assertNotNull("sym.pc0 must exist after parquet partition rebuild", pc0After);
             Assert.assertTrue("sym.pc0 must exist after parquet partition rebuild",
                     pc0After.length > 0);
@@ -1816,13 +1816,13 @@ public class CheckpointTest extends AbstractCairoTest {
 
             String dbRoot = engine.getConfiguration().getDbRoot();
             File tableDir = new File(dbRoot, tableToken.getDirName());
-            File[] partDirs = tableDir.listFiles((d, n) -> n.startsWith("2024-01-01"));
+            File[] partDirs = tableDir.listFiles((_, n) -> n.startsWith("2024-01-01"));
             Assert.assertNotNull("partition dir missing", partDirs);
             Assert.assertTrue("partition dir missing", partDirs.length > 0);
             File partDir = partDirs[0];
 
-            File[] sym1Pci = partDir.listFiles((d, n) -> n.startsWith("sym1.pci"));
-            File[] sym2Pci = partDir.listFiles((d, n) -> n.startsWith("sym2.pci"));
+            File[] sym1Pci = partDir.listFiles((_, n) -> n.startsWith("sym1.pci"));
+            File[] sym2Pci = partDir.listFiles((_, n) -> n.startsWith("sym2.pci"));
             Assert.assertNotNull("sym1.pci missing", sym1Pci);
             Assert.assertTrue("sym1.pci missing", sym1Pci.length > 0);
             Assert.assertNotNull("sym2.pci missing", sym2Pci);
@@ -3496,7 +3496,7 @@ public class CheckpointTest extends AbstractCairoTest {
     private static void corruptIndexKeyEntry(String dbRoot, String tableDirName) {
         File tableDir = new File(dbRoot, "db/" + tableDirName);
         File partDir = new File(tableDir, "1970");
-        File[] keyFiles = partDir.listFiles((dir, name) -> name.startsWith("sym" + ".k"));
+        File[] keyFiles = partDir.listFiles((_, name) -> name.startsWith("sym" + ".k"));
         if (keyFiles == null || keyFiles.length == 0) {
             throw new IllegalStateException("No key file found for column: " + "sym");
         }
@@ -3528,7 +3528,7 @@ public class CheckpointTest extends AbstractCairoTest {
     }
 
     private static File findParquetPartitionDir(File tableDir, String partitionPrefix) {
-        File[] dirs = tableDir.listFiles((dir, name) -> name.startsWith(partitionPrefix));
+        File[] dirs = tableDir.listFiles((_, name) -> name.startsWith(partitionPrefix));
         Assert.assertNotNull("no directories matching " + partitionPrefix, dirs);
         for (File dir : dirs) {
             if (new File(dir, "data.parquet").exists()) {
@@ -4214,7 +4214,7 @@ public class CheckpointTest extends AbstractCairoTest {
             File partDir = new File(tableDir, "1970");
 
             // Find .k file (may have txn suffix)
-            File[] keyFiles = partDir.listFiles((dir, name) -> name.startsWith("sym" + ".k"));
+            File[] keyFiles = partDir.listFiles((_, name) -> name.startsWith("sym" + ".k"));
             if (keyFiles == null || keyFiles.length == 0) {
                 throw new IllegalStateException("No key file found for column: " + "sym" + " in " + partDir);
             }

--- a/core/src/test/java/io/questdb/test/griffin/ParquetTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParquetTest.java
@@ -996,11 +996,13 @@ public class ParquetTest extends AbstractCairoTest {
             // SYMBOL column (toIndexKey(SymbolTable.VALUE_IS_NULL) == 0).
             // The bug manifests when this index path returns no rows.
             assertSql(
-                    "QUERY PLAN\n" +
-                            "DeferredSingleSymbolFilterPageFrame\n" +
-                            "    Index forward scan on: id\n" +
-                            "      filter: id=0\n" +
-                            "    Frame forward scan on: x\n",
+                    """
+                            QUERY PLAN
+                            DeferredSingleSymbolFilterPageFrame
+                                Index forward scan on: id
+                                  filter: id=0
+                                Frame forward scan on: x
+                            """,
                     "explain select * from x where id = null"
             );
 
@@ -1058,11 +1060,13 @@ public class ParquetTest extends AbstractCairoTest {
             // reason. The "id=0" filter is the NULL key for an indexed
             // SYMBOL column (toIndexKey(SymbolTable.VALUE_IS_NULL) == 0).
             assertSql(
-                    "QUERY PLAN\n" +
-                            "DeferredSingleSymbolFilterPageFrame\n" +
-                            "    Index forward scan on: id\n" +
-                            "      filter: id=0\n" +
-                            "    Frame forward scan on: x\n",
+                    """
+                            QUERY PLAN
+                            DeferredSingleSymbolFilterPageFrame
+                                Index forward scan on: id
+                                  filter: id=0
+                                Frame forward scan on: x
+                            """,
                     "explain select * from x where id = null"
             );
 
@@ -2109,10 +2113,12 @@ public class ParquetTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertSql(
-                    "s\tts\n" +
-                            "hello\t2020-01-01T00:00:00.000000Z\n" +
-                            "héllo\t2020-01-01T06:00:00.000000Z\n" +
-                            "world\t2020-01-01T12:00:00.000000Z\n",
+                    """
+                            s\tts
+                            hello\t2020-01-01T00:00:00.000000Z
+                            héllo\t2020-01-01T06:00:00.000000Z
+                            world\t2020-01-01T12:00:00.000000Z
+                            """,
                     "x order by ts"
             );
         });
@@ -2145,9 +2151,11 @@ public class ParquetTest extends AbstractCairoTest {
             drainWalQueue();
 
             assertSql(
-                    "s\tts\ts2\n" +
-                            "hello\t2020-01-01T00:00:00.000000Z\t\n" +
-                            "aa\t2020-01-01T06:00:00.000000Z\théllo\n",
+                    """
+                            s\tts\ts2
+                            hello\t2020-01-01T00:00:00.000000Z\t
+                            aa\t2020-01-01T06:00:00.000000Z\théllo
+                            """,
                     "x order by ts"
             );
         });
@@ -2310,8 +2318,8 @@ public class ParquetTest extends AbstractCairoTest {
         final String singleNullArrayExpected = "[".repeat(dims) + "null" + "]".repeat(dims);
 
         final String arrExpr = arr
-                .replaceAll(" ", "")
-                .replaceAll("\n", "")
+                .replace(" ", "")
+                .replace("\n", "")
                 .replace("ARRAY", "");
 
         assertMemoryLeak(() -> {

--- a/core/src/test/java/io/questdb/test/griffin/ParquetTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParquetTest.java
@@ -965,6 +965,119 @@ public class ParquetTest extends AbstractCairoTest {
         });
     }
 
+    // Red regression for the indexParquetPartition all-null-chunk bug.
+    // When a SYMBOL row group has null_count == num_values, the _pm decoder
+    // skips materialising the chunk buffer and reports size == 0 (see
+    // RowGroupBuffers javadoc). TableWriter.indexParquetPartition walks the
+    // returned buffer to add index entries but has no size == 0 branch, so
+    // no entries are emitted for the NULL key and "WHERE id = null" silently
+    // returns zero rows against an indexed historic Parquet partition.
+    @Test
+    public void testIndexAllNullSymbolChunkOnParquetPartition() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table x (id symbol, ts timestamp) timestamp(ts) partition by day;");
+            // All rows in the '2024-06-10' partition have NULL symbol: the
+            // parquet row group stats report null_count == num_values, which
+            // is the trigger for the _pm decoder size == 0 fast path.
+            execute("insert into x values(null, '2024-06-10T00:00:00.000000Z');");
+            execute("insert into x values(null, '2024-06-10T01:00:00.000000Z');");
+            execute("insert into x values(null, '2024-06-10T02:00:00.000000Z');");
+            // Trailing partition keeps '2024-06-10' as a historic (non-last)
+            // partition so ADD INDEX routes it through indexParquetPartition
+            // via indexHistoricPartitions.
+            execute("insert into x values('k1', '2024-06-15T00:00:00.000000Z');");
+
+            execute("alter table x convert partition to parquet where ts in '2024-06-10';");
+            execute("alter table x alter column id add index;");
+
+            // Pin the plan so a silently-degraded full scan cannot mask a
+            // broken index by returning the right answer for the wrong
+            // reason. The "id=0" filter is the NULL key for an indexed
+            // SYMBOL column (toIndexKey(SymbolTable.VALUE_IS_NULL) == 0).
+            // The bug manifests when this index path returns no rows.
+            assertSql(
+                    "QUERY PLAN\n" +
+                            "DeferredSingleSymbolFilterPageFrame\n" +
+                            "    Index forward scan on: id\n" +
+                            "      filter: id=0\n" +
+                            "    Frame forward scan on: x\n",
+                    "explain select * from x where id = null"
+            );
+
+            assertSql(
+                    """
+                            id\tts
+                            \t2024-06-10T00:00:00.000000Z
+                            \t2024-06-10T01:00:00.000000Z
+                            \t2024-06-10T02:00:00.000000Z
+                            """,
+                    "x where id = null"
+            );
+        });
+    }
+
+    // Red regression for the O3PartitionJob.updateParquetIndexes all-null
+    // chunk bug fixed in commit f93a7c4395. The _pm decoder fast-paths a
+    // SYMBOL row group whose chunk stats report null_count == num_values
+    // and returns size == 0 (see RowGroupBuffers javadoc). The O3-rewrite
+    // path walked the empty chunk buffer and emitted no entries for the
+    // NULL key, so an indexed WHERE id = null against the rewritten
+    // partition silently returned zero rows.
+    //
+    // The existing fuzz seed in WalWriterFuzzTest depends on the shared
+    // worker pool schedule (to land an all-null SYMBOL chunk in a rewritten
+    // row group) and on FuzzRunner.checkIndexRandomValueScan picking a
+    // NULL row from that partition. This test removes both layers of luck
+    // by constructing the all-null chunk explicitly and asserting on the
+    // NULL filter directly.
+    @Test
+    public void testIndexAllNullSymbolChunkOnParquetPartitionAfterO3Rewrite() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table x (id symbol index, ts timestamp) timestamp(ts) partition by day;");
+            // Two NULL-id rows in '2024-06-10' produce a single all-NULL
+            // parquet row group after conversion.
+            execute("insert into x values(null, '2024-06-10T01:00:00.000000Z');");
+            execute("insert into x values(null, '2024-06-10T02:00:00.000000Z');");
+            // Trailing partition keeps '2024-06-10' a historic (non-last)
+            // partition so the O3 insert below routes through O3PartitionJob.
+            execute("insert into x values('k1', '2024-06-15T00:00:00.000000Z');");
+
+            execute("alter table x convert partition to parquet where ts in '2024-06-10';");
+
+            // O3-insert another NULL-id row into the parquet partition. The
+            // partition is rewritten through O3PartitionJob, which calls
+            // updateParquetIndexes against the new row group. That chunk is
+            // still all-NULL for id, so the _pm decoder returns size == 0
+            // and only the size == 0 branch produces index entries for the
+            // NULL key. The new row's earlier timestamp guarantees an O3
+            // (rather than append) path.
+            execute("insert into x values(null, '2024-06-10T00:30:00.000000Z');");
+
+            // Pin the plan so a silently-degraded full scan cannot mask a
+            // broken index by returning the right answer for the wrong
+            // reason. The "id=0" filter is the NULL key for an indexed
+            // SYMBOL column (toIndexKey(SymbolTable.VALUE_IS_NULL) == 0).
+            assertSql(
+                    "QUERY PLAN\n" +
+                            "DeferredSingleSymbolFilterPageFrame\n" +
+                            "    Index forward scan on: id\n" +
+                            "      filter: id=0\n" +
+                            "    Frame forward scan on: x\n",
+                    "explain select * from x where id = null"
+            );
+
+            assertSql(
+                    """
+                            id\tts
+                            \t2024-06-10T00:30:00.000000Z
+                            \t2024-06-10T01:00:00.000000Z
+                            \t2024-06-10T02:00:00.000000Z
+                            """,
+                    "x where id = null"
+            );
+        });
+    }
+
     // TODO(puzpuzpuz): enable when we support DDLs for parquet partitions
     @Ignore
     @Test


### PR DESCRIPTION
## Summary

Indexed `WHERE col = null` could return zero rows from a Parquet partition whose SYMBOL column was entirely NULL in a row group. Three call sites that rebuild a covering index from a decoded Parquet chunk shared the same defect:

- `O3PartitionJob.updateParquetIndexes` runs after an O3 insert rewrites a Parquet partition.
- `TableWriter.indexParquetPartition` runs when `ALTER TABLE ALTER COLUMN ... ADD INDEX` covers a historic Parquet partition.
- `TableSnapshotRestore.rebuildTableFiles` runs during checkpoint restore for any Parquet partition that needs its bitmap index rebuilt.

The `_pm`-backed Rust decoder has a documented optimisation (see the `RowGroupBuffers` javadoc): when a column chunk's stats report `null_count == num_values` it skips materialising the buffer and returns `size = 0`. In all three sites the walk iterated zero bytes and wrote no index entries; in the O3 path, the subsequent `zeroColumnTopsAfterParquetRewrite` also set `columnTop = 0`, disabling `PostingIndexFwdReader`'s implicit-null synthesis. The net effect was an index that recognised no NULL rows for that column in that partition.

The fix detects the documented `size == 0` convention and emits explicit null index entries for every row the row group covers. The null-fill loop is extracted into `BitmapIndexUtils.addNullEntries(IndexWriter, startRowId, endRowIdExclusive)` so the convention is named in one place and the next caller that touches this code path cannot forget it. No Rust-side change.

## Tradeoffs

- Adds one extra branch in the per-row-group loop at each call site. Each check is a single comparison and only takes the new path on chunks the decoder fast-pathed away, so runtime cost is negligible.
- Other consumers of `RowGroupBuffers` outside these three sites have not been audited.

## Tests

- `WalWriterFuzzTest.testConvertPartitionToParquetAllNullChunkIndex` was the original CI-seeded fuzz reproducer. It depends on the shared worker pool schedule to land an all-null SYMBOL chunk in a rewritten row group, and on `FuzzRunner.checkIndexRandomValueScan` happening to pick a NULL row from that partition for its random assertion. On master with these seeds it fails reliably; a future schedule shift or different random pick could mask a re-regression. Kept for incidental coverage.
- `ParquetTest.testIndexAllNullSymbolChunkOnParquetPartitionAfterO3Rewrite` constructs the all-null chunk explicitly (insert NULLs with the column already indexed, convert to Parquet, O3-insert another NULL row to force the rewrite) and asserts on `WHERE id = null` directly. The indexed query plan is pinned to `Index forward scan on: id  filter: id=0` so a silently-degraded full scan cannot mask a broken index by returning the right answer for the wrong reason. Confirmed to fail without the `O3PartitionJob` fix.
- `ParquetTest.testIndexAllNullSymbolChunkOnParquetPartition` covers the `ALTER TABLE ADD INDEX` path with the same explicit-chunk + pinned-plan pattern. Confirmed to fail without the `TableWriter.indexParquetPartition` fix.
- `CheckpointTest.testCheckpointRestoreRebuildsBitmapIndexesOnParquetAllNullChunk` invokes `TableSnapshotRestore.rebuildTableFiles` directly against a Parquet partition whose only SYMBOL chunk is all-NULL, and asserts `count() WHERE sym = null` returns the inserted rows. Confirmed to fail without the `TableSnapshotRestore` fix.

## Test plan

- mvn -pl core -Dtest='ParquetTest#testIndexAllNullSymbolChunkOnParquetPartition*' test
- mvn -pl core -Dtest='CheckpointTest#testCheckpointRestoreRebuildsBitmapIndexesOnParquetAllNullChunk' test
- mvn -pl core -Dtest='WalWriterFuzzTest#testConvertPartitionToParquet*' test