### PR TITLE
fix(core): fix posting index crash and missing rows after partition squash

### DIFF
--- a/benchmarks/src/main/java/org/questdb/PostingIndexBenchmarkSuite.java
+++ b/benchmarks/src/main/java/org/questdb/PostingIndexBenchmarkSuite.java
@@ -107,6 +107,9 @@ public class PostingIndexBenchmarkSuite {
         //   "wal":             walFastLag* and walLargePartition*
         //   "wal_o3":          walLargePartitionO3* — O3 commit paths
         //                      (commitDense + rebuildSidecarsByCopy)
+        //   "wal_o3_spill":    walLargePartitionO3SpillReseal — reseal cost as
+        //                      the spill budget forces mid-stream flushes
+        //                      (commitDense's flushAllPendingDense vs seal())
         //   "io":              page-fault analysis only (skip JMH benchmarks)
         //   anything else:     literal regex body, expanded to
         //                      "PostingIndexBenchmarkSuite\.(<token>)$"
@@ -119,6 +122,7 @@ public class PostingIndexBenchmarkSuite {
             case "wal" -> suiteName + "\\.(walFastLag|walLargePartition).*";
             case "wal_o3" -> suiteName + "\\.walLargePartitionO3.*";
             case "wal_o3_append" -> suiteName + "\\.walLargePartitionO3AppendInsert.*";
+            case "wal_o3_spill" -> suiteName + "\\.walLargePartitionO3SpillReseal.*";
             case "io" -> null;
             default -> suiteName + "\\.(" + filter + ")$";
         };
@@ -128,7 +132,7 @@ public class PostingIndexBenchmarkSuite {
             org.openjdk.jmh.runner.options.ChainedOptionsBuilder builder = new OptionsBuilder()
                     .include(includePattern)
                     .resultFormat(ResultFormatType.TEXT);
-            if ("wal_o3".equals(filter) || "wal_o3_append".equals(filter)) {
+            if ("wal_o3".equals(filter) || "wal_o3_append".equals(filter) || "wal_o3_spill".equals(filter)) {
                 builder.forks(1)
                         .warmupIterations(1)
                         .measurementIterations(2);
@@ -484,6 +488,38 @@ public class PostingIndexBenchmarkSuite {
                 ", 0), '2024-01-01T00:00:00.000000Z'::TIMESTAMP), " +
                 "rnd_symbol(" + s.keyCount + ", 4, 8, 0), " + s.extraValues + " " +
                 "FROM long_sequence(" + WalLargePartitionO3State.BATCH_ROWS + ")";
+        s.engine.execute(sql, s.ctx);
+        s.applyJob.drain(0);
+        s.checkJob.run(0);
+        s.applyJob.drain(0);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    @Fork(1)
+    @Warmup(iterations = 1)
+    @Measurement(iterations = 3)
+    public void walLargePartitionO3SpillReseal(WalLargePartitionO3SpillState s) throws Exception {
+        // Same O3-mutating insert as walLargePartitionO3Insert (forces
+        // sealPostingIndexForPartition's canSkipRebuild=false reseal:
+        // discardForRebuild + index + commitDense + rebuildSidecars), but with
+        // cairo.posting.index.indexer.spill.bytes.max parameterised so the
+        // reseal's index() loop spills a controlled number of times:
+        //   - spillBytesMax=256MiB: no mid-stream flush. commitDense stays on
+        //     flushAllPendingDense (the unchanged fast path) -- a no-op for the
+        //     fix, so this column is the no-regression baseline.
+        //   - spillBytesMax=2MiB / 256KiB: re-indexing the ~1M-row partition
+        //     trips compactIfOverBudget, so commitDense routes through seal()
+        //     (flushAllPending + sealFull consolidation). This is the path the
+        //     fix added; before the fix it crashed (covering) or dropped rows
+        //     (non-covering), so there is no pre-fix number to compare against.
+        // Single shot on a freshly preloaded partition (Level.Iteration setup).
+        String sql = "INSERT INTO walbench(ts, sym, " + s.extraColumns + ") " +
+                "SELECT dateadd('u', rnd_int(1, " + WalLargePartitionO3SpillState.PRELOAD_TS_LIMIT_US +
+                ", 0), '2024-01-01T00:00:00.000000Z'::TIMESTAMP), " +
+                "rnd_symbol(" + s.keyCount + ", 4, 8, 0), " + s.extraValues + " " +
+                "FROM long_sequence(" + WalLargePartitionO3SpillState.BATCH_ROWS + ")";
         s.engine.execute(sql, s.ctx);
         s.applyJob.drain(0);
         s.checkJob.run(0);
@@ -2248,6 +2284,105 @@ public class PostingIndexBenchmarkSuite {
             // The benchmark body then interleaves new rows across this
             // entire range, forcing O3 mutation on every commit.
             int batches = partitionSize / BATCH_ROWS;
+            for (int i = 0; i < batches; i++) {
+                int batchOffsetUs = i * BATCH_ROWS + 1;
+                String batchSql = "INSERT INTO walbench(ts, sym, " + extraColumns + ") " +
+                        "SELECT dateadd('u', x::INT + " + batchOffsetUs + ", '2024-01-01T00:00:00.000000Z'::TIMESTAMP), " +
+                        "rnd_symbol(" + keyCount + ", 4, 8, 0), " + extraValues + " " +
+                        "FROM long_sequence(" + BATCH_ROWS + ")";
+                engine.execute(batchSql, ctx);
+                applyJob.drain(0);
+                checkJob.run(0);
+                applyJob.drain(0);
+            }
+        }
+
+        @TearDown(Level.Iteration)
+        public void tearDown() {
+            Misc.free(applyJob);
+            Misc.free(compiler);
+            Misc.free(engine);
+            deleteDirRecursive(tmpDir.toFile());
+        }
+    }
+
+    /**
+     * State for {@code walLargePartitionO3SpillReseal}: preload a single ~1M-row
+     * DAY partition, then let the benchmark O3-mutate it so the posting index
+     * reseals from the column file. {@code keyCount} is small so each symbol is
+     * hot and re-indexing the partition spills enough rowids to cross the small
+     * {@link #spillBytesMax} budgets. {@code spillBytesMax} controls how often
+     * the reseal's index() loop flushes mid-stream, selecting commitDense's
+     * fast path (no flush) vs its seal() consolidation path (>=1 flush).
+     */
+    @State(Scope.Benchmark)
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public static class WalLargePartitionO3SpillState {
+        static final int BATCH_ROWS = 100_000;
+        static final int PARTITION_SIZE = 1_000_000;
+        // Matches the preload span (1us spacing over PARTITION_SIZE rows) so the
+        // benchmark's O3 rows land inside the existing data and force mutation
+        // (canSkipRebuild=false), not a pure append.
+        static final int PRELOAD_TS_LIMIT_US = PARTITION_SIZE;
+
+        ApplyWal2TableJob applyJob;
+        CheckWalTransactionsJob checkJob;
+        SqlCompilerImpl compiler;
+        SqlExecutionContextImpl ctx;
+        CairoEngine engine;
+        String extraColumns;
+        String extraValues;
+        @Param({"posting_covering", "posting"})
+        String indexType;
+        int keyCount = 100;
+        // cairo.posting.index.indexer.spill.bytes.max. 256MiB never flushes
+        // mid-stream (flushAllPendingDense fast path = no-regression baseline);
+        // 2MiB and 256KiB trip compactIfOverBudget so commitDense routes through
+        // seal() (the path the fix added).
+        @Param({"268435456", "2097152", "262144"})
+        long spillBytesMax;
+        java.nio.file.Path tmpDir;
+
+        @Setup(Level.Iteration)
+        public void setup() throws Exception {
+            tmpDir = Files.createTempDirectory("suite-largepart-o3-spill");
+            CairoConfiguration config = new DefaultCairoConfiguration(tmpDir.toString()) {
+                @Override
+                public long getPostingIndexerSpillBytesMax() {
+                    return spillBytesMax;
+                }
+
+                @Override
+                public byte getPostingIndexRowIdEncoding() {
+                    return IS_DELTA ? PostingIndexUtils.ENCODING_DELTA : PostingIndexUtils.ENCODING_ADAPTIVE;
+                }
+
+                @Override
+                public int getRndFunctionMemoryMaxPages() {
+                    return 4096;
+                }
+            };
+            engine = new CairoEngine(config);
+            ctx = new SqlExecutionContextImpl(engine, 1)
+                    .with(config.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                            null, null, -1, null);
+            compiler = new SqlCompilerImpl(engine);
+
+            String ddl = switch (indexType) {
+                case "posting" -> "CREATE TABLE walbench (ts TIMESTAMP, sym SYMBOL INDEX TYPE " + POSTING_SQL +
+                        ", price DOUBLE, name VARCHAR) TIMESTAMP(ts) PARTITION BY DAY WAL";
+                case "posting_covering" -> "CREATE TABLE walbench (ts TIMESTAMP, sym SYMBOL INDEX TYPE " + POSTING_SQL +
+                        " INCLUDE (price), price DOUBLE, name VARCHAR) TIMESTAMP(ts) PARTITION BY DAY WAL";
+                default -> throw new IllegalArgumentException(indexType);
+            };
+            extraColumns = "price, name";
+            extraValues = "rnd_double() * 1000, rnd_varchar(10, 20, 0)";
+            engine.execute(ddl, ctx);
+            applyJob = new ApplyWal2TableJob(engine, 0);
+            checkJob = new CheckWalTransactionsJob(engine);
+
+            int batches = PARTITION_SIZE / BATCH_ROWS;
             for (int i = 0; i < batches; i++) {
                 int batchOffsetUs = i * BATCH_ROWS + 1;
                 String batchSql = "INSERT INTO walbench(ts, sym, " + extraColumns + ") " +

--- a/benchmarks/src/main/java/org/questdb/PostingIndexBenchmarkSuite.java
+++ b/benchmarks/src/main/java/org/questdb/PostingIndexBenchmarkSuite.java
@@ -499,7 +499,7 @@ public class PostingIndexBenchmarkSuite {
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     @Fork(1)
     @Warmup(iterations = 1)
-    @Measurement(iterations = 3)
+    @Measurement(iterations = 2)
     public void walLargePartitionO3SpillReseal(WalLargePartitionO3SpillState s) throws Exception {
         // Same O3-mutating insert as walLargePartitionO3Insert (forces
         // sealPostingIndexForPartition's canSkipRebuild=false reseal:
@@ -2361,6 +2361,17 @@ public class PostingIndexBenchmarkSuite {
                 @Override
                 public int getRndFunctionMemoryMaxPages() {
                     return 4096;
+                }
+
+                @Override
+                public boolean isPostingIndexAutoIncludeTimestamp() {
+                    // Without this, POSTING auto-covers the designated timestamp,
+                    // so the "posting" variant would also be covering and the two
+                    // @Param values would measure the same path. Disabling it keeps
+                    // "posting" on the non-covering reseal (commitDense -> seal,
+                    // no rebuildSidecars) and "posting_covering" on the covering
+                    // reseal via the explicit INCLUDE (price) below.
+                    return false;
                 }
             };
             engine = new CairoEngine(config);

--- a/core/src/main/java/io/questdb/MessageBusImpl.java
+++ b/core/src/main/java/io/questdb/MessageBusImpl.java
@@ -265,6 +265,8 @@ public class MessageBusImpl implements MessageBus {
     @TestOnly
     public void clear() {
         columnPurgeSubSeq.clear();
+        postingSealPurgeSubSeq.clear();
+        groupByLongTopKSubSeq.clear();
         groupByMergeShardSubSeq.clear();
         indexerSubSeq.clear();
         latestBySubSeq.clear();
@@ -279,6 +281,7 @@ public class MessageBusImpl implements MessageBus {
         copyExportRequestSubSeq.clear();
         vectorAggregateSubSeq.clear();
         walTxnNotificationSubSequence.clear();
+        queryCacheEventSubSeq.clear();
         unorderedPageFrameReduceSubSeq.clear();
         for (int i = 0, n = pageFrameReduceSubSeq.length; i < n; i++) {
             pageFrameReduceSubSeq[i].clear();

--- a/core/src/main/java/io/questdb/cairo/ColumnIndexer.java
+++ b/core/src/main/java/io/questdb/cairo/ColumnIndexer.java
@@ -142,6 +142,9 @@ public interface ColumnIndexer extends QuietCloseable {
     default void seal() {
     }
 
+    default void setCoveredColumnAddrSizes(LongList dataSizes, LongList auxSizes) {
+    }
+
     default void setCoveredColumnNameTxns(LongList txns) {
     }
 

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -3396,10 +3396,21 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                             // rotating the .pv and recording a purge for the
                             // superseded file. The pooled writer is freed below
                             // without draining that outbox through a TableWriter,
-                            // so reclaim the superseded value file inline. Safe
-                            // here: this is a fresh, uncommitted parquet index
-                            // whose old gens no committed reader can pick.
-                            indexWriter.unlinkPendingSealPurgesDirect();
+                            // so the superseded value file would leak. Reclaim it
+                            // inline -- but ONLY in rewrite mode, where the index
+                            // is built into a fresh txn-named directory that is
+                            // invisible to readers until the commit bumps _txn
+                            // (the old dir stays at srcNameTxn): no committed
+                            // reader can pick the superseded prev gen, whose entry
+                            // is tagged with the pre-seal txn. In update-in-place
+                            // mode the directory is the live committed one, where
+                            // a reader pinned at the pre-commit txn could still
+                            // walk to and map the superseded .pv, so it is not
+                            // safe to unlink here (that far-rarer case still leaks
+                            // the intermediate, like the pre-fix behaviour).
+                            if (isRewrite) {
+                                indexWriter.unlinkPendingSealPurgesDirect();
+                            }
                         } else {
                             indexWriter.commit();
                         }

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -3405,9 +3405,15 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                             // is tagged with the pre-seal txn. In update-in-place
                             // mode the directory is the live committed one, where
                             // a reader pinned at the pre-commit txn could still
-                            // walk to and map the superseded .pv, so it is not
-                            // safe to unlink here (that far-rarer case still leaks
-                            // the intermediate, like the pre-fix behaviour).
+                            // walk to and map the superseded .pv, so it is NOT
+                            // safe to unlink here. That far-rarer case keeps one
+                            // superseded .pv on disk -- bounded, not growing: the
+                            // next in-place rebuild's of(isInit) truncates and
+                            // reuses it, so the on-disk count stays at two
+                            // (.pv.0 + active). That is a known gap (full
+                            // reclamation needs a scoreboard-gated deferred purge
+                            // routed to the writer thread), still strictly better
+                            // than the pre-fix data loss it replaces.
                             if (isRewrite) {
                                 indexWriter.unlinkPendingSealPurgesDirect();
                             }

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -3397,21 +3397,26 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                         // No-op on BitmapIndexWriter.
                         indexWriter.setNextTxnAtSeal(tableWriter.getTxn() + 1L);
                         if (IndexType.isPosting(indexType)) {
-                            indexWriter.commitDense();
-                            // commitDense may have sealed (spill-driven reseal),
-                            // rotating the .pv and recording a purge for the
-                            // superseded file. The pooled writer is freed below
-                            // without ever draining that outbox through a
-                            // TableWriter (the native reseal does, this path
-                            // didn't), so the superseded .pv would leak. Hand the
-                            // purge to the writer's deferred queue: it is published
-                            // after the commit and the scoreboard-gated job deletes
-                            // the .pv only once no reader is pinned in its txn
-                            // window -- safe for both the rewrite (fresh dir) and
-                            // update-in-place (live committed dir) cases. Tagged
-                            // with getTxn() as the current (pre-commit) txn so the
-                            // seal's getTxn()+1 entry is treated as finite-future.
-                            tableWriter.deferParquetPostingSealPurges(indexWriter, tableWriter.getTxn());
+                            // commitDense may seal (spill-driven reseal), rotating the
+                            // .pv and recording a purge for the superseded file. The
+                            // pooled writer is freed below without ever draining that
+                            // outbox through a TableWriter (the native reseal does, this
+                            // path didn't), so the superseded .pv would leak. Drain it in
+                            // a finally: an I/O fault inside commitDense's seal/sync can
+                            // throw AFTER the purge was recorded, and the defer must still
+                            // hand the entry off rather than drop it (idempotent no-op on
+                            // an empty outbox). The deferred entry is published after the
+                            // commit and the scoreboard-gated job deletes the .pv only
+                            // once no reader is pinned in its txn window -- safe for both
+                            // the rewrite (fresh dir) and update-in-place (live committed
+                            // dir) cases. Tagged with getTxn() as the current (pre-commit)
+                            // txn so the seal's getTxn()+1 entry is treated as
+                            // finite-future.
+                            try {
+                                indexWriter.commitDense();
+                            } finally {
+                                tableWriter.deferParquetPostingSealPurges(indexWriter, tableWriter.getTxn());
+                            }
                         } else {
                             indexWriter.commit();
                         }

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -3338,6 +3338,12 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                         }
 
                         indexWriter.of(path.trimTo(pLen), columnName, columnNameTxn, indexBlockCapacity);
+                        // The 4-arg of(...) above does not carry the partition
+                        // identity, but a deferred seal-purge needs it to find the
+                        // .pv directory later. srcNameTxn is this rebuild's dir
+                        // name-txn (the new txn dir in rewrite mode, srcNameTxn in
+                        // update-in-place mode).
+                        indexWriter.setPartitionContext(partitionTimestamp, srcNameTxn);
 
                         // In rewrite mode all columns exist in the new parquet file
                         // (the Rust encoder fills missing columns with NULLs),
@@ -3395,28 +3401,17 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                             // commitDense may have sealed (spill-driven reseal),
                             // rotating the .pv and recording a purge for the
                             // superseded file. The pooled writer is freed below
-                            // without draining that outbox through a TableWriter,
-                            // so the superseded value file would leak. Reclaim it
-                            // inline -- but ONLY in rewrite mode, where the index
-                            // is built into a fresh txn-named directory that is
-                            // invisible to readers until the commit bumps _txn
-                            // (the old dir stays at srcNameTxn): no committed
-                            // reader can pick the superseded prev gen, whose entry
-                            // is tagged with the pre-seal txn. In update-in-place
-                            // mode the directory is the live committed one, where
-                            // a reader pinned at the pre-commit txn could still
-                            // walk to and map the superseded .pv, so it is NOT
-                            // safe to unlink here. That far-rarer case keeps one
-                            // superseded .pv on disk -- bounded, not growing: the
-                            // next in-place rebuild's of(isInit) truncates and
-                            // reuses it, so the on-disk count stays at two
-                            // (.pv.0 + active). That is a known gap (full
-                            // reclamation needs a scoreboard-gated deferred purge
-                            // routed to the writer thread), still strictly better
-                            // than the pre-fix data loss it replaces.
-                            if (isRewrite) {
-                                indexWriter.unlinkPendingSealPurgesDirect();
-                            }
+                            // without ever draining that outbox through a
+                            // TableWriter (the native reseal does, this path
+                            // didn't), so the superseded .pv would leak. Hand the
+                            // purge to the writer's deferred queue: it is published
+                            // after the commit and the scoreboard-gated job deletes
+                            // the .pv only once no reader is pinned in its txn
+                            // window -- safe for both the rewrite (fresh dir) and
+                            // update-in-place (live committed dir) cases. Tagged
+                            // with getTxn() as the current (pre-commit) txn so the
+                            // seal's getTxn()+1 entry is treated as finite-future.
+                            tableWriter.deferParquetPostingSealPurges(indexWriter, tableWriter.getTxn());
                         } else {
                             indexWriter.commit();
                         }

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -3392,6 +3392,14 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                         indexWriter.setNextTxnAtSeal(tableWriter.getTxn() + 1L);
                         if (IndexType.isPosting(indexType)) {
                             indexWriter.commitDense();
+                            // commitDense may have sealed (spill-driven reseal),
+                            // rotating the .pv and recording a purge for the
+                            // superseded file. The pooled writer is freed below
+                            // without draining that outbox through a TableWriter,
+                            // so reclaim the superseded value file inline. Safe
+                            // here: this is a fresh, uncommitted parquet index
+                            // whose old gens no committed reader can pick.
+                            indexWriter.unlinkPendingSealPurgesDirect();
                         } else {
                             indexWriter.commit();
                         }

--- a/core/src/main/java/io/questdb/cairo/SymbolColumnIndexer.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolColumnIndexer.java
@@ -265,6 +265,11 @@ public class SymbolColumnIndexer implements ColumnIndexer, Mutable {
     }
 
     @Override
+    public void setCoveredColumnAddrSizes(LongList dataSizes, LongList auxSizes) {
+        writer.setCoveredColumnAddrSizes(dataSizes, auxSizes);
+    }
+
+    @Override
     public void setCoveredColumnNameTxns(LongList txns) {
         writer.setCoveredColumnNameTxns(txns);
     }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -6049,6 +6049,10 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     private void deferPendingPostingSealPurges(ColumnIndexer indexer, long currentTableTxn) {
+        // The native (writer-thread) reseal twin of deferParquetPostingSealPurges,
+        // which is the O3-worker path. This one runs only post-join, so -- unlike the
+        // parquet path -- no O3 worker is concurrently stashing into the list.
+        assert o3PartitionUpdRemaining.get() == 0 : "native posting seal-purge defer ran with O3 partition workers in flight";
         // First publish entries already safe for the current committed txn.
         // Only finite future entries must cross an indexer reopen in the
         // TableWriter-owned list below.
@@ -6076,6 +6080,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     private void discardAbandonedDeferredPostingSealPurges0(long currentTableTxn) {
+        assert o3PartitionUpdRemaining.get() == 0 : "deferred posting seal-purge discard ran with O3 partition workers in flight";
         int writePos = 0;
         for (int readPos = 0, n = deferredPostingSealPurges.size(); readPos < n; readPos++) {
             PostingSealPurgeTask task = deferredPostingSealPurges.getQuick(readPos);
@@ -10840,6 +10845,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     private void publishDeferredPostingSealPurges0(long currentTableTxn, boolean persistOnQueueFull, int queueRetryCount) {
+        assert o3PartitionUpdRemaining.get() == 0 : "deferred posting seal-purge publish ran with O3 partition workers in flight";
         if (deferredPostingSealPurges.size() == 0) {
             return;
         }
@@ -12339,6 +12345,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * @return true if at least one column indexer was touched.
      */
     private boolean sealPostingIndexForPartition(long partitionTimestamp, boolean canSkipRebuild) {
+        // Invariant: posting seal runs only after every O3 partition worker has
+        // joined (finishO3Commit / post-await, or a writer-thread squash). It reads
+        // the just-written partition column data and rotates value files; a worker
+        // still in flight would race that. o3PartitionUpdRemaining is the work-steal
+        // drain counter -- 0 means no O3 partition task is outstanding.
+        assert o3PartitionUpdRemaining.get() == 0 : "posting seal ran with O3 partition workers in flight";
         // Tables without any POSTING index incur per-call filesystem and
         // metadata work below, including a stat(2). Bail out before any of
         // that when no POSTING index column exists.
@@ -12518,6 +12530,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     private void sealPostingIndexesForO3Partitions() {
+        assert o3PartitionUpdRemaining.get() == 0 : "posting seal sweep ran with O3 partition workers in flight";
         // O3 rebuilds posting indexes via pool IndexWriters that have no covering
         // configuration and never seal (FD-based close skips seal). Re-open each
         // affected partition's posting index, seal it (converting sparse gens to

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -4941,7 +4941,11 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             return;
         }
         for (int colIdx = 0; colIdx < columnCount; colIdx++) {
-            if (!metadata.isColumnIndexed(colIdx)) {
+            // metadata can mark a column indexed before its indexer slot is populated
+            // (a WAL metadata change applied ahead of openPartition), so indexers may
+            // be shorter than columnCount -- mirror the `index < indexers.size()` guard
+            // used elsewhere (see the updateIndexes path) to avoid an out-of-bounds get.
+            if (!metadata.isColumnIndexed(colIdx) || colIdx >= indexers.size()) {
                 continue;
             }
             ColumnIndexer indexer = indexers.getQuick(colIdx);
@@ -7126,9 +7130,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * and feeds each column here, instead of re-opening the file per column.
      *
      * @param allowDestructiveRecovery passed straight to createIndexFiles: true only
-     *                                  for a fresh ADD INDEX build (no live indexer
-     *                                  holds the .pk); false for the O3/squash covering
-     *                                  reseal, where readers may pin the committed .pk.
+     *                                 for a fresh ADD INDEX build (no live indexer
+     *                                 holds the .pk); false for the O3/squash covering
+     *                                 reseal, where readers may pin the committed .pk.
      */
     private void indexParquetColumn(
             SymbolColumnIndexer indexer,
@@ -11044,8 +11048,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         int coveringPathLen = -1;
         try {
             for (int colIdx = 0; colIdx < columnCount; colIdx++) {
+                // indexers may be shorter than columnCount when a WAL metadata change
+                // marked a column indexed before its indexer slot was populated; guard
+                // the get the same way the updateIndexes path does.
                 if (metadata.getColumnType(colIdx) <= 0
                         || !metadata.isColumnIndexed(colIdx)
+                        || colIdx >= indexers.size()
                         || !IndexType.isPosting(metadata.getColumnIndexType(colIdx))) {
                     continue;
                 }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -4028,6 +4028,19 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     getPrimaryColumn(i).jumpTo(newTransientRowCount << shl);
                 }
             }
+            // Configure covering on the posting writers BEFORE indexing. A
+            // covering posting index writes its .pc covered sidecar inline
+            // (writeSidecarGenData), reached both from the commit below and from
+            // a mid-stream spill flush inside updateIndexesParallel; the spill
+            // path bounds RSS for large batches and must still produce a complete
+            // sidecar. Every other index path configures covering before it
+            // indexes (see configureCoveringIfNeeded call sites); the WAL
+            // fast-lag path is the exception because
+            // publishPostingIndexesForLastPartitionFastLag's addr-based
+            // configureCovering clears the writer-owned cover schema set at
+            // openPartition. Restore it here so spill-flushed generations carry
+            // their covered data; otherwise a covered read over-reads the .pc.
+            configureCoveringForLastPartitionFastLag();
             updateIndexesParallel(initialTransientRowCount, newTransientRowCount);
             try {
                 publishPostingIndexesForLastPartitionFastLag();
@@ -4912,6 +4925,27 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         if (timestampIndex != -1) {
             o3TimestampMem = o3MemColumns1.getQuick(getPrimaryColumnIndex(timestampIndex));
             o3TimestampMemCpy = o3MemColumns2.getQuick(getPrimaryColumnIndex(timestampIndex));
+        }
+    }
+
+    private void configureCoveringForLastPartitionFastLag() {
+        // Wire each covering POSTING writer's covered-column read maps for the
+        // last (active) partition before updateIndexesParallel indexes into it,
+        // so a mid-stream spill flush during indexing writes a complete .pc
+        // covered sidecar. configureCoveringIfNeeded is a no-op for non-covering
+        // and non-posting columns. Runs serially on the writer thread, so the
+        // shared covering* scratch it uses is safe.
+        if (lastPartitionTimestamp == Long.MIN_VALUE) {
+            return;
+        }
+        for (int colIdx = 0; colIdx < columnCount; colIdx++) {
+            if (!metadata.isColumnIndexed(colIdx)) {
+                continue;
+            }
+            ColumnIndexer indexer = indexers.getQuick(colIdx);
+            if (indexer != null) {
+                configureCoveringIfNeeded(indexer, colIdx, lastPartitionTimestamp);
+            }
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -7121,6 +7121,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 indexer.getWriter().setCurrentTableTxn(txWriter.getTxn());
                 indexer.configureWriter(path.trimTo(plen), columnName, columnNameTxn, columnTop, timestamp, txWriter.getPartitionNameTxnByPartitionTimestamp(timestamp));
                 indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn() + 1);
+                // Discard any existing chain generations before re-adding from the
+                // parquet. On a fresh ADD INDEX this is a no-op (empty chain); on an
+                // O3/squash reseal of an already-indexed parquet partition it stops the
+                // rebuilt rows being appended on top of the O3 worker's .pv, which would
+                // otherwise double the row count.
+                indexer.getWriter().discardForRebuild();
 
                 final IntList coveringColumnIndices = metadata.getColumnMetadata(columnIndex).getCoveringColumnIndices();
                 final boolean hasCovering = coveringColumnIndices != null && coveringColumnIndices.size() > 0;
@@ -12328,6 +12334,82 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     /**
+     * Materialise the covering sidecars (.pci/.pc) for a PARQUET partition's covering
+     * posting indexes. sealPostingIndexForPartition's native reseal reads native column
+     * files (absent on parquet) and skips parquet, but the O3 worker that rewrites a
+     * parquet partition builds only the non-covering .pv. Without rebuilding the
+     * covering here -- in finishO3Commit / squash, before the commit exposes the new
+     * version -- a concurrent reader can open the new parquet version, walk the chain
+     * (count() correct) but find no .pci, report coverCount=0 and resolve covered
+     * values as NULL. indexParquetPartition reads the rewritten parquet and wires up
+     * both the .pv and the covering sidecars.
+     *
+     * @return true if at least one covering posting column was rebuilt.
+     */
+    private boolean resealParquetCoveringForPartition(long partitionTimestamp) {
+        final int partitionIndex = getPartitionIndexByTimestamp(partitionTimestamp);
+        if (partitionIndex < 0) {
+            return false;
+        }
+        boolean processed = false;
+        long partitionNameTxn = setStateForTimestamp(path, partitionTimestamp);
+        int plen = path.size();
+        if (!ff.exists(path.slash().$()) && PartitionBy.isPartitioned(partitionBy)) {
+            path.trimTo(pathSize);
+            partitionNameTxn = txWriter.getTxn();
+            setPathForNativePartition(path, timestampType, partitionBy, partitionTimestamp, partitionNameTxn);
+            plen = path.size();
+        }
+        final long partitionSize = txWriter.getPartitionRowCountByTimestamp(partitionTimestamp);
+        try {
+            for (int colIdx = 0; colIdx < columnCount; colIdx++) {
+                if (metadata.getColumnType(colIdx) <= 0 || !metadata.isColumnIndexed(colIdx)
+                        || !IndexType.isPosting(metadata.getColumnIndexType(colIdx))) {
+                    continue;
+                }
+                final IntList coveringCols = metadata.getColumnMetadata(colIdx).getCoveringColumnIndices();
+                if (coveringCols == null || coveringCols.size() == 0) {
+                    // Non-covering parquet posting: the worker-built .pv stands.
+                    continue;
+                }
+                final long columnTop = columnVersionWriter.getColumnTop(partitionTimestamp, colIdx);
+                if (columnTop == -1 || columnTop >= partitionSize) {
+                    continue;
+                }
+                final ColumnIndexer indexer = indexers.getQuick(colIdx);
+                if (!(indexer instanceof SymbolColumnIndexer)) {
+                    continue;
+                }
+                final long columnNameTxn = columnVersionWriter.getColumnNameTxn(partitionTimestamp, colIdx);
+                try {
+                    indexParquetPartition(
+                            (SymbolColumnIndexer) indexer,
+                            metadata.getColumnName(colIdx),
+                            partitionIndex,
+                            colIdx,
+                            columnNameTxn,
+                            metadata.getIndexValueBlockCapacity(colIdx),
+                            metadata.getColumnIndexType(colIdx),
+                            plen,
+                            partitionTimestamp
+                    );
+                    // Publish the seal-purges the rebuild's discardForRebuild queued for
+                    // the superseded .pv/.pc so the scoreboard-gated PostingSealPurgeJob
+                    // reclaims them; otherwise each O3/squash reseal leaks a value file.
+                    deferPendingPostingSealPurges(indexer, txWriter.getTxn());
+                    processed = true;
+                } finally {
+                    indexer.releaseIndexWriter();
+                    path.trimTo(plen);
+                }
+            }
+        } finally {
+            path.trimTo(pathSize);
+        }
+        return processed;
+    }
+
+    /**
      * Per-partition helper for {@link #sealPostingIndexesForO3Partitions()}.
      * Opens each posting-index column on the given partition, folds any O3
      * tentative state into the active view, rolls back stale rowids left over
@@ -12365,7 +12447,14 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             return false;
         }
         if (txWriter.isPartitionParquetByPartitionTimestamp(partitionTimestamp)) {
-            return false;
+            // The native reseal below reads native column files, which a parquet
+            // partition lacks. But an O3/squash rewrite that produces a new parquet
+            // version with a COVERING posting index still needs that version's covering
+            // sidecars (.pci/.pc) materialised -- the O3 worker builds only the
+            // non-covering .pv -- else a reader opening the new version walks the chain
+            // (count() correct) but finds no .pci, reports coverCount=0 and returns NULL
+            // covered values. Rebuild covering from the parquet here, pre-commit.
+            return resealParquetCoveringForPartition(partitionTimestamp);
         }
 
         boolean processed = false;

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -271,6 +271,11 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     private final ParquetPartitionDecoder parquetDecoder = new ParquetPartitionDecoder();
     private final ParquetFileDecoder parquetFileDecoder = new ParquetFileDecoder();
     private final ParquetMetaFileReader parquetMetaReader = new ParquetMetaFileReader();
+    // Guards deferParquetPostingSealPurges' drain into deferredPostingSealPurges +
+    // the task pool: parquet index rebuilds run on parallel O3 workers, so several
+    // can stash seal-purges at once. The writer-thread native reseal touches the
+    // same list only after the O3 workers join, so it needs no lock.
+    private final Object parquetSealPurgeLock = new Object();
     private final int partitionBy;
     private final DateFormat partitionDirFmt;
     private final LongList partitionRemoveCandidates = new LongList();
@@ -6005,6 +6010,29 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 }
             }
             dedupColumnCommitAddresses.clear();
+        }
+    }
+
+    // Routes a parquet index rebuild's seal-purges into the same deferred path
+    // the native reseal uses, so the post-commit publishDeferredPostingSealPurges
+    // and the scoreboard-gated PostingSealPurgeJob reclaim the superseded .pv when
+    // no reader is pinned in its [from, to) txn window. Unlike the native reseal,
+    // updateParquetIndexes runs on parallel O3 workers and frees its pooled writer
+    // before the commit -- without this its outbox is discarded by close().
+    // publishPendingPurges only touches the thread-safe global queue and the
+    // writer's own outbox (lock-free); drainPendingFuturePurges mutates the shared
+    // deferredPostingSealPurges list and task pool, so it runs under the lock.
+    void deferParquetPostingSealPurges(IndexWriter writer, long currentTableTxn) {
+        writer.publishPendingPurges(messageBus, tableToken, partitionBy, timestampType, currentTableTxn);
+        synchronized (parquetSealPurgeLock) {
+            writer.drainPendingFuturePurges(
+                    deferredPostingSealPurges,
+                    getDeferredPostingSealPurgeTaskPool(),
+                    tableToken,
+                    partitionBy,
+                    timestampType,
+                    currentTableTxn
+            );
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -7156,7 +7156,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         // A fresh ALTER TABLE ADD INDEX build holds no live indexer, so an existing
         // torn .pk may be destructively reset (allowDestructiveRecovery = true). The
         // O3/squash covering reseal runs while readers may hold the .pk, so it passes
-        // false -- a committed .pk is left intact (hasInitialisedKeyFileHeader bails).
+        // false -- a committed .pk is preserved (createIndexFiles' non-destructive
+        // branch returns early on ff.exists, never resetting it).
         createIndexFiles(columnName, columnNameTxn, indexValueBlockSize, indexType, plen, true, allowDestructiveRecovery);
         final long partitionSize = txWriter.getPartitionRowCountByTimestamp(timestamp);
         final long columnTop = columnVersionWriter.getColumnTop(timestamp, columnIndex);
@@ -12488,6 +12489,10 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     continue;
                 }
                 if (parquetAddr == 0) {
+                    // First eligible covering column: open the shared decoder and log the
+                    // reseal once per partition (the extracted indexParquetColumn no longer
+                    // logs, unlike the old per-column indexParquetPartition reseal path).
+                    LOG.info().$("resealing parquet covering index [path=").$substr(pathRootSize, path).I$();
                     final long parquetFileSize = txWriter.getPartitionParquetFileSize(partitionIndex);
                     openParquetMetadataOrThrow(path, plen, parquetFileSize);
                     parquetSize = parquetMetaReader.getParquetFileSize();

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -10979,6 +10979,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         indexer.configureCovering(o3SealAddrs, o3SealAuxAddrs, o3SealTops, o3SealShifts, coveringCols, o3SealTypes, coverCount,
                                 metadata.getTimestampIndex());
                         indexer.setCoveredColumnNameTxns(o3SealNameTxns);
+                        indexer.setCoveredColumnAddrSizes(o3SealMappedSizes, o3SealAuxMappedSizes);
                         // WAL fast-lag uses getTxn() (NOT getTxn()+1L like the
                         // O3 seal paths). See publishToChain javadoc: the
                         // partition stays attached and openPartition's
@@ -12468,6 +12469,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         indexer.configureCovering(o3SealAddrs, o3SealAuxAddrs, o3SealTops, o3SealShifts, coveringCols, o3SealTypes, coverCount,
                                 metadata.getTimestampIndex());
                         indexer.setCoveredColumnNameTxns(o3SealNameTxns);
+                        indexer.setCoveredColumnAddrSizes(o3SealMappedSizes, o3SealAuxMappedSizes);
                         // Same getTxn()+1 convention as the REBUILD entry
                         // above and as O3CopyJob's setO3PathContext. Picker
                         // (per-gen visibility via slot[0].TXN_AT_SEAL) keeps

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -4935,7 +4935,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         // covered sidecar. configureCoveringIfNeeded is a no-op for non-covering
         // and non-posting columns. Runs serially on the writer thread, so the
         // shared covering* scratch it uses is safe.
-        if (lastPartitionTimestamp == Long.MIN_VALUE) {
+        // hasPostingIndexers short-circuits the per-commit column scan for the
+        // common non-posting table (this runs on every WAL fast-lag commit).
+        if (!hasPostingIndexers || lastPartitionTimestamp == Long.MIN_VALUE) {
             return;
         }
         for (int colIdx = 0; colIdx < columnCount; colIdx++) {
@@ -4997,6 +4999,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 coveringAddrs, coveringAuxAddrs, coveringTops, coveringShifts,
                 coveringIndices, coveringTypes, coverCount, metadata.getTimestampIndex());
         indexer.setCoveredColumnNameTxns(coveringNameTxns);
+        // No setCoveredColumnAddrSizes here, unlike the O3-seal / fast-lag sites that
+        // map whole on-disk column files and pass o3Seal*MappedSizes. getCovered*ReadAddr
+        // bounds-asserts addr-based reads only when that list is non-empty; leaving it
+        // empty makes the asserts skip, which is correct for this path: the covered reads
+        // are columnTop-relative over temp files sized to exactly (partitionSize - colTop)
+        // rows, so an in-range rowId cannot address past the mapping by construction.
     }
 
     private void configureCoveringIfNeeded(ColumnIndexer indexer, int columnIndex, long partitionTimestamp) {
@@ -6946,6 +6954,19 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
     }
 
+    private boolean hasCoveringPostingIndex() {
+        for (int i = 0; i < columnCount; i++) {
+            if (metadata.getColumnType(i) > 0 && metadata.isColumnIndexed(i)
+                    && IndexType.isPosting(metadata.getColumnIndexType(i))) {
+                final IntList covering = metadata.getColumnMetadata(i).getCoveringColumnIndices();
+                if (covering != null && covering.size() > 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     private boolean hasPostingIndex() {
         for (int i = 0; i < columnCount; i++) {
             if (metadata.getColumnType(i) > 0 && metadata.isColumnIndexed(i)
@@ -7097,6 +7118,172 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
     }
 
+    /**
+     * Index one SYMBOL column (plus its covered columns, if any) of an already-open
+     * parquet partition decoder into the column's posting index, then seal. The
+     * caller owns the parquet mmap + {@link #parquetDecoder} lifecycle, so a reseal
+     * touching several covering columns of one partition decodes the parquet once
+     * and feeds each column here, instead of re-opening the file per column.
+     *
+     * @param allowDestructiveRecovery passed straight to createIndexFiles: true only
+     *                                  for a fresh ADD INDEX build (no live indexer
+     *                                  holds the .pk); false for the O3/squash covering
+     *                                  reseal, where readers may pin the committed .pk.
+     */
+    private void indexParquetColumn(
+            SymbolColumnIndexer indexer,
+            CharSequence columnName,
+            int columnIndex,
+            long columnNameTxn,
+            int indexValueBlockSize,
+            byte indexType,
+            int plen,
+            long timestamp,
+            RowGroupBuffers rowGroupBuffers,
+            boolean allowDestructiveRecovery
+    ) {
+        final ParquetMetaFileReader parquetMetadata = parquetDecoder.metadata();
+
+        int parquetColumnIndex = findParquetColumnIndex(parquetMetadata, columnIndex);
+        if (parquetColumnIndex == -1) {
+            path.trimTo(plen);
+            LOG.error().$("could not find symbol column for indexing in parquet, skipping [path=").$substr(pathRootSize, path)
+                    .$(", columnIndex=").$(columnIndex)
+                    .I$();
+            return;
+        }
+
+        // A fresh ALTER TABLE ADD INDEX build holds no live indexer, so an existing
+        // torn .pk may be destructively reset (allowDestructiveRecovery = true). The
+        // O3/squash covering reseal runs while readers may hold the .pk, so it passes
+        // false -- a committed .pk is left intact (hasInitialisedKeyFileHeader bails).
+        createIndexFiles(columnName, columnNameTxn, indexValueBlockSize, indexType, plen, true, allowDestructiveRecovery);
+        final long partitionSize = txWriter.getPartitionRowCountByTimestamp(timestamp);
+        final long columnTop = columnVersionWriter.getColumnTop(timestamp, columnIndex);
+
+        // Invariant: on a parquet partition the indexed SYMBOL's columnTop
+        // is either 0 (column has data from row 0) or partitionSize (column
+        // is all-NULL in this partition). zeroColumnTopsAfterParquetRewrite
+        // collapses every intermediate 0 < columnTop < partitionSize down
+        // to 0 at convert time, so the merged decode below can rely on
+        // columnTop == 0 whenever it executes. A future ATTACH PARQUET /
+        // restore path that bypasses that routine must restore this
+        // invariant before reaching here, or the rowLo formula at the
+        // decodeRowGroup call would truncate the covered columns.
+        assert columnTop == 0 || columnTop == partitionSize
+                : "parquet partition indexed SYMBOL columnTop=" + columnTop
+                + " is neither 0 nor partitionSize=" + partitionSize
+                + " (timestamp=" + timestamp + ", columnIndex=" + columnIndex + ")";
+
+        if (columnTop > -1 && partitionSize > columnTop) {
+            indexer.getWriter().setCurrentTableTxn(txWriter.getTxn());
+            indexer.configureWriter(path.trimTo(plen), columnName, columnNameTxn, columnTop, timestamp, txWriter.getPartitionNameTxnByPartitionTimestamp(timestamp));
+            indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn() + 1);
+            // Discard any existing chain generations before re-adding from the
+            // parquet. On a fresh ADD INDEX this is a no-op (empty chain); on an
+            // O3/squash reseal of an already-indexed parquet partition it stops the
+            // rebuilt rows being appended on top of the O3 worker's .pv, which would
+            // otherwise double the row count.
+            indexer.getWriter().discardForRebuild();
+
+            final IntList coveringColumnIndices = metadata.getColumnMetadata(columnIndex).getCoveringColumnIndices();
+            final boolean hasCovering = coveringColumnIndices != null && coveringColumnIndices.size() > 0;
+            final int coverCount = hasCovering ? coveringColumnIndices.size() : 0;
+
+            // Build combined column list: SYMBOL (chunk 0) + covered
+            // columns (chunks 1..N). A single decodeRowGroup call per
+            // row group replaces the two separate decode loops.
+            parquetColumnIdsAndTypes.clear();
+            parquetColumnIdsAndTypes.add(parquetColumnIndex);
+            parquetColumnIdsAndTypes.add(ColumnType.SYMBOL);
+
+            // covSlotMeta packs per-slot state: [decodedChunkIdx, colType,
+            // dataVecBytesWritten] (3 longs per slot). Slots whose column
+            // is absent from parquet have decodedChunkIdx == -1.
+            final DirectLongList covSlotMeta = hasCovering ? getTempDirectLongList(3L * coverCount) : null;
+            // Mmap-backed temp files for covered column data (+ aux for
+            // var-size). Written via mmap in the row-group loop and read
+            // from the same addresses during seal — no write()/re-mmap
+            // round-trip. The ObjList is closed in the finally block.
+            final ObjList<MemoryMARW> covMmaps = hasCovering ? new ObjList<>(2 * coverCount) : null;
+            int includedCoveredCount = 0;
+
+            try {
+                if (hasCovering) {
+                    includedCoveredCount = prepareCoveredColumnMmaps(
+                            coveringColumnIndices, timestamp, plen,
+                            parquetMetadata, partitionSize, covSlotMeta, covMmaps);
+                }
+
+                long rowCount = 0;
+                final int rowGroupCount = parquetMetadata.getRowGroupCount();
+                final IndexWriter indexWriter = indexer.getWriter();
+                for (int rowGroupIndex = 0; rowGroupIndex < rowGroupCount; rowGroupIndex++) {
+                    final long rowGroupSize = parquetMetadata.getRowGroupSize(rowGroupIndex);
+
+                    // For row groups fully below columnTop, covered columns
+                    // still need decoding (their column_top may differ from
+                    // the symbol's) but the SYMBOL data is skipped.
+                    final boolean belowColumnTop = rowCount + rowGroupSize <= columnTop;
+                    if (belowColumnTop && includedCoveredCount == 0) {
+                        rowCount += rowGroupSize;
+                        continue;
+                    }
+
+                    parquetDecoder.decodeRowGroup(
+                            rowGroupBuffers,
+                            parquetColumnIdsAndTypes,
+                            rowGroupIndex,
+                            belowColumnTop ? 0 : (int) Math.max(0, columnTop - rowCount),
+                            (int) rowGroupSize
+                    );
+
+                    // Accumulate covered column data into mmap'd temp files.
+                    if (includedCoveredCount > 0) {
+                        accumulateCoveredColumnsFromRowGroup(
+                                coveringColumnIndices, covSlotMeta, covMmaps,
+                                rowGroupBuffers, rowGroupIndex, rowGroupSize);
+                    }
+
+                    // Feed SYMBOL column to the posting index.
+                    if (!belowColumnTop) {
+                        long rowId = Math.max(rowCount, columnTop);
+                        final long addr = rowGroupBuffers.getChunkDataPtr(0);
+                        final long size = rowGroupBuffers.getChunkDataSize(0);
+                        if (size == 0) {
+                            BitmapIndexUtils.addNullEntries(indexWriter, rowId, rowCount + rowGroupSize);
+                        } else {
+                            for (long p = addr, lim = addr + size; p < lim; p += 4, rowId++) {
+                                indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);
+                            }
+                        }
+                    }
+
+                    rowCount += rowGroupSize;
+                }
+
+                // Wire up covered column addresses for the seal path.
+                if (hasCovering) {
+                    configureCoveringFromMmaps(
+                            indexer, coveringColumnIndices, timestamp,
+                            covMmaps);
+                }
+
+                indexWriter.setMaxValue(partitionSize - 1);
+                indexer.seal();
+            } finally {
+                if (hasCovering) {
+                    indexer.releaseCoveredColumnReadMappings();
+                }
+                Misc.freeObjListIfCloseable(covMmaps);
+                if (hasCovering) {
+                    cleanupMaterialisedCoveredColumnTempFiles(
+                            coveringColumnIndices, timestamp, plen);
+                }
+            }
+        }
+    }
+
     private void indexParquetPartition(
             SymbolColumnIndexer indexer,
             CharSequence columnName,
@@ -7121,143 +7308,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             path.trimTo(plen).concat(PARQUET_PARTITION_NAME).$();
             parquetAddr = mapRO(ff, path.$(), LOG, parquetSize, MemoryTag.MMAP_PARQUET_PARTITION_DECODER);
             parquetDecoder.of(parquetMetaReader, parquetAddr, parquetSize, MemoryTag.NATIVE_PARQUET_PARTITION_DECODER);
-            final ParquetMetaFileReader parquetMetadata = parquetDecoder.metadata();
-
-            int parquetColumnIndex = findParquetColumnIndex(parquetMetadata, columnIndex);
-            if (parquetColumnIndex == -1) {
-                path.trimTo(plen);
-                LOG.error().$("could not find symbol column for indexing in parquet, skipping [path=").$substr(pathRootSize, path)
-                        .$(", columnIndex=").$(columnIndex)
-                        .I$();
-                return;
-            }
-
-            // ALTER TABLE ALTER COLUMN ADD INDEX (parquet partition): building a fresh index from scratch.
-            createIndexFiles(columnName, columnNameTxn, indexValueBlockSize, indexType, plen, true, true);
-            final long partitionSize = txWriter.getPartitionRowCountByTimestamp(timestamp);
-            final long columnTop = columnVersionWriter.getColumnTop(timestamp, columnIndex);
-
-            // Invariant: on a parquet partition the indexed SYMBOL's columnTop
-            // is either 0 (column has data from row 0) or partitionSize (column
-            // is all-NULL in this partition). zeroColumnTopsAfterParquetRewrite
-            // collapses every intermediate 0 < columnTop < partitionSize down
-            // to 0 at convert time, so the merged decode below can rely on
-            // columnTop == 0 whenever it executes. A future ATTACH PARQUET /
-            // restore path that bypasses that routine must restore this
-            // invariant before reaching here, or the rowLo formula at the
-            // decodeRowGroup call would truncate the covered columns.
-            assert columnTop == 0 || columnTop == partitionSize
-                    : "parquet partition indexed SYMBOL columnTop=" + columnTop
-                    + " is neither 0 nor partitionSize=" + partitionSize
-                    + " (timestamp=" + timestamp + ", columnIndex=" + columnIndex + ")";
-
-            if (columnTop > -1 && partitionSize > columnTop) {
-                indexer.getWriter().setCurrentTableTxn(txWriter.getTxn());
-                indexer.configureWriter(path.trimTo(plen), columnName, columnNameTxn, columnTop, timestamp, txWriter.getPartitionNameTxnByPartitionTimestamp(timestamp));
-                indexer.getWriter().setNextTxnAtSeal(txWriter.getTxn() + 1);
-                // Discard any existing chain generations before re-adding from the
-                // parquet. On a fresh ADD INDEX this is a no-op (empty chain); on an
-                // O3/squash reseal of an already-indexed parquet partition it stops the
-                // rebuilt rows being appended on top of the O3 worker's .pv, which would
-                // otherwise double the row count.
-                indexer.getWriter().discardForRebuild();
-
-                final IntList coveringColumnIndices = metadata.getColumnMetadata(columnIndex).getCoveringColumnIndices();
-                final boolean hasCovering = coveringColumnIndices != null && coveringColumnIndices.size() > 0;
-                final int coverCount = hasCovering ? coveringColumnIndices.size() : 0;
-
-                // Build combined column list: SYMBOL (chunk 0) + covered
-                // columns (chunks 1..N). A single decodeRowGroup call per
-                // row group replaces the two separate decode loops.
-                parquetColumnIdsAndTypes.clear();
-                parquetColumnIdsAndTypes.add(parquetColumnIndex);
-                parquetColumnIdsAndTypes.add(ColumnType.SYMBOL);
-
-                // covSlotMeta packs per-slot state: [decodedChunkIdx, colType,
-                // dataVecBytesWritten] (3 longs per slot). Slots whose column
-                // is absent from parquet have decodedChunkIdx == -1.
-                final DirectLongList covSlotMeta = hasCovering ? getTempDirectLongList(3L * coverCount) : null;
-                // Mmap-backed temp files for covered column data (+ aux for
-                // var-size). Written via mmap in the row-group loop and read
-                // from the same addresses during seal — no write()/re-mmap
-                // round-trip. The ObjList is closed in the finally block.
-                final ObjList<MemoryMARW> covMmaps = hasCovering ? new ObjList<>(2 * coverCount) : null;
-                int includedCoveredCount = 0;
-
-                try {
-                    if (hasCovering) {
-                        includedCoveredCount = prepareCoveredColumnMmaps(
-                                coveringColumnIndices, timestamp, plen,
-                                parquetMetadata, partitionSize, covSlotMeta, covMmaps);
-                    }
-
-                    long rowCount = 0;
-                    final int rowGroupCount = parquetMetadata.getRowGroupCount();
-                    final IndexWriter indexWriter = indexer.getWriter();
-                    for (int rowGroupIndex = 0; rowGroupIndex < rowGroupCount; rowGroupIndex++) {
-                        final long rowGroupSize = parquetMetadata.getRowGroupSize(rowGroupIndex);
-
-                        // For row groups fully below columnTop, covered columns
-                        // still need decoding (their column_top may differ from
-                        // the symbol's) but the SYMBOL data is skipped.
-                        final boolean belowColumnTop = rowCount + rowGroupSize <= columnTop;
-                        if (belowColumnTop && includedCoveredCount == 0) {
-                            rowCount += rowGroupSize;
-                            continue;
-                        }
-
-                        parquetDecoder.decodeRowGroup(
-                                rowGroupBuffers,
-                                parquetColumnIdsAndTypes,
-                                rowGroupIndex,
-                                belowColumnTop ? 0 : (int) Math.max(0, columnTop - rowCount),
-                                (int) rowGroupSize
-                        );
-
-                        // Accumulate covered column data into mmap'd temp files.
-                        if (includedCoveredCount > 0) {
-                            accumulateCoveredColumnsFromRowGroup(
-                                    coveringColumnIndices, covSlotMeta, covMmaps,
-                                    rowGroupBuffers, rowGroupIndex, rowGroupSize);
-                        }
-
-                        // Feed SYMBOL column to the posting index.
-                        if (!belowColumnTop) {
-                            long rowId = Math.max(rowCount, columnTop);
-                            final long addr = rowGroupBuffers.getChunkDataPtr(0);
-                            final long size = rowGroupBuffers.getChunkDataSize(0);
-                            if (size == 0) {
-                                BitmapIndexUtils.addNullEntries(indexWriter, rowId, rowCount + rowGroupSize);
-                            } else {
-                                for (long p = addr, lim = addr + size; p < lim; p += 4, rowId++) {
-                                    indexWriter.add(TableUtils.toIndexKey(Unsafe.getInt(p)), rowId);
-                                }
-                            }
-                        }
-
-                        rowCount += rowGroupSize;
-                    }
-
-                    // Wire up covered column addresses for the seal path.
-                    if (hasCovering) {
-                        configureCoveringFromMmaps(
-                                indexer, coveringColumnIndices, timestamp,
-                                covMmaps);
-                    }
-
-                    indexWriter.setMaxValue(partitionSize - 1);
-                    indexer.seal();
-                } finally {
-                    if (hasCovering) {
-                        indexer.releaseCoveredColumnReadMappings();
-                    }
-                    Misc.freeObjListIfCloseable(covMmaps);
-                    if (hasCovering) {
-                        cleanupMaterialisedCoveredColumnTempFiles(
-                                coveringColumnIndices, timestamp, plen);
-                    }
-                }
-            }
+            // Fresh ADD INDEX over a parquet partition indexes a single column and
+            // holds no live indexer, so destructive .pk recovery is permitted.
+            indexParquetColumn(indexer, columnName, columnIndex, columnNameTxn, indexValueBlockSize, indexType, plen, timestamp, rowGroupBuffers, true);
         } finally {
             // Release the decoder's native state before tearing down the mmaps it
             // borrows from. ParquetPartitionDecoder documents a clear-then-munmap
@@ -10879,6 +10932,14 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     private void publishDeferredPostingSealPurges(long currentTableTxn, boolean persistOnQueueFull, int queueRetryCount) {
+        // Fast path: every caller runs post-join (the 0-body asserts
+        // o3PartitionUpdRemaining == 0), so no O3 worker mutates
+        // deferredPostingSealPurges here and this size() read needs no lock. It skips
+        // the monitor for the common empty case -- every non-posting table, and
+        // posting tables with nothing pending -- on this per-commit path.
+        if (deferredPostingSealPurges.size() == 0) {
+            return;
+        }
         synchronized (parquetSealPurgeLock) {
             publishDeferredPostingSealPurges0(currentTableTxn, persistOnQueueFull, queueRetryCount);
         }
@@ -12381,6 +12442,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * @return true if at least one covering posting column was rebuilt.
      */
     private boolean resealParquetCoveringForPartition(long partitionTimestamp) {
+        // No covering posting index anywhere on the table: the worker-built
+        // non-covering .pv already stands, so skip the path resolution + stat(2)
+        // and the per-column scan entirely.
+        if (!hasCoveringPostingIndex()) {
+            return false;
+        }
         final int partitionIndex = getPartitionIndexByTimestamp(partitionTimestamp);
         if (partitionIndex < 0) {
             return false;
@@ -12395,7 +12462,14 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             plen = path.size();
         }
         final long partitionSize = txWriter.getPartitionRowCountByTimestamp(partitionTimestamp);
-        try {
+        // One parquet open/mmap/decoder for the whole partition: a partition with
+        // several covering posting columns decodes the file once and feeds each
+        // column to indexParquetColumn, instead of re-opening the parquet per
+        // column. Opened lazily on the first eligible column, so a partition whose
+        // covering columns are all absent / all-NULL pays nothing for the open.
+        long parquetAddr = 0;
+        long parquetSize = 0;
+        try (RowGroupBuffers rowGroupBuffers = new RowGroupBuffers(MemoryTag.NATIVE_TABLE_WRITER)) {
             for (int colIdx = 0; colIdx < columnCount; colIdx++) {
                 if (metadata.getColumnType(colIdx) <= 0 || !metadata.isColumnIndexed(colIdx)
                         || !IndexType.isPosting(metadata.getColumnIndexType(colIdx))) {
@@ -12410,27 +12484,40 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 if (columnTop == -1 || columnTop >= partitionSize) {
                     continue;
                 }
-                final ColumnIndexer indexer = indexers.getQuick(colIdx);
-                if (!(indexer instanceof SymbolColumnIndexer)) {
+                if (!(indexers.getQuick(colIdx) instanceof SymbolColumnIndexer indexer)) {
                     continue;
+                }
+                if (parquetAddr == 0) {
+                    final long parquetFileSize = txWriter.getPartitionParquetFileSize(partitionIndex);
+                    openParquetMetadataOrThrow(path, plen, parquetFileSize);
+                    parquetSize = parquetMetaReader.getParquetFileSize();
+                    path.trimTo(plen).concat(PARQUET_PARTITION_NAME).$();
+                    parquetAddr = mapRO(ff, path.$(), LOG, parquetSize, MemoryTag.MMAP_PARQUET_PARTITION_DECODER);
+                    parquetDecoder.of(parquetMetaReader, parquetAddr, parquetSize, MemoryTag.NATIVE_PARQUET_PARTITION_DECODER);
                 }
                 final long columnNameTxn = columnVersionWriter.getColumnNameTxn(partitionTimestamp, colIdx);
                 try {
-                    indexParquetPartition(
-                            (SymbolColumnIndexer) indexer,
-                            metadata.getColumnName(colIdx),
-                            partitionIndex,
-                            colIdx,
-                            columnNameTxn,
-                            metadata.getIndexValueBlockCapacity(colIdx),
-                            metadata.getColumnIndexType(colIdx),
-                            plen,
-                            partitionTimestamp
-                    );
-                    // Publish the seal-purges the rebuild's discardForRebuild queued for
-                    // the superseded .pv/.pc so the scoreboard-gated PostingSealPurgeJob
-                    // reclaims them; otherwise each O3/squash reseal leaks a value file.
-                    deferPendingPostingSealPurges(indexer, txWriter.getTxn());
+                    try {
+                        indexParquetColumn(
+                                indexer,
+                                metadata.getColumnName(colIdx),
+                                colIdx,
+                                columnNameTxn,
+                                metadata.getIndexValueBlockCapacity(colIdx),
+                                metadata.getColumnIndexType(colIdx),
+                                plen,
+                                partitionTimestamp,
+                                rowGroupBuffers,
+                                false
+                        );
+                    } finally {
+                        // Drain the rebuild's seal-purge outbox (the .pv/.pc its
+                        // discardForRebuild superseded) before releaseIndexWriter frees
+                        // it -- in a finally so an I/O fault mid-seal still hands the entry
+                        // to the scoreboard-gated PostingSealPurgeJob instead of leaking
+                        // the value file (idempotent no-op on an empty outbox).
+                        deferPendingPostingSealPurges(indexer, txWriter.getTxn());
+                    }
                     processed = true;
                 } finally {
                     indexer.releaseIndexWriter();
@@ -12438,6 +12525,19 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 }
             }
         } finally {
+            // Unconditional teardown: a never-opened decoder/reader reads back 0 here
+            // (munmaps skipped, clear() a no-op), and a metadata open that succeeded
+            // before a mapRO failure is still released.
+            Misc.free(parquetDecoder);
+            if (parquetAddr != 0) {
+                ff.munmap(parquetAddr, parquetSize, MemoryTag.MMAP_PARQUET_PARTITION_DECODER);
+            }
+            final long parquetMetaAddr = parquetMetaReader.getAddr();
+            final long parquetMetaSize = parquetMetaReader.getFileSize();
+            parquetMetaReader.clear();
+            if (parquetMetaAddr != 0) {
+                ff.munmap(parquetMetaAddr, parquetMetaSize, MemoryTag.MMAP_PARQUET_METADATA_READER);
+            }
             path.trimTo(pathSize);
         }
         return processed;

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -13105,13 +13105,14 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         // files after switch.
         updateIndexes();
         // Flush posting index sidecar data before the partition switch.
-        // PostingIndexWriter reads covered column values from the MemoryMA
-        // objects that were set via configureCovering(). Those MemoryMA
-        // objects are the TableWriter's column memories — the same Java
-        // objects get remapped to the new partition's files in openPartition().
-        // Any unflushed pending/spill data still holds row IDs from the
-        // current partition, so we must write the sidecar gen block now,
-        // while the MemoryMA still points to the correct file.
+        // Unflushed pending/spill data still holds row IDs from the CURRENT
+        // partition, and PostingIndexWriter resolves covered column values by
+        // NAME against that partition's files -- a fresh read-only mmap opened
+        // in mapColumnFile, keyed by coveredPartitionPath, NOT the TableWriter's
+        // live MemoryMA column memories. openPartition() below re-points the
+        // indexer at the new partition's path, so we must write the sidecar gen
+        // block now, while the writer still resolves covered columns against the
+        // current partition's files.
         final int sealThreshold = configuration.getPostingSealGenThreshold();
         // The seal here runs before the upcoming switchPartitions/commit, so
         // tag any chain entry the seal publishes with txnAtSeal=getTxn()+1

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -271,10 +271,15 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     private final ParquetPartitionDecoder parquetDecoder = new ParquetPartitionDecoder();
     private final ParquetFileDecoder parquetFileDecoder = new ParquetFileDecoder();
     private final ParquetMetaFileReader parquetMetaReader = new ParquetMetaFileReader();
-    // Guards deferParquetPostingSealPurges' drain into deferredPostingSealPurges +
-    // the task pool: parquet index rebuilds run on parallel O3 workers, so several
-    // can stash seal-purges at once. The writer-thread native reseal touches the
-    // same list only after the O3 workers join, so it needs no lock.
+    // Guards EVERY access to deferredPostingSealPurges + the seal-purge task pool.
+    // Parquet index rebuilds run on parallel O3 workers, so several stash seal-purges
+    // at once; the writer-thread paths touch the same list only after the O3 workers
+    // join. Historically the writer side held no lock and leaned on that join ordering
+    // alone for safety. Every list/pool access -- writer and worker -- now takes this
+    // lock, so the non-thread-safe ObjList/ObjectStackPool are safe by construction,
+    // not by timing: a future change that moved a mutation into the O3 window can no
+    // longer corrupt them. The lock is a leaf (nothing else is held across it) and the
+    // writer paths run post-join uncontended, so it costs nothing measurable.
     private final Object parquetSealPurgeLock = new Object();
     private final int partitionBy;
     private final DateFormat partitionDirFmt;
@@ -4664,6 +4669,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     private void closeDeferredPostingSealPurges() {
+        synchronized (parquetSealPurgeLock) {
+            closeDeferredPostingSealPurges0();
+        }
+    }
+
+    private void closeDeferredPostingSealPurges0() {
         long currentTableTxn = txWriter != null ? txWriter.getTxn() : -1L;
         if (txWriter != null) {
             publishDeferredPostingSealPurgesOnClose(currentTableTxn);
@@ -6021,7 +6032,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     // before the commit -- without this its outbox is discarded by close().
     // publishPendingPurges only touches the thread-safe global queue and the
     // writer's own outbox (lock-free); drainPendingFuturePurges mutates the shared
-    // deferredPostingSealPurges list and task pool, so it runs under the lock.
+    // deferredPostingSealPurges list and task pool under parquetSealPurgeLock -- the
+    // same lock every writer-side list/pool access now also takes.
     void deferParquetPostingSealPurges(IndexWriter writer, long currentTableTxn) {
         writer.publishPendingPurges(messageBus, tableToken, partitionBy, timestampType, currentTableTxn);
         synchronized (parquetSealPurgeLock) {
@@ -6043,17 +6055,27 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         indexer.publishPendingPurges(messageBus, tableToken, partitionBy, timestampType, currentTableTxn);
 
         IndexWriter writer = indexer.getWriter();
-        writer.drainPendingFuturePurges(
-                deferredPostingSealPurges,
-                getDeferredPostingSealPurgeTaskPool(),
-                tableToken,
-                partitionBy,
-                timestampType,
-                currentTableTxn
-        );
+        // Same lock the parquet O3-worker path takes; keeps every deferredPostingSealPurges
+        // + task-pool mutation under parquetSealPurgeLock (structural, not timing, safety).
+        synchronized (parquetSealPurgeLock) {
+            writer.drainPendingFuturePurges(
+                    deferredPostingSealPurges,
+                    getDeferredPostingSealPurgeTaskPool(),
+                    tableToken,
+                    partitionBy,
+                    timestampType,
+                    currentTableTxn
+            );
+        }
     }
 
     private void discardAbandonedDeferredPostingSealPurges(long currentTableTxn) {
+        synchronized (parquetSealPurgeLock) {
+            discardAbandonedDeferredPostingSealPurges0(currentTableTxn);
+        }
+    }
+
+    private void discardAbandonedDeferredPostingSealPurges0(long currentTableTxn) {
         int writePos = 0;
         for (int readPos = 0, n = deferredPostingSealPurges.size(); readPos < n; readPos++) {
             PostingSealPurgeTask task = deferredPostingSealPurges.getQuick(readPos);
@@ -6625,6 +6647,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     private ObjectStackPool<PostingSealPurgeTask> getDeferredPostingSealPurgeTaskPool() {
+        assert Thread.holdsLock(parquetSealPurgeLock);
         if (deferredPostingSealPurgeTaskPool == null) {
             deferredPostingSealPurgeTaskPool = new ObjectStackPool<>(PostingSealPurgeTask::new, 16);
         }
@@ -8687,6 +8710,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     private void persistDeferredPostingSealPurgesDirect(long currentTableTxn) {
+        assert Thread.holdsLock(parquetSealPurgeLock);
         if (!PostingSealPurgeJob.persistReadyTasksDirect(engine, deferredPostingSealPurges, 0, deferredPostingSealPurges.size(), currentTableTxn)) {
             return;
         }
@@ -10763,6 +10787,26 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             long currentTableTxn,
             LongList orphanSealTxns
     ) {
+        synchronized (parquetSealPurgeLock) {
+            publishAbandonedPostingSealPurges0(
+                    columnName,
+                    columnNameTxn,
+                    partitionTimestamp,
+                    partitionNameTxn,
+                    currentTableTxn,
+                    orphanSealTxns
+            );
+        }
+    }
+
+    private void publishAbandonedPostingSealPurges0(
+            CharSequence columnName,
+            long columnNameTxn,
+            long partitionTimestamp,
+            long partitionNameTxn,
+            long currentTableTxn,
+            LongList orphanSealTxns
+    ) {
         if (orphanSealTxns.size() == 0) {
             return;
         }
@@ -10790,6 +10834,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     private void publishDeferredPostingSealPurges(long currentTableTxn, boolean persistOnQueueFull, int queueRetryCount) {
+        synchronized (parquetSealPurgeLock) {
+            publishDeferredPostingSealPurges0(currentTableTxn, persistOnQueueFull, queueRetryCount);
+        }
+    }
+
+    private void publishDeferredPostingSealPurges0(long currentTableTxn, boolean persistOnQueueFull, int queueRetryCount) {
         if (deferredPostingSealPurges.size() == 0) {
             return;
         }
@@ -11409,6 +11459,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * close if they still cannot be handed off). Best-effort: never throws.
      */
     private void recoverSpilledPostingSealPurges() {
+        synchronized (parquetSealPurgeLock) {
+            recoverSpilledPostingSealPurges0();
+        }
+    }
+
+    private void recoverSpilledPostingSealPurges0() {
         path.trimTo(pathSize).concat(POSTING_SEAL_PURGE_PENDING_FILE_NAME);
         if (!ff.exists(path.$())) {
             path.trimTo(pathSize);
@@ -11491,12 +11547,14 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     private void releaseDeferredPostingSealPurgeTask(PostingSealPurgeTask task) {
+        assert Thread.holdsLock(parquetSealPurgeLock);
         if (deferredPostingSealPurgeTaskPool != null) {
             deferredPostingSealPurgeTaskPool.release(task);
         }
     }
 
     private int releaseDirectPersistedPostingSealPurges(int readPos, int writePos, int n, long currentTableTxn) {
+        assert Thread.holdsLock(parquetSealPurgeLock);
         for (int i = readPos; i < n; i++) {
             PostingSealPurgeTask task = deferredPostingSealPurges.getQuick(i);
             if (task.isEmpty() || task.getToTableTxn() <= currentTableTxn) {
@@ -12622,6 +12680,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * dropping them with a critical log.
      */
     private boolean spillReadyPostingSealPurges(long currentTableTxn) {
+        assert Thread.holdsLock(parquetSealPurgeLock);
         if (currentTableTxn < 0) {
             // No committed table txn (writer never fully opened): readiness is
             // undefined, so do not spill. Fall back to the drop path.

--- a/core/src/main/java/io/questdb/cairo/TableWriterMetadata.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterMetadata.java
@@ -313,6 +313,13 @@ public class TableWriterMetadata extends AbstractRecordMetadata implements Table
                 oldMeta.isSymbolCacheFlag()
         );
         newColumnMetadata.setParquetEncodingConfig(oldMeta.getParquetEncodingConfig());
+        // Preserve the covering-index schema across a symbol-capacity change.
+        // The covering column indices (and, derived from them, the column's
+        // covering flag) live on the column metadata; rebuilding the column to
+        // change its capacity must carry them over, otherwise the next
+        // rewriteAndSwapMetadata() persists a _meta with no covering flag/section
+        // and every reader thereafter sees the posting index as non-covering.
+        newColumnMetadata.setCoveringColumnIndices(oldMeta.getCoveringColumnIndices());
         columnMetadata.set(columnIndex, newColumnMetadata);
     }
 

--- a/core/src/main/java/io/questdb/cairo/idx/IndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/IndexWriter.java
@@ -362,4 +362,16 @@ public interface IndexWriter extends Closeable, Mutable {
      * Truncates the index, removing all data.
      */
     void truncate();
+
+    /**
+     * Reclaims the value files recorded for seal-purge by unlinking them
+     * directly, bypassing the scoreboard-gated purge queue, then clears the
+     * pending-purge outbox. Only safe when the superseded files are invisible
+     * to every reader (a fresh, uncommitted index build). Used by the parquet
+     * rebuild path, whose pooled writer is freed without ever draining its
+     * outbox through a TableWriter. No-op for writers without a seal-purge
+     * outbox (e.g. BITMAP).
+     */
+    default void unlinkPendingSealPurgesDirect() {
+    }
 }

--- a/core/src/main/java/io/questdb/cairo/idx/IndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/IndexWriter.java
@@ -294,6 +294,9 @@ public interface IndexWriter extends Closeable, Mutable {
     default void sealIfMultiGen(int threshold) {
     }
 
+    default void setCoveredColumnAddrSizes(LongList dataSizes, LongList auxSizes) {
+    }
+
     default void setCoveredColumnNameTxns(LongList txns) {
     }
 

--- a/core/src/main/java/io/questdb/cairo/idx/IndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/IndexWriter.java
@@ -349,6 +349,15 @@ public interface IndexWriter extends Closeable, Mutable {
     }
 
     /**
+     * Records the partition timestamp and name-txn on the writer so a deferred
+     * seal-purge task can reconstruct the value-file directory after the writer
+     * is freed. The path-based of(...) overloads used by the parquet rebuild do
+     * not carry these. No-op for writers without a seal-purge outbox (e.g. BITMAP).
+     */
+    default void setPartitionContext(long partitionTimestamp, long partitionNameTxn) {
+    }
+
+    /**
      * Syncs the index files to disk.
      *
      * @param async true for async sync, false for sync
@@ -362,16 +371,4 @@ public interface IndexWriter extends Closeable, Mutable {
      * Truncates the index, removing all data.
      */
     void truncate();
-
-    /**
-     * Reclaims the value files recorded for seal-purge by unlinking them
-     * directly, bypassing the scoreboard-gated purge queue, then clears the
-     * pending-purge outbox. Only safe when the superseded files are invisible
-     * to every reader (a fresh, uncommitted index build). Used by the parquet
-     * rebuild path, whose pooled writer is freed without ever draining its
-     * outbox through a TableWriter. No-op for writers without a seal-purge
-     * outbox (e.g. BITMAP).
-     */
-    default void unlinkPendingSealPurgesDirect() {
-    }
 }

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
@@ -293,35 +293,6 @@ public final class PostingIndexChainWriter {
         return activePageOffset;
     }
 
-    /**
-     * Read the current head entry's cover end-offset footer into {@code out}
-     * (cleared first). Lets a caller preserve the footer across a republish it
-     * cannot recompute -- e.g. a same-sealTxn gen flush whose writer-side
-     * coverCount field is transiently 0 (between clearCovering and the next
-     * configureCovering), or a freshly reopened per-partition writer that has
-     * not yet captured the live sidecar extent. The head entry on disk carries
-     * the authoritative footer from the seal that wrote the .pc, so reusing it
-     * keeps the chain entry pointing at the existing covered data instead of
-     * publishing an empty footer (which makes readers see the partition as
-     * having no covered values). Leaves {@code out} empty when there is no head
-     * or no cover footer.
-     */
-    public void readHeadCoverEndOffsets(MemoryARW keyMem, LongList out) {
-        out.clear();
-        if (!hasHead()) {
-            return;
-        }
-        long headOffset = headEntryOffset;
-        int genCount = keyMem.getInt(headOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
-        long len = keyMem.getLong(headOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN);
-        long footerOffset = PostingIndexChainEntry.resolveCoverFooterOffset(headOffset, genCount);
-        long footerBytesAvailable = Math.max(0L, headOffset + len - footerOffset);
-        int coverCount = (int) (footerBytesAvailable / PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE);
-        for (int c = 0; c < coverCount; c++) {
-            out.add(keyMem.getLong(footerOffset + (long) c * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE));
-        }
-    }
-
     public long getCurrentTxnAtSeal() {
         return currentTxnAtSeal;
     }
@@ -468,6 +439,35 @@ public final class PostingIndexChainWriter {
      */
     public long peekNextSealTxn() {
         return genCounter + 1L;
+    }
+
+    /**
+     * Read the current head entry's cover end-offset footer into {@code out}
+     * (cleared first). Lets a caller preserve the footer across a republish it
+     * cannot recompute -- e.g. a same-sealTxn gen flush whose writer-side
+     * coverCount field is transiently 0 (between clearCovering and the next
+     * configureCovering), or a freshly reopened per-partition writer that has
+     * not yet captured the live sidecar extent. The head entry on disk carries
+     * the authoritative footer from the seal that wrote the .pc, so reusing it
+     * keeps the chain entry pointing at the existing covered data instead of
+     * publishing an empty footer (which makes readers see the partition as
+     * having no covered values). Leaves {@code out} empty when there is no head
+     * or no cover footer.
+     */
+    public void readHeadCoverEndOffsets(MemoryARW keyMem, LongList out) {
+        out.clear();
+        if (!hasHead()) {
+            return;
+        }
+        long headOffset = headEntryOffset;
+        int genCount = keyMem.getInt(headOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
+        long len = keyMem.getLong(headOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN);
+        long footerOffset = PostingIndexChainEntry.resolveCoverFooterOffset(headOffset, genCount);
+        long footerBytesAvailable = Math.max(0L, headOffset + len - footerOffset);
+        int coverCount = (int) (footerBytesAvailable / PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE);
+        for (int c = 0; c < coverCount; c++) {
+            out.add(keyMem.getLong(footerOffset + (long) c * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE));
+        }
     }
 
     /**

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexChainWriter.java
@@ -293,6 +293,35 @@ public final class PostingIndexChainWriter {
         return activePageOffset;
     }
 
+    /**
+     * Read the current head entry's cover end-offset footer into {@code out}
+     * (cleared first). Lets a caller preserve the footer across a republish it
+     * cannot recompute -- e.g. a same-sealTxn gen flush whose writer-side
+     * coverCount field is transiently 0 (between clearCovering and the next
+     * configureCovering), or a freshly reopened per-partition writer that has
+     * not yet captured the live sidecar extent. The head entry on disk carries
+     * the authoritative footer from the seal that wrote the .pc, so reusing it
+     * keeps the chain entry pointing at the existing covered data instead of
+     * publishing an empty footer (which makes readers see the partition as
+     * having no covered values). Leaves {@code out} empty when there is no head
+     * or no cover footer.
+     */
+    public void readHeadCoverEndOffsets(MemoryARW keyMem, LongList out) {
+        out.clear();
+        if (!hasHead()) {
+            return;
+        }
+        long headOffset = headEntryOffset;
+        int genCount = keyMem.getInt(headOffset + PostingIndexUtils.V2_ENTRY_OFFSET_GEN_COUNT);
+        long len = keyMem.getLong(headOffset + PostingIndexUtils.V2_ENTRY_OFFSET_LEN);
+        long footerOffset = PostingIndexChainEntry.resolveCoverFooterOffset(headOffset, genCount);
+        long footerBytesAvailable = Math.max(0L, headOffset + len - footerOffset);
+        int coverCount = (int) (footerBytesAvailable / PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE);
+        for (int c = 0; c < coverCount; c++) {
+            out.add(keyMem.getLong(footerOffset + (long) c * PostingIndexUtils.COVER_END_OFFSET_ENTRY_SIZE));
+        }
+    }
+
     public long getCurrentTxnAtSeal() {
         return currentTxnAtSeal;
     }

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -116,7 +116,9 @@ public class PostingIndexWriter implements IndexWriter {
     // extendHead, built once per chain publish from each cover column's
     // current sidecar append offset. Reused across calls to avoid allocations.
     private final LongList coverEndOffsetsScratch = new LongList();
-    // O3 addr-based covering: caller-provided native memory addresses
+    // O3 addr-based covering: caller-provided native memory addresses, plus the
+    // mapped byte length of each (the *AddrSizes lists bound the addr-based
+    // covered data/aux reads under -ea).
     private final LongList coveredColumnAddrSizes = new LongList();
     private final LongList coveredColumnAddrs = new LongList();
     private final LongList coveredColumnAuxAddrSizes = new LongList();
@@ -395,6 +397,11 @@ public class PostingIndexWriter implements IndexWriter {
                 hasPendingData = false;
                 activeKeyCount = 0;
                 coverCount = 0;
+                // Drop the cover-extent cache so a pooled reopen for a different
+                // column/partition starts clean. No live read depends on this
+                // (publishToChain rewrites the cache before every captureCoverEndOffsets),
+                // but clearing it keeps the cache's safety structural, not ordering-bound.
+                coverEndOffsetsCache.clear();
                 sealTarget = null;
                 releasePendingPurges();
                 pendingDiscardOldSealTxn = -1L;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -54,8 +54,8 @@ import io.questdb.std.LongList;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
 import io.questdb.std.Numbers;
-import io.questdb.std.ObjectStackPool;
 import io.questdb.std.ObjList;
+import io.questdb.std.ObjectStackPool;
 import io.questdb.std.Unsafe;
 import io.questdb.std.Vect;
 import io.questdb.std.str.LPSZ;
@@ -1474,6 +1474,17 @@ public class PostingIndexWriter implements IndexWriter {
     }
 
     @Override
+    public void setPartitionContext(long partitionTimestamp, long partitionNameTxn) {
+        // The path-based of(...) overloads used by the parquet rebuild do not
+        // carry the partition timestamp / name-txn, but a deferred seal-purge
+        // task needs them to reconstruct the .pv directory after this writer is
+        // freed. recordPostingSealPurge stamps each outbox entry with these, so
+        // the caller sets them before commitDense seals.
+        this.partitionTimestamp = partitionTimestamp;
+        this.partitionNameTxn = partitionNameTxn;
+    }
+
+    @Override
     public void sync(boolean async) {
         // .pv before .pk: a torn write must never leave the chain head (keyMem)
         // pointing at unsynced gen bytes in valueMem.
@@ -1556,32 +1567,6 @@ public class PostingIndexWriter implements IndexWriter {
         hasPendingData = false;
         activeKeyCount = 0;
         allocateNativeBuffers();
-    }
-
-    @Override
-    public void unlinkPendingSealPurgesDirect() {
-        // Reclaim the superseded value file(s) from a spill-driven reseal by
-        // unlinking them directly, then clear the outbox. The native reseal
-        // defers these through the TableWriter's scoreboard-gated purge queue,
-        // but the parquet rebuild (O3PartitionJob.updateParquetIndexes) frees
-        // its pooled writer right after commitDense without ever draining the
-        // outbox, so a queued purge would simply be discarded by close(). A
-        // direct unlink is safe there because the parquet rebuild produces a
-        // fresh, uncommitted index: the chain head is tagged with the upcoming
-        // txn, so no committed reader can pick the superseded gens, and a
-        // rewrite failure removes the whole partition directory. coverCount is
-        // 0 on that path, so no sidecar (.pc) files exist for the old sealTxn.
-        assert coverCount == 0 : "unlinkPendingSealPurgesDirect does not reclaim covered sidecars";
-        if (pendingPurges.size() > 0 && partitionPath.size() > 0) {
-            final Path p = Path.getThreadLocal(partitionPath);
-            final int plen = p.size();
-            for (int i = 0, n = pendingPurges.size(); i < n; i++) {
-                final PendingSealPurge entry = pendingPurges.getQuick(i);
-                ff.removeQuiet(PostingIndexUtils.valueFileName(
-                        p.trimTo(plen), indexName, entry.postingColumnNameTxn, entry.sealTxn));
-            }
-        }
-        releasePendingPurges();
     }
 
     private static int compressSidecarBlock(long rawBuf, int valueCount, int shift, int colType,

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -477,7 +477,30 @@ public class PostingIndexWriter implements IndexWriter {
     // bytes on disk in non-assert builds.
     public void commitDense() {
         assert coverCount == 0 : "commitDense does not write covered sidecars; use seal()/commit() for covering indexes";
-        flushAllPendingDense();
+        if (genCount > 0) {
+            // flushAllPendingDense assumes it writes the first and only gen at
+            // offset 0. That precondition breaks when the caller's preceding
+            // add()-loop (a full index() rebuild over a large/squashed
+            // partition) tripped the spill budget: compactIfOverBudget then ran
+            // flushAllPending, persisting one or more sparse gens to this .pv.
+            // A standalone flushAllPendingDense would extendHead(newGenCount=1),
+            // overwriting gen-dir slot 0 to point at the freshly appended dense
+            // gen -- orphaning those sparse gens (silently dropping the rows
+            // they hold) and leaving the surviving gen-0 at a non-zero file
+            // offset. The covering rebuildSidecars by-copy path reads gen-0 from
+            // valueMem.addressOf(0) and SIGSEGVs on the layout mismatch; the
+            // non-covering path returns short counts. Consolidate every gen into
+            // a single dense gen-0 at offset 0 via the seal path instead: seal()
+            // first runs flushAllPending to drain the final pending batch, then
+            // sealFull re-encodes all gens (all sparse here, so never the
+            // incremental path) into one dense gen-0 at offset 0 -- exactly the
+            // shape the by-copy rebuild and the fast path both expect.
+            // coverCount == 0 keeps seal() sidecar-free, matching commitDense's
+            // contract; rebuildSidecars writes the sidecars afterward.
+            seal();
+        } else {
+            flushAllPendingDense();
+        }
         int commitMode = configuration.getCommitMode();
         if (commitMode != CommitMode.NOSYNC) {
             boolean async = commitMode == CommitMode.ASYNC;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -492,11 +492,11 @@ public class PostingIndexWriter implements IndexWriter {
             // non-covering path returns short counts. Consolidate every gen into
             // a single dense gen-0 at offset 0 via the seal path instead: seal()
             // first runs flushAllPending to drain the final pending batch, then
-            // sealFull re-encodes all gens (all sparse here, so never the
-            // incremental path) into one dense gen-0 at offset 0 -- exactly the
-            // shape the by-copy rebuild and the fast path both expect.
-            // coverCount == 0 keeps seal() sidecar-free, matching commitDense's
-            // contract; rebuildSidecars writes the sidecars afterward.
+            // re-encodes all gens into one dense gen-0 at offset 0 -- exactly the
+            // shape the by-copy rebuild and the fast path both expect. (Whether
+            // seal takes the full or incremental re-encode, gen-0 lands at offset
+            // 0.) coverCount == 0 keeps seal() sidecar-free, matching
+            // commitDense's contract; rebuildSidecars writes the sidecars after.
             seal();
         } else {
             flushAllPendingDense();

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -106,6 +106,12 @@ public class PostingIndexWriter implements IndexWriter {
     // reused across reopens via resetState().
     private final PostingIndexChainWriter chain = new PostingIndexChainWriter();
     private final CairoConfiguration configuration;
+    // Last-known valid byte extent of each cover column's .pcN, indexed by cover
+    // slot. Updated from the live sidecar handle's append offset whenever it is
+    // open (see captureCoverEndOffsets). Reused when the handle is closed so a
+    // chain-head republish (extendHead) that runs after closeSidecarMems does not
+    // clobber the entry's cover-end with 0 and make the on-disk .pc unreadable.
+    private final LongList coverEndOffsetsCache = new LongList();
     // Reusable scratch list passed to PostingIndexChainWriter.appendNewEntry /
     // extendHead, built once per chain publish from each cover column's
     // current sidecar append offset. Reused across calls to avoid allocations.
@@ -1893,17 +1899,43 @@ public class PostingIndexWriter implements IndexWriter {
      */
     private void captureCoverEndOffsets() {
         coverEndOffsetsScratch.clear();
-        if (coverCount <= 0) {
+        // The transient coverCount field is reset to 0 mid-reseal (clearCovering
+        // before the next configureCovering), and the sidecar handles are closed
+        // after each seal -- but the index is still covering on disk. Republishing
+        // the chain head in that window with an empty footer (coverCount==0) makes
+        // PostingIndexChainWriter.extendHead shrink the entry LEN to exclude the
+        // cover footer, so a concurrent covered read of the republished entry sees
+        // sidecarFileEndOffsets==0, fails to map the existing .pc and returns NULL
+        // for the whole partition -- the native in-place reseal covered-read race.
+        // Fall back to the last-known cover layout so the entry keeps its footer.
+        int effectiveCoverCount = coverCount > 0 ? coverCount : coverEndOffsetsCache.size();
+        if (effectiveCoverCount <= 0) {
             return;
         }
-        coverEndOffsetsScratch.setPos(coverCount);
-        for (int c = 0; c < coverCount; c++) {
-            long endOffset = 0L;
-            if (c < sidecarMems.size()) {
-                MemoryMARW mem = sidecarMems.getQuick(c);
-                if (mem != null && mem.isOpen()) {
-                    endOffset = mem.getAppendOffset();
-                }
+        // Keep the cache sized to the live cover count when it is known, so a later
+        // transient coverCount==0 republish reuses exactly the right layout (and a
+        // covering reconfigure that shrinks the cover set cannot over-report).
+        if (coverCount > 0 && coverEndOffsetsCache.size() != coverCount) {
+            int old = coverEndOffsetsCache.size();
+            coverEndOffsetsCache.setPos(coverCount);
+            for (int c = old; c < coverCount; c++) {
+                coverEndOffsetsCache.setQuick(c, 0L);
+            }
+        }
+        coverEndOffsetsScratch.setPos(effectiveCoverCount);
+        for (int c = 0; c < effectiveCoverCount; c++) {
+            long endOffset;
+            MemoryMARW mem = c < sidecarMems.size() ? sidecarMems.getQuick(c) : null;
+            if (mem != null && mem.isOpen()) {
+                // Handle open: its append offset is the authoritative valid extent
+                // of this .pcN. Remember it so a later republish can reuse it.
+                endOffset = mem.getAppendOffset();
+                coverEndOffsetsCache.setQuick(c, endOffset);
+            } else {
+                // Handle closed / transient coverCount==0: reuse the last-known
+                // extent. The .pc on disk for this head's sealTxn is unchanged. A
+                // genuinely never-written slot keeps its cached 0 and publishes 0.
+                endOffset = coverEndOffsetsCache.getQuick(c);
             }
             coverEndOffsetsScratch.setQuick(c, endOffset);
         }
@@ -3680,6 +3712,23 @@ public class PostingIndexWriter implements IndexWriter {
         // tripping the appendNewEntry monotonicity assertion.
         boolean newEntry = !chain.hasHead() || this.sealTxn != chain.getHeadSealTxn();
         long entryBase = newEntry ? chain.getRegionLimit() : chain.getHeadEntryOffset();
+
+        // For a same-sealTxn head extension the new gen-dir written below
+        // overwrites the head entry's cover footer. Snapshot it into the cache
+        // first so captureCoverEndOffsets can republish the existing extents even
+        // when the writer's live coverCount is transiently 0 (between
+        // clearCovering and configureCovering) or its sidecar handles are closed.
+        // Without this the footer is dropped and a concurrent covered read of the
+        // just-republished entry returns NULL for the whole partition.
+        if (!newEntry) {
+            chain.readHeadCoverEndOffsets(keyMem, coverEndOffsetsCache);
+        } else {
+            // New sealTxn: the cached extents belong to the superseded sealTxn's
+            // .pc (a different file), so drop them. The new entry publishes an
+            // empty footer until rebuildSidecars writes the new .pc and
+            // repopulates the cache from the live sidecar handle.
+            coverEndOffsetsCache.clear();
+        }
 
         long dirOffset = PostingIndexChainEntry.resolveGenDirOffset(entryBase, overrideGenIndex);
         long slotTxnAtSeal = pendingTxnAtSeal >= 0 ? pendingTxnAtSeal : 0L;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -71,7 +71,7 @@ import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;
 import static io.questdb.cairo.idx.PostingIndexUtils.*;
 
 /**
- * Delta + FoR64 BitPacking bitmap index writer.
+ * Delta + FoR64 BitPacking posting index writer.
  * <p>
  * Each commit appends one generation (covering all keys) to the value file.
  * No symbol table needed — encoding is purely arithmetic.
@@ -111,7 +111,9 @@ public class PostingIndexWriter implements IndexWriter {
     // current sidecar append offset. Reused across calls to avoid allocations.
     private final LongList coverEndOffsetsScratch = new LongList();
     // O3 addr-based covering: caller-provided native memory addresses
+    private final LongList coveredColumnAddrSizes = new LongList();
     private final LongList coveredColumnAddrs = new LongList();
+    private final LongList coveredColumnAuxAddrSizes = new LongList();
     private final LongList coveredColumnAuxAddrs = new LongList();
     private final IntList coveredColumnIndices = new IntList();
     private final LongList coveredColumnNameTxns = new LongList();
@@ -532,7 +534,9 @@ public class PostingIndexWriter implements IndexWriter {
         this.coveredColumnNames.clear();
         this.coveredColumnNameTxns.clear();
         this.coveredColumnAddrs.clear();
+        this.coveredColumnAddrSizes.clear();
         this.coveredColumnAuxAddrs.clear();
+        this.coveredColumnAuxAddrSizes.clear();
         this.coveredColumnTops.clear();
         this.coveredColumnShifts.clear();
         this.coveredColumnIndices.clear();
@@ -562,7 +566,9 @@ public class PostingIndexWriter implements IndexWriter {
         this.coveredColumnNames.clear();
         this.coveredColumnNameTxns.clear();
         this.coveredColumnAddrs.clear();
+        this.coveredColumnAddrSizes.clear();
         this.coveredColumnAuxAddrs.clear();
+        this.coveredColumnAuxAddrSizes.clear();
         this.coveredColumnTops.clear();
         this.coveredColumnShifts.clear();
         this.coveredColumnIndices.clear();
@@ -1219,7 +1225,9 @@ public class PostingIndexWriter implements IndexWriter {
     public void releaseCoveredColumnReadMappings() {
         unmapCoveredColumnReads();
         this.coveredColumnAddrs.clear();
+        this.coveredColumnAddrSizes.clear();
         this.coveredColumnAuxAddrs.clear();
+        this.coveredColumnAuxAddrSizes.clear();
     }
 
     @Override
@@ -1414,6 +1422,17 @@ public class PostingIndexWriter implements IndexWriter {
     public void sealIfMultiGen(int threshold) {
         if (keyMem.isOpen() && partitionPath.size() > 0 && genCount > threshold) {
             seal();
+        }
+    }
+
+    public void setCoveredColumnAddrSizes(LongList dataSizes, LongList auxSizes) {
+        coveredColumnAddrSizes.clear();
+        coveredColumnAuxAddrSizes.clear();
+        if (dataSizes != null) {
+            coveredColumnAddrSizes.addAll(dataSizes);
+        }
+        if (auxSizes != null) {
+            coveredColumnAuxAddrSizes.addAll(auxSizes);
         }
     }
 
@@ -3162,7 +3181,14 @@ public class PostingIndexWriter implements IndexWriter {
         if (addr == 0) {
             return 0;
         }
+        // size == 0: addr-based caller-owned aux mapping (see getCoveredDataReadAddr).
         if (size == 0) {
+            assert covIdx >= coveredColumnAuxAddrSizes.size()
+                    || coveredColumnAuxAddrSizes.getQuick(covIdx) == 0
+                    || offset + needed <= coveredColumnAuxAddrSizes.getQuick(covIdx)
+                    : "addr-based covered aux read out of bounds [covIdx=" + covIdx
+                    + ", offset=" + offset + ", needed=" + needed
+                    + ", mapped=" + coveredColumnAuxAddrSizes.getQuick(covIdx) + ']';
             return addr + offset;
         }
         if (offset + needed > size) {
@@ -3195,8 +3221,18 @@ public class PostingIndexWriter implements IndexWriter {
         if (addr == 0) {
             return 0;
         }
-        // size == 0 means addr-based (O3): caller-provided buffer, no bounds check or remap
+        // size == 0 means addr-based (O3 seal / fast-lag): the mapping is owned by
+        // the caller (TableWriter), so we never munmap/remap it -- coveredColReadSizes
+        // stays 0 precisely so unmapCoveredColumnReads leaves caller memory alone.
+        // When the caller supplied the mapped length via setCoveredColumnAddrSizes,
+        // assert the read stays inside it (an empty list -- test/parquet -- skips it).
         if (size == 0) {
+            assert covIdx >= coveredColumnAddrSizes.size()
+                    || coveredColumnAddrSizes.getQuick(covIdx) == 0
+                    || offset + needed <= coveredColumnAddrSizes.getQuick(covIdx)
+                    : "addr-based covered data read out of bounds [covIdx=" + covIdx
+                    + ", offset=" + offset + ", needed=" + needed
+                    + ", mapped=" + coveredColumnAddrSizes.getQuick(covIdx) + ']';
             return addr + offset;
         }
         // size > 0 means name-based: writer-owned mmap, remap if file grew

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -1558,6 +1558,32 @@ public class PostingIndexWriter implements IndexWriter {
         allocateNativeBuffers();
     }
 
+    @Override
+    public void unlinkPendingSealPurgesDirect() {
+        // Reclaim the superseded value file(s) from a spill-driven reseal by
+        // unlinking them directly, then clear the outbox. The native reseal
+        // defers these through the TableWriter's scoreboard-gated purge queue,
+        // but the parquet rebuild (O3PartitionJob.updateParquetIndexes) frees
+        // its pooled writer right after commitDense without ever draining the
+        // outbox, so a queued purge would simply be discarded by close(). A
+        // direct unlink is safe there because the parquet rebuild produces a
+        // fresh, uncommitted index: the chain head is tagged with the upcoming
+        // txn, so no committed reader can pick the superseded gens, and a
+        // rewrite failure removes the whole partition directory. coverCount is
+        // 0 on that path, so no sidecar (.pc) files exist for the old sealTxn.
+        assert coverCount == 0 : "unlinkPendingSealPurgesDirect does not reclaim covered sidecars";
+        if (pendingPurges.size() > 0 && partitionPath.size() > 0) {
+            final Path p = Path.getThreadLocal(partitionPath);
+            final int plen = p.size();
+            for (int i = 0, n = pendingPurges.size(); i < n; i++) {
+                final PendingSealPurge entry = pendingPurges.getQuick(i);
+                ff.removeQuiet(PostingIndexUtils.valueFileName(
+                        p.trimTo(plen), indexName, entry.postingColumnNameTxn, entry.sealTxn));
+            }
+        }
+        releasePendingPurges();
+    }
+
     private static int compressSidecarBlock(long rawBuf, int valueCount, int shift, int colType,
                                             boolean isDesignatedTs,
                                             long destBuf, long longWorkspaceAddr, long exceptionWorkspaceAddr) {

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -1210,18 +1210,13 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             if (tsIndex >= 0 && tsIndex != columnIndex) {
                 CharSequence tsName = metadata.getColumnName(tsIndex);
                 boolean isTimestampAlreadyIncluded = false;
-                if (coveringColumnNames != null) {
-                    for (int i = 0, n = coveringColumnNames.size(); i < n; i++) {
-                        if (metadata.getColumnIndexQuiet(coveringColumnNames.get(i)) == tsIndex) {
-                            isTimestampAlreadyIncluded = true;
-                            break;
-                        }
+                for (int i = 0, n = coveringColumnNames.size(); i < n; i++) {
+                    if (metadata.getColumnIndexQuiet(coveringColumnNames.get(i)) == tsIndex) {
+                        isTimestampAlreadyIncluded = true;
+                        break;
                     }
                 }
                 if (!isTimestampAlreadyIncluded) {
-                    if (coveringColumnNames == null) {
-                        coveringColumnNames = new ObjList<>(1);
-                    }
                     coveringColumnNames.add(tsName);
                 }
             }
@@ -1917,7 +1912,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         try (TableRecordMetadata tableMetadata = engine.getTableMetadata(matViewToken)) {
             tok = SqlUtil.fetchNext(lexer);
             if (tok == null || (!isAlterKeyword(tok) && !isResumeKeyword(tok) && !isSuspendKeyword(tok) && !isSetKeyword(tok))) {
-                compileAlterMatViewExt(executionContext, tok, matViewToken, matViewNamePosition);
+                compileAlterMatViewExt(tok, matViewToken, matViewNamePosition);
                 return;
             }
             if (isAlterKeyword(tok)) {
@@ -2047,7 +2042,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             } else if (isSetKeyword(tok)) {
                 tok = SqlUtil.fetchNext(lexer);
                 if (tok == null || (!isTtlKeyword(tok) && !isRefreshKeyword(tok))) {
-                    compileAlterMatViewSetExt(executionContext, tok, matViewToken, matViewNamePosition);
+                    compileAlterMatViewSetExt(tok, matViewToken, matViewNamePosition);
                     return;
                 }
                 if (isTtlKeyword(tok)) {
@@ -2284,7 +2279,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             } else if (isDropKeyword(tok)) {
                 tok = SqlUtil.fetchNext(lexer);
                 if (tok == null || (!isColumnKeyword(tok) && !isPartitionKeyword(tok))) {
-                    compileAlterTableDropExt(executionContext, tok, tableToken, tableNamePosition);
+                    compileAlterTableDropExt(tok, tableToken, tableNamePosition);
                     return;
                 }
                 if (isColumnKeyword(tok)) {
@@ -2522,7 +2517,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             } else if (isSetKeyword(tok)) {
                 tok = SqlUtil.fetchNext(lexer);
                 if (tok == null || (!isParamKeyword(tok) && !isTtlKeyword(tok) && !isTypeKeyword(tok))) {
-                    compileAlterTableSetExt(executionContext, tok, tableToken, tableNamePosition);
+                    compileAlterTableSetExt(tok, tableToken, tableNamePosition);
                     return;
                 }
                 if (isParamKeyword(tok)) {
@@ -2582,9 +2577,9 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                     alterTableDedupEnable(tableNamePosition, tableToken, tableMetadata, lexer);
                 }
             } else if (isEnableKeyword(tok)) {
-                compileAlterTableEnableExt(executionContext, tok, tableToken, tableNamePosition);
+                compileAlterTableEnableExt(tok, tableToken, tableNamePosition);
             } else if (isDisableKeyword(tok)) {
-                compileAlterTableDisableExt(executionContext, tok, tableToken, tableNamePosition);
+                compileAlterTableDisableExt(tok, tableToken, tableNamePosition);
             } else {
                 throw SqlException.$(lexer.lastTokenPosition(), ALTER_TABLE_EXPECTED_TOKEN_DESCR).put(" expected");
             }
@@ -5193,7 +5188,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         throw SqlException.position(lexer.lastTokenPosition()).put("'table' or 'materialized' or 'view' expected");
     }
 
-    protected void compileAlterMatViewExt(SqlExecutionContext executionContext, CharSequence tok, TableToken matViewToken, int matViewNamePosition) throws SqlException {
+    protected void compileAlterMatViewExt(CharSequence tok, TableToken matViewToken, int matViewNamePosition) throws SqlException {
         LOG.debug().$("'alter' or 'resume' or 'suspend' or 'set' expected [matViewToken=").$(matViewToken)
                 .$(", matViewNamePosition=").$(matViewNamePosition)
                 .$(']').$();
@@ -5203,7 +5198,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         throw SqlException.$(lexer.lastTokenPosition(), "'alter' or 'resume' or 'suspend' or 'set' expected");
     }
 
-    protected void compileAlterMatViewSetExt(SqlExecutionContext executionContext, CharSequence tok, TableToken matViewToken, int matViewNamePosition) throws SqlException {
+    protected void compileAlterMatViewSetExt(CharSequence tok, TableToken matViewToken, int matViewNamePosition) throws SqlException {
         LOG.debug().$("'ttl' or 'refresh' expected [matViewToken=").$(matViewToken)
                 .$(", matViewNamePosition=").$(matViewNamePosition)
                 .$(']').$();
@@ -5213,7 +5208,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         throw SqlException.$(lexer.lastTokenPosition(), "'ttl' or 'refresh' expected");
     }
 
-    protected void compileAlterTableDisableExt(SqlExecutionContext executionContext, CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
+    protected void compileAlterTableDisableExt(CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
         LOG.debug().$(ALTER_TABLE_EXPECTED_TOKEN_DESCR).$(" expected [tableToken=").$(tableToken)
                 .$(", tableNamePosition=").$(tableNamePosition)
                 .$(']').$();
@@ -5223,7 +5218,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         throw SqlException.$(lexer.lastTokenPosition(), ALTER_TABLE_EXPECTED_TOKEN_DESCR).put(" expected");
     }
 
-    protected void compileAlterTableDropExt(SqlExecutionContext executionContext, CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
+    protected void compileAlterTableDropExt(CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
         LOG.debug().$("'column' or 'partition' expected [tableToken=").$(tableToken)
                 .$(", tableNamePosition=").$(tableNamePosition)
                 .$(']').$();
@@ -5233,7 +5228,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         throw SqlException.$(lexer.lastTokenPosition(), "'column' or 'partition' expected");
     }
 
-    protected void compileAlterTableEnableExt(SqlExecutionContext executionContext, CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
+    protected void compileAlterTableEnableExt(CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
         LOG.debug().$(ALTER_TABLE_EXPECTED_TOKEN_DESCR).$(" expected [tableToken=").$(tableToken)
                 .$(", tableNamePosition=").$(tableNamePosition)
                 .$(']').$();
@@ -5243,7 +5238,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         throw SqlException.$(lexer.lastTokenPosition(), ALTER_TABLE_EXPECTED_TOKEN_DESCR).put(" expected");
     }
 
-    protected void compileAlterTableSetExt(SqlExecutionContext executionContext, CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
+    protected void compileAlterTableSetExt(CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
         LOG.debug().$("'param', 'ttl' or 'type' expected [tableToken=").$(tableToken)
                 .$(", tableNamePosition=").$(tableNamePosition)
                 .$(']').$();

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -1210,18 +1210,13 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             if (tsIndex >= 0 && tsIndex != columnIndex) {
                 CharSequence tsName = metadata.getColumnName(tsIndex);
                 boolean isTimestampAlreadyIncluded = false;
-                if (coveringColumnNames != null) {
-                    for (int i = 0, n = coveringColumnNames.size(); i < n; i++) {
-                        if (metadata.getColumnIndexQuiet(coveringColumnNames.get(i)) == tsIndex) {
-                            isTimestampAlreadyIncluded = true;
-                            break;
-                        }
+                for (int i = 0, n = coveringColumnNames.size(); i < n; i++) {
+                    if (metadata.getColumnIndexQuiet(coveringColumnNames.get(i)) == tsIndex) {
+                        isTimestampAlreadyIncluded = true;
+                        break;
                     }
                 }
                 if (!isTimestampAlreadyIncluded) {
-                    if (coveringColumnNames == null) {
-                        coveringColumnNames = new ObjList<>(1);
-                    }
                     coveringColumnNames.add(tsName);
                 }
             }

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -1198,12 +1198,14 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             }
         }
 
-        // Auto-append the designated timestamp on POSTING indexes, even
-        // when the user gave no INCLUDE clause. This is the bare
-        // ALTER TABLE ... ADD INDEX TYPE POSTING case; without the
-        // append the default config's covering benefit silently
-        // disappears.
-        if (IndexType.isPosting(indexType) && configuration.isPostingIndexAutoIncludeTimestamp()) {
+        // Auto-append the designated timestamp on POSTING indexes, but only
+        // when the user gave an INCLUDE clause with at least one column. A bare
+        // ALTER TABLE ... ADD INDEX TYPE POSTING (no INCLUDE) is a plain,
+        // non-covering posting index; the timestamp is auto-added only to round
+        // out an explicit covering set, never to turn a non-covering index into
+        // a covering one on its own.
+        if (IndexType.isPosting(indexType) && configuration.isPostingIndexAutoIncludeTimestamp()
+                && coveringColumnNames != null && coveringColumnNames.size() > 0) {
             int tsIndex = metadata.getTimestampIndex();
             if (tsIndex >= 0 && tsIndex != columnIndex) {
                 CharSequence tsName = metadata.getColumnName(tsIndex);

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -1210,13 +1210,18 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             if (tsIndex >= 0 && tsIndex != columnIndex) {
                 CharSequence tsName = metadata.getColumnName(tsIndex);
                 boolean isTimestampAlreadyIncluded = false;
-                for (int i = 0, n = coveringColumnNames.size(); i < n; i++) {
-                    if (metadata.getColumnIndexQuiet(coveringColumnNames.get(i)) == tsIndex) {
-                        isTimestampAlreadyIncluded = true;
-                        break;
+                if (coveringColumnNames != null) {
+                    for (int i = 0, n = coveringColumnNames.size(); i < n; i++) {
+                        if (metadata.getColumnIndexQuiet(coveringColumnNames.get(i)) == tsIndex) {
+                            isTimestampAlreadyIncluded = true;
+                            break;
+                        }
                     }
                 }
                 if (!isTimestampAlreadyIncluded) {
+                    if (coveringColumnNames == null) {
+                        coveringColumnNames = new ObjList<>(1);
+                    }
                     coveringColumnNames.add(tsName);
                 }
             }
@@ -1912,7 +1917,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         try (TableRecordMetadata tableMetadata = engine.getTableMetadata(matViewToken)) {
             tok = SqlUtil.fetchNext(lexer);
             if (tok == null || (!isAlterKeyword(tok) && !isResumeKeyword(tok) && !isSuspendKeyword(tok) && !isSetKeyword(tok))) {
-                compileAlterMatViewExt(tok, matViewToken, matViewNamePosition);
+                compileAlterMatViewExt(executionContext, tok, matViewToken, matViewNamePosition);
                 return;
             }
             if (isAlterKeyword(tok)) {
@@ -2042,7 +2047,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             } else if (isSetKeyword(tok)) {
                 tok = SqlUtil.fetchNext(lexer);
                 if (tok == null || (!isTtlKeyword(tok) && !isRefreshKeyword(tok))) {
-                    compileAlterMatViewSetExt(tok, matViewToken, matViewNamePosition);
+                    compileAlterMatViewSetExt(executionContext, tok, matViewToken, matViewNamePosition);
                     return;
                 }
                 if (isTtlKeyword(tok)) {
@@ -2279,7 +2284,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             } else if (isDropKeyword(tok)) {
                 tok = SqlUtil.fetchNext(lexer);
                 if (tok == null || (!isColumnKeyword(tok) && !isPartitionKeyword(tok))) {
-                    compileAlterTableDropExt(tok, tableToken, tableNamePosition);
+                    compileAlterTableDropExt(executionContext, tok, tableToken, tableNamePosition);
                     return;
                 }
                 if (isColumnKeyword(tok)) {
@@ -2517,7 +2522,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             } else if (isSetKeyword(tok)) {
                 tok = SqlUtil.fetchNext(lexer);
                 if (tok == null || (!isParamKeyword(tok) && !isTtlKeyword(tok) && !isTypeKeyword(tok))) {
-                    compileAlterTableSetExt(tok, tableToken, tableNamePosition);
+                    compileAlterTableSetExt(executionContext, tok, tableToken, tableNamePosition);
                     return;
                 }
                 if (isParamKeyword(tok)) {
@@ -2577,9 +2582,9 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                     alterTableDedupEnable(tableNamePosition, tableToken, tableMetadata, lexer);
                 }
             } else if (isEnableKeyword(tok)) {
-                compileAlterTableEnableExt(tok, tableToken, tableNamePosition);
+                compileAlterTableEnableExt(executionContext, tok, tableToken, tableNamePosition);
             } else if (isDisableKeyword(tok)) {
-                compileAlterTableDisableExt(tok, tableToken, tableNamePosition);
+                compileAlterTableDisableExt(executionContext, tok, tableToken, tableNamePosition);
             } else {
                 throw SqlException.$(lexer.lastTokenPosition(), ALTER_TABLE_EXPECTED_TOKEN_DESCR).put(" expected");
             }
@@ -5188,7 +5193,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         throw SqlException.position(lexer.lastTokenPosition()).put("'table' or 'materialized' or 'view' expected");
     }
 
-    protected void compileAlterMatViewExt(CharSequence tok, TableToken matViewToken, int matViewNamePosition) throws SqlException {
+    protected void compileAlterMatViewExt(SqlExecutionContext executionContext, CharSequence tok, TableToken matViewToken, int matViewNamePosition) throws SqlException {
         LOG.debug().$("'alter' or 'resume' or 'suspend' or 'set' expected [matViewToken=").$(matViewToken)
                 .$(", matViewNamePosition=").$(matViewNamePosition)
                 .$(']').$();
@@ -5198,7 +5203,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         throw SqlException.$(lexer.lastTokenPosition(), "'alter' or 'resume' or 'suspend' or 'set' expected");
     }
 
-    protected void compileAlterMatViewSetExt(CharSequence tok, TableToken matViewToken, int matViewNamePosition) throws SqlException {
+    protected void compileAlterMatViewSetExt(SqlExecutionContext executionContext, CharSequence tok, TableToken matViewToken, int matViewNamePosition) throws SqlException {
         LOG.debug().$("'ttl' or 'refresh' expected [matViewToken=").$(matViewToken)
                 .$(", matViewNamePosition=").$(matViewNamePosition)
                 .$(']').$();
@@ -5208,7 +5213,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         throw SqlException.$(lexer.lastTokenPosition(), "'ttl' or 'refresh' expected");
     }
 
-    protected void compileAlterTableDisableExt(CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
+    protected void compileAlterTableDisableExt(SqlExecutionContext executionContext, CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
         LOG.debug().$(ALTER_TABLE_EXPECTED_TOKEN_DESCR).$(" expected [tableToken=").$(tableToken)
                 .$(", tableNamePosition=").$(tableNamePosition)
                 .$(']').$();
@@ -5218,7 +5223,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         throw SqlException.$(lexer.lastTokenPosition(), ALTER_TABLE_EXPECTED_TOKEN_DESCR).put(" expected");
     }
 
-    protected void compileAlterTableDropExt(CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
+    protected void compileAlterTableDropExt(SqlExecutionContext executionContext, CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
         LOG.debug().$("'column' or 'partition' expected [tableToken=").$(tableToken)
                 .$(", tableNamePosition=").$(tableNamePosition)
                 .$(']').$();
@@ -5228,7 +5233,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         throw SqlException.$(lexer.lastTokenPosition(), "'column' or 'partition' expected");
     }
 
-    protected void compileAlterTableEnableExt(CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
+    protected void compileAlterTableEnableExt(SqlExecutionContext executionContext, CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
         LOG.debug().$(ALTER_TABLE_EXPECTED_TOKEN_DESCR).$(" expected [tableToken=").$(tableToken)
                 .$(", tableNamePosition=").$(tableNamePosition)
                 .$(']').$();
@@ -5238,7 +5243,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         throw SqlException.$(lexer.lastTokenPosition(), ALTER_TABLE_EXPECTED_TOKEN_DESCR).put(" expected");
     }
 
-    protected void compileAlterTableSetExt(CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
+    protected void compileAlterTableSetExt(SqlExecutionContext executionContext, CharSequence tok, TableToken tableToken, int tableNamePosition) throws SqlException {
         LOG.debug().$("'param', 'ttl' or 'type' expected [tableToken=").$(tableToken)
                 .$(", tableNamePosition=").$(tableNamePosition)
                 .$(']').$();

--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateTableOperationImpl.java
@@ -192,13 +192,11 @@ public class CreateTableOperationImpl implements CreateTableOperation {
             this.columnNames.add(Chars.toString(colName));
             CreateTableColumnModel model = createColumnModelMap.get(colName);
             ObjList<CharSequence> coverNames = model.getCoveringColumnNames();
-            // Set the COVERING flag whenever resolveCoveringColumnIndices
-            // will produce a non-empty list — that is, either the user gave
-            // an INCLUDE clause, or auto-include applies (POSTING index on
-            // a column other than the designated timestamp).
-            boolean hasCovering = coverNames.size() > 0
-                    || (autoIncludeTimestamp && timestampIndex >= 0 && i != timestampIndex
-                    && IndexType.isPosting(model.getIndexType()));
+            // Covering iff the user gave an INCLUDE clause with at least one
+            // column. The timestamp auto-include only rounds out an explicit
+            // covering set (see resolveCoveringColumnIndices); a bare POSTING
+            // index with no INCLUDE is non-covering.
+            boolean hasCovering = coverNames.size() > 0;
             addColumnBits(
                     model.getColumnType(),
                     model.getSymbolCacheFlag(),
@@ -769,13 +767,11 @@ public class CreateTableOperationImpl implements CreateTableOperation {
             }
             this.columnNames.add(columnName);
             ObjList<CharSequence> coverNames = augmentedCoveringNames.get(columnName);
-            // Set the COVERING flag whenever resolveCoveringFromAugmented
-            // will produce a non-empty list — that is, either the user gave
-            // an INCLUDE clause, or auto-include applies (POSTING index on
-            // a column other than the designated timestamp).
-            boolean hasCovering = (coverNames != null && coverNames.size() > 0)
-                    || (autoIncludeTimestamp && this.timestampIndex >= 0 && i != this.timestampIndex
-                    && IndexType.isPosting(indexType));
+            // Covering iff the user gave an INCLUDE clause with at least one
+            // column. The timestamp auto-include only rounds out an explicit
+            // covering set (see resolveCoveringFromAugmented); a bare POSTING
+            // index with no INCLUDE is non-covering.
+            boolean hasCovering = coverNames != null && coverNames.size() > 0;
             this.addColumnBits(
                     columnType,
                     symbolCacheFlag,
@@ -879,15 +875,13 @@ public class CreateTableOperationImpl implements CreateTableOperation {
                     indices.add(idx);
                 }
             }
-            // Auto-append the designated timestamp on POSTING indexes,
-            // including the bare INDEX TYPE POSTING case where the user
-            // gave no INCLUDE list. Skip when this column is itself the
-            // timestamp (you cannot cover yourself).
-            if (autoIncludeTimestamp && timestampIndex >= 0 && i != timestampIndex
+            // Auto-append the designated timestamp on POSTING indexes, but only
+            // when the user gave an INCLUDE clause with at least one column -- a
+            // bare INDEX TYPE POSTING (no INCLUDE) stays non-covering. Skip when
+            // this column is itself the timestamp (you cannot cover yourself).
+            if (autoIncludeTimestamp && indices != null && indices.size() > 0
+                    && timestampIndex >= 0 && i != timestampIndex
                     && IndexType.isPosting(model.getIndexType())) {
-                if (indices == null) {
-                    indices = new IntList(1);
-                }
                 maybeAppendTimestamp(indices, timestampIndex);
             }
             coveringColumnIndicesList.add(indices);
@@ -914,16 +908,13 @@ public class CreateTableOperationImpl implements CreateTableOperation {
                     indices.add(idx);
                 }
             }
-            // Auto-append the designated timestamp on POSTING indexes,
-            // including the no-INCLUDE case (the out-of-line INDEX(...)
-            // clause used by CTAS does not accept INCLUDE today, so this
-            // is the only way users get covering on CTAS). Skip when this
-            // column is itself the timestamp.
-            if (autoIncludeTimestamp && timestampIndex >= 0 && i != timestampIndex
+            // Auto-append the designated timestamp on POSTING indexes, but only
+            // when the user gave an INCLUDE clause with at least one column -- a
+            // bare INDEX TYPE POSTING (no INCLUDE) stays non-covering. Skip when
+            // this column is itself the timestamp.
+            if (autoIncludeTimestamp && indices != null && indices.size() > 0
+                    && timestampIndex >= 0 && i != timestampIndex
                     && IndexType.isPosting(getIndexType(i))) {
-                if (indices == null) {
-                    indices = new IntList(1);
-                }
                 maybeAppendTimestamp(indices, timestampIndex);
             }
             coveringColumnIndicesList.add(indices);

--- a/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
@@ -1142,16 +1142,16 @@ public class CreateTableTest extends AbstractCairoTest {
     public void testCreateTablePostingIndexShowCreate() throws Exception {
         assertMemoryLeak(() -> {
             execute("CREATE TABLE tab (s SYMBOL INDEX TYPE POSTING, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
-            // The default cairo.posting.index.auto.include.timestamp=true
-            // appends the designated timestamp to the covering list, so
-            // SHOW CREATE TABLE renders an explicit INCLUDE (ts) clause.
+            // A bare INDEX TYPE POSTING (no INCLUDE) is non-covering, so SHOW
+            // CREATE TABLE renders no INCLUDE clause. The timestamp auto-include
+            // only rounds out an explicit INCLUDE set.
             assertQuery("SHOW CREATE TABLE tab")
                     .noLeakCheck()
                     .noRandomAccess()
                     .returns("""
                             ddl
                             CREATE TABLE 'tab' (\s
-                            \ts SYMBOL INDEX TYPE POSTING INCLUDE (ts),
+                            \ts SYMBOL INDEX TYPE POSTING,
                             \tts TIMESTAMP
                             ) timestamp(ts) PARTITION BY DAY BYPASS WAL;
                             """);
@@ -1511,12 +1511,13 @@ public class CreateTableTest extends AbstractCairoTest {
                     """);
             drainWalQueue();
 
-            // Query BEFORE releaseAllWriters (unsealed sparse gens)
+            // Query BEFORE releaseAllWriters (unsealed sparse gens). A bare
+            // INDEX TYPE POSTING is non-covering, so SELECT * takes the plain
+            // posting-filter cursor: it supports random access and reports a
+            // lazy size (size() == -1), unlike the covering cursor.
             assertQuery("SELECT * FROM t WHERE s = 'A'")
                     .noLeakCheck()
-                    .expectSize()
                     .timestamp("ts")
-                    .noRandomAccess()
                     .returns("""
                             ts\ts
                             2024-01-01T00:00:00.000000Z\tA
@@ -1530,9 +1531,7 @@ public class CreateTableTest extends AbstractCairoTest {
             // Query AFTER seal (dense gen, stride-indexed)
             assertQuery("SELECT * FROM t WHERE s = 'A'")
                     .noLeakCheck()
-                    .expectSize()
                     .timestamp("ts")
-                    .noRandomAccess()
                     .returns("""
                             ts\ts
                             2024-01-01T00:00:00.000000Z\tA
@@ -1542,9 +1541,7 @@ public class CreateTableTest extends AbstractCairoTest {
 
             assertQuery("SELECT * FROM t WHERE s = 'B'")
                     .noLeakCheck()
-                    .expectSize()
                     .timestamp("ts")
-                    .noRandomAccess()
                     .returns("""
                             ts\ts
                             2024-01-01T01:00:00.000000Z\tB
@@ -1553,9 +1550,7 @@ public class CreateTableTest extends AbstractCairoTest {
 
             assertQuery("SELECT * FROM t WHERE s = 'C'")
                     .noLeakCheck()
-                    .expectSize()
                     .timestamp("ts")
-                    .noRandomAccess()
                     .returns("""
                             ts\ts
                             2024-01-01T03:00:00.000000Z\tC
@@ -1565,7 +1560,6 @@ public class CreateTableTest extends AbstractCairoTest {
             assertQuery("SELECT * FROM t WHERE s = 'Z'")
                     .noLeakCheck()
                     .timestamp("ts")
-                    .noRandomAccess()
                     .returns("""
                             ts\ts
                             """);
@@ -1591,9 +1585,7 @@ public class CreateTableTest extends AbstractCairoTest {
             // readers can see it without waiting for close/seal.
             assertQuery("SELECT * FROM t WHERE s = 'A'")
                     .noLeakCheck()
-                    .expectSize()
                     .timestamp("ts")
-                    .noRandomAccess()
                     .returns("""
                             ts\ts
                             2024-01-01T00:00:00.000000Z\tA

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -4272,6 +4272,220 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * Reproduces the SIGSEGV in PostingIndexWriter.decodeDenseGenStride when
+     * squashing partitions over a COVERING posting index whose reseal index()
+     * loop trips the spill budget (compactIfOverBudget -> mid-stream
+     * flushAllPending). The mid-stream sparse flush lands a gen at file
+     * offset 0; commitDense then appends the dense gen-0 at a NON-ZERO offset
+     * and publishes a single-gen chain entry that points there. rebuildSidecars
+     * takes the genCount==1 by-copy path: accumulateDenseGen0Counts reads the
+     * gen via its real FILE_OFFSET (correct), but writeSidecarForColumn decodes
+     * from valueMem.addressOf(0) (the orphaned sparse gen) -- a stride-index
+     * mismatch that over-reads native memory and SIGSEGVs (no AssertionError,
+     * just a JVM crash). The fix makes commitDense consolidate via seal() when
+     * prior gens exist, so gen-0 lands back at offset 0 with every row intact;
+     * the covering query then returns the same rows as the non-covering
+     * fallback.
+     */
+    @Test
+    public void testSquashCoveringPostingWithMidStreamSpillFlush() throws Exception {
+        // Force a mid-stream flushAllPending during the squash reseal index()
+        // loop: a tiny spill budget means a few dozen rowids for a hot key push
+        // totalSpillBytes over the threshold, so compactIfOverBudget fires
+        // before commitDense writes the final dense gen.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        // Allow the split sub-partitions to form and persist until the explicit
+        // squashPartitions() call (see testSquashPartitionsResealFailureMarks...).
+        node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
+        node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 20);
+        node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 20);
+
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_squash_spill (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            // Seed a hot key 'A' with enough rowids in 2024-01-01 that the
+            // reseal index() loop spills well past the 256-byte budget.
+            execute("""
+                    INSERT INTO t_squash_spill
+                    SELECT dateadd('s', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP),
+                           'A', x::DOUBLE
+                    FROM long_sequence(400)
+                    """);
+            // Extend the day's max timestamp to 20:00 so there is a late tail
+            // for the O3 insert below to split off (mirrors the split recipe in
+            // testSquashPartitionsResealFailureMarksWriterDistressed).
+            execute("""
+                    INSERT INTO t_squash_spill VALUES
+                    ('2024-01-01T20:00:00.000000Z', 'A', 1000000.0)
+                    """);
+            // O3 into a late prefix (19:00 < 20:00) splits the last partition.
+            execute("""
+                    INSERT INTO t_squash_spill VALUES
+                    ('2024-01-01T19:00:00.000000Z', 'B', -1.0)
+                    """);
+
+            assertQuery("SELECT count() FROM table_partitions('t_squash_spill')")
+                    .noLeakCheck()
+                    .expectSize()
+                    .noRandomAccess()
+                    .returns("""
+                            count
+                            2
+                            """);
+
+            // Truth from the non-covering fallback path.
+            printSql("SELECT /*+ no_covering */ count(), sum(price) FROM t_squash_spill WHERE sym = 'A'");
+            String truth = sink.toString();
+
+            engine.releaseAllWriters();
+            try (TableWriter w = TestUtils.getWriter(engine, "t_squash_spill")) {
+                // Squash reseals the covering posting index for the target
+                // partition: discardForRebuild -> index() (mid-stream flush) ->
+                // commitDense -> rebuildSidecars (by-copy). The buggy decode
+                // SIGSEGVs here.
+                w.squashPartitions();
+            }
+
+            assertQuery("SELECT count() FROM table_partitions('t_squash_spill')")
+                    .noLeakCheck()
+                    .expectSize()
+                    .noRandomAccess()
+                    .returns("""
+                            count
+                            1
+                            """);
+
+            // The covering path must return the same rows as the fallback.
+            printSql("SELECT count(), sum(price) FROM t_squash_spill WHERE sym = 'A'");
+            TestUtils.assertEquals(
+                    "covering result after squash must match the no_covering fallback",
+                    truth, sink.toString());
+        });
+    }
+
+    /**
+     * Non-covering twin of testSquashCoveringPostingWithMidStreamSpillFlush.
+     * The non-covering squash reseal also runs discardForRebuild -> index() ->
+     * commitDense; the same mid-stream flushAllPending orphans the early sparse
+     * gen. Without a sidecar rebuild there is no SIGSEGV, but commitDense's
+     * extendHead(newGenCount=1) silently drops the pre-flush rows, so an indexed
+     * predicate returns short counts. Asserting full counts proves the
+     * commitDense consolidation fix restores completeness on this path too.
+     */
+    @Test
+    public void testSquashNonCoveringPostingWithMidStreamSpillFlush() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        // POSTING auto-includes the designated timestamp by default, which would
+        // make this a covering index (and crash, like the covering test).
+        // Disable it so the reseal genuinely takes the non-covering branch.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
+        node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 20);
+        node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 20);
+
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_squash_spill_nc (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING,
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            execute("""
+                    INSERT INTO t_squash_spill_nc
+                    SELECT dateadd('s', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP),
+                           'A', x::DOUBLE
+                    FROM long_sequence(400)
+                    """);
+            execute("""
+                    INSERT INTO t_squash_spill_nc VALUES
+                    ('2024-01-01T20:00:00.000000Z', 'A', 1000000.0)
+                    """);
+            execute("""
+                    INSERT INTO t_squash_spill_nc VALUES
+                    ('2024-01-01T19:00:00.000000Z', 'B', -1.0)
+                    """);
+
+            // 401 'A' rows total (400 + the 20:00 sentinel).
+            printSql("SELECT /*+ no_covering */ count() FROM t_squash_spill_nc WHERE sym = 'A'");
+            String truth = sink.toString();
+
+            engine.releaseAllWriters();
+            try (TableWriter w = TestUtils.getWriter(engine, "t_squash_spill_nc")) {
+                w.squashPartitions();
+            }
+
+            // Index-driven count must still see every 'A' rowid after the reseal.
+            printSql("SELECT count() FROM t_squash_spill_nc WHERE sym = 'A'");
+            TestUtils.assertEquals(
+                    "indexed count after squash must keep every rowid (no orphaned gen)",
+                    truth, sink.toString());
+        });
+    }
+
+    /**
+     * Drives the reported crash through its original entry point: WAL apply.
+     * housekeep() auto-squashes split sub-partitions inside
+     * commitWalInsertTransactions, and with a covering posting index over a hot
+     * key plus a tiny spill budget the squash reseal mid-stream flushes -- the
+     * exact wal-apply_N -> squashSplitPartitions -> sealPostingIndexForPartition
+     * -> rebuildSidecars -> decodeDenseGenStride path from the hs_err report.
+     * The crash happens inside drainWalQueue; with the fix the drained table
+     * returns the same rows as the non-covering fallback.
+     */
+    @Test
+    public void testWalApplyAutoSquashCoveringPostingWithMidStreamSpillFlush() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
+        // Low split ceiling so housekeep squashes the accumulated splits during
+        // a later drain rather than letting them persist.
+        node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 2);
+        node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 2);
+
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_wal_squash_spill (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            // Hot key 'A' seeded across the day; the 23:00 sentinel keeps the
+            // partition's max late so the O3 prefixes below split rather than
+            // append.
+            execute("""
+                    INSERT INTO t_wal_squash_spill
+                    SELECT dateadd('s', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP),
+                           'A', x::DOUBLE
+                    FROM long_sequence(400)
+                    """);
+            execute("INSERT INTO t_wal_squash_spill VALUES ('2024-01-01T23:00:00.000000Z', 'A', 1000000.0)");
+            drainWalQueue();
+
+            // Several O3 prefixes into the late tail create split sub-partitions;
+            // once they exceed MAX_SPLITS, a subsequent drain's housekeep squashes
+            // them and reseals the covering posting index over all 400+ 'A' rows.
+            for (int i = 0; i < 6; i++) {
+                execute("INSERT INTO t_wal_squash_spill VALUES " +
+                        "('2024-01-01T22:" + i + "0:00.000000Z', 'B', " + (-1 - i) + ".0)");
+                drainWalQueue();
+            }
+
+            printSql("SELECT /*+ no_covering */ count(), sum(price) FROM t_wal_squash_spill WHERE sym = 'A'");
+            String truth = sink.toString();
+            printSql("SELECT count(), sum(price) FROM t_wal_squash_spill WHERE sym = 'A'");
+            TestUtils.assertEquals(
+                    "covering result after WAL auto-squash must match the no_covering fallback",
+                    truth, sink.toString());
+        });
+    }
+
+    /**
      * Reproduces the SIGSEGV from the JMH walFastLag bench (hs_err_pid19555):
      * MemoryCR.getLong over-read inside PostingIndexChainEntry.read on a
      * covering posting index. The bench ran walFastLagInsertAndQuery in a

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -573,6 +573,45 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    /**
+     * WAL-apply auto-scale reproduction, mirroring the field scenario more
+     * closely than the explicit-ALTER test: a covering posting index on a WAL
+     * table, ingested with high, growing symbol cardinality so the WAL apply job
+     * fires scaleSymbolCapacities() -> changeSymbolCapacity() repeatedly (the
+     * field 256 -> 2048 -> 4096 growth). Asserts both that the planner keeps
+     * choosing the covering scan (covering mapping is read from the reader _meta,
+     * which updateColumnSymbolCapacity must preserve) and that the covered
+     * sidecar still serves correct data afterwards.
+     */
+    @Test
+    public void testWalCoveringPlanSurvivesAutoScaleHeavyIngest() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE x (ts TIMESTAMP, sym SYMBOL CAPACITY 16 INDEX TYPE POSTING INCLUDE (val), val DOUBLE) " +
+                    "TIMESTAMP(ts) PARTITION BY DAY WAL");
+            final String coveringPlan =
+                    "SelectedRecord\n" +
+                            "    CoveringIndex on: sym with: ts, val\n" +
+                            "      filter: sym='zzz'\n";
+            assertPlanNoLeakCheck("SELECT ts, val FROM x WHERE sym = 'zzz'", coveringPlan);
+
+            final long dayMicros = 86_400_000_000L;
+            for (int day = 0; day < 6; day++) {
+                execute("INSERT INTO x " +
+                        "SELECT (" + (day * dayMicros) + " + x)::timestamp, rnd_symbol(4000,4,10,0), x::double " +
+                        "FROM long_sequence(30000)");
+                drainWalQueue();
+            }
+            // One known covered row to verify the covered read after all the auto-scaling.
+            execute("INSERT INTO x VALUES (" + (9 * dayMicros) + ", 'zzz', 7.0)");
+            drainWalQueue();
+
+            // The planner must still choose the covering posting index after auto-scale.
+            assertPlanNoLeakCheck("SELECT ts, val FROM x WHERE sym = 'zzz'", coveringPlan);
+            // The covered sidecar read must still return correct data.
+            assertSql("count\tsum\n1\t7.0\n", "SELECT count(), sum(val) FROM x WHERE sym = 'zzz'");
+        });
+    }
+
     @Test
     public void testO3DeferredPostingSealPurgeRunsAfterCommit() throws Exception {
         assertMemoryLeak(() -> {

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -74,6 +74,7 @@ import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -5097,6 +5098,229 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                                 + "intermediate from the spill-driven reseal survived: "
                                 + java.util.Arrays.toString(names),
                         1, pvCount);
+            }
+        });
+    }
+
+    /**
+     * Concurrent covered-read integration test: a COVERING posting index
+     * (sym INCLUDE price) over several parquet partitions, rewritten out-of-order
+     * across the real 4-worker O3 pool under a tiny spill budget, while background
+     * threads continuously serve {@code count(), sum(price) WHERE sym='A'} from the
+     * covering sidecars. This is the multi-threaded covering analogue of
+     * testParquetPostingSpillConcurrentReadFuzz; it exercises the interaction the
+     * single-threaded covering tests never do:
+     * <ul>
+     *   <li>multiple O3 workers running updateParquetIndexes -> commitDense ->
+     *       configureCovering -> rebuildSidecars and depositing .pv/.pc purges into
+     *       the shared deferredPostingSealPurges list/pool under parquetSealPurgeLock;</li>
+     *   <li>the scoreboard-gated PostingSealPurgeJob (on the pool) reclaiming
+     *       superseded .pv/.pc while readers hold real txn pins;</li>
+     *   <li>readers resolving covered values (the addr-based covered read) against a
+     *       sidecar a concurrent reseal/purge is rotating.</li>
+     * </ul>
+     * Oracles (all under -ea, so the audit's holdsLock / no-O3-in-flight /
+     * covered-bounds asserts also fire on the worker threads): rows are only added,
+     * so the covered 'A' count must be monotonic and never below the committed
+     * floor; sum(price) must never drop below the initial covered total and must
+     * stay &gt;= count (every price &gt;= 1); no reader may crash; and after a final
+     * purge pass with nothing pinned, each partition keeps exactly one .pv (no purge
+     * lost or double-freed). The floor is read BEFORE the count so a commit landing
+     * mid-read can never make a valid snapshot look short.
+     * <p>
+     * IGNORED pending root-cause: this reproducer FAILS. Single-threaded the covered
+     * query is correct (count=dayCount*hotPerDay, sum=dayCount*sum(1..hotPerDay)), but
+     * under the concurrent O3 reseal a reader observes a CORRECT posting count
+     * (count >= the committed floor) together with a PARTIAL covered sum -- the price
+     * values of the partitions being resealed read as 0 while their row ids are still
+     * counted (e.g. count>=5000 but sum=1001000 == only 2 of 5 days' prices). The
+     * covered-value (sidecar) read races the writer-thread covering reseal
+     * (sealPostingIndexForPartition -> rebuildSidecars) in a way the posting row-id
+     * read does not. Reproducible across seeds. Un-@Ignore to reproduce.
+     */
+    @Ignore("Reproducer for a covered-value partial-read under concurrent O3 reseal; " +
+            "count() is correct but sum(covered) reads 0 for resealing partitions. Single-threaded is correct.")
+    @Test
+    public void testMultiThreadedO3CoveringPostingConcurrentReaderFuzz() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+
+        assertMemoryLeak(() -> {
+            final int dayCount = 4 + rnd.nextInt(4); // 4..7 days; keeps sum < 1e7 (no sci-notation)
+            final int hotPerDay = 1000;
+            final long perDaySum = (long) hotPerDay * (hotPerDay + 1) / 2; // sum(1..hotPerDay)
+            final long initialRows = (long) dayCount * hotPerDay;
+            final long initialSum = (long) dayCount * perDaySum;
+
+            execute("""
+                    CREATE TABLE t_cov (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            // hotPerDay 'A' rows/day with price = row index, so the covered total is
+            // deterministic and every partition's reseal spills (tiny budget).
+            for (int d = 1; d <= dayCount; d++) {
+                execute("INSERT INTO t_cov SELECT dateadd('s', x::INT, '2024-02-0" + d
+                        + "T00:00:00.000000Z'::TIMESTAMP), 'A', x::DOUBLE FROM long_sequence(" + hotPerDay + ")");
+            }
+            for (int d = 1; d <= dayCount; d++) {
+                execute("ALTER TABLE t_cov CONVERT PARTITION TO PARQUET LIST '2024-02-0" + d + "'");
+            }
+
+            final AtomicReference<Throwable> bgError = new AtomicReference<>();
+            final AtomicBoolean stop = new AtomicBoolean();
+            final AtomicLong rowFloor = new AtomicLong(initialRows);
+            final int readerCount = 3;
+            final Thread[] readers = new Thread[readerCount];
+            for (int r = 0; r < readerCount; r++) {
+                readers[r] = new Thread(() -> {
+                    try (
+                            SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                                    .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                            null, null, -1, null);
+                            SqlCompiler compiler = engine.getSqlCompiler()
+                    ) {
+                        long prevCount = 0;
+                        while (!stop.get() && bgError.get() == null) {
+                            // Read the floor BEFORE the snapshot: the floor was committed
+                            // at an earlier time, and rows only ever get added, so a valid
+                            // snapshot taken later cannot be below it.
+                            final long floor = rowFloor.get();
+                            final long count;
+                            final double sum;
+                            try (RecordCursorFactory f = compiler.compile(
+                                    "SELECT count(), sum(price) FROM t_cov WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                                 RecordCursor cur = f.getCursor(ctx)) {
+                                if (cur.hasNext()) {
+                                    count = cur.getRecord().getLong(0);
+                                    sum = cur.getRecord().getDouble(1);
+                                } else {
+                                    count = -1;
+                                    sum = -1;
+                                }
+                            }
+                            if (count < floor) {
+                                throw new AssertionError("covered 'A' count fell below the committed floor: "
+                                        + count + " < " + floor);
+                            }
+                            if (count < prevCount) {
+                                throw new AssertionError("covered 'A' count went backwards: " + prevCount + " -> " + count);
+                            }
+                            if (sum < (double) initialSum - 0.5) {
+                                throw new AssertionError("covered sum(price) dropped below the initial total "
+                                        + initialSum + ": " + sum + " (a covered value was lost/corrupted)");
+                            }
+                            if (sum < (double) count - 0.5) {
+                                throw new AssertionError("covered sum(price)=" + sum + " < count=" + count
+                                        + " -- a covered value resolved as < 1 (stale/garbage sidecar)");
+                            }
+                            prevCount = count;
+                        }
+                    } catch (Throwable e) {
+                        bgError.set(e);
+                    }
+                }, "covering-posting-reader-" + r);
+                readers[r].setDaemon(true);
+                readers[r].start();
+            }
+
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.setupWorkerPool(pool, engine);
+            pool.start(LOG);
+            long expectedRows = initialRows;
+            try {
+                final int batches = 6 + rnd.nextInt(10);
+                for (int b = 0; b < batches && bgError.get() == null; b++) {
+                    // O3-insert 'A' rows (price 1.0) into a random subset of the parquet
+                    // days: one commit -> a partition task per touched day, run across the
+                    // pool, each calling deferParquetPostingSealPurges (covering: .pv + .pc).
+                    final StringBuilder sql = new StringBuilder("INSERT INTO t_cov VALUES ");
+                    int added = 0;
+                    for (int d = 1; d <= dayCount; d++) {
+                        if (rnd.nextBoolean()) {
+                            continue;
+                        }
+                        final int n = 1 + rnd.nextInt(3);
+                        for (int i = 0; i < n; i++) {
+                            if (added > 0) {
+                                sql.append(',');
+                            }
+                            sql.append("('2024-02-0").append(d).append("T00:")
+                                    .append(String.format("%02d", 1 + rnd.nextInt(58)))
+                                    .append(":00.500000Z', 'A', 1.0)");
+                            added++;
+                        }
+                    }
+                    if (added == 0) {
+                        continue;
+                    }
+                    execute(sql.toString());
+                    expectedRows += added;
+                    // Publish the new floor only AFTER the commit is visible.
+                    rowFloor.set(expectedRows);
+                }
+            } finally {
+                stop.set(true);
+                for (Thread t : readers) {
+                    t.join(30_000);
+                    Assert.assertFalse("reader thread did not terminate", t.isAlive());
+                }
+                pool.halt();
+            }
+
+            Assert.assertNull("concurrent covered reader threw: " + bgError.get(), bgError.get());
+
+            // Drain deferred purges with nothing pinned, then verify the exact final
+            // covered totals (count exact; sum within epsilon to dodge double formatting).
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
+            engine.releaseAllWriters();
+
+            final long expectedSum = initialSum + (expectedRows - initialRows); // each O3 row adds price 1.0
+            try (
+                    SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                            .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                    null, null, -1, null);
+                    SqlCompiler compiler = engine.getSqlCompiler();
+                    RecordCursorFactory f = compiler.compile(
+                            "SELECT count(), sum(price) FROM t_cov WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                    RecordCursor cur = f.getCursor(ctx)
+            ) {
+                Assert.assertTrue("final covered query returned no row", cur.hasNext());
+                Assert.assertEquals("final covered 'A' count", expectedRows, cur.getRecord().getLong(0));
+                Assert.assertEquals("final covered sum(price)", (double) expectedSum, cur.getRecord().getDouble(1), 0.5);
+            }
+
+            // Each parquet partition must keep exactly one value file (no purge lost
+            // or double-freed under concurrent covering deposit).
+            final TableToken token = engine.getTableTokenIfExists("t_cov");
+            Assert.assertNotNull("table must exist", token);
+            try (TableReader reader = engine.getReader(token)) {
+                Assert.assertEquals("all days must remain", dayCount, reader.getTxFile().getPartitionCount());
+                for (int i = 0; i < dayCount; i++) {
+                    final long partitionTs = reader.getTxFile().getPartitionTimestampByIndex(i);
+                    final long partitionNameTxn = reader.getTxFile().getPartitionNameTxn(i);
+                    try (Path path = new Path()) {
+                        path.of(configuration.getDbRoot()).concat(token);
+                        setPathForNativePartition(path, ColumnType.TIMESTAMP, PartitionBy.DAY, partitionTs, partitionNameTxn);
+                        final String[] names = new java.io.File(path.toString()).list();
+                        Assert.assertNotNull("partition dir must exist: " + path, names);
+                        int pvCount = 0;
+                        for (String n : names) {
+                            if (n.startsWith("sym.pv.")) {
+                                pvCount++;
+                            }
+                        }
+                        Assert.assertEquals(
+                                "partition " + i + " must keep exactly one value file: "
+                                        + java.util.Arrays.toString(names),
+                                1, pvCount);
+                    }
+                }
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -5753,17 +5753,16 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
-     * Native-only reproducer of the OPEN native-partition covered-read race (the
+     * Native-only regression for the fixed native-partition covered-read race (the
      * cleanest form; see testMultiThreadedO3CoveringMixedNativeParquetReaderFuzz for
-     * the full diagnosis). Identical to the parquet reproducer but the partitions are
+     * the diagnosis). Identical to the parquet reproducer but the partitions are
      * NEVER converted to parquet, so every O3 commit reseals a NATIVE partition in
-     * place. Fails the same way -- one partition's covered values transiently read 0
-     * -- while the all-parquet reproducer passes, confirming the race is native-reseal
-     * specific and distinct from the parquet expose-before-.pci bug already fixed.
-     * Un-ignore once the native in-place reseal publishes covered data before it
-     * publishes the new sealTxn chain entry.
+     * place. Before the fix this failed ~5 in 8 (one partition's covered values
+     * transiently read 0 because the in-place reseal republished the chain head with
+     * the cover footer dropped while the writer's coverCount field was transiently
+     * 0); after the fix it passes (validated 0/75). The fix preserves the head's
+     * cover footer across the transient coverCount=0 window.
      */
-    @Ignore("Reproducer for the OPEN native-partition covered-read race (fails ~5/8); un-ignore when fixed.")
     @Test
     public void testMultiThreadedO3CoveringNativeOnlyConcurrentReaderFuzz() throws Exception {
         node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
@@ -6212,23 +6211,18 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      * mix. A defect in either reseal path -- or in how the two share the deferred
      * seal-purge state -- drops a covered partition and the monotonic oracle fires.
      * <p>
-     * OPEN BUG (caught by this test, 2026-06-05, NOT yet fixed): fails ~1 in 4 runs
-     * with "covered sum(price) dropped below the initial total" -- exactly one
-     * partition's covered values transiently read 0 under a concurrent O3 reseal.
-     * This is a DISTINCT, native-partition-specific covered-read race, NOT the
-     * parquet expose-before-.pci bug fixed by resealParquetCoveringForPartition:
-     * the all-parquet reproducer (testMultiThreadedO3CoveringPostingConcurrent
-     * ReaderFuzz) passes 0/10+ while this mixed/native variant fails ~1/4. Proven
-     * via instrumentation: coverCount is NOT 0 (the .pci is present and valid -- no
-     * notexist/short/badmagic/count0), so the .pci truncation is not the cause; the
-     * covered DATA reads 0 for a whole NATIVE partition (getCoveredDouble falls back
-     * to NaN -> SQL sum() skips it). Likely an expose-before-cover-DATA window in the
-     * NATIVE in-place reseal (the new sealTxn chain entry becomes visible before that
-     * version's covered .pc data is materialised). Un-ignore once the native reseal
-     * publishes covered data before the chain entry. Reproduce with
-     * generateRandom(LOG, s0, s1) e.g. 483763479454950L, 1780617824721L.
+     * Regression for a fixed native-partition covered-read race (distinct from the
+     * parquet expose-before-.pci bug). Before the fix this failed ~1 in 4: a native
+     * in-place reseal republished the chain head while the writer's transient
+     * coverCount field was 0 (clearCovering had reset it), so extendHead sized the
+     * entry LEN without the cover footer; a concurrent covered read derived
+     * coverCount=0, could not map the still-present .pc, and getCoveredDouble
+     * returned NaN for a whole partition. Fixed by preserving the head's cover
+     * footer across the transient coverCount=0 window (PostingIndexWriter
+     * captureCoverEndOffsets falls back to a cache seeded from the head entry by
+     * publishToChain/PostingIndexChainWriter.readHeadCoverEndOffsets). See also the
+     * unit test testWriterEntryPreservesCoverFooterAfterClearCoveringCommit.
      */
-    @Ignore("Reproducer for an OPEN native-partition covered-read race; see javadoc. Un-ignore when fixed.")
     @Test
     public void testMultiThreadedO3CoveringMixedNativeParquetReaderFuzz() throws Exception {
         node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
@@ -7005,34 +6999,27 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
-     * Reproduces the writer-side root cause of the GraalVM SIGSEGV in
-     * hs_err_pid19555 (PostingIndexBenchmarkSuite.walFastLagInsertAndQuery
-     * on bench/posting-wal-fastlag): a covering posting index whose chain
-     * head had LEN=104 (= entrySize(genCount=1, coverCount=0)) while .pci
-     * advertised coverCount=1. This test drives PostingIndexWriter through
-     * the same lifecycle the WAL fast-lag path follows in production:
-     * <ol>
-     * <li> configureCovering(...) -> coverCount=1 on the writer.
-     * <li> add() rows, seal() -> publishes a chain entry with cover footer.
-     * <li> clearCovering() -> writer's coverCount field is reset to 0
-     *     (this is what TableWriter does in the finally block of
-     *     sealPostingIndexesForLastPartitionFastLag, line 11367).
-     * <li> add() more rows, commit() -> flushAllPending() publishes via
-     *     extendHead, which rewrites the head entry's LEN using
-     *     entrySize(genCount, coverCount=0), DROPPING the cover footer.
-     * </ol>
-     * After step 4, the chain head's LEN no longer accommodates a cover
-     * footer slot, even though the table's covering schema (mirrored in
-     * .pci) still says one cover. A reader sourcing coverCount=1 from the
-     * .pci sidecar and walking the chain steps past the entry's LEN to
-     * read the (non-existent) footer - in production this surfaces as a
-     * SIGSEGV when the entry hugs the end of the .pk mmap. With the
-     * picker/read clamp fix in place the read self-bounds against the
-     * entry's LEN and zero-fills the missing cover slot, so the reader
-     * recovers gracefully.
+     * Regression for the native-partition covered-read race root cause: a covering
+     * posting index whose writer-side coverCount field is transiently reset to 0 by
+     * clearCovering() must NOT drop the chain head's cover footer on the next
+     * commit()/extendHead. clearCovering happens in TableWriter's WAL fast-lag seal
+     * finally block, and between an in-place reseal's clearCovering and the next
+     * configureCovering. Before the fix, extendHead sized the head entry with
+     * entrySize(genCount, coverCount=0) -- DROPPING the cover footer -- so a
+     * concurrent covered read saw sidecarFileEndOffsets==0, failed to map the
+     * still-present .pc and returned NULL for the whole partition.
+     * <p>
+     * publishToChain now snapshots the head's existing footer
+     * (PostingIndexChainWriter.readHeadCoverEndOffsets) before the new gen-dir
+     * overwrites it and republishes those extents, so the footer survives the
+     * transient coverCount=0 window. Drives the same lifecycle: configureCovering
+     * -> add -> seal (footer written); clearCovering (coverCount field -> 0); add ->
+     * commit (extendHead). After the commit the head LEN must still accommodate the
+     * cover footer, and the picker must read the preserved, non-zero cover end
+     * offset (not 0, not a stale/garbage slot).
      */
     @Test
-    public void testWriterEntrysCoverFooterShrinksAfterClearCoveringCommit() throws Exception {
+    public void testWriterEntryPreservesCoverFooterAfterClearCoveringCommit() throws Exception {
         assertMemoryLeak(() -> {
             try (Path path = new Path().of(configuration.getDbRoot())) {
                 String name = "writer_clear_covering_then_commit";
@@ -7136,49 +7123,24 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                             }
                         }
                         Assert.assertEquals(
-                                "RED: with the writer-side bug, the head's LEN no "
-                                        + "longer includes the cover footer because "
-                                        + "extendHead used coverCount=0 for the size "
-                                        + "calculation. Expected coverCount=1 sized "
-                                        + "entry, observed coverCount=0 sized entry.",
-                                PostingIndexChainEntry.entrySize(genCountAfterCommit, 0),
-                                lenAfterCommit
-                        );
-                        Assert.assertNotEquals(
-                                "RED: the schema-correct LEN would include cover footer "
-                                        + "bytes, but the writer dropped them",
+                                "FIXED: publishToChain preserves the cover footer across the "
+                                        + "clearCovering()/commit() window, so the head LEN stays "
+                                        + "sized for coverCount=1 (entrySize(genCount, 1)) instead "
+                                        + "of shrinking to entrySize(genCount, 0)",
                                 PostingIndexChainEntry.entrySize(genCountAfterCommit, coverCount),
                                 lenAfterCommit
                         );
 
-                        // Final: prove Fix A keeps the reader from
-                        // dereferencing past the entry on this corrupted-footer
-                        // entry. Plant a sentinel byte pattern into the bytes
-                        // immediately past the entry's LEN - the (mis-computed)
-                        // cover footer offset for coverCount=1 lands on these
-                        // bytes. Without the picker/read clamp, getLong reads
-                        // the sentinel and assigns it as the cover end offset.
-                        // With the clamp, the read self-bounds against the
-                        // entry's LEN and zero-fills the missing slot.
+                        // The picker reads coverCount=1 with the PRESERVED, non-zero
+                        // cover end offset (the .pc extent written at seal), not 0.
+                        // Before the fix this slot would be dropped/zero and a covered
+                        // read would see the partition as having no covered data.
                         LPSZ keyFile = PostingIndexUtils.keyFileName(
                                 path.trimTo(plen), name, COLUMN_NAME_TXN_NONE);
                         long fileSize = ff.length(keyFile);
                         try (MemoryCMARWImpl mem = new MemoryCMARWImpl(
                                 ff, keyFile, ff.getPageSize(), fileSize,
                                 MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
-                            PostingIndexChainWriter chain = new PostingIndexChainWriter();
-                            chain.openExisting(mem);
-                            PostingIndexChainEntry.Snapshot head = new PostingIndexChainEntry.Snapshot();
-                            chain.loadHeadEntry(mem, head);
-                            // The unfixed cover loop would read at offset
-                            // (header + genCount * GEN_DIR_ENTRY_SIZE) for
-                            // each cover slot. Plant a sentinel there so a
-                            // failing clamp surfaces as a non-zero value.
-                            long footerOffset = PostingIndexChainEntry.resolveCoverFooterOffset(
-                                    head.offset, head.genCount);
-                            final long sentinel = 0xDEAD_BEEF_CAFE_BABEL;
-                            mem.putLong(footerOffset, sentinel);
-
                             PostingIndexChainHeader.Snapshot header = new PostingIndexChainHeader.Snapshot();
                             PostingIndexChainEntry.Snapshot entry = new PostingIndexChainEntry.Snapshot();
                             int rc = PostingIndexChainPicker.pick(
@@ -7187,17 +7149,14 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                             Assert.assertEquals(
                                     PostingIndexChainPicker.RESULT_OK, rc);
                             Assert.assertEquals(
-                                    "Fix A: missing cover slot is zero-filled instead "
-                                            + "of dereferencing past the entry",
+                                    "the preserved cover footer still carries coverCount slots",
                                     coverCount, entry.coverFileEndOffsets.size());
-                            Assert.assertEquals(
-                                    "RED without Fix A: the picker would read the planted "
-                                            + "sentinel " + Long.toHexString(sentinel)
-                                            + "L as the cover end offset because the cover "
-                                            + "footer loop is not clamped against the entry's "
-                                            + "own LEN field. With Fix A, the clamp returns 0 "
-                                            + "instead.",
-                                    0L, entry.coverFileEndOffsets.getQuick(0));
+                            Assert.assertTrue(
+                                    "the preserved cover end offset must be the non-zero .pc "
+                                            + "extent written at seal, not 0 (0 would make a "
+                                            + "covered read see the partition as having no covered "
+                                            + "data): " + entry.coverFileEndOffsets.getQuick(0),
+                                    entry.coverFileEndOffsets.getQuick(0) > 0);
                         }
                     }
                 } finally {

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -4444,6 +4444,79 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * The original bug's trigger at scale: fragment one day into many split
+     * sub-partitions, then squash them all in a single squashSplitPartitions
+     * pass. The merged partition holds the full hot key, so its covering reseal
+     * (discardForRebuild -> index() -> commitDense) trips the spill budget and
+     * commitDense must consolidate -- the path that SIGSEGVd before the fix.
+     * Twenty separate O3 commits into the late tail build twenty+ splits (kept
+     * from auto-squashing by the high MAX_SPLITS), then squashPartitions()
+     * collapses them to one and the covering result must match the truth.
+     */
+    @Test
+    public void testSquashManySplitPartitionsCoveringPostingSpill() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
+        // High ceilings so housekeep does not auto-squash before the explicit call.
+        node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 50);
+        node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 50);
+
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_manysplit (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            // 2000 hot 'A' rows early in the day so the squash reseal spills.
+            execute("""
+                    INSERT INTO t_manysplit
+                    SELECT dateadd('s', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP),
+                           'A', x::DOUBLE
+                    FROM long_sequence(2000)
+                    """);
+            // Late sentinel keeps the day's max at 23:00 so the O3 prefixes split.
+            execute("INSERT INTO t_manysplit VALUES ('2024-01-01T23:00:00.000000Z', 'A', 1000000.0)");
+            // Twenty separate O3 commits into distinct late-tail minutes; each
+            // splits the trailing sub-partition, accumulating many splits.
+            final int splitInserts = 20;
+            for (int i = 0; i < splitInserts; i++) {
+                execute("INSERT INTO t_manysplit VALUES ('2024-01-01T22:"
+                        + String.format("%02d", i) + ":00.000000Z', 'B', " + (-1 - i) + ".0)");
+            }
+
+            final long splitCount = selectLong("SELECT count() FROM table_partitions('t_manysplit')");
+            Assert.assertTrue(
+                    "test setup must fragment the day into many split sub-partitions, got " + splitCount,
+                    splitCount > 10);
+
+            engine.releaseAllWriters();
+            try (TableWriter w = TestUtils.getWriter(engine, "t_manysplit")) {
+                // squashPartitions() -> squashPartitionForce -> squashSplitPartitions
+                // -> sealPostingIndexForPartition: the reported reseal path, now over
+                // a partition merged from 20+ splits.
+                w.squashPartitions();
+            }
+
+            assertQuery("SELECT count() FROM table_partitions('t_manysplit')")
+                    .noLeakCheck()
+                    .expectSize()
+                    .noRandomAccess()
+                    .returns("""
+                            count
+                            1
+                            """);
+
+            // 2000 'A' rows (sum 1..2000 = 2001000) plus the 23:00 sentinel
+            // (1000000) = 2001 rows, sum 3001000, served through the covering index.
+            assertQuery("SELECT count(), sum(price) FROM t_manysplit WHERE sym = 'A'")
+                    .noLeakCheck()
+                    .returnsOnce("count\tsum\n2001\t3001000.0\n");
+        });
+    }
+
+    /**
      * Non-covering twin of testSquashCoveringPostingWithMidStreamSpillFlush.
      * The non-covering squash reseal also runs discardForRebuild -> index() ->
      * commitDense; the same mid-stream flushAllPending orphans the early sparse

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -485,6 +485,94 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    /**
+     * Field report reproduction: a covering POSTING index on a single
+     * actively-growing partition fed by sequential (in-order) WAL/ILP commits.
+     * Covered reads return wrong values (or SIGSEGV) once enough rows of a hot
+     * key accumulate. No O3, squash, or parquet conversion is involved -- plain
+     * append is enough.
+     * <p>
+     * Mechanism: the WAL fast-lag commit indexes the new rows in
+     * {@code updateIndexesParallel} (the add() phase) and only afterwards, in
+     * {@code publishPostingIndexesForLastPartitionFastLag}, calls
+     * {@code configureCovering} + {@code commit()}. When a hot key's spill arena
+     * crosses the budget mid-add, {@code compactIfOverBudget -> flushAllPending}
+     * drains a sparse generation right there -- but covering is not configured
+     * yet, so {@code writeSidecarGenData} short-circuits and the generation gets
+     * a gen-dir entry and .pv rows with no .pc covered block (its .pc header slot
+     * stays 0). A later covered read walks that generation with a 0 sidecar
+     * offset and reads past the .pc mapping: count() (served from the index row
+     * addresses) stays correct while sum(value) (served from the covering
+     * sidecar) is wrong. The fix defers the mid-add spill flush so the whole
+     * batch flushes once, after covering is configured, with .pc written.
+     * <p>
+     * A small spill budget reproduces at ~4M rows what the field report hit at
+     * ~45M rows under the default 256 MiB budget.
+     */
+    @Test
+    public void testWalFastLagCoveringSpillWritesCoveredSidecar() throws Exception {
+        setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256 * 1024);
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE flt (
+                        ts TIMESTAMP,
+                        ParameterID SYMBOL INDEX TYPE POSTING INCLUDE (value),
+                        value DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+
+            final int batches = 40;
+            final int rowsPerBatch = 100_000; // per-commit hot-key spill (~hundreds of KiB) exceeds the 256 KiB budget
+            final long base = 1_700_000_000_000_000L; // arbitrary instant; all rows stay in one day
+            long start = base;
+            for (int b = 0; b < batches; b++) {
+                execute("INSERT INTO flt " +
+                        "SELECT timestamp_sequence(cast(" + start + " as timestamp), 1), 'KCAS', 1.0 " +
+                        "FROM long_sequence(" + rowsPerBatch + ")");
+                start += rowsPerBatch; // keep the next batch strictly after the previous -> in-order append
+                drainWalQueue();
+            }
+
+            final long total = (long) batches * rowsPerBatch;
+            // count() is served by the index row addresses, sum(value) by the
+            // covering sidecar. A healthy covering index keeps them consistent;
+            // the orphaned-sidecar bug leaves count() right but sum(value) wrong
+            // (and over-reads the .pc -- a bare SIGSEGV without assertions).
+            assertSql(
+                    "count\tsum\n" + total + "\t" + (double) total + "\n",
+                    "SELECT count(), sum(value) FROM flt WHERE ParameterID = 'KCAS'"
+            );
+        });
+    }
+
+    /**
+     * Plan-fallback reproduction: a symbol-capacity change must not drop the
+     * covering-index schema. When the symbol capacity grows (automatically as new
+     * symbols arrive, or via ALTER), changeSymbolCapacity -> updateColumnSymbolCapacity
+     * rebuilds the symbol column's metadata; that rebuild used to forget the
+     * covering column indices, so the next metadata rewrite persisted a _meta with
+     * no covering flag/section and the planner stopped choosing the covering scan.
+     */
+    @Test
+    public void testCoveringSurvivesSymbolCapacityChange() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE x (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (val), val DOUBLE) " +
+                    "TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("INSERT INTO x VALUES (1, 'a', 1.0)");
+            drainWalQueue();
+            execute("ALTER TABLE x ALTER COLUMN sym SYMBOL CAPACITY 8192");
+            drainWalQueue();
+            // Fresh compile after the capacity change: the covering posting index
+            // must still be chosen.
+            assertPlanNoLeakCheck(
+                    "SELECT ts, val FROM x WHERE sym = 'b'",
+                    "SelectedRecord\n" +
+                            "    CoveringIndex on: sym with: ts, val\n" +
+                            "      filter: sym='b'\n"
+            );
+        });
+    }
+
     @Test
     public void testO3DeferredPostingSealPurgeRunsAfterCommit() throws Exception {
         assertMemoryLeak(() -> {

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -5128,18 +5128,35 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      * lost or double-freed). The floor is read BEFORE the count so a commit landing
      * mid-read can never make a valid snapshot look short.
      * <p>
-     * IGNORED pending root-cause: this reproducer FAILS. Single-threaded the covered
-     * query is correct (count=dayCount*hotPerDay, sum=dayCount*sum(1..hotPerDay)), but
-     * under the concurrent O3 reseal a reader observes a CORRECT posting count
-     * (count >= the committed floor) together with a PARTIAL covered sum -- the price
-     * values of the partitions being resealed read as 0 while their row ids are still
-     * counted (e.g. count>=5000 but sum=1001000 == only 2 of 5 days' prices). The
-     * covered-value (sidecar) read races the writer-thread covering reseal
-     * (sealPostingIndexForPartition -> rebuildSidecars) in a way the posting row-id
-     * read does not. Reproducible across seeds. Un-@Ignore to reproduce.
+     * IGNORED reproducer for a PARQUET-specific covered-read race (still open).
+     * Under concurrent O3 rewrite of parquet partitions, a reader observes a correct
+     * posting count but a covered sum that is short by whole partitions -- the covered
+     * values of the partition(s) being rewritten read as 0. Proven scope:
+     * <ul>
+     *   <li>single-threaded the covered query is correct (count and sum exact);</li>
+     *   <li>with the CONVERT-to-parquet removed (native partitions) it passes -- the
+     *       race is parquet-only;</li>
+     *   <li>NOT the unversioned .pci in-place rewrite (openSidecarFiles truncates a
+     *       single per-column-version .pci under readers, which is itself unsafe, but
+     *       making it write-once did NOT fix this symptom) and NOT the chain entry's
+     *       covered end-offset (instrumented: sidecarFileEndOffsets is non-zero, and
+     *       the .pc length covers publishedEnd, when the read still returns 0).</li>
+     * </ul>
+     * So the covering .pc data the writer-thread parquet seal publishes is not yet
+     * visible to a concurrent reader's mmap when the chain extent is published, or the
+     * reader does not remap the .pc on the partition-version change. Un-@Ignore to
+     * reproduce (fails within ~300ms, whole-partition-multiple covered sum).
+     * <p>
+     * Further narrowed: the 0 originates in the dense/stride covered-value read
+     * (findDenseVarBlockBase / the per-stride .pc lookup) returning an empty stride
+     * for the rewritten parquet partition, even though the .pc is mapped to a valid
+     * non-zero extent. So the writer-thread parquet seal's dense .pc data/stride-index
+     * is not yet consistently visible to a concurrent reader when its chain entry is
+     * published, OR the reader reuses a stale .pc mapping across the parquet
+     * version change. Root-cause continues in a follow-up.
      */
-    @Ignore("Reproducer for a covered-value partial-read under concurrent O3 reseal; " +
-            "count() is correct but sum(covered) reads 0 for resealing partitions. Single-threaded is correct.")
+    @Ignore("Open: parquet-specific covered-read race -- covered values of a parquet " +
+            "partition under concurrent O3 rewrite read 0 (count correct). Native passes.")
     @Test
     public void testMultiThreadedO3CoveringPostingConcurrentReaderFuzz() throws Exception {
         node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -5123,6 +5123,269 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * Use-after-free probe: a COVERING cursor held open across a full O3 rewrite +
+     * seal-purge must keep returning its pinned snapshot and never read a reclaimed
+     * value file. Opens a covered SELECT over several parquet partitions, reads
+     * about half (pinning those partition versions through the txn scoreboard), then
+     * runs several O3 commits across the 4-worker pool plus a PostingSealPurgeJob
+     * that rotates and reclaims superseded .pv/.pc, then drains the SAME cursor to
+     * the end. The pinned snapshot is the table at open time: every covered price
+     * must be a real seeded value (>= 1, never 0/NaN) and the row count must equal
+     * the rows present at open. A scoreboard gap that reclaims a pinned value file
+     * SIGSEGVs or returns garbage here.
+     */
+    @Test
+    public void testCoveringCursorHeldAcrossO3ReclaimNoCrash() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+
+        assertMemoryLeak(() -> {
+            final int dayCount = 4 + rnd.nextInt(3); // 4..6 days
+            final int hotPerDay = 1000;
+            final long initialRows = (long) dayCount * hotPerDay;
+
+            execute("""
+                    CREATE TABLE t_cov_hold (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            for (int d = 1; d <= dayCount; d++) {
+                execute("INSERT INTO t_cov_hold SELECT dateadd('s', x::INT, '2024-02-0" + d
+                        + "T00:00:00.000000Z'::TIMESTAMP), 'A', x::DOUBLE FROM long_sequence(" + hotPerDay + ")");
+            }
+            for (int d = 1; d <= dayCount; d++) {
+                execute("ALTER TABLE t_cov_hold CONVERT PARTITION TO PARQUET LIST '2024-02-0" + d + "'");
+            }
+
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.setupWorkerPool(pool, engine);
+            pool.start(LOG);
+            try (
+                    SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                            .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                    null, null, -1, null);
+                    SqlCompiler compiler = engine.getSqlCompiler()
+            ) {
+                long pinnedCount = 0;
+                try (RecordCursorFactory f = compiler.compile(
+                        "SELECT price FROM t_cov_hold WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                     RecordCursor cur = f.getCursor(ctx)) {
+                    final io.questdb.cairo.sql.Record rec = cur.getRecord();
+                    final long half = initialRows / 2;
+                    // Read about half, pinning the snapshot via the txn scoreboard.
+                    while (pinnedCount < half && cur.hasNext()) {
+                        final double p = rec.getDouble(0);
+                        if (Double.isNaN(p) || p < 1.0) {
+                            throw new AssertionError("held cursor read a NULL/garbage covered value before O3: " + p);
+                        }
+                        pinnedCount++;
+                    }
+                    // Rotate + reclaim superseded value files under the held cursor.
+                    for (int b = 0; b < 8; b++) {
+                        final StringBuilder sql = new StringBuilder("INSERT INTO t_cov_hold VALUES ");
+                        int added = 0;
+                        for (int d = 1; d <= dayCount; d++) {
+                            if (rnd.nextBoolean()) {
+                                continue;
+                            }
+                            if (added > 0) {
+                                sql.append(',');
+                            }
+                            sql.append("('2024-02-0").append(d).append("T00:")
+                                    .append(String.format("%02d", 1 + rnd.nextInt(58)))
+                                    .append(":00.500000Z', 'A', 1.0)");
+                            added++;
+                        }
+                        if (added > 0) {
+                            execute(sql.toString());
+                        }
+                    }
+                    // The pool's own PostingSealPurgeJob reclaims the superseded .pv/.pc
+                    // concurrently (scoreboard-gated); it owns the log writer, so we must
+                    // not construct a competing one here. Give it a moment to attempt the
+                    // reclaim against the still-pinned cursor.
+                    Os.sleep(50);
+                    // Drain the SAME pinned cursor -- must not crash or read garbage.
+                    while (cur.hasNext()) {
+                        final double p = rec.getDouble(0);
+                        if (Double.isNaN(p) || p < 1.0) {
+                            throw new AssertionError("held cursor read a NULL/garbage covered value after O3+purge "
+                                    + "(reclaimed a pinned value file?): " + p);
+                        }
+                        pinnedCount++;
+                    }
+                }
+                Assert.assertEquals("held cursor must return exactly its pinned snapshot rows",
+                        initialRows, pinnedCount);
+            } finally {
+                pool.halt();
+            }
+        });
+    }
+
+    /**
+     * Wide covering hardening test: the index covers TWO data columns
+     * (INCLUDE price, qty), so each partition reseal materialises two
+     * sealTxn-versioned .pc data files alongside the .pci, and a covered read
+     * walks two per-cover sidecars per row. Same all-parquet O3 churn + reader
+     * threads as the reproducer, with the covered count, sum(price) AND sum(qty)
+     * all held monotonic; a mismatched per-cover sidecar offset or a dropped .pc
+     * for one of the two covered columns fails the oracle.
+     */
+    @Test
+    public void testMultiThreadedO3CoveringWideConcurrentReaderFuzz() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+
+        assertMemoryLeak(() -> {
+            final int dayCount = 4 + rnd.nextInt(4); // 4..7 days
+            final int hotPerDay = 1000;
+            final long perDaySum = (long) hotPerDay * (hotPerDay + 1) / 2;
+            final long initialRows = (long) dayCount * hotPerDay;
+            final long initialSum = (long) dayCount * perDaySum;
+
+            execute("""
+                    CREATE TABLE t_cov_wide (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price, qty),
+                        price DOUBLE,
+                        qty LONG
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            for (int d = 1; d <= dayCount; d++) {
+                execute("INSERT INTO t_cov_wide SELECT dateadd('s', x::INT, '2024-02-0" + d
+                        + "T00:00:00.000000Z'::TIMESTAMP), 'A', x::DOUBLE, x::LONG FROM long_sequence(" + hotPerDay + ")");
+            }
+            for (int d = 1; d <= dayCount; d++) {
+                execute("ALTER TABLE t_cov_wide CONVERT PARTITION TO PARQUET LIST '2024-02-0" + d + "'");
+            }
+
+            final AtomicReference<Throwable> bgError = new AtomicReference<>();
+            final AtomicBoolean stop = new AtomicBoolean();
+            final AtomicLong rowFloor = new AtomicLong(initialRows);
+            final int readerCount = 3;
+            final Thread[] readers = new Thread[readerCount];
+            for (int r = 0; r < readerCount; r++) {
+                readers[r] = new Thread(() -> {
+                    try (
+                            SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                                    .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                            null, null, -1, null);
+                            SqlCompiler compiler = engine.getSqlCompiler()
+                    ) {
+                        while (!stop.get() && bgError.get() == null) {
+                            final long floor = rowFloor.get();
+                            final long count;
+                            final double sumPrice;
+                            final double sumQty;
+                            try (RecordCursorFactory f = compiler.compile(
+                                    "SELECT count(), sum(price), sum(qty) FROM t_cov_wide WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                                 RecordCursor cur = f.getCursor(ctx)) {
+                                if (cur.hasNext()) {
+                                    count = cur.getRecord().getLong(0);
+                                    sumPrice = cur.getRecord().getDouble(1);
+                                    sumQty = cur.getRecord().getDouble(2);
+                                } else {
+                                    count = -1;
+                                    sumPrice = -1;
+                                    sumQty = -1;
+                                }
+                            }
+                            if (count < floor) {
+                                throw new AssertionError("covered 'A' count fell below the committed floor: "
+                                        + count + " < " + floor);
+                            }
+                            if (sumPrice < (double) initialSum - 0.5) {
+                                throw new AssertionError("covered sum(price) dropped below the initial total "
+                                        + initialSum + ": " + sumPrice);
+                            }
+                            if (sumQty < (double) initialSum - 0.5) {
+                                throw new AssertionError("covered sum(qty) dropped below the initial total "
+                                        + initialSum + ": " + sumQty);
+                            }
+                            if (sumPrice < (double) count - 0.5 || sumQty < (double) count - 0.5) {
+                                throw new AssertionError("a covered column resolved as < 1: count=" + count
+                                        + " sum(price)=" + sumPrice + " sum(qty)=" + sumQty);
+                            }
+                        }
+                    } catch (Throwable e) {
+                        bgError.set(e);
+                    }
+                }, "covering-wide-reader-" + r);
+                readers[r].setDaemon(true);
+                readers[r].start();
+            }
+
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.setupWorkerPool(pool, engine);
+            pool.start(LOG);
+            long expectedRows = initialRows;
+            try {
+                final int batches = 6 + rnd.nextInt(10);
+                for (int b = 0; b < batches && bgError.get() == null; b++) {
+                    final StringBuilder sql = new StringBuilder("INSERT INTO t_cov_wide VALUES ");
+                    int added = 0;
+                    for (int d = 1; d <= dayCount; d++) {
+                        if (rnd.nextBoolean()) {
+                            continue;
+                        }
+                        final int n = 1 + rnd.nextInt(3);
+                        for (int i = 0; i < n; i++) {
+                            if (added > 0) {
+                                sql.append(',');
+                            }
+                            sql.append("('2024-02-0").append(d).append("T00:")
+                                    .append(String.format("%02d", 1 + rnd.nextInt(58)))
+                                    .append(":00.500000Z', 'A', 1.0, 1)");
+                            added++;
+                        }
+                    }
+                    if (added == 0) {
+                        continue;
+                    }
+                    execute(sql.toString());
+                    expectedRows += added;
+                    rowFloor.set(expectedRows);
+                }
+            } finally {
+                stop.set(true);
+                for (Thread t : readers) {
+                    t.join(30_000);
+                    Assert.assertFalse("reader thread did not terminate", t.isAlive());
+                }
+                pool.halt();
+            }
+
+            Assert.assertNull("concurrent wide covered reader threw: " + bgError.get(), bgError.get());
+
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
+            engine.releaseAllWriters();
+
+            final long expectedSum = initialSum + (expectedRows - initialRows);
+            try (
+                    SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                            .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                    null, null, -1, null);
+                    SqlCompiler compiler = engine.getSqlCompiler();
+                    RecordCursorFactory f = compiler.compile(
+                            "SELECT count(), sum(price), sum(qty) FROM t_cov_wide WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                    RecordCursor cur = f.getCursor(ctx)
+            ) {
+                Assert.assertTrue("final covered query returned no row", cur.hasNext());
+                Assert.assertEquals("final covered 'A' count", expectedRows, cur.getRecord().getLong(0));
+                Assert.assertEquals("final covered sum(price)", (double) expectedSum, cur.getRecord().getDouble(1), 0.5);
+                Assert.assertEquals("final covered sum(qty)", (double) expectedSum, cur.getRecord().getDouble(2), 0.5);
+            }
+        });
+    }
+
+    /**
      * Concurrent LATEST ON covered-read hardening test. Stresses the covering
      * BACKWARD reader (PostingIndexBwdReader / findLatestRow + symbol-rank), a
      * code path the sum/count reproducer never touches. A COVERING posting index

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -5123,6 +5123,303 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * Two-covering-indexes hardening test: one table carries TWO covering posting
+     * indexes (sym1 INCLUDE price, sym2 INCLUDE price), so every O3 commit reseals
+     * BOTH covering indexes of each rewritten partition in the same seal sweep.
+     * Each row sets sym1='A' and sym2='B', so a covered read through either index
+     * sees the same monotonically-growing total; a reseal of one index that
+     * corrupts or drops the other's covered values fails the per-index oracle.
+     */
+    @Test
+    public void testMultiThreadedO3TwoCoveringIndexesConcurrentReaderFuzz() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+
+        assertMemoryLeak(() -> {
+            final int dayCount = 4 + rnd.nextInt(4); // 4..7 days
+            final int hotPerDay = 1000;
+            final long perDaySum = (long) hotPerDay * (hotPerDay + 1) / 2;
+            final long initialRows = (long) dayCount * hotPerDay;
+            final long initialSum = (long) dayCount * perDaySum;
+
+            execute("""
+                    CREATE TABLE t_cov_two (
+                        ts TIMESTAMP,
+                        sym1 SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        sym2 SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            for (int d = 1; d <= dayCount; d++) {
+                execute("INSERT INTO t_cov_two SELECT dateadd('s', x::INT, '2024-02-0" + d
+                        + "T00:00:00.000000Z'::TIMESTAMP), 'A', 'B', x::DOUBLE FROM long_sequence(" + hotPerDay + ")");
+            }
+            for (int d = 1; d <= dayCount; d++) {
+                execute("ALTER TABLE t_cov_two CONVERT PARTITION TO PARQUET LIST '2024-02-0" + d + "'");
+            }
+
+            final AtomicReference<Throwable> bgError = new AtomicReference<>();
+            final AtomicBoolean stop = new AtomicBoolean();
+            final AtomicLong rowFloor = new AtomicLong(initialRows);
+            final int readerCount = 4;
+            final Thread[] readers = new Thread[readerCount];
+            for (int r = 0; r < readerCount; r++) {
+                // Even readers probe sym1, odd readers probe sym2.
+                final String pred = (r % 2 == 0) ? "sym1 = 'A'" : "sym2 = 'B'";
+                readers[r] = new Thread(() -> {
+                    try (
+                            SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                                    .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                            null, null, -1, null);
+                            SqlCompiler compiler = engine.getSqlCompiler()
+                    ) {
+                        while (!stop.get() && bgError.get() == null) {
+                            final long floor = rowFloor.get();
+                            final long count;
+                            final double sum;
+                            try (RecordCursorFactory f = compiler.compile(
+                                    "SELECT count(), sum(price) FROM t_cov_two WHERE " + pred, ctx).getRecordCursorFactory();
+                                 RecordCursor cur = f.getCursor(ctx)) {
+                                if (cur.hasNext()) {
+                                    count = cur.getRecord().getLong(0);
+                                    sum = cur.getRecord().getDouble(1);
+                                } else {
+                                    count = -1;
+                                    sum = -1;
+                                }
+                            }
+                            if (count < floor) {
+                                throw new AssertionError("[" + pred + "] covered count fell below the floor: " + count + " < " + floor);
+                            }
+                            if (sum < (double) initialSum - 0.5) {
+                                throw new AssertionError("[" + pred + "] covered sum(price) dropped below the initial total "
+                                        + initialSum + ": " + sum);
+                            }
+                            if (sum < (double) count - 0.5) {
+                                throw new AssertionError("[" + pred + "] covered sum(price)=" + sum + " < count=" + count
+                                        + " -- a covered value resolved as < 1");
+                            }
+                        }
+                    } catch (Throwable e) {
+                        bgError.set(e);
+                    }
+                }, "covering-two-reader-" + r);
+                readers[r].setDaemon(true);
+                readers[r].start();
+            }
+
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.setupWorkerPool(pool, engine);
+            pool.start(LOG);
+            long expectedRows = initialRows;
+            try {
+                final int batches = 6 + rnd.nextInt(10);
+                for (int b = 0; b < batches && bgError.get() == null; b++) {
+                    final StringBuilder sql = new StringBuilder("INSERT INTO t_cov_two VALUES ");
+                    int added = 0;
+                    for (int d = 1; d <= dayCount; d++) {
+                        if (rnd.nextBoolean()) {
+                            continue;
+                        }
+                        final int n = 1 + rnd.nextInt(3);
+                        for (int i = 0; i < n; i++) {
+                            if (added > 0) {
+                                sql.append(',');
+                            }
+                            sql.append("('2024-02-0").append(d).append("T00:")
+                                    .append(String.format("%02d", 1 + rnd.nextInt(58)))
+                                    .append(":00.500000Z', 'A', 'B', 1.0)");
+                            added++;
+                        }
+                    }
+                    if (added == 0) {
+                        continue;
+                    }
+                    execute(sql.toString());
+                    expectedRows += added;
+                    rowFloor.set(expectedRows);
+                }
+            } finally {
+                stop.set(true);
+                for (Thread t : readers) {
+                    t.join(30_000);
+                    Assert.assertFalse("reader thread did not terminate", t.isAlive());
+                }
+                pool.halt();
+            }
+
+            Assert.assertNull("concurrent two-index covered reader threw: " + bgError.get(), bgError.get());
+
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
+            engine.releaseAllWriters();
+
+            final long expectedSum = initialSum + (expectedRows - initialRows);
+            try (
+                    SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                            .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                    null, null, -1, null);
+                    SqlCompiler compiler = engine.getSqlCompiler()
+            ) {
+                for (String pred : new String[]{"sym1 = 'A'", "sym2 = 'B'"}) {
+                    try (RecordCursorFactory f = compiler.compile(
+                            "SELECT count(), sum(price) FROM t_cov_two WHERE " + pred, ctx).getRecordCursorFactory();
+                         RecordCursor cur = f.getCursor(ctx)) {
+                        Assert.assertTrue("final covered query returned no row for " + pred, cur.hasNext());
+                        Assert.assertEquals("final covered count [" + pred + ']', expectedRows, cur.getRecord().getLong(0));
+                        Assert.assertEquals("final covered sum(price) [" + pred + ']', (double) expectedSum, cur.getRecord().getDouble(1), 0.5);
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Covered VARCHAR (variable-size) hardening test. The reproducer covers a
+     * fixed-size DOUBLE; this covers a VARCHAR, exercising the variable-size .pc
+     * sidecar path (per-row offset+len into a var data block) under concurrent O3
+     * rewrite. Every 'A' row carries a non-null label, so count(label) must always
+     * equal count() -- a covered varchar that resolves to NULL/empty mid-reseal
+     * drops count(label) below count() and fails the oracle.
+     */
+    @Test
+    public void testMultiThreadedO3CoveringVarcharConcurrentReaderFuzz() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+
+        assertMemoryLeak(() -> {
+            final int dayCount = 4 + rnd.nextInt(4); // 4..7 days
+            final int hotPerDay = 1000;
+            final long initialRows = (long) dayCount * hotPerDay;
+
+            execute("""
+                    CREATE TABLE t_cov_vc (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (label),
+                        label VARCHAR
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            for (int d = 1; d <= dayCount; d++) {
+                execute("INSERT INTO t_cov_vc SELECT dateadd('s', x::INT, '2024-02-0" + d
+                        + "T00:00:00.000000Z'::TIMESTAMP), 'A', ('lbl' || x)::VARCHAR FROM long_sequence(" + hotPerDay + ")");
+            }
+            for (int d = 1; d <= dayCount; d++) {
+                execute("ALTER TABLE t_cov_vc CONVERT PARTITION TO PARQUET LIST '2024-02-0" + d + "'");
+            }
+
+            final AtomicReference<Throwable> bgError = new AtomicReference<>();
+            final AtomicBoolean stop = new AtomicBoolean();
+            final AtomicLong rowFloor = new AtomicLong(initialRows);
+            final int readerCount = 3;
+            final Thread[] readers = new Thread[readerCount];
+            for (int r = 0; r < readerCount; r++) {
+                readers[r] = new Thread(() -> {
+                    try (
+                            SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                                    .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                            null, null, -1, null);
+                            SqlCompiler compiler = engine.getSqlCompiler()
+                    ) {
+                        while (!stop.get() && bgError.get() == null) {
+                            final long floor = rowFloor.get();
+                            final long count;
+                            final long labelCount;
+                            try (RecordCursorFactory f = compiler.compile(
+                                    "SELECT count(), count(label) FROM t_cov_vc WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                                 RecordCursor cur = f.getCursor(ctx)) {
+                                if (cur.hasNext()) {
+                                    count = cur.getRecord().getLong(0);
+                                    labelCount = cur.getRecord().getLong(1);
+                                } else {
+                                    count = -1;
+                                    labelCount = -1;
+                                }
+                            }
+                            if (count < floor) {
+                                throw new AssertionError("covered 'A' count fell below the committed floor: "
+                                        + count + " < " + floor);
+                            }
+                            if (labelCount != count) {
+                                throw new AssertionError("covered VARCHAR resolved to NULL for "
+                                        + (count - labelCount) + " of " + count
+                                        + " rows -- a covered var value was lost/corrupted mid-reseal");
+                            }
+                        }
+                    } catch (Throwable e) {
+                        bgError.set(e);
+                    }
+                }, "covering-varchar-reader-" + r);
+                readers[r].setDaemon(true);
+                readers[r].start();
+            }
+
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.setupWorkerPool(pool, engine);
+            pool.start(LOG);
+            long expectedRows = initialRows;
+            try {
+                final int batches = 6 + rnd.nextInt(10);
+                for (int b = 0; b < batches && bgError.get() == null; b++) {
+                    final StringBuilder sql = new StringBuilder("INSERT INTO t_cov_vc VALUES ");
+                    int added = 0;
+                    for (int d = 1; d <= dayCount; d++) {
+                        if (rnd.nextBoolean()) {
+                            continue;
+                        }
+                        final int n = 1 + rnd.nextInt(3);
+                        for (int i = 0; i < n; i++) {
+                            if (added > 0) {
+                                sql.append(',');
+                            }
+                            sql.append("('2024-02-0").append(d).append("T00:")
+                                    .append(String.format("%02d", 1 + rnd.nextInt(58)))
+                                    .append(":00.500000Z', 'A', 'z')");
+                            added++;
+                        }
+                    }
+                    if (added == 0) {
+                        continue;
+                    }
+                    execute(sql.toString());
+                    expectedRows += added;
+                    rowFloor.set(expectedRows);
+                }
+            } finally {
+                stop.set(true);
+                for (Thread t : readers) {
+                    t.join(30_000);
+                    Assert.assertFalse("reader thread did not terminate", t.isAlive());
+                }
+                pool.halt();
+            }
+
+            Assert.assertNull("concurrent covered varchar reader threw: " + bgError.get(), bgError.get());
+
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
+            engine.releaseAllWriters();
+
+            try (
+                    SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                            .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                    null, null, -1, null);
+                    SqlCompiler compiler = engine.getSqlCompiler();
+                    RecordCursorFactory f = compiler.compile(
+                            "SELECT count(), count(label) FROM t_cov_vc WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                    RecordCursor cur = f.getCursor(ctx)
+            ) {
+                Assert.assertTrue("final covered query returned no row", cur.hasNext());
+                Assert.assertEquals("final covered 'A' count", expectedRows, cur.getRecord().getLong(0));
+                Assert.assertEquals("final covered non-null label count", expectedRows, cur.getRecord().getLong(1));
+            }
+        });
+    }
+
+    /**
      * Covered-read hardening across row-id encodings. Same all-parquet O3 churn as
      * the reproducer, but each run pins a random posting row-id encoding (adaptive /
      * Elias-Fano / delta), so the covering reader decodes .pv chains under a

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -94,6 +94,18 @@ import static io.questdb.cairo.TableUtils.setPathForNativePartition;
  */
 public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
+    @Override
+    public void setUp() {
+        super.setUp();
+        // Every test must start with an empty shared posting-seal-purge ring. Many
+        // tests here run a WorkerPool + O3, which publish purge tasks into the
+        // engine-wide MessageBus ring; with no PostingSealPurgeJob draining it in the
+        // harness the residue can saturate the ring and starve a later test's purge --
+        // e.g. leaving a superseded .pv unreclaimed, or making a saturation assertion
+        // see no room. Draining here makes each test independent of the prior one.
+        drainPostingSealPurgeQueue();
+    }
+
     /**
      * Review C2: the full-partition SELECT DISTINCT path calls
      * collectDistinctKeys(), not collectDistinctKeysInRange(). The no-range

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -5145,9 +5145,9 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      * correct. Fix belongs writer-side: the covering sidecars must exist before the new
      * parquet partition version becomes reader-visible. Un-@Ignore to reproduce (~300ms).
      */
-    @Ignore("Open (root-caused): parquet rewrite exposes the new partition version " +
-            "before its covering .pci/.pc sidecars are written, so a concurrent covered " +
-            "read sees coverCount=0 and returns NULL. Native passes.")
+    @Ignore("Open (root-caused): a multi-partition O3/squash commit exposes some rewritten " +
+            "parquet partition versions with only the .pv and no covering .pci, so a concurrent " +
+            "covered read sees coverCount=0 and returns NULL. Native passes.")
     @Test
     public void testMultiThreadedO3CoveringPostingConcurrentReaderFuzz() throws Exception {
         node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -4369,6 +4369,82 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * Squashes MULTIPLE split sub-partitions in one squashSplitPartitions call,
+     * matching the reported failure shape more closely than the 2-sub-partition
+     * testSquashCoveringPostingWithMidStreamSpillFlush. The reported crash fired
+     * from squashSplitPartitions (the IIIZ overload) -> sealPostingIndexForPartition
+     * during WAL housekeep; squashPartitions() reaches the same overload via
+     * squashPartitionForce, so this drives that exact reseal deterministically.
+     * Four O3 prefixes build four split sub-partitions of one day over the hot
+     * key 'A'; squashPartitions() merges them, and with the 256-byte spill budget
+     * the merge's reseal index() loop flushes mid-stream -- the path that
+     * SIGSEGVd before the commitDense consolidation fix.
+     */
+    @Test
+    public void testSquashSplitPartitionsCoveringPostingMultiSplitSpill() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
+        node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 20);
+        node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 20);
+
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_multisplit (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            // Hot key 'A' across the early day.
+            execute("""
+                    INSERT INTO t_multisplit
+                    SELECT dateadd('s', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP),
+                           'A', x::DOUBLE
+                    FROM long_sequence(400)
+                    """);
+            // Late sentinel keeps the day's max at 23:00 so each O3 prefix below
+            // lands inside the range and splits rather than appends.
+            execute("INSERT INTO t_multisplit VALUES ('2024-01-01T23:00:00.000000Z', 'A', 1000000.0)");
+            // Four O3 prefixes at distinct late minutes build several split
+            // sub-partitions of 2024-01-01.
+            execute("INSERT INTO t_multisplit VALUES ('2024-01-01T22:10:00.000000Z', 'B', -1.0)");
+            execute("INSERT INTO t_multisplit VALUES ('2024-01-01T22:20:00.000000Z', 'B', -2.0)");
+            execute("INSERT INTO t_multisplit VALUES ('2024-01-01T22:30:00.000000Z', 'B', -3.0)");
+            execute("INSERT INTO t_multisplit VALUES ('2024-01-01T22:40:00.000000Z', 'B', -4.0)");
+
+            final long splitCount = selectLong("SELECT count() FROM table_partitions('t_multisplit')");
+            Assert.assertTrue(
+                    "test setup must produce more than two split sub-partitions for "
+                            + "squashSplitPartitions to merge, got " + splitCount,
+                    splitCount > 2);
+
+            printSql("SELECT /*+ no_covering */ count(), sum(price) FROM t_multisplit WHERE sym = 'A'");
+            String truth = sink.toString();
+
+            engine.releaseAllWriters();
+            try (TableWriter w = TestUtils.getWriter(engine, "t_multisplit")) {
+                // squashPartitions() -> squashPartitionForce -> squashSplitPartitions
+                // -> sealPostingIndexForPartition (the reported reseal path).
+                w.squashPartitions();
+            }
+
+            assertQuery("SELECT count() FROM table_partitions('t_multisplit')")
+                    .noLeakCheck()
+                    .expectSize()
+                    .noRandomAccess()
+                    .returns("""
+                            count
+                            1
+                            """);
+
+            printSql("SELECT count(), sum(price) FROM t_multisplit WHERE sym = 'A'");
+            TestUtils.assertEquals(
+                    "covering result after multi-split squash must match the no_covering fallback",
+                    truth, sink.toString());
+        });
+    }
+
+    /**
      * Non-covering twin of testSquashCoveringPostingWithMidStreamSpillFlush.
      * The non-covering squash reseal also runs discardForRebuild -> index() ->
      * commitDense; the same mid-stream flushAllPending orphans the early sparse

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -4844,6 +4844,74 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * C4 (deterministic counterpart of the covering-parquet fuzz tests): an O3 write
+     * that rewrites an already-parquet partition carrying a COVERING posting index must
+     * rebuild that new parquet version's covering sidecars (.pci/.pc). The O3 worker
+     * builds only the non-covering .pv; resealParquetCoveringForPartition (reached via
+     * sealPostingIndexForPartition's parquet branch in finishO3Commit) re-materialises
+     * the covering from the rewritten parquet. Without it a reader opens the new version,
+     * walks the chain (count correct) but finds coverCount=0 and resolves covered values
+     * as NULL. The covering cursor is forced/verified by expectSize()+noRandomAccess();
+     * the sum(price)/first(tag) assertions would read NULL covered values without the fix.
+     */
+    @Test
+    public void testO3CoveringPostingParquetResealKeepsCoveredValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_pq_cov_reseal (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price, tag),
+                        price DOUBLE,
+                        tag VARCHAR
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            // 200 'A' rows in 2024-01-01 (price 1..200, sum 20100, tag 'TA').
+            execute("""
+                    INSERT INTO t_pq_cov_reseal
+                    SELECT dateadd('s', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP),
+                           'A', x::DOUBLE, 'TA'
+                    FROM long_sequence(200)
+                    """);
+            // 10 more 'A' rows in 2024-01-02 (price 1001..1010, sum 10055) so 'A'
+            // spans a native partition too, and the converted one is not the tail.
+            execute("""
+                    INSERT INTO t_pq_cov_reseal
+                    SELECT dateadd('s', x::INT, '2024-01-02T00:00:00.000000Z'::TIMESTAMP),
+                           'A', (1000 + x)::DOUBLE, 'TA'
+                    FROM long_sequence(10)
+                    """);
+            drainWalQueue();
+            execute("ALTER TABLE t_pq_cov_reseal CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            drainWalQueue();
+            // O3 merge into the already-parquet partition rewrites it; the covering
+            // sidecars for the new parquet version must be rebuilt for the new 'B' rows
+            // (and the existing 'A' rows) to resolve their covered price/tag.
+            execute("""
+                    INSERT INTO t_pq_cov_reseal VALUES
+                    ('2024-01-01T00:01:00.500000Z', 'B', -1.0, 'TB'),
+                    ('2024-01-01T00:02:00.500000Z', 'B', -2.0, 'TB')
+                    """);
+            drainWalQueue();
+            engine.releaseAllWriters();
+
+            // expectSize()+noRandomAccess() => the covering cursor was selected and not
+            // a forward-scan fallback; sum(price)/first(tag) come from the .pc sidecars.
+            assertQuery("SELECT count(*) rows, sum(price) sum_price, first(tag) first_tag FROM t_pq_cov_reseal WHERE sym = 'A'")
+                    .noRandomAccess()
+                    .expectSize()
+                    .noLeakCheck()
+                    .returns("rows\tsum_price\tfirst_tag\n210\t30155.0\tTA\n");
+            // The O3-inserted 'B' rows live in the rewritten parquet partition; their
+            // covered values must be non-NULL after the reseal.
+            assertQuery("SELECT count(*) rows, sum(price) sum_price, first(tag) first_tag FROM t_pq_cov_reseal WHERE sym = 'B'")
+                    .noRandomAccess()
+                    .expectSize()
+                    .noLeakCheck()
+                    .returns("rows\tsum_price\tfirst_tag\n2\t-3.0\tTB\n");
+        });
+    }
+
+    /**
      * The parquet index-rebuild path (O3PartitionJob.updateParquetIndexes ->
      * commitDense) is the third commitDense caller. When its index() loop trips
      * the spill budget, commitDense routes through seal(), which rotates the .pv

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -4702,16 +4702,19 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
-     * Concurrent-read fuzz for the parquet reseal value-file reclaim. Background
-     * threads continuously query the posting index on a parquet partition while
-     * the main thread repeatedly O3-rewrites that partition under a tiny spill
-     * budget, so every rewrite drives commitDense -> seal ->
-     * unlinkPendingSealPurgesDirect (the inline reclaim, gated on isRewrite).
-     * If the reclaim ever unlinked a value file a reader still resolves, a
-     * concurrent count() would fail to open it. 'A' rows are only ever added, so
-     * each reader's observed count must be monotonic and never below the initial
-     * 2010, with no reader crash; the final count is asserted exactly. Random
-     * batch sizes and O3 timestamps vary the rewrite shape across runs.
+     * Concurrent-read safety guard for the parquet reseal value-file reclaim
+     * (unlinkPendingSealPurgesDirect). Background threads continuously query the
+     * posting index on a parquet partition while the main thread repeatedly
+     * O3-rewrites it under a tiny spill budget, so every rewrite drives
+     * commitDense -> seal -> the inline reclaim (gated on isRewrite). The reclaim
+     * DELETES a value file; if it ever deleted one a reader still resolves, a
+     * concurrent count() would fail to open it or return a short count -- so the
+     * 'A' count (rows are only added) must stay monotonic, never below the
+     * initial 2010, with no reader crash. This catches a reclaim that unlinks a
+     * still-live file (fault injection: deleting the active .pv makes it fail).
+     * The trailing single-.pv assertion additionally guards against the reclaim
+     * regressing into a leak across many rewrites; the deterministic counterpart
+     * is testConvertToParquetPostingResealSpillDoesNotLeakValueFile.
      */
     @Test
     public void testParquetPostingSpillConcurrentReadFuzz() throws Exception {
@@ -4799,6 +4802,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                 stop.set(true);
                 for (Thread t : readers) {
                     t.join(30_000);
+                    Assert.assertFalse("reader thread did not terminate", t.isAlive());
                 }
             }
 
@@ -4806,6 +4810,36 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             assertQuery("SELECT count() FROM xq WHERE sym = 'A'")
                     .noLeakCheck()
                     .returnsOnce("count\n" + expectedA + "\n");
+
+            // The reclaim must also have kept the partition free of leaked
+            // intermediates across every rewrite: exactly one value file remains.
+            engine.releaseAllWriters();
+            final TableToken token = engine.getTableTokenIfExists("xq");
+            Assert.assertNotNull("table must exist", token);
+            long partitionTs;
+            long partitionNameTxn;
+            try (TableReader reader = engine.getReader(token)) {
+                partitionTs = reader.getTxFile().getPartitionTimestampByIndex(0);
+                partitionNameTxn = reader.getTxFile().getPartitionNameTxn(0);
+            }
+            try (Path path = new Path()) {
+                path.of(configuration.getDbRoot()).concat(token);
+                setPathForNativePartition(path, ColumnType.TIMESTAMP, PartitionBy.DAY, partitionTs, partitionNameTxn);
+                final java.io.File dir = new java.io.File(path.toString());
+                final String[] names = dir.list();
+                Assert.assertNotNull("partition dir must exist: " + dir, names);
+                int pvCount = 0;
+                for (String nm : names) {
+                    if (nm.startsWith("sym.pv.")) {
+                        pvCount++;
+                    }
+                }
+                Assert.assertEquals(
+                        "exactly one value file must remain after the rewrites; a leaked "
+                                + "intermediate from the spill-driven reseal survived: "
+                                + java.util.Arrays.toString(names),
+                        1, pvCount);
+            }
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -5123,6 +5123,533 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * Concurrent LATEST ON covered-read hardening test. Stresses the covering
+     * BACKWARD reader (PostingIndexBwdReader / findLatestRow + symbol-rank), a
+     * code path the sum/count reproducer never touches. A COVERING posting index
+     * (sym INCLUDE price) over several parquet partitions is rewritten out of
+     * order across the real 4-worker O3 pool under a tiny spill budget while
+     * reader threads continuously resolve the latest covered price per sym via
+     * {@code SELECT price ... WHERE sym='A' LATEST ON ts PARTITION BY sym}.
+     * <p>
+     * A single sentinel 'A' row is seeded at the global max timestamp with a
+     * unique price; every background O3 insert lands at an EARLIER timestamp, so
+     * the latest 'A' row never changes and its covered price must always read
+     * back as the sentinel. O3 also rewrites the sentinel's (last) partition, so
+     * the backward reader scans a partition mid-reseal: if the new version is
+     * exposed before its covering .pci/.pc is materialised, or the reseal rotates
+     * the sidecar under the reader, the latest covered price comes back wrong
+     * (NULL / stale / garbage) and the assertion fires. The -ea audit asserts and
+     * any reader SIGSEGV are the other oracles.
+     */
+    @Test
+    public void testMultiThreadedO3CoveringLatestByConcurrentReaderFuzz() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+
+        assertMemoryLeak(() -> {
+            final int dayCount = 4 + rnd.nextInt(4); // 4..7 days
+            final int hotPerDay = 1000;
+            final double sentinelPrice = 777_777.0;
+            // Sentinel 'A' row at the global max ts (last day, end of day). Every
+            // hot row and every later O3 insert is strictly earlier, so the latest
+            // 'A' is always this row and its covered price must read back exactly.
+            final String sentinelTs = "2024-02-0" + dayCount + "T23:59:59.000000Z";
+            final long initialRows = (long) dayCount * hotPerDay + 1; // +1 sentinel
+
+            execute("""
+                    CREATE TABLE t_cov_latest (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            for (int d = 1; d <= dayCount; d++) {
+                execute("INSERT INTO t_cov_latest SELECT dateadd('s', x::INT, '2024-02-0" + d
+                        + "T00:00:00.000000Z'::TIMESTAMP), 'A', x::DOUBLE FROM long_sequence(" + hotPerDay + ")");
+            }
+            execute("INSERT INTO t_cov_latest VALUES ('" + sentinelTs + "', 'A', " + sentinelPrice + ")");
+            for (int d = 1; d <= dayCount; d++) {
+                execute("ALTER TABLE t_cov_latest CONVERT PARTITION TO PARQUET LIST '2024-02-0" + d + "'");
+            }
+
+            // Confirm the read path under test is the covering backward reader.
+            final String latestSql = "SELECT price FROM t_cov_latest WHERE sym = 'A' LATEST ON ts PARTITION BY sym";
+            final String plan;
+            try (RecordCursorFactory pf = select(latestSql)) {
+                planSink.clear();
+                pf.toPlan(planSink);
+                plan = planSink.getSink().toString();
+            }
+            Assert.assertTrue("LATEST ON must use the covering index:\n" + plan, plan.contains("CoveringIndex"));
+
+            final AtomicReference<Throwable> bgError = new AtomicReference<>();
+            final AtomicBoolean stop = new AtomicBoolean();
+            final int readerCount = 3;
+            final Thread[] readers = new Thread[readerCount];
+            for (int r = 0; r < readerCount; r++) {
+                readers[r] = new Thread(() -> {
+                    try (
+                            SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                                    .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                            null, null, -1, null);
+                            SqlCompiler compiler = engine.getSqlCompiler()
+                    ) {
+                        while (!stop.get() && bgError.get() == null) {
+                            final double latest;
+                            try (RecordCursorFactory f = compiler.compile(latestSql, ctx).getRecordCursorFactory();
+                                 RecordCursor cur = f.getCursor(ctx)) {
+                                latest = cur.hasNext() ? cur.getRecord().getDouble(0) : Double.NaN;
+                            }
+                            if (Double.isNaN(latest)) {
+                                throw new AssertionError("latest covered 'A' price resolved to NULL/NaN -- "
+                                        + "covering sidecar missing or not yet materialised under reseal");
+                            }
+                            if (Math.abs(latest - sentinelPrice) > 0.5) {
+                                throw new AssertionError("latest covered 'A' price changed from the sentinel "
+                                        + sentinelPrice + " to " + latest
+                                        + " -- the backward reader read a stale/garbage covered value mid-reseal");
+                            }
+                        }
+                    } catch (Throwable e) {
+                        bgError.set(e);
+                    }
+                }, "covering-latest-reader-" + r);
+                readers[r].setDaemon(true);
+                readers[r].start();
+            }
+
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.setupWorkerPool(pool, engine);
+            pool.start(LOG);
+            long expectedRows = initialRows;
+            try {
+                final int batches = 6 + rnd.nextInt(10);
+                for (int b = 0; b < batches && bgError.get() == null; b++) {
+                    // O3-insert 'A' rows strictly earlier than the sentinel into a random
+                    // subset of the parquet days (including the sentinel's last day, which
+                    // forces that partition to reseal under the backward reader).
+                    final StringBuilder sql = new StringBuilder("INSERT INTO t_cov_latest VALUES ");
+                    int added = 0;
+                    for (int d = 1; d <= dayCount; d++) {
+                        if (rnd.nextBoolean()) {
+                            continue;
+                        }
+                        final int n = 1 + rnd.nextInt(3);
+                        for (int i = 0; i < n; i++) {
+                            if (added > 0) {
+                                sql.append(',');
+                            }
+                            sql.append("('2024-02-0").append(d).append("T00:")
+                                    .append(String.format("%02d", 1 + rnd.nextInt(58)))
+                                    .append(":00.500000Z', 'A', 1.0)");
+                            added++;
+                        }
+                    }
+                    if (added == 0) {
+                        continue;
+                    }
+                    execute(sql.toString());
+                    expectedRows += added;
+                }
+            } finally {
+                stop.set(true);
+                for (Thread t : readers) {
+                    t.join(30_000);
+                    Assert.assertFalse("reader thread did not terminate", t.isAlive());
+                }
+                pool.halt();
+            }
+
+            Assert.assertNull("concurrent latest-by covered reader threw: " + bgError.get(), bgError.get());
+
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
+            engine.releaseAllWriters();
+
+            try (
+                    SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                            .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                    null, null, -1, null);
+                    SqlCompiler compiler = engine.getSqlCompiler()
+            ) {
+                try (RecordCursorFactory f = compiler.compile(latestSql, ctx).getRecordCursorFactory();
+                     RecordCursor cur = f.getCursor(ctx)) {
+                    Assert.assertTrue("final latest query returned no row", cur.hasNext());
+                    Assert.assertEquals("final latest covered 'A' price", sentinelPrice, cur.getRecord().getDouble(0), 0.5);
+                }
+                try (RecordCursorFactory f = compiler.compile(
+                        "SELECT count() FROM t_cov_latest WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                     RecordCursor cur = f.getCursor(ctx)) {
+                    Assert.assertTrue(cur.hasNext());
+                    Assert.assertEquals("final covered 'A' count", expectedRows, cur.getRecord().getLong(0));
+                }
+            }
+        });
+    }
+
+    /**
+     * Mixed native + parquet covered-read hardening test. The parquet reproducer
+     * rewrites an all-parquet table; this one leaves a random proper subset of the
+     * partitions native and converts the rest to parquet, then O3-inserts across
+     * BOTH so a single commit can reseal a native partition in place AND a parquet
+     * partition via resealParquetCoveringForPartition in the same seal sweep, while
+     * reader threads aggregate {@code count(), sum(price) WHERE sym='A'} across the
+     * mix. A defect in either reseal path -- or in how the two share the deferred
+     * seal-purge state -- drops a covered partition and the monotonic oracle fires.
+     * <p>
+     * OPEN BUG (caught by this test, 2026-06-05, NOT yet fixed): fails ~1 in 4 runs
+     * with "covered sum(price) dropped below the initial total" -- exactly one
+     * partition's covered values transiently read 0 under a concurrent O3 reseal.
+     * This is a DISTINCT, native-partition-specific covered-read race, NOT the
+     * parquet expose-before-.pci bug fixed by resealParquetCoveringForPartition:
+     * the all-parquet reproducer (testMultiThreadedO3CoveringPostingConcurrent
+     * ReaderFuzz) passes 0/10+ while this mixed/native variant fails ~1/4. Proven
+     * via instrumentation: coverCount is NOT 0 (the .pci is present and valid -- no
+     * notexist/short/badmagic/count0), so the .pci truncation is not the cause; the
+     * covered DATA reads 0 for a whole NATIVE partition (getCoveredDouble falls back
+     * to NaN -> SQL sum() skips it). Likely an expose-before-cover-DATA window in the
+     * NATIVE in-place reseal (the new sealTxn chain entry becomes visible before that
+     * version's covered .pc data is materialised). Un-ignore once the native reseal
+     * publishes covered data before the chain entry. Reproduce with
+     * generateRandom(LOG, s0, s1) e.g. 483763479454950L, 1780617824721L.
+     */
+    @Ignore("Reproducer for an OPEN native-partition covered-read race; see javadoc. Un-ignore when fixed.")
+    @Test
+    public void testMultiThreadedO3CoveringMixedNativeParquetReaderFuzz() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+
+        assertMemoryLeak(() -> {
+            final int dayCount = 4 + rnd.nextInt(4); // 4..7 days
+            final int hotPerDay = 1000;
+            final long perDaySum = (long) hotPerDay * (hotPerDay + 1) / 2;
+            final long initialRows = (long) dayCount * hotPerDay;
+            final long initialSum = (long) dayCount * perDaySum;
+
+            execute("""
+                    CREATE TABLE t_cov_mix (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            for (int d = 1; d <= dayCount; d++) {
+                execute("INSERT INTO t_cov_mix SELECT dateadd('s', x::INT, '2024-02-0" + d
+                        + "T00:00:00.000000Z'::TIMESTAMP), 'A', x::DOUBLE FROM long_sequence(" + hotPerDay + ")");
+            }
+            // Convert a random proper subset to parquet: keep >=1 parquet and >=1 native
+            // so both reseal paths stay live in the same run.
+            final boolean[] isParquet = new boolean[dayCount + 1];
+            int parquetDays = 0;
+            for (int d = 1; d <= dayCount; d++) {
+                if (rnd.nextBoolean()) {
+                    isParquet[d] = true;
+                    parquetDays++;
+                }
+            }
+            if (parquetDays == 0) {
+                isParquet[1] = true;
+            } else if (parquetDays == dayCount) {
+                isParquet[dayCount] = false;
+            }
+            for (int d = 1; d <= dayCount; d++) {
+                if (isParquet[d]) {
+                    execute("ALTER TABLE t_cov_mix CONVERT PARTITION TO PARQUET LIST '2024-02-0" + d + "'");
+                }
+            }
+
+            final AtomicReference<Throwable> bgError = new AtomicReference<>();
+            final AtomicBoolean stop = new AtomicBoolean();
+            final AtomicLong rowFloor = new AtomicLong(initialRows);
+            final int readerCount = 3;
+            final Thread[] readers = new Thread[readerCount];
+            for (int r = 0; r < readerCount; r++) {
+                readers[r] = new Thread(() -> {
+                    try (
+                            SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                                    .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                            null, null, -1, null);
+                            SqlCompiler compiler = engine.getSqlCompiler()
+                    ) {
+                        long prevCount = 0;
+                        while (!stop.get() && bgError.get() == null) {
+                            final long floor = rowFloor.get();
+                            final long count;
+                            final double sum;
+                            try (RecordCursorFactory f = compiler.compile(
+                                    "SELECT count(), sum(price) FROM t_cov_mix WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                                 RecordCursor cur = f.getCursor(ctx)) {
+                                if (cur.hasNext()) {
+                                    count = cur.getRecord().getLong(0);
+                                    sum = cur.getRecord().getDouble(1);
+                                } else {
+                                    count = -1;
+                                    sum = -1;
+                                }
+                            }
+                            if (count < floor) {
+                                throw new AssertionError("covered 'A' count fell below the committed floor: "
+                                        + count + " < " + floor);
+                            }
+                            if (count < prevCount) {
+                                throw new AssertionError("covered 'A' count went backwards: " + prevCount + " -> " + count);
+                            }
+                            if (sum < (double) initialSum - 0.5) {
+                                throw new AssertionError("covered sum(price) dropped below the initial total "
+                                        + initialSum + ": " + sum);
+                            }
+                            if (sum < (double) count - 0.5) {
+                                throw new AssertionError("covered sum(price)=" + sum + " < count=" + count
+                                        + " -- a covered value resolved as < 1 (stale/garbage sidecar)");
+                            }
+                            prevCount = count;
+                        }
+                    } catch (Throwable e) {
+                        bgError.set(e);
+                    }
+                }, "covering-mix-reader-" + r);
+                readers[r].setDaemon(true);
+                readers[r].start();
+            }
+
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.setupWorkerPool(pool, engine);
+            pool.start(LOG);
+            long expectedRows = initialRows;
+            try {
+                final int batches = 6 + rnd.nextInt(10);
+                for (int b = 0; b < batches && bgError.get() == null; b++) {
+                    final StringBuilder sql = new StringBuilder("INSERT INTO t_cov_mix VALUES ");
+                    int added = 0;
+                    for (int d = 1; d <= dayCount; d++) {
+                        if (rnd.nextBoolean()) {
+                            continue;
+                        }
+                        final int n = 1 + rnd.nextInt(3);
+                        for (int i = 0; i < n; i++) {
+                            if (added > 0) {
+                                sql.append(',');
+                            }
+                            sql.append("('2024-02-0").append(d).append("T00:")
+                                    .append(String.format("%02d", 1 + rnd.nextInt(58)))
+                                    .append(":00.500000Z', 'A', 1.0)");
+                            added++;
+                        }
+                    }
+                    if (added == 0) {
+                        continue;
+                    }
+                    execute(sql.toString());
+                    expectedRows += added;
+                    rowFloor.set(expectedRows);
+                }
+            } finally {
+                stop.set(true);
+                for (Thread t : readers) {
+                    t.join(30_000);
+                    Assert.assertFalse("reader thread did not terminate", t.isAlive());
+                }
+                pool.halt();
+            }
+
+            Assert.assertNull("concurrent mixed covered reader threw: " + bgError.get(), bgError.get());
+
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
+            engine.releaseAllWriters();
+
+            final long expectedSum = initialSum + (expectedRows - initialRows);
+            try (
+                    SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                            .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                    null, null, -1, null);
+                    SqlCompiler compiler = engine.getSqlCompiler();
+                    RecordCursorFactory f = compiler.compile(
+                            "SELECT count(), sum(price) FROM t_cov_mix WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                    RecordCursor cur = f.getCursor(ctx)
+            ) {
+                Assert.assertTrue("final covered query returned no row", cur.hasNext());
+                Assert.assertEquals("final covered 'A' count", expectedRows, cur.getRecord().getLong(0));
+                Assert.assertEquals("final covered sum(price)", (double) expectedSum, cur.getRecord().getDouble(1), 0.5);
+            }
+        });
+    }
+
+    /**
+     * Multi-key covered-read hardening test. The single-key reproducer keeps one
+     * posting chain hot; this one drives K symbols, each with its own covering
+     * chain and per-key covered totals, over parquet partitions rewritten out of
+     * order across the pool. Readers pick a random key and aggregate
+     * {@code count(), sum(price) WHERE sym = ?}, so a reader navigates one key's
+     * chain/sidecars while O3 reseals the others -- stressing the per-key chain
+     * navigation and the symbol-rank maps the covering cursor builds. Each key's
+     * count and sum are independently monotonic; a cross-key sidecar mix-up or a
+     * dropped key partition trips that key's floor.
+     */
+    @Test
+    public void testMultiThreadedO3CoveringMultiKeyConcurrentReaderFuzz() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+
+        assertMemoryLeak(() -> {
+            final String[] syms = {"A", "B", "C", "D", "E"};
+            final int K = syms.length;
+            final int dayCount = 4 + rnd.nextInt(4); // 4..7 days
+            final int hotPerDay = 1000;
+            final long perDaySum = (long) hotPerDay * (hotPerDay + 1) / 2;
+            final long initialRowsPerSym = (long) dayCount * hotPerDay;
+            final long initialSumPerSym = (long) dayCount * perDaySum;
+
+            execute("""
+                    CREATE TABLE t_cov_mk (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            for (int d = 1; d <= dayCount; d++) {
+                for (int k = 0; k < K; k++) {
+                    execute("INSERT INTO t_cov_mk SELECT dateadd('s', x::INT, '2024-02-0" + d
+                            + "T00:00:00.000000Z'::TIMESTAMP), '" + syms[k] + "', x::DOUBLE FROM long_sequence(" + hotPerDay + ")");
+                }
+            }
+            for (int d = 1; d <= dayCount; d++) {
+                execute("ALTER TABLE t_cov_mk CONVERT PARTITION TO PARQUET LIST '2024-02-0" + d + "'");
+            }
+
+            final AtomicReference<Throwable> bgError = new AtomicReference<>();
+            final AtomicBoolean stop = new AtomicBoolean();
+            final AtomicLong[] floors = new AtomicLong[K];
+            for (int k = 0; k < K; k++) {
+                floors[k] = new AtomicLong(initialRowsPerSym);
+            }
+            final int readerCount = 3;
+            final Thread[] readers = new Thread[readerCount];
+            for (int r = 0; r < readerCount; r++) {
+                final int seed = r;
+                readers[r] = new Thread(() -> {
+                    final Rnd rRnd = new Rnd(seed + 1, seed + 100);
+                    try (
+                            SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                                    .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                            null, null, -1, null);
+                            SqlCompiler compiler = engine.getSqlCompiler()
+                    ) {
+                        while (!stop.get() && bgError.get() == null) {
+                            final int k = rRnd.nextInt(K);
+                            final long floor = floors[k].get();
+                            final long count;
+                            final double sum;
+                            try (RecordCursorFactory f = compiler.compile(
+                                    "SELECT count(), sum(price) FROM t_cov_mk WHERE sym = '" + syms[k] + "'", ctx).getRecordCursorFactory();
+                                 RecordCursor cur = f.getCursor(ctx)) {
+                                if (cur.hasNext()) {
+                                    count = cur.getRecord().getLong(0);
+                                    sum = cur.getRecord().getDouble(1);
+                                } else {
+                                    count = -1;
+                                    sum = -1;
+                                }
+                            }
+                            if (count < floor) {
+                                throw new AssertionError("covered '" + syms[k] + "' count fell below its floor: "
+                                        + count + " < " + floor);
+                            }
+                            if (sum < (double) initialSumPerSym - 0.5) {
+                                throw new AssertionError("covered '" + syms[k] + "' sum dropped below its initial total "
+                                        + initialSumPerSym + ": " + sum);
+                            }
+                            if (sum < (double) count - 0.5) {
+                                throw new AssertionError("covered '" + syms[k] + "' sum=" + sum + " < count=" + count
+                                        + " -- a covered value resolved as < 1 (cross-key or stale sidecar)");
+                            }
+                        }
+                    } catch (Throwable e) {
+                        bgError.set(e);
+                    }
+                }, "covering-mk-reader-" + r);
+                readers[r].setDaemon(true);
+                readers[r].start();
+            }
+
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.setupWorkerPool(pool, engine);
+            pool.start(LOG);
+            final long[] expectedRows = new long[K];
+            for (int k = 0; k < K; k++) {
+                expectedRows[k] = initialRowsPerSym;
+            }
+            try {
+                final int batches = 8 + rnd.nextInt(12);
+                for (int b = 0; b < batches && bgError.get() == null; b++) {
+                    // One commit O3-inserts a random key into a random subset of days.
+                    final int k = rnd.nextInt(K);
+                    final StringBuilder sql = new StringBuilder("INSERT INTO t_cov_mk VALUES ");
+                    int added = 0;
+                    for (int d = 1; d <= dayCount; d++) {
+                        if (rnd.nextBoolean()) {
+                            continue;
+                        }
+                        final int n = 1 + rnd.nextInt(3);
+                        for (int i = 0; i < n; i++) {
+                            if (added > 0) {
+                                sql.append(',');
+                            }
+                            sql.append("('2024-02-0").append(d).append("T00:")
+                                    .append(String.format("%02d", 1 + rnd.nextInt(58)))
+                                    .append(":00.500000Z', '").append(syms[k]).append("', 1.0)");
+                            added++;
+                        }
+                    }
+                    if (added == 0) {
+                        continue;
+                    }
+                    execute(sql.toString());
+                    expectedRows[k] += added;
+                    floors[k].set(expectedRows[k]);
+                }
+            } finally {
+                stop.set(true);
+                for (Thread t : readers) {
+                    t.join(30_000);
+                    Assert.assertFalse("reader thread did not terminate", t.isAlive());
+                }
+                pool.halt();
+            }
+
+            Assert.assertNull("concurrent multi-key covered reader threw: " + bgError.get(), bgError.get());
+
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
+            engine.releaseAllWriters();
+
+            try (
+                    SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                            .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                    null, null, -1, null);
+                    SqlCompiler compiler = engine.getSqlCompiler()
+            ) {
+                for (int k = 0; k < K; k++) {
+                    final long expSum = initialSumPerSym + (expectedRows[k] - initialRowsPerSym);
+                    try (RecordCursorFactory f = compiler.compile(
+                            "SELECT count(), sum(price) FROM t_cov_mk WHERE sym = '" + syms[k] + "'", ctx).getRecordCursorFactory();
+                         RecordCursor cur = f.getCursor(ctx)) {
+                        Assert.assertTrue("final covered query returned no row for " + syms[k], cur.hasNext());
+                        Assert.assertEquals("final covered '" + syms[k] + "' count", expectedRows[k], cur.getRecord().getLong(0));
+                        Assert.assertEquals("final covered '" + syms[k] + "' sum", (double) expSum, cur.getRecord().getDouble(1), 0.5);
+                    }
+                }
+            }
+        });
+    }
+
+    /**
      * Concurrent covered-read integration test: a COVERING posting index
      * (sym INCLUDE price) over several parquet partitions, rewritten out-of-order
      * across the real 4-worker O3 pool under a tiny spill budget, while background

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -74,17 +74,15 @@ import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;
-import static io.questdb.cairo.TableUtils.DETACHED_DIR_MARKER;
-import static io.questdb.cairo.TableUtils.setPathForNativePartition;
+import static io.questdb.cairo.TableUtils.*;
 
 /**
  * Red tests for the critical findings raised in the PR review of #6861.
@@ -523,8 +521,8 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
             final int batches = 40;
             final int rowsPerBatch = 100_000; // per-commit hot-key spill (~hundreds of KiB) exceeds the 256 KiB budget
-            final long base = 1_700_000_000_000_000L; // arbitrary instant; all rows stay in one day
-            long start = base;
+            // arbitrary instant; all rows stay in one day
+            long start = 1_700_000_000_000_000L;
             for (int b = 0; b < batches; b++) {
                 execute("INSERT INTO flt " +
                         "SELECT timestamp_sequence(cast(" + start + " as timestamp), 1), 'KCAS', 1.0 " +
@@ -566,9 +564,11 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             // must still be chosen.
             assertPlanNoLeakCheck(
                     "SELECT ts, val FROM x WHERE sym = 'b'",
-                    "SelectedRecord\n" +
-                            "    CoveringIndex on: sym with: ts, val\n" +
-                            "      filter: sym='b'\n"
+                    """
+                            SelectedRecord
+                                CoveringIndex on: sym with: ts, val
+                                  filter: sym='b'
+                            """
             );
         });
     }
@@ -589,9 +589,11 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             execute("CREATE TABLE x (ts TIMESTAMP, sym SYMBOL CAPACITY 16 INDEX TYPE POSTING INCLUDE (val), val DOUBLE) " +
                     "TIMESTAMP(ts) PARTITION BY DAY WAL");
             final String coveringPlan =
-                    "SelectedRecord\n" +
-                            "    CoveringIndex on: sym with: ts, val\n" +
-                            "      filter: sym='zzz'\n";
+                    """
+                            SelectedRecord
+                                CoveringIndex on: sym with: ts, val
+                                  filter: sym='zzz'
+                            """;
             assertPlanNoLeakCheck("SELECT ts, val FROM x WHERE sym = 'zzz'", coveringPlan);
 
             final long dayMicros = 86_400_000_000L;
@@ -4523,9 +4525,22 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
             // The covering path must return every 'A' row: 400 (sum 1..400 =
             // 80200) plus the 20:00 sentinel (1000000) = 401 rows, sum 1080200.
+            // Assert the covering plan alongside the result so a future optimizer
+            // change that silently falls back to a base-table scan (sym.d/price.d
+            // intact, only the covering sidecar corrupt) fails here instead of
+            // masking the bug.
             assertQuery("SELECT count(), sum(price) FROM t_squash_spill WHERE sym = 'A'")
-                    .noLeakCheck()
-                    .returnsOnce("count\tsum\n401\t1080200.0\n");
+                    .withPlan("""
+                            Async Group By workers: 1
+                              vectorized: true
+                              values: [count(*),sum(price)]
+                              filter: null
+                                CoveringIndex on: sym with: price
+                                  filter: sym='A'
+                            """)
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\tsum\n401\t1080200.0\n");
         });
     }
 
@@ -4596,10 +4611,20 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                             """);
 
             // 400 'A' rows (sum 1..400 = 80200) plus the 23:00 sentinel
-            // (1000000) = 401 rows, sum 1080200.
+            // (1000000) = 401 rows, sum 1080200. The withPlan pin keeps the read
+            // on the CoveringIndex so a base-scan fallback cannot mask the bug.
             assertQuery("SELECT count(), sum(price) FROM t_multisplit WHERE sym = 'A'")
-                    .noLeakCheck()
-                    .returnsOnce("count\tsum\n401\t1080200.0\n");
+                    .withPlan("""
+                            Async Group By workers: 1
+                              vectorized: true
+                              values: [count(*),sum(price)]
+                              filter: null
+                                CoveringIndex on: sym with: price
+                                  filter: sym='A'
+                            """)
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\tsum\n401\t1080200.0\n");
         });
     }
 
@@ -4669,10 +4694,20 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                             """);
 
             // 2000 'A' rows (sum 1..2000 = 2001000) plus the 23:00 sentinel
-            // (1000000) = 2001 rows, sum 3001000, served through the covering index.
+            // (1000000) = 2001 rows, sum 3001000. The withPlan pin keeps the read
+            // on the CoveringIndex so a base-scan fallback cannot mask the bug.
             assertQuery("SELECT count(), sum(price) FROM t_manysplit WHERE sym = 'A'")
-                    .noLeakCheck()
-                    .returnsOnce("count\tsum\n2001\t3001000.0\n");
+                    .withPlan("""
+                            Async Group By workers: 1
+                              vectorized: true
+                              values: [count(*),sum(price)]
+                              filter: null
+                                CoveringIndex on: sym with: price
+                                  filter: sym='A'
+                            """)
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\tsum\n2001\t3001000.0\n");
         });
     }
 
@@ -4782,10 +4817,20 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             }
 
             // 400 'A' rows (sum 1..400 = 80200) plus the 23:00 sentinel (1000000)
-            // = 401 rows, sum 1080200, served through the covering index.
+            // = 401 rows, sum 1080200. The withPlan pin keeps the read on the
+            // CoveringIndex so a base-scan fallback cannot mask the bug.
             assertQuery("SELECT count(), sum(price) FROM t_wal_squash_spill WHERE sym = 'A'")
-                    .noLeakCheck()
-                    .returnsOnce("count\tsum\n401\t1080200.0\n");
+                    .withPlan("""
+                            Async Group By workers: 1
+                              vectorized: true
+                              values: [count(*),sum(price)]
+                              filter: null
+                                CoveringIndex on: sym with: price
+                                  filter: sym='A'
+                            """)
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\tsum\n401\t1080200.0\n");
         });
     }
 
@@ -4833,13 +4878,34 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             // The hot key (which drove the mid-stream spill) and the O3-inserted
             // rows must both come back intact through the covering index. The
             // aggregates are deterministic: 'A' = 400 rows, sum(1..400) = 80200;
-            // 'B' = 3 rows, sum(-1,-2,-3) = -6.
+            // 'B' = 3 rows, sum(-1,-2,-3) = -6. Assert the covering plan alongside
+            // the result so a future fallback to a base-table scan (sym.d/price.d
+            // intact, only the covering sidecar corrupt) fails here instead of
+            // masking the bug.
             assertQuery("SELECT count(), sum(price) FROM t_o3_reseal WHERE sym = 'A'")
-                    .noLeakCheck()
-                    .returnsOnce("count\tsum\n400\t80200.0\n");
+                    .withPlan("""
+                            Async Group By workers: 1
+                              vectorized: true
+                              values: [count(*),sum(price)]
+                              filter: null
+                                CoveringIndex on: sym with: price
+                                  filter: sym='A'
+                            """)
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\tsum\n400\t80200.0\n");
             assertQuery("SELECT count(), sum(price) FROM t_o3_reseal WHERE sym = 'B'")
-                    .noLeakCheck()
-                    .returnsOnce("count\tsum\n3\t-6.0\n");
+                    .withPlan("""
+                            Async Group By workers: 1
+                              vectorized: true
+                              values: [count(*),sum(price)]
+                              filter: null
+                                CoveringIndex on: sym with: price
+                                  filter: sym='B'
+                            """)
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\tsum\n3\t-6.0\n");
         });
     }
 
@@ -4851,8 +4917,10 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      * sealPostingIndexForPartition's parquet branch in finishO3Commit) re-materialises
      * the covering from the rewritten parquet. Without it a reader opens the new version,
      * walks the chain (count correct) but finds coverCount=0 and resolves covered values
-     * as NULL. The covering cursor is forced/verified by expectSize()+noRandomAccess();
-     * the sum(price)/first(tag) assertions would read NULL covered values without the fix.
+     * as NULL. A withPlan() check forces the covering cursor (expectSize()/
+     * noRandomAccess() describe only the outer aggregation and would also pass a base-scan
+     * fallback); the sum(price)/first(tag) assertions would read NULL covered values
+     * without the fix.
      */
     @Test
     public void testO3CoveringPostingParquetResealKeepsCoveredValues() throws Exception {
@@ -4894,19 +4962,37 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             drainWalQueue();
             engine.releaseAllWriters();
 
-            // expectSize()+noRandomAccess() => the covering cursor was selected and not
-            // a forward-scan fallback; sum(price)/first(tag) come from the .pc sidecars.
+            // Assert the covering plan alongside the result: sum(price)/first(tag)
+            // must be served by the CoveringIndex, not a base-table scan.
+            // expectSize()/noRandomAccess() describe only the outer aggregation and
+            // pass either way, so without this plan check a future optimizer
+            // fallback to a forward scan (intact base columns, NULL-ed covering
+            // sidecars) would mask the bug.
             assertQuery("SELECT count(*) rows, sum(price) sum_price, first(tag) first_tag FROM t_pq_cov_reseal WHERE sym = 'A'")
+                    .withPlan("""
+                            Async Group By workers: 1
+                              vectorized: true
+                              values: [count(*),sum(price),first(tag)]
+                              filter: null
+                                CoveringIndex on: sym with: price, tag
+                                  filter: sym='A'
+                            """)
                     .noRandomAccess()
                     .expectSize()
-                    .noLeakCheck()
                     .returns("rows\tsum_price\tfirst_tag\n210\t30155.0\tTA\n");
             // The O3-inserted 'B' rows live in the rewritten parquet partition; their
             // covered values must be non-NULL after the reseal.
             assertQuery("SELECT count(*) rows, sum(price) sum_price, first(tag) first_tag FROM t_pq_cov_reseal WHERE sym = 'B'")
+                    .withPlan("""
+                            Async Group By workers: 1
+                              vectorized: true
+                              values: [count(*),sum(price),first(tag)]
+                              filter: null
+                                CoveringIndex on: sym with: price, tag
+                                  filter: sym='B'
+                            """)
                     .noRandomAccess()
                     .expectSize()
-                    .noLeakCheck()
                     .returns("rows\tsum_price\tfirst_tag\n2\t-3.0\tTB\n");
         });
     }
@@ -6683,9 +6769,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             TestUtils.setupWorkerPool(pool, engine);
             pool.start(LOG);
             final long[] expectedRows = new long[K];
-            for (int k = 0; k < K; k++) {
-                expectedRows[k] = initialRowsPerSym;
-            }
+            Arrays.fill(expectedRows, initialRowsPerSym);
             try {
                 final int batches = 8 + rnd.nextInt(12);
                 for (int b = 0; b < batches && bgError.get() == null; b++) {
@@ -7112,9 +7196,9 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      * the writer's covering schema (coverCount, sidecarMems) so a
      * subsequent commit() between seals still publishes a chain entry
      * with a correctly-sized cover footer. This is the symmetric
-     * counterpart to {@link #testWriterEntrysCoverFooterShrinksAfterClearCoveringCommit},
-     * which documents that the old clearCovering()-then-commit() flow
-     * shrinks the footer.
+     * counterpart to {@link #testWriterEntryPreservesCoverFooterAfterClearCoveringCommit},
+     * which covers the clearCovering()-then-commit() flow, where the
+     * footer instead survives via publishToChain's head-footer snapshot.
      */
     @Test
     public void testWriterEntrysCoverFooterPersistsAfterReleaseReadMappingsCommit() throws Exception {

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -4606,6 +4606,98 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * The parquet index-rebuild path (O3PartitionJob.updateParquetIndexes ->
+     * commitDense) is the third commitDense caller. When its index() loop trips
+     * the spill budget, commitDense routes through seal(), which rotates the .pv
+     * to a new sealTxn. Unlike the native reseal, the pooled parquet writer is
+     * freed (close() -> releasePendingPurges) without ever draining its pending
+     * seal-purge, so the superseded intermediate .pv would leak on disk
+     * permanently (no directory sweep, no recovery-walk reclaim). The fix unlinks
+     * the superseded value file inline -- safe because the parquet rebuild is a
+     * fresh, uncommitted index whose prev gens are never picked by a committed
+     * reader. After a spill-driven CONVERT, exactly one .pv must remain.
+     */
+    @Test
+    public void testConvertToParquetPostingResealSpillDoesNotLeakValueFile() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_pq_leak (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            // Hot key 'A' so the parquet rebuild's index() loop spills past the
+            // 256-byte budget mid-stream (genCount > 0 -> commitDense seals).
+            execute("""
+                    INSERT INTO t_pq_leak
+                    SELECT dateadd('s', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP), 'A'
+                    FROM long_sequence(2000)
+                    """);
+            // A second partition so the converted one is not the active tail.
+            execute("""
+                    INSERT INTO t_pq_leak
+                    SELECT dateadd('s', x::INT, '2024-01-02T00:00:00.000000Z'::TIMESTAMP), 'A'
+                    FROM long_sequence(10)
+                    """);
+            drainWalQueue();
+            execute("ALTER TABLE t_pq_leak CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            drainWalQueue();
+            // O3 into the already-parquet partition rewrites it; updateParquetIndexes
+            // rebuilds the posting index over all 2000+ 'A' rows, tripping the spill
+            // budget -> commitDense seals -> the rotated intermediate .pv would leak.
+            execute("""
+                    INSERT INTO t_pq_leak VALUES
+                    ('2024-01-01T00:10:00.500000Z', 'A'),
+                    ('2024-01-01T00:20:00.500000Z', 'A')
+                    """);
+            drainWalQueue();
+
+            // Drain any queued posting-seal purges; the leaked intermediate is
+            // never queued, so this would not reclaim it.
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
+            engine.releaseAllWriters();
+
+            // Index still returns every 'A' rowid after the parquet reseal
+            // (2000 + 2 O3 rows in the converted partition + 10 in the next).
+            assertQuery("SELECT count() FROM t_pq_leak WHERE sym = 'A'")
+                    .noLeakCheck()
+                    .returnsOnce("count\n2012\n");
+
+            final TableToken token = engine.getTableTokenIfExists("t_pq_leak");
+            Assert.assertNotNull("table must exist", token);
+            long partitionTs;
+            long partitionNameTxn;
+            try (TableReader reader = engine.getReader(token)) {
+                partitionTs = reader.getTxFile().getPartitionTimestampByIndex(0);
+                partitionNameTxn = reader.getTxFile().getPartitionNameTxn(0);
+            }
+            try (Path path = new Path()) {
+                path.of(configuration.getDbRoot()).concat(token);
+                setPathForNativePartition(path, ColumnType.TIMESTAMP, PartitionBy.DAY, partitionTs, partitionNameTxn);
+                final java.io.File dir = new java.io.File(path.toString());
+                final String[] names = dir.list();
+                Assert.assertNotNull("partition dir must exist: " + dir, names);
+                int pvCount = 0;
+                for (String n : names) {
+                    if (n.startsWith("sym.pv.")) {
+                        pvCount++;
+                    }
+                }
+                Assert.assertEquals(
+                        "exactly one active value file must remain; a superseded intermediate "
+                                + ".pv from the spill-driven parquet reseal leaked: "
+                                + java.util.Arrays.toString(names),
+                        1, pvCount);
+            }
+        });
+    }
+
+    /**
      * Reproduces the SIGSEGV from the JMH walFastLag bench (hs_err_pid19555):
      * MemoryCR.getLong over-read inside PostingIndexChainEntry.read on a
      * covering posting index. The bench ran walFastLagInsertAndQuery in a

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -5128,35 +5128,26 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      * lost or double-freed). The floor is read BEFORE the count so a commit landing
      * mid-read can never make a valid snapshot look short.
      * <p>
-     * IGNORED reproducer for a PARQUET-specific covered-read race (still open).
-     * Under concurrent O3 rewrite of parquet partitions, a reader observes a correct
-     * posting count but a covered sum that is short by whole partitions -- the covered
-     * values of the partition(s) being rewritten read as 0. Proven scope:
-     * <ul>
-     *   <li>single-threaded the covered query is correct (count and sum exact);</li>
-     *   <li>with the CONVERT-to-parquet removed (native partitions) it passes -- the
-     *       race is parquet-only;</li>
-     *   <li>NOT the unversioned .pci in-place rewrite (openSidecarFiles truncates a
-     *       single per-column-version .pci under readers, which is itself unsafe, but
-     *       making it write-once did NOT fix this symptom) and NOT the chain entry's
-     *       covered end-offset (instrumented: sidecarFileEndOffsets is non-zero, and
-     *       the .pc length covers publishedEnd, when the read still returns 0).</li>
-     * </ul>
-     * So the covering .pc data the writer-thread parquet seal publishes is not yet
-     * visible to a concurrent reader's mmap when the chain extent is published, or the
-     * reader does not remap the .pc on the partition-version change. Un-@Ignore to
-     * reproduce (fails within ~300ms, whole-partition-multiple covered sum).
-     * <p>
-     * Further narrowed: the 0 originates in the dense/stride covered-value read
-     * (findDenseVarBlockBase / the per-stride .pc lookup) returning an empty stride
-     * for the rewritten parquet partition, even though the .pc is mapped to a valid
-     * non-zero extent. So the writer-thread parquet seal's dense .pc data/stride-index
-     * is not yet consistently visible to a concurrent reader when its chain entry is
-     * published, OR the reader reuses a stale .pc mapping across the parquet
-     * version change. Root-cause continues in a follow-up.
+     * IGNORED reproducer for a PARQUET-specific covered-read race (root cause known,
+     * fix pending). Under concurrent O3 rewrite of parquet partitions a reader sees a
+     * correct posting count() but a sum(price) short by whole partitions, because the
+     * covered values read as SQL NULL (count() counts them; sum() skips NULLs).
+     * ROOT CAUSE (fully traced via instrumentation): getCoveredDouble returns NaN ->
+     * keyBlockAddrs == null while isCurrentGenDense == true -> cacheSidecarKeyAddrs
+     * early-returned on coverCount == 0 -> openSidecarFilesIfPresent found the .pci
+     * file MISSING when the reader opened the rewritten parquet partition version. The
+     * parquet O3 rewrite exposes the new partition version (with its sealTxn-versioned
+     * .pv row-ids) to readers BEFORE the writer-thread covering seal
+     * (sealPostingIndexForPartition) writes that version's .pci/.pc sidecars, so a
+     * reader catches a window where the partition is covered but its .pci does not yet
+     * exist, reports coverCount=0, and returns NULL covered values. Native partitions
+     * reseal in place (the .pci is always present), hence they pass. Single-threaded is
+     * correct. Fix belongs writer-side: the covering sidecars must exist before the new
+     * parquet partition version becomes reader-visible. Un-@Ignore to reproduce (~300ms).
      */
-    @Ignore("Open: parquet-specific covered-read race -- covered values of a parquet " +
-            "partition under concurrent O3 rewrite read 0 (count correct). Native passes.")
+    @Ignore("Open (root-caused): parquet rewrite exposes the new partition version " +
+            "before its covering .pci/.pc sidecars are written, so a concurrent covered " +
+            "read sees coverCount=0 and returns NULL. Native passes.")
     @Test
     public void testMultiThreadedO3CoveringPostingConcurrentReaderFuzz() throws Exception {
         node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -4338,10 +4338,6 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                             2
                             """);
 
-            // Truth from the non-covering fallback path.
-            printSql("SELECT /*+ no_covering */ count(), sum(price) FROM t_squash_spill WHERE sym = 'A'");
-            String truth = sink.toString();
-
             engine.releaseAllWriters();
             try (TableWriter w = TestUtils.getWriter(engine, "t_squash_spill")) {
                 // Squash reseals the covering posting index for the target
@@ -4360,11 +4356,11 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                             1
                             """);
 
-            // The covering path must return the same rows as the fallback.
-            printSql("SELECT count(), sum(price) FROM t_squash_spill WHERE sym = 'A'");
-            TestUtils.assertEquals(
-                    "covering result after squash must match the no_covering fallback",
-                    truth, sink.toString());
+            // The covering path must return every 'A' row: 400 (sum 1..400 =
+            // 80200) plus the 20:00 sentinel (1000000) = 401 rows, sum 1080200.
+            assertQuery("SELECT count(), sum(price) FROM t_squash_spill WHERE sym = 'A'")
+                    .noLeakCheck()
+                    .returnsOnce("count\tsum\n401\t1080200.0\n");
         });
     }
 
@@ -4418,9 +4414,6 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                             + "squashSplitPartitions to merge, got " + splitCount,
                     splitCount > 2);
 
-            printSql("SELECT /*+ no_covering */ count(), sum(price) FROM t_multisplit WHERE sym = 'A'");
-            String truth = sink.toString();
-
             engine.releaseAllWriters();
             try (TableWriter w = TestUtils.getWriter(engine, "t_multisplit")) {
                 // squashPartitions() -> squashPartitionForce -> squashSplitPartitions
@@ -4437,10 +4430,11 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                             1
                             """);
 
-            printSql("SELECT count(), sum(price) FROM t_multisplit WHERE sym = 'A'");
-            TestUtils.assertEquals(
-                    "covering result after multi-split squash must match the no_covering fallback",
-                    truth, sink.toString());
+            // 400 'A' rows (sum 1..400 = 80200) plus the 23:00 sentinel
+            // (1000000) = 401 rows, sum 1080200.
+            assertQuery("SELECT count(), sum(price) FROM t_multisplit WHERE sym = 'A'")
+                    .noLeakCheck()
+                    .returnsOnce("count\tsum\n401\t1080200.0\n");
         });
     }
 
@@ -4487,20 +4481,17 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                     ('2024-01-01T19:00:00.000000Z', 'B', -1.0)
                     """);
 
-            // 401 'A' rows total (400 + the 20:00 sentinel).
-            printSql("SELECT /*+ no_covering */ count() FROM t_squash_spill_nc WHERE sym = 'A'");
-            String truth = sink.toString();
-
             engine.releaseAllWriters();
             try (TableWriter w = TestUtils.getWriter(engine, "t_squash_spill_nc")) {
                 w.squashPartitions();
             }
 
-            // Index-driven count must still see every 'A' rowid after the reseal.
-            printSql("SELECT count() FROM t_squash_spill_nc WHERE sym = 'A'");
-            TestUtils.assertEquals(
-                    "indexed count after squash must keep every rowid (no orphaned gen)",
-                    truth, sink.toString());
+            // Index-driven count must still see every 'A' rowid after the reseal:
+            // 400 rows plus the 20:00 sentinel = 401. Without the fix the orphaned
+            // gen drops the pre-flush rowids and this comes back short.
+            assertQuery("SELECT count() FROM t_squash_spill_nc WHERE sym = 'A'")
+                    .noLeakCheck()
+                    .returnsOnce("count\n401\n");
         });
     }
 
@@ -4552,12 +4543,65 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                 drainWalQueue();
             }
 
-            printSql("SELECT /*+ no_covering */ count(), sum(price) FROM t_wal_squash_spill WHERE sym = 'A'");
-            String truth = sink.toString();
-            printSql("SELECT count(), sum(price) FROM t_wal_squash_spill WHERE sym = 'A'");
-            TestUtils.assertEquals(
-                    "covering result after WAL auto-squash must match the no_covering fallback",
-                    truth, sink.toString());
+            // 400 'A' rows (sum 1..400 = 80200) plus the 23:00 sentinel (1000000)
+            // = 401 rows, sum 1080200, served through the covering index.
+            assertQuery("SELECT count(), sum(price) FROM t_wal_squash_spill WHERE sym = 'A'")
+                    .noLeakCheck()
+                    .returnsOnce("count\tsum\n401\t1080200.0\n");
+        });
+    }
+
+    /**
+     * Exercises the commitDense consolidation fix through the plain O3 commit
+     * reseal -- sealPostingIndexesForO3Partitions ->
+     * sealPostingIndexForPartition(..., canSkipRebuild=false) -> discardForRebuild
+     * -> index() -> commitDense() -- with no squashPartitions() involved. This is
+     * the most common production trigger of the reseal: an O3 insert whose
+     * timestamps land inside the existing partition range makes
+     * partitionMutates=true, so the covering posting index rebuilds the whole
+     * partition from sym.d. With the tiny spill budget the rebuild's index() loop
+     * trips compactIfOverBudget mid-stream, so commitDense must consolidate the
+     * orphaned sparse gen instead of dropping it. SIGSEGVs without the fix; with
+     * it, both the hot key and the O3-inserted rows resolve through the index.
+     */
+    @Test
+    public void testO3CommitCoveringPostingResealWithMidStreamSpillFlush() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_o3_reseal (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            // Hot key 'A', 400 in-order rows across 2024-01-01 [00:00:01, 00:06:40].
+            execute("""
+                    INSERT INTO t_o3_reseal
+                    SELECT dateadd('s', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP),
+                           'A', x::DOUBLE
+                    FROM long_sequence(400)
+                    """);
+            // O3 insert: timestamps inside the existing range -> partitionMutates
+            // -> canSkipRebuild=false reseal of the whole partition (no squash).
+            execute("""
+                    INSERT INTO t_o3_reseal VALUES
+                    ('2024-01-01T00:03:00.000000Z', 'B', -1.0),
+                    ('2024-01-01T00:03:30.000000Z', 'B', -2.0),
+                    ('2024-01-01T00:04:00.000000Z', 'B', -3.0)
+                    """);
+
+            // The hot key (which drove the mid-stream spill) and the O3-inserted
+            // rows must both come back intact through the covering index. The
+            // aggregates are deterministic: 'A' = 400 rows, sum(1..400) = 80200;
+            // 'B' = 3 rows, sum(-1,-2,-3) = -6.
+            assertQuery("SELECT count(), sum(price) FROM t_o3_reseal WHERE sym = 'A'")
+                    .noLeakCheck()
+                    .returnsOnce("count\tsum\n400\t80200.0\n");
+            assertQuery("SELECT count(), sum(price) FROM t_o3_reseal WHERE sym = 'B'")
+                    .noLeakCheck()
+                    .returnsOnce("count\tsum\n3\t-6.0\n");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -51,6 +51,8 @@ import io.questdb.cairo.sql.RowCursor;
 import io.questdb.cairo.vm.MemoryCMARWImpl;
 import io.questdb.cairo.vm.Vm;
 import io.questdb.cairo.vm.api.MemoryMARW;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.mp.MPSequence;
 import io.questdb.mp.RingQueue;
 import io.questdb.mp.SCSequence;
@@ -60,6 +62,7 @@ import io.questdb.std.IntList;
 import io.questdb.std.LongList;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Os;
+import io.questdb.std.Rnd;
 import io.questdb.std.Unsafe;
 import io.questdb.std.datetime.microtime.MicrosFormatUtils;
 import io.questdb.std.str.LPSZ;
@@ -75,6 +78,7 @@ import org.junit.Test;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.questdb.cairo.TableUtils.COLUMN_NAME_TXN_NONE;
 import static io.questdb.cairo.TableUtils.DETACHED_DIR_MARKER;
@@ -4694,6 +4698,114 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                                 + java.util.Arrays.toString(names),
                         1, pvCount);
             }
+        });
+    }
+
+    /**
+     * Concurrent-read fuzz for the parquet reseal value-file reclaim. Background
+     * threads continuously query the posting index on a parquet partition while
+     * the main thread repeatedly O3-rewrites that partition under a tiny spill
+     * budget, so every rewrite drives commitDense -> seal ->
+     * unlinkPendingSealPurgesDirect (the inline reclaim, gated on isRewrite).
+     * If the reclaim ever unlinked a value file a reader still resolves, a
+     * concurrent count() would fail to open it. 'A' rows are only ever added, so
+     * each reader's observed count must be monotonic and never below the initial
+     * 2010, with no reader crash; the final count is asserted exactly. Random
+     * batch sizes and O3 timestamps vary the rewrite shape across runs.
+     */
+    @Test
+    public void testParquetPostingSpillConcurrentReadFuzz() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE xq (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING)
+                    TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            // 2000 hot 'A' rows in one row group (so the O3 inserts below take the
+            // isRewrite=true rebuild) plus a second partition so the converted one
+            // is not the active tail.
+            execute("""
+                    INSERT INTO xq
+                    SELECT dateadd('s', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP), 'A'
+                    FROM long_sequence(2000)
+                    """);
+            execute("""
+                    INSERT INTO xq
+                    SELECT dateadd('s', x::INT, '2024-01-02T00:00:00.000000Z'::TIMESTAMP), 'A'
+                    FROM long_sequence(10)
+                    """);
+            drainWalQueue();
+            execute("ALTER TABLE xq CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            drainWalQueue();
+
+            final AtomicReference<Throwable> bgError = new AtomicReference<>();
+            final AtomicBoolean stop = new AtomicBoolean();
+            final int readerCount = 3;
+            final Thread[] readers = new Thread[readerCount];
+            for (int r = 0; r < readerCount; r++) {
+                readers[r] = new Thread(() -> {
+                    try (
+                            SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                                    .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                            null, null, -1, null);
+                            SqlCompiler compiler = engine.getSqlCompiler()
+                    ) {
+                        long prev = 0;
+                        while (!stop.get() && bgError.get() == null) {
+                            final long a;
+                            try (RecordCursorFactory f = compiler.compile(
+                                    "SELECT count() FROM xq WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                                 RecordCursor cur = f.getCursor(ctx)) {
+                                a = cur.hasNext() ? cur.getRecord().getLong(0) : -1;
+                            }
+                            if (a < 2010) {
+                                throw new AssertionError("'A' count fell below the initial 2010: " + a);
+                            }
+                            if (a < prev) {
+                                throw new AssertionError("'A' count went backwards: " + prev + " -> " + a);
+                            }
+                            prev = a;
+                        }
+                    } catch (Throwable e) {
+                        bgError.set(e);
+                    }
+                }, "parquet-posting-reader-" + r);
+                readers[r].setDaemon(true);
+                readers[r].start();
+            }
+
+            long expectedA = 2010;
+            try {
+                final int batches = 8 + rnd.nextInt(8);
+                for (int b = 0; b < batches && bgError.get() == null; b++) {
+                    final int n = 1 + rnd.nextInt(4);
+                    final StringBuilder sql = new StringBuilder("INSERT INTO xq VALUES ");
+                    for (int i = 0; i < n; i++) {
+                        if (i > 0) {
+                            sql.append(',');
+                        }
+                        // O3 timestamp inside the converted partition's [1s, 1999s] range.
+                        sql.append("(dateadd('s', ").append(1 + rnd.nextInt(1999))
+                                .append(", '2024-01-01T00:00:00.000000Z'::TIMESTAMP), 'A')");
+                    }
+                    execute(sql.toString());
+                    drainWalQueue();
+                    expectedA += n;
+                }
+            } finally {
+                stop.set(true);
+                for (Thread t : readers) {
+                    t.join(30_000);
+                }
+            }
+
+            Assert.assertNull("concurrent reader threw: " + bgError.get(), bgError.get());
+            assertQuery("SELECT count() FROM xq WHERE sym = 'A'")
+                    .noLeakCheck()
+                    .returnsOnce("count\n" + expectedA + "\n");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -4616,10 +4616,11 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      * to a new sealTxn. Unlike the native reseal, the pooled parquet writer is
      * freed (close() -> releasePendingPurges) without ever draining its pending
      * seal-purge, so the superseded intermediate .pv would leak on disk
-     * permanently (no directory sweep, no recovery-walk reclaim). The fix unlinks
-     * the superseded value file inline -- safe because the parquet rebuild is a
-     * fresh, uncommitted index whose prev gens are never picked by a committed
-     * reader. After a spill-driven CONVERT, exactly one .pv must remain.
+     * permanently (no directory sweep, no recovery-walk reclaim). The fix hands
+     * the purge to the TableWriter's deferred queue; after the commit, the
+     * scoreboard-gated PostingSealPurgeJob reclaims the superseded .pv. After a
+     * spill-driven CONVERT + O3 rewrite and a purge-job pass, exactly one .pv
+     * must remain.
      */
     @Test
     public void testConvertToParquetPostingResealSpillDoesNotLeakValueFile() throws Exception {
@@ -4702,19 +4703,106 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
-     * Concurrent-read safety guard for the parquet reseal value-file reclaim
-     * (unlinkPendingSealPurgesDirect). Background threads continuously query the
-     * posting index on a parquet partition while the main thread repeatedly
-     * O3-rewrites it under a tiny spill budget, so every rewrite drives
-     * commitDense -> seal -> the inline reclaim (gated on isRewrite). The reclaim
-     * DELETES a value file; if it ever deleted one a reader still resolves, a
-     * concurrent count() would fail to open it or return a short count -- so the
-     * 'A' count (rows are only added) must stay monotonic, never below the
-     * initial 2010, with no reader crash. This catches a reclaim that unlinks a
-     * still-live file (fault injection: deleting the active .pv makes it fail).
-     * The trailing single-.pv assertion additionally guards against the reclaim
-     * regressing into a leak across many rewrites; the deterministic counterpart
-     * is testConvertToParquetPostingResealSpillDoesNotLeakValueFile.
+     * Update-in-place twin of testConvertToParquetPostingResealSpillDoesNotLeakValueFile.
+     * Forcing many small row groups plus disabled rewrite thresholds makes the O3
+     * insert update the parquet file in place (isRewrite=false), so the posting
+     * index rebuilds into the LIVE committed directory. The spill-driven reseal's
+     * superseded .pv cannot be unlinked inline there (a reader pinned at the
+     * pre-commit txn could still map it), so it is routed to the scoreboard-gated
+     * deferred purge instead. After the commit and a purge-job run, exactly one
+     * value file must remain -- the case that leaked before the deferred purge.
+     */
+    @Test
+    public void testInPlaceParquetPostingResealSpillReclaimsValueFile() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        // Multi-row-group + rewrite triggers off -> O3 updates the parquet file
+        // in place (isRewrite=false) rather than rewriting to a new directory.
+        node1.setProperty(PropertyKey.CAIRO_PARTITION_ENCODER_PARQUET_ROW_GROUP_SIZE, 100);
+        node1.setProperty(PropertyKey.CAIRO_PARTITION_ENCODER_PARQUET_O3_REWRITE_UNUSED_RATIO, "1.0");
+        node1.setProperty(PropertyKey.CAIRO_PARTITION_ENCODER_PARQUET_O3_REWRITE_UNUSED_MAX_BYTES, Long.MAX_VALUE);
+
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_pq_inplace (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING
+                    ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                    """);
+            execute("""
+                    INSERT INTO t_pq_inplace
+                    SELECT dateadd('s', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP), 'A'
+                    FROM long_sequence(2000)
+                    """);
+            execute("""
+                    INSERT INTO t_pq_inplace
+                    SELECT dateadd('s', x::INT, '2024-01-02T00:00:00.000000Z'::TIMESTAMP), 'A'
+                    FROM long_sequence(10)
+                    """);
+            drainWalQueue();
+            execute("ALTER TABLE t_pq_inplace CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            drainWalQueue();
+            // O3 into the parquet partition; with the config above this updates in
+            // place (isRewrite=false) and rebuilds the index over all 2000+ 'A'
+            // rows, tripping the spill budget -> commitDense seals -> deferred purge.
+            execute("""
+                    INSERT INTO t_pq_inplace VALUES
+                    ('2024-01-01T00:10:00.500000Z', 'A'),
+                    ('2024-01-01T00:20:00.500000Z', 'A')
+                    """);
+            drainWalQueue();
+
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
+            engine.releaseAllWriters();
+
+            assertQuery("SELECT count() FROM t_pq_inplace WHERE sym = 'A'")
+                    .noLeakCheck()
+                    .returnsOnce("count\n2012\n");
+
+            final TableToken token = engine.getTableTokenIfExists("t_pq_inplace");
+            Assert.assertNotNull("table must exist", token);
+            long partitionTs;
+            long partitionNameTxn;
+            try (TableReader reader = engine.getReader(token)) {
+                partitionTs = reader.getTxFile().getPartitionTimestampByIndex(0);
+                partitionNameTxn = reader.getTxFile().getPartitionNameTxn(0);
+            }
+            try (Path path = new Path()) {
+                path.of(configuration.getDbRoot()).concat(token);
+                setPathForNativePartition(path, ColumnType.TIMESTAMP, PartitionBy.DAY, partitionTs, partitionNameTxn);
+                final java.io.File dir = new java.io.File(path.toString());
+                final String[] names = dir.list();
+                Assert.assertNotNull("partition dir must exist: " + dir, names);
+                int pvCount = 0;
+                for (String n : names) {
+                    if (n.startsWith("sym.pv.")) {
+                        pvCount++;
+                    }
+                }
+                Assert.assertEquals(
+                        "exactly one value file must remain after the in-place reseal; the "
+                                + "superseded intermediate must be reclaimed by the deferred purge: "
+                                + java.util.Arrays.toString(names),
+                        1, pvCount);
+            }
+        });
+    }
+
+    /**
+     * Concurrent-read integration test for the parquet reseal value-file reclaim
+     * (deferParquetPostingSealPurges -> scoreboard-gated PostingSealPurgeJob).
+     * Background threads continuously query the posting index on a parquet
+     * partition while the main thread repeatedly O3-rewrites it under a tiny
+     * spill budget, so every rewrite drives commitDense -> seal -> a deferred
+     * purge. The 'A' count (rows are only added) must stay monotonic, never below
+     * the initial 2010, with no reader crash -- the reclaim is scoreboard-gated,
+     * so it must never delete a .pv a reader still resolves. The trailing
+     * single-.pv assertion (after a purge-job pass with nothing pinned) guards
+     * against the reclaim regressing into a leak across many rewrites; the
+     * deterministic counterpart is
+     * testConvertToParquetPostingResealSpillDoesNotLeakValueFile.
      */
     @Test
     public void testParquetPostingSpillConcurrentReadFuzz() throws Exception {
@@ -4813,7 +4901,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
             // The reclaim must also have kept the partition free of leaked
             // intermediates across every rewrite: exactly one value file remains.
+            // The rewrite purges are deferred and scoreboard-gated, so with the
+            // readers stopped and writers released (nothing pinned) a purge-job
+            // pass reclaims every superseded .pv.
             engine.releaseAllWriters();
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
             final TableToken token = engine.getTableTokenIfExists("xq");
             Assert.assertNotNull("table must exist", token);
             long partitionTs;

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -5135,6 +5135,158 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * Writer release/reopen under covering reads. Mid-fuzz the writer is released
+     * (engine.releaseAllWriters()) so the next O3 insert reopens it through the
+     * posting-index recovery path (chain head trim / superseded-gen drop) while
+     * reader threads keep serving count()/sum(price) from the covering sidecars.
+     * Rows are only added, so the covered total stays monotonic; a recovery reopen
+     * that loses a committed gen or trims a live chain head would drop the total.
+     * All-parquet, so the recovery reseal takes the safe path.
+     */
+    @Test
+    public void testMultiThreadedO3CoveringWriterReopenConcurrentReaderFuzz() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+
+        assertMemoryLeak(() -> {
+            final int dayCount = 4 + rnd.nextInt(4); // 4..7 days
+            final int hotPerDay = 1000;
+            final long perDaySum = (long) hotPerDay * (hotPerDay + 1) / 2;
+            final long initialRows = (long) dayCount * hotPerDay;
+            final long initialSum = (long) dayCount * perDaySum;
+
+            execute("""
+                    CREATE TABLE t_cov_reopen (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            for (int d = 1; d <= dayCount; d++) {
+                execute("INSERT INTO t_cov_reopen SELECT dateadd('s', x::INT, '2024-02-0" + d
+                        + "T00:00:00.000000Z'::TIMESTAMP), 'A', x::DOUBLE FROM long_sequence(" + hotPerDay + ")");
+            }
+            for (int d = 1; d <= dayCount; d++) {
+                execute("ALTER TABLE t_cov_reopen CONVERT PARTITION TO PARQUET LIST '2024-02-0" + d + "'");
+            }
+
+            final AtomicReference<Throwable> bgError = new AtomicReference<>();
+            final AtomicBoolean stop = new AtomicBoolean();
+            final AtomicLong rowFloor = new AtomicLong(initialRows);
+            final int readerCount = 3;
+            final Thread[] readers = new Thread[readerCount];
+            for (int r = 0; r < readerCount; r++) {
+                readers[r] = new Thread(() -> {
+                    try (
+                            SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                                    .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                            null, null, -1, null);
+                            SqlCompiler compiler = engine.getSqlCompiler()
+                    ) {
+                        while (!stop.get() && bgError.get() == null) {
+                            final long floor = rowFloor.get();
+                            final long count;
+                            final double sum;
+                            try (RecordCursorFactory f = compiler.compile(
+                                    "SELECT count(), sum(price) FROM t_cov_reopen WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                                 RecordCursor cur = f.getCursor(ctx)) {
+                                if (cur.hasNext()) {
+                                    count = cur.getRecord().getLong(0);
+                                    sum = cur.getRecord().getDouble(1);
+                                } else {
+                                    count = -1;
+                                    sum = -1;
+                                }
+                            }
+                            if (count < floor) {
+                                throw new AssertionError("covered 'A' count fell below the committed floor: " + count + " < " + floor);
+                            }
+                            if (sum < (double) initialSum - 0.5) {
+                                throw new AssertionError("covered sum(price) dropped below the initial total " + initialSum + ": " + sum);
+                            }
+                            if (sum < (double) count - 0.5) {
+                                throw new AssertionError("covered sum(price)=" + sum + " < count=" + count + " -- a covered value resolved as < 1");
+                            }
+                        }
+                    } catch (Throwable e) {
+                        bgError.set(e);
+                    }
+                }, "covering-reopen-reader-" + r);
+                readers[r].setDaemon(true);
+                readers[r].start();
+            }
+
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.setupWorkerPool(pool, engine);
+            pool.start(LOG);
+            long expectedRows = initialRows;
+            try {
+                final int batches = 6 + rnd.nextInt(10);
+                for (int b = 0; b < batches && bgError.get() == null; b++) {
+                    final StringBuilder sql = new StringBuilder("INSERT INTO t_cov_reopen VALUES ");
+                    int added = 0;
+                    for (int d = 1; d <= dayCount; d++) {
+                        if (rnd.nextBoolean()) {
+                            continue;
+                        }
+                        final int n = 1 + rnd.nextInt(3);
+                        for (int i = 0; i < n; i++) {
+                            if (added > 0) {
+                                sql.append(',');
+                            }
+                            sql.append("('2024-02-0").append(d).append("T00:")
+                                    .append(String.format("%02d", 1 + rnd.nextInt(58)))
+                                    .append(":00.500000Z', 'A', 1.0)");
+                            added++;
+                        }
+                    }
+                    if (added == 0) {
+                        continue;
+                    }
+                    execute(sql.toString());
+                    expectedRows += added;
+                    rowFloor.set(expectedRows);
+                    // Periodically release the writer so the next insert reopens it
+                    // through the posting-index recovery path under the live readers.
+                    if (rnd.nextInt(3) == 0) {
+                        engine.releaseAllWriters();
+                    }
+                }
+            } finally {
+                stop.set(true);
+                for (Thread t : readers) {
+                    t.join(30_000);
+                    Assert.assertFalse("reader thread did not terminate", t.isAlive());
+                }
+                pool.halt();
+            }
+
+            Assert.assertNull("concurrent writer-reopen covered reader threw: " + bgError.get(), bgError.get());
+
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
+            engine.releaseAllWriters();
+
+            final long expectedSum = initialSum + (expectedRows - initialRows);
+            try (
+                    SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                            .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                    null, null, -1, null);
+                    SqlCompiler compiler = engine.getSqlCompiler();
+                    RecordCursorFactory f = compiler.compile(
+                            "SELECT count(), sum(price) FROM t_cov_reopen WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                    RecordCursor cur = f.getCursor(ctx)
+            ) {
+                Assert.assertTrue("final covered query returned no row", cur.hasNext());
+                Assert.assertEquals("final covered 'A' count", expectedRows, cur.getRecord().getLong(0));
+                Assert.assertEquals("final covered sum(price)", (double) expectedSum, cur.getRecord().getDouble(1), 0.5);
+            }
+        });
+    }
+
+    /**
      * DROP PARTITION concurrent with covering reads. A covering read for 'A'
      * iterates the posting index across ALL partitions, so while it runs the writer
      * drops random EARLIER parquet partitions (their index files are removed,

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -56,6 +56,7 @@ import io.questdb.griffin.SqlExecutionContextImpl;
 import io.questdb.mp.MPSequence;
 import io.questdb.mp.RingQueue;
 import io.questdb.mp.SCSequence;
+import io.questdb.mp.WorkerPool;
 import io.questdb.std.DirectBitSet;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.IntList;
@@ -4786,6 +4787,96 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                                 + "superseded intermediate must be reclaimed by the deferred purge: "
                                 + java.util.Arrays.toString(names),
                         1, pvCount);
+            }
+        });
+    }
+
+    /**
+     * Exercises the concurrent deposit into deferParquetPostingSealPurges: a real
+     * WorkerPool runs O3PartitionJob on multiple threads, and one O3 insert that
+     * touches every parquet partition dispatches a partition task per day, so
+     * several workers run updateParquetIndexes -> commitDense -> seal -> the
+     * deferred purge at once, contending on parquetSealPurgeLock. The single-
+     * threaded tests never hit this path. After a purge-job pass, every
+     * partition must keep exactly one value file (no purge lost or double-freed
+     * under contention) and the indexed count must be exact.
+     */
+    @Test
+    public void testMultiThreadedO3ParquetPostingSpillReclaimsAcrossPartitions() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+
+        assertMemoryLeak(() -> {
+            final int dayCount = 6;
+            execute("""
+                    CREATE TABLE t_mt (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            // 2000 hot 'A' rows per day so every partition's reseal spills.
+            for (int d = 1; d <= dayCount; d++) {
+                execute("INSERT INTO t_mt SELECT dateadd('s', x::INT, '2024-01-0" + d
+                        + "T00:00:00.000000Z'::TIMESTAMP), 'A' FROM long_sequence(2000)");
+            }
+            for (int d = 1; d <= dayCount; d++) {
+                execute("ALTER TABLE t_mt CONVERT PARTITION TO PARQUET LIST '2024-01-0" + d + "'");
+            }
+
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.setupWorkerPool(pool, engine);
+            pool.start(LOG);
+            try {
+                // One O3 insert with a row inside every parquet day's range -> one
+                // commit, one partition task per day, run across the pool workers.
+                final StringBuilder sql = new StringBuilder("INSERT INTO t_mt VALUES ");
+                for (int d = 1; d <= dayCount; d++) {
+                    if (d > 1) {
+                        sql.append(',');
+                    }
+                    sql.append("('2024-01-0").append(d).append("T00:10:00.500000Z', 'A')");
+                }
+                execute(sql.toString());
+            } finally {
+                pool.halt();
+            }
+
+            // Pool halted: drain the deferred purges with nothing pinned.
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
+            engine.releaseAllWriters();
+
+            // 6 days * 2000 + 6 O3 rows.
+            assertQuery("SELECT count() FROM t_mt WHERE sym = 'A'")
+                    .noLeakCheck()
+                    .returnsOnce("count\n" + (dayCount * 2000 + dayCount) + "\n");
+
+            // Every parquet partition must keep exactly one value file.
+            final TableToken token = engine.getTableTokenIfExists("t_mt");
+            Assert.assertNotNull("table must exist", token);
+            try (TableReader reader = engine.getReader(token)) {
+                Assert.assertEquals("all days must remain", dayCount, reader.getTxFile().getPartitionCount());
+                for (int i = 0; i < dayCount; i++) {
+                    final long partitionTs = reader.getTxFile().getPartitionTimestampByIndex(i);
+                    final long partitionNameTxn = reader.getTxFile().getPartitionNameTxn(i);
+                    try (Path path = new Path()) {
+                        path.of(configuration.getDbRoot()).concat(token);
+                        setPathForNativePartition(path, ColumnType.TIMESTAMP, PartitionBy.DAY, partitionTs, partitionNameTxn);
+                        final String[] names = new java.io.File(path.toString()).list();
+                        Assert.assertNotNull("partition dir must exist: " + path, names);
+                        int pvCount = 0;
+                        for (String n : names) {
+                            if (n.startsWith("sym.pv.")) {
+                                pvCount++;
+                            }
+                        }
+                        Assert.assertEquals(
+                                "partition " + i + " must keep exactly one value file (no purge lost or "
+                                        + "double-freed under concurrent deposit): " + java.util.Arrays.toString(names),
+                                1, pvCount);
+                    }
+                }
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -5135,6 +5135,153 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * DROP PARTITION concurrent with covering reads. A covering read for 'A'
+     * iterates the posting index across ALL partitions, so while it runs the writer
+     * drops random EARLIER parquet partitions (their index files are removed,
+     * scoreboard-gated) and O3-inserts into a PROTECTED last partition (never
+     * dropped). Readers project only the protected partition (ts >= last day), whose
+     * covered count/sum is therefore monotonic; a DROP that corrupts the shared
+     * index iteration or frees a partition under the reader would drop the protected
+     * total or crash. The all-parquet protected partition reseals on the safe path.
+     */
+    @Test
+    public void testMultiThreadedO3CoveringDropPartitionConcurrentReaderFuzz() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+
+        assertMemoryLeak(() -> {
+            final int dayCount = 5 + rnd.nextInt(3); // 5..7 days; >=4 droppable + 1 protected
+            final int hotPerDay = 1000;
+            final long perDaySum = (long) hotPerDay * (hotPerDay + 1) / 2;
+            final String protectedDay = "2024-02-0" + dayCount;
+
+            execute("""
+                    CREATE TABLE t_cov_drop (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            for (int d = 1; d <= dayCount; d++) {
+                execute("INSERT INTO t_cov_drop SELECT dateadd('s', x::INT, '2024-02-0" + d
+                        + "T00:00:00.000000Z'::TIMESTAMP), 'A', x::DOUBLE FROM long_sequence(" + hotPerDay + ")");
+            }
+            for (int d = 1; d <= dayCount; d++) {
+                execute("ALTER TABLE t_cov_drop CONVERT PARTITION TO PARQUET LIST '2024-02-0" + d + "'");
+            }
+
+            final AtomicReference<Throwable> bgError = new AtomicReference<>();
+            final AtomicBoolean stop = new AtomicBoolean();
+            final AtomicLong protectedFloor = new AtomicLong(hotPerDay);
+            final String protectedPred = "sym = 'A' AND ts >= '" + protectedDay + "T00:00:00.000000Z'";
+            final int readerCount = 3;
+            final Thread[] readers = new Thread[readerCount];
+            for (int r = 0; r < readerCount; r++) {
+                readers[r] = new Thread(() -> {
+                    try (
+                            SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                                    .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                            null, null, -1, null);
+                            SqlCompiler compiler = engine.getSqlCompiler()
+                    ) {
+                        while (!stop.get() && bgError.get() == null) {
+                            final long floor = protectedFloor.get();
+                            final long count;
+                            final double sum;
+                            try (RecordCursorFactory f = compiler.compile(
+                                    "SELECT count(), sum(price) FROM t_cov_drop WHERE " + protectedPred, ctx).getRecordCursorFactory();
+                                 RecordCursor cur = f.getCursor(ctx)) {
+                                if (cur.hasNext()) {
+                                    count = cur.getRecord().getLong(0);
+                                    sum = cur.getRecord().getDouble(1);
+                                } else {
+                                    count = -1;
+                                    sum = -1;
+                                }
+                            }
+                            if (count < floor) {
+                                throw new AssertionError("protected-partition covered count fell below floor: " + count + " < " + floor);
+                            }
+                            if (sum < (double) perDaySum - 0.5) {
+                                throw new AssertionError("protected-partition covered sum dropped below its initial total "
+                                        + perDaySum + ": " + sum);
+                            }
+                            if (sum < (double) count - 0.5) {
+                                throw new AssertionError("protected covered sum=" + sum + " < count=" + count + " -- a covered value resolved as < 1");
+                            }
+                        }
+                    } catch (Throwable e) {
+                        bgError.set(e);
+                    }
+                }, "covering-drop-reader-" + r);
+                readers[r].setDaemon(true);
+                readers[r].start();
+            }
+
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.setupWorkerPool(pool, engine);
+            pool.start(LOG);
+            long protectedExpected = hotPerDay;
+            int nextDropDay = 1;
+            try {
+                final int batches = 6 + rnd.nextInt(8);
+                for (int b = 0; b < batches && bgError.get() == null; b++) {
+                    // Always O3-insert into the protected last partition (forces its reseal).
+                    final StringBuilder sql = new StringBuilder("INSERT INTO t_cov_drop VALUES ");
+                    final int n = 1 + rnd.nextInt(3);
+                    for (int i = 0; i < n; i++) {
+                        if (i > 0) {
+                            sql.append(',');
+                        }
+                        sql.append("('").append(protectedDay).append("T00:")
+                                .append(String.format("%02d", 1 + rnd.nextInt(58)))
+                                .append(":00.500000Z', 'A', 1.0)");
+                    }
+                    execute(sql.toString());
+                    protectedExpected += n;
+                    protectedFloor.set(protectedExpected);
+
+                    // Drop the next earlier partition (1..dayCount-1) roughly every other batch.
+                    if (nextDropDay < dayCount && rnd.nextBoolean()) {
+                        execute("ALTER TABLE t_cov_drop DROP PARTITION LIST '2024-02-0" + nextDropDay + "'");
+                        nextDropDay++;
+                    }
+                }
+            } finally {
+                stop.set(true);
+                for (Thread t : readers) {
+                    t.join(30_000);
+                    Assert.assertFalse("reader thread did not terminate", t.isAlive());
+                }
+                pool.halt();
+            }
+
+            Assert.assertNull("concurrent drop-partition covered reader threw: " + bgError.get(), bgError.get());
+
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                runPostingSealPurgeJob(purgeJob);
+            }
+            engine.releaseAllWriters();
+
+            final long expectedSum = perDaySum + (protectedExpected - hotPerDay);
+            try (
+                    SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                            .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                    null, null, -1, null);
+                    SqlCompiler compiler = engine.getSqlCompiler();
+                    RecordCursorFactory f = compiler.compile(
+                            "SELECT count(), sum(price) FROM t_cov_drop WHERE " + protectedPred, ctx).getRecordCursorFactory();
+                    RecordCursor cur = f.getCursor(ctx)
+            ) {
+                Assert.assertTrue("final protected query returned no row", cur.hasNext());
+                Assert.assertEquals("final protected covered count", protectedExpected, cur.getRecord().getLong(0));
+                Assert.assertEquals("final protected covered sum(price)", (double) expectedSum, cur.getRecord().getDouble(1), 0.5);
+            }
+        });
+    }
+
+    /**
      * Two-covering-indexes hardening test: one table carries TWO covering posting
      * indexes (sym1 INCLUDE price, sym2 INCLUDE price), so every O3 commit reseals
      * BOTH covering indexes of each rewritten partition in the same seal sweep.

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -5123,6 +5123,48 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * Covered-read hardening across row-id encodings. Same all-parquet O3 churn as
+     * the reproducer, but each run pins a random posting row-id encoding (adaptive /
+     * Elias-Fano / delta), so the covering reader decodes .pv chains under a
+     * different codec while partitions are rewritten out of order. The covered
+     * count/sum oracle is encoding-independent; a decode bug under one codec surfaces
+     * as a dropped/garbage covered value.
+     */
+    @Test
+    public void testMultiThreadedO3CoveringEncodingConcurrentReaderFuzz() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+        final int enc = rnd.nextInt(3);
+        if (enc == 1) {
+            node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_ROW_ID_ENCODING, "ef");
+        } else if (enc == 2) {
+            node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_ROW_ID_ENCODING, "delta");
+        } // enc == 0 -> adaptive (default)
+        assertMemoryLeak(() -> runConcurrentCoveredSumCountFuzz("t_cov_enc", true, rnd));
+    }
+
+    /**
+     * Native-only reproducer of the OPEN native-partition covered-read race (the
+     * cleanest form; see testMultiThreadedO3CoveringMixedNativeParquetReaderFuzz for
+     * the full diagnosis). Identical to the parquet reproducer but the partitions are
+     * NEVER converted to parquet, so every O3 commit reseals a NATIVE partition in
+     * place. Fails the same way -- one partition's covered values transiently read 0
+     * -- while the all-parquet reproducer passes, confirming the race is native-reseal
+     * specific and distinct from the parquet expose-before-.pci bug already fixed.
+     * Un-ignore once the native in-place reseal publishes covered data before it
+     * publishes the new sealTxn chain entry.
+     */
+    @Ignore("Reproducer for the OPEN native-partition covered-read race (fails ~5/8); un-ignore when fixed.")
+    @Test
+    public void testMultiThreadedO3CoveringNativeOnlyConcurrentReaderFuzz() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_AUTO_INCLUDE_TIMESTAMP, false);
+        final Rnd rnd = TestUtils.generateRandom(LOG);
+        assertMemoryLeak(() -> runConcurrentCoveredSumCountFuzz("t_cov_native", false, rnd));
+    }
+
+    /**
      * Use-after-free probe: a COVERING cursor held open across a full O3 rewrite +
      * seal-purge must keep returning its pinned snapshot and never read a reclaimed
      * value file. Opens a covered SELECT over several parquet partitions, reads
@@ -6626,6 +6668,148 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                 .returns("count\n"
                         + expectedCount
                         + "\n");
+    }
+
+    // Shared single-key covered sum/count concurrent-reader workload. Seeds
+    // dayCount days of 'A' rows (price = row index), optionally converts them all to
+    // parquet, then runs reader threads asserting the covered count/sum stay
+    // monotonic (rows are only ADDED, so a valid snapshot can never drop below the
+    // committed floor) while a 4-worker pool rewrites partitions out of order under a
+    // tiny spill budget. Verifies the exact final totals. Callers set the spill /
+    // auto-include / row-id-encoding properties before invoking. Pass toParquet=false
+    // to exercise the native in-place reseal path.
+    private void runConcurrentCoveredSumCountFuzz(String tableName, boolean toParquet, Rnd rnd) throws Exception {
+        final int dayCount = 4 + rnd.nextInt(4); // 4..7 days; keeps sum < 1e7
+        final int hotPerDay = 1000;
+        final long perDaySum = (long) hotPerDay * (hotPerDay + 1) / 2;
+        final long initialRows = (long) dayCount * hotPerDay;
+        final long initialSum = (long) dayCount * perDaySum;
+
+        execute("CREATE TABLE " + tableName + " (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (price), price DOUBLE) "
+                + "TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+        for (int d = 1; d <= dayCount; d++) {
+            execute("INSERT INTO " + tableName + " SELECT dateadd('s', x::INT, '2024-02-0" + d
+                    + "T00:00:00.000000Z'::TIMESTAMP), 'A', x::DOUBLE FROM long_sequence(" + hotPerDay + ")");
+        }
+        if (toParquet) {
+            for (int d = 1; d <= dayCount; d++) {
+                execute("ALTER TABLE " + tableName + " CONVERT PARTITION TO PARQUET LIST '2024-02-0" + d + "'");
+            }
+        }
+
+        final AtomicReference<Throwable> bgError = new AtomicReference<>();
+        final AtomicBoolean stop = new AtomicBoolean();
+        final AtomicLong rowFloor = new AtomicLong(initialRows);
+        final int readerCount = 3;
+        final Thread[] readers = new Thread[readerCount];
+        for (int r = 0; r < readerCount; r++) {
+            readers[r] = new Thread(() -> {
+                try (
+                        SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                                .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                        null, null, -1, null);
+                        SqlCompiler compiler = engine.getSqlCompiler()
+                ) {
+                    long prevCount = 0;
+                    while (!stop.get() && bgError.get() == null) {
+                        final long floor = rowFloor.get();
+                        final long count;
+                        final double sum;
+                        try (RecordCursorFactory f = compiler.compile(
+                                "SELECT count(), sum(price) FROM " + tableName + " WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                             RecordCursor cur = f.getCursor(ctx)) {
+                            if (cur.hasNext()) {
+                                count = cur.getRecord().getLong(0);
+                                sum = cur.getRecord().getDouble(1);
+                            } else {
+                                count = -1;
+                                sum = -1;
+                            }
+                        }
+                        if (count < floor) {
+                            throw new AssertionError("covered 'A' count fell below the committed floor: " + count + " < " + floor);
+                        }
+                        if (count < prevCount) {
+                            throw new AssertionError("covered 'A' count went backwards: " + prevCount + " -> " + count);
+                        }
+                        if (sum < (double) initialSum - 0.5) {
+                            throw new AssertionError("covered sum(price) dropped below the initial total " + initialSum + ": " + sum);
+                        }
+                        if (sum < (double) count - 0.5) {
+                            throw new AssertionError("covered sum(price)=" + sum + " < count=" + count
+                                    + " -- a covered value resolved as < 1 (stale/garbage sidecar)");
+                        }
+                        prevCount = count;
+                    }
+                } catch (Throwable e) {
+                    bgError.set(e);
+                }
+            }, "covering-reader-" + r);
+            readers[r].setDaemon(true);
+            readers[r].start();
+        }
+
+        final WorkerPool pool = new WorkerPool(() -> 4);
+        TestUtils.setupWorkerPool(pool, engine);
+        pool.start(LOG);
+        long expectedRows = initialRows;
+        try {
+            final int batches = 6 + rnd.nextInt(10);
+            for (int b = 0; b < batches && bgError.get() == null; b++) {
+                final StringBuilder sql = new StringBuilder("INSERT INTO " + tableName + " VALUES ");
+                int added = 0;
+                for (int d = 1; d <= dayCount; d++) {
+                    if (rnd.nextBoolean()) {
+                        continue;
+                    }
+                    final int n = 1 + rnd.nextInt(3);
+                    for (int i = 0; i < n; i++) {
+                        if (added > 0) {
+                            sql.append(',');
+                        }
+                        sql.append("('2024-02-0").append(d).append("T00:")
+                                .append(String.format("%02d", 1 + rnd.nextInt(58)))
+                                .append(":00.500000Z', 'A', 1.0)");
+                        added++;
+                    }
+                }
+                if (added == 0) {
+                    continue;
+                }
+                execute(sql.toString());
+                expectedRows += added;
+                rowFloor.set(expectedRows);
+            }
+        } finally {
+            stop.set(true);
+            for (Thread t : readers) {
+                t.join(30_000);
+                Assert.assertFalse("reader thread did not terminate", t.isAlive());
+            }
+            pool.halt();
+        }
+
+        Assert.assertNull("concurrent covered reader threw: " + bgError.get(), bgError.get());
+
+        try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+            runPostingSealPurgeJob(purgeJob);
+        }
+        engine.releaseAllWriters();
+
+        final long expectedSum = initialSum + (expectedRows - initialRows);
+        try (
+                SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                        .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                null, null, -1, null);
+                SqlCompiler compiler = engine.getSqlCompiler();
+                RecordCursorFactory f = compiler.compile(
+                        "SELECT count(), sum(price) FROM " + tableName + " WHERE sym = 'A'", ctx).getRecordCursorFactory();
+                RecordCursor cur = f.getCursor(ctx)
+        ) {
+            Assert.assertTrue("final covered query returned no row", cur.hasNext());
+            Assert.assertEquals("final covered 'A' count", expectedRows, cur.getRecord().getLong(0));
+            Assert.assertEquals("final covered sum(price)", (double) expectedSum, cur.getRecord().getDouble(1), 0.5);
+        }
     }
 
     private void fillPostingSealPurgeQueue(TableToken liveToken) {

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -540,6 +540,14 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             final TableToken tableToken = engine.getTableTokenIfExists(tableName);
             Assert.assertNotNull("table must exist", tableToken);
 
+            // Earlier covering-index tests in this class leave purge tasks in the
+            // shared MessageBus ring (no PostingSealPurgeJob drains it in the test
+            // harness), so it can arrive already saturated. Sibling tests clear it
+            // by running a purge job first; this test must instead keep the ring
+            // full via the liveJob below, so drain the residue directly so its own
+            // fillPostingSealPurgeQueue saturation starts from an empty ring.
+            drainPostingSealPurgeQueue();
+
             // A live PostingSealPurgeJob owns the sys.posting_seal_purge_log
             // writer for the entire close, exactly as in a running server. It is
             // not draining concurrently (CPU-starved or in error backoff), so the
@@ -1259,7 +1267,10 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             // Set up the shape produced by the fuzz failure: a non-WAL table
             // with a POSTING symbol index, a renamed indexed column, and a
             // symbol-capacity change before the O3/replace-style insert.
-            execute("CREATE TABLE " + tableName + " (ts TIMESTAMP, sym2 SYMBOL INDEX TYPE POSTING, sym_top SYMBOL CAPACITY 128, marker LONG) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+            // sym2 carries an explicit INCLUDE (ts) so the index is covering --
+            // the test asserts a CoveringIndex plan below. A bare INDEX TYPE
+            // POSTING is non-covering and would not produce that plan.
+            execute("CREATE TABLE " + tableName + " (ts TIMESTAMP, sym2 SYMBOL INDEX TYPE POSTING INCLUDE (ts), sym_top SYMBOL CAPACITY 128, marker LONG) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
             execute(insertPostingRowsSql(-85, 0));
             execute("ALTER TABLE " + tableName + " RENAME COLUMN sym2 TO new_col_11");
             execute(insertPostingRowsSql(0, 10));
@@ -1372,10 +1383,15 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testParquetIndexWriteUsesCommitDense() throws Exception {
-        // O3PartitionJob.updateParquetIndexes goes through commitDense for POSTING.
-        // That path runs when O3 mutates an already-parquet partition. Convert the
-        // first partition to parquet, then O3-insert into it to trigger the rewrite.
-        // After that, the chain head must hold a single dense gen.
+        // O3PartitionJob.updateParquetIndexes goes through commitDense for a
+        // NON-covering POSTING index. That path runs when O3 mutates an
+        // already-parquet partition. A bare INDEX TYPE POSTING (no INCLUDE) is
+        // non-covering, so this exercises commitDense: a covering parquet
+        // partition is instead resealed (resealParquetCoveringForPartition
+        // rebuilds .pv + .pci/.pc), which intentionally rotates the value file.
+        // Convert the first partition to parquet, then O3-insert into it to
+        // trigger the rewrite. After that the chain head must hold a single
+        // dense gen with no rotated .pv.
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_parquet_posting (
@@ -2900,10 +2916,14 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         };
 
         assertMemoryLeak(ff, () -> {
+            // sym carries an explicit INCLUDE (ts) so the index is covering:
+            // the test arms a fault on the second seal-time .pv rotation, which
+            // only happens for a covering seal. A bare INDEX TYPE POSTING is
+            // non-covering and never rotates .pv at seal time.
             execute("""
                     CREATE TABLE t_c1_chain_head (
                         ts TIMESTAMP,
-                        sym SYMBOL INDEX TYPE POSTING
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (ts)
                     ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
                     """);
             execute("""
@@ -5128,26 +5148,19 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      * lost or double-freed). The floor is read BEFORE the count so a commit landing
      * mid-read can never make a valid snapshot look short.
      * <p>
-     * IGNORED reproducer for a PARQUET-specific covered-read race (root cause known,
-     * fix pending). Under concurrent O3 rewrite of parquet partitions a reader sees a
-     * correct posting count() but a sum(price) short by whole partitions, because the
-     * covered values read as SQL NULL (count() counts them; sum() skips NULLs).
-     * ROOT CAUSE (fully traced via instrumentation): getCoveredDouble returns NaN ->
-     * keyBlockAddrs == null while isCurrentGenDense == true -> cacheSidecarKeyAddrs
-     * early-returned on coverCount == 0 -> openSidecarFilesIfPresent found the .pci
-     * file MISSING when the reader opened the rewritten parquet partition version. The
-     * parquet O3 rewrite exposes the new partition version (with its sealTxn-versioned
-     * .pv row-ids) to readers BEFORE the writer-thread covering seal
-     * (sealPostingIndexForPartition) writes that version's .pci/.pc sidecars, so a
-     * reader catches a window where the partition is covered but its .pci does not yet
-     * exist, reports coverCount=0, and returns NULL covered values. Native partitions
-     * reseal in place (the .pci is always present), hence they pass. Single-threaded is
-     * correct. Fix belongs writer-side: the covering sidecars must exist before the new
-     * parquet partition version becomes reader-visible. Un-@Ignore to reproduce (~300ms).
+     * Regression for a fixed PARQUET-specific covered-read race. Before the fix, an
+     * O3/squash rewrite of a parquet partition exposed the new version with only the
+     * .pv (so count() was correct) but never materialised its covering .pci/.pc:
+     * sealPostingIndexForPartition skipped parquet, and the O3 worker builds only the
+     * non-covering .pv. A concurrent covered read then opened the new version, found
+     * the .pci missing, reported coverCount=0 and returned NULL covered values (count
+     * right, sum(price) short by whole partitions). Native partitions reseal in place
+     * (the .pci is always present), hence they passed. Fixed by
+     * resealParquetCoveringForPartition, which rebuilds covering for parquet partitions
+     * with a covering index in the seal sweep / squash, before the commit exposes the
+     * version (with discardForRebuild to avoid double-counting and a deferred
+     * seal-purge publish so superseded value files are reclaimed).
      */
-    @Ignore("Open (root-caused): a multi-partition O3/squash commit exposes some rewritten " +
-            "parquet partition versions with only the .pv and no covering .pci, so a concurrent " +
-            "covered read sees coverCount=0 and returns NULL. Native passes.")
     @Test
     public void testMultiThreadedO3CoveringPostingConcurrentReaderFuzz() throws Exception {
         node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256);

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
@@ -2386,9 +2386,10 @@ public class CoveringIndexTest extends AbstractCairoTest {
 
     @Test
     public void testAutoIncludeTimestampAlterNoInclude() throws Exception {
-        // ALTER TABLE ... ADD INDEX TYPE POSTING with no INCLUDE clause
-        // must still auto-append the designated timestamp so the bare
-        // alter case picks up the same covering benefit as inline CREATE.
+        // ALTER TABLE ... ADD INDEX TYPE POSTING with no INCLUDE clause is a
+        // plain, non-covering posting index. The timestamp auto-include only
+        // rounds out an explicit INCLUDE set, so a bare ALTER must NOT produce
+        // a covering index.
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_ts_alter_noinc (
@@ -2402,11 +2403,8 @@ public class CoveringIndexTest extends AbstractCairoTest {
             try (TableReader reader = getReader("t_ts_alter_noinc")) {
                 TableReaderMetadata metadata = reader.getMetadata();
                 int symIdx = metadata.getColumnIndex("sym");
-                IntList coveringIndices = metadata.getColumnMetadata(symIdx).getCoveringColumnIndices();
-                assertNotNull("covering INCLUDE list missing for ALTER POSTING with auto-include",
-                        coveringIndices);
-                assertEquals(1, coveringIndices.size());
-                assertEquals(metadata.getColumnIndex("ts"), coveringIndices.getQuick(0));
+                assertFalse(metadata.getColumnMetadata(symIdx).isCovering());
+                assertNull(metadata.getColumnMetadata(symIdx).getCoveringColumnIndices());
             }
 
             execute("""
@@ -2417,7 +2415,7 @@ public class CoveringIndexTest extends AbstractCairoTest {
             engine.releaseAllWriters();
 
             String plan = getPlan("SELECT ts FROM t_ts_alter_noinc WHERE sym = 'A'");
-            assertTrue("Expected CoveringIndex plan for ts-only projection after ALTER:\n" + plan,
+            assertFalse("bare ALTER POSTING (no INCLUDE) must not use a CoveringIndex plan:\n" + plan,
                     plan.contains("CoveringIndex"));
         });
     }
@@ -2465,6 +2463,101 @@ public class CoveringIndexTest extends AbstractCairoTest {
     public void testAutoIncludeTimestampConfigDefaultIsTrue() {
         assertTrue("Default should be true",
                 engine.getConfiguration().isPostingIndexAutoIncludeTimestamp());
+    }
+
+    @Test
+    public void testAutoIncludeTimestampCoversLatestOn() throws Exception {
+        // The LATEST ON special path must use the covering index for the
+        // AUTO-INCLUDED timestamp, not just an explicitly listed column. With
+        // POSTING INCLUDE (price) the designated ts is auto-appended to the
+        // covering set, so a LATEST ON query that projects ts is served from
+        // the covering index instead of the column files. Guards the auto-
+        // include feature's payoff on the latest-on path after the bare-POSTING
+        // auto-cover was removed.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_ts_cov_latest (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            execute("""
+                    INSERT INTO t_ts_cov_latest VALUES
+                        ('2024-01-01T00:00:00', 'A', 10.0),
+                        ('2024-01-02T00:00:00', 'B', 20.0),
+                        ('2024-01-03T00:00:00', 'A', 30.0)
+                    """);
+            engine.releaseAllWriters();
+
+            // Projecting the auto-included ts through LATEST ON must stay covering.
+            String plan = getPlan("SELECT ts FROM t_ts_cov_latest WHERE sym = 'A' LATEST ON ts PARTITION BY sym");
+            assertTrue("Expected CoveringIndex latest-on plan for auto-included ts:\n" + plan,
+                    plan.contains("CoveringIndex"));
+
+            assertQuery("SELECT ts FROM t_ts_cov_latest WHERE sym = 'A' LATEST ON ts PARTITION BY sym")
+                    .timestamp("ts")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("""
+                            ts
+                            2024-01-03T00:00:00.000000Z
+                            """);
+        });
+    }
+
+    @Test
+    public void testAutoIncludeTimestampCoversWhereFilter() throws Exception {
+        // Positive twin of testAutoIncludeTimestampPostingNoInclude (which now
+        // asserts the bare, non-covering case): with an explicit INCLUDE the
+        // designated ts is auto-appended, so projecting ONLY the auto-included
+        // ts (not the explicitly covered price) is still served from the
+        // covering index. This is the auto-include feature's whole point -- the
+        // common SELECT ts ... WHERE sym = ... pattern stays covering.
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_ts_cov_where (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                        price DOUBLE
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+
+            // Metadata: covering = {price, ts}, with ts auto-appended.
+            try (TableReader reader = getReader("t_ts_cov_where")) {
+                TableReaderMetadata metadata = reader.getMetadata();
+                int symIdx = metadata.getColumnIndex("sym");
+                IntList coveringIndices = metadata.getColumnMetadata(symIdx).getCoveringColumnIndices();
+                assertNotNull(coveringIndices);
+                assertEquals(2, coveringIndices.size());
+                assertEquals(metadata.getColumnIndex("price"), coveringIndices.getQuick(0));
+                assertEquals(metadata.getColumnIndex("ts"), coveringIndices.getQuick(1));
+            }
+
+            execute("""
+                    INSERT INTO t_ts_cov_where VALUES
+                        ('2024-01-01T00:00:00', 'A', 10.0),
+                        ('2024-01-01T01:00:00', 'B', 20.0),
+                        ('2024-01-01T02:00:00', 'A', 30.0)
+                    """);
+            engine.releaseAllWriters();
+
+            // Projecting only the auto-included ts must use CoveringIndex.
+            String plan = getPlan("SELECT ts FROM t_ts_cov_where WHERE sym = 'A'");
+            assertTrue("Expected CoveringIndex plan for auto-included ts projection:\n" + plan,
+                    plan.contains("CoveringIndex"));
+
+            assertQuery("SELECT ts FROM t_ts_cov_where WHERE sym = 'A'")
+                    .timestamp("ts")
+                    .noRandomAccess()
+                    .expectSize()
+                    .noLeakCheck()
+                    .returns("""
+                            ts
+                            2024-01-01T00:00:00.000000Z
+                            2024-01-01T02:00:00.000000Z
+                            """);
+        });
     }
 
     @Test
@@ -2516,11 +2609,10 @@ public class CoveringIndexTest extends AbstractCairoTest {
     @Test
     public void testAutoIncludeTimestampCreateTableAsSelectNoInclude() throws Exception {
         // CREATE TABLE AS SELECT with an out-of-line INDEX(... TYPE POSTING)
-        // clause goes through resolveCoveringFromAugmented and must also
-        // auto-append the designated timestamp when no INCLUDE is given.
-        // The out-of-line parser does not accept INCLUDE today, so this
-        // is the only way users can request a posting index for CTAS, and
-        // the default config promises auto-include here too.
+        // clause goes through resolveCoveringFromAugmented. The out-of-line
+        // parser does not accept INCLUDE today, so a CTAS posting index has no
+        // INCLUDE columns and must therefore stay non-covering: the timestamp
+        // auto-include only rounds out an explicit INCLUDE set.
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_src_noinc (ts TIMESTAMP, sym SYMBOL, price DOUBLE)
@@ -2540,11 +2632,8 @@ public class CoveringIndexTest extends AbstractCairoTest {
             try (TableReader reader = getReader("t_ctas_noinc")) {
                 TableReaderMetadata metadata = reader.getMetadata();
                 int symIdx = metadata.getColumnIndex("sym");
-                IntList coveringIndices = metadata.getColumnMetadata(symIdx).getCoveringColumnIndices();
-                assertNotNull("covering INCLUDE list missing for CTAS POSTING with auto-include",
-                        coveringIndices);
-                assertEquals(1, coveringIndices.size());
-                assertEquals(metadata.getColumnIndex("ts"), coveringIndices.getQuick(0));
+                assertFalse(metadata.getColumnMetadata(symIdx).isCovering());
+                assertNull(metadata.getColumnMetadata(symIdx).getCoveringColumnIndices());
             }
         });
     }
@@ -2606,11 +2695,9 @@ public class CoveringIndexTest extends AbstractCairoTest {
 
     @Test
     public void testAutoIncludeTimestampPostingNoInclude() throws Exception {
-        // POSTING index without INCLUDE clause — auto-include must still
-        // append the designated timestamp so the common
-        // SELECT ts FROM t WHERE sym = ... pattern can use a CoveringIndex
-        // plan. Otherwise turning on a posting index silently produces an
-        // empty INCLUDE list and no covering benefit at all.
+        // POSTING index without INCLUDE clause -- auto-include must NOT trigger.
+        // A bare INDEX TYPE POSTING is a plain, non-covering posting index; the
+        // timestamp auto-include only rounds out an explicit INCLUDE set.
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_ts_noinc (
@@ -2620,14 +2707,12 @@ public class CoveringIndexTest extends AbstractCairoTest {
                     ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
                     """);
 
-            // Verify metadata: covering should contain just ts.
+            // Verify metadata: no covering list at all.
             try (TableReader reader = getReader("t_ts_noinc")) {
                 TableReaderMetadata metadata = reader.getMetadata();
                 int symIdx = metadata.getColumnIndex("sym");
-                IntList coveringIndices = metadata.getColumnMetadata(symIdx).getCoveringColumnIndices();
-                assertNotNull("covering INCLUDE list missing for POSTING with auto-include", coveringIndices);
-                assertEquals(1, coveringIndices.size());
-                assertEquals(metadata.getColumnIndex("ts"), coveringIndices.getQuick(0));
+                assertFalse(metadata.getColumnMetadata(symIdx).isCovering());
+                assertNull(metadata.getColumnMetadata(symIdx).getCoveringColumnIndices());
             }
 
             execute("""
@@ -2637,10 +2722,9 @@ public class CoveringIndexTest extends AbstractCairoTest {
                     """);
             engine.releaseAllWriters();
 
-            // Query that selects only sym and ts must use CoveringIndex
-            // because ts is auto-included.
-            String plan = getPlan("SELECT ts FROM t_ts_noinc WHERE sym = 'A'");
-            assertTrue("Expected CoveringIndex plan for ts-only projection:\n" + plan,
+            // No INCLUDE at all -- CoveringIndex must not be used.
+            String plan = getPlan("SELECT ts, price FROM t_ts_noinc WHERE sym = 'A'");
+            assertFalse("Should not use CoveringIndex without INCLUDE:\n" + plan,
                     plan.contains("CoveringIndex"));
         });
     }
@@ -10277,11 +10361,14 @@ public class CoveringIndexTest extends AbstractCairoTest {
         // nothing. Realistic shape: a populated table with a few known symbols, a
         // dashboard query for a value that has never been written. The fuzz hit
         // this via CREATE VIEW; assertQuery exercises the same API path directly.
+        // The covering cursor under test only kicks in for a covering index, so
+        // sym carries an explicit INCLUDE (ts) -- a bare INDEX TYPE POSTING is
+        // non-covering and would take the plain posting-filter path instead.
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_unknown_sym (
                         ts TIMESTAMP,
-                        sym SYMBOL INDEX TYPE POSTING,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (ts),
                         price DOUBLE
                     ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
                     """);
@@ -12744,10 +12831,9 @@ public class CoveringIndexTest extends AbstractCairoTest {
 
     @Test
     public void testNonCoveringTableUnchanged() throws Exception {
-        // POSTING index without INCLUDE: with the default
-        // cairo.posting.index.auto.include.timestamp=true the designated
-        // timestamp is auto-appended so the bare INDEX TYPE POSTING case
-        // still gets covering on the latest-by query path.
+        // POSTING index without INCLUDE is a plain, non-covering posting index.
+        // The timestamp auto-include only rounds out an explicit INCLUDE set, so
+        // a bare INDEX TYPE POSTING must carry no covering column list.
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE plain (
@@ -12762,11 +12848,8 @@ public class CoveringIndexTest extends AbstractCairoTest {
                 int symIdx = metadata.getColumnIndex("sym");
                 assertTrue(metadata.isColumnIndexed(symIdx));
                 assertEquals(IndexType.POSTING, metadata.getColumnIndexType(symIdx));
-                assertTrue(metadata.getColumnMetadata(symIdx).isCovering());
-                IntList coveringIndices = metadata.getColumnMetadata(symIdx).getCoveringColumnIndices();
-                assertNotNull(coveringIndices);
-                assertEquals(1, coveringIndices.size());
-                assertEquals(metadata.getColumnIndex("ts"), coveringIndices.getQuick(0));
+                assertFalse(metadata.getColumnMetadata(symIdx).isCovering());
+                assertNull(metadata.getColumnMetadata(symIdx).getCoveringColumnIndices());
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/PostingIndexO3ConcurrencyFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/PostingIndexO3ConcurrencyFuzzTest.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.fuzz;
+
+import io.questdb.PropertyKey;
+import io.questdb.std.Rnd;
+import org.junit.Test;
+
+/**
+ * Fuzz suite targeting thread-unsafe interactions between the POSTING/covering
+ * index and the O3 jobs (O3CopyJob, O3PartitionJob, O3OpenColumnJob) and
+ * TableWriter, run over the shared 4-worker O3 pool that {@link AbstractFuzzTest}
+ * starts (which also runs PostingSealPurgeJob, ColumnIndexerJob and the partition
+ * purge job). Each test:
+ * <ul>
+ *   <li>forces OUT-OF-ORDER inserts (setFuzzCounts isO3=true) so O3CopyJob /
+ *       O3PartitionJob actually run on the worker threads, not inline;</li>
+ *   <li>drives runtime covering POSTING indexes (addCoveringIndexProb &gt; 0 emits
+ *       ALTER ... ADD INDEX TYPE POSTING INCLUDE (...)) on top of the random
+ *       BITMAP/POSTING/DELTA/EF index types the framework already assigns to
+ *       sym2/sym_top;</li>
+ *   <li>cranks a tiny posting indexer spill budget so the mid-stream-flush /
+ *       commitDense consolidation and seal/reseal path (the squash SIGSEGV class)
+ *       is hit under O3 worker contention;</li>
+ *   <li>relies on -ea assertions added during the concurrency audit as oracles:
+ *       parquetSealPurgeLock Thread.holdsLock guards, the
+ *       o3PartitionUpdRemaining==0 temporal-separation guards on the seal/purge
+ *       paths, and the addr-based covered-read bounds check. A regression that
+ *       reintroduces a race trips one of these on a worker thread, which the
+ *       fuzz harness propagates as a test failure;</li>
+ *   <li>asserts the WAL and parallel-WAL tables match the single-threaded non-WAL
+ *       reference row-for-row AND index-for-index (assertRandomIndexes), so a
+ *       posting/covering index returning wrong rows fails immediately.</li>
+ * </ul>
+ * Reproduce a failure by replacing {@code generateRandom(LOG)} with
+ * {@code generateRandom(LOG, s0, s1)} using the {@code random seeds: ...} log line.
+ */
+public class PostingIndexO3ConcurrencyFuzzTest extends AbstractFuzzTest {
+
+    // A tiny posting indexer spill budget forces compactIfOverBudget ->
+    // flushAllPending mid-build, so a full index() rebuild over an O3-merged or
+    // squashed partition trips the spill budget and commitDense must consolidate
+    // sparse gens -- the exact path the squash/covering SIGSEGV came from. The
+    // budget is engine-global, so the non-WAL oracle table spills identically and
+    // the result-set comparison stays apples-to-apples.
+    private void forcePostingSpill(Rnd rnd) {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_INDEX_INDEXER_SPILL_BYTES_MAX, 256L + rnd.nextInt(64 * 1024));
+    }
+
+    @Test
+    public void testCoveringPostingO3NativeSpillFuzz() throws Exception {
+        Rnd rnd = generateRandom(LOG);
+        forcePostingSpill(rnd);
+        // Native-only (no parquet): exercises O3CopyJob.updateIndex on per-partition
+        // O3Basket indexers + the writer-thread covering reseal sweep
+        // (sealPostingIndexForPartition: discardForRebuild -> index -> commitDense ->
+        // configureCovering -> rebuildSidecars) under spill pressure, across the pool.
+        setFuzzProbabilities(
+                0.05,  // cancelRowsProb -- rollback within a commit
+                0.05,  // notSetProb -- column tops
+                0.1,   // nullSetProb -- index implicit-null synthesis
+                0.1,   // rollbackProb
+                0.1,   // colAddProb -- adds SYMBOL cols, ~90% indexed (random posting variant)
+                0.05,  // colRemoveProb
+                0.1,   // colRenameProb -- posting aux-file relink
+                0.0,   // colTypeChangeProb
+                1.0,   // dataAddProb
+                0.05,  // equalTsRowsProb -- equal-ts O3 merge edge
+                0.05,  // partitionDropProb
+                0.0,   // partitionToParquetProb
+                0.0,   // partitionToNativeProb
+                0.1,   // truncateProb
+                0.0,   // tableDropProb -- keep oracle table stable
+                0.8,   // setTtlProb
+                0.15,  // replaceProb -- REPLACE RANGE, heavy index rewrite
+                0.0,   // symbolAccessProb
+                0.05,  // queryProb
+                0.0,   // setParquetEncodingProb
+                0.6    // addCoveringIndexProb
+        );
+        setFuzzCounts(true, 600_000, 400, 20, 10, 1000, 80_000, 20);
+        // Tiny apply quota + split-min-size=1 + low max-splits force partition
+        // splits then squashSplitPartitions, the original reseal trigger.
+        setFuzzProperties(1, 1, getRndO3PartitionSplitMaxCount(rnd));
+        runFuzz(rnd);
+    }
+
+    @Test
+    public void testCoveringPostingParquetO3SpillFuzz() throws Exception {
+        Rnd rnd = generateRandom(LOG);
+        forcePostingSpill(rnd);
+        // Parquet rewrite: O3PartitionJob.updateParquetIndexes runs on the workers
+        // and each calls back into TableWriter.deferParquetPostingSealPurges under
+        // parquetSealPurgeLock; several partitions in flight contend on the shared
+        // deferredPostingSealPurges list + task pool. The PostingSealPurgeJob on the
+        // pool then reclaims the superseded .pv/.pc, scoreboard-gated.
+        setFuzzProbabilities(
+                0.01,
+                0.01,
+                0.1,
+                0.1,
+                0.05,
+                0.05,
+                0.1,
+                0.0,
+                1.0,
+                0.01,
+                0.01,
+                0.5,   // partitionToParquetProb
+                0.5,   // partitionToNativeProb
+                0.1,
+                0.0,
+                0.8,
+                0.1,   // replaceProb
+                0.0,
+                0.01,
+                0.1,   // setParquetEncodingProb
+                0.6    // addCoveringIndexProb
+        );
+        setFuzzCounts(true, 300_000, 300, 20, 10, 1000, 50_000, 12);
+        setFuzzProperties(1, getRndO3PartitionSplit(rnd), getRndO3PartitionSplitMaxCount(rnd));
+        runFuzz(rnd);
+    }
+
+    @Test
+    public void testCoveringPostingSquashSpillFuzz() throws Exception {
+        Rnd rnd = generateRandom(LOG);
+        forcePostingSpill(rnd);
+        // Maximal split/squash churn: split-min-size=1, max-splits=1 means every O3
+        // insert into a partition splits it and the next commit squashes, repeatedly
+        // reseal-ing the merged partition's covering index under spill pressure.
+        setFuzzProbabilities(
+                0.1,   // cancelRowsProb
+                0.05,
+                0.1,
+                0.15,  // rollbackProb
+                0.1,   // colAddProb
+                0.05,
+                0.05,
+                0.0,
+                1.0,
+                0.1,   // equalTsRowsProb
+                0.02,
+                0.0,
+                0.0,
+                0.05,
+                0.0,
+                0.8,
+                0.2,   // replaceProb -- heavy
+                0.0,
+                0.05,
+                0.0,
+                0.7    // addCoveringIndexProb
+        );
+        setFuzzCounts(true, 400_000, 500, 16, 8, 800, 60_000, 24);
+        setFuzzProperties(1, 1, 1);
+        runFuzz(rnd);
+    }
+}


### PR DESCRIPTION
tandem: https://github.com/questdb/questdb-enterprise/pull/1042

This fixes a set of correctness, resource and concurrency bugs in the POSTING /
covering index that surface across partition squash, the plain O3 commit path,
parquet partition reseal, and the WAL fast-lag apply path. It also corrects the
default covering behaviour of a bare `INDEX TYPE POSTING` declaration. Each
change is described below with its symptom and fix.

## 1. JVM crash and missing rows after partition squash

A table with a `POSTING` index can crash the JVM (covering index) or return
short/incorrect indexed counts (non-covering index) after its partitions are
squashed. The reported failure is a `SIGSEGV` in
`PostingIndexWriter.decodeDenseGenStride`, reached from a `wal-apply` thread:

```
squashSplitPartitions -> sealPostingIndexForPartition -> rebuildSidecars
  -> rebuildSidecarsByCopy -> writeSidecarForColumn -> decodeDenseGenStride  (SIGSEGV)
```

The squash and O3 reseal path runs `discardForRebuild()` -> `index()` ->
`commitDense()`. `commitDense()` assumed it writes the first and only generation
at `.pv` offset 0. When `index()` rebuilds a large or squashed partition that
holds a hot key, the `add()` loop trips the spill budget
(`cairo.posting.index.indexer.spill.bytes.max`, default 256 MiB) and
`compactIfOverBudget()` runs `flushAllPending()`, persisting one or more
**sparse** generations to the `.pv` mid-stream. `flushAllPendingDense()` then
appends the dense gen-0 at a non-zero file offset and `extendHead(newGenCount=1)`
overwrites gen-dir slot 0 to point at it, orphaning the sparse generations:

- Covering: `rebuildSidecars`' by-copy path decodes gen-0 from
  `valueMem.addressOf(0)` (the orphaned generation) while
  `accumulateDenseGen0Counts` reads the real file offset. The stride-index
  mismatch makes `decodeDenseGenStride` over-read native memory and crash.
- Non-covering: no sidecar rebuild, so no crash, but the orphaned rows are
  silently dropped and indexed predicates return short counts.

Fix: `commitDense()` consolidates through `seal()` when generations already
exist (`genCount > 0`). `seal()` drains the final pending batch and re-encodes
every generation into a single dense gen-0 at offset 0 -- the shape both the
by-copy rebuild and the dense fast path expect. `coverCount` is 0 at
`commitDense()` time (covering config is applied afterward), so `seal()` stays
sidecar-free and `rebuildSidecars()` writes the sidecars as before. The common
path (no spill, `genCount == 0`) still takes `flushAllPendingDense()` unchanged.

This also fires on the plain O3 commit path (an in-range O3 insert that mutates a
partition, no squash) and the WAL apply auto-squash path -- both reproduced
below.

## 2. Covered reads return NULL after an O3/squash reseal of a parquet partition

A parquet partition that carries a **covering** posting index returned NULL for
its covered columns after an O3 write rewrote it (e.g. `sum(price)` over the
covering index silently dropped the whole partition's rows). Two distinct causes:

- The O3 worker that rewrites a parquet partition builds only the non-covering
  `.pv`. `sealPostingIndexForPartition` previously skipped parquet partitions
  entirely, so the new parquet version had no `.pci`/`.pc` covering sidecars: a
  reader walked the chain (count correct) but found `coverCount == 0` and
  resolved covered values as NULL. `sealPostingIndexForPartition` now rebuilds
  the covering sidecars for parquet partitions from the rewritten parquet
  (`resealParquetCoveringForPartition` -> `indexParquetColumn`), pre-commit, in
  `finishO3Commit` / squash.
- A same-`sealTxn` chain-head republish (`extendHead`) overwrote the head
  entry's cover-end footer with an empty footer whenever the writer's live
  `coverCount` was transiently 0 (between `clearCovering` and the next
  `configureCovering`) or its sidecar handles were closed. A concurrent covered
  read of the republished entry then saw `sidecarFileEndOffsets == 0`, failed to
  map the existing `.pc`, and returned NULL for the whole partition.
  `PostingIndexChainWriter.readHeadCoverEndOffsets` snapshots the on-disk footer
  into `coverEndOffsetsCache` before the gen-dir overwrite, so `captureCoverEndOffsets`
  republishes the real extents instead of an empty footer.

## 3. WAL fast-lag covered sidecar incomplete after a mid-stream spill

On the WAL fast-lag apply path, a mid-stream spill flush during
`updateIndexesParallel` could write an incomplete `.pc` covered sidecar:
`publishPostingIndexesForLastPartitionFastLag`'s addr-based `configureCovering`
clears the writer-owned cover schema set at `openPartition`, so a spill flush
during indexing produced a sidecar missing its covered data, and a later covered
read over-read the `.pc`. `applyLagToLastPartition` now calls
`configureCoveringForLastPartitionFastLag()` to restore the covering
configuration on each posting writer **before** indexing, so spill-flushed
generations carry their covered data. The seal paths also forward the covered
columns' mapped byte lengths (`setCoveredColumnAddrSizes`), which bound the
addr-based covered reads under assertions.

## 4. Covering lost on a symbol-capacity change

`ALTER TABLE ... ALTER COLUMN ... SYMBOL CAPACITY` rebuilds the column metadata.
`updateColumnSymbolCapacity` did not carry over the covering-column indices, so
the next `rewriteAndSwapMetadata()` persisted a `_meta` with no covering
flag/section and every reader thereafter saw the posting index as non-covering.
`updateColumnSymbolCapacity` now preserves `getCoveringColumnIndices()`.

## 5. DDL: a bare `INDEX TYPE POSTING` is now non-covering (intentional, technically breaking)

A bare `INDEX TYPE POSTING` with no `INCLUDE` clause used to auto-append the
designated timestamp to the covering set, silently making the index covering.
That was an unintended default and should not have shipped in that state: a plain
posting index without an explicit `INCLUDE` is now **non-covering**. The
timestamp auto-include (`cairo.posting.index.auto.include.timestamp`, still
default true) now only rounds out an **explicit** `INCLUDE` set; it never turns a
non-covering index into a covering one on its own.

This is a technically breaking change to the default, surfaced consistently
across `CREATE TABLE`, CTAS, `ALTER TABLE ... ADD INDEX` and `SHOW CREATE TABLE`.
It is not expected to affect existing deployments: the covering flag is persisted
per-column in `_meta`, so existing tables created with a bare posting index keep
their covering flag on disk and do not change on read; only newly created or
re-declared indexes are affected. No known usage relies on the old implicit
covering. `SHOW CREATE TABLE tab` for `s SYMBOL INDEX TYPE POSTING` now renders
`INDEX TYPE POSTING` (no `INCLUDE (ts)`), and `SELECT * WHERE s = ...` takes the
plain posting-filter cursor (random access, lazy size) instead of the covering
cursor.

## 6. Resource: parquet reseal value-file leak

When the parquet index rebuild (`O3PartitionJob.updateParquetIndexes`) spills,
the post-fix `commitDense` seals and rotates the `.pv`, recording a purge for the
superseded file. The pooled parquet writer is freed immediately and its
`close()` discards the purge outbox without draining it through a `TableWriter`
(as the native reseal does), so the superseded intermediate `.pv` leaked
permanently on disk -- no directory sweep or recovery walk reclaims it.

`deferParquetPostingSealPurges` hands the rebuild's seal-purges to the
`TableWriter`'s deferred queue, published after the commit; the scoreboard-gated
`PostingSealPurgeJob` deletes the `.pv` only once no reader is pinned in its
`[from, to)` txn window. The hand-off runs in a `finally` around `commitDense`
(both the parquet-worker path and the writer-thread covering reseal), so an I/O
fault inside the seal's `sync` -- which can throw after the purge is recorded --
still hands the entry off instead of dropping it (idempotent no-op on an empty
outbox).

## 7. Concurrency hardening: a single lock for the seal-purge state

Parquet index rebuilds run on parallel O3 workers and stash seal-purges
concurrently, while the writer-thread paths touch the same `deferredPostingSealPurges`
list and task pool only after the O3 workers join. The writer side previously
held no lock and leaned on that join ordering alone. Every list/pool access --
writer and worker -- now takes `parquetSealPurgeLock` (a leaf lock, uncontended
on the post-join writer paths), so the non-thread-safe `ObjList`/`ObjectStackPool`
are safe by construction, not by timing. The post-join invariant itself is
asserted (`o3PartitionUpdRemaining.get() == 0`) on every seal/defer/publish path,
so a future change that moved a mutation into the O3 window can no longer corrupt
them silently. The per-commit publish path short-circuits on an empty list before
taking the lock.

## Performance

The `commitDense` change is a single branch gated on `genCount > 0`, so the
common path is untouched; only a reseal that already spilled past the budget
takes the new `seal()` route. The `seal()` route re-encodes the spilled
generations into a single dense gen-0 -- the irreducible cost of consolidating
them correctly; the old `flushAllPendingDense` was cheaper only because it was
wrong (orphaned the spilled gens).

`resealParquetCoveringForPartition` decodes a partition's parquet once and feeds
every covering posting column from the shared decoder, instead of re-opening and
re-mapping the whole parquet file per column. `configureCoveringForLastPartitionFastLag`
and the per-commit seal-purge publish short-circuit before any work for tables
with no posting / no covering posting index.

`PostingIndexBenchmarkSuite.walLargePartitionO3SpillReseal` (added here) measures
an O3 reseal of a ~1M-row covering-posting partition with the spill budget
parameterised. Indicative single-shot numbers (n=2, noisy):

| `spillBytesMax` | reseal path | ms/op |
| --- | --- | --- |
| 256 MiB | `flushAllPendingDense` (common) | ~129 |
| 2 MiB | `seal()` consolidation | ~143 |
| 256 KiB | `seal()` consolidation | ~139 |

- The 256 MiB row is the no-regression baseline: that path runs the same
  `flushAllPendingDense` with or without this change.
- The 2 MiB / 256 KiB rows cost roughly 10% more on this reseal, but they only
  exist because of the fix -- before it they crashed (covering) or dropped rows
  (non-covering), so there is no faster correct baseline.
- No standard benchmark sets a sub-256-MiB spill budget, so headline numbers are
  not expected to move. Run it with `-Dquestdb.suite.bench=wal_o3_spill`.

## Test plan

Squash path (the reported trigger), each verified to fail with the fix reverted:

- `testSquashCoveringPostingWithMidStreamSpillFlush` -- covering index,
  `squashPartitions()` -> `squashSplitPartitions` reseal; SIGSEGVs without the
  fix (confirmed via hs_err).
- `testSquashSplitPartitionsCoveringPostingMultiSplitSpill` -- merges several
  split sub-partitions in one `squashSplitPartitions` call (the reported
  overload), asserting correctness after the squash.
- `testSquashNonCoveringPostingWithMidStreamSpillFlush` -- non-covering index
  (auto-include-timestamp disabled); returns short counts without the fix,
  correct after.
- `testWalApplyAutoSquashCoveringPostingWithMidStreamSpillFlush` -- drives the
  crash through WAL apply housekeep auto-squash, the reported entry point.
- `testO3CommitCoveringPostingResealWithMidStreamSpillFlush` -- drives the reseal
  through the plain O3 commit path (`sealPostingIndexesForO3Partitions`, no
  squash) via an in-range O3 insert that mutates the partition.

Parquet covering reseal (cause 2 above):

- `testO3CoveringPostingParquetResealKeepsCoveredValues` -- deterministic: an O3
  merge into an already-parquet covering-posting partition; asserts exact covered
  `sum(price)` / `first(tag)` through the covering cursor (`expectSize()` +
  `noRandomAccess()` confirm the covering cursor, not a forward-scan fallback).
  Reads NULL covered values without the parquet-covering reseal.
- `testConvertToParquetPostingResealSpillDoesNotLeakValueFile` -- reproduces the
  parquet reseal `.pv` leak on disk and asserts a single value file remains.

WAL fast-lag, cover-footer preservation, symbol-capacity covering, and the
non-covering DDL default each have targeted regression tests; the concurrent
covered-read race and the lock/temporal-separation invariants are covered by
`PostingIndexO3ConcurrencyFuzzTest` (native + parquet, requires `-ea`).

Regression: `PostingIndexCriticalIssuesTest`, all covering-package tests,
`PostingIndexOracleTest`/`Ef`/`Delta`, `PostingFSSTIndexTest`,
`PostingIndexStressTest`/`Ef`/`Delta` and `O3SquashPartitionTest` all pass.
