### PR TITLE
fix(core): validate months-based TTL granularity on materialized views

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -5192,13 +5192,13 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
     }
 
     protected void compileAlterMatViewExt(SqlExecutionContext executionContext, CharSequence tok, TableToken matViewToken, int matViewNamePosition) throws SqlException {
-        LOG.debug().$("'alter' or 'resume' or 'suspend' expected [matViewToken=").$(matViewToken)
+        LOG.debug().$("'alter' or 'resume' or 'suspend' or 'set' expected [matViewToken=").$(matViewToken)
                 .$(", matViewNamePosition=").$(matViewNamePosition)
                 .$(']').$();
         if (tok == null) {
-            throw SqlException.$(lexer.getPosition(), "'alter' or 'resume' or 'suspend' expected");
+            throw SqlException.$(lexer.getPosition(), "'alter' or 'resume' or 'suspend' or 'set' expected");
         }
-        throw SqlException.$(lexer.lastTokenPosition(), "'alter' or 'resume' or 'suspend' expected");
+        throw SqlException.$(lexer.lastTokenPosition(), "'alter' or 'resume' or 'suspend' or 'set' expected");
     }
 
     protected void compileAlterMatViewSetExt(SqlExecutionContext executionContext, CharSequence tok, TableToken matViewToken, int matViewNamePosition) throws SqlException {

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationImpl.java
@@ -683,8 +683,9 @@ public class CreateMatViewOperationImpl implements CreateMatViewOperation {
                       : PartitionBy.DAY;
             createTableOperation.setPartitionBy(partitionBy);
             final int ttlHoursOrMonths = createTableOperation.getTtlHoursOrMonths();
-            if (ttlHoursOrMonths > 0) {
-                // Don't forget to validate TTL against PARTITION BY.
+            if (ttlHoursOrMonths != 0) {
+                // Don't forget to validate TTL against PARTITION BY. Negative values are
+                // months-based TTL; validateTtlGranularity handles both signs.
                 PartitionBy.validateTtlGranularity(partitionBy, ttlHoursOrMonths, createTableOperation.getTtlPosition());
             }
         }

--- a/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
@@ -791,6 +791,21 @@ public class CreateMatViewTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCreateMatViewNoPartitionByInvalidMonthsTtl() throws Exception {
+        assertMemoryLeak(() -> {
+            createTable(TABLE1);
+            // sample by 2h derives a YEAR partition; 7 months is not a whole number of years,
+            // so the months-based (negative) TTL must be rejected at build time.
+            assertExceptionNoLeakCheck(
+                    "create materialized view test as (select ts, avg(v) from " + TABLE1 + " sample by 2h) ttl 7 months",
+                    82,
+                    "TTL value must be an integer multiple of the partition size (its time interval)"
+            );
+            assertNull(getMatViewDefinition("test"));
+        });
+    }
+
+    @Test
     public void testCreateMatViewNoPartitionByNoParentheses() throws Exception {
         testCreateMatViewNoPartitionBy(false);
     }

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -1138,12 +1138,12 @@ public class MatViewTest extends AbstractCairoTest {
             assertExceptionNoLeakCheck(
                     "alter materialized view price_1h",
                     32,
-                    "'alter' or 'resume' or 'suspend' expected"
+                    "'alter' or 'resume' or 'suspend' or 'set' expected"
             );
             assertExceptionNoLeakCheck(
                     "alter materialized view price_1h foobar",
                     33,
-                    "'alter' or 'resume' or 'suspend' expected"
+                    "'alter' or 'resume' or 'suspend' or 'set' expected"
             );
             assertExceptionNoLeakCheck(
                     "alter materialized view price_1h alter",


### PR DESCRIPTION
## What

When a materialized view omits an explicit `PARTITION BY`,
`CreateMatViewOperationImpl.updateMatViewTablePartitionBy()` derives the
partition unit (`DAY`, `MONTH`, or `YEAR`) from the `SAMPLE BY` interval and then
validates the requested `TTL` against that derived partition size. The guard
around that validation only fired for positive TTL values, so a months-based
`TTL` slipped through unchecked.

QuestDB encodes TTL as a single int: positive is hours, negative is months, zero
is unset. `PartitionBy.validateTtlGranularity()` already handles both signs, so
only the caller's guard was too narrow. This change widens it from
`ttlHoursOrMonths > 0` to `ttlHoursOrMonths != 0`, so a months-based TTL goes
through the same check as an hours-based one. Zero still skips validation, since
it means no TTL.

It also lists `set` in the "expected" error that `compileAlterMatViewExt()`
raises for an unrecognized token after `ALTER MATERIALIZED VIEW <name>`, since
`SET` (e.g. `SET TTL`, `SET REFRESH`) is a valid continuation.

## Why

`testCreateMatViewNoPartitionByInvalidTtl` already validated the hours-based
derived-partition path, but the months-based path was unguarded: a months-based
TTL that is not a whole multiple of the derived partition was accepted and
produced an invalid configuration. This closes that gap.

It is also the OSS half of a tandem change with questdb-enterprise#1027.
Enterprise builds used to intercept materialized-view TTL and translate it into a
storage policy; #1027 restores native TTL there, routing Enterprise materialized
views back onto this OSS validation, so the months-based case has to be covered
for them as well.

## Behavior change

`CREATE MATERIALIZED VIEW ... TTL N months` on a view with a derived partition is
now rejected at build time when `N` months is not an integer multiple of the
partition size. For example, `SAMPLE BY 2h` derives a `YEAR` partition, so
`TTL 7 months` is rejected -- 7 months is not a whole number of years. The same
statement was previously accepted. Hours-based TTL is unaffected, and `TTL 0`
(no TTL) still skips the check.

This tightens an existing path rather than only adding new behavior, so a view
that relied on the previously-unvalidated combination would now fail to create.

## Test plan

- Added `testCreateMatViewNoPartitionByInvalidMonthsTtl` in `CreateMatViewTest`:
  a `SAMPLE BY 2h` view (derives `YEAR`) with `TTL 7 months` is rejected, and no
  mat-view definition is created.
- `testCreateMatViewNoPartitionByInvalidTtl` continues to cover the hours-based
  path (`SAMPLE BY 30s` -> `DAY`, `TTL 12 hours` rejected).
- Updated `MatViewTest.testAlterSymbolCapacityInvalidStatement` to expect the
  `set`-inclusive error message.

Required by https://github.com/questdb/questdb-enterprise/pull/1027
