### PR TITLE
fix(sql): fix statistical aggregates returning NULL on sparse-NULL data

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractStdDevGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractStdDevGroupByFunction.java
@@ -100,13 +100,23 @@ public abstract class AbstractStdDevGroupByFunction extends DoubleFunction imple
     // Chan et al. [CGL82; CGL83]
     @Override
     public void merge(MapValue destValue, MapValue srcValue) {
+        long srcCount = srcValue.getLong(valueIndex + 2);
+        if (srcCount == 0) {
+            return;
+        }
+        long destCount = destValue.getLong(valueIndex + 2);
+        if (destCount == 0) {
+            destValue.putDouble(valueIndex, srcValue.getDouble(valueIndex));
+            destValue.putDouble(valueIndex + 1, srcValue.getDouble(valueIndex + 1));
+            destValue.putLong(valueIndex + 2, srcCount);
+            return;
+        }
+
         double srcMean = srcValue.getDouble(valueIndex);
         double srcSum = srcValue.getDouble(valueIndex + 1);
-        long srcCount = srcValue.getLong(valueIndex + 2);
 
         double destMean = destValue.getDouble(valueIndex);
         double destSum = destValue.getDouble(valueIndex + 1);
-        long destCount = destValue.getLong(valueIndex + 2);
 
         long mergedCount = srcCount + destCount;
         double delta = destMean - srcMean;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CorrGroupByFunctionFactory.java
@@ -157,19 +157,32 @@ public class CorrGroupByFunctionFactory implements FunctionFactory {
         // Chan et al. [CGL82; CGL83]
         @Override
         public void merge(MapValue destValue, MapValue srcValue) {
+            long srcCount = srcValue.getLong(valueIndex + 5);
+            if (srcCount == 0) {
+                return;
+            }
+            long destCount = destValue.getLong(valueIndex + 5);
+            if (destCount == 0) {
+                destValue.putDouble(valueIndex, srcValue.getDouble(valueIndex));
+                destValue.putDouble(valueIndex + 1, srcValue.getDouble(valueIndex + 1));
+                destValue.putDouble(valueIndex + 2, srcValue.getDouble(valueIndex + 2));
+                destValue.putDouble(valueIndex + 3, srcValue.getDouble(valueIndex + 3));
+                destValue.putDouble(valueIndex + 4, srcValue.getDouble(valueIndex + 4));
+                destValue.putLong(valueIndex + 5, srcCount);
+                return;
+            }
+
             double srcMeanY = srcValue.getDouble(valueIndex);
             double srcSumY = srcValue.getDouble(valueIndex + 1);
             double srcMeanX = srcValue.getDouble(valueIndex + 2);
             double srcSumX = srcValue.getDouble(valueIndex + 3);
             double srcSumXY = srcValue.getDouble(valueIndex + 4);
-            long srcCount = srcValue.getLong(valueIndex + 5);
 
             double destMeanY = destValue.getDouble(valueIndex);
             double destSumY = destValue.getDouble(valueIndex + 1);
             double destMeanX = destValue.getDouble(valueIndex + 2);
             double destSumX = destValue.getDouble(valueIndex + 3);
             double destSumXY = destValue.getDouble(valueIndex + 4);
-            long destCount = destValue.getLong(valueIndex + 5);
 
             long mergedCount = srcCount + destCount;
             double deltaY = destMeanY - srcMeanY;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarSampleGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/CovarSampleGroupByFunctionFactory.java
@@ -82,15 +82,26 @@ public class CovarSampleGroupByFunctionFactory implements FunctionFactory {
         // Chan et al. [CGL82; CGL83]
         @Override
         public void merge(MapValue destValue, MapValue srcValue) {
+            long srcCount = srcValue.getLong(valueIndex + 3);
+            if (srcCount == 0) {
+                return;
+            }
+            long destCount = destValue.getLong(valueIndex + 3);
+            if (destCount == 0) {
+                destValue.putDouble(valueIndex, srcValue.getDouble(valueIndex));
+                destValue.putDouble(valueIndex + 1, srcValue.getDouble(valueIndex + 1));
+                destValue.putDouble(valueIndex + 2, srcValue.getDouble(valueIndex + 2));
+                destValue.putLong(valueIndex + 3, srcCount);
+                return;
+            }
+
             double srcMeanY = srcValue.getDouble(valueIndex);
             double srcMeanX = srcValue.getDouble(valueIndex + 1);
             double srcSumXY = srcValue.getDouble(valueIndex + 2);
-            long srcCount = srcValue.getLong(valueIndex + 3);
 
             double destMeanY = destValue.getDouble(valueIndex);
             double destMeanX = destValue.getDouble(valueIndex + 1);
             double destSumXY = destValue.getDouble(valueIndex + 2);
-            long destCount = destValue.getLong(valueIndex + 3);
 
             long mergedCount = srcCount + destCount;
             double deltaY = destMeanY - srcMeanY;

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CorrParallelGroupByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CorrParallelGroupByTest.java
@@ -1,0 +1,145 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.PropertyKey;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.mp.WorkerPool;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+// Locks in the fix for https://github.com/questdb/questdb/issues/7160 — corr() returning NULL
+// under parallel GROUP BY when many worker partials see only NULL (y, x) pairs.
+public class CorrParallelGroupByTest extends AbstractCairoTest {
+
+    @Override
+    @Before
+    public void setUp() {
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_ENABLED, "true");
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_SHARDING_THRESHOLD, 1);
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_WORK_STEALING_THRESHOLD, 1);
+        setProperty(PropertyKey.CAIRO_SQL_PAGE_FRAME_MAX_ROWS, 64);
+        setProperty(PropertyKey.CAIRO_PAGE_FRAME_SHARD_COUNT, 2);
+        setProperty(PropertyKey.CAIRO_PAGE_FRAME_REDUCE_QUEUE_CAPACITY, 2);
+        super.setUp();
+    }
+
+    @Test
+    public void testParallelAllNull() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            execute(
+                    compiler,
+                    "CREATE TABLE tbl AS (" +
+                            "    SELECT" +
+                            "        cast(null AS double) x," +
+                            "        cast(null AS double) y" +
+                            "    FROM long_sequence(4_000)" +
+                            ")",
+                    ctx
+            );
+            assertQueryNoLeakCheck(
+                    compiler,
+                    "corr\nnull\n",
+                    "SELECT corr(y, x) FROM tbl",
+                    null,
+                    ctx,
+                    false,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testParallelKeyedSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            execute(
+                    compiler,
+                    "CREATE TABLE tbl AS (" +
+                            "    SELECT" +
+                            "        x % 4 AS grp," +
+                            "        CASE WHEN x BETWEEN 1500 AND 1509 THEN cast(x AS double) ELSE cast(null AS double) END x_val," +
+                            "        CASE WHEN x BETWEEN 1500 AND 1509 THEN cast(2 * x + 5 AS double) ELSE cast(null AS double) END y_val" +
+                            "    FROM long_sequence(4_000)" +
+                            ")",
+                    ctx
+            );
+            assertQueryNoLeakCheck(
+                    compiler,
+                    "grp\tcorr\n" +
+                            "0\t1.0\n" +
+                            "1\t1.0\n" +
+                            "2\t1.0\n" +
+                            "3\t1.0\n",
+                    "SELECT grp, corr(y_val, x_val) FROM tbl ORDER BY grp",
+                    null,
+                    ctx,
+                    true,
+                    true
+            );
+        });
+    }
+
+    @Test
+    public void testParallelSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            execute(
+                    compiler,
+                    "CREATE TABLE tbl AS (" +
+                            "    SELECT" +
+                            "        CASE WHEN x BETWEEN 1500 AND 1509 THEN cast(x AS double) ELSE cast(null AS double) END x," +
+                            "        CASE WHEN x BETWEEN 1500 AND 1509 THEN cast(2 * x + 5 AS double) ELSE cast(null AS double) END y" +
+                            "    FROM long_sequence(4_000)" +
+                            ")",
+                    ctx
+            );
+            assertQueryNoLeakCheck(
+                    compiler,
+                    "corr\n1.0\n",
+                    "SELECT corr(y, x) FROM tbl",
+                    null,
+                    ctx,
+                    false,
+                    true
+            );
+        });
+    }
+
+    private void runWithPool(PoolRunnable body) throws Exception {
+        assertMemoryLeak(() -> {
+            try (WorkerPool pool = new WorkerPool(() -> 4)) {
+                TestUtils.execute(pool, (engine, compiler, sqlExecutionContext) ->
+                        body.run(compiler, sqlExecutionContext), configuration, LOG);
+            }
+        });
+    }
+
+    @FunctionalInterface
+    private interface PoolRunnable {
+        void run(SqlCompiler compiler, SqlExecutionContext ctx) throws Exception;
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CovarParallelGroupByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/CovarParallelGroupByTest.java
@@ -1,0 +1,132 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.PropertyKey;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.mp.WorkerPool;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+// Exercises the parallel-merge path for covar_samp and covar_pop, both sharing
+// CovarSampleGroupByFunction.merge(). Same empty-partial NaN-poisoning bug
+// as https://github.com/questdb/questdb/issues/7160 for corr().
+public class CovarParallelGroupByTest extends AbstractCairoTest {
+
+    @Override
+    @Before
+    public void setUp() {
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_ENABLED, "true");
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_SHARDING_THRESHOLD, 1);
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_WORK_STEALING_THRESHOLD, 1);
+        setProperty(PropertyKey.CAIRO_SQL_PAGE_FRAME_MAX_ROWS, 64);
+        setProperty(PropertyKey.CAIRO_PAGE_FRAME_SHARD_COUNT, 2);
+        setProperty(PropertyKey.CAIRO_PAGE_FRAME_REDUCE_QUEUE_CAPACITY, 2);
+        super.setUp();
+    }
+
+    @Test
+    public void testParallelCovarPopSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            createSparseTable(compiler, ctx);
+            assertQueryNoLeakCheck(
+                    compiler,
+                    "covar_pop\n16.5\n",
+                    "SELECT covar_pop(y, x) FROM tbl",
+                    null, ctx, false, true
+            );
+        });
+    }
+
+    @Test
+    public void testParallelCovarSampSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            createSparseTable(compiler, ctx);
+            assertQueryNoLeakCheck(
+                    compiler,
+                    "covar_samp\n18.333333333333332\n",
+                    "SELECT covar_samp(y, x) FROM tbl",
+                    null, ctx, false, true
+            );
+        });
+    }
+
+    @Test
+    public void testParallelKeyedSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            execute(
+                    compiler,
+                    "CREATE TABLE tbl AS (" +
+                            "    SELECT" +
+                            "        x % 4 AS grp," +
+                            "        CASE WHEN x BETWEEN 1500 AND 1509 THEN cast(x AS double) ELSE cast(null AS double) END x_val," +
+                            "        CASE WHEN x BETWEEN 1500 AND 1509 THEN cast(2 * x + 5 AS double) ELSE cast(null AS double) END y_val" +
+                            "    FROM long_sequence(4_000)" +
+                            ")",
+                    ctx
+            );
+            assertQueryNoLeakCheck(
+                    compiler,
+                    "grp\tcovar_pop\tcovar_samp\n" +
+                            "0\t21.333333333333332\t32.0\n" +
+                            "1\t21.333333333333332\t32.0\n" +
+                            "2\t8.0\t16.0\n" +
+                            "3\t8.0\t16.0\n",
+                    "SELECT grp, covar_pop(y_val, x_val), covar_samp(y_val, x_val) FROM tbl ORDER BY grp",
+                    null, ctx, true, true
+            );
+        });
+    }
+
+    private void createSparseTable(SqlCompiler compiler, SqlExecutionContext ctx) throws Exception {
+        execute(
+                compiler,
+                "CREATE TABLE tbl AS (" +
+                        "    SELECT" +
+                        "        CASE WHEN x BETWEEN 1500 AND 1509 THEN cast(x AS double) ELSE cast(null AS double) END x," +
+                        "        CASE WHEN x BETWEEN 1500 AND 1509 THEN cast(2 * x + 5 AS double) ELSE cast(null AS double) END y" +
+                        "    FROM long_sequence(4_000)" +
+                        ")",
+                ctx
+        );
+    }
+
+    private void runWithPool(PoolRunnable body) throws Exception {
+        assertMemoryLeak(() -> {
+            try (WorkerPool pool = new WorkerPool(() -> 4)) {
+                TestUtils.execute(pool, (engine, compiler, sqlExecutionContext) ->
+                        body.run(compiler, sqlExecutionContext), configuration, LOG);
+            }
+        });
+    }
+
+    @FunctionalInterface
+    private interface PoolRunnable {
+        void run(SqlCompiler compiler, SqlExecutionContext ctx) throws Exception;
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StdDevParallelGroupByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/StdDevParallelGroupByTest.java
@@ -1,0 +1,156 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.PropertyKey;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.mp.WorkerPool;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+// Exercises the parallel-merge path for the Welford-based variance/stddev family
+// (var_pop, var_samp, stddev_pop, stddev_samp), all sharing AbstractStdDevGroupByFunction.merge().
+// Same empty-partial NaN-poisoning bug as https://github.com/questdb/questdb/issues/7160 for corr().
+public class StdDevParallelGroupByTest extends AbstractCairoTest {
+
+    @Override
+    @Before
+    public void setUp() {
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_ENABLED, "true");
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_SHARDING_THRESHOLD, 1);
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_WORK_STEALING_THRESHOLD, 1);
+        setProperty(PropertyKey.CAIRO_SQL_PAGE_FRAME_MAX_ROWS, 64);
+        setProperty(PropertyKey.CAIRO_PAGE_FRAME_SHARD_COUNT, 2);
+        setProperty(PropertyKey.CAIRO_PAGE_FRAME_REDUCE_QUEUE_CAPACITY, 2);
+        super.setUp();
+    }
+
+    @Test
+    public void testParallelKeyedSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            execute(
+                    compiler,
+                    "CREATE TABLE tbl AS (" +
+                            "    SELECT" +
+                            "        x % 4 AS grp," +
+                            "        CASE WHEN x BETWEEN 1500 AND 1509 THEN cast(x AS double) ELSE cast(null AS double) END val" +
+                            "    FROM long_sequence(4_000)" +
+                            ")",
+                    ctx
+            );
+            assertQueryNoLeakCheck(
+                    compiler,
+                    "grp\tvar_pop\tvar_samp\tstddev_pop\tstddev_samp\n" +
+                            "0\t10.666666666666666\t16.0\t3.265986323710904\t4.0\n" +
+                            "1\t10.666666666666666\t16.0\t3.265986323710904\t4.0\n" +
+                            "2\t4.0\t8.0\t2.0\t2.8284271247461903\n" +
+                            "3\t4.0\t8.0\t2.0\t2.8284271247461903\n",
+                    "SELECT grp, var_pop(val), var_samp(val), stddev_pop(val), stddev_samp(val) FROM tbl ORDER BY grp",
+                    null, ctx, true, true
+            );
+        });
+    }
+
+    @Test
+    public void testParallelStdDevPopSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            createSparseTable(compiler, ctx);
+            assertQueryNoLeakCheck(
+                    compiler,
+                    "stddev_pop\n2.8722813232690143\n",
+                    "SELECT stddev_pop(x) FROM tbl",
+                    null, ctx, false, true
+            );
+        });
+    }
+
+    @Test
+    public void testParallelStdDevSampSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            createSparseTable(compiler, ctx);
+            assertQueryNoLeakCheck(
+                    compiler,
+                    "stddev_samp\n3.0276503540974917\n",
+                    "SELECT stddev_samp(x) FROM tbl",
+                    null, ctx, false, true
+            );
+        });
+    }
+
+    @Test
+    public void testParallelVarPopSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            createSparseTable(compiler, ctx);
+            assertQueryNoLeakCheck(
+                    compiler,
+                    "var_pop\n8.25\n",
+                    "SELECT var_pop(x) FROM tbl",
+                    null, ctx, false, true
+            );
+        });
+    }
+
+    @Test
+    public void testParallelVarSampSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            createSparseTable(compiler, ctx);
+            assertQueryNoLeakCheck(
+                    compiler,
+                    "var_samp\n9.166666666666666\n",
+                    "SELECT var_samp(x) FROM tbl",
+                    null, ctx, false, true
+            );
+        });
+    }
+
+    private void createSparseTable(SqlCompiler compiler, SqlExecutionContext ctx) throws Exception {
+        execute(
+                compiler,
+                "CREATE TABLE tbl AS (" +
+                        "    SELECT" +
+                        "        CASE WHEN x BETWEEN 1500 AND 1509 THEN cast(x AS double) ELSE cast(null AS double) END x" +
+                        "    FROM long_sequence(4_000)" +
+                        ")",
+                ctx
+        );
+    }
+
+    private void runWithPool(PoolRunnable body) throws Exception {
+        assertMemoryLeak(() -> {
+            try (WorkerPool pool = new WorkerPool(() -> 4)) {
+                TestUtils.execute(pool, (engine, compiler, sqlExecutionContext) ->
+                        body.run(compiler, sqlExecutionContext), configuration, LOG);
+            }
+        });
+    }
+
+    @FunctionalInterface
+    private interface PoolRunnable {
+        void run(SqlCompiler compiler, SqlExecutionContext ctx) throws Exception;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #7160 

`corr`, `stddev_pop`, `stddev_samp`, `var_pop`, `var_samp`, `covar_pop`, and `covar_samp` were returning `NULL` on sparse-NULL data on GROUP BY parallel.

The merge algorithm that is called when parallel workers need to merge partial results of the aggregate was not considering empty partials. When partials were empty, a NaN value was being propagated and was surfaced as an SQL `NULL`. 

## Changes

- Applied the same merge fix guard from #7104 to all those aggregates
- Tests that confirmed the bug were added, and after the fix, they became green