### PR TITLE
fix(sql): fix UNION ALL column mismatch under aggregates

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -198,6 +198,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final String cairoSqlCopyRoot;
     private final String cairoSqlCopyWorkRoot;
     private final boolean cairoSqlLegacyOperatorPrecedence;
+    private final boolean cairoSqlLegacyUnionColumnPropagation;
     private final long cairoTableRegistryAutoReloadFrequency;
     private final int cairoTableRegistryCompactionThreshold;
     private final int cairoUnorderedPageFrameReduceQueueCapacity;
@@ -1828,6 +1829,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                 );
             }
             this.cairoSqlLegacyOperatorPrecedence = getBoolean(properties, env, PropertyKey.CAIRO_SQL_LEGACY_OPERATOR_PRECEDENCE, false);
+            this.cairoSqlLegacyUnionColumnPropagation = getBoolean(properties, env, PropertyKey.CAIRO_SQL_LEGACY_UNION_COLUMN_PROPAGATION, false);
             this.sqlWindowInitialRangeBufferSize = getInt(properties, env, PropertyKey.CAIRO_SQL_ANALYTIC_INITIAL_RANGE_BUFFER_SIZE, 32);
             this.sqlTxnScoreboardEntryCount = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_O3_TXN_SCOREBOARD_ENTRY_COUNT, 16384));
             this.latestByQueueCapacity = Numbers.ceilPow2(getInt(properties, env, PropertyKey.CAIRO_LATEST_ON_QUEUE_CAPACITY, 32));
@@ -5108,6 +5110,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean isCairoMetadataCacheSnapshotOrdered() {
             return cairoMetadataCacheSnapshotOrdered;
+        }
+
+        @Override
+        public boolean isCairoSqlLegacyUnionColumnPropagation() {
+            return cairoSqlLegacyUnionColumnPropagation;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -269,6 +269,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     CAIRO_SQL_INTERVAL_MAX_INTERVALS_AFTER_MERGE("cairo.sql.interval.max.intervals.after.merge"),
     CAIRO_SQL_INTERVAL_INCREMENTAL_MERGE_THRESHOLD("cairo.sql.interval.incremental.merge.threshold"),
     CAIRO_SQL_LEGACY_OPERATOR_PRECEDENCE("cairo.sql.legacy.operator.precedence"),
+    CAIRO_SQL_LEGACY_UNION_COLUMN_PROPAGATION("cairo.sql.legacy.union.column.propagation"),
     CAIRO_O3_TXN_SCOREBOARD_ENTRY_COUNT("cairo.o3.txn.scoreboard.entry.count"),
     CAIRO_LATEST_ON_QUEUE_CAPACITY("cairo.latestby.queue.capacity"),
     CAIRO_O3_PARTITION_PURGE_LIST_INITIAL_CAPACITY("cairo.o3.partition.purge.list.initial.capacity"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -950,6 +950,18 @@ public interface CairoConfiguration {
     boolean isCairoMetadataCacheSnapshotOrdered();
 
     /**
+     * Rollback flag for the by-name column emit to UNION siblings in the SQL optimizer's top-down
+     * column propagation. The optimizer matches UNION columns by position; the legacy by-name emit
+     * could prune one branch inconsistently and crash code generation when branch aliases differed.
+     * When {@code true}, restores the legacy by-name behavior. Defaults to {@code false}.
+     *
+     * @return whether to restore the legacy by-name UNION column propagation
+     */
+    default boolean isCairoSqlLegacyUnionColumnPropagation() {
+        return false;
+    }
+
+    /**
      * A flag to enable/disable checkpoint recovery mechanism. Defaults to {@code true}.
      *
      * @return enable/disable flag for recovering from the checkpoint

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -1538,6 +1538,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public boolean isCairoSqlLegacyUnionColumnPropagation() {
+        return getDelegate().isCairoSqlLegacyUnionColumnPropagation();
+    }
+
+    @Override
     public boolean isCheckpointRecoveryEnabled() {
         return getDelegate().isCheckpointRecoveryEnabled();
     }

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -6138,15 +6138,22 @@ public class SqlOptimiser implements Mutable {
         final boolean nestedAllowsColumnChange = nested != null && nested.allowsColumnsChange()
                 && model.allowsNestedColumnsChange();
 
-        // Don't emit this model's columns to its UNION sibling by name. In UNION, columns are
-        // matched by position, not name. A branch's column expressions reference its own source
-        // names (e.g. "SELECT close price ..." references "close"), which generally don't match
-        // the sibling's projection aliases (e.g. "price"), so only the accidentally-equal names
-        // resolve. When the outer query selects nothing from the union (e.g. count()/sum()), this
-        // used to prune just the immediate sibling down to those few matching names while leaving
-        // the other branches intact, so the union sides diverged in column count and code
-        // generation hit an assertion. The indexed propagation below (the loop over
-        // unionColumnIndexes) handles cross-branch propagation correctly, by position.
+        // By default, don't emit this model's columns to its UNION sibling by name. In UNION,
+        // columns are matched by position, not name. A branch's column expressions reference its
+        // own source names (e.g. "SELECT close price ..." references "close"), which generally
+        // don't match the sibling's projection aliases (e.g. "price"), so only the
+        // accidentally-equal names resolve. When the outer query selects nothing from the union
+        // (e.g. count()/sum()), this used to prune just the immediate sibling down to those few
+        // matching names while leaving the other branches intact, so the union sides diverged in
+        // column count and code generation hit an assertion. The indexed propagation below (the
+        // loop over unionColumnIndexes) handles cross-branch propagation correctly, by position.
+        // The cairo.sql.legacy.union.column.propagation flag restores the old by-name emit.
+        if (configuration.isCairoSqlLegacyUnionColumnPropagation()) {
+            final IQueryModel union = skipNoneTypeModels(model.getUnionModel());
+            if (!topLevel && modelIsFlex(union)) {
+                emitColumnLiteralsTopDown(model.getColumns(), union);
+            }
+        }
 
         // process join models and their join conditions
         final ObjList<IQueryModel> joinModels = model.getJoinModels();

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -6138,10 +6138,15 @@ public class SqlOptimiser implements Mutable {
         final boolean nestedAllowsColumnChange = nested != null && nested.allowsColumnsChange()
                 && model.allowsNestedColumnsChange();
 
-        final IQueryModel union = skipNoneTypeModels(model.getUnionModel());
-        if (!topLevel && modelIsFlex(union)) {
-            emitColumnLiteralsTopDown(model.getColumns(), union);
-        }
+        // Don't emit this model's columns to its UNION sibling by name. In UNION, columns are
+        // matched by position, not name. A branch's column expressions reference its own source
+        // names (e.g. "SELECT close price ..." references "close"), which generally don't match
+        // the sibling's projection aliases (e.g. "price"), so only the accidentally-equal names
+        // resolve. When the outer query selects nothing from the union (e.g. count()/sum()), this
+        // used to prune just the immediate sibling down to those few matching names while leaving
+        // the other branches intact, so the union sides diverged in column count and code
+        // generation hit an assertion. The indexed propagation below (the loop over
+        // unionColumnIndexes) handles cross-branch propagation correctly, by position.
 
         // process join models and their join conditions
         final ObjList<IQueryModel> joinModels = model.getJoinModels();

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -703,6 +703,7 @@ public class ServerMainTest extends AbstractBootstrapTest {
                                     "cairo.sql.window.tree.max.bytes\tQDB_CAIRO_SQL_WINDOW_TREE_MAX_BYTES\t9223372036854775807\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.window.tree.max.pages\tQDB_CAIRO_SQL_WINDOW_TREE_MAX_PAGES\t2147483647\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.legacy.operator.precedence\tQDB_CAIRO_SQL_LEGACY_OPERATOR_PRECEDENCE\tfalse\tdefault\tfalse\tfalse\n" +
+                                    "cairo.sql.legacy.union.column.propagation\tQDB_CAIRO_SQL_LEGACY_UNION_COLUMN_PROPAGATION\tfalse\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.window.tree.page.size\tQDB_CAIRO_SQL_WINDOW_TREE_PAGE_SIZE\t524288\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.with.clause.model.pool.capacity\tQDB_CAIRO_SQL_WITH_CLAUSE_MODEL_POOL_CAPACITY\t128\tdefault\tfalse\tfalse\n" +
                                     "cairo.sql.orderby.sort.enabled\tQDB_CAIRO_SQL_ORDERBY_SORT_ENABLED\ttrue\tdefault\tfalse\tfalse\n" +

--- a/core/src/test/java/io/questdb/test/cairo/view/ViewQueryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/view/ViewQueryTest.java
@@ -46,9 +46,9 @@ public class ViewQueryTest extends AbstractViewTest {
                             ") timestamp(timestamp) PARTITION BY DAY WAL " +
                             "DEDUP UPSERT KEYS(timestamp,tvId)"
             );
-            for (String t : new String[]{"crypto_price_1m", "forex_price_1m", "commodity_price_1m"}) {
-                execute("CREATE TABLE '" + t + "' (LIKE equity_price_1m)");
-            }
+            execute("CREATE TABLE 'crypto_price_1m' (LIKE equity_price_1m)");
+            execute("CREATE TABLE 'forex_price_1m' (LIKE equity_price_1m)");
+            execute("CREATE TABLE 'commodity_price_1m' (LIKE equity_price_1m)");
             // equity: A -> latest close 11, B -> 20  (2 rows after LATEST ON)
             execute("INSERT INTO equity_price_1m(timestamp, tvId, close) VALUES " +
                     "('2024-01-01T00:00:01.000000Z', 'A', 10.0), " +

--- a/core/src/test/java/io/questdb/test/cairo/view/ViewQueryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/view/ViewQueryTest.java
@@ -29,6 +29,73 @@ import org.junit.Test;
 public class ViewQueryTest extends AbstractViewTest {
 
     @Test
+    public void testAggregateOverUnionAllOfLatestOnView() throws Exception {
+        // Regression test: count()/sum() over a VIEW defined as a UNION ALL of LATEST ON
+        // sub-queries used to crash with an AssertionError in SqlCodeGenerator
+        // (presenting as a 500 in the web console). Top-down column pruning over the
+        // union chain pruned one branch down to just the LATEST ON partition key while
+        // leaving the others with all projected columns, so the union sides diverged in
+        // column count.
+        assertMemoryLeak(() -> {
+            for (String t : new String[]{"equity_price_1m", "crypto_price_1m", "forex_price_1m", "commodity_price_1m"}) {
+                execute(
+                        "CREATE TABLE '" + t + "' (" +
+                                "timestamp TIMESTAMP, " +
+                                "tvId SYMBOL INDEX CAPACITY 256, " +
+                                "symbol SYMBOL INDEX CAPACITY 256, " +
+                                "open DOUBLE, high DOUBLE, low DOUBLE, close DOUBLE, volume DOUBLE" +
+                                ") timestamp(timestamp) PARTITION BY DAY WAL " +
+                                "DEDUP UPSERT KEYS(timestamp,tvId)"
+                );
+            }
+            // equity: A -> latest close 11, B -> 20  (2 rows after LATEST ON)
+            execute("INSERT INTO equity_price_1m(timestamp, tvId, close) VALUES " +
+                    "('2024-01-01T00:00:01.000000Z', 'A', 10.0), " +
+                    "('2024-01-01T00:00:02.000000Z', 'A', 11.0), " +
+                    "('2024-01-01T00:00:01.000000Z', 'B', 20.0)");
+            // crypto: C -> 30  (1 row)
+            execute("INSERT INTO crypto_price_1m(timestamp, tvId, close) VALUES ('2024-01-01T00:00:01.000000Z', 'C', 30.0)");
+            // forex: D -> latest close 41  (1 row)
+            execute("INSERT INTO forex_price_1m(timestamp, tvId, close) VALUES " +
+                    "('2024-01-01T00:00:01.000000Z', 'D', 40.0), " +
+                    "('2024-01-01T00:00:02.000000Z', 'D', 41.0)");
+            // commodity: E -> 50  (1 row)
+            execute("INSERT INTO commodity_price_1m(timestamp, tvId, close) VALUES ('2024-01-01T00:00:01.000000Z', 'E', 50.0)");
+            drainWalQueue();
+
+            final String query1 = "SELECT tvId, close price, timestamp mts FROM equity_price_1m LATEST ON timestamp PARTITION BY tvId " +
+                    "UNION ALL " +
+                    "SELECT tvId, close price, timestamp mts FROM crypto_price_1m LATEST ON timestamp PARTITION BY tvId " +
+                    "UNION ALL " +
+                    "SELECT tvId, close price, timestamp mts FROM forex_price_1m LATEST ON timestamp PARTITION BY tvId " +
+                    "UNION ALL " +
+                    "SELECT tvId, close price, timestamp mts FROM commodity_price_1m LATEST ON timestamp PARTITION BY tvId";
+            execute("CREATE VIEW latest_prices AS (" + query1 + ")");
+            drainWalAndViewQueues();
+
+            // 2 + 1 + 1 + 1 = 5 rows
+            assertQuery("select count() from latest_prices")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("""
+                            count
+                            5
+                            """);
+
+            // 11 + 20 + 30 + 41 + 50 = 152
+            assertQuery("select sum(price) from latest_prices")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("""
+                            sum
+                            152.0
+                            """);
+        });
+    }
+
+    @Test
     public void testCreateConstantView() throws Exception {
         assertMemoryLeak(() -> {
             final String query1 = "select 42 as col";

--- a/core/src/test/java/io/questdb/test/cairo/view/ViewQueryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/view/ViewQueryTest.java
@@ -37,16 +37,17 @@ public class ViewQueryTest extends AbstractViewTest {
         // leaving the others with all projected columns, so the union sides diverged in
         // column count.
         assertMemoryLeak(() -> {
-            for (String t : new String[]{"equity_price_1m", "crypto_price_1m", "forex_price_1m", "commodity_price_1m"}) {
-                execute(
-                        "CREATE TABLE '" + t + "' (" +
-                                "timestamp TIMESTAMP, " +
-                                "tvId SYMBOL INDEX CAPACITY 256, " +
-                                "symbol SYMBOL INDEX CAPACITY 256, " +
-                                "open DOUBLE, high DOUBLE, low DOUBLE, close DOUBLE, volume DOUBLE" +
-                                ") timestamp(timestamp) PARTITION BY DAY WAL " +
-                                "DEDUP UPSERT KEYS(timestamp,tvId)"
-                );
+            execute(
+                    "CREATE TABLE 'equity_price_1m' (" +
+                            "timestamp TIMESTAMP, " +
+                            "tvId SYMBOL INDEX CAPACITY 256, " +
+                            "symbol SYMBOL INDEX CAPACITY 256, " +
+                            "open DOUBLE, high DOUBLE, low DOUBLE, close DOUBLE, volume DOUBLE" +
+                            ") timestamp(timestamp) PARTITION BY DAY WAL " +
+                            "DEDUP UPSERT KEYS(timestamp,tvId)"
+            );
+            for (String t : new String[]{"crypto_price_1m", "forex_price_1m", "commodity_price_1m"}) {
+                execute("CREATE TABLE '" + t + "' (LIKE equity_price_1m)");
             }
             // equity: A -> latest close 11, B -> 20  (2 rows after LATEST ON)
             execute("INSERT INTO equity_price_1m(timestamp, tvId, close) VALUES " +

--- a/core/src/test/java/io/questdb/test/griffin/UnionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/UnionTest.java
@@ -38,24 +38,30 @@ public class UnionTest extends AbstractCairoTest {
     @Test
     public void testAggregateOverUnionAllLegacyFlagReintroducesCrash() throws Exception {
         // The cairo.sql.legacy.union.column.propagation flag restores the pre-fix by-name emit,
-        // which reintroduces the column-count divergence so the otherwise-fixed query fails again.
-        // Guards the rollback switch against silently becoming a no-op.
+        // which reintroduces the column-count divergence so the otherwise-fixed query fails again
+        // with an AssertionError during code generation. Guards the rollback switch against
+        // silently becoming a no-op. Reset the flag in finally so it cannot leak into other tests
+        // in this class (overrides are otherwise only cleared at @AfterClass).
         setProperty(PropertyKey.CAIRO_SQL_LEGACY_UNION_COLUMN_PROPAGATION, "true");
-        assertMemoryLeak(() -> {
-            execute("create table u1 (a symbol, close double)");
-            execute("create table u2 (a symbol, close double)");
-            execute("insert into u1 values ('x', 1.0), ('y', 2.0)");
-            execute("insert into u2 values ('z', 3.0)");
+        try {
+            assertMemoryLeak(() -> {
+                execute("create table u1 (a symbol, close double)");
+                execute("create table u2 (a symbol, close double)");
+                execute("insert into u1 values ('x', 1.0), ('y', 2.0)");
+                execute("insert into u2 values ('z', 3.0)");
 
-            final String unionSql = "select a, close price from u1 union all select a, close price from u2";
-            boolean threw = false;
-            try (RecordCursorFactory ignored = select("select count() from (" + unionSql + ")")) {
-                // unreachable: the legacy by-name emit diverges the branch column counts
-            } catch (AssertionError | Exception e) {
-                threw = true;
-            }
-            Assert.assertTrue("legacy flag should restore the by-name emit and reintroduce the crash", threw);
-        });
+                final String unionSql = "select a, close price from u1 union all select a, close price from u2";
+                boolean threw = false;
+                try (RecordCursorFactory ignored = select("select count() from (" + unionSql + ")")) {
+                    // unreachable: the legacy by-name emit diverges the branch column counts
+                } catch (AssertionError e) {
+                    threw = true;
+                }
+                Assert.assertTrue("legacy flag should restore the by-name emit and reintroduce the crash", threw);
+            });
+        } finally {
+            setProperty(PropertyKey.CAIRO_SQL_LEGACY_UNION_COLUMN_PROPAGATION, "false");
+        }
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/UnionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/UnionTest.java
@@ -24,14 +24,39 @@
 
 package io.questdb.test.griffin;
 
+import io.questdb.PropertyKey;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.griffin.engine.functions.rnd.SharedRandom;
 import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
 
 public class UnionTest extends AbstractCairoTest {
+
+    @Test
+    public void testAggregateOverUnionAllLegacyFlagReintroducesCrash() throws Exception {
+        // The cairo.sql.legacy.union.column.propagation flag restores the pre-fix by-name emit,
+        // which reintroduces the column-count divergence so the otherwise-fixed query fails again.
+        // Guards the rollback switch against silently becoming a no-op.
+        setProperty(PropertyKey.CAIRO_SQL_LEGACY_UNION_COLUMN_PROPAGATION, "true");
+        assertMemoryLeak(() -> {
+            execute("create table u1 (a symbol, close double)");
+            execute("create table u2 (a symbol, close double)");
+            execute("insert into u1 values ('x', 1.0), ('y', 2.0)");
+            execute("insert into u2 values ('z', 3.0)");
+
+            final String unionSql = "select a, close price from u1 union all select a, close price from u2";
+            boolean threw = false;
+            try (RecordCursorFactory ignored = select("select count() from (" + unionSql + ")")) {
+                // unreachable: the legacy by-name emit diverges the branch column counts
+            } catch (AssertionError | Exception e) {
+                threw = true;
+            }
+            Assert.assertTrue("legacy flag should restore the by-name emit and reintroduce the crash", threw);
+        });
+    }
 
     @Test
     public void testAggregateOverUnionAllOfLatestOn() throws Exception {

--- a/core/src/test/java/io/questdb/test/griffin/UnionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/UnionTest.java
@@ -34,6 +34,103 @@ import java.util.Arrays;
 public class UnionTest extends AbstractCairoTest {
 
     @Test
+    public void testAggregateOverUnionAllOfLatestOn() throws Exception {
+        // Regression test: an aggregate (count/sum) over a UNION ALL of LATEST ON
+        // sub-queries used to crash with an AssertionError in SqlCodeGenerator
+        // (columnCount == metadataB.getColumnCount()). Top-down column pruning over
+        // the union chain pruned one branch down to just the LATEST ON partition key
+        // while leaving the others with all projected columns, so the union sides
+        // diverged in column count. Not specific to count() - any aggregate that
+        // prunes the projection triggers it.
+        assertMemoryLeak(() -> {
+            for (int i = 1; i <= 4; i++) {
+                execute("create table t" + i + " (tvId symbol, close double, timestamp timestamp) timestamp(timestamp) partition by day wal");
+            }
+            // t1: A -> latest close 11, B -> 20  (2 rows after LATEST ON)
+            execute("insert into t1 values " +
+                    "('A', 10.0, '2024-01-01T00:00:01.000000Z'), " +
+                    "('A', 11.0, '2024-01-01T00:00:02.000000Z'), " +
+                    "('B', 20.0, '2024-01-01T00:00:01.000000Z')");
+            // t2: C -> 30  (1 row)
+            execute("insert into t2 values ('C', 30.0, '2024-01-01T00:00:01.000000Z')");
+            // t3: D -> latest close 41  (1 row)
+            execute("insert into t3 values " +
+                    "('D', 40.0, '2024-01-01T00:00:01.000000Z'), " +
+                    "('D', 41.0, '2024-01-01T00:00:02.000000Z')");
+            // t4: E -> 50  (1 row)
+            execute("insert into t4 values ('E', 50.0, '2024-01-01T00:00:01.000000Z')");
+            drainWalQueue();
+
+            final String unionSql =
+                    "SELECT tvId, close price, timestamp mts FROM t1 LATEST ON timestamp PARTITION BY tvId " +
+                            "UNION ALL " +
+                            "SELECT tvId, close price, timestamp mts FROM t2 LATEST ON timestamp PARTITION BY tvId " +
+                            "UNION ALL " +
+                            "SELECT tvId, close price, timestamp mts FROM t3 LATEST ON timestamp PARTITION BY tvId " +
+                            "UNION ALL " +
+                            "SELECT tvId, close price, timestamp mts FROM t4 LATEST ON timestamp PARTITION BY tvId";
+
+            // 2 + 1 + 1 + 1 = 5 rows
+            assertQuery("select count() from (" + unionSql + ")")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("""
+                            count
+                            5
+                            """);
+            // 11 + 20 + 30 + 41 + 50 = 152
+            assertQuery("select sum(price) from (" + unionSql + ")")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("""
+                            sum
+                            152.0
+                            """);
+        });
+    }
+
+    @Test
+    public void testAggregateOverUnionAllWithAliasMismatch() throws Exception {
+        // Minimal root-cause regression test: the crash is driven by alias divergence between
+        // UNION ALL branches, not by LATEST ON (which only forces the CHOOSE-wrapper structure).
+        // Here one column is aliased (close -> price) and one is not (a). The old by-name emit
+        // matched only the same-named column (a) into the sibling, pruning it to 1 column while
+        // the head kept 2, so the union sides diverged in column count under count()/sum().
+        assertMemoryLeak(() -> {
+            execute("create table u1 (a symbol, close double)");
+            execute("create table u2 (a symbol, close double)");
+            execute("insert into u1 values ('x', 1.0), ('y', 2.0)");
+            execute("insert into u2 values ('z', 3.0)");
+
+            final String unionSql =
+                    "select a, close price from u1 " +
+                            "union all " +
+                            "select a, close price from u2";
+
+            // 2 + 1 = 3 rows
+            assertQuery("select count() from (" + unionSql + ")")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("""
+                            count
+                            3
+                            """);
+            // 1 + 2 + 3 = 6
+            assertQuery("select sum(price) from (" + unionSql + ")")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("""
+                            sum
+                            6.0
+                            """);
+        });
+    }
+
+    @Test
     public void testExcept() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table events2 (contact symbol, groupid symbol, eventid string)");


### PR DESCRIPTION
## Problem

An aggregate (`count()`, `sum()`, ...) over a `UNION ALL` of aliased sub-queries crashed query compilation with an `AssertionError`, which surfaced as a 500 in the web console and a "failure when getting column type" error. Minimal reproducer:

```sql
select count() from (
    select a, close price from u1
    union all
    select a, close price from u2
);
```

It was originally reported through a view built as a `UNION ALL` of `LATEST ON` sub-queries, but `LATEST ON` is incidental — it only forces the per-branch CHOOSE-wrapper structure that keeps the projection aliases distinct.

## Root cause

`SqlOptimiser.propagateTopDownColumns0()` emitted a model's columns to its `UNION` sibling by name. The optimizer's column-propagation machinery resolves literals against the target's alias map, so across a `UNION` boundary it only matches columns whose source name happens to equal the sibling's alias. The emit also fires only for the union head at non-top-level, so it reaches just the head's immediate sibling.

When the outer query selects nothing from the union (an aggregate), this pruned that one branch down to the few matching-by-name columns while leaving the other branches intact. The branches then disagreed on column count, and `SqlCodeGenerator.checkIfSetCastIsRequired()` tripped its `columnCount == metadataB.getColumnCount()` assertion.

## Fix

`UNION` columns are matched by position, not name. The indexed, by-position propagation added in #6744 already handles cross-branch column propagation correctly, so this removes the superseded by-name emit.

- For same-alias unions (the common case) the two mechanisms are equivalent — no plan change.
- For differently-aliased unions the by-name emit was silently wrong; by-position propagation is correct.

## Rollback flag

`cairo.sql.legacy.union.column.propagation` (default `false`) restores the old by-name emit, as an operational rollback if the optimizer change has an unforeseen effect on a workload. `EntPropServerConfiguration` and `EntCairoConfigurationWrapper` extend the OSS classes, so enterprise servers honor the flag with no extra wiring; the interface getter is a `default` method, so no other config implementer needs changes.

## Tradeoffs and risk

- The change removes a code path rather than adding one, so the main risk is mis-pruning union branches elsewhere. This was checked across union shapes (subset projection, nested unions, union in join, UNION vs UNION ALL, GROUP BY and LATEST ON branches): the by-position loop runs earlier and over the full sibling chain, so it subsumes the removed emit.
- The ~1079 `SqlParserTest` model assertions, which print each branch's pruned column list, are unchanged — query plans are stable.
- Net effect on the compile path is one fewer tree-walk; there is no data-path impact.

## Tests

- `UnionTest.testAggregateOverUnionAllOfLatestOn` — `count()` and `sum()` over a 4-branch `UNION ALL` of `LATEST ON` sub-queries.
- `UnionTest.testAggregateOverUnionAllWithAliasMismatch` — minimal 2-branch case with no `LATEST ON`, isolating alias divergence as the trigger.
- `UnionTest.testAggregateOverUnionAllLegacyFlagReintroducesCrash` — with the rollback flag on, the otherwise-fixed query fails again, guarding the switch against becoming a no-op.
- `ViewQueryTest.testAggregateOverUnionAllOfLatestOnView` — the original report, through a `CREATE VIEW` (one table plus `CREATE TABLE ... (LIKE ...)` clones).
- The first three (flag off) fail without the fix (`AssertionError`) and pass with it.
- Regression-checked green: UnionTest, UnionAllCastTest, UnionStringyCastTest, FilterPushdownIntoUnionTest, LatestByTest, ParallelLatestByTest, SqlParserTest, SqlOptimiserTest, SqlCodeGeneratorTest, PropertyKeyTest, PropServerConfigurationTest, the view test suite, GroupByTest, DistinctTest, ViewFuzzTest, MatViewFuzzTest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
