### PR TITLE
fix: wrong Java version in requirements section of CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ you wish to understand how our maintainers work together, you can refer to
 ## Requirements
 
 - Operating system - **x86-64 or ARM64**: Windows, Linux, FreeBSD, and macOS
-- Java 17 64-bit (strict requirement — no earlier, no later)
+- Java 25 64-bit (strict requirement — no earlier, no later)
 - Maven 3 (latest version recommended; from your package manager on Linux/macOS
   ([Homebrew](https://github.com/Homebrew/brew)) or
   [from the jar](https://maven.apache.org/install.html) for any OS)


### PR DESCRIPTION
## Summary
The Requirements section in CONTRIBUTING.md listed "Java 17 64-bit (strict requirement — no earlier, no later)", but the rest of the same file and core/README.md both specify Java 25 as the required version. The Java 17 reference is stale and would cause contributors to set up the wrong JDK before they even get to the setup instructions that contradict it.

## How to reproduce
1. Open CONTRIBUTING.md
2. Read the Requirements section under "Environment setup" — it says Java 17
3. Read the "Setting up Java and JAVA_HOME" section just below — it says Java 25
4. Check core/README.md prerequisites — also says Java 25

## Test plan
- Verify CONTRIBUTING.md Requirements section now reads "Java 25 64-bit (strict requirement — no earlier, no later)"
- Confirm it matches the JAVA_HOME section and core/README.md