### PR TITLE
fix(qwp): fix WebSocket test timeout for worst-case fragmentation

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/RssMemoryLimitTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/RssMemoryLimitTest.java
@@ -79,7 +79,7 @@ public class RssMemoryLimitTest extends AbstractCairoTest {
 
     @Test
     public void testLargeTxEventuallySucceeds() throws Exception {
-        long limitMiB = 60;
+        long limitMiB = Os.isLinux() ? 60 : 30;
         assertMemoryLeak(limitMiB, () -> {
             // fewer transactions on slow CI runners (Mac, Windows); the workload below still triggers
             // memory pressure during WAL apply, which the easing-up log assertion at the end verifies

--- a/core/src/test/java/io/questdb/test/cairo/RssMemoryLimitTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/RssMemoryLimitTest.java
@@ -79,7 +79,7 @@ public class RssMemoryLimitTest extends AbstractCairoTest {
 
     @Test
     public void testLargeTxEventuallySucceeds() throws Exception {
-        long limitMiB = Os.isLinux() ? 60 : 30;
+        long limitMiB = 60;
         assertMemoryLeak(limitMiB, () -> {
             // fewer transactions on slow CI runners (Mac, Windows); the workload below still triggers
             // memory pressure during WAL apply, which the easing-up log assertion at the end verifies

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/AbstractQwpWebSocketTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/AbstractQwpWebSocketTest.java
@@ -49,6 +49,12 @@ import org.junit.Before;
 
 public class AbstractQwpWebSocketTest extends AbstractCairoTest {
 
+    // Default close drain timeout (5s) is too tight: worst-case WS fragmentation
+    // (recvChunk=1) drives one kqueue/epoll round-trip per byte against the
+    // single-worker test server, so large payloads or fuzz batches with concurrent
+    // WAL apply can push close() drain past a minute on loaded CI. 5 minutes covers
+    // that without masking real bugs.
+    private static final long CLOSE_FLUSH_TIMEOUT_MS = 300_000L;
     private static final Log LOG = LogFactory.getLog(AbstractQwpWebSocketTest.class);
     protected int recvChunk;
     protected int sendChunk;
@@ -77,7 +83,7 @@ public class AbstractQwpWebSocketTest extends AbstractCairoTest {
      */
     protected static QwpWebSocketSender connectWs(int port) {
         return (QwpWebSocketSender) Sender.fromConfig(
-                "ws::addr=localhost:" + port + ";close_flush_timeout_millis=300000;");
+                "ws::addr=localhost:" + port + ";close_flush_timeout_millis=" + CLOSE_FLUSH_TIMEOUT_MS + ";");
     }
 
     /**
@@ -91,7 +97,7 @@ public class AbstractQwpWebSocketTest extends AbstractCairoTest {
         return (QwpWebSocketSender) Sender.builder(Sender.Transport.WEBSOCKET)
                 .address("localhost:" + port)
                 .errorHandler(errorHandler)
-                .closeFlushTimeoutMillis(300_000L)
+                .closeFlushTimeoutMillis(CLOSE_FLUSH_TIMEOUT_MS)
                 .build();
     }
 
@@ -122,7 +128,7 @@ public class AbstractQwpWebSocketTest extends AbstractCairoTest {
                 .autoFlushRows(rows)
                 .autoFlushBytes(bytes)
                 .autoFlushIntervalMillis(intervalMillis)
-                .closeFlushTimeoutMillis(300_000L)
+                .closeFlushTimeoutMillis(CLOSE_FLUSH_TIMEOUT_MS)
                 .build();
     }
 
@@ -152,7 +158,7 @@ public class AbstractQwpWebSocketTest extends AbstractCairoTest {
         appendAutoFlushRows(cfg, autoFlushRows);
         appendAutoFlushBytes(cfg, autoFlushBytes);
         appendAutoFlushInterval(cfg, autoFlushIntervalNanos);
-        cfg.append("close_flush_timeout_millis=300000;");
+        cfg.append("close_flush_timeout_millis=").append(CLOSE_FLUSH_TIMEOUT_MS).append(';');
         return (QwpWebSocketSender) Sender.fromConfig(cfg.toString());
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/AbstractQwpWebSocketTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/AbstractQwpWebSocketTest.java
@@ -77,7 +77,7 @@ public class AbstractQwpWebSocketTest extends AbstractCairoTest {
      */
     protected static QwpWebSocketSender connectWs(int port) {
         return (QwpWebSocketSender) Sender.fromConfig(
-                "ws::addr=localhost:" + port + ";close_flush_timeout_millis=60000;");
+                "ws::addr=localhost:" + port + ";close_flush_timeout_millis=300000;");
     }
 
     /**
@@ -91,7 +91,7 @@ public class AbstractQwpWebSocketTest extends AbstractCairoTest {
         return (QwpWebSocketSender) Sender.builder(Sender.Transport.WEBSOCKET)
                 .address("localhost:" + port)
                 .errorHandler(errorHandler)
-                .closeFlushTimeoutMillis(60_000L)
+                .closeFlushTimeoutMillis(300_000L)
                 .build();
     }
 
@@ -122,7 +122,7 @@ public class AbstractQwpWebSocketTest extends AbstractCairoTest {
                 .autoFlushRows(rows)
                 .autoFlushBytes(bytes)
                 .autoFlushIntervalMillis(intervalMillis)
-                .closeFlushTimeoutMillis(60_000L)
+                .closeFlushTimeoutMillis(300_000L)
                 .build();
     }
 
@@ -152,11 +152,7 @@ public class AbstractQwpWebSocketTest extends AbstractCairoTest {
         appendAutoFlushRows(cfg, autoFlushRows);
         appendAutoFlushBytes(cfg, autoFlushBytes);
         appendAutoFlushInterval(cfg, autoFlushIntervalNanos);
-        // Default close drain timeout (5s) is too tight for fuzz tests that
-        // push hundreds of batches against a single-worker test server with
-        // concurrent ALTERs slowing down WAL apply. 60s is enough headroom
-        // without masking real problems.
-        cfg.append("close_flush_timeout_millis=60000;");
+        cfg.append("close_flush_timeout_millis=300000;");
         return (QwpWebSocketSender) Sender.fromConfig(cfg.toString());
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpMalformedTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpMalformedTest.java
@@ -114,7 +114,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             try (QwpUdpReceiver receiver = receiverFactory.create(NO_AUTO_CREATE_CONF, engine)) {
                 sendValidRow("nonexistent_table", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 1);
 
                 // Datagram was received and processed, but no table was created
                 Assert.assertEquals(1, receiver.getProcessedCount());
@@ -189,7 +189,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             try (QwpUdpReceiver receiver = receiverFactory.create(rcvBufFail, engine)) {
                 sendValidRow("rcvbuf_test", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 1);
 
                 Assert.assertEquals(1, receiver.getProcessedCount());
                 Assert.assertEquals(0, receiver.getTotalDroppedCount());
@@ -292,7 +292,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
                 // identical data sent twice
                 sendValidRow("dup_test", 1L, 1_000_000L);
                 sendValidRow("dup_test", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(0, receiver.getTotalDroppedCount());
             }
@@ -316,7 +316,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
                 );
                 sendRawBytes(header);
                 sendValidRow("bad_flags", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 // header validator throws INVALID_MAGIC for conflicting flags
                 Assert.assertEquals(1, receiver.getDroppedBadMagicCount());
@@ -336,7 +336,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
             try (QwpUdpReceiver receiver = receiverFactory.create(RCVR_CONF, engine)) {
                 sendRawBytes(new byte[12]);
                 sendValidRow("magic_zeros", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(1, receiver.getDroppedBadMagicCount());
             }
@@ -359,7 +359,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
                 );
                 sendRawBytes(header);
                 sendValidRow("magic_ilp3", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(1, receiver.getDroppedBadMagicCount());
             }
@@ -388,7 +388,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
                 sendRawBytes(badVersion);
                 // valid row
                 sendValidRow("multi_bad", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 4);
 
                 Assert.assertEquals(1, receiver.getDroppedTooShortCount());
                 Assert.assertEquals(1, receiver.getDroppedBadMagicCount());
@@ -431,7 +431,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
             try (QwpUdpReceiver receiver = receiverFactory.create(conf, engine)) {
                 sendRawBytes(new byte[12]);
                 sendValidRow("noise_then_valid", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(1, receiver.getDroppedBadMagicCount());
 
@@ -450,7 +450,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
             try (QwpUdpReceiver receiver = receiverFactory.create(RCVR_CONF, engine)) {
                 sendValidRow("ooo_test", 1L, 2_000_000L);
                 sendValidRow("ooo_test", 2L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(0, receiver.getTotalDroppedCount());
             }
@@ -473,7 +473,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
                 );
                 sendRawBytes(header);
                 sendValidRow("trunc_test", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(1, receiver.getDroppedTruncatedCount());
             }
@@ -497,7 +497,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
                 );
                 sendRawBytes(header);
                 sendValidRow("too_large", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 // PAYLOAD_TOO_LARGE hits the default branch -> droppedParseErrorCount
                 Assert.assertEquals(1, receiver.getDroppedParseErrorCount());
@@ -521,7 +521,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
                 rnd.nextBytes(garbage);
                 sendRawBytes(garbage);
                 sendValidRow("random_test", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(1, receiver.getTotalDroppedCount());
             }
@@ -540,7 +540,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
             try (QwpUdpReceiver receiver = receiverFactory.create(RCVR_CONF, engine)) {
                 sendRawBytes(new byte[]{0, 0, 0, 0});
                 sendValidRow("short_test", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(1, receiver.getDroppedTooShortCount());
             }
@@ -559,7 +559,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
             try (QwpUdpReceiver receiver = receiverFactory.create(RCVR_CONF, engine)) {
                 sendRawBytes(new byte[11]);
                 sendValidRow("short11", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(1, receiver.getDroppedTooShortCount());
             }
@@ -604,7 +604,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
                 System.arraycopy(badData, 0, datagram, header.length + schema.length, badData.length);
                 sendRawBytes(datagram);
                 sendValidRow("trunc_col", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(1, receiver.getDroppedParseErrorCount());
             }
@@ -631,7 +631,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
                 datagram[header.length + 1] = (byte) 0xFF;
                 sendRawBytes(datagram);
                 sendValidRow("trunc_name", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(1, receiver.getDroppedParseErrorCount());
             }
@@ -654,7 +654,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
                 );
                 sendRawBytes(header);
                 sendValidRow("version_test", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(1, receiver.getDroppedBadVersionCount());
             }
@@ -677,7 +677,7 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
                 );
                 sendRawBytes(header);
                 sendValidRow("zero_payload", 1L, 1_000_000L);
-                drainReceiver(receiver);
+                drainReceiver(receiver, 2);
 
                 Assert.assertEquals(1, receiver.getDroppedParseErrorCount());
             }
@@ -712,19 +712,17 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
         return buf;
     }
 
-    private static void drainReceiver(QwpUdpReceiver receiver) {
+    private static void drainReceiver(QwpUdpReceiver receiver, int expectedDatagrams) {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(20);
-        boolean everReceived = false;
         while (System.nanoTime() < deadline) {
-            boolean received = receiver.runSerially();
-            if (received) {
-                everReceived = true;
-            } else if (everReceived) {
-                break;
+            receiver.runSerially();
+            if (receiver.getProcessedCount() + receiver.getTotalDroppedCount() >= expectedDatagrams) {
+                return;
             }
             Os.pause();
         }
-        Assert.assertTrue("timeout: receiver did not process any datagrams", everReceived);
+        Assert.fail("timeout: expected " + expectedDatagrams + " datagrams but got "
+                + (receiver.getProcessedCount() + receiver.getTotalDroppedCount()));
     }
 
     private static QwpUdpSender newSender() {


### PR DESCRIPTION
## Summary

- Increase `close_flush_timeout_millis` from 60 s to 300 s in all `connectWs()` test helper overloads

The QWP WebSocket fuzz harness (`AbstractQwpWebSocketTest`) randomizes recv/send fragmentation chunk sizes in [1, 500] before each test. When the recv chunk lands on 1, the server reads the incoming payload one byte at a time — each byte triggers a full kqueue/epoll dispatcher round-trip on the single-worker test server.

`testLargePayloadPerRow` sends ~540 KB (3 rows x ~180 KB each: 100 KB string + 80 KB double array). With `recvChunk=1`, that produces ~540,000 dispatcher round-trips. On a loaded macOS CI runner at ~100+ us per round-trip, this exceeds the 60 s close-drain timeout, causing a spurious `LineSender close() drain timed out` failure.

Observed on [build 236071](https://dev.azure.com/questdb/questdb/_build/results?buildId=236071) with seeds `3271152615876L, 1779709158855L` which produce `recvChunk=1`.

## Test plan

- CI passes with the updated timeout, including the mac-other job that failed before
- Fuzz tests still exercise full [1, 500] fragmentation range — no chunk floor change

🤖 Generated with [Claude Code](https://claude.com/claude-code)