### PR TITLE
test(sql): verify drop partition list preserves unlisted day

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/AlterTableDropPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableDropPartitionTest.java
@@ -286,6 +286,30 @@ public class AlterTableDropPartitionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testDropPartitionListPreservesUnlistedDayPartitionBetweenDroppedPartitions() throws Exception {
+        assertMemoryLeak(() -> {
+            createX("DAY", 720000000);
+
+            String expectedBeforeDrop = "count\n" +
+                    "120\n";
+
+            assertPartitionResult(expectedBeforeDrop, "2018-01-05");
+            assertPartitionResult(expectedBeforeDrop, "2018-01-06");
+            assertPartitionResult(expectedBeforeDrop, "2018-01-07");
+
+            execute("alter table x drop partition list '2018-01-05', '2018-01-07'");
+
+            String expectedAfterDrop = "count\n" +
+                    "0\n";
+
+            assertPartitionResult(expectedAfterDrop, "2018-01-05");
+            assertPartitionResult(expectedBeforeDrop, "2018-01-06");
+            assertPartitionResult(expectedAfterDrop, "2018-01-07");
+        });
+    }
+
+
+    @Test
     public void testDropPartitionMacFileReadTimeoutError() throws Exception {
         assertMemoryLeak(new FilesFacadeImpl() {
                              private boolean returnError = true;


### PR DESCRIPTION
This PR adds a test for `ALTER TABLE ... DROP PARTITION LIST` on a table partitioned by day.

The test drops two specific partitions, `2018-01-05` and `2018-01-07`, and then checks that `2018-01-06` is still there. This makes sure QuestDB only drops the partitions the user asks for, instead of accidentally treating the list like a full date range.

The existing tests already check that listed partitions can be removed. This test adds one more safety check by making sure nearby data that was not listed for deletion is preserved.

This is my first PR to QuestDB, so I would appreciate any feedback on the test style or placement.