### PR TITLE
ci(build): add git low-speed timeout to fuzz CI checkouts

### DIFF
--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -1,4 +1,13 @@
 steps:
+  - bash: |
+      # Abort any git HTTP transfer that averages below 100 KiB/s for 30s
+      # so Azure's checkout retry picks a fresh TCP connection instead of
+      # crawling for 30-60 min. Mitigates the per-flow upstream-network
+      # stalls observed on the FSN1 dedicated-server boxes.
+      git config --global http.lowSpeedLimit 102400
+      git config --global http.lowSpeedTime 30
+    displayName: "Set git low-speed abort thresholds"
+    condition: startsWith(variables['poolName'], 'hetzner-')
   - checkout: self
     fetchDepth: 1
     lfs: false

--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -1,5 +1,13 @@
 steps:
   - bash: |
+      # Agent.MachineName is set on the agent at runtime, but YAML step
+      # conditions are evaluated server-side before dispatch, so a
+      # condition referencing it always sees an empty string. Check the
+      # agent-side env var from inside the script instead.
+      if [[ "${AGENT_MACHINENAME:-}" != dedi-incus-* ]]; then
+        echo "Skipping on ${AGENT_MACHINENAME:-unknown}; only applied to dedi-incus-* hosts"
+        exit 0
+      fi
       # Abort any git HTTP transfer that averages below 100 KiB/s for 30s
       # so Azure's checkout retry picks a fresh TCP connection instead of
       # crawling for 30-60 min. Mitigates the per-flow upstream-network
@@ -7,7 +15,6 @@ steps:
       git config --global http.lowSpeedLimit 102400
       git config --global http.lowSpeedTime 30
     displayName: "Set git low-speed abort thresholds"
-    condition: startsWith(variables['Agent.MachineName'], 'dedi-incus-')
   - checkout: self
     fetchDepth: 1
     lfs: false

--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -1,11 +1,10 @@
 steps:
   - bash: |
-      # Agent.MachineName is set on the agent at runtime, but YAML step
-      # conditions are evaluated server-side before dispatch, so a
-      # condition referencing it always sees an empty string. Check the
-      # agent-side env var from inside the script instead.
-      if [[ "${AGENT_MACHINENAME:-}" != dedi-incus-* ]]; then
-        echo "Skipping on ${AGENT_MACHINENAME:-unknown}; only applied to dedi-incus-* hosts"
+      # Apply only to Hetzner self-hosted agents. AGENT_MACHINENAME is the
+      # agent's self-configured name (e.g. "hetzner-incus-12"), distinct
+      # from the OS hostname and from the timeline's workerName.
+      if [[ "${AGENT_MACHINENAME:-}" != hetzner-incus-* ]]; then
+        echo "Skipping on ${AGENT_MACHINENAME:-unknown}; only applied to hetzner-incus-* agents"
         exit 0
       fi
       # Abort any git HTTP transfer that averages below 100 KiB/s for 30s

--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -7,7 +7,7 @@ steps:
       git config --global http.lowSpeedLimit 102400
       git config --global http.lowSpeedTime 30
     displayName: "Set git low-speed abort thresholds"
-    condition: startsWith(variables['poolName'], 'hetzner-')
+    condition: startsWith(variables['Agent.MachineName'], 'dedi-incus-')
   - checkout: self
     fetchDepth: 1
     lfs: false

--- a/ci/test-fuzz.yml
+++ b/ci/test-fuzz.yml
@@ -51,15 +51,6 @@ stages:
           ARCHIVED_CRASH_LOG: "$(Build.ArtifactStagingDirectory)/questdb-crash-$(Build.SourceBranchName)-$(Build.SourceVersion)-$(System.StageAttempt)-$(Agent.OS)-$(jdk).log"
         steps:
           - bash: |
-              # Kill any git HTTP transfer that averages below 100 KiB/s for
-              # 30 seconds. Lets Azure's checkout-task retry re-establish on
-              # a fresh 5-tuple instead of crawling for 30-60 min at 30 KiB/s.
-              # See investigation around the slow Hetzner checkouts.
-              git config --global http.lowSpeedLimit 102400
-              git config --global http.lowSpeedTime 30
-              git config --global --get-regexp '^http\.lowSpeed'
-            displayName: "Set git low-speed abort thresholds"
-          - bash: |
               sudo apt-get update && sudo apt-get install -y openjdk-25-jdk maven build-essential zip
               JAVA_PATH="/usr/lib/jvm/java-25-openjdk-amd64"
               echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_PATH"

--- a/ci/test-fuzz.yml
+++ b/ci/test-fuzz.yml
@@ -51,6 +51,15 @@ stages:
           ARCHIVED_CRASH_LOG: "$(Build.ArtifactStagingDirectory)/questdb-crash-$(Build.SourceBranchName)-$(Build.SourceVersion)-$(System.StageAttempt)-$(Agent.OS)-$(jdk).log"
         steps:
           - bash: |
+              # Kill any git HTTP transfer that averages below 100 KiB/s for
+              # 30 seconds. Lets Azure's checkout-task retry re-establish on
+              # a fresh 5-tuple instead of crawling for 30-60 min at 30 KiB/s.
+              # See investigation around the slow Hetzner checkouts.
+              git config --global http.lowSpeedLimit 102400
+              git config --global http.lowSpeedTime 30
+              git config --global --get-regexp '^http\.lowSpeed'
+            displayName: "Set git low-speed abort thresholds"
+          - bash: |
               sudo apt-get update && sudo apt-get install -y openjdk-25-jdk maven build-essential zip
               JAVA_PATH="/usr/lib/jvm/java-25-openjdk-amd64"
               echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_PATH"


### PR DESCRIPTION
set http.lowSpeedLimit=100 KiB/s, http.lowSpeedTime=30s before the checkout step. Kills any HTTP transfer that averages below the threshold for 30s so Azure's retry can pick a fresh TCP connection, instead of crawling for 30-60 min at 30 KiB/s as recent Hetzner checkout stalls did. Scoped to fuzz only for fast feedback.