### PR TITLE
chore(core): return NULL for columns added after parquet conversion

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryPool.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryPool.java
@@ -566,8 +566,14 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
             clearAddresses();
             if (parquetColumns.size() > 0) {
                 decoder.decodeRowGroup(rowGroupBuffers, parquetColumns, rowGroup, rowLo, rowHi);
-                remapColumns();
             }
+            // Always size and zero the address slots, even when nothing is decoded.
+            // When parquetColumns is empty (every projected column was added after the
+            // partition was converted to parquet), remapColumns() maps every column to
+            // address 0 (NULL) without touching rowGroupBuffers. Skipping this left the
+            // slots holding stale pointers from a previously decoded frame whose buffers
+            // this frame reuses, which the accessors then dereferenced.
+            remapColumns();
         }
 
         public void decodeRemainingColumns(

--- a/core/src/test/java/io/questdb/test/griffin/ParquetLateMaterializationFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParquetLateMaterializationFuzzTest.java
@@ -304,8 +304,9 @@ public class ParquetLateMaterializationFuzzTest extends AbstractCairoTest {
                     "SELECT c_vc FROM x",
                     "SELECT c_long, c_sym, c_vc FROM x",
             };
-            final String[] expected = new String[queries.length];
-            for (int i = 0; i < queries.length; i++) {
+            final int queryCount = queries.length;
+            final String[] expected = new String[queryCount];
+            for (int i = 0; i < queryCount; i++) {
                 sink.clear();
                 printSql(queries[i], sink);
                 expected[i] = sink.toString();
@@ -315,7 +316,7 @@ public class ParquetLateMaterializationFuzzTest extends AbstractCairoTest {
             // the newer ones, so an ascending scan primes the buffers from a present
             // frame and then reuses them for the absent frames.
             execute("ALTER TABLE x CONVERT PARTITION TO PARQUET WHERE ts < '2024-02-01'");
-            for (int i = 0; i < queries.length; i++) {
+            for (int i = 0; i < queryCount; i++) {
                 assertSql(expected[i], queries[i]);
             }
         });

--- a/core/src/test/java/io/questdb/test/griffin/ParquetLateMaterializationFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParquetLateMaterializationFuzzTest.java
@@ -263,6 +263,103 @@ public class ParquetLateMaterializationFuzzTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testProjectOnlyAddedColumnsAcrossParquetPartitions() throws Exception {
+        // Regression for the parquet read fault when a query projects ONLY column(s)
+        // absent from a parquet partition because they were added by ALTER TABLE ADD
+        // COLUMN after that partition's parquet file was written. Decoding such a
+        // projection produces an empty decode pass. The page-address buffers are pooled
+        // and reused frame to frame, so the empty pass must zero them; otherwise it
+        // leaves the real page pointers written by the previous, populated frame, and
+        // the record accessors read those stale pointers -- returning a neighbouring
+        // partition's value instead of NULL, or dereferencing freed memory.
+        //
+        // To reuse a populated buffer, the column must be present in the OLDER
+        // partitions (which prime the buffers first on an ascending scan) and absent
+        // from the NEWER ones. The newer partitions are converted before the columns
+        // exist, so their parquet files omit the columns entirely; the older partitions
+        // are written and converted afterwards, so their parquet files contain them.
+        // Ten older partitions exceed the parquet frame cache, forcing primed buffers to
+        // be reused for the absent newer frames.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE x (id INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+            // Five newer partitions (one row each), converted before the columns exist.
+            execute("INSERT INTO x SELECT x::int, timestamp_sequence('2024-02-01T00:00:00.000000Z', 86400000000L) FROM long_sequence(5)");
+            execute("ALTER TABLE x CONVERT PARTITION TO PARQUET WHERE ts >= '2024-02-01'");
+
+            execute("ALTER TABLE x ADD COLUMN c_long LONG");
+            execute("ALTER TABLE x ADD COLUMN c_sym SYMBOL");
+            execute("ALTER TABLE x ADD COLUMN c_vc VARCHAR");
+            // Ten older partitions (one row each) carrying the new columns.
+            execute(
+                    "INSERT INTO x SELECT (100 + x)::int, timestamp_sequence('2024-01-01T00:00:00.000000Z', 86400000000L), " +
+                            "(1000 + x)::long, ('s' || (x % 3)), ('v' || x) FROM long_sequence(10)"
+            );
+
+            // Read the projections while the older partitions are still native: this is
+            // the correct result (older values then NULLs) and never touches the pooled
+            // parquet buffers for the present columns.
+            final String[] queries = {
+                    "SELECT c_long FROM x",
+                    "SELECT c_sym FROM x",
+                    "SELECT c_vc FROM x",
+                    "SELECT c_long, c_sym, c_vc FROM x",
+            };
+            final String[] expected = new String[queries.length];
+            for (int i = 0; i < queries.length; i++) {
+                sink.clear();
+                printSql(queries[i], sink);
+                expected[i] = sink.toString();
+            }
+
+            // Now the new columns are present in the older parquet files and absent from
+            // the newer ones, so an ascending scan primes the buffers from a present
+            // frame and then reuses them for the absent frames.
+            execute("ALTER TABLE x CONVERT PARTITION TO PARQUET WHERE ts < '2024-02-01'");
+            for (int i = 0; i < queries.length; i++) {
+                assertSql(expected[i], queries[i]);
+            }
+        });
+    }
+
+    @Test
+    public void testAggregateOnlyAddedColumnsAcrossParquetPartitions() throws Exception {
+        // Companion to testProjectOnlyAddedColumnsAcrossParquetPartitions covering the
+        // parallel aggregation path: the unconditional zeroing of the page buffers must
+        // not change correct NULL handling when a non-keyed aggregation reads only the
+        // absent columns. The same older-present / newer-absent layout is converted in
+        // two phases so the older parquet files carry the columns and the newer ones omit
+        // them.
+        WorkerPool pool = new WorkerPool(() -> 4);
+        TestUtils.execute(
+                pool,
+                (engine, compiler, sqlExecutionContext) -> {
+                    sqlExecutionContext.setJitMode(enableJitCompiler ? SqlJitMode.JIT_MODE_ENABLED : SqlJitMode.JIT_MODE_DISABLED);
+                    engine.execute("create table x (id int, ts timestamp) timestamp(ts) partition by day;", sqlExecutionContext);
+                    engine.execute(
+                            "insert into x select x::int, timestamp_sequence('2024-02-01T00:00:00.000000Z', 86400000000L) from long_sequence(5);",
+                            sqlExecutionContext
+                    );
+                    engine.execute("alter table x convert partition to parquet where ts >= '2024-02-01';", sqlExecutionContext);
+                    engine.execute("alter table x add column c long;", sqlExecutionContext);
+                    engine.execute("alter table x add column c_sym symbol;", sqlExecutionContext);
+                    engine.execute(
+                            "insert into x select (100 + x)::int, timestamp_sequence('2024-01-01T00:00:00.000000Z', 86400000000L), (1000 + x)::long, ('s' || (x % 3)) from long_sequence(10);",
+                            sqlExecutionContext
+                    );
+
+                    final StringSink expected = new StringSink();
+                    final CharSequence query = "select sum(c) s, count(c) cnt, count(c_sym) cnt_sym from x";
+                    engine.print(query, expected, sqlExecutionContext);
+
+                    engine.execute("alter table x convert partition to parquet where ts < '2024-02-01';", sqlExecutionContext);
+                    TestUtils.assertSql(engine, sqlExecutionContext, query, sink, expected);
+                },
+                configuration,
+                LOG
+        );
+    }
+
+    @Test
     public void testLateMaterializationDateColumn() throws Exception {
         WorkerPool pool = new WorkerPool(() -> 4);
         TestUtils.execute(


### PR DESCRIPTION
# Background

When `ALTER TABLE ADD COLUMN` adds a column after a partition has already been converted to parquet, that column is not part of the partition's parquet file. Reading it should return NULL for every row of that partition, the same as a native column top.

A query that projects only such absent column(s) decodes no parquet columns for that partition. `PageFrameMemoryPool` reuses a small pool of per-frame page-address buffers across frames. The decode pass reset the buffer positions but only re-sized and zeroed the address slots when at least one parquet column was decoded. With nothing to decode, the buffers kept the page pointers written by the previously decoded frame. The record accessors then read those stale pointers and returned a neighbouring partition's value instead of NULL; when a retained pointer referenced memory that had since been freed, the read faulted.

The path is reachable from a plain `SELECT` on a primary instance. It surfaced in the parquet late-materialization fuzz test on CI rather than from a user report.

## Change

`ParquetBuffers.decode()` now calls `remapColumns()` unconditionally. `remapColumns()` sizes and zeroes the four address lists and then maps each query column to its decoded buffer. When no parquet columns were decoded, every column lacks a parquet index and maps to address 0 (NULL) without touching the row-group buffers, which is the intended result for a column absent from the partition.

## Effects

- Projecting only added-after-conversion columns returns NULL, matching both the native read path and the result when the same column is projected alongside a present column.
- `remapColumns()` now runs on every decode, including the empty case. It walks the column mapping and zeroes four `DirectLongList`s sized to the column count. This adds a small constant per-frame cost that the previous code skipped when nothing was decoded. The cost is negligible next to a row-group decode, but the empty pass is no longer free.
- Only the record-scan cursor exhibited the fault in practice. It reuses an eight-buffer pool across frames, so a populated buffer can be reused for a later empty pass. The parallel aggregation and late-materialization paths use a single-buffer pool that they release per task, so their empty passes always saw a fresh, zeroed buffer and their behavior does not change.
- The sibling late-materialization path `decodeRemainingColumns()` needs no change. It relies on `decode()` having sized and zeroed the buffer first, which now always happens.

## Test plan

- Added `testProjectOnlyAddedColumnsAcrossParquetPartitions` to `ParquetLateMaterializationFuzzTest`. It builds older partitions whose parquet files carry the added columns and newer partitions whose parquet files omit them, captures the correct result while the older partitions are still native, converts them to parquet, then asserts the parquet read matches. It covers LONG, SYMBOL and VARCHAR projections plus a multi-column projection.
- Confirmed this test fails before the change (newer rows read stale values from older partitions) and passes after.
- Added `testAggregateOnlyAddedColumnsAcrossParquetPartitions` covering a non-keyed aggregation over only the absent columns. It passes both before and after the change, since the aggregation path was not affected, and guards NULL handling on that path.
- `ParquetLateMaterializationFuzzTest` passes in full (48 tests).
- `AlterTableConvertPartitionTest` passes in full (38 tests).