### PR TITLE
Add test for non-ascii symbols with spaces in columns at the same time

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/line/tcp/LineTcpReceiverFuzzTest.java
@@ -166,6 +166,14 @@ public class LineTcpReceiverFuzzTest extends AbstractLineTcpReceiverFuzzTest {
         runTest();
     }
 
+    // Added test case with non-ascii symbols with space to check that we do not have any issues with symbol names containing spaces and non-ascii characters when we reorder columns, add new columns, skip duplicates
+    @Test
+    public void testReorderingAddSkipDuplicateWithNonAsciiSymbolsWithSpace() throws Exception {
+        initLoadParameters(100, Os.isWindows() ? 3 : 5, 5, 5, 50);
+        initFuzzParameters(4, 4, 4, -1, 4, true, true, true);
+        runTest();
+    }
+
     @Override
     protected Log getLog() {
         return LOG;


### PR DESCRIPTION
Looking at the existing fuzz tests in **_LineTcpRecieverFuzzTest_**, I notices there are two flags that have never been turned on at the same time: non-ASCII identifiers and symbol values containing spaces. Each one is tested on its own, but never together.

This matters because they touch different parts of the ILP parser, and a bug that only appears when both are active would slip through the entire existing suite unnoticed. 

My solution added a single fuzz test: _**testReorderingAddSkipDuplicateWithNonAsciiSymbolsWithSpace**_ that runs the full scenario with both flags enabled, closing that gap without needing any big changes to the test framework. 