### PR TITLE
perf(sql): single-pass parquet decode for covering index build

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -825,17 +825,22 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         columnMetadata.setCoveringColumnIndices(coveringColumnIndices);
 
         final SymbolColumnIndexer indexer = new SymbolColumnIndexer(configuration, indexType);
-        writeIndex(columnName, indexValueBlockSize, indexType, columnIndex, indexer);
+        try {
+            writeIndex(columnName, indexValueBlockSize, indexType, columnIndex, indexer);
 
-        columnMetadata.setIndexType(indexType);
-        columnMetadata.setIndexValueBlockCapacity(indexValueBlockSize);
+            columnMetadata.setIndexType(indexType);
+            columnMetadata.setIndexValueBlockCapacity(indexValueBlockSize);
 
-        // set the index flag in metadata and create new _meta.swp
-        rewriteAndSwapMetadata(metadata);
-        clearTodoAndCommitMeta();
+            // set the index flag in metadata and create new _meta.swp
+            rewriteAndSwapMetadata(metadata);
+            clearTodoAndCommitMeta();
 
-        indexers.extendAndSet(columnIndex, indexer);
-        populateDenseIndexerList();
+            indexers.extendAndSet(columnIndex, indexer);
+            populateDenseIndexerList();
+        } catch (Throwable th) {
+            Misc.free(indexer);
+            throw th;
+        }
 
         try (MetadataCacheWriter metadataRW = engine.getMetadataCache().writeLock()) {
             metadataRW.hydrateTable(metadata);
@@ -3630,6 +3635,131 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
     }
 
+    private void accumulateAllNullFixedChunk(MemoryMARW mem, int columnType, long rowCount) {
+        final long fixSize = rowCount * ColumnType.sizeOf(columnType);
+        if (fixSize == 0) {
+            return;
+        }
+        long nullBuf = Unsafe.malloc(fixSize, MemoryTag.NATIVE_TABLE_WRITER);
+        try {
+            TableUtils.setNull(columnType, nullBuf, rowCount);
+            mem.putBlockOfBytes(nullBuf, fixSize);
+        } finally {
+            Unsafe.free(nullBuf, fixSize, MemoryTag.NATIVE_TABLE_WRITER);
+        }
+    }
+
+    private void accumulateAllNullVarSizeChunk(
+            ColumnTypeDriver driver,
+            MemoryMARW auxMem,
+            MemoryMARW dataMem,
+            int rowGroupIndex,
+            long rowCount,
+            long dataVecBytesWritten
+    ) {
+        final long dataSize = rowCount * driver.getDataVectorMinEntrySize();
+        final long auxSize = driver.getAuxVectorSize(rowCount);
+
+        long nullDataBuf = 0;
+        long nullAuxBuf = 0;
+        try {
+            if (dataSize > 0) {
+                nullDataBuf = Unsafe.malloc(dataSize, MemoryTag.NATIVE_TABLE_WRITER);
+                driver.setDataVectorEntriesToNull(nullDataBuf, rowCount);
+                dataMem.putBlockOfBytes(nullDataBuf, dataSize);
+            }
+            if (auxSize > 0) {
+                nullAuxBuf = Unsafe.malloc(auxSize, MemoryTag.NATIVE_TABLE_WRITER);
+                driver.setFullAuxVectorNull(nullAuxBuf, rowCount);
+                if (dataVecBytesWritten > 0 && rowCount > 0) {
+                    driver.shiftCopyAuxVector(
+                            -dataVecBytesWritten, nullAuxBuf, 0,
+                            rowCount - 1, nullAuxBuf, auxSize);
+                }
+                long auxPtr = nullAuxBuf;
+                long auxBytes = auxSize;
+                if (rowGroupIndex > 0) {
+                    final long adjust = driver.getMinAuxVectorSize();
+                    auxPtr += adjust;
+                    auxBytes -= adjust;
+                }
+                auxMem.putBlockOfBytes(auxPtr, auxBytes);
+            }
+        } finally {
+            if (nullAuxBuf != 0) {
+                Unsafe.free(nullAuxBuf, auxSize, MemoryTag.NATIVE_TABLE_WRITER);
+            }
+            if (nullDataBuf != 0) {
+                Unsafe.free(nullDataBuf, dataSize, MemoryTag.NATIVE_TABLE_WRITER);
+            }
+        }
+    }
+
+    /**
+     * Accumulates one decoded row group's worth of covered column data into
+     * mmap-backed temp files. Called from the merged row-group loop inside
+     * {@link #indexParquetPartition}. Each covered slot's MemoryMARW pair
+     * (data + aux) in {@code covMmaps} grows via mmap extend; the caller
+     * passes the final base addresses to PostingIndexWriter after the loop.
+     *
+     * <p>{@code covSlotMeta} layout per slot (3 longs):
+     * [0] decodedChunkIdx (-1 if skipped), [1] colType, [2] dataVecBytesWritten.
+     */
+    private void accumulateCoveredColumnsFromRowGroup(
+            IntList coveringColumnIndices,
+            DirectLongList covSlotMeta,
+            ObjList<MemoryMARW> covMmaps,
+            RowGroupBuffers rowGroupBuffers,
+            int rowGroupIndex,
+            long rowGroupRowCount
+    ) {
+        final int coverCount = coveringColumnIndices.size();
+        for (int slot = 0; slot < coverCount; slot++) {
+            final int decodedChunkIdx = (int) covSlotMeta.get(3L * slot);
+            if (decodedChunkIdx < 0) {
+                continue;
+            }
+            final int columnType = (int) covSlotMeta.get(3L * slot + 1);
+            final long srcDataPtr = rowGroupBuffers.getChunkDataPtr(decodedChunkIdx);
+            final long srcDataSize = rowGroupBuffers.getChunkDataSize(decodedChunkIdx);
+            long srcAuxPtr = rowGroupBuffers.getChunkAuxPtr(decodedChunkIdx);
+            long srcAuxSize = rowGroupBuffers.getChunkAuxSize(decodedChunkIdx);
+
+            final MemoryMARW dataMem = covMmaps.getQuick(2 * slot + 1);
+            if (ColumnType.isVarSize(columnType)) {
+                final MemoryMARW auxMem = covMmaps.getQuick(2 * slot);
+                final ColumnTypeDriver driver = ColumnType.getDriver(columnType);
+                final long dataVecBytesWritten = covSlotMeta.get(3L * slot + 2);
+
+                if (srcDataPtr == 0 && srcAuxPtr == 0) {
+                    accumulateAllNullVarSizeChunk(
+                            driver, auxMem, dataMem, rowGroupIndex,
+                            rowGroupRowCount, dataVecBytesWritten);
+                    covSlotMeta.set(3L * slot + 2,
+                            dataVecBytesWritten + rowGroupRowCount * driver.getDataVectorMinEntrySize());
+                    continue;
+                }
+                if (rowGroupIndex > 0) {
+                    driver.shiftCopyAuxVector(
+                            -dataVecBytesWritten, srcAuxPtr, 0,
+                            rowGroupRowCount - 1, srcAuxPtr, srcAuxSize);
+                    final long adjust = driver.getMinAuxVectorSize();
+                    srcAuxPtr += adjust;
+                    srcAuxSize -= adjust;
+                }
+                dataMem.putBlockOfBytes(srcDataPtr, srcDataSize);
+                auxMem.putBlockOfBytes(srcAuxPtr, srcAuxSize);
+                covSlotMeta.set(3L * slot + 2, dataVecBytesWritten + srcDataSize);
+            } else {
+                if (srcDataPtr == 0) {
+                    accumulateAllNullFixedChunk(dataMem, columnType, rowGroupRowCount);
+                } else {
+                    dataMem.putBlockOfBytes(srcDataPtr, srcDataSize);
+                }
+            }
+        }
+    }
+
     private void addColumnToMeta(
             CharSequence columnName,
             int columnType,
@@ -4416,27 +4546,26 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     /**
-     * Deletes the temp .d (and .i for var-size) files that
-     * {@link #materialiseCoveredColumnsFromParquet} created at the standard
-     * paths inside the partition. Iterates the {@code materialisedSlots} list
-     * populated by the materialise step so we touch only the slots we actually
-     * wrote.
+     * Removes covered-column temp files (.d and .i) for ALL covered columns
+     * of the given index. Used by the single-pass parquet indexing path where
+     * the caller does not track individual materialised slots.
      */
     private void cleanupMaterialisedCoveredColumnTempFiles(
             IntList coveringColumnIndices,
             long partitionTimestamp,
-            int plen,
-            IntList materialisedSlots
+            int plen
     ) {
-        for (int i = 0, n = materialisedSlots.size(); i < n; i++) {
-            final int slot = materialisedSlots.getQuick(i);
+        for (int slot = 0, n = coveringColumnIndices.size(); slot < n; slot++) {
             final int tableColIdx = coveringColumnIndices.getQuick(slot);
+            if (tableColIdx < 0) {
+                continue;
+            }
             final int columnType = metadata.getColumnType(tableColIdx);
-            final CharSequence columnName = metadata.getColumnName(tableColIdx);
-            final long columnNameTxn = columnVersionWriter.getColumnNameTxn(partitionTimestamp, tableColIdx);
-            ff.removeQuiet(dFile(path.trimTo(plen), columnName, columnNameTxn));
+            final CharSequence colName = metadata.getColumnName(tableColIdx);
+            final long colNameTxn = columnVersionWriter.getColumnNameTxn(partitionTimestamp, tableColIdx);
+            ff.removeQuiet(dFile(path.trimTo(plen), colName, colNameTxn));
             if (ColumnType.isVarSize(columnType)) {
-                ff.removeQuiet(iFile(path.trimTo(plen), columnName, columnNameTxn));
+                ff.removeQuiet(iFile(path.trimTo(plen), colName, colNameTxn));
             }
         }
         path.trimTo(plen);
@@ -4708,6 +4837,56 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             o3TimestampMem = o3MemColumns1.getQuick(getPrimaryColumnIndex(timestampIndex));
             o3TimestampMemCpy = o3MemColumns2.getQuick(getPrimaryColumnIndex(timestampIndex));
         }
+    }
+
+    /**
+     * Wires up the addr-based covering path on the indexer so that
+     * seal reads covered column data from the mmap-backed temp files.
+     * The mmap addresses are stable because the row-group loop has
+     * finished and no more extends will occur.
+     */
+    private void configureCoveringFromMmaps(
+            SymbolColumnIndexer indexer,
+            IntList coveringColumnIndices,
+            long partitionTimestamp,
+            ObjList<MemoryMARW> covMmaps
+    ) {
+        final int coverCount = coveringColumnIndices.size();
+        coveringAddrs.setPos(coverCount);
+        coveringAuxAddrs.setPos(coverCount);
+        coveringTops.clear();
+        coveringShifts.clear();
+        coveringIndices.clear();
+        coveringTypes.clear();
+        coveringNameTxns.clear();
+
+        for (int slot = 0; slot < coverCount; slot++) {
+            int covCol = coveringColumnIndices.getQuick(slot);
+            if (covCol < 0 || metadata.getColumnType(covCol) <= 0) {
+                coveringAddrs.setQuick(slot, 0);
+                coveringAuxAddrs.setQuick(slot, 0);
+                coveringTops.add(0);
+                coveringShifts.add(0);
+                coveringIndices.add(-1);
+                coveringTypes.add(-1);
+                coveringNameTxns.add(TableUtils.COLUMN_NAME_TXN_NONE);
+                continue;
+            }
+            int covType = metadata.getColumnType(covCol);
+            MemoryMARW dataMem = covMmaps.getQuick(2 * slot + 1);
+            MemoryMARW auxMem = covMmaps.getQuick(2 * slot);
+            coveringAddrs.setQuick(slot, dataMem != null && dataMem.isOpen() ? dataMem.addressOf(0) : 0);
+            coveringAuxAddrs.setQuick(slot, auxMem != null && auxMem.isOpen() ? auxMem.addressOf(0) : 0);
+            coveringTops.add(columnVersionWriter.getColumnTopQuick(partitionTimestamp, covCol));
+            coveringShifts.add(ColumnType.pow2SizeOf(covType));
+            coveringIndices.add(covCol);
+            coveringTypes.add(covType);
+            coveringNameTxns.add(columnVersionWriter.getColumnNameTxn(partitionTimestamp, covCol));
+        }
+        indexer.configureCovering(
+                coveringAddrs, coveringAuxAddrs, coveringTops, coveringShifts,
+                coveringIndices, coveringTypes, coverCount, metadata.getTimestampIndex());
+        indexer.setCoveredColumnNameTxns(coveringNameTxns);
     }
 
     private void configureCoveringIfNeeded(ColumnIndexer indexer, int columnIndex, long partitionTimestamp) {
@@ -6764,7 +6943,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     if (hasCovering) {
                         configureCoveringFromMmaps(
                                 indexer, coveringColumnIndices, timestamp,
-                                covSlotMeta, covMmaps);
+                                covMmaps);
                     }
 
                     indexWriter.setMaxValue(partitionSize - 1);
@@ -7088,13 +7267,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                             .put("invalid covering column file size [path=").put(colFile)
                             .put(", size=").put(fileSize).put(']');
                 }
-                if (fileSize == 0) {
-                    if (!isVarSize) {
-                        throw CairoException.critical(0)
-                                .put("covering column file is empty [path=").put(colFile)
-                                .put(", size=").put(fileSize).put(']');
-                    }
-                } else {
+                if (fileSize > 0) {
                     long addr = TableUtils.mapRO(ff, fd, fileSize, MemoryTag.MMAP_DEFAULT);
                     o3SealAddrs.setQuick(c, addr);
                     o3SealMappedSizes.setQuick(c, fileSize);
@@ -7125,462 +7298,6 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     ff.close(auxFd);
                 }
             }
-        }
-    }
-
-    /**
-     * Accumulates one decoded row group's worth of covered column data into
-     * mmap-backed temp files. Called from the merged row-group loop inside
-     * {@link #indexParquetPartition}. Each covered slot's MemoryMARW pair
-     * (data + aux) in {@code covMmaps} grows via mmap extend; the caller
-     * passes the final base addresses to PostingIndexWriter after the loop.
-     *
-     * <p>{@code covSlotMeta} layout per slot (3 longs):
-     * [0] decodedChunkIdx (-1 if skipped), [1] colType, [2] dataVecBytesWritten.
-     */
-    private void accumulateCoveredColumnsFromRowGroup(
-            IntList coveringColumnIndices,
-            DirectLongList covSlotMeta,
-            ObjList<MemoryMARW> covMmaps,
-            RowGroupBuffers rowGroupBuffers,
-            int rowGroupIndex,
-            long rowGroupRowCount
-    ) {
-        final int coverCount = coveringColumnIndices.size();
-        for (int slot = 0; slot < coverCount; slot++) {
-            final int decodedChunkIdx = (int) covSlotMeta.get(3L * slot);
-            if (decodedChunkIdx < 0) {
-                continue;
-            }
-            final int columnType = (int) covSlotMeta.get(3L * slot + 1);
-            final long srcDataPtr = rowGroupBuffers.getChunkDataPtr(decodedChunkIdx);
-            final long srcDataSize = rowGroupBuffers.getChunkDataSize(decodedChunkIdx);
-            long srcAuxPtr = rowGroupBuffers.getChunkAuxPtr(decodedChunkIdx);
-            long srcAuxSize = rowGroupBuffers.getChunkAuxSize(decodedChunkIdx);
-
-            final MemoryMARW dataMem = covMmaps.getQuick(2 * slot + 1);
-            if (ColumnType.isVarSize(columnType)) {
-                final MemoryMARW auxMem = covMmaps.getQuick(2 * slot);
-                final ColumnTypeDriver driver = ColumnType.getDriver(columnType);
-                final long dataVecBytesWritten = covSlotMeta.get(3L * slot + 2);
-
-                if (srcDataPtr == 0 && srcAuxPtr == 0) {
-                    accumulateAllNullVarSizeChunk(
-                            driver, auxMem, dataMem, rowGroupIndex,
-                            rowGroupRowCount, dataVecBytesWritten);
-                    covSlotMeta.set(3L * slot + 2,
-                            dataVecBytesWritten + rowGroupRowCount * driver.getDataVectorMinEntrySize());
-                    continue;
-                }
-                if (rowGroupIndex > 0) {
-                    driver.shiftCopyAuxVector(
-                            -dataVecBytesWritten, srcAuxPtr, 0,
-                            rowGroupRowCount - 1, srcAuxPtr, srcAuxSize);
-                    final long adjust = driver.getMinAuxVectorSize();
-                    srcAuxPtr += adjust;
-                    srcAuxSize -= adjust;
-                }
-                dataMem.putBlockOfBytes(srcDataPtr, srcDataSize);
-                auxMem.putBlockOfBytes(srcAuxPtr, srcAuxSize);
-                covSlotMeta.set(3L * slot + 2, dataVecBytesWritten + srcDataSize);
-            } else {
-                if (srcDataPtr == 0) {
-                    accumulateAllNullFixedChunk(dataMem, columnType, rowGroupRowCount);
-                } else {
-                    dataMem.putBlockOfBytes(srcDataPtr, srcDataSize);
-                }
-            }
-        }
-    }
-
-    private void accumulateAllNullFixedChunk(MemoryMARW mem, int columnType, long rowCount) {
-        final long fixSize = rowCount * ColumnType.sizeOf(columnType);
-        if (fixSize == 0) {
-            return;
-        }
-        long nullBuf = Unsafe.malloc(fixSize, MemoryTag.NATIVE_TABLE_WRITER);
-        try {
-            TableUtils.setNull(columnType, nullBuf, rowCount);
-            mem.putBlockOfBytes(nullBuf, fixSize);
-        } finally {
-            Unsafe.free(nullBuf, fixSize, MemoryTag.NATIVE_TABLE_WRITER);
-        }
-    }
-
-    private void accumulateAllNullVarSizeChunk(
-            ColumnTypeDriver driver,
-            MemoryMARW auxMem,
-            MemoryMARW dataMem,
-            int rowGroupIndex,
-            long rowCount,
-            long dataVecBytesWritten
-    ) {
-        final long dataSize = rowCount * driver.getDataVectorMinEntrySize();
-        final long auxSize = driver.getAuxVectorSize(rowCount);
-
-        long nullDataBuf = 0;
-        long nullAuxBuf = 0;
-        try {
-            if (dataSize > 0) {
-                nullDataBuf = Unsafe.malloc(dataSize, MemoryTag.NATIVE_TABLE_WRITER);
-                driver.setDataVectorEntriesToNull(nullDataBuf, rowCount);
-                dataMem.putBlockOfBytes(nullDataBuf, dataSize);
-            }
-            if (auxSize > 0) {
-                nullAuxBuf = Unsafe.malloc(auxSize, MemoryTag.NATIVE_TABLE_WRITER);
-                driver.setFullAuxVectorNull(nullAuxBuf, rowCount);
-                if (dataVecBytesWritten > 0 && rowCount > 0) {
-                    driver.shiftCopyAuxVector(
-                            -dataVecBytesWritten, nullAuxBuf, 0,
-                            rowCount - 1, nullAuxBuf, auxSize);
-                }
-                long auxPtr = nullAuxBuf;
-                long auxBytes = auxSize;
-                if (rowGroupIndex > 0) {
-                    final long adjust = driver.getMinAuxVectorSize();
-                    auxPtr += adjust;
-                    auxBytes -= adjust;
-                }
-                auxMem.putBlockOfBytes(auxPtr, auxBytes);
-            }
-        } finally {
-            if (nullAuxBuf != 0) {
-                Unsafe.free(nullAuxBuf, auxSize, MemoryTag.NATIVE_TABLE_WRITER);
-            }
-            if (nullDataBuf != 0) {
-                Unsafe.free(nullDataBuf, dataSize, MemoryTag.NATIVE_TABLE_WRITER);
-            }
-        }
-    }
-
-    /**
-     * Removes covered-column temp files (.d and .i) for ALL covered columns
-     * of the given index. Used by the single-pass parquet indexing path where
-     * the caller does not track individual materialised slots.
-     */
-    private void cleanupMaterialisedCoveredColumnTempFiles(
-            IntList coveringColumnIndices,
-            long partitionTimestamp,
-            int plen
-    ) {
-        for (int slot = 0, n = coveringColumnIndices.size(); slot < n; slot++) {
-            final int tableColIdx = coveringColumnIndices.getQuick(slot);
-            if (tableColIdx < 0) {
-                continue;
-            }
-            final int columnType = metadata.getColumnType(tableColIdx);
-            final CharSequence colName = metadata.getColumnName(tableColIdx);
-            final long colNameTxn = columnVersionWriter.getColumnNameTxn(partitionTimestamp, tableColIdx);
-            ff.removeQuiet(dFile(path.trimTo(plen), colName, colNameTxn));
-            if (ColumnType.isVarSize(columnType)) {
-                ff.removeQuiet(iFile(path.trimTo(plen), colName, colNameTxn));
-            }
-        }
-        path.trimTo(plen);
-    }
-
-    /**
-     * Wires up the addr-based covering path on the indexer so that
-     * seal reads covered column data from the mmap-backed temp files.
-     * The mmap addresses are stable because the row-group loop has
-     * finished and no more extends will occur.
-     */
-    private void configureCoveringFromMmaps(
-            SymbolColumnIndexer indexer,
-            IntList coveringColumnIndices,
-            long partitionTimestamp,
-            DirectLongList covSlotMeta,
-            ObjList<MemoryMARW> covMmaps
-    ) {
-        final int coverCount = coveringColumnIndices.size();
-        coveringAddrs.setPos(coverCount);
-        coveringAuxAddrs.setPos(coverCount);
-        coveringTops.clear();
-        coveringShifts.clear();
-        coveringIndices.clear();
-        coveringTypes.clear();
-        coveringNameTxns.clear();
-
-        for (int slot = 0; slot < coverCount; slot++) {
-            int covCol = coveringColumnIndices.getQuick(slot);
-            if (covCol < 0 || metadata.getColumnType(covCol) <= 0) {
-                coveringAddrs.setQuick(slot, 0);
-                coveringAuxAddrs.setQuick(slot, 0);
-                coveringTops.add(0);
-                coveringShifts.add(0);
-                coveringIndices.add(-1);
-                coveringTypes.add(-1);
-                coveringNameTxns.add(TableUtils.COLUMN_NAME_TXN_NONE);
-                continue;
-            }
-            int covType = metadata.getColumnType(covCol);
-            MemoryMARW dataMem = covMmaps.getQuick(2 * slot + 1);
-            MemoryMARW auxMem = covMmaps.getQuick(2 * slot);
-            coveringAddrs.setQuick(slot, dataMem != null && dataMem.isOpen() ? dataMem.addressOf(0) : 0);
-            coveringAuxAddrs.setQuick(slot, auxMem != null && auxMem.isOpen() ? auxMem.addressOf(0) : 0);
-            coveringTops.add(columnVersionWriter.getColumnTopQuick(partitionTimestamp, covCol));
-            coveringShifts.add(ColumnType.pow2SizeOf(covType));
-            coveringIndices.add(covCol);
-            coveringTypes.add(covType);
-            coveringNameTxns.add(columnVersionWriter.getColumnNameTxn(partitionTimestamp, covCol));
-        }
-        indexer.configureCovering(
-                coveringAddrs, coveringAuxAddrs, coveringTops, coveringShifts,
-                coveringIndices, coveringTypes, coverCount, metadata.getTimestampIndex());
-        indexer.setCoveredColumnNameTxns(coveringNameTxns);
-    }
-
-    /**
-     * Opens mmap-backed temp files for each covered column and populates
-     * the combined parquet decode column list. Returns the number of
-     * covered columns actually included (those present in the parquet
-     * schema).
-     *
-     * <p>{@code covSlotMeta} is filled with 3 longs per slot:
-     * [decodedChunkIdx, colType, dataVecBytesWritten].
-     * Slots whose column is absent from parquet get decodedChunkIdx == -1.
-     *
-     * <p>{@code covMmaps} is filled with 2 entries per slot:
-     * [auxMem (null for fixed-size), dataMem]. Both are null for skipped slots.
-     */
-    private int prepareCoveredColumnMmaps(
-            IntList coveringColumnIndices,
-            long partitionTimestamp,
-            int plen,
-            ParquetMetaFileReader parquetMetadata,
-            DirectLongList covSlotMeta,
-            ObjList<MemoryMARW> covMmaps
-    ) {
-        final int coverCount = coveringColumnIndices.size();
-        final long appendPageSize = configuration.getDataAppendPageSize();
-        int includedCount = 0;
-
-        for (int slot = 0; slot < coverCount; slot++) {
-            final int tableColIdx = coveringColumnIndices.getQuick(slot);
-            if (tableColIdx < 0 || metadata.getColumnType(tableColIdx) <= 0) {
-                covSlotMeta.add(-1L);
-                covSlotMeta.add(0L);
-                covSlotMeta.add(0L);
-                covMmaps.add(null);
-                covMmaps.add(null);
-                continue;
-            }
-            final int parquetColIdx = findParquetColumnIndex(parquetMetadata, tableColIdx);
-            if (parquetColIdx < 0) {
-                covSlotMeta.add(-1L);
-                covSlotMeta.add(0L);
-                covSlotMeta.add(0L);
-                covMmaps.add(null);
-                covMmaps.add(null);
-                continue;
-            }
-
-            final int columnType = metadata.getColumnType(tableColIdx);
-            final CharSequence colName = metadata.getColumnName(tableColIdx);
-            final long colNameTxn = columnVersionWriter.getColumnNameTxn(partitionTimestamp, tableColIdx);
-
-            ff.removeQuiet(dFile(path.trimTo(plen), colName, colNameTxn));
-            MemoryMARW dataMem = Vm.getCMARWInstance();
-            dataMem.of(ff, dFile(path.trimTo(plen), colName, colNameTxn),
-                    appendPageSize, 0L, MemoryTag.NATIVE_TABLE_WRITER);
-
-            MemoryMARW auxMem = null;
-            if (ColumnType.isVarSize(columnType)) {
-                ff.removeQuiet(iFile(path.trimTo(plen), colName, colNameTxn));
-                auxMem = Vm.getCMARWInstance();
-                auxMem.of(ff, iFile(path.trimTo(plen), colName, colNameTxn),
-                        appendPageSize, 0L, MemoryTag.NATIVE_TABLE_WRITER);
-            }
-
-            // +1 because chunk index 0 is the SYMBOL column
-            covSlotMeta.add(includedCount + 1);
-            covSlotMeta.add(columnType);
-            covSlotMeta.add(0L);
-            covMmaps.add(auxMem);
-            covMmaps.add(dataMem);
-
-            parquetColumnIdsAndTypes.add(parquetColIdx);
-            parquetColumnIdsAndTypes.add(columnType);
-            includedCount++;
-        }
-        path.trimTo(plen);
-        return includedCount;
-    }
-
-    /**
-     * Decodes ALL covered columns from this Parquet partition into native
-     * {@code .d} (and, for var-size types, {@code .i}) files at the standard
-     * paths inside the partition. Mirrors
-     * {@link #produceNativeFromParquet(Path, Path, long, int, long)} -- one
-     * row-group iteration produces data for every covered column at once, so
-     * the cost is {@code rowGroupCount} decodes rather than
-     * {@code coverCount * rowGroupCount}. Posting-index seal then finds these
-     * files via its existing names-based {@code mapColumnFile} path; the
-     * caller deletes them in a finally via
-     * {@link #cleanupMaterialisedCoveredColumnTempFiles}.
-     *
-     * <p>A column that does not exist in this Parquet partition's schema
-     * (covered column added AFTER convert) is silently skipped -- the
-     * sidecar for that slot stays at its zero-filled maxCompressedSize
-     * allocation and the reader honours column_top.
-     *
-     * <p>Populates {@code materialisedSlots} with the slot indices for which
-     * a temp file was written, so the cleanup pass touches only those.
-     */
-    private void materialiseCoveredColumnsFromParquet(
-            IntList coveringColumnIndices,
-            long partitionTimestamp,
-            int plen,
-            RowGroupBuffers rowGroupBuffers,
-            ParquetMetaFileReader parquetMetadata,
-            IntList materialisedSlots
-    ) {
-        final int coverCount = coveringColumnIndices.size();
-        // [auxFd, dataFd, dataVecBytesWritten] per slot; auxFd == -1 means
-        // fixed-width, dataFd == -1 means the slot was skipped.
-        final DirectLongList slotFds = getTempDirectLongList(3L * coverCount);
-        boolean ok = false;
-        try {
-            parquetColumnIdsAndTypes.clear();
-            int includedCount = 0;
-            for (int slot = 0; slot < coverCount; slot++) {
-                final int tableColIdx = coveringColumnIndices.getQuick(slot);
-                if (tableColIdx < 0 || metadata.getColumnType(tableColIdx) <= 0) {
-                    slotFds.add(-1L);
-                    slotFds.add(-1L);
-                    slotFds.add(0L);
-                    continue;
-                }
-                final int parquetColIdx = findParquetColumnIndex(parquetMetadata, tableColIdx);
-                if (parquetColIdx < 0) {
-                    // Covered column not in this Parquet partition; column_top
-                    // makes the read synthesise null on the read side.
-                    slotFds.add(-1L);
-                    slotFds.add(-1L);
-                    slotFds.add(0L);
-                    continue;
-                }
-
-                final int columnType = metadata.getColumnType(tableColIdx);
-                final CharSequence columnName = metadata.getColumnName(tableColIdx);
-                final long columnNameTxn = columnVersionWriter.getColumnNameTxn(partitionTimestamp, tableColIdx);
-
-                // Track this slot for cleanup BEFORE any I/O. If openAppend
-                // throws after creating a file, the finally sweep finds and
-                // removes it. Without this, an openAppend partial would leak
-                // until the next ADD INDEX retry pre-deletes it.
-                materialisedSlots.add(slot);
-
-                // Pre-fill slotFds with sentinels. Each open below sets the
-                // corresponding slot. If an open throws after a previous one
-                // succeeded, the outer finally still sees the captured fd
-                // in slotFds and closes it -- otherwise the in-progress fd
-                // would leak. Matches produceNativeFromParquet's pattern.
-                final long slotBase = slotFds.size();
-                slotFds.add(-1L);
-                slotFds.add(-1L);
-                slotFds.add(0L);
-
-                // Pre-delete any leftover temp files from a prior crashed
-                // attempt -- openAppend would otherwise add new bytes after
-                // stale partial content on WAL-apply retry.
-                ff.removeQuiet(dFile(path.trimTo(plen), columnName, columnNameTxn));
-                if (ColumnType.isVarSize(columnType)) {
-                    ff.removeQuiet(iFile(path.trimTo(plen), columnName, columnNameTxn));
-                    slotFds.set(slotBase, openAppend(ff,
-                            iFile(path.trimTo(plen), columnName, columnNameTxn), LOG));
-                }
-                slotFds.set(slotBase + 1, openAppend(ff,
-                        dFile(path.trimTo(plen), columnName, columnNameTxn), LOG));
-
-                parquetColumnIdsAndTypes.add(parquetColIdx);
-                parquetColumnIdsAndTypes.add(columnType);
-                includedCount++;
-            }
-            path.trimTo(plen);
-
-            if (includedCount == 0) {
-                ok = true;
-                return;
-            }
-
-            // Single row-group loop fills every included column.
-            final int rowGroupCount = parquetMetadata.getRowGroupCount();
-            for (int rgi = 0; rgi < rowGroupCount; rgi++) {
-                assert parquetMetadata.getRowGroupSize(rgi) <= Integer.MAX_VALUE;
-                final long rgRowCount = parquetDecoder.decodeRowGroup(
-                        rowGroupBuffers,
-                        parquetColumnIdsAndTypes,
-                        rgi,
-                        0,
-                        (int) parquetMetadata.getRowGroupSize(rgi)
-                );
-                // Map slot -> position in the parquetColumnIdsAndTypes
-                // included list (skipped slots are not in the list).
-                int decodedColIdx = 0;
-                for (int slot = 0; slot < coverCount; slot++) {
-                    final long dataFd = slotFds.get(3L * slot + 1);
-                    if (dataFd < 0) {
-                        continue;
-                    }
-                    final int tableColIdx = coveringColumnIndices.getQuick(slot);
-                    final int columnType = metadata.getColumnType(tableColIdx);
-                    final long srcDataPtr = rowGroupBuffers.getChunkDataPtr(decodedColIdx);
-                    final long srcDataSize = rowGroupBuffers.getChunkDataSize(decodedColIdx);
-                    long srcAuxPtr = rowGroupBuffers.getChunkAuxPtr(decodedColIdx);
-                    long srcAuxSize = rowGroupBuffers.getChunkAuxSize(decodedColIdx);
-
-                    if (ColumnType.isVarSize(columnType)) {
-                        final long auxFd = slotFds.get(3L * slot);
-                        final ColumnTypeDriver driver = ColumnType.getDriver(columnType);
-                        final long dataVecBytesWritten = slotFds.get(3L * slot + 2);
-                        if (srcDataPtr == 0 && srcAuxPtr == 0) {
-                            final long newDvbw = appendAllNullVarSizeChunk(
-                                    driver, auxFd, dataFd, rgi, rgRowCount, dataVecBytesWritten);
-                            slotFds.set(3L * slot + 2, newDvbw);
-                            decodedColIdx++;
-                            continue;
-                        }
-                        if (rgi > 0) {
-                            driver.shiftCopyAuxVector(-dataVecBytesWritten, srcAuxPtr, 0, rgRowCount - 1, srcAuxPtr, srcAuxSize);
-                            final long adjust = driver.getMinAuxVectorSize();
-                            srcAuxPtr += adjust;
-                            srcAuxSize -= adjust;
-                        }
-                        appendBuffer(dataFd, srcDataPtr, srcDataSize);
-                        appendBuffer(auxFd, srcAuxPtr, srcAuxSize);
-                        slotFds.set(3L * slot + 2, dataVecBytesWritten + srcDataSize);
-                    } else {
-                        if (srcDataPtr == 0) {
-                            appendAllNullFixedChunk(dataFd, columnType, rgRowCount);
-                        } else {
-                            appendBuffer(dataFd, srcDataPtr, srcDataSize);
-                        }
-                    }
-                    decodedColIdx++;
-                }
-            }
-            ok = true;
-        } finally {
-            // Close all open fds.
-            for (long i = 0, n = slotFds.size() / 3; i < n; i++) {
-                final long auxFd = slotFds.get(3L * i);
-                if (auxFd >= 0) ff.close(auxFd);
-                final long dataFd = slotFds.get(3L * i + 1);
-                if (dataFd >= 0) ff.close(dataFd);
-            }
-            slotFds.resetCapacity();
-            // If we threw mid-decode, sweep up any temp files we may have
-            // produced so a retry pre-delete finds a clean state. The caller's
-            // finally runs only when materialise completes and the try block
-            // is entered; a throw here escapes before that, so this is the
-            // only cleanup path for mid-decode failures.
-            if (!ok) {
-                cleanupMaterialisedCoveredColumnTempFiles(
-                        coveringColumnIndices, partitionTimestamp, plen, materialisedSlots);
-                materialisedSlots.clear();
-            }
-            path.trimTo(plen);
         }
     }
 
@@ -8718,6 +8435,83 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             }
         }
         indexCount = denseIndexers.size();
+    }
+
+    /**
+     * Opens mmap-backed temp files for each covered column and populates
+     * the combined parquet decode column list. Returns the number of
+     * covered columns actually included (those present in the parquet
+     * schema).
+     *
+     * <p>{@code covSlotMeta} is filled with 3 longs per slot:
+     * [decodedChunkIdx, colType, dataVecBytesWritten].
+     * Slots whose column is absent from parquet get decodedChunkIdx == -1.
+     *
+     * <p>{@code covMmaps} is filled with 2 entries per slot:
+     * [auxMem (null for fixed-size), dataMem]. Both are null for skipped slots.
+     */
+    private int prepareCoveredColumnMmaps(
+            IntList coveringColumnIndices,
+            long partitionTimestamp,
+            int plen,
+            ParquetMetaFileReader parquetMetadata,
+            DirectLongList covSlotMeta,
+            ObjList<MemoryMARW> covMmaps
+    ) {
+        final int coverCount = coveringColumnIndices.size();
+        final long appendPageSize = configuration.getDataAppendPageSize();
+        int includedCount = 0;
+
+        for (int slot = 0; slot < coverCount; slot++) {
+            final int tableColIdx = coveringColumnIndices.getQuick(slot);
+            if (tableColIdx < 0 || metadata.getColumnType(tableColIdx) <= 0) {
+                covSlotMeta.add(-1L);
+                covSlotMeta.add(0L);
+                covSlotMeta.add(0L);
+                covMmaps.add(null);
+                covMmaps.add(null);
+                continue;
+            }
+            final int parquetColIdx = findParquetColumnIndex(parquetMetadata, tableColIdx);
+            if (parquetColIdx < 0) {
+                covSlotMeta.add(-1L);
+                covSlotMeta.add(0L);
+                covSlotMeta.add(0L);
+                covMmaps.add(null);
+                covMmaps.add(null);
+                continue;
+            }
+
+            final int columnType = metadata.getColumnType(tableColIdx);
+            final CharSequence colName = metadata.getColumnName(tableColIdx);
+            final long colNameTxn = columnVersionWriter.getColumnNameTxn(partitionTimestamp, tableColIdx);
+
+            ff.removeQuiet(dFile(path.trimTo(plen), colName, colNameTxn));
+            MemoryMARW dataMem = Vm.getCMARWInstance();
+            dataMem.of(ff, dFile(path.trimTo(plen), colName, colNameTxn),
+                    appendPageSize, 0L, MemoryTag.NATIVE_TABLE_WRITER);
+
+            // +1 because chunk index 0 is the SYMBOL column
+            covSlotMeta.add(includedCount + 1);
+            covSlotMeta.add(columnType);
+            covSlotMeta.add(0L);
+            covMmaps.add(null);
+            covMmaps.add(dataMem);
+
+            if (ColumnType.isVarSize(columnType)) {
+                ff.removeQuiet(iFile(path.trimTo(plen), colName, colNameTxn));
+                MemoryMARW auxMem = Vm.getCMARWInstance();
+                auxMem.of(ff, iFile(path.trimTo(plen), colName, colNameTxn),
+                        appendPageSize, 0L, MemoryTag.NATIVE_TABLE_WRITER);
+                covMmaps.setQuick(covMmaps.size() - 2, auxMem);
+            }
+
+            parquetColumnIdsAndTypes.add(parquetColIdx);
+            parquetColumnIdsAndTypes.add(columnType);
+            includedCount++;
+        }
+        path.trimTo(plen);
+        return includedCount;
     }
 
     private void processAsyncWriterCommand(

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -6858,6 +6858,20 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             final long partitionSize = txWriter.getPartitionRowCountByTimestamp(timestamp);
             final long columnTop = columnVersionWriter.getColumnTop(timestamp, columnIndex);
 
+            // Invariant: on a parquet partition the indexed SYMBOL's columnTop
+            // is either 0 (column has data from row 0) or partitionSize (column
+            // is all-NULL in this partition). zeroColumnTopsAfterParquetRewrite
+            // collapses every intermediate 0 < columnTop < partitionSize down
+            // to 0 at convert time, so the merged decode below can rely on
+            // columnTop == 0 whenever it executes. A future ATTACH PARQUET /
+            // restore path that bypasses that routine must restore this
+            // invariant before reaching here, or the rowLo formula at the
+            // decodeRowGroup call would truncate the covered columns.
+            assert columnTop == 0 || columnTop == partitionSize
+                    : "parquet partition indexed SYMBOL columnTop=" + columnTop
+                    + " is neither 0 nor partitionSize=" + partitionSize
+                    + " (timestamp=" + timestamp + ", columnIndex=" + columnIndex + ")";
+
             if (columnTop > -1 && partitionSize > columnTop) {
                 indexer.getWriter().setCurrentTableTxn(txWriter.getTxn());
                 indexer.configureWriter(path.trimTo(plen), columnName, columnNameTxn, columnTop, timestamp, txWriter.getPartitionNameTxnByPartitionTimestamp(timestamp));
@@ -6889,7 +6903,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     if (hasCovering) {
                         includedCoveredCount = prepareCoveredColumnMmaps(
                                 coveringColumnIndices, timestamp, plen,
-                                parquetMetadata, covSlotMeta, covMmaps);
+                                parquetMetadata, partitionSize, covSlotMeta, covMmaps);
                     }
 
                     long rowCount = 0;
@@ -8443,28 +8457,54 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * covered columns actually included (those present in the parquet
      * schema).
      *
+     * <p>Sizes the scratch mmaps from parquet row-count metadata where the
+     * size is known exactly (fixed-size data, var-size aux), and falls back
+     * to the configured data-append page size for var-size data, whose
+     * decoded size is not derivable from metadata.
+     *
      * <p>{@code covSlotMeta} is filled with 3 longs per slot:
      * [decodedChunkIdx, colType, dataVecBytesWritten].
      * Slots whose column is absent from parquet get decodedChunkIdx == -1.
      *
      * <p>{@code covMmaps} is filled with 2 entries per slot:
      * [auxMem (null for fixed-size), dataMem]. Both are null for skipped slots.
+     *
+     * <p>Slots whose covered column is fully null in this partition (columnTop
+     * equals or exceeds partitionSize -- the column was added after the
+     * partition was created) are skipped without opening scratch files or
+     * decoding the parquet column. The indexer paths in PostingIndexWriter
+     * short-circuit to a null sentinel whenever {@code rowId < colTop}, and
+     * {@code configureCoveringFromMmaps} reads colTop straight from
+     * columnVersionWriter, so the indexer emits nulls for every row of every
+     * key without ever dereferencing a data address. The
+     * {@code zeroColumnTopsAfterParquetRewrite} routine normalises parquet
+     * partitions to {@code colTop in {0, partitionSize}}, so {@code >=
+     * partitionSize} is the right tripwire here.
      */
     private int prepareCoveredColumnMmaps(
             IntList coveringColumnIndices,
             long partitionTimestamp,
             int plen,
             ParquetMetaFileReader parquetMetadata,
+            long partitionSize,
             DirectLongList covSlotMeta,
             ObjList<MemoryMARW> covMmaps
     ) {
         final int coverCount = coveringColumnIndices.size();
-        final long appendPageSize = configuration.getDataAppendPageSize();
         int includedCount = 0;
 
         for (int slot = 0; slot < coverCount; slot++) {
             final int tableColIdx = coveringColumnIndices.getQuick(slot);
             if (tableColIdx < 0 || metadata.getColumnType(tableColIdx) <= 0) {
+                covSlotMeta.add(-1L);
+                covSlotMeta.add(0L);
+                covSlotMeta.add(0L);
+                covMmaps.add(null);
+                covMmaps.add(null);
+                continue;
+            }
+            final long coveredColTop = columnVersionWriter.getColumnTop(partitionTimestamp, tableColIdx);
+            if (coveredColTop >= partitionSize) {
                 covSlotMeta.add(-1L);
                 covSlotMeta.add(0L);
                 covSlotMeta.add(0L);
@@ -8483,13 +8523,25 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             }
 
             final int columnType = metadata.getColumnType(tableColIdx);
+            final boolean isVarSize = ColumnType.isVarSize(columnType);
             final CharSequence colName = metadata.getColumnName(tableColIdx);
             final long colNameTxn = columnVersionWriter.getColumnNameTxn(partitionTimestamp, tableColIdx);
+
+            // Fixed-size data: total bytes are exact (rowCount * entrySize),
+            // so the scratch file is pre-sized exactly and never extends.
+            // Var-size data: decoded size depends on actual entry contents and
+            // is not derivable from parquet metadata, so fall back to the
+            // configured data-append page size and let the mmap grow on demand
+            // at that pace -- the same extend pace TableWriter uses for every
+            // other var-size data vector.
+            final long dataPreSize = isVarSize
+                    ? configuration.getDataAppendPageSize()
+                    : Files.ceilPageSize((long) ColumnType.sizeOf(columnType) * partitionSize);
 
             ff.removeQuiet(dFile(path.trimTo(plen), colName, colNameTxn));
             MemoryMARW dataMem = Vm.getCMARWInstance();
             dataMem.of(ff, dFile(path.trimTo(plen), colName, colNameTxn),
-                    appendPageSize, 0L, MemoryTag.NATIVE_TABLE_WRITER);
+                    dataPreSize, 0L, MemoryTag.NATIVE_TABLE_WRITER);
 
             // +1 because chunk index 0 is the SYMBOL column
             covSlotMeta.add(includedCount + 1);
@@ -8498,11 +8550,16 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             covMmaps.add(null);
             covMmaps.add(dataMem);
 
-            if (ColumnType.isVarSize(columnType)) {
+            if (isVarSize) {
+                // Var-size aux: bytes are exact (driver-defined fixed entry
+                // width times row count, accounting for the N+1 storage model
+                // where applicable).
+                final long auxPreSize = Files.ceilPageSize(
+                        ColumnType.getDriver(columnType).getAuxVectorSize(partitionSize));
                 ff.removeQuiet(iFile(path.trimTo(plen), colName, colNameTxn));
                 MemoryMARW auxMem = Vm.getCMARWInstance();
                 auxMem.of(ff, iFile(path.trimTo(plen), colName, colNameTxn),
-                        appendPageSize, 0L, MemoryTag.NATIVE_TABLE_WRITER);
+                        auxPreSize, 0L, MemoryTag.NATIVE_TABLE_WRITER);
                 covMmaps.setQuick(covMmaps.size() - 2, auxMem);
             }
 

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -203,6 +203,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     private final RingQueue<TableWriterTask> commandQueue;
     private final SCSequence commandSubSeq;
     private final CairoConfiguration configuration;
+    private final LongList coveringAddrs = new LongList();
+    private final LongList coveringAuxAddrs = new LongList();
     private final IntList coveringIndices = new IntList();
     private final LongList coveringNameTxns = new LongList();
     private final ObjList<CharSequence> coveringNames = new ObjList<>();
@@ -6680,47 +6682,48 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             if (columnTop > -1 && partitionSize > columnTop) {
                 indexer.getWriter().setCurrentTableTxn(txWriter.getTxn());
                 indexer.configureWriter(path.trimTo(plen), columnName, columnNameTxn, columnTop, timestamp, txWriter.getPartitionNameTxnByPartitionTimestamp(timestamp));
+                indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn() + 1);
 
-                // Materialise all covered columns from Parquet into native
-                // .d/.i temp files in the partition dir BEFORE seal runs.
-                // A single row-group iteration produces data for all covered
-                // columns at once -- coverCount x rowGroupCount decodes
-                // collapsed to rowGroupCount. Without these files, seal's
-                // names-based mapColumnFile silently leaves
-                // covered{Col,Aux}ReadAddrs at 0 and the .pc* sidecars end
-                // up empty. The finally below deletes the temp files; peak
-                // disk during seal is roughly the uncompressed total of all
-                // covered columns for this partition.
                 final IntList coveringColumnIndices = metadata.getColumnMetadata(columnIndex).getCoveringColumnIndices();
-                final IntList materialisedSlots;
-                if (coveringColumnIndices != null && coveringColumnIndices.size() > 0) {
-                    materialisedSlots = new IntList(coveringColumnIndices.size());
-                    materialiseCoveredColumnsFromParquet(
-                            coveringColumnIndices, timestamp, plen,
-                            rowGroupBuffers, parquetMetadata, materialisedSlots);
-                } else {
-                    materialisedSlots = null;
-                }
+                final boolean hasCovering = coveringColumnIndices != null && coveringColumnIndices.size() > 0;
+                final int coverCount = hasCovering ? coveringColumnIndices.size() : 0;
+
+                // Build combined column list: SYMBOL (chunk 0) + covered
+                // columns (chunks 1..N). A single decodeRowGroup call per
+                // row group replaces the two separate decode loops.
+                parquetColumnIdsAndTypes.clear();
+                parquetColumnIdsAndTypes.add(parquetColumnIndex);
+                parquetColumnIdsAndTypes.add(ColumnType.SYMBOL);
+
+                // covSlotMeta packs per-slot state: [decodedChunkIdx, colType,
+                // dataVecBytesWritten] (3 longs per slot). Slots whose column
+                // is absent from parquet have decodedChunkIdx == -1.
+                final DirectLongList covSlotMeta = hasCovering ? getTempDirectLongList(3L * coverCount) : null;
+                // Mmap-backed temp files for covered column data (+ aux for
+                // var-size). Written via mmap in the row-group loop and read
+                // from the same addresses during seal — no write()/re-mmap
+                // round-trip. The ObjList is closed in the finally block.
+                final ObjList<MemoryMARW> covMmaps = hasCovering ? new ObjList<>(2 * coverCount) : null;
+                int includedCoveredCount = 0;
 
                 try {
-                    // posting-index covering sidecars must be wired up before
-                    // seal, otherwise .pci / .pc<N> files are not produced.
-                    configureCoveringIfNeeded(indexer, columnIndex, timestamp);
-                    // Tag this seal's chain entry with the txn the upcoming
-                    // clearTodoAndCommitMeta will assign. Must come AFTER
-                    // configureWriter (of() inside it resets pendingTxnAtSeal).
-                    indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn() + 1);
-
-                    parquetColumnIdsAndTypes.clear();
-                    parquetColumnIdsAndTypes.add(parquetColumnIndex);
-                    parquetColumnIdsAndTypes.add(ColumnType.SYMBOL);
+                    if (hasCovering) {
+                        includedCoveredCount = prepareCoveredColumnMmaps(
+                                coveringColumnIndices, timestamp, plen,
+                                parquetMetadata, covSlotMeta, covMmaps);
+                    }
 
                     long rowCount = 0;
                     final int rowGroupCount = parquetMetadata.getRowGroupCount();
                     final IndexWriter indexWriter = indexer.getWriter();
                     for (int rowGroupIndex = 0; rowGroupIndex < rowGroupCount; rowGroupIndex++) {
                         final long rowGroupSize = parquetMetadata.getRowGroupSize(rowGroupIndex);
-                        if (rowCount + rowGroupSize <= columnTop) {
+
+                        // For row groups fully below columnTop, covered columns
+                        // still need decoding (their column_top may differ from
+                        // the symbol's) but the SYMBOL data is skipped.
+                        final boolean belowColumnTop = rowCount + rowGroupSize <= columnTop;
+                        if (belowColumnTop && includedCoveredCount == 0) {
                             rowCount += rowGroupSize;
                             continue;
                         }
@@ -6729,29 +6732,51 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                                 rowGroupBuffers,
                                 parquetColumnIdsAndTypes,
                                 rowGroupIndex,
-                                (int) Math.max(0, columnTop - rowCount),
+                                belowColumnTop ? 0 : (int) Math.max(0, columnTop - rowCount),
                                 (int) rowGroupSize
                         );
 
-                        long rowId = Math.max(rowCount, columnTop);
-                        final long addr = rowGroupBuffers.getChunkDataPtr(0);
-                        final long size = rowGroupBuffers.getChunkDataSize(0);
-                        if (size == 0) {
-                            BitmapIndexUtils.addNullEntries(indexWriter, rowId, rowCount + rowGroupSize);
-                        } else {
-                            for (long p = addr, lim = addr + size; p < lim; p += 4, rowId++) {
-                                indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);
+                        // Accumulate covered column data into mmap'd temp files.
+                        if (includedCoveredCount > 0) {
+                            accumulateCoveredColumnsFromRowGroup(
+                                    coveringColumnIndices, covSlotMeta, covMmaps,
+                                    rowGroupBuffers, rowGroupIndex, rowGroupSize);
+                        }
+
+                        // Feed SYMBOL column to the posting index.
+                        if (!belowColumnTop) {
+                            long rowId = Math.max(rowCount, columnTop);
+                            final long addr = rowGroupBuffers.getChunkDataPtr(0);
+                            final long size = rowGroupBuffers.getChunkDataSize(0);
+                            if (size == 0) {
+                                BitmapIndexUtils.addNullEntries(indexWriter, rowId, rowCount + rowGroupSize);
+                            } else {
+                                for (long p = addr, lim = addr + size; p < lim; p += 4, rowId++) {
+                                    indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);
+                                }
                             }
                         }
 
                         rowCount += rowGroupSize;
                     }
+
+                    // Wire up covered column addresses for the seal path.
+                    if (hasCovering) {
+                        configureCoveringFromMmaps(
+                                indexer, coveringColumnIndices, timestamp,
+                                covSlotMeta, covMmaps);
+                    }
+
                     indexWriter.setMaxValue(partitionSize - 1);
                     indexer.seal();
                 } finally {
-                    if (materialisedSlots != null) {
+                    if (hasCovering) {
+                        indexer.releaseCoveredColumnReadMappings();
+                    }
+                    Misc.freeObjListIfCloseable(covMmaps);
+                    if (hasCovering) {
                         cleanupMaterialisedCoveredColumnTempFiles(
-                                coveringColumnIndices, timestamp, plen, materialisedSlots);
+                                coveringColumnIndices, timestamp, plen);
                     }
                 }
             }
@@ -7101,6 +7126,285 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 }
             }
         }
+    }
+
+    /**
+     * Accumulates one decoded row group's worth of covered column data into
+     * mmap-backed temp files. Called from the merged row-group loop inside
+     * {@link #indexParquetPartition}. Each covered slot's MemoryMARW pair
+     * (data + aux) in {@code covMmaps} grows via mmap extend; the caller
+     * passes the final base addresses to PostingIndexWriter after the loop.
+     *
+     * <p>{@code covSlotMeta} layout per slot (3 longs):
+     * [0] decodedChunkIdx (-1 if skipped), [1] colType, [2] dataVecBytesWritten.
+     */
+    private void accumulateCoveredColumnsFromRowGroup(
+            IntList coveringColumnIndices,
+            DirectLongList covSlotMeta,
+            ObjList<MemoryMARW> covMmaps,
+            RowGroupBuffers rowGroupBuffers,
+            int rowGroupIndex,
+            long rowGroupRowCount
+    ) {
+        final int coverCount = coveringColumnIndices.size();
+        for (int slot = 0; slot < coverCount; slot++) {
+            final int decodedChunkIdx = (int) covSlotMeta.get(3L * slot);
+            if (decodedChunkIdx < 0) {
+                continue;
+            }
+            final int columnType = (int) covSlotMeta.get(3L * slot + 1);
+            final long srcDataPtr = rowGroupBuffers.getChunkDataPtr(decodedChunkIdx);
+            final long srcDataSize = rowGroupBuffers.getChunkDataSize(decodedChunkIdx);
+            long srcAuxPtr = rowGroupBuffers.getChunkAuxPtr(decodedChunkIdx);
+            long srcAuxSize = rowGroupBuffers.getChunkAuxSize(decodedChunkIdx);
+
+            final MemoryMARW dataMem = covMmaps.getQuick(2 * slot + 1);
+            if (ColumnType.isVarSize(columnType)) {
+                final MemoryMARW auxMem = covMmaps.getQuick(2 * slot);
+                final ColumnTypeDriver driver = ColumnType.getDriver(columnType);
+                final long dataVecBytesWritten = covSlotMeta.get(3L * slot + 2);
+
+                if (srcDataPtr == 0 && srcAuxPtr == 0) {
+                    accumulateAllNullVarSizeChunk(
+                            driver, auxMem, dataMem, rowGroupIndex,
+                            rowGroupRowCount, dataVecBytesWritten);
+                    covSlotMeta.set(3L * slot + 2,
+                            dataVecBytesWritten + rowGroupRowCount * driver.getDataVectorMinEntrySize());
+                    continue;
+                }
+                if (rowGroupIndex > 0) {
+                    driver.shiftCopyAuxVector(
+                            -dataVecBytesWritten, srcAuxPtr, 0,
+                            rowGroupRowCount - 1, srcAuxPtr, srcAuxSize);
+                    final long adjust = driver.getMinAuxVectorSize();
+                    srcAuxPtr += adjust;
+                    srcAuxSize -= adjust;
+                }
+                dataMem.putBlockOfBytes(srcDataPtr, srcDataSize);
+                auxMem.putBlockOfBytes(srcAuxPtr, srcAuxSize);
+                covSlotMeta.set(3L * slot + 2, dataVecBytesWritten + srcDataSize);
+            } else {
+                if (srcDataPtr == 0) {
+                    accumulateAllNullFixedChunk(dataMem, columnType, rowGroupRowCount);
+                } else {
+                    dataMem.putBlockOfBytes(srcDataPtr, srcDataSize);
+                }
+            }
+        }
+    }
+
+    private void accumulateAllNullFixedChunk(MemoryMARW mem, int columnType, long rowCount) {
+        final long fixSize = rowCount * ColumnType.sizeOf(columnType);
+        if (fixSize == 0) {
+            return;
+        }
+        long nullBuf = Unsafe.malloc(fixSize, MemoryTag.NATIVE_TABLE_WRITER);
+        try {
+            TableUtils.setNull(columnType, nullBuf, rowCount);
+            mem.putBlockOfBytes(nullBuf, fixSize);
+        } finally {
+            Unsafe.free(nullBuf, fixSize, MemoryTag.NATIVE_TABLE_WRITER);
+        }
+    }
+
+    private void accumulateAllNullVarSizeChunk(
+            ColumnTypeDriver driver,
+            MemoryMARW auxMem,
+            MemoryMARW dataMem,
+            int rowGroupIndex,
+            long rowCount,
+            long dataVecBytesWritten
+    ) {
+        final long dataSize = rowCount * driver.getDataVectorMinEntrySize();
+        final long auxSize = driver.getAuxVectorSize(rowCount);
+
+        long nullDataBuf = 0;
+        long nullAuxBuf = 0;
+        try {
+            if (dataSize > 0) {
+                nullDataBuf = Unsafe.malloc(dataSize, MemoryTag.NATIVE_TABLE_WRITER);
+                driver.setDataVectorEntriesToNull(nullDataBuf, rowCount);
+                dataMem.putBlockOfBytes(nullDataBuf, dataSize);
+            }
+            if (auxSize > 0) {
+                nullAuxBuf = Unsafe.malloc(auxSize, MemoryTag.NATIVE_TABLE_WRITER);
+                driver.setFullAuxVectorNull(nullAuxBuf, rowCount);
+                if (dataVecBytesWritten > 0 && rowCount > 0) {
+                    driver.shiftCopyAuxVector(
+                            -dataVecBytesWritten, nullAuxBuf, 0,
+                            rowCount - 1, nullAuxBuf, auxSize);
+                }
+                long auxPtr = nullAuxBuf;
+                long auxBytes = auxSize;
+                if (rowGroupIndex > 0) {
+                    final long adjust = driver.getMinAuxVectorSize();
+                    auxPtr += adjust;
+                    auxBytes -= adjust;
+                }
+                auxMem.putBlockOfBytes(auxPtr, auxBytes);
+            }
+        } finally {
+            if (nullAuxBuf != 0) {
+                Unsafe.free(nullAuxBuf, auxSize, MemoryTag.NATIVE_TABLE_WRITER);
+            }
+            if (nullDataBuf != 0) {
+                Unsafe.free(nullDataBuf, dataSize, MemoryTag.NATIVE_TABLE_WRITER);
+            }
+        }
+    }
+
+    /**
+     * Removes covered-column temp files (.d and .i) for ALL covered columns
+     * of the given index. Used by the single-pass parquet indexing path where
+     * the caller does not track individual materialised slots.
+     */
+    private void cleanupMaterialisedCoveredColumnTempFiles(
+            IntList coveringColumnIndices,
+            long partitionTimestamp,
+            int plen
+    ) {
+        for (int slot = 0, n = coveringColumnIndices.size(); slot < n; slot++) {
+            final int tableColIdx = coveringColumnIndices.getQuick(slot);
+            if (tableColIdx < 0) {
+                continue;
+            }
+            final int columnType = metadata.getColumnType(tableColIdx);
+            final CharSequence colName = metadata.getColumnName(tableColIdx);
+            final long colNameTxn = columnVersionWriter.getColumnNameTxn(partitionTimestamp, tableColIdx);
+            ff.removeQuiet(dFile(path.trimTo(plen), colName, colNameTxn));
+            if (ColumnType.isVarSize(columnType)) {
+                ff.removeQuiet(iFile(path.trimTo(plen), colName, colNameTxn));
+            }
+        }
+        path.trimTo(plen);
+    }
+
+    /**
+     * Wires up the addr-based covering path on the indexer so that
+     * seal reads covered column data from the mmap-backed temp files.
+     * The mmap addresses are stable because the row-group loop has
+     * finished and no more extends will occur.
+     */
+    private void configureCoveringFromMmaps(
+            SymbolColumnIndexer indexer,
+            IntList coveringColumnIndices,
+            long partitionTimestamp,
+            DirectLongList covSlotMeta,
+            ObjList<MemoryMARW> covMmaps
+    ) {
+        final int coverCount = coveringColumnIndices.size();
+        coveringAddrs.setPos(coverCount);
+        coveringAuxAddrs.setPos(coverCount);
+        coveringTops.clear();
+        coveringShifts.clear();
+        coveringIndices.clear();
+        coveringTypes.clear();
+        coveringNameTxns.clear();
+
+        for (int slot = 0; slot < coverCount; slot++) {
+            int covCol = coveringColumnIndices.getQuick(slot);
+            if (covCol < 0 || metadata.getColumnType(covCol) <= 0) {
+                coveringAddrs.setQuick(slot, 0);
+                coveringAuxAddrs.setQuick(slot, 0);
+                coveringTops.add(0);
+                coveringShifts.add(0);
+                coveringIndices.add(-1);
+                coveringTypes.add(-1);
+                coveringNameTxns.add(TableUtils.COLUMN_NAME_TXN_NONE);
+                continue;
+            }
+            int covType = metadata.getColumnType(covCol);
+            MemoryMARW dataMem = covMmaps.getQuick(2 * slot + 1);
+            MemoryMARW auxMem = covMmaps.getQuick(2 * slot);
+            coveringAddrs.setQuick(slot, dataMem != null && dataMem.isOpen() ? dataMem.addressOf(0) : 0);
+            coveringAuxAddrs.setQuick(slot, auxMem != null && auxMem.isOpen() ? auxMem.addressOf(0) : 0);
+            coveringTops.add(columnVersionWriter.getColumnTopQuick(partitionTimestamp, covCol));
+            coveringShifts.add(ColumnType.pow2SizeOf(covType));
+            coveringIndices.add(covCol);
+            coveringTypes.add(covType);
+            coveringNameTxns.add(columnVersionWriter.getColumnNameTxn(partitionTimestamp, covCol));
+        }
+        indexer.configureCovering(
+                coveringAddrs, coveringAuxAddrs, coveringTops, coveringShifts,
+                coveringIndices, coveringTypes, coverCount, metadata.getTimestampIndex());
+        indexer.setCoveredColumnNameTxns(coveringNameTxns);
+    }
+
+    /**
+     * Opens mmap-backed temp files for each covered column and populates
+     * the combined parquet decode column list. Returns the number of
+     * covered columns actually included (those present in the parquet
+     * schema).
+     *
+     * <p>{@code covSlotMeta} is filled with 3 longs per slot:
+     * [decodedChunkIdx, colType, dataVecBytesWritten].
+     * Slots whose column is absent from parquet get decodedChunkIdx == -1.
+     *
+     * <p>{@code covMmaps} is filled with 2 entries per slot:
+     * [auxMem (null for fixed-size), dataMem]. Both are null for skipped slots.
+     */
+    private int prepareCoveredColumnMmaps(
+            IntList coveringColumnIndices,
+            long partitionTimestamp,
+            int plen,
+            ParquetMetaFileReader parquetMetadata,
+            DirectLongList covSlotMeta,
+            ObjList<MemoryMARW> covMmaps
+    ) {
+        final int coverCount = coveringColumnIndices.size();
+        final long appendPageSize = configuration.getDataAppendPageSize();
+        int includedCount = 0;
+
+        for (int slot = 0; slot < coverCount; slot++) {
+            final int tableColIdx = coveringColumnIndices.getQuick(slot);
+            if (tableColIdx < 0 || metadata.getColumnType(tableColIdx) <= 0) {
+                covSlotMeta.add(-1L);
+                covSlotMeta.add(0L);
+                covSlotMeta.add(0L);
+                covMmaps.add(null);
+                covMmaps.add(null);
+                continue;
+            }
+            final int parquetColIdx = findParquetColumnIndex(parquetMetadata, tableColIdx);
+            if (parquetColIdx < 0) {
+                covSlotMeta.add(-1L);
+                covSlotMeta.add(0L);
+                covSlotMeta.add(0L);
+                covMmaps.add(null);
+                covMmaps.add(null);
+                continue;
+            }
+
+            final int columnType = metadata.getColumnType(tableColIdx);
+            final CharSequence colName = metadata.getColumnName(tableColIdx);
+            final long colNameTxn = columnVersionWriter.getColumnNameTxn(partitionTimestamp, tableColIdx);
+
+            ff.removeQuiet(dFile(path.trimTo(plen), colName, colNameTxn));
+            MemoryMARW dataMem = Vm.getCMARWInstance();
+            dataMem.of(ff, dFile(path.trimTo(plen), colName, colNameTxn),
+                    appendPageSize, 0L, MemoryTag.NATIVE_TABLE_WRITER);
+
+            MemoryMARW auxMem = null;
+            if (ColumnType.isVarSize(columnType)) {
+                ff.removeQuiet(iFile(path.trimTo(plen), colName, colNameTxn));
+                auxMem = Vm.getCMARWInstance();
+                auxMem.of(ff, iFile(path.trimTo(plen), colName, colNameTxn),
+                        appendPageSize, 0L, MemoryTag.NATIVE_TABLE_WRITER);
+            }
+
+            // +1 because chunk index 0 is the SYMBOL column
+            covSlotMeta.add(includedCount + 1);
+            covSlotMeta.add(columnType);
+            covSlotMeta.add(0L);
+            covMmaps.add(auxMem);
+            covMmaps.add(dataMem);
+
+            parquetColumnIdsAndTypes.add(parquetColIdx);
+            parquetColumnIdsAndTypes.add(columnType);
+            includedCount++;
+        }
+        path.trimTo(plen);
+        return includedCount;
     }
 
     /**

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
@@ -802,6 +802,55 @@ public class CoveringIndexTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAlterAddIndexParquetCoveredMmapLeakOnAuxOpenFailure() throws Exception {
+        // When prepareCoveredColumnMmaps opens the .d file for a var-size
+        // covered column but the subsequent .i file open fails, the already-
+        // opened .d MemoryMARW must not leak. Both are added to covMmaps only
+        // after both opens succeed, so a failure on .i leaves .d unreachable
+        // by the finally cleanup. assertMemoryLeak catches the leaked mmap.
+        final AtomicBoolean failArmed = new AtomicBoolean(false);
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public long openRW(LPSZ name, int opts) {
+                if (failArmed.get() && Utf8s.endsWithAscii(name, ".i")) {
+                    return -1;
+                }
+                return super.openRW(name, opts);
+            }
+        };
+        assertMemoryLeak(ff, () -> {
+            execute("""
+                    CREATE TABLE t_leak (
+                        ts TIMESTAMP,
+                        sym SYMBOL,
+                        tag VARCHAR
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            execute("""
+                    INSERT INTO t_leak VALUES
+                    ('2024-01-01T00:00:00', 'A', 'v1'),
+                    ('2024-01-01T01:00:00', 'B', 'v2'),
+                    ('2024-01-02T00:00:00', 'A', 'v3')
+                    """);
+            engine.releaseAllWriters();
+            execute("ALTER TABLE t_leak CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            assertSql(
+                    "name\tisParquet\n2024-01-01\ttrue\n",
+                    "SELECT name, isParquet FROM table_partitions('t_leak') WHERE name = '2024-01-01'"
+            );
+
+            failArmed.set(true);
+            try {
+                execute("ALTER TABLE t_leak ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (tag)");
+                fail("expected CairoException from .i open failure");
+            } catch (CairoException e) {
+                assertTrue(e.getMessage().contains("could not open read-write"));
+            }
+            failArmed.set(false);
+        });
+    }
+
+    @Test
     public void testAlterAddIndexIncludeMissingColumnPosition() throws Exception {
         // The SqlException must point at the missing column name, not 0.
         assertMemoryLeak(() -> {

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
@@ -288,6 +288,72 @@ public class CoveringIndexTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAddPostingCoveringIndexAllNullRowGroupsParquetWal() throws Exception {
+        // A fixed-size (qty INT) and a var-size (tag VARCHAR) covered column are
+        // both added MID-PARTITION: 50 rows exist before ADD COLUMN, 50 after,
+        // all in one day partition, then converted to Parquet. CONVERT zeroes
+        // column_top and stores nulls for rows 0..49. With a tiny Parquet row
+        // group (16 rows), the pre-add region spans whole row groups that are
+        // entirely null. If the decoder hands those row groups back with a zero
+        // data pointer, accumulateCoveredColumnsFromRowGroup routes them through
+        // accumulateAllNullFixedChunk / accumulateAllNullVarSizeChunk. The
+        // covering scan must agree with the no_covering fallback row-for-row,
+        // including the null pre-add region.
+        node1.setProperty(io.questdb.PropertyKey.CAIRO_PARTITION_ENCODER_PARQUET_ROW_GROUP_SIZE, 16);
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_allnull_rg (
+                        ts TIMESTAMP,
+                        sym SYMBOL,
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            // First batch: qty/tag do not exist yet.
+            execute("""
+                    INSERT INTO t_allnull_rg
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE
+                    FROM long_sequence(50)
+                    """);
+            drainWalQueue();
+            execute("ALTER TABLE t_allnull_rg ADD COLUMN qty INT");
+            execute("ALTER TABLE t_allnull_rg ADD COLUMN tag VARCHAR");
+            drainWalQueue();
+            // Second batch into the same day partition: qty/tag have values.
+            execute("""
+                    INSERT INTO t_allnull_rg
+                    SELECT
+                        dateadd('m', (x + 60)::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE, x::INT, 'V' || (x % 4)
+                    FROM long_sequence(50)
+                    """);
+            drainWalQueue();
+
+            execute("ALTER TABLE t_allnull_rg CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            drainWalQueue();
+            execute("ALTER TABLE t_allnull_rg ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (price, qty, tag)");
+            drainWalQueue();
+
+            assertSql(
+                    "suspended\nfalse\n",
+                    "SELECT suspended FROM wal_tables() WHERE name = 't_allnull_rg'"
+            );
+            // 25 rows of sym='A0' across the partition; the pre-add rows have
+            // qty/tag null, the rest have values. Covering must match the
+            // fallback exactly, including the all-null pre-add row groups.
+            assertSqlCursors(
+                    "SELECT ts, sym, price, qty, tag FROM t_allnull_rg WHERE sym = 'A0' ORDER BY ts",
+                    "SELECT /*+ no_covering */ ts, sym, price, qty, tag FROM t_allnull_rg WHERE sym = 'A0' ORDER BY ts"
+            );
+            assertSqlCursors(
+                    "SELECT ts, sym, price, qty, tag FROM t_allnull_rg ORDER BY ts",
+                    "SELECT /*+ no_covering */ ts, sym, price, qty, tag FROM t_allnull_rg ORDER BY ts"
+            );
+        });
+    }
+
+    @Test
     public void testAddPostingCoveringIndexHandlesMidPartitionColumnTopNativeWal() throws Exception {
         // Native counterpart to ...ParquetWal below. Column added mid-partition
         // on a WAL table, NO convert -- the partition stays native. The existing
@@ -492,6 +558,99 @@ public class CoveringIndexTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAddPostingCoveringIndexNewColumnAfterAllParquetThenNativeAppendWal() throws Exception {
+        // Two parquet historic partitions + a native last partition where the
+        // new column has actual data, exercising column_top on both sides at
+        // once. Layout after the prepare steps:
+        //   2024-01-01 PARQUET  tag column_top == partition_size (not in schema)
+        //   2024-01-02 PARQUET  tag column_top == partition_size (not in schema)
+        //   2024-01-03 NATIVE   tag column_top == 0 (regular .d/.i)
+        // ADD INDEX TYPE POSTING ... INCLUDE (price, tag) then runs all three
+        // paths in one go:
+        //   * indexHistoricPartitions -> indexParquetPartition twice: tag has
+        //     no parquet chunk so the merged decode skips it and seal must
+        //     synthesise null for every row from column_top, not read whatever
+        //     stale bytes a zero-filled sidecar would hold.
+        //   * indexLastPartition -> indexNativePartition once: tag is a normal
+        //     column on disk and seal reads it through the standard native
+        //     covering path.
+        // Covering vs no_covering cursor compare pins both behaviours: any
+        // mismatch (parquet leg synthesising the wrong value, or native leg
+        // wiring the wrong .d/.i, or the merged decode silently truncating
+        // price on parquet) surfaces as cursor divergence.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_repro_post_add (
+                        ts TIMESTAMP,
+                        sym SYMBOL,
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            execute("""
+                    INSERT INTO t_repro_post_add
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE
+                    FROM long_sequence(100)
+                    UNION ALL
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-02T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE
+                    FROM long_sequence(100)
+                    """);
+            drainWalQueue();
+
+            // Convert ALL existing partitions to parquet, including the last.
+            execute("ALTER TABLE t_repro_post_add CONVERT PARTITION TO PARQUET WHERE ts >= 0");
+            drainWalQueue();
+
+            // ADD COLUMN after every partition is already parquet -- the new
+            // column lives in NO parquet schema and gets column_top equal to
+            // each partition's row count.
+            execute("ALTER TABLE t_repro_post_add ADD COLUMN tag VARCHAR");
+            drainWalQueue();
+
+            // Append into a NEW day partition -- this stays native and the new
+            // column has real values here, not column_top synthesis.
+            execute("""
+                    INSERT INTO t_repro_post_add
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-03T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE, 'V' || (x % 4)
+                    FROM long_sequence(100)
+                    """);
+            drainWalQueue();
+
+            execute("ALTER TABLE t_repro_post_add ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (price, tag)");
+            drainWalQueue();
+
+            assertSql(
+                    "suspended\nfalse\n",
+                    "SELECT suspended FROM wal_tables() WHERE name = 't_repro_post_add'"
+            );
+
+            // Aggregate sanity: 25 sym='A0' rows per partition (x%4==0 for x in
+            // {4,8,..,100}) -> 75 rows total, sum(price) = 1300*3 = 3900, and
+            // tag is NULL on the two parquet partitions, 'V0' on the native one,
+            // so exactly 50 nulls and 25 'V0's.
+            assertSql(
+                    "rows\tsum_price\tnull_tag\tv0_tag\n75\t3900.0\t50\t25\n",
+                    "SELECT count(*) rows, sum(price) sum_price, " +
+                            "sum(CASE WHEN tag IS NULL THEN 1 ELSE 0 END) null_tag, " +
+                            "sum(CASE WHEN tag = 'V0' THEN 1 ELSE 0 END) v0_tag " +
+                            "FROM t_repro_post_add WHERE sym = 'A0'"
+            );
+
+            // Strongest assertion: covering scan must agree row-for-row with
+            // the no_covering fallback across both parquet and native legs.
+            assertSqlCursors(
+                    "SELECT ts, sym, price, tag FROM t_repro_post_add WHERE sym = 'A0' ORDER BY ts",
+                    "SELECT /*+ no_covering */ ts, sym, price, tag FROM t_repro_post_add WHERE sym = 'A0' ORDER BY ts"
+            );
+        });
+    }
+
+    @Test
     public void testAddPostingCoveringIndexNonWalActivePartitionCannotBeParquet() throws Exception {
         // Non-WAL counterpart to the WAL bug below. That bug needs a Parquet
         // LAST partition -- but a non-WAL table can never have one: CONVERT
@@ -538,6 +697,221 @@ public class CoveringIndexTest extends AbstractCairoTest {
             assertSql(
                     "sum_price\tfirst_tag\n1300.0\tV0\n",
                     "SELECT sum(price) sum_price, first(tag) first_tag FROM t_repro_nowal WHERE sym = 'A0'"
+            );
+        });
+    }
+
+    @Test
+    public void testAddPostingCoveringIndexOnSymbolAddedAfterParquetConvertWal() throws Exception {
+        // Mirror of the NewColumnAfterAllParquet... test above, but with the
+        // new column being the INDEXED SYMBOL rather than a covered one. ADD
+        // COLUMN sym2 SYMBOL after parquet conversion gives sym2 column_top
+        // == partition_size on every existing parquet partition -- the column
+        // simply isn't in those parquet schemas at all. So during ADD INDEX:
+        //   * indexHistoricPartitions -> indexParquetPartition: the
+        //     findParquetColumnIndex == -1 early-return at "could not find
+        //     symbol column for indexing in parquet" fires for both parquet
+        //     partitions; no index files, no covering sidecars are created
+        //     for them, and -- importantly -- the merged decode at
+        //     TableWriter.java:6914 is never reached on those partitions.
+        //   * indexLastPartition -> indexNativePartition: the native
+        //     2024-01-03 partition (where sym2 has real values from a
+        //     post-ADD-COLUMN insert) is indexed via the regular native
+        //     path.
+        // Layout after the prepare steps:
+        //   2024-01-01 PARQUET  sym2 column_top == 100, not in schema
+        //   2024-01-02 PARQUET  sym2 column_top == 100, not in schema
+        //   2024-01-03 NATIVE   sym2 column_top == 0,   real B0-B3 values
+        // A WHERE sym2 = 'B0' covering scan must produce exactly the 25
+        // matching rows from 2024-01-03 with their price values, and agree
+        // row-for-row with the no_covering fallback. NULL probes against the
+        // two parquet partitions must come back via column_top, not via the
+        // (non-existent) index files.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_repro_sym2 (
+                        ts TIMESTAMP,
+                        sym1 SYMBOL,
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            execute("""
+                    INSERT INTO t_repro_sym2
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE
+                    FROM long_sequence(100)
+                    UNION ALL
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-02T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE
+                    FROM long_sequence(100)
+                    """);
+            drainWalQueue();
+
+            execute("ALTER TABLE t_repro_sym2 CONVERT PARTITION TO PARQUET WHERE ts >= 0");
+            drainWalQueue();
+
+            // New SYMBOL column AFTER all partitions are parquet.
+            execute("ALTER TABLE t_repro_sym2 ADD COLUMN sym2 SYMBOL");
+            drainWalQueue();
+
+            // Native partition where sym2 has real values.
+            execute("""
+                    INSERT INTO t_repro_sym2
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-03T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE, 'B' || (x % 4)
+                    FROM long_sequence(100)
+                    """);
+            drainWalQueue();
+
+            execute("ALTER TABLE t_repro_sym2 ALTER COLUMN sym2 ADD INDEX TYPE POSTING INCLUDE (price)");
+            drainWalQueue();
+
+            assertSql(
+                    "suspended\nfalse\n",
+                    "SELECT suspended FROM wal_tables() WHERE name = 't_repro_sym2'"
+            );
+            assertSql(
+                    "indexed\ntrue\n",
+                    "SELECT indexed FROM table_columns('t_repro_sym2') WHERE \"column\" = 'sym2'"
+            );
+
+            // x % 4 == 0 for x in {4,8,..,100}: 25 rows in 2024-01-03,
+            // sum(price) = 4*(1+2+...+25) = 1300. The two parquet partitions
+            // contribute zero rows (sym2 is null there).
+            assertSql(
+                    "rows\tsum_price\n25\t1300.0\n",
+                    "SELECT count(*) rows, sum(price) sum_price FROM t_repro_sym2 WHERE sym2 = 'B0'"
+            );
+
+            // 200 rows across the two parquet partitions where sym2 IS NULL
+            // -- this is the column_top synthesis path, not the index. Any
+            // missing partition's worth of nulls would surface here.
+            assertSql(
+                    "null_rows\n200\n",
+                    "SELECT count(*) null_rows FROM t_repro_sym2 WHERE sym2 IS NULL"
+            );
+
+            // Covering vs no_covering must agree row-for-row.
+            assertSqlCursors(
+                    "SELECT ts, sym2, price FROM t_repro_sym2 WHERE sym2 = 'B0' ORDER BY ts",
+                    "SELECT /*+ no_covering */ ts, sym2, price FROM t_repro_sym2 WHERE sym2 = 'B0' ORDER BY ts"
+            );
+        });
+    }
+
+    @Test
+    public void testAddPostingCoveringIndexSkipsScratchForAllNullParquetWal() throws Exception {
+        // Regression guard for the all-null covered-column skip in
+        // prepareCoveredColumnMmaps. Two parquet partitions get a new VARCHAR
+        // column 'tag' AFTER conversion, leaving columnTop == partitionSize
+        // on both. ALTER ADD INDEX must NOT open scratch tag.d / tag.i files
+        // under those partitions: the indexer's rowId < colTop fast path emits
+        // null sentinels straight from the colTop value handed to it by
+        // configureCoveringFromMmaps, with no data address ever dereferenced.
+        // A regression that reintroduces materialisation (writing the null
+        // pattern into a scratch mmap, or accumulating per row group through
+        // accumulateAllNullVarSizeChunk) would create those files via the
+        // ff.openRW path below and flip the counter.
+        final AtomicBoolean failArmed = new AtomicBoolean(false);
+        final AtomicInteger badOpens = new AtomicInteger(0);
+        final StringBuilder badNames = new StringBuilder();
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public long openRW(LPSZ name, int opts) {
+                if (failArmed.get() && name != null
+                        && (Utf8s.containsAscii(name, "2024-01-01") || Utf8s.containsAscii(name, "2024-01-02"))
+                        && (Utf8s.containsAscii(name, "tag.d") || Utf8s.containsAscii(name, "tag.i"))) {
+                    badOpens.incrementAndGet();
+                    badNames.append(name).append(';');
+                }
+                return super.openRW(name, opts);
+            }
+        };
+        assertMemoryLeak(ff, () -> {
+            execute("""
+                    CREATE TABLE t_null_parquet_skip (
+                        ts TIMESTAMP,
+                        sym SYMBOL,
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            execute("""
+                    INSERT INTO t_null_parquet_skip
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE
+                    FROM long_sequence(100)
+                    UNION ALL
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-02T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE
+                    FROM long_sequence(100)
+                    """);
+            drainWalQueue();
+
+            execute("ALTER TABLE t_null_parquet_skip CONVERT PARTITION TO PARQUET WHERE ts >= 0");
+            drainWalQueue();
+
+            // ADD COLUMN after every partition is parquet: 'tag' lives in NO
+            // parquet schema and gets columnTop == partition_size on both
+            // existing parquet partitions.
+            execute("ALTER TABLE t_null_parquet_skip ADD COLUMN tag VARCHAR");
+            drainWalQueue();
+
+            // A native partition where 'tag' has real values, so the index
+            // build has at least one partition that DOES need to materialise
+            // and we exercise the per-partition code path twice with the
+            // tripwire only catching the parquet cases.
+            execute("""
+                    INSERT INTO t_null_parquet_skip
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-03T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE, 'V' || (x % 4)
+                    FROM long_sequence(100)
+                    """);
+            drainWalQueue();
+
+            failArmed.set(true);
+            try {
+                execute("ALTER TABLE t_null_parquet_skip ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (tag)");
+                drainWalQueue();
+            } finally {
+                failArmed.set(false);
+            }
+
+            assertSql(
+                    "suspended\nfalse\n",
+                    "SELECT suspended FROM wal_tables() WHERE name = 't_null_parquet_skip'"
+            );
+
+            // The actual regression guard: no scratch tag.d / tag.i opens in
+            // the parquet partition directories during ADD INDEX. The
+            // covering scan below verifies the indexer still returns the
+            // correct null sentinels through the rowId < colTop fast path.
+            assertEquals("openRW(tag.d|tag.i) under 2024-01-01 or 2024-01-02 "
+                            + "must be 0 -- the all-null covered-column slot must skip "
+                            + "scratch materialisation. Opens recorded: " + badNames,
+                    0, badOpens.get());
+
+            // Sanity: 25 sym='A0' rows per partition. tag is NULL on the two
+            // parquet partitions (50 rows) and 'V0' on the native one (25
+            // rows). The covering scan must agree row-for-row with the
+            // no_covering fallback, which means the indexer emitted the
+            // correct null pattern for the parquet legs without reading
+            // any scratch file.
+            assertSql(
+                    "rows\tnull_tag\tv0_tag\n75\t50\t25\n",
+                    "SELECT count(*) rows, "
+                            + "sum(CASE WHEN tag IS NULL THEN 1 ELSE 0 END) null_tag, "
+                            + "sum(CASE WHEN tag = 'V0' THEN 1 ELSE 0 END) v0_tag "
+                            + "FROM t_null_parquet_skip WHERE sym = 'A0'"
+            );
+            assertSqlCursors(
+                    "SELECT ts, sym, price, tag FROM t_null_parquet_skip WHERE sym = 'A0' ORDER BY ts",
+                    "SELECT /*+ no_covering */ ts, sym, price, tag FROM t_null_parquet_skip WHERE sym = 'A0' ORDER BY ts"
             );
         });
     }
@@ -790,6 +1164,54 @@ public class CoveringIndexTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAlterAddIndexFreesIndexerOnPostBuildMetadataFailure() throws Exception {
+        // writeIndex() has its own try/catch that frees the indexer on a build
+        // failure. addIndex()'s outer try/catch only does meaningful work when
+        // the build SUCCEEDS but a later step fails -- before the indexer is
+        // stored in the dense `indexers` list. Here the metadata swap
+        // (rewriteAndSwapMetadata -> openMetaSwapFile) fails AFTER writeIndex
+        // built the index, so the freshly built indexer is orphaned: not freed
+        // by writeIndex's catch, not yet tracked in `indexers`. Only addIndex's
+        // catch frees it; assertMemoryLeak fails if that catch is removed.
+        final AtomicBoolean failArmed = new AtomicBoolean(false);
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public long openRW(LPSZ name, int opts) {
+                if (failArmed.get() && name != null && Utf8s.containsAscii(name, "_meta.swp")) {
+                    return -1;
+                }
+                return super.openRW(name, opts);
+            }
+        };
+        assertMemoryLeak(ff, () -> {
+            execute("""
+                    CREATE TABLE t_post_build_fail (
+                        ts TIMESTAMP,
+                        sym SYMBOL,
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            execute("""
+                    INSERT INTO t_post_build_fail VALUES
+                    ('2024-01-01T00:00:00', 'A', 10.0),
+                    ('2024-01-01T01:00:00', 'B', 20.0),
+                    ('2024-01-02T00:00:00', 'A', 30.0)
+                    """);
+            engine.releaseAllWriters();
+
+            failArmed.set(true);
+            try {
+                execute("ALTER TABLE t_post_build_fail ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (price)");
+                fail("expected exception from _meta.swp open failure after index build");
+            } catch (CairoException e) {
+                assertNotNull(e.getMessage());
+            } finally {
+                failArmed.set(false);
+            }
+        });
+    }
+
+    @Test
     public void testAlterAddIndexIncludeDuplicatePosition() throws Exception {
         // The SqlException must point at the duplicated column name, not
         // position 0.
@@ -798,6 +1220,29 @@ public class CoveringIndexTest extends AbstractCairoTest {
             String sql = "ALTER TABLE t_alt_dup ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (price, price)";
             int expected = sql.indexOf("price, price") + "price, ".length();
             assertException(sql, expected, "duplicate column in INCLUDE");
+        });
+    }
+
+    @Test
+    public void testAlterAddIndexIncludeMissingColumnPosition() throws Exception {
+        // The SqlException must point at the missing column name, not 0.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t_alt_miss (ts TIMESTAMP, sym SYMBOL, price DOUBLE) TIMESTAMP(ts)");
+            String sql = "ALTER TABLE t_alt_miss ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (ghost)";
+            int expected = sql.indexOf("ghost");
+            assertException(sql, expected, "INCLUDE column does not exist");
+        });
+    }
+
+    @Test
+    public void testAlterAddIndexIncludeSelfReferencePosition() throws Exception {
+        // The SqlException must point at the offending sym name in the
+        // INCLUDE list, not 0.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t_alt_self (ts TIMESTAMP, sym SYMBOL, price DOUBLE) TIMESTAMP(ts)");
+            String sql = "ALTER TABLE t_alt_self ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (sym)";
+            int expected = sql.lastIndexOf("sym");
+            assertException(sql, expected, "INCLUDE must not contain the indexed column");
         });
     }
 
@@ -851,25 +1296,58 @@ public class CoveringIndexTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testAlterAddIndexIncludeMissingColumnPosition() throws Exception {
-        // The SqlException must point at the missing column name, not 0.
-        assertMemoryLeak(() -> {
-            execute("CREATE TABLE t_alt_miss (ts TIMESTAMP, sym SYMBOL, price DOUBLE) TIMESTAMP(ts)");
-            String sql = "ALTER TABLE t_alt_miss ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (ghost)";
-            int expected = sql.indexOf("ghost");
-            assertException(sql, expected, "INCLUDE column does not exist");
-        });
-    }
+    public void testAlterAddIndexParquetCoveredMmapMultiSlotCleanupOnLaterSlotFailure() throws Exception {
+        // Multi-slot variant of ...MmapLeakOnAuxOpenFailure. With TWO var-size
+        // covered columns, prepareCoveredColumnMmaps fully opens slot 0's .d +
+        // .i (both added to covMmaps) before slot 1's .i open fails. The
+        // exception must leave slot 0's two mmaps AND slot 1's already-opened .d
+        // reachable by the caller's finally (Misc.freeObjListIfCloseable);
+        // assertMemoryLeak catches any leak. The single-slot test iterates the
+        // loop once and never exercises cleanup of an earlier, fully-opened slot.
+        final AtomicBoolean failArmed = new AtomicBoolean(false);
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public long openRW(LPSZ name, int opts) {
+                // Fail only the SECOND covered column's aux (.i) open, after the
+                // first column's .d and .i have both opened.
+                if (failArmed.get() && name != null
+                        && Utf8s.containsAscii(name, "tag2")
+                        && Utf8s.endsWithAscii(name, ".i")) {
+                    return -1;
+                }
+                return super.openRW(name, opts);
+            }
+        };
+        assertMemoryLeak(ff, () -> {
+            execute("""
+                    CREATE TABLE t_leak_multi (
+                        ts TIMESTAMP,
+                        sym SYMBOL,
+                        tag1 VARCHAR,
+                        tag2 VARCHAR
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            execute("""
+                    INSERT INTO t_leak_multi VALUES
+                    ('2024-01-01T00:00:00', 'A', 'a1', 'b1'),
+                    ('2024-01-01T01:00:00', 'B', 'a2', 'b2'),
+                    ('2024-01-02T00:00:00', 'A', 'a3', 'b3')
+                    """);
+            engine.releaseAllWriters();
+            execute("ALTER TABLE t_leak_multi CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            assertSql(
+                    "name\tisParquet\n2024-01-01\ttrue\n",
+                    "SELECT name, isParquet FROM table_partitions('t_leak_multi') WHERE name = '2024-01-01'"
+            );
 
-    @Test
-    public void testAlterAddIndexIncludeSelfReferencePosition() throws Exception {
-        // The SqlException must point at the offending sym name in the
-        // INCLUDE list, not 0.
-        assertMemoryLeak(() -> {
-            execute("CREATE TABLE t_alt_self (ts TIMESTAMP, sym SYMBOL, price DOUBLE) TIMESTAMP(ts)");
-            String sql = "ALTER TABLE t_alt_self ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (sym)";
-            int expected = sql.lastIndexOf("sym");
-            assertException(sql, expected, "INCLUDE must not contain the indexed column");
+            failArmed.set(true);
+            try {
+                execute("ALTER TABLE t_leak_multi ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (tag1, tag2)");
+                fail("expected CairoException from tag2 .i open failure");
+            } catch (CairoException e) {
+                assertTrue(e.getMessage().contains("could not open read-write"));
+            }
+            failArmed.set(false);
         });
     }
 
@@ -10635,6 +11113,79 @@ public class CoveringIndexTest extends AbstractCairoTest {
         });
     }
 
+    /**
+     * Regression for the MultiKey cursor's resume bug. The resume branch
+     * of MultiKeyCoveringPageFrameCursor.nextImpl previously did not
+     * advance currentKeyIdx after the parked CoveringRowCursor exhausted,
+     * so the cursor kept reopening the SAME (key, partition) tuple and
+     * producing the same frames forever. The page-frame buffers
+     * accumulated until the RSS limit fired -- a 2-key multi-key query
+     * with ~28 M rows per key tripped at 15.4 GiB on a 16 GB Mac.
+     * <p>
+     * To trigger the bug deterministically with small data we lower
+     * {@code maxRowsPerFrame} via the {@code @TestOnly} setter so a
+     * 200-row dataset is enough to force the multi-frame-per-key resume
+     * path. Without the fix the test hangs or OOMs; with the fix it
+     * returns the expected count.
+     */
+    @Test
+    public void testMultiKeyResumeAdvancesKeyIndexAfterCursorExhausts() throws Exception {
+        final int capForTest = 50;
+        CoveringIndexRecordCursorFactory.setMaxRowsPerFrameForTesting(capForTest);
+        try {
+            assertMemoryLeak(() -> {
+                execute("""
+                        CREATE TABLE t_mk_resume (
+                            ts TIMESTAMP,
+                            sym SYMBOL,
+                            payload VARCHAR
+                        ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                        """);
+                // 200 rows per partition, alternating between two symbols.
+                // With a 50-row per-frame cap, each (key, partition) tuple
+                // produces 2 frames -- exactly the shape the bug exposed.
+                execute("""
+                        INSERT INTO t_mk_resume
+                        SELECT
+                            dateadd('s', x::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),
+                            CASE WHEN x % 2 = 0 THEN 'K0' ELSE 'K1' END,
+                            'payload-' || x
+                        FROM long_sequence(200)
+                        """);
+                drainWalQueue();
+                execute("ALTER TABLE t_mk_resume ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (payload)");
+                drainWalQueue();
+
+                // Multi-key COUNT — would loop forever on the bugged code
+                // because the resume branch never advances past K0 once
+                // its parked cursor exhausts; the test's surefire timeout
+                // would surface that as a hang.
+                assertSql(
+                        "count\n200\n",
+                        "SELECT count() FROM t_mk_resume WHERE sym IN ('K0','K1')"
+                );
+
+                // Per-key counts also exercise the resume path on both
+                // keys and validate that the per-key totals stay correct
+                // (without the fix some frames would carry duplicate K0
+                // rows from re-iteration, inflating K0 and missing K1).
+                assertSql(
+                        "sym\tc\nK0\t100\nK1\t100\n",
+                        "SELECT sym, count() c FROM t_mk_resume WHERE sym IN ('K0','K1') GROUP BY sym ORDER BY sym"
+                );
+
+                // Covered VARCHAR read through the multi-key cursor: the
+                // 200 unique payloads must come back exactly once each.
+                assertSql(
+                        "c\n200\n",
+                        "SELECT count_distinct(payload::string) c FROM t_mk_resume WHERE sym IN ('K0','K1')"
+                );
+            });
+        } finally {
+            CoveringIndexRecordCursorFactory.setMaxRowsPerFrameForTesting(-1);
+        }
+    }
+
     @Test
     public void testMultiPartitionAlterAndQuery() throws Exception {
         // Multiple partitions, ALTER TABLE, then query across all
@@ -13138,6 +13689,46 @@ public class CoveringIndexTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSingleKeyResumeProducesAllRowsAcrossFrameCap() throws Exception {
+        final int capForTest = 50;
+        CoveringIndexRecordCursorFactory.setMaxRowsPerFrameForTesting(capForTest);
+        try {
+            assertMemoryLeak(() -> {
+                execute("""
+                        CREATE TABLE t_sk_resume (
+                            ts TIMESTAMP,
+                            sym SYMBOL,
+                            payload VARCHAR
+                        ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                        """);
+                execute("""
+                        INSERT INTO t_sk_resume
+                        SELECT
+                            dateadd('s', x::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),
+                            'K0',
+                            'payload-' || x
+                        FROM long_sequence(200)
+                        """);
+                drainWalQueue();
+                execute("ALTER TABLE t_sk_resume ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (payload)");
+                drainWalQueue();
+
+                assertSql(
+                        "count\n200\n",
+                        "SELECT count() FROM t_sk_resume WHERE sym = 'K0'"
+                );
+
+                assertSql(
+                        "c\n200\n",
+                        "SELECT count_distinct(payload::string) c FROM t_sk_resume WHERE sym = 'K0'"
+                );
+            });
+        } finally {
+            CoveringIndexRecordCursorFactory.setMaxRowsPerFrameForTesting(-1);
+        }
+    }
+
+    @Test
     public void testSparseGenCoverWithLeadingBlockTrim() throws Exception {
         assertMemoryLeak(() -> {
             try (Path path = new Path().of(configuration.getDbRoot())) {
@@ -14309,119 +14900,6 @@ public class CoveringIndexTest extends AbstractCairoTest {
             String planText = planSink.getSink().toString();
             assertFalse("Plan should not contain '" + "CoveringIndex" + "':\n" + planText,
                     planText.contains("CoveringIndex"));
-        }
-    }
-
-    /**
-     * Regression for the MultiKey cursor's resume bug. The resume branch
-     * of MultiKeyCoveringPageFrameCursor.nextImpl previously did not
-     * advance currentKeyIdx after the parked CoveringRowCursor exhausted,
-     * so the cursor kept reopening the SAME (key, partition) tuple and
-     * producing the same frames forever. The page-frame buffers
-     * accumulated until the RSS limit fired -- a 2-key multi-key query
-     * with ~28 M rows per key tripped at 15.4 GiB on a 16 GB Mac.
-     * <p>
-     * To trigger the bug deterministically with small data we lower
-     * {@code maxRowsPerFrame} via the {@code @TestOnly} setter so a
-     * 200-row dataset is enough to force the multi-frame-per-key resume
-     * path. Without the fix the test hangs or OOMs; with the fix it
-     * returns the expected count.
-     */
-    @Test
-    public void testMultiKeyResumeAdvancesKeyIndexAfterCursorExhausts() throws Exception {
-        final int capForTest = 50;
-        CoveringIndexRecordCursorFactory.setMaxRowsPerFrameForTesting(capForTest);
-        try {
-            assertMemoryLeak(() -> {
-                execute("""
-                        CREATE TABLE t_mk_resume (
-                            ts TIMESTAMP,
-                            sym SYMBOL,
-                            payload VARCHAR
-                        ) TIMESTAMP(ts) PARTITION BY DAY WAL
-                        """);
-                // 200 rows per partition, alternating between two symbols.
-                // With a 50-row per-frame cap, each (key, partition) tuple
-                // produces 2 frames -- exactly the shape the bug exposed.
-                execute("""
-                        INSERT INTO t_mk_resume
-                        SELECT
-                            dateadd('s', x::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),
-                            CASE WHEN x % 2 = 0 THEN 'K0' ELSE 'K1' END,
-                            'payload-' || x
-                        FROM long_sequence(200)
-                        """);
-                drainWalQueue();
-                execute("ALTER TABLE t_mk_resume ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (payload)");
-                drainWalQueue();
-
-                // Multi-key COUNT — would loop forever on the bugged code
-                // because the resume branch never advances past K0 once
-                // its parked cursor exhausts; the test's surefire timeout
-                // would surface that as a hang.
-                assertSql(
-                        "count\n200\n",
-                        "SELECT count() FROM t_mk_resume WHERE sym IN ('K0','K1')"
-                );
-
-                // Per-key counts also exercise the resume path on both
-                // keys and validate that the per-key totals stay correct
-                // (without the fix some frames would carry duplicate K0
-                // rows from re-iteration, inflating K0 and missing K1).
-                assertSql(
-                        "sym\tc\nK0\t100\nK1\t100\n",
-                        "SELECT sym, count() c FROM t_mk_resume WHERE sym IN ('K0','K1') GROUP BY sym ORDER BY sym"
-                );
-
-                // Covered VARCHAR read through the multi-key cursor: the
-                // 200 unique payloads must come back exactly once each.
-                assertSql(
-                        "c\n200\n",
-                        "SELECT count_distinct(payload::string) c FROM t_mk_resume WHERE sym IN ('K0','K1')"
-                );
-            });
-        } finally {
-            CoveringIndexRecordCursorFactory.setMaxRowsPerFrameForTesting(-1);
-        }
-    }
-
-    @Test
-    public void testSingleKeyResumeProducesAllRowsAcrossFrameCap() throws Exception {
-        final int capForTest = 50;
-        CoveringIndexRecordCursorFactory.setMaxRowsPerFrameForTesting(capForTest);
-        try {
-            assertMemoryLeak(() -> {
-                execute("""
-                        CREATE TABLE t_sk_resume (
-                            ts TIMESTAMP,
-                            sym SYMBOL,
-                            payload VARCHAR
-                        ) TIMESTAMP(ts) PARTITION BY DAY WAL
-                        """);
-                execute("""
-                        INSERT INTO t_sk_resume
-                        SELECT
-                            dateadd('s', x::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),
-                            'K0',
-                            'payload-' || x
-                        FROM long_sequence(200)
-                        """);
-                drainWalQueue();
-                execute("ALTER TABLE t_sk_resume ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (payload)");
-                drainWalQueue();
-
-                assertSql(
-                        "count\n200\n",
-                        "SELECT count() FROM t_sk_resume WHERE sym = 'K0'"
-                );
-
-                assertSql(
-                        "c\n200\n",
-                        "SELECT count_distinct(payload::string) c FROM t_sk_resume WHERE sym = 'K0'"
-                );
-            });
-        } finally {
-            CoveringIndexRecordCursorFactory.setMaxRowsPerFrameForTesting(-1);
         }
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
@@ -288,6 +288,83 @@ public class CoveringIndexTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAddPostingCoveringIndexAllNullFixedAndVarSizeNativeWal() throws Exception {
+        // Native counterpart to ...SkipsScratchForAllNullParquetWal /
+        // ...AllNullRowGroupsParquetWal. A fixed-size (qty INT) and a var-size
+        // (tag VARCHAR) covered column are added AFTER two native partitions are
+        // fully populated, so column_top == partition_size on both and qty.d /
+        // tag.d / tag.i are 0-byte files there. A third native partition carries
+        // real qty/tag values. ALTER ADD INDEX builds the covering index for all
+        // three partitions: the native build path (PostingIndexWriter.mapColumnFile)
+        // must skip the empty covered files for the two back-filled partitions
+        // and let the indexer synthesise nulls via the rowId < colTop fast path,
+        // while materialising the third. The covering scan must match the
+        // no_covering fallback row-for-row. The pre-existing native all-null
+        // tests cover only a VARCHAR column; this pins the fixed-size case too.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_allnull_native (
+                        ts TIMESTAMP,
+                        sym SYMBOL,
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            execute("""
+                    INSERT INTO t_allnull_native
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE
+                    FROM long_sequence(100)
+                    UNION ALL
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-02T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE
+                    FROM long_sequence(100)
+                    """);
+            drainWalQueue();
+
+            // Added after 2024-01-01 and 2024-01-02 are full: column_top equals
+            // partition_size on both, so qty.d / tag.d / tag.i are 0-byte files.
+            execute("ALTER TABLE t_allnull_native ADD COLUMN qty INT");
+            execute("ALTER TABLE t_allnull_native ADD COLUMN tag VARCHAR");
+            drainWalQueue();
+
+            // A later native partition where qty/tag carry real values, so the
+            // index build exercises both the all-null skip and a populated seal.
+            execute("""
+                    INSERT INTO t_allnull_native
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-03T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE, x::INT, 'V' || (x % 4)
+                    FROM long_sequence(100)
+                    """);
+            drainWalQueue();
+            // No CONVERT -- every partition stays native.
+            execute("ALTER TABLE t_allnull_native ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (price, qty, tag)");
+            drainWalQueue();
+
+            assertSql(
+                    "suspended\nfalse\n",
+                    "SELECT suspended FROM wal_tables() WHERE name = 't_allnull_native'"
+            );
+            // 25 sym='A0' rows per partition (75 total). qty/tag null on the two
+            // back-filled partitions (50 rows) and populated on the third (25).
+            assertSql(
+                    "rows\tnull_qty\tnull_tag\tv0_tag\n75\t50\t50\t25\n",
+                    "SELECT count(*) rows, " +
+                            "sum(CASE WHEN qty IS NULL THEN 1 ELSE 0 END) null_qty, " +
+                            "sum(CASE WHEN tag IS NULL THEN 1 ELSE 0 END) null_tag, " +
+                            "sum(CASE WHEN tag = 'V0' THEN 1 ELSE 0 END) v0_tag " +
+                            "FROM t_allnull_native WHERE sym = 'A0'"
+            );
+            assertSqlCursors(
+                    "SELECT ts, sym, price, qty, tag FROM t_allnull_native WHERE sym = 'A0' ORDER BY ts",
+                    "SELECT /*+ no_covering */ ts, sym, price, qty, tag FROM t_allnull_native WHERE sym = 'A0' ORDER BY ts"
+            );
+        });
+    }
+
+    @Test
     public void testAddPostingCoveringIndexAllNullRowGroupsParquetWal() throws Exception {
         // A fixed-size (qty INT) and a var-size (tag VARCHAR) covered column are
         // both added MID-PARTITION: 50 rows exist before ADD COLUMN, 50 after,
@@ -558,6 +635,59 @@ public class CoveringIndexTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAddPostingCoveringIndexIncludesFixedSizeColumnAddedToFullyPopulatedNativeWal() throws Exception {
+        // Fixed-size sibling of ...IncludesColumnAddedToFullyPopulatedNativeWal.
+        // qty INT is added AFTER the native partition is fully populated, so
+        // column_top == partition_row_count and qty.d is a 0-byte file; every
+        // row reads qty as null. The native covering build
+        // (PostingIndexWriter.mapColumnFile) must skip the empty fixed-size file
+        // and let the indexer synthesise nulls via the rowId < colTop fast path,
+        // matching the Parquet provider variant. The existing native test covers
+        // only a VARCHAR column, which always took the empty-file skip; this
+        // pins the fixed-size case.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_added_fixed_n (
+                        ts TIMESTAMP,
+                        sym SYMBOL,
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            execute("""
+                    INSERT INTO t_added_fixed_n
+                    SELECT
+                        dateadd('m', x::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4), x::DOUBLE
+                    FROM long_sequence(100)
+                    """);
+            drainWalQueue();
+            execute("ALTER TABLE t_added_fixed_n ADD COLUMN qty INT");
+            drainWalQueue();
+            // No CONVERT -- native partition. column_top for qty == 100; all rows
+            // read qty as null.
+            execute("ALTER TABLE t_added_fixed_n ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (price, qty)");
+            drainWalQueue();
+
+            assertSql(
+                    "suspended\nfalse\n",
+                    "SELECT suspended FROM wal_tables() WHERE name = 't_added_fixed_n'"
+            );
+            // 25 sym='A0' rows, sum(price)=1300, all-null qty -- identical shape
+            // to the VARCHAR sibling test above.
+            assertSql(
+                    "rows\tsum_price\tnull_qty\n25\t1300.0\t25\n",
+                    "SELECT count(*) rows, sum(price) sum_price, " +
+                            "sum(CASE WHEN qty IS NULL THEN 1 ELSE 0 END) null_qty " +
+                            "FROM t_added_fixed_n WHERE sym = 'A0'"
+            );
+            assertSqlCursors(
+                    "SELECT ts, sym, price, qty FROM t_added_fixed_n WHERE sym = 'A0' ORDER BY ts",
+                    "SELECT /*+ no_covering */ ts, sym, price, qty FROM t_added_fixed_n WHERE sym = 'A0' ORDER BY ts"
+            );
+        });
+    }
+
+    @Test
     public void testAddPostingCoveringIndexNewColumnAfterAllParquetThenNativeAppendWal() throws Exception {
         // Two parquet historic partitions + a native last partition where the
         // new column has actual data, exercising column_top on both sides at
@@ -798,6 +928,65 @@ public class CoveringIndexTest extends AbstractCairoTest {
             assertSqlCursors(
                     "SELECT ts, sym2, price FROM t_repro_sym2 WHERE sym2 = 'B0' ORDER BY ts",
                     "SELECT /*+ no_covering */ ts, sym2, price FROM t_repro_sym2 WHERE sym2 = 'B0' ORDER BY ts"
+            );
+        });
+    }
+
+    @Test
+    public void testAddPostingCoveringIndexParquetVarSizeScratchMmapExtendsWal() throws Exception {
+        // Forces the parquet single-pass build to extend (mremap) the var-size
+        // covered-column DATA scratch mmap mid-decode. prepareCoveredColumnMmaps
+        // pre-sizes that scratch to the data-append page size (2 MB in tests) and
+        // grows it on demand as accumulateCoveredColumnsFromRowGroup appends each
+        // row group's decoded data via putBlockOfBytes. A STRING covered column
+        // whose decoded data exceeds 2 MB across several row groups triggers an
+        // extend that may relocate the mapping base; configureCoveringFromMmaps
+        // must then read the post-extend addressOf(0), not a stale base, when it
+        // wires the seal. Every other parquet var-size test stays within a few KB
+        // (single page, no extend) and the large var-size tests are native (a
+        // different memory class), so this is the only coverage of the extend.
+        //
+        // 8000 rows x 200-char STRING is ~3.2 MB of .d data; a 2000-row parquet
+        // row group is ~0.8 MB, so the running total crosses 2 MB on the third
+        // group and the remaining groups append past the extend.
+        node1.setProperty(io.questdb.PropertyKey.CAIRO_PARTITION_ENCODER_PARQUET_ROW_GROUP_SIZE, 2000);
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_vs_extend (
+                        ts TIMESTAMP,
+                        sym SYMBOL,
+                        s STRING
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            execute("""
+                    INSERT INTO t_vs_extend
+                    SELECT
+                        dateadd('s', x::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),
+                        'A' || (x % 4),
+                        rnd_str(200, 200, 0)
+                    FROM long_sequence(8000)
+                    """);
+            drainWalQueue();
+            execute("ALTER TABLE t_vs_extend CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            drainWalQueue();
+            execute("ALTER TABLE t_vs_extend ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (s)");
+            drainWalQueue();
+
+            assertSql(
+                    "suspended\nfalse\n",
+                    "SELECT suspended FROM wal_tables() WHERE name = 't_vs_extend'"
+            );
+            // The covering scan reads s from the sidecar built off the extended
+            // scratch mmap; it must match the no_covering fallback for every row.
+            // WHERE sym = 'A0' selects the covering factory (a bare ORDER BY ts
+            // would not). 2000 of the 8000 rows have sym = 'A0'.
+            assertSql(
+                    "count\n2000\n",
+                    "SELECT count() FROM t_vs_extend WHERE sym = 'A0'"
+            );
+            assertSqlCursors(
+                    "SELECT ts, sym, s FROM t_vs_extend WHERE sym = 'A0' ORDER BY ts",
+                    "SELECT /*+ no_covering */ ts, sym, s FROM t_vs_extend WHERE sym = 'A0' ORDER BY ts"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
@@ -10332,13 +10332,13 @@ public class CoveringIndexTest extends AbstractCairoTest {
         final AtomicBoolean failArmed = new AtomicBoolean(false);
         ff = new TestFilesFacadeImpl() {
             @Override
-            public long openAppend(LPSZ name) {
+            public long openRW(LPSZ name, int opts) {
                 if (failArmed.get() && name != null
                         && Utf8s.endsWithAscii(name, "price.d")) {
                     failArmed.set(false);
                     return -1;
                 }
-                return super.openAppend(name);
+                return super.openRW(name, opts);
             }
         };
         assertMemoryLeak(ff, () -> {


### PR DESCRIPTION
## Summary

- Merge the two separate row-group decode loops in `indexParquetPartition` into a single pass that decodes the SYMBOL column and all covered columns together in one `decodeRowGroup` call per row group
- Replace the `write()`/re-`mmap` round-trip for covered column data with direct mmap-backed `MemoryMARW` writes: decoded data flows into the mmap and the same addresses feed `PostingIndexWriter`'s addr-based `configureCovering` path during seal
- Eliminate the separate `materialiseCoveredColumnsFromParquet` call on this code path

### Before

1. `materialiseCoveredColumnsFromParquet` decoded all covered columns from every row group, writing to temp files via `write()` syscalls
2. A second row-group loop decoded just the SYMBOL column and fed it to `indexWriter.add()`
3. `seal()` opened the temp files via `mmap` to read covered column data for sidecar writing

The parquet file was fully decoded twice and the covered column data made a disk round-trip through `write()` then `mmap` read.

### After

1. A single row-group loop decodes SYMBOL + all covered columns together
2. Covered column data accumulates into `MemoryMARW` instances (file-backed mmap) via `putBlockOfBytes`
3. `seal()` reads from the same mmap addresses — no re-open, no second decode pass

## Test plan

- CoveringIndexTest (364 tests) passes, including all parquet-specific covering index tests
- O3ParquetPartitionFuzzTest passes
- PostingIndexOomFallbackTest passes
- Updated fault-injection test to match new file-open path (`openRW` instead of `openAppend`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)