### PR TITLE
fix(sql): fix count() over a GROUP BY subquery reporting phantom duplicates

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -6215,17 +6215,14 @@ public class SqlOptimiser implements Mutable {
             propagateTopDownColumns0(jm, false, model, true);
         }
 
-        // If this is group by model we need to add all non-selected keys, only if this is sub-query
-        // For top level models top-down column list will be empty
-        if (model.getSelectModelType() == IQueryModel.SELECT_MODEL_GROUP_BY && model.getTopDownColumns().size() > 0) {
-            final ObjList<QueryColumn> bottomUpColumns = model.getBottomUpColumns();
-            for (int i = 0, n = bottomUpColumns.size(); i < n; i++) {
-                QueryColumn qc = bottomUpColumns.getQuick(i);
-                if (qc.getAst().type != FUNCTION || !functionParser.getFunctionFactoryCache().isGroupBy(qc.getAst().token)) {
-                    model.addTopDownColumn(qc, qc.getAlias());
-                }
-            }
-        }
+        // If this is a group by sub-query whose projection will be pruned to its top-down columns,
+        // retain all non-selected grouping keys so pruning cannot collapse the keyed group by into a
+        // scalar aggregate. This early pass preserves the key ordering for the common case where the
+        // parent already contributed top-down columns; it is repeated once more below, after the
+        // model's own WHERE/HAVING and ORDER BY literals have been emitted, to also cover a HAVING-style
+        // filter that references only an aggregate alias (its literals are the sole top-down contributor,
+        // so an empty list here would skip retention). For top level models the list is empty -> no-op.
+        retainGroupByKeysAsTopDownColumns(model);
 
         // latest on
         if (model.getLatestBy().size() > 0) {
@@ -6258,6 +6255,14 @@ public class SqlOptimiser implements Mutable {
         if (!topLevel) {
             emitLiteralsTopDown(model.getOrderBy(), model);
         }
+
+        // Repeat group by key retention now that the model's own WHERE/HAVING and ORDER BY literals
+        // have been emitted into top-down columns. This covers HAVING-style filters on a group by
+        // sub-query whose only top-down contribution is an aggregate alias (e.g. count() > 1); the
+        // early pass above would have observed an empty list and skipped, letting pruning collapse the
+        // keyed group by into a scalar aggregate. addTopDownColumn() dedupes by alias, so re-running is
+        // idempotent and leaves the key ordering from the early pass untouched in the common case.
+        retainGroupByKeysAsTopDownColumns(model);
 
         if (nestedIsFlex && nestedAllowsColumnChange) {
             emitColumnLiteralsTopDown(model.getColumns(), nested);
@@ -7248,6 +7253,23 @@ public class SqlOptimiser implements Mutable {
                 }
             }
             node = sqlNodeStack.poll();
+        }
+    }
+
+    // Adds every non-aggregate grouping key of a GROUP BY model to its top-down column list, so that
+    // top-down column pruning cannot drop the keys that define the grouping. Runs only when the model
+    // already has top-down columns, i.e. when it is a sub-query whose projection will be pruned; for a
+    // top level model the top-down list is empty and the bottom-up projection is used verbatim, so there
+    // is nothing to protect. addTopDownColumn() dedupes by alias, making repeated calls idempotent.
+    private void retainGroupByKeysAsTopDownColumns(IQueryModel model) {
+        if (model.getSelectModelType() == IQueryModel.SELECT_MODEL_GROUP_BY && model.getTopDownColumns().size() > 0) {
+            final ObjList<QueryColumn> bottomUpColumns = model.getBottomUpColumns();
+            for (int i = 0, n = bottomUpColumns.size(); i < n; i++) {
+                QueryColumn qc = bottomUpColumns.getQuick(i);
+                if (qc.getAst().type != FUNCTION || !functionParser.getFunctionFactoryCache().isGroupBy(qc.getAst().token)) {
+                    model.addTopDownColumn(qc, qc.getAlias());
+                }
+            }
         }
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/CountTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/CountTest.java
@@ -154,6 +154,57 @@ public class CountTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCountOverKeyedGroupBySubqueryWithHavingFilter() throws Exception {
+        // https://github.com/questdb/questdb/issues/7201
+        // count()/size over a keyed GROUP BY subquery, filtered on the aggregate alias
+        // (a HAVING-style predicate), must keep the grouping keys. The top-down column
+        // pruning used to drop the unreferenced keys, collapsing the keyed group by into
+        // a scalar count() and producing phantom "duplicate" groups.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tab (ts TIMESTAMP, s SYMBOL INDEX) " +
+                    "TIMESTAMP(ts) PARTITION BY DAY WAL DEDUP UPSERT KEYS(ts, s)");
+            execute("INSERT INTO tab " +
+                    "SELECT '2020-02-27T12:00:00.000000Z'::TIMESTAMP, ('sym' || (x - 1)) " +
+                    "FROM long_sequence(12)");
+            drainWalQueue();
+
+            // the keyed group by must survive in the plan (not collapse into a bare Count)
+            assertPlanNoLeakCheck(
+                    "SELECT count() dups FROM (SELECT ts, s, count() c FROM tab) WHERE c > 1",
+                    """
+                            Count
+                                Filter filter: 1<c
+                                    Async Group By workers: 1
+                                      keys: [ts,s]
+                                      values: [count(*)]
+                                      filter: null
+                                        PageFrame
+                                            Row forward scan
+                                            Frame forward scan on: tab
+                            """
+            );
+
+            // all 12 (ts,s) pairs are unique, so no group has count > 1
+            assertSql("dups\n0\n", "SELECT count() dups FROM (SELECT ts, s, count() c FROM tab) WHERE c > 1");
+            // the materialized projection over the same subquery agrees: it is empty
+            assertSql("ts\ts\tc\n", "SELECT ts, s, c FROM (SELECT ts, s, count() c FROM tab) WHERE c > 1");
+            // without the predicate, count() over the subquery counts the 12 groups
+            assertSql("count\n12\n", "SELECT count() FROM (SELECT ts, s, count() c FROM tab)");
+            // a single-key subquery behaves the same way
+            assertSql("count\n0\n", "SELECT count() FROM (SELECT s, count() c FROM tab) WHERE c > 1");
+
+            // genuine duplicates are still reported: 3 symbols, each repeated 4 times
+            execute("CREATE TABLE dup (ts TIMESTAMP, s SYMBOL) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("INSERT INTO dup " +
+                    "SELECT ('2020-02-27T12:00:00.000000Z'::TIMESTAMP + x), ('sym' || (x % 3)) " +
+                    "FROM long_sequence(12)");
+            assertSql("dups\n3\n", "SELECT count() dups FROM (SELECT s, count() c FROM dup) WHERE c > 1");
+            // a non-count outer aggregate over the filtered subquery is also correct: 3 groups of 4
+            assertSql("sum\n12\n", "SELECT sum(c) FROM (SELECT s, count() c FROM dup) WHERE c > 1");
+        });
+    }
+
+    @Test
     public void testCountUuid() throws Exception {
         assertQuery("select count(uuid), first(uuid), last(uuid) from x where id % 2 = 0")
                 .ddl("create table x as (" +

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/CountTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/CountTest.java
@@ -170,8 +170,7 @@ public class CountTest extends AbstractCairoTest {
 
             // the keyed group by must survive in the plan (not collapse into a bare Count)
             assertPlanNoLeakCheck(
-                    "SELECT count() dups FROM (SELECT ts, s, count() c FROM tab) WHERE c > 1",
-                    """
+                    "SELECT count() dups FROM (SELECT ts, s, count() c FROM tab) WHERE c > 1", """
                             Count
                                 Filter filter: 1<c
                                     Async Group By workers: 1
@@ -185,22 +184,44 @@ public class CountTest extends AbstractCairoTest {
             );
 
             // all 12 (ts,s) pairs are unique, so no group has count > 1
-            assertSql("dups\n0\n", "SELECT count() dups FROM (SELECT ts, s, count() c FROM tab) WHERE c > 1");
+            assertQuery("SELECT count() dups FROM (SELECT ts, s, count() c FROM tab) WHERE c > 1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("dups\n0\n");
             // the materialized projection over the same subquery agrees: it is empty
-            assertSql("ts\ts\tc\n", "SELECT ts, s, c FROM (SELECT ts, s, count() c FROM tab) WHERE c > 1");
+            assertQuery("SELECT ts, s, c FROM (SELECT ts, s, count() c FROM tab) WHERE c > 1")
+                    .noLeakCheck()
+                    .returns("ts\ts\tc\n");
             // without the predicate, count() over the subquery counts the 12 groups
-            assertSql("count\n12\n", "SELECT count() FROM (SELECT ts, s, count() c FROM tab)");
+            assertQuery("SELECT count() FROM (SELECT ts, s, count() c FROM tab)")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\n12\n");
             // a single-key subquery behaves the same way
-            assertSql("count\n0\n", "SELECT count() FROM (SELECT s, count() c FROM tab) WHERE c > 1");
+            assertQuery("SELECT count() FROM (SELECT s, count() c FROM tab) WHERE c > 1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\n0\n");
 
             // genuine duplicates are still reported: 3 symbols, each repeated 4 times
             execute("CREATE TABLE dup (ts TIMESTAMP, s SYMBOL) TIMESTAMP(ts) PARTITION BY DAY");
             execute("INSERT INTO dup " +
                     "SELECT ('2020-02-27T12:00:00.000000Z'::TIMESTAMP + x), ('sym' || (x % 3)) " +
                     "FROM long_sequence(12)");
-            assertSql("dups\n3\n", "SELECT count() dups FROM (SELECT s, count() c FROM dup) WHERE c > 1");
+            assertQuery("SELECT count() dups FROM (SELECT s, count() c FROM dup) WHERE c > 1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("dups\n3\n");
             // a non-count outer aggregate over the filtered subquery is also correct: 3 groups of 4
-            assertSql("sum\n12\n", "SELECT sum(c) FROM (SELECT s, count() c FROM dup) WHERE c > 1");
+            assertQuery("SELECT sum(c) FROM (SELECT s, count() c FROM dup) WHERE c > 1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("sum\n12\n");
         });
     }
 


### PR DESCRIPTION
Fixes #7201

## What was wrong

`count()` over a keyed `GROUP BY` subquery, filtered on the aggregate alias (a HAVING-style predicate), reported duplicate groups that do not exist. For example, on a table holding 12 distinct `(ts, s)` rows:

```sql
-- expected 0 (all 12 pairs are unique), returned 1
SELECT count() dups FROM (SELECT ts, s, count() c FROM tab) WHERE c > 1;
```

The materialized projection over the same subquery (`SELECT ts, s, c FROM (...) WHERE c > 1`) was empty and the bare group by (`SELECT ts, s, count() c FROM tab`) showed all 12 symbols with `c = 1`, so the two query shapes disagreed on identical data.

## Root cause

The query plan showed the keyed group by had been replaced by a scalar `count()`:

```
Count
    Filter filter: 1<c
        Count            <- subquery collapsed to count() over the whole table = 12
            PageFrame
```

The `WHERE c > 1` is pushed into the subquery as a filter on the group by model. `propagateTopDownColumns0()` has a guard that re-adds a group by sub-query's grouping keys to its top-down columns so column pruning cannot drop them, but it ran before the model's own WHERE/HAVING and ORDER BY literals had been emitted into the top-down list. For the `count()` shape the outer query contributes no key literals, so the HAVING alias `c` was the sole top-down contributor and was added only after the guard had already observed an empty list and skipped. The keys `ts` and `s` were left unprotected, pruning collapsed the keyed group by into a scalar aggregate, and `12 > 1` falsely counted one group. The materialized projection and the bare group by both contribute key literals, which is why only the non-materializing `count()`/size path was affected.

## Fix

`retainGroupByKeysAsTopDownColumns()` now runs twice: once at the original early position, which preserves key ordering for the common case where the parent already contributed top-down columns, and once more after the WHERE/HAVING and ORDER BY literals have been emitted, which covers the HAVING-only contributor case. `addTopDownColumn()` dedupes by alias, so the second pass is idempotent and adds keys only where the early pass missed them.

This is purely additive relative to the previous behavior: keys can only be added where the original pass missed them, never reordered or removed. There is no measurable performance change — it only affects query compilation, adding one idempotent pass over a model's columns.

## Test plan

- Added regression test `CountTest#testCountOverKeyedGroupBySubqueryWithHavingFilter`, which asserts the plan keeps the keyed group by, that the buggy query returns `0`, that a genuine duplicate is still reported (`dups=3`, `sum=12`), and that the unaffected shapes (`count()=12`, empty projection, single-key) stay correct.
- Ran the optimizer-adjacent suites with zero failures: CountTest, GroupByTest, SqlOptimiserTest, ExplainPlanTest, SampleByTest, UnionTest, DistinctTest, SelectTest, OrderByTest, SubQueryTest, SqlParserTest, WindowFunctionTest, JoinTest, HorizonJoinTest, LimitTest, LatestByTest, NestedSetOperationTest, CoveringIndexTest, MatViewTest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)