### PR TITLE
chore(qwp): exclude dropped datagrams from processedCount

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/qwp/server/LinuxMMQwpUdpReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/LinuxMMQwpUdpReceiver.java
@@ -68,7 +68,9 @@ public class LinuxMMQwpUdpReceiver extends QwpUdpReceiver {
             long p = msgVec;
             for (int i = 0; i < count; i++) {
                 int datagramState = processDatagram(nf.getMMsgBuf(p), (int) nf.getMMsgBufLen(p));
-                processedCount++;
+                if ((datagramState & DATAGRAM_DROPPED) == 0) {
+                    processedCount++;
+                }
                 if ((datagramState & DATAGRAM_TRIGGERED_COMMIT) != 0) {
                     totalCount = 0;
                 }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpUdpReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpUdpReceiver.java
@@ -60,6 +60,7 @@ import static io.questdb.cutlass.qwp.protocol.QwpConstants.HEADER_SIZE;
 
 public class QwpUdpReceiver extends SynchronizedJob implements Closeable {
     private static final Log LOG = LogFactory.getLog(QwpUdpReceiver.class);
+    protected static final int DATAGRAM_DROPPED = 4;
     protected static final int DATAGRAM_LEFT_UNCOMMITTED_ROWS = 1;
     protected static final int DATAGRAM_TRIGGERED_COMMIT = 2;
 
@@ -258,7 +259,9 @@ public class QwpUdpReceiver extends SynchronizedJob implements Closeable {
         while ((count = nf.recvRaw(fd, buf, bufLen)) > 0) {
             ran = true;
             int datagramState = processDatagram(buf, count);
-            processedCount++;
+            if ((datagramState & DATAGRAM_DROPPED) == 0) {
+                processedCount++;
+            }
             if ((datagramState & DATAGRAM_TRIGGERED_COMMIT) != 0) {
                 totalCount = 0;
             }
@@ -327,7 +330,7 @@ public class QwpUdpReceiver extends SynchronizedJob implements Closeable {
     protected int processDatagram(long address, int length) {
         if (length < HEADER_SIZE) {
             droppedTooShortCount++;
-            return 0;
+            return DATAGRAM_DROPPED;
         }
         try {
             messageHeader.parse(address, length);
@@ -338,14 +341,14 @@ public class QwpUdpReceiver extends SynchronizedJob implements Closeable {
                 default -> droppedParseErrorCount++;
             }
             LOG.error().$("header parse error: ").$(e.getFlyweightMessage()).$();
-            return 0;
+            return DATAGRAM_DROPPED;
         }
         long totalLength = HEADER_SIZE + messageHeader.getPayloadLength();
         if (totalLength > length) {
             droppedTruncatedCount++;
             LOG.error().$("payload extends beyond datagram [payloadLen=").$(messageHeader.getPayloadLength())
                     .$(", received=").$(length).$(']').$();
-            return 0;
+            return DATAGRAM_DROPPED;
         }
         int datagramState = 0;
         try {
@@ -377,7 +380,7 @@ public class QwpUdpReceiver extends SynchronizedJob implements Closeable {
         } catch (Throwable t) {
             droppedParseErrorCount++;
             LOG.error().$("datagram processing error: ").$(t.getMessage()).$();
-            return 0;
+            return DATAGRAM_DROPPED;
         }
         return datagramState;
     }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpMalformedTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpMalformedTest.java
@@ -373,37 +373,6 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testMultipleMalformedThenValid() throws Exception {
-        assertMemoryLeak(() -> {
-            try (QwpUdpReceiver receiver = receiverFactory.create(RCVR_CONF, engine)) {
-                // too short
-                sendRawBytes(new byte[]{0, 0, 0, 0});
-                // bad magic
-                sendRawBytes(new byte[12]);
-                // bad version
-                byte[] badVersion = createHeader(
-                        VALID_MAGIC,
-                        (byte) 2, (byte) 0, 0, 0L
-                );
-                sendRawBytes(badVersion);
-                // valid row
-                sendValidRow("multi_bad", 1L, 1_000_000L);
-                drainReceiver(receiver, 4);
-
-                Assert.assertEquals(1, receiver.getDroppedTooShortCount());
-                Assert.assertEquals(1, receiver.getDroppedBadMagicCount());
-                Assert.assertEquals(1, receiver.getDroppedBadVersionCount());
-            }
-
-            drainWalQueue();
-            assertSql(
-                    "count\n1\n",
-                    "SELECT count() FROM multi_bad"
-            );
-        });
-    }
-
-    @Test
     public void testMalformedDatagramDoesNotCountTowardsMaxUncommittedDatagrams() throws Exception {
         QwpUdpReceiverConfiguration conf = new DefaultQwpUdpReceiverConfiguration() {
             @Override
@@ -441,6 +410,37 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
 
             drainWalQueue();
             assertSql("count\n1\n", "SELECT count() FROM noise_then_valid");
+        });
+    }
+
+    @Test
+    public void testMultipleMalformedThenValid() throws Exception {
+        assertMemoryLeak(() -> {
+            try (QwpUdpReceiver receiver = receiverFactory.create(RCVR_CONF, engine)) {
+                // too short
+                sendRawBytes(new byte[]{0, 0, 0, 0});
+                // bad magic
+                sendRawBytes(new byte[12]);
+                // bad version
+                byte[] badVersion = createHeader(
+                        VALID_MAGIC,
+                        (byte) 2, (byte) 0, 0, 0L
+                );
+                sendRawBytes(badVersion);
+                // valid row
+                sendValidRow("multi_bad", 1L, 1_000_000L);
+                drainReceiver(receiver, 4);
+
+                Assert.assertEquals(1, receiver.getDroppedTooShortCount());
+                Assert.assertEquals(1, receiver.getDroppedBadMagicCount());
+                Assert.assertEquals(1, receiver.getDroppedBadVersionCount());
+            }
+
+            drainWalQueue();
+            assertSql(
+                    "count\n1\n",
+                    "SELECT count() FROM multi_bad"
+            );
         });
     }
 
@@ -509,6 +509,30 @@ public class QwpUdpMalformedTest extends AbstractCairoTest {
                     "count\n1\n",
                     "SELECT count() FROM too_large"
             );
+        });
+    }
+
+    @Test
+    public void testProcessedCountDoesNotIncludeDroppedDatagrams() throws Exception {
+        // Regression test: drainReceiver() uses processedCount + totalDroppedCount as a
+        // "datagrams seen so far" signal. If processedCount is incremented even when
+        // processDatagram() classifies the packet as dropped, a single bad datagram bumps
+        // both counters and silently doubles its contribution, letting callers proceed
+        // before subsequent valid datagrams have been read from the kernel buffer.
+        assertMemoryLeak(() -> {
+            try (QwpUdpReceiver receiver = receiverFactory.create(RCVR_CONF, engine)) {
+                sendRawBytes(new byte[11]); // shorter than HEADER_SIZE -> droppedTooShort
+
+                long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(20);
+                while (System.nanoTime() < deadline && receiver.getDroppedTooShortCount() == 0) {
+                    receiver.runSerially();
+                    Os.pause();
+                }
+
+                Assert.assertEquals(1, receiver.getDroppedTooShortCount());
+                Assert.assertEquals("processedCount must not include dropped datagrams",
+                        0, receiver.getProcessedCount());
+            }
         });
     }
 


### PR DESCRIPTION
drainReceiver() in the malformed-datagram tests polls on processedCount + totalDroppedCount. Bumping processedCount on drops double-counted them, letting drainReceiver return one datagram short and pass even when a trailing valid datagram never arrived.

processDatagram() now returns a DATAGRAM_DROPPED flag on the four error paths, and both runSerially() callers skip the processedCount++ when it is set.

this stabilizes a flaky testTooShortElevenBytes()