### PR TITLE
chore(core): bump questdb-client version to 1.3.2

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -117,7 +117,7 @@
           -->
         <uberjar.name>benchmarks</uberjar.name>
 
-        <questdb.client.version>1.3.1-SNAPSHOT</questdb.client.version>
+        <questdb.client.version>1.3.2</questdb.client.version>
     </properties>
 
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -45,7 +45,7 @@
         -->
         <qdbr.rustflags>-D warnings</qdbr.rustflags>
 
-        <questdb.client.version>1.3.1-SNAPSHOT</questdb.client.version>
+        <questdb.client.version>1.3.2</questdb.client.version>
     </properties>
 
     <version>9.4.1-SNAPSHOT</version>
@@ -236,7 +236,7 @@
         <profile>
             <id>local-client</id>
             <properties>
-                <questdb.client.version>1.3.1-SNAPSHOT</questdb.client.version>
+                <questdb.client.version>1.3.2</questdb.client.version>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
                 <module>java-questdb-client</module>
             </modules>
             <properties>
-                <questdb.client.version>1.3.1-SNAPSHOT</questdb.client.version>
+                <questdb.client.version>1.3.2</questdb.client.version>
             </properties>
         </profile>
     </profiles>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -40,7 +40,7 @@
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
 
-        <questdb.client.version>1.3.1-SNAPSHOT</questdb.client.version>
+        <questdb.client.version>1.3.2</questdb.client.version>
     </properties>
 
     <dependencies>
@@ -144,7 +144,7 @@
         <profile>
             <id>local-client</id>
             <properties>
-                <questdb.client.version>1.3.1-SNAPSHOT</questdb.client.version>
+                <questdb.client.version>1.3.2</questdb.client.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
## Summary
- Update `questdb.client.version` property from `1.3.1-SNAPSHOT` to `1.3.2` in all modules (core, utils, benchmarks) and their `local-client` profiles
- Advance `java-questdb-client` submodule pointer to include recent pooling, lifecycle, and timeout fixes

## Test plan
- Verify the project compiles with `mvn compile test-compile`
- Run client-dependent tests to confirm dependency resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)