### PR TITLE
fix(sql): reject views and materialized views in SHOW CREATE TABLE

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParserCallback.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParserCallback.java
@@ -52,15 +52,21 @@ public interface SqlParserCallback {
                 SqlException.matViewDoesNotExist(tableNameExpr.position, tableNameExpr.token)
         );
         if (!viewToken.isMatView()) {
-            throw SqlException.$(tableNameExpr.position, "materialized view name expected, got table name");
+            throw SqlException.$(tableNameExpr.position, viewToken.isView()
+                    ? "materialized view name expected, got view name"
+                    : "materialized view name expected, got table name");
         }
         return viewToken;
     }
 
-    static TableToken getTableToken(ExpressionNode tableNameExpr, SqlExecutionContext executionContext, Path path) throws SqlException {
-        return getTableToken(tableNameExpr, executionContext, path,
+    static @NotNull TableToken getTableToken(ExpressionNode tableNameExpr, SqlExecutionContext executionContext, Path path) throws SqlException {
+        final TableToken tableToken = getTableToken(tableNameExpr, executionContext, path,
                 SqlException.tableDoesNotExist(tableNameExpr.position, tableNameExpr.token)
         );
+        if (tableToken.isMatView() || tableToken.isView()) {
+            throw SqlException.$(tableNameExpr.position, "table name expected, got view or materialized view name");
+        }
+        return tableToken;
     }
 
     static @NotNull TableToken getViewToken(ExpressionNode tableNameExpr, SqlExecutionContext executionContext, Path path) throws SqlException {
@@ -68,7 +74,9 @@ public interface SqlParserCallback {
                 SqlException.viewDoesNotExist(tableNameExpr.position, tableNameExpr.token)
         );
         if (!viewToken.isView()) {
-            throw SqlException.$(tableNameExpr.position, "view name expected, got table name");
+            throw SqlException.$(tableNameExpr.position, viewToken.isMatView()
+                    ? "view name expected, got materialized view name"
+                    : "view name expected, got table name");
         }
         return viewToken;
     }

--- a/core/src/main/java/io/questdb/griffin/engine/table/ShowCreateTableRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/ShowCreateTableRecordCursorFactory.java
@@ -186,6 +186,9 @@ public class ShowCreateTableRecordCursorFactory extends AbstractRecordCursorFact
                     throw TableReferenceOutOfDateException.of(this.tableToken);
                 }
             }
+            // SHOW CREATE TABLE rejects views and materialized views during parsing
+            // (see SqlParserCallback.getTableToken); guard against any future caller that bypasses it.
+            assert !tableToken.isView() && !tableToken.isMatView();
 
             toTop();
             return this;

--- a/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
@@ -2169,6 +2169,20 @@ public class CreateMatViewTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testShowCreateMatViewFailView() throws Exception {
+        assertMemoryLeak(() -> {
+            createTable(TABLE1);
+            execute("create view " + VIEW1 + " as (select ts, avg(v) as v from " + TABLE1 + " sample by 1m)");
+            drainWalAndViewQueues();
+            assertExceptionNoLeakCheck(
+                    "show create materialized view " + VIEW1,
+                    30,
+                    "materialized view name expected, got view name"
+            );
+        });
+    }
+
+    @Test
     public void testShowCreatePeriodMatView() throws Exception {
         final String query = "select ts, v+v doubleV, avg(v) from " + TABLE1 + " sample by 30s";
         final DdlSerializationTest[] tests = new DdlSerializationTest[]{

--- a/core/src/test/java/io/questdb/test/cairo/view/ViewsFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/view/ViewsFunctionTest.java
@@ -103,6 +103,19 @@ public class ViewsFunctionTest extends AbstractViewTest {
     }
 
     @Test
+    public void testShowCreateViewFailMatView() throws Exception {
+        assertMemoryLeak(() -> {
+            createTable(TABLE1);
+            createMatView("test_mv", "select ts, k, avg(v) from " + TABLE1 + " sample by 30s");
+            assertExceptionNoLeakCheck(
+                    "show create view test_mv",
+                    17,
+                    "view name expected, got materialized view name"
+            );
+        });
+    }
+
+    @Test
     public void testViewsConsistentWithMatViewsAndTablesCommands() throws Exception {
         assertMemoryLeak(() -> {
             setCurrentMicros(1750345200000000L);

--- a/core/src/test/java/io/questdb/test/griffin/ShowCreateTableTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ShowCreateTableTest.java
@@ -194,6 +194,73 @@ public class ShowCreateTableTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testMatViewRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base (ts timestamp, v double) timestamp(ts) partition by day wal");
+            execute("create materialized view base_1h as (select ts, max(v) from base sample by 1h) partition by week");
+            drainWalAndViewQueues();
+            assertExceptionNoLeakCheck(
+                    "show create table base_1h",
+                    18,
+                    "table name expected, got view or materialized view name"
+            );
+        });
+    }
+
+    @Test
+    public void testMatViewRejectedCaseInsensitive() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base (ts timestamp, v double) timestamp(ts) partition by day wal");
+            execute("create materialized view base_1h as (select ts, max(v) from base sample by 1h) partition by week");
+            drainWalAndViewQueues();
+            // the keyword casing must not change the outcome - the position still points at the name
+            assertExceptionNoLeakCheck(
+                    "ShOw CrEaTe TaBlE base_1h",
+                    18,
+                    "table name expected, got view or materialized view name"
+            );
+        });
+    }
+
+    @Test
+    public void testMatViewRejectedQuotedName() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base (ts timestamp, v double) timestamp(ts) partition by day wal");
+            execute("create materialized view 'base 1h' as (select ts, max(v) from base sample by 1h) partition by week");
+            drainWalAndViewQueues();
+            // the position points at the opening quote of the quoted identifier
+            assertExceptionNoLeakCheck(
+                    "show create table 'base 1h'",
+                    18,
+                    "table name expected, got view or materialized view name"
+            );
+        });
+    }
+
+    @Test
+    public void testMatViewStillAccessibleViaShowCreateMatView() throws Exception {
+        // a materialized view rejected by SHOW CREATE TABLE must remain reachable via the dedicated statement
+        assertMemoryLeak(() -> {
+            execute("create table base (ts timestamp, v double) timestamp(ts) partition by day wal");
+            execute("create materialized view base_1h as (select ts, max(v) from base sample by 1h) partition by week");
+            drainWalAndViewQueues();
+            printSql("show create materialized view base_1h");
+            TestUtils.assertContains(sink.toString(), "CREATE MATERIALIZED VIEW 'base_1h'");
+        });
+    }
+
+    @Test
+    public void testMissingNameReportsDoesNotExist() throws Exception {
+        // the existence check must run before the view/matview check, so an unknown
+        // name reports "does not exist" rather than the "got view" message
+        assertMemoryLeak(() -> assertExceptionNoLeakCheck(
+                "show create table nope",
+                18,
+                "table does not exist"
+        ));
+    }
+
+    @Test
     public void testMinimalDdl() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table foo (ts timestamp)");
@@ -686,6 +753,46 @@ public class ShowCreateTableTest extends AbstractCairoTest {
                             \tts TIMESTAMP
                             ) timestamp(ts) PARTITION BY HOUR TTL 2 YEARS BYPASS WAL;
                             """);
+        });
+    }
+
+    @Test
+    public void testViewRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base (ts timestamp, v double) timestamp(ts) partition by day wal");
+            execute("create view base_view as (select ts, max(v) from base sample by 1h)");
+            drainWalAndViewQueues();
+            assertExceptionNoLeakCheck(
+                    "show create table base_view",
+                    18,
+                    "table name expected, got view or materialized view name"
+            );
+        });
+    }
+
+    @Test
+    public void testViewRejectedQuotedName() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base (ts timestamp, v double) timestamp(ts) partition by day wal");
+            execute("create view 'base view' as (select ts, max(v) from base sample by 1h)");
+            drainWalAndViewQueues();
+            assertExceptionNoLeakCheck(
+                    "show create table 'base view'",
+                    18,
+                    "table name expected, got view or materialized view name"
+            );
+        });
+    }
+
+    @Test
+    public void testViewStillAccessibleViaShowCreateView() throws Exception {
+        // a view rejected by SHOW CREATE TABLE must remain reachable via the dedicated statement
+        assertMemoryLeak(() -> {
+            execute("create table base (ts timestamp, v double) timestamp(ts) partition by day wal");
+            execute("create view base_view as (select ts, max(v) from base sample by 1h)");
+            drainWalAndViewQueues();
+            printSql("show create view base_view");
+            TestUtils.assertContains(sink.toString(), "CREATE VIEW 'base_view'");
         });
     }
 


### PR DESCRIPTION
## What

`SHOW CREATE TABLE <name>` resolved any object kind and rendered a `CREATE TABLE` statement for it. Run against a view or materialized view, it produced misleading DDL: the output looked like a table definition, and executing it would have created a plain table rather than the view. The dedicated `SHOW CREATE VIEW` / `SHOW CREATE MATERIALIZED VIEW` statements already rejected the wrong object kind; the plain-table path did not.

This change makes `SHOW CREATE TABLE` reject views and materialized views.

## Changes

- **`SqlParserCallback.getTableToken`** now throws `table name expected, got view or materialized view name` (pointing at the name) when the resolved token is a view or materialized view. Both the OSS and Enterprise compile paths call this shared helper, so both are covered. The existing "table does not exist" check still runs first, so an unknown name continues to report that rather than the new message.
- **Sibling guards tightened for symmetry.** Previously `SHOW CREATE VIEW <matview>` and `SHOW CREATE MATERIALIZED VIEW <view>` both reported the generic "got table name". They now report "got materialized view name" and "got view name" respectively, so the error names the actual object kind.
- **Defensive assertion** in `ShowCreateTableRecordCursorFactory.ShowCreateTableCursor.of()`: if a view/matview token ever reaches the factory through a future caller that bypasses the parser guard, it fails fast instead of rendering bogus DDL. This is unreachable today (grep confirms the only two construction sites both go through `getTableToken`).

## Behavior change / compatibility

This is a user-visible behavior change: `SHOW CREATE TABLE <view>` previously returned a (misleading) result and now errors. Anyone who relied on the old output should use `SHOW CREATE VIEW` / `SHOW CREATE MATERIALIZED VIEW`. No existing test depended on the old behavior.

## Test plan

- New tests in `ShowCreateTableTest`: matview and view rejection (plain, quoted, and mixed-case identifiers), an explicit check that a non-existent name still reports "table does not exist", and two regression guards confirming the views remain reachable via their dedicated statements.
- New `ViewsFunctionTest.testShowCreateViewFailMatView` and `CreateMatViewTest.testShowCreateMatViewFailView` cover the tightened sibling messages.
- Full `ShowCreateTableTest` passes (45 tests), as does the Enterprise subclass which inherits these tests against the Enterprise compiler path (51 tests).