### PR TITLE
ci(core): split windows/mac PR ci runs into a separate pipeline

### DIFF
--- a/ci/test-hosted-pipeline.yml
+++ b/ci/test-hosted-pipeline.yml
@@ -1,0 +1,37 @@
+# On-demand macOS/Windows test pipeline.
+trigger: none
+
+pr:
+  branches:
+    include:
+      - master
+  drafts: false
+
+variables:
+  QDB_LOG_W_FILE_LOCATION: "$(Build.BinariesDirectory)/tests.log"
+  ARCHIVED_LOGS: "$(Build.ArtifactStagingDirectory)/questdb-$(Build.SourceBranchName)-$(Build.SourceVersion)-$(System.StageAttempt)-$(Agent.OS)-$(jdk).zip"
+  DIFF_COVER_THRESHOLD_PCT: 50
+  excludeTests: ""
+  includeTests: "%regex[.*[^o].class]"
+  MAVEN_CACHE_FOLDER: $(HOME)/.m2/repository
+  MAVEN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Xmx3g -XX:+UseParallelGC"
+  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 "
+  MAVEN_VERSION: "version"
+  MAVEN_VERSION_OPTION: "Default"
+  # Hosted mac/windows jobs (hosted-jobs.yml) override this to "-pl core -am" and
+  # drop the unused web console.
+  TEST_REACTOR_ARGS: ""
+  WEB_CONSOLE_PROFILE: "-P build-web-console"
+
+stages:
+  - stage: CheckChanges
+    displayName: "Check Changes"
+    jobs:
+      - template: templates/check-changes-job.yml
+
+  - stage: HostedRunTestsBranches
+    displayName: "Hosted Running tests"
+    dependsOn:
+      - CheckChanges
+    jobs:
+      - template: templates/hosted-jobs.yml

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -17,8 +17,8 @@ variables:
   MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 "
   MAVEN_VERSION: "version"
   MAVEN_VERSION_OPTION: "Default"
-  # Full-reactor defaults for the self-hosted Linux jobs. Hosted mac/windows jobs
-  # (hosted-jobs.yml) override these to "-pl core -am" and drop the unused web console.
+  # Full-reactor defaults for the self-hosted Linux jobs. The hosted mac/windows
+  # jobs run on demand in test-hosted-pipeline.yml, not here.
   TEST_REACTOR_ARGS: ""
   WEB_CONSOLE_PROFILE: "-P build-web-console"
 
@@ -159,13 +159,6 @@ stages:
       - template: templates/self-hosted-jobs.yml
     variables:
       excludeTests: "**/griffin/**,**/cairo/**,**/cutlass/pgwire/**,**/cutlass/http/**,**/std/*,**/std/str/**,**/std/datetime/microtime/**,**/std/fastdouble/**,**/std/bytes/**,**/log/**,**/sqllogictest/*,**/network/**"
-
-  - stage: HostedRunTestsBranches
-    displayName: "Hosted Running tests"
-    dependsOn:
-      - CheckChanges
-    jobs:
-      - template: templates/hosted-jobs.yml
 
   - stage: SelfHostedRunTestsCoverageBranches
     displayName: "SelfHosted Running tests with cover"


### PR DESCRIPTION
Hosted mac/windows agents do not scale to every PR commit. This moves the
`HostedRunTestsBranches` matrix out of `test-pipeline.yml` into a new
`ci/test-hosted-pipeline.yml`. The main PR pipeline keeps Linux, coverage, and
lint and no longer runs hosted jobs on every push.

The new pipeline keeps a `pr` trigger but is meant to run on demand: with the
Azure DevOps "Require a team member's comment before building" setting enabled,
a developer starts it by commenting `/azp run <pipeline name>` once the cheaper
stages and review are green.

Tradeoff: Windows/macOS regressions are no longer caught automatically and can
merge if nobody triggers the run. `/azp run` is also honored only for
collaborators and only on mergeable (conflict-free) PRs.

Follow-up (outside this PR): register the new pipeline in Azure DevOps with the
"require comment" setting, and update `master` branch protection so the old
auto-running Win/Mac checks no longer block merges.

## Test plan

- `test-pipeline.yml` runs its remaining stages with no `HostedRunTestsBranches`.
- After registration, `/azp run <name>` on a mergeable PR runs only the mac/windows matrix.
- A plain push does not auto-start the new pipeline.
