### PR TITLE
perf(storage): reduce Parquet file size for timestamp and floating-point columns

### DIFF
--- a/core/rust/qdbr/src/parquet_read/decode.rs
+++ b/core/rust/qdbr/src/parquet_read/decode.rs
@@ -1390,6 +1390,32 @@ fn decode_int96_dispatch<const FILTERED: bool, const FILL_NULLS: bool>(
     }
 }
 
+/// Reverse a BYTE_STREAM_SPLIT data page back into the contiguous little-endian
+/// value layout that the Plain decoder expects. The page holds `elem_size`
+/// byte-streams laid out back to back, where stream k contains the k-th byte of
+/// every value; this interleaves them: out[j*elem_size + k] = data[k*n + j],
+/// with n the number of values. The reconstructed buffer is then handed to the
+/// ordinary Plain decoder, so null handling and filtering stay shared.
+fn byte_stream_split_to_plain(data: &[u8], elem_size: usize) -> ParquetResult<Vec<u8>> {
+    if elem_size == 0 || !data.len().is_multiple_of(elem_size) {
+        return Err(fmt_err!(
+            InvalidLayout,
+            "BYTE_STREAM_SPLIT page length {} is not a multiple of element size {}",
+            data.len(),
+            elem_size
+        ));
+    }
+    let n = data.len() / elem_size;
+    let mut out = vec![0u8; data.len()];
+    for k in 0..elem_size {
+        let stream = &data[k * n..(k + 1) * n];
+        for (j, &b) in stream.iter().enumerate() {
+            out[j * elem_size + k] = b;
+        }
+    }
+    Ok(out)
+}
+
 fn decode_double_dispatch<const FILTERED: bool, const FILL_NULLS: bool>(
     page: &DataPage,
     dict: Option<&DictPage>,
@@ -1409,6 +1435,17 @@ fn decode_double_dispatch<const FILTERED: bool, const FILL_NULLS: bool>(
                 page,
                 mode,
                 &mut PlainPrimitiveDecoder::<f64>::new(values_buffer, bufs, f64::NAN),
+            )?;
+            Ok(true)
+        }
+        (Encoding::ByteStreamSplit, _, ColumnTypeTag::Double) => {
+            clear_aux_buffers(bufs);
+
+            let reconstructed = byte_stream_split_to_plain(values_buffer, size_of::<f64>())?;
+            decode_page0_mode::<_, FILTERED, FILL_NULLS>(
+                page,
+                mode,
+                &mut PlainPrimitiveDecoder::<f64>::new(&reconstructed, bufs, f64::NAN),
             )?;
             Ok(true)
         }
@@ -1490,6 +1527,15 @@ fn decode_other_fixed_dispatch<const FILTERED: bool, const FILL_NULLS: bool>(
                 page,
                 mode,
                 &mut PlainPrimitiveDecoder::<f32>::new(values_buffer, bufs, f32::NAN),
+            )?;
+            Ok(true)
+        }
+        (Encoding::ByteStreamSplit, _, PhysicalType::Float, ColumnTypeTag::Float) => {
+            let reconstructed = byte_stream_split_to_plain(values_buffer, size_of::<f32>())?;
+            decode_page0_mode::<_, FILTERED, FILL_NULLS>(
+                page,
+                mode,
+                &mut PlainPrimitiveDecoder::<f32>::new(&reconstructed, bufs, f32::NAN),
             )?;
             Ok(true)
         }
@@ -2638,6 +2684,63 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_decode_byte_stream_split_double_and_float() {
+        // Explicit BYTE_STREAM_SPLIT config: encoding id 5 with the explicit
+        // flag (bit 24) set. Round-trips Double and Float through our own
+        // encoder and decoder, including NaN nulls placed at every other row.
+        const BSS_CONFIG: i32 = 5 | (1 << 24);
+
+        #[cfg(miri)]
+        let (row_count, row_group_size, data_page_size) = (100, 10, 10);
+        #[cfg(not(miri))]
+        let (row_count, row_group_size, data_page_size) = (10000, 1000, 1000);
+        let version = Version::V2;
+
+        let expected_buffs: Vec<(ColumnBuffers, ColumnType)> = vec![
+            (
+                create_col_data_buff::<f64, 8, _>(row_count, f64::NAN.to_le_bytes(), |d: f64| {
+                    d.to_le_bytes()
+                }),
+                ColumnTypeTag::Double.into_type(),
+            ),
+            (
+                create_col_data_buff::<f32, 4, _>(row_count, f32::NAN.to_le_bytes(), |d: f32| {
+                    d.to_le_bytes()
+                }),
+                ColumnTypeTag::Float.into_type(),
+            ),
+        ];
+
+        let columns = vec![
+            create_fix_column_with_config(
+                0,
+                row_count,
+                "double_col",
+                expected_buffs[0].0.data_vec.as_ref(),
+                ColumnTypeTag::Double.into_type(),
+                BSS_CONFIG,
+            ),
+            create_fix_column_with_config(
+                1,
+                row_count,
+                "float_col",
+                expected_buffs[1].0.data_vec.as_ref(),
+                ColumnTypeTag::Float.into_type(),
+                BSS_CONFIG,
+            ),
+        ];
+
+        assert_columns(
+            row_count,
+            row_group_size,
+            data_page_size,
+            version,
+            columns,
+            &expected_buffs,
+        );
+    }
+
     fn assert_columns(
         row_count: usize,
         row_group_size: usize,
@@ -3307,6 +3410,33 @@ mod tests {
             false,
             false,
             0,
+        )
+        .unwrap()
+    }
+
+    fn create_fix_column_with_config(
+        id: i32,
+        row_count: usize,
+        name: &'static str,
+        primary_data: &[u8],
+        col_type: ColumnType,
+        parquet_encoding_config: i32,
+    ) -> Column {
+        Column::from_raw_data(
+            id,
+            name,
+            col_type.code(),
+            0,
+            row_count,
+            primary_data.as_ptr(),
+            primary_data.len(),
+            null(),
+            0,
+            null(),
+            0,
+            false,
+            false,
+            parquet_encoding_config,
         )
         .unwrap()
     }

--- a/core/rust/qdbr/src/parquet_write/encode.rs
+++ b/core/rust/qdbr/src/parquet_write/encode.rs
@@ -610,6 +610,14 @@ fn encode_float_dispatch(
             options,
             bloom_set,
         ),
+        (Encoding::ByteStreamSplit, Float) => plain::encode_byte_stream_split::<f32>(
+            columns,
+            first_partition_start,
+            last_partition_end,
+            pt,
+            options,
+            bloom_set,
+        ),
         _ => unsupported(encoding, column_tag, "Float"),
     }
 }
@@ -636,6 +644,14 @@ fn encode_double_dispatch(
             bloom_set,
         ),
         (Encoding::RleDictionary, Double) => rle_dictionary::encode_simd::<f64>(
+            columns,
+            first_partition_start,
+            last_partition_end,
+            pt,
+            options,
+            bloom_set,
+        ),
+        (Encoding::ByteStreamSplit, Double) => plain::encode_byte_stream_split::<f64>(
             columns,
             first_partition_start,
             last_partition_end,

--- a/core/rust/qdbr/src/parquet_write/encoders/numeric.rs
+++ b/core/rust/qdbr/src/parquet_write/encoders/numeric.rs
@@ -419,6 +419,23 @@ pub trait SimdEncodable: NativeType {
                     ))
                 }
             }
+            Encoding::ByteStreamSplit => {
+                // Emit K separate byte-streams, where stream k holds the k-th
+                // little-endian byte of every non-null value. This is a pure
+                // transpose of the Plain layout: it isolates the low-entropy
+                // high bytes (sign/exponent of floats) from the noisy mantissa
+                // bytes so a downstream compressor squeezes each stream on its
+                // own. Decoding reverses the transpose. See the matching reader
+                // path in parquet_read::decode.
+                let n = size_of::<Self>();
+                buffer.reserve(n * non_null_count);
+                for k in 0..n {
+                    for x in slice.iter().filter(|x| !x.is_null()) {
+                        buffer.push(x.to_bytes().as_ref()[k]);
+                    }
+                }
+                Ok(buffer)
+            }
             other => Err(fmt_err!(Unsupported, "unsupported encoding {other:?}")),
         }
     }

--- a/core/rust/qdbr/src/parquet_write/encoders/plain/mod.rs
+++ b/core/rust/qdbr/src/parquet_write/encoders/plain/mod.rs
@@ -17,8 +17,8 @@ mod varlen;
 
 pub use fixed::{bytes_to_page, encode_fixed_len_bytes};
 pub use primitive::{
-    boolean_to_page, encode_boolean, encode_decimal, encode_int_notnull, encode_int_nullable,
-    encode_simd,
+    boolean_to_page, encode_boolean, encode_byte_stream_split, encode_decimal, encode_int_notnull,
+    encode_int_nullable, encode_simd,
 };
 pub use varlen::{
     binary_to_page, encode_binary, encode_string, encode_varchar, string_to_page, varchar_to_page,

--- a/core/rust/qdbr/src/parquet_write/encoders/plain/primitive.rs
+++ b/core/rust/qdbr/src/parquet_write/encoders/plain/primitive.rs
@@ -38,6 +38,54 @@ pub fn encode_simd<T>(
 where
     T: SimdEncodable,
 {
+    encode_simd_with::<T>(
+        columns,
+        first_partition_start,
+        last_partition_end,
+        primitive_type,
+        options,
+        bloom_set,
+        Encoding::Plain,
+    )
+}
+
+/// Encode a SIMD-encodable floating-point type as BYTE_STREAM_SPLIT pages.
+/// Shares the Plain page layout (def levels, statistics, bloom) and only
+/// transposes the value bytes into per-byte streams.
+pub fn encode_byte_stream_split<T>(
+    columns: &[Column],
+    first_partition_start: usize,
+    last_partition_end: usize,
+    primitive_type: &PrimitiveType,
+    options: WriteOptions,
+    bloom_set: Option<Arc<Mutex<HashSet<u64>>>>,
+) -> ParquetResult<Vec<Page>>
+where
+    T: SimdEncodable,
+{
+    encode_simd_with::<T>(
+        columns,
+        first_partition_start,
+        last_partition_end,
+        primitive_type,
+        options,
+        bloom_set,
+        Encoding::ByteStreamSplit,
+    )
+}
+
+fn encode_simd_with<T>(
+    columns: &[Column],
+    first_partition_start: usize,
+    last_partition_end: usize,
+    primitive_type: &PrimitiveType,
+    options: WriteOptions,
+    bloom_set: Option<Arc<Mutex<HashSet<u64>>>>,
+    encoding: Encoding,
+) -> ParquetResult<Vec<Page>>
+where
+    T: SimdEncodable,
+{
     let rows_per_page = rows_per_primitive_page(&options, primitive_type.physical_type);
     encode_column_chunk(
         columns,
@@ -54,6 +102,7 @@ where
                 options,
                 primitive_type.clone(),
                 bloom,
+                encoding,
             )
         },
     )
@@ -190,6 +239,7 @@ pub fn encode_boolean(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn simd_segments_to_page<T: SimdEncodable>(
     columns: &[Column],
     first_partition_start: usize,
@@ -198,6 +248,7 @@ fn simd_segments_to_page<T: SimdEncodable>(
     options: WriteOptions,
     primitive_type: PrimitiveType,
     bloom_hashes: Option<&mut HashSet<u64>>,
+    encoding: Encoding,
 ) -> ParquetResult<Page> {
     assert_eq!(primitive_type.field_info.repetition, Repetition::Optional);
 
@@ -210,7 +261,7 @@ fn simd_segments_to_page<T: SimdEncodable>(
     match views.next() {
         None => {
             // Single view: use SIMD-accelerated path (fused def levels + stats + bloom).
-            simd_single_view_page(first, options, primitive_type, bloom_hashes)
+            simd_single_view_page(first, options, primitive_type, bloom_hashes, encoding)
         }
         Some(second) => {
             // Multiple views: scalar single-pass fallback.
@@ -221,6 +272,7 @@ fn simd_segments_to_page<T: SimdEncodable>(
                 options,
                 primitive_type,
                 bloom_hashes,
+                encoding,
             )
         }
     }
@@ -232,6 +284,7 @@ fn simd_single_view_page<T: SimdEncodable>(
     options: WriteOptions,
     primitive_type: PrimitiveType,
     bloom_hashes: Option<&mut HashSet<u64>>,
+    encoding: Encoding,
 ) -> ParquetResult<Page> {
     let num_rows = view.num_rows();
     let mut buffer = Vec::new();
@@ -266,7 +319,7 @@ fn simd_single_view_page<T: SimdEncodable>(
     let definition_levels_byte_length = buffer.len();
     let null_count = view.adjusted_column_top + result.null_count;
 
-    let buffer = T::encode_data(view.slice, result.null_count, Encoding::Plain, buffer)?;
+    let buffer = T::encode_data(view.slice, result.null_count, encoding, buffer)?;
 
     let statistics = if options.write_statistics {
         Some(build_statistics(
@@ -286,13 +339,14 @@ fn simd_single_view_page<T: SimdEncodable>(
         statistics,
         primitive_type,
         options,
-        Encoding::Plain,
+        encoding,
         false,
     )
     .map(Page::Data)
 }
 
 /// Scalar fallback for multi-partition pages.
+#[allow(clippy::too_many_arguments)]
 fn simd_multi_view_page<'a, T: SimdEncodable>(
     first: PartitionChunkView<'a, T>,
     remaining: impl Iterator<Item = PartitionChunkView<'a, T>>,
@@ -300,6 +354,7 @@ fn simd_multi_view_page<'a, T: SimdEncodable>(
     options: WriteOptions,
     primitive_type: PrimitiveType,
     mut bloom_hashes: Option<&mut HashSet<u64>>,
+    encoding: Encoding,
 ) -> ParquetResult<Page> {
     let num_rows = window.row_count;
     let mut validity = FlatValidity::new();
@@ -331,7 +386,8 @@ fn simd_multi_view_page<'a, T: SimdEncodable>(
     let null_count = def_levels.null_count;
     let definition_levels_byte_length = def_levels.definition_levels_byte_length;
 
-    // Pass 2: append present values, updating stats/bloom.
+    // Pass 2: update stats/bloom over the present values, and (for Plain) append
+    // them contiguously.
     for view in &views {
         for &value in view.slice {
             if !value.is_null() {
@@ -341,7 +397,25 @@ fn simd_multi_view_page<'a, T: SimdEncodable>(
                 if let Some(ref mut h) = bloom_hashes {
                     h.insert(hash_native(value));
                 }
-                buffer.extend_from_slice(value.to_bytes().as_ref());
+                if encoding == Encoding::Plain {
+                    buffer.extend_from_slice(value.to_bytes().as_ref());
+                }
+            }
+        }
+    }
+
+    // BYTE_STREAM_SPLIT writes K per-byte streams instead of contiguous values:
+    // stream k holds the k-th little-endian byte of every non-null value, across
+    // all views in order. Decoding reverses this transpose.
+    if encoding == Encoding::ByteStreamSplit {
+        let n = size_of::<T>();
+        for k in 0..n {
+            for view in &views {
+                for &value in view.slice {
+                    if !value.is_null() {
+                        buffer.push(value.to_bytes().as_ref()[k]);
+                    }
+                }
             }
         }
     }
@@ -364,7 +438,7 @@ fn simd_multi_view_page<'a, T: SimdEncodable>(
         stats,
         primitive_type,
         options,
-        Encoding::Plain,
+        encoding,
         false,
     )
     .map(Page::Data)

--- a/core/rust/qdbr/src/parquet_write/mod.rs
+++ b/core/rust/qdbr/src/parquet_write/mod.rs
@@ -1039,6 +1039,84 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_byte_stream_split_double_arrow_roundtrip() {
+        // Encode a Double column with BYTE_STREAM_SPLIT and read it back with the
+        // independent arrow/parquet reader. This confirms the encoder emits
+        // spec-compliant bytes, not merely a layout that is symmetric with our
+        // own decoder.
+        let mut buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        // Values span a few exponents so the high (exponent) bytes actually vary
+        // across the streams, exercising the transpose rather than constant bytes.
+        let col_data: Vec<f64> = (0..1000).map(|i| i as f64 * 0.1 + 1.0).collect();
+        // encoding=5 (byte_stream_split), compression=0 (global default).
+        let bss_config = schema::ParquetEncodingConfig::new(5, 0, 0).raw();
+
+        let col = Column::from_raw_data(
+            0,
+            "bss_double",
+            ColumnTypeTag::Double.into_type().code(),
+            0,
+            1000,
+            col_data.as_ptr() as *const u8,
+            col_data.len() * size_of::<f64>(),
+            null(),
+            0,
+            null(),
+            0,
+            false,
+            false,
+            bss_config,
+        )
+        .unwrap();
+
+        let partition = Partition { table: "t".to_string(), columns: vec![col] };
+        ParquetWriter::new(&mut buf)
+            .with_statistics(true)
+            .finish(partition)
+            .expect("parquet writer");
+
+        buf.set_position(0);
+        let bytes: Bytes = buf.into_inner().into();
+
+        // Metadata: the column chunk must advertise BYTE_STREAM_SPLIT (thrift id 9).
+        let metadata = parquet2::read::read_metadata_with_size(
+            &mut std::io::Cursor::new(bytes.to_byte_slice()),
+            bytes.len() as u64,
+        )
+        .expect("read metadata");
+        let encs = metadata.row_groups[0].columns()[0].column_encoding();
+        assert!(
+            encs.iter().any(|e| e.0 == 9),
+            "expected BYTE_STREAM_SPLIT (9), got {:?}",
+            encs
+        );
+
+        // Data: the independent arrow reader must recover the original values.
+        let reader = ParquetRecordBatchReaderBuilder::try_new(bytes.clone())
+            .expect("reader")
+            .with_batch_size(8192)
+            .build()
+            .expect("builder");
+        let mut idx = 0usize;
+        for batch in reader.flatten() {
+            let arr = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<arrow::array::Float64Array>()
+                .expect("downcast");
+            for i in 0..arr.len() {
+                assert!(
+                    (arr.value(i) - (idx as f64 * 0.1 + 1.0)).abs() < 1e-12,
+                    "value mismatch at row {idx}: got {}",
+                    arr.value(i)
+                );
+                idx += 1;
+            }
+        }
+        assert_eq!(idx, 1000, "expected 1000 rows back");
+    }
+
     /// Helper: pack RleDictionary encoding config (encoding=2, explicit flag set)
     pub(crate) fn rle_dict_config() -> i32 {
         2 | (1 << 24)

--- a/core/rust/qdbr/src/parquet_write/schema.rs
+++ b/core/rust/qdbr/src/parquet_write/schema.rs
@@ -499,10 +499,26 @@ pub fn to_encodings(partition: &Partition) -> Vec<Encoding> {
             if let Some(enc) = c.parquet_encoding_config.encoding() {
                 validate_encoding(c.data_type, enc)
             } else {
-                encoding_map(c.data_type)
+                default_encoding(c.data_type, c.designated_timestamp)
             }
         })
         .collect()
+}
+
+/// Default encoding for a column when the user has not set an explicit
+/// per-column override. The designated timestamp is a sorted, monotonic int64,
+/// so DELTA_BINARY_PACKED stores its near-constant deltas far more compactly
+/// than PLAIN. All other columns fall back to `encoding_map`. Non-designated
+/// timestamps are deliberately excluded: they are not guaranteed to be sorted,
+/// so delta coding offers no reliable benefit over PLAIN for them.
+fn default_encoding(data_type: ColumnType, is_designated_timestamp: bool) -> Encoding {
+    if is_designated_timestamp {
+        // validate_encoding falls back to encoding_map if the type ever stops
+        // supporting DELTA_BINARY_PACKED, so this stays correct by construction.
+        validate_encoding(data_type, Encoding::DeltaBinaryPacked)
+    } else {
+        encoding_map(data_type)
+    }
 }
 
 /// Check whether the given encoding_id is valid for the column type tag.
@@ -1049,6 +1065,53 @@ mod tests {
         );
         assert_eq!(
             validate_encoding(col_type(ColumnTypeTag::String), Encoding::DeltaBinaryPacked),
+            Encoding::DeltaLengthByteArray
+        );
+    }
+
+    #[test]
+    fn test_default_encoding_designated_timestamp_is_delta() {
+        // The designated timestamp defaults to DELTA_BINARY_PACKED rather than PLAIN.
+        assert_eq!(
+            default_encoding(col_type(ColumnTypeTag::Timestamp), true),
+            Encoding::DeltaBinaryPacked
+        );
+    }
+
+    #[test]
+    fn test_default_encoding_non_designated_timestamp_is_plain() {
+        // A non-designated timestamp is not guaranteed sorted, so it keeps PLAIN.
+        assert_eq!(
+            default_encoding(col_type(ColumnTypeTag::Timestamp), false),
+            Encoding::Plain
+        );
+    }
+
+    #[test]
+    fn test_default_encoding_non_timestamp_unaffected() {
+        // The designated-timestamp default must not change other column types.
+        // Plain types stay Plain.
+        for tag in [
+            ColumnTypeTag::Long,
+            ColumnTypeTag::Int,
+            ColumnTypeTag::Double,
+            ColumnTypeTag::Float,
+            ColumnTypeTag::Date,
+        ] {
+            assert_eq!(
+                default_encoding(col_type(tag), false),
+                Encoding::Plain,
+                "{:?} should default to Plain",
+                tag
+            );
+        }
+        // Symbol / string-like types keep their encoding_map defaults.
+        assert_eq!(
+            default_encoding(col_type(ColumnTypeTag::Symbol), false),
+            Encoding::RleDictionary
+        );
+        assert_eq!(
+            default_encoding(col_type(ColumnTypeTag::Varchar), false),
             Encoding::DeltaLengthByteArray
         );
     }

--- a/core/rust/qdbr/src/parquet_write/schema.rs
+++ b/core/rust/qdbr/src/parquet_write/schema.rs
@@ -577,6 +577,12 @@ fn validate_encoding(data_type: ColumnType, encoding: Encoding) -> Encoding {
                 | ColumnTypeTag::GeoInt
                 | ColumnTypeTag::GeoLong
         ),
+        Encoding::ByteStreamSplit => {
+            matches!(
+                data_type.tag(),
+                ColumnTypeTag::Float | ColumnTypeTag::Double
+            )
+        }
         _ => false,
     };
     if valid {
@@ -1117,12 +1123,17 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_encoding_byte_stream_split_falls_back() {
-        // ByteStreamSplit is not supported for any type, should fall back
+    fn test_validate_encoding_byte_stream_split() {
+        // ByteStreamSplit is valid for floating-point columns.
         assert_eq!(
             validate_encoding(col_type(ColumnTypeTag::Float), Encoding::ByteStreamSplit),
-            Encoding::Plain
+            Encoding::ByteStreamSplit
         );
+        assert_eq!(
+            validate_encoding(col_type(ColumnTypeTag::Double), Encoding::ByteStreamSplit),
+            Encoding::ByteStreamSplit
+        );
+        // Non-floating types fall back to their default encoding.
         assert_eq!(
             validate_encoding(col_type(ColumnTypeTag::Int), Encoding::ByteStreamSplit),
             Encoding::Plain

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/parquet/ParquetEncodingTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/parquet/ParquetEncodingTest.java
@@ -68,10 +68,13 @@ public class ParquetEncodingTest {
     };
 
     @Test
-    public void testByteStreamSplitRejectedForAllTypes() {
+    public void testByteStreamSplitOnlyForFloatAndDouble() {
         for (int colType : COLUMN_TYPES) {
-            Assert.assertFalse(
-                    "BYTE_STREAM_SPLIT should be rejected for " + ColumnType.nameOf(colType),
+            int tag = ColumnType.tagOf(colType);
+            boolean expected = tag == ColumnType.FLOAT || tag == ColumnType.DOUBLE;
+            Assert.assertEquals(
+                    "BYTE_STREAM_SPLIT for " + ColumnType.nameOf(colType),
+                    expected,
                     ParquetEncoding.isValidForColumnType(ENCODING_BYTE_STREAM_SPLIT, colType)
             );
         }
@@ -186,6 +189,7 @@ public class ParquetEncodingTest {
                     || tag == ColumnType.GEOSHORT
                     || tag == ColumnType.GEOINT
                     || tag == ColumnType.GEOLONG;
+            case ENCODING_BYTE_STREAM_SPLIT -> tag == ColumnType.FLOAT || tag == ColumnType.DOUBLE;
             default -> false;
         };
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/parquet/PartitionEncoderTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/parquet/PartitionEncoderTest.java
@@ -214,6 +214,51 @@ public class PartitionEncoderTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testDesignatedTimestampDefaultsToDeltaBinaryPacked() throws Exception {
+        // Without an explicit PARQUET(...) override, the designated timestamp is a
+        // sorted, monotonic int64 and defaults to DELTA_BINARY_PACKED. A plain LONG
+        // column is not guaranteed sorted and keeps the PLAIN default.
+        assertMemoryLeak(() -> {
+            inputRoot = root;
+            execute("CREATE TABLE x (" +
+                    " a_long LONG," +
+                    " ts TIMESTAMP" +
+                    ") TIMESTAMP(ts) PARTITION BY MONTH");
+
+            execute("INSERT INTO x SELECT" +
+                    " CASE WHEN x % 2 = 0 THEN rnd_long() ELSE NULL END," +
+                    " timestamp_sequence('2015-01-01', 1_000_000)" +
+                    " FROM long_sequence(1000)");
+
+            try (
+                    Path path = new Path();
+                    PartitionDescriptor partitionDescriptor = new PartitionDescriptor();
+                    TableReader reader = engine.getReader("x")
+            ) {
+                path.of(root).concat("x.parquet").$();
+                PartitionEncoder.populateFromTableReader(reader, partitionDescriptor, 0);
+                PartitionEncoder.encode(partitionDescriptor, path);
+                assertSqlCursors(
+                        "SELECT * FROM x",
+                        "SELECT * FROM read_parquet('x.parquet')"
+                );
+                ParquetTestUtils.assertColumnsUseEncoding(
+                        path.toString(),
+                        configuration.getFilesFacade(),
+                        ParquetEncoding.ENCODING_DELTA_BINARY_PACKED,
+                        1 // ts (designated timestamp)
+                );
+                ParquetTestUtils.assertColumnsDoNotUseEncoding(
+                        path.toString(),
+                        configuration.getFilesFacade(),
+                        ParquetEncoding.ENCODING_DELTA_BINARY_PACKED,
+                        0 // a_long stays PLAIN
+                );
+            }
+        });
+    }
+
+    @Test
     public void testSymbolCompressionOnly() throws Exception {
         assertMemoryLeak(() -> {
             inputRoot = root;

--- a/docs/lossy-float-compression.md
+++ b/docs/lossy-float-compression.md
@@ -265,8 +265,18 @@ Self-contained and useful on its own, independent of any lossy work:
   `(DeltaBinaryPacked, Timestamp)` (`encode.rs:503-523`), so this was a default
   change only. Covered by Rust unit tests in `schema.rs` and a Java round-trip
   test `PartitionEncoderTest.testDesignatedTimestampDefaultsToDeltaBinaryPacked`.
-- **PR1b:** implement `BYTE_STREAM_SPLIT` for `Double`/`Float`. It is currently
-  *declared*
+- **PR1b (done):** implement `BYTE_STREAM_SPLIT` for `Double`/`Float`, both
+  encoder and decoder. Encoder transposes the Plain little-endian bytes into K
+  per-byte streams (`encoders/numeric.rs` `encode_data`, threaded through
+  `encoders/plain/primitive.rs` and dispatched in `encode.rs`); `validate_encoding`
+  accepts it for floating types only. Decoder un-transposes the page back to the
+  contiguous layout and reuses the existing `PlainPrimitiveDecoder`
+  (`parquet_read/decode.rs` `byte_stream_split_to_plain`). Tests: schema
+  validation, a self round-trip through our own decoder (Double + Float with NaN
+  nulls), and an independent `arrow`-reader round-trip that confirms the bytes are
+  spec-compliant rather than merely symmetric with our decoder.
+
+  It was previously *declared*
   (config id 5 parses) but **not implemented**: `validate_encoding` has no arm
   for it and the dispatch in `encode.rs` only matches PLAIN/RleDictionary, so it
   silently falls back to PLAIN (`schema.rs:1057` test confirms). BYTE_STREAM_SPLIT

--- a/docs/lossy-float-compression.md
+++ b/docs/lossy-float-compression.md
@@ -1,0 +1,368 @@
+# Lossy float compression for Parquet partitions
+
+## Status
+
+Design proposal. No implementation yet.
+
+## Summary
+
+Add optional, per-column **lossy** compression for `DOUBLE`/`FLOAT` columns, applied
+when a partition is converted to Parquet. The user specifies an accepted error
+(a relative tolerance), and the encoder discards numeric precision below that
+threshold so the generic Parquet compressor (ZSTD et al.) can shrink the column
+far beyond what lossless encoding achieves.
+
+The feature is inspired by the `LnQ16` codec family in the arctic TickStore
+(`arctic/tickstore/coding.py`), which logarithmically quantizes financial tick
+values to ~16-bit integers at a near-constant relative error (~1 basis point)
+across a very large dynamic range.
+
+## Motivation
+
+Financial tick data (prices, quantities) is stored at far higher precision than
+anyone queries it at. A price recorded to 15 significant decimal digits is
+wasteful when downstream analysis only cares to ~1 basis point (1e-4). The
+excess mantissa bits are effectively noise, and noise does not compress: a raw
+`DOUBLE` column of prices stored losslessly in Parquet still costs close to its
+full 8 bytes per value after ZSTD, because the low-order mantissa bits are
+high-entropy.
+
+Discarding precision the user has declared irrelevant turns that noise into
+zeros (or into a narrow integer range), which compresses dramatically. The
+arctic codec reaches roughly 2 bytes per value at ~1 bp error on real tick
+series. This proposal brings the same trade-off to QuestDB without disturbing
+its hot-path storage.
+
+## Goals
+
+- Per-column, opt-in lossy compression for `DOUBLE`/`FLOAT`, specified as an
+  accepted relative error.
+- A closed-form mapping from accepted error to codec parameters, plus a cheap
+  calibration step to predict the resulting byte size.
+- Correct handling of NULL (the `NaN` sentinel), and of zero / negative values.
+- No change to QuestDB's native (`.d`) storage path or its hot-write/random-access
+  performance characteristics.
+- Round-trippable: a decoded value is guaranteed within the declared tolerance
+  of the original.
+
+## Non-goals
+
+- Lossy compression of native `.d` columns. See "Why Parquet only" below.
+- Lossy compression of non-floating types.
+- Automatic, age-based conversion of partitions to Parquet. That is a separate,
+  pre-existing future item (`SqlCompilerImpl.java:4943`).
+
+## Background: current QuestDB storage
+
+QuestDB has two partition storage tiers:
+
+- **Native (`.d` files)** — the default for every partition. `DOUBLE` columns are
+  raw IEEE-754 little-endian values, memory-mapped 1:1 and addressed as
+  `base + i*8` (`MemoryPARWImpl`, write path `TableWriter.putDouble`,
+  `TableWriter.java:13758`). There is **no compression layer** in native storage.
+  The format depends on fixed-width random access, which a variable-rate codec
+  would break.
+- **Parquet partitions** — opt-in, per-partition, via DDL:
+  `ALTER TABLE t CONVERT PARTITION TO PARQUET [WHERE ...]` and the inverse
+  `CONVERT PARTITION TO NATIVE` (`AlterOperation.java:71-72`,
+  `TableWriter.convertPartitionNativeToParquet` ~`1531`). Conversion is manual;
+  there is no automatic tiering. The active (latest) partition stays native on
+  non-WAL tables; WAL tables may have a Parquet active partition, merged via the
+  O3 path. Direct appends to a Parquet partition are not allowed
+  (`TableWriter.java:8802`).
+
+### Why Parquet only
+
+Converting a partition to Parquet is already an explicit "freeze this cold data
+to save disk, and accept slower access" decision. That is precisely the moment a
+user would also accept losing irrelevant precision. Native storage is the speed
+tier (fast ingest, O(1) random access, SIMD/JIT execution over raw layout); a
+lossy variable-rate codec there would fight everything native is good at, and
+native has no compression layer to extend in the first place. So lossy
+compression is scoped as an extension of the Parquet conversion path.
+
+## What TickStore does, and how it maps onto QuestDB
+
+TickStore predates having a columnar file format underneath it, so it hand-rolls
+three techniques. Two of the three are already provided by Parquet as standard
+encodings; only the third is genuinely new.
+
+### 1. Row-masks -> already provided by Parquet nulls
+
+TickStore stores a per-column packed bitmap (`ROWMASK`, lz4-compressed) marking
+which rows have a value, so each sparse column stores only its present values
+(`tickstore.py:1407`, `rm = ~np.isnan(val)`).
+
+QuestDB's Parquet encoder already does exactly this. A NULL double (the
+`Double.NaN` sentinel) maps to a real Parquet null at definition level 0:
+
+- `parquet_write/encoders/numeric.rs:510` — the `f64` encoder's `is_null()` is
+  `self.is_nan()`.
+- `parquet_write/simd.rs:836` — `encode_f64_def_levels()` records NaN positions
+  in the RLE/bit-packed definition-level bitmap.
+- `parquet_write/encoders/numeric.rs:316` — null values are filtered out of the
+  value buffer entirely.
+
+So an absent value costs ~0 data bytes plus a bit in an RLE bitmap — the rowmask,
+standardized. **Do not port it.** (Caveat: the sparse-column win only
+materializes if the schema actually leaves untouched fields NULL per row; that is
+a data-modeling decision, not a codec one.)
+
+### 2. Index delta-zigzag -> supported, but not the default
+
+TickStore delta-encodes the monotonic timestamp index and varint-packs it
+(`tickstore.py:1385`, `np.diff(idx, prepend=0)`).
+
+Parquet's `DELTA_BINARY_PACKED` is exactly delta + zigzag + bit-packing for
+integer columns, and QuestDB validates it as legal for the timestamp type
+(`schema.rs:549-563`, `Timestamp` is in the accepted set). **But it is not the
+default.** `encoding_map` (`schema.rs:691-699`) hands every numeric column
+`Plain`:
+
+```rust
+match data_type.tag() {
+    Symbol                    => RleDictionary,
+    Binary | Varchar | String => DeltaLengthByteArray,
+    _                         => Plain,   // Long, Int, Timestamp, Double, ...
+}
+```
+
+So the designated timestamp — a sorted, monotonic microsecond `int64`, about the
+most delta-friendly column that exists — is written as raw 8-byte values today.
+A user can already opt in by setting that column's encoding to id 4
+(`DELTA_BINARY_PACKED`) via the per-column config, but it is never chosen
+automatically. **Do not reimplement; change the default.**
+
+### 3. LnQ logarithmic quantization -> genuinely new
+
+Parquet has no lossy float encoding. This is the only piece worth building.
+
+## Design
+
+### Two codec tiers
+
+An IEEE-754 double is already a companded (log-like) representation: exponent
+plus mantissa. That gives two natural realizations of "constant relative error,"
+at different aggression levels.
+
+**Tier A — mantissa bit-rounding ("bit grooming").** Zero the low mantissa bits,
+keeping the top `k`. The value remains a valid IEEE-754 double, so:
+
+- the relative error is bounded by `2^-(k+1)`,
+- the Parquet **read path needs zero changes** (it is still a normal double),
+- the zeroed low bytes become constant and compress to almost nothing under
+  `BYTE_STREAM_SPLIT` + ZSTD.
+
+This is the simple, low-risk 80%. It does not reach arctic's ratios because the
+value is still physically a 64-bit double, but it requires no inverse transform.
+
+**Tier B — companded narrow-integer codec (the arctic-style path).** Map each
+value through a companding curve, quantize to a narrow integer (int16/int32),
+store that integer column in Parquet (with `DELTA_BINARY_PACKED`), and apply the
+inverse transform on read. This reaches ~2 bytes per value but changes the
+on-disk type and adds a decode step to every read of the column.
+
+For the companding curve, **prefer mu-law over TickStore's raw
+`ln(x * 2^prescale + preadd)`**:
+
+```
+mu-law:   y = sign(x) * ln(1 + mu*|x|/Xmax) / ln(1 + mu)      (encode, y in [-1,1])
+inverse:  x = sign(y) * (Xmax/mu) * ((1+mu)^|y| - 1)          (decode)
+```
+
+mu-law improves on the raw-log formulation because:
+
+- It handles **sign and zero natively** (symmetric, smooth through 0), removing
+  TickStore's `abs()` + `*sign` + `preadd` workarounds that exist only because
+  `ln(0) = -inf`.
+- It is **bounded** to `[-1,1]`, eliminating the `prescale` tuning that exists
+  only to stop float32 log math overflowing (TickStore overflows at ~2.2e27).
+- Its range parameter `Xmax` can be **derived from Parquet per-page min/max
+  statistics**, which the encoder already computes — nothing extra to store.
+
+The trade-off to validate: raw log gives constant *relative* error across the
+entire range; mu-law gives constant relative error only in its logarithmic
+region `|x| >> Xmax/mu` and transitions to constant *absolute* error near zero.
+For tick prices this is usually acceptable or even preferable (more robust than a
+log blow-up near zero), but the realized error profile must be plotted against a
+real price/quantity distribution before declaring it equivalent to the flat-bps
+guarantee.
+
+### Sizing the quantizer from an accepted error (closed form)
+
+The quantizer parameters follow directly from the accepted relative error `eps`
+and the column's log-dynamic-range `R = ln(xmax/xmin)`; no search is needed.
+
+**Raw log / LnQ.** Stored code `i = round(ln(x) * K)`, `K = 2^n / R`. The
+log-domain step is `1/K`, and a half-step error in log space approximates the
+relative error, so:
+
+```
+rtol ~= R / 2^(n+1)        =>        n = ceil( log2( ln(xmax/xmin) / (2*eps) ) )
+```
+
+This reproduces TickStore's own numbers: its `loss` parameter is `2^16/K`, giving
+`rtol ~= loss / 2^17` — `loss=15` yields 114 ppm, matching its "LnQ15, 115 ppm"
+comment. Worked example: prices spanning `1e-3 .. 1e6` (`R ~= 20.7`) at
+`eps = 1 bp = 1e-4` need `n = ceil(log2(20.7 / 2e-4)) = 17` bits per value before
+delta and entropy coding.
+
+**mu-law.** Relative-error floor in the log region `~= ln(1+mu) / 2^n`, with the
+relative/absolute crossover at `|x| ~= Xmax/mu`. So pick `mu` from the dynamic
+range you want kept relative, and `n` from `eps` — two one-line formulas.
+
+**mantissa rounding.** `eps ~= 2^-(k+1)` => `k = ceil(log2(1/(2*eps)))` mantissa
+bits kept. Trivial.
+
+### Predicting the byte size (calibration)
+
+The formulas above size the *quantizer* — its entropy ceiling in bits per
+sample. They do **not** predict the final file size, because after delta-coding,
+ZSTD exploits temporal autocorrelation that is entirely data-dependent. So the
+workflow is:
+
+1. Closed-form: pick `n` / `mu` / `loss` / `k` for the error target (instant).
+2. Calibration sweep: encode a representative sample at 3-4 settings, measure
+   realized rtol and compressed bytes, interpolate. Encoding is fast, so this is
+   a seconds-long step and the only empirical part.
+
+## Configuration surface
+
+The accepted error is a per-column property supplied at conversion time. Two
+delivery mechanisms, not mutually exclusive:
+
+- **DDL `WITH` clause** on the conversion statement (per-column, explicit):
+
+  ```sql
+  ALTER TABLE trades CONVERT PARTITION TO PARQUET WHERE timestamp < '2026-01-01'
+    WITH (price LOSSY 1bps, size LOSSY 1bps);   -- illustrative syntax
+  ```
+
+- **Per-column Parquet config defaults** via `cairo.partition.encoder.parquet.*`
+  configuration, for tables converted without an explicit clause.
+
+Both feed the existing per-column config plumbing: `TableColumnMetadata`
+`parquetEncodingConfig` (`TableColumnMetadata.java:45`), packed by
+`TableUtils.packParquetConfig` (bit layout `TableUtils.java:249`). The packed
+i32 currently uses bits 0-25 (encoding, compression, level, explicit flag, bloom
+flag — `schema.rs:581-597`); the lossy codec id and a precision parameter need a
+home in the spare high bits, or a widening of this config word. This is a
+schema/forward-compat decision to settle early because the packed config is
+persisted.
+
+## Implementation plan
+
+Three independent, separately shippable pieces, smallest and most reusable first.
+
+### PR 1 — lossless prerequisites (no precision loss)
+
+Self-contained and useful on its own, independent of any lossy work:
+
+- **PR1a (done):** default the designated timestamp to `DELTA_BINARY_PACKED`.
+  Implemented as a `default_encoding(data_type, is_designated_timestamp)` helper
+  in `to_encodings` (`schema.rs`); non-designated timestamps stay PLAIN since
+  they are not guaranteed sorted. The encode dispatch already supported
+  `(DeltaBinaryPacked, Timestamp)` (`encode.rs:503-523`), so this was a default
+  change only. Covered by Rust unit tests in `schema.rs` and a Java round-trip
+  test `PartitionEncoderTest.testDesignatedTimestampDefaultsToDeltaBinaryPacked`.
+- **PR1b:** implement `BYTE_STREAM_SPLIT` for `Double`/`Float`. It is currently
+  *declared*
+  (config id 5 parses) but **not implemented**: `validate_encoding` has no arm
+  for it and the dispatch in `encode.rs` only matches PLAIN/RleDictionary, so it
+  silently falls back to PLAIN (`schema.rs:1057` test confirms). BYTE_STREAM_SPLIT
+  is the encoding that makes Tier A's rounded doubles compress well, so it is a
+  prerequisite for Tier A and a lossless win regardless.
+
+### PR 2 — Tier A: mantissa bit-rounding
+
+- Add a lossy codec id + precision (kept-mantissa-bits or accepted rtol) to the
+  packed per-column config.
+- In the Rust encoder, apply the rounding pass to `Double`/`Float` columns before
+  encoding; the output remains a valid double, so the read path is untouched.
+- Pair with `BYTE_STREAM_SPLIT` + ZSTD from PR 1.
+- DDL `WITH (... LOSSY ...)` parsing.
+
+### PR 3 — Tier B: mu-law companded narrow-int codec
+
+- Encode `Double`/`Float` as a companded int16/int32 column plus the metadata
+  needed to invert (`mu`, `Xmax` from page stats, `n`).
+- Inverse transform on the Parquet read path for these columns.
+- This is the larger change: it touches the read path and introduces a stored
+  type distinct from the logical column type, so it needs careful handling in the
+  Parquet reader and in anything that inspects Parquet column types.
+
+## Read path
+
+- Tier A requires no read changes: the stored value is a normal double already
+  within tolerance.
+- Tier B requires the Parquet reader to recognize the companded column and apply
+  the inverse transform, materializing a `DOUBLE` for the rest of the engine. The
+  logical column type stays `DOUBLE`; only the physical Parquet representation
+  differs. Predicate pushdown / page-stats pruning on these columns must account
+  for the transform (min/max in companded space map monotonically to value space,
+  so range pruning is still valid, but the comparison must be done correctly).
+
+## Testing
+
+Per repository conventions (`assertMemoryLeak`, error-path resource cleanup):
+
+- Round-trip error bound: for each codec and a range of `eps`, assert every
+  decoded value is within the declared tolerance of the original, across the full
+  dynamic range including subnormals, very large, and very small magnitudes.
+- NULL handling: `NaN` must round-trip as a Parquet null (Tier A) or be excluded
+  from companding and restored as NULL (Tier B). Confirm null doubles still cost
+  ~0 data bytes.
+- Sign and zero: signed inputs and exact zeros for Tier B (mu-law) round-trip
+  correctly.
+- Non-finite guard: `+inf`/`-inf` inputs must fail fast or be treated as NULL,
+  never silently corrupt (cf. TickStore's `_assert_finite`).
+- Resource cleanup on every error path in the encoder and the
+  convert-to-Parquet / convert-back-to-native flows.
+- Convert-to-Parquet-then-back-to-native: define and test the semantics —
+  conversion back to native cannot recover lost precision; the rounded values are
+  what persist.
+- Calibration: a test asserting the closed-form `rtol` formula matches measured
+  round-trip error within a small margin for each codec.
+
+## Risks and trade-offs
+
+- **Irreversible precision loss.** Once a partition is converted with a lossy
+  codec, the original precision is gone; converting back to native restores the
+  rounded values, not the originals. This must be explicit in the DDL and
+  documented; it is the one genuinely destructive operation here.
+- **Tier B read cost.** The inverse transform runs on every read of a companded
+  column, trading CPU for the smaller on-disk size. Acceptable for cold archival
+  data, but it is a real cost and should be measured, not assumed negligible.
+- **mu-law near-zero behaviour.** Constant-relative only in the log region; the
+  flat-bps guarantee does not hold for tiny magnitudes. Validate against real
+  distributions before claiming arctic-equivalent error.
+- **Persisted config format.** The packed per-column config is written to disk;
+  the lossy codec id and precision must be laid out with forward compatibility in
+  mind, and old files without the field must read back correctly.
+- **Interoperability.** Tier A output is plain Parquet readable by any tool.
+  Tier B stores integers plus QuestDB-specific transform metadata; external
+  readers see integers, not the intended doubles, unless they know the transform.
+  This narrows Tier B's interop benefit relative to staying lossless.
+
+## Open questions
+
+- Error specification units in DDL: relative tolerance (`1bps`, `1e-4`),
+  kept-significant-bits, or kept-decimal-digits? Relative tolerance maps cleanly
+  to all three codecs via the closed-form sizing.
+- Should `Xmax` for mu-law be per-page (from Parquet stats, adapts to local
+  range) or per-column (one value, simpler, stored once)?
+- Is Tier B worth the read-path complexity and interop cost, or does Tier A +
+  `BYTE_STREAM_SPLIT` + ZSTD capture enough of the benefit for the target
+  workloads? Decide with the calibration sweep on real data before committing to
+  PR 3.
+
+## References
+
+- arctic TickStore codecs: `arctic/tickstore/coding.py` (`LnQ16_VQL`, `ln_q16` /
+  `e_q16`, `log_q16` / `exp_q16`), rowmask and index encoding in
+  `arctic/tickstore/tickstore.py`.
+- QuestDB Parquet encoder: `core/rust/qdbr/src/parquet_write/`
+  (`schema.rs`, `encode.rs`, `simd.rs`, `encoders/numeric.rs`).
+- Parquet config plumbing: `TableColumnMetadata.java`, `TableUtils.java`
+  (`packParquetConfig`), `PartitionEncoder.java`, `ParquetEncoding.java`,
+  `ParquetCompression.java`.


### PR DESCRIPTION
## What

Two improvements to how QuestDB encodes partitions converted to Parquet
(`ALTER TABLE ... CONVERT PARTITION TO PARQUET`):

- The designated timestamp now defaults to `DELTA_BINARY_PACKED` instead of
  `PLAIN`. A sorted, monotonic microsecond timestamp has small, near-constant
  deltas that this encoding stores far more compactly. It applies automatically
  to every converted partition. Non-designated timestamps keep `PLAIN`, since
  they are not guaranteed to be sorted and delta coding offers them no reliable
  benefit.
- `BYTE_STREAM_SPLIT` is now implemented for `FLOAT` and `DOUBLE` columns, both
  encoder and decoder. It was previously accepted by the per-column encoding
  config but silently fell back to `PLAIN`, and the read path had no decoder for
  it. It transposes the value bytes into per-byte streams, which clusters the
  low-entropy high bytes (a float's sign and exponent change little from row to
  row) so the compressor squeezes them, while isolating the noisy mantissa
  bytes. Opt in per column with `PARQUET(byte_stream_split)`.

Both changes are lossless.

## Impact

- Smaller Parquet partitions. The timestamp change is automatic; on a sorted
  timestamp column it cuts that column's size substantially. `BYTE_STREAM_SPLIT`
  helps floating-point columns whose high bytes vary little across rows; the
  benefit is data-dependent and can be small or negligible for high-entropy
  float data.
- `BYTE_STREAM_SPLIT` adds a byte transpose on encode and an inverse transpose
  on decode (the decoder reconstructs the contiguous layout and reuses the
  existing plain decoder, so null handling and filtering are unchanged). It
  trades a small amount of CPU for size and is opt-in.
- `DELTA_BINARY_PACKED` was already implemented and validated for the timestamp
  type; this only changes the default selection, so the encode and decode paths
  themselves are unchanged.
- No change to native (non-Parquet) storage, to ingestion, or to reading
  existing Parquet files.

## Test plan

- Rust unit tests for the default encoding selection (designated vs
  non-designated timestamp) and for `BYTE_STREAM_SPLIT` validity (accepted for
  FLOAT/DOUBLE only, other types fall back).
- Rust round-trip tests for `BYTE_STREAM_SPLIT` through both the QuestDB decoder
  and an independent arrow reader, confirming the output is spec-compliant and
  not merely symmetric with our own decoder, including NaN-null handling.
- Full Rust lib suite: 908 tests pass.
- Java tests against a locally rebuilt native library on JDK 25 -
  `PartitionEncoderTest`, `ParquetEncodingTest`, `ReadParquetFunctionTest`:
  125 tests pass.
