### PR TITLE
fix(qwp): drain recv buffer on WebSocket graceful close to prevent TCP RST

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -441,6 +441,15 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
         responseSink.resumeSend();
     }
 
+    public void drainRecvBuffer() {
+        try {
+            while (socket.recv(recvBuffer, recvBufferSize) > 0) {
+                // discard
+            }
+        } catch (Throwable ignored) {
+        }
+    }
+
     public void scheduleRetry(HttpRequestProcessor processor, RescheduleContext rescheduleContext) throws PeerIsSlowToReadException, ServerDisconnectException {
         try {
             pendingRetry = true;

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
@@ -788,6 +788,7 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
             Socket socket = context.getSocket();
             if (socket != null) {
                 socket.shutdown(Net.SHUT_WR);
+                context.drainRecvBuffer();
             }
         } catch (Throwable ignored) {
         }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressUpgradeProcessor.java
@@ -855,6 +855,7 @@ public class QwpEgressUpgradeProcessor implements HttpRequestProcessor, QuietClo
             Socket socket = context.getSocket();
             if (socket != null) {
                 socket.shutdown(Net.SHUT_WR);
+                context.drainRecvBuffer();
             }
         } catch (Throwable ignored) {
         }


### PR DESCRIPTION
## Summary

- `gracefulCloseAndDisconnect()` now drains the kernel recv buffer after `shutdown(SHUT_WR)`, preventing TCP RST from destroying in-flight CLOSE frames
- Adds `HttpConnectionContext.drainRecvBuffer()` helper used by both egress and ingress WebSocket processors

When the server detects an oversized WebSocket frame, it parses only the WS header (~8 bytes) before sending a CLOSE(1009) diagnostic back to the client. The remaining client payload (~4 KB in the reproducer) stays unread in the kernel recv buffer. The framework later calls `close()` on the socket, which on Linux sends TCP RST when unread data remains — this RST races with the CLOSE frame already written to the send buffer and can destroy it in transit. The client then sees `ECONNRESET` (error 104) instead of the WebSocket close code and reason text.

The fix reads and discards any residual data from the kernel recv buffer between `shutdown(SHUT_WR)` and the framework's `close()`, so the TCP connection tears down with a clean FIN-ACK sequence.

## Test plan

- `QwpEgressErrorCoverageTest.testOversizedQueryFrameSurfacesCloseDiagnosticUnderTinySendChunk` — the flaky test that exercises 1-byte send+recv fragmentation with a 2 KB recv buffer and a 4 KB query; client must see `code=1009` and `frame payload exceeds` in the error
- `QwpEgressErrorCoverageTest.testOversizedQueryFrameSurfacesCloseDiagnostic` — same scenario without the tiny send chunk cap
- Full QWP egress and ingress test suites pass without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)