### PR TITLE
test(core): fix fuzz test Rnd drift causing flaky WAL comparison failures

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunner.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunner.java
@@ -1333,7 +1333,8 @@ public class FuzzRunner {
             }
 
             long startMicro = System.nanoTime() / 1000;
-            applyNonWal(transactions, tableNameNoWal, rnd);
+            Rnd nonWalRnd = new Rnd(rnd.getSeed0(), rnd.getSeed1());
+            applyNonWal(transactions, tableNameNoWal, nonWalRnd);
             long endNonWalMicro = System.nanoTime() / 1000;
             long nonWalTotal = endNonWalMicro - startMicro;
             try (SqlCompiler compiler = engine.getSqlCompiler()) {


### PR DESCRIPTION
## Summary

- `FuzzRunner.applyNonWal()` shares the test's `Rnd` instance for
  `purgeAndReloadReaders()` calls inside its transaction loop. When the injected
  IO failure triggers a transaction retry (`i--`), the extra loop iteration
  consumes additional `Rnd` state. This shifts the `Rnd` entering
  `drainWalQueue()`, which changes the `forceReleaseTableWriter()` timing,
  alters WAL application batching, and moves TTL enforcement to different
  points — producing different final data in the WAL table.
- Give `applyNonWal` its own `Rnd` copy so IO failure retries cannot shift
  downstream `Rnd` state.

## Test plan

- Run `WalWriterFuzzTest.testAddDropColumnDropPartition` 30 times — 0 failures (was ~20-30% failure rate before the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)