### PR TITLE
test(core): fix flaky easing-up log assertion in RssMemoryLimitTest

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -82,7 +82,9 @@ import static io.questdb.tasks.TableWriterTask.CMD_ALTER_TABLE;
 import static io.questdb.tasks.TableWriterTask.CMD_UPDATE_TABLE;
 
 public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificationTask> implements Closeable {
-    private static final Log LOG = LogFactory.getLog(ApplyWal2TableJob.class);
+    // this field is modified via reflection from tests, via LogFactory.enableGuaranteedLogging
+    @SuppressWarnings("FieldMayBeFinal")
+    private static Log LOG = LogFactory.getLog(ApplyWal2TableJob.class);
     private final BlockFileWriter blockFileWriter;
     private final CairoConfiguration config;
     private final CairoEngine engine;

--- a/core/src/test/java/io/questdb/test/cairo/RssMemoryLimitTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/RssMemoryLimitTest.java
@@ -27,6 +27,7 @@ package io.questdb.test.cairo;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.TableToken;
+import io.questdb.cairo.wal.ApplyWal2TableJob;
 import io.questdb.griffin.engine.QueryProgress;
 import io.questdb.log.LogFactory;
 import io.questdb.std.MemoryTag;
@@ -47,7 +48,7 @@ public class RssMemoryLimitTest extends AbstractCairoTest {
 
     @Override
     public void setUp() {
-        LogFactory.enableGuaranteedLogging(QueryProgress.class);
+        LogFactory.enableGuaranteedLogging(QueryProgress.class, ApplyWal2TableJob.class);
         super.setUp();
         capture.start();
     }
@@ -56,7 +57,7 @@ public class RssMemoryLimitTest extends AbstractCairoTest {
     public void tearDown() throws Exception {
         capture.stop();
         super.tearDown();
-        LogFactory.disableGuaranteedLogging(QueryProgress.class);
+        LogFactory.disableGuaranteedLogging(QueryProgress.class, ApplyWal2TableJob.class);
     }
 
     @Test


### PR DESCRIPTION
`RssMemoryLimitTest.testLargeTxEventuallySucceeds` intermittently times out,
mostly on the slower Windows and Mac CI jobs, at:

```
capture.waitForRegex("table writing memory pressure is easing up \\[table=");
```

## Root cause

The assertion waits for an INFO line emitted by `ApplyWal2TableJob`, but that
logger is non-guaranteed. QuestDB's async logger discards a record when the ring
buffer is full: `Logger.next()` receives a negative cursor from `seq.next()` and
returns `NullLogRecord`, dropping the message. A guaranteed logger instead calls
`seq.nextBully()`, which blocks until a slot frees.

During the test, each WAL apply merges a 500k-row transaction into ~366 daily
partitions and emits a burst of per-partition `TableWriter` records into the
shared log buffer. The apply job logs the "easing up" line immediately behind
that burst; while the consumer is still draining the burst the buffer stays
full, so the line is dropped and the wait never completes. The "job finished"
line emitted just before it disappears for the same reason. The memory-pressure
recovery itself behaves correctly in the failing runs — the data is applied, the
count matches, and the table is never suspended — only the log line the test
waits on is lost.

The test already marks `QueryProgress` as guaranteed, which is why the
count-query assertions never flake, but it did not mark the apply job.

## Change

- `RssMemoryLimitTest` adds `ApplyWal2TableJob.class` to the
  `enableGuaranteedLogging` / `disableGuaranteedLogging` set, so the apply job's
  producer blocks for a buffer slot instead of dropping the record.
- `ApplyWal2TableJob.LOG` becomes non-final. `LogFactory.setLogger` installs the
  guaranteed logger by setting the static `LOG` field via reflection, which is
  not reliable on a final field. `QueryProgress.LOG` is non-final for the same
  reason.

## Tradeoffs

- Production behavior is unchanged: the `LOG` field is only swapped by test
  setup, never at runtime.
- The fix covers only the line the test asserts on. The high-volume
  `TableWriter` records stay non-guaranteed and can still be dropped under buffer
  pressure; this PR does not change that.
- Guaranteed logging lets the apply job's producer block on a full buffer. The
  number of `ApplyWal2TableJob` records is small, so the added latency stays
  within the test.
- `ApplyWal2TableJob.LOG` is now a mutable static field rather than a constant.

## Test plan

- Run `RssMemoryLimitTest` on the Linux, Windows, and Mac CI jobs.
- Confirm `testLargeTxEventuallySucceeds` passes, including repeated runs on the
  Windows and Mac jobs where it previously flaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
