### PR TITLE
feat(sql): add `is_end_of_month` SQL function

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/IsEndOfMonthFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/IsEndOfMonthFunctionFactory.java
@@ -34,6 +34,7 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.BooleanFunction;
 import io.questdb.griffin.engine.functions.UnaryFunction;
 import io.questdb.std.IntList;
+import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 
 public class IsEndOfMonthFunctionFactory implements FunctionFactory {
@@ -44,7 +45,13 @@ public class IsEndOfMonthFunctionFactory implements FunctionFactory {
     }
 
     @Override
-    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
         final Function arg = args.getQuick(0);
         return new Func(arg, ColumnType.getTimestampDriver(ColumnType.getTimestampType(arg.getType())));
     }
@@ -67,6 +74,9 @@ public class IsEndOfMonthFunctionFactory implements FunctionFactory {
         @Override
         public boolean getBool(Record rec) {
             final long value = arg.getTimestamp(rec);
+            if (value == Numbers.LONG_NULL) {
+                return false;
+            }
             return driver.getDayOfMonth(value) == driver.getDaysPerMonth(value);
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/IsEndOfMonthFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/IsEndOfMonthFunctionFactory.java
@@ -1,0 +1,78 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.date;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.TimestampDriver;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+
+public class IsEndOfMonthFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "is_end_of_month(N)";
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        final Function arg = args.getQuick(0);
+        return new Func(arg, ColumnType.getTimestampDriver(ColumnType.getTimestampType(arg.getType())));
+    }
+
+    private static final class Func extends BooleanFunction implements UnaryFunction {
+
+        private final Function arg;
+        private final TimestampDriver driver;
+
+        public Func(Function arg, TimestampDriver driver) {
+            this.arg = arg;
+            this.driver = driver;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            final long value = arg.getTimestamp(rec);
+            return driver.getDayOfMonth(value) == driver.getDaysPerMonth(value);
+        }
+
+        @Override
+        public String getName() {
+            return "is_end_of_month";
+        }
+    }
+}

--- a/core/src/main/resources/function_list.txt
+++ b/core/src/main/resources/function_list.txt
@@ -275,6 +275,7 @@ io.questdb.griffin.engine.functions.date.MicrosOfMillsFunctionFactory
 io.questdb.griffin.engine.functions.date.MillisOfSecondFunctionFactory
 io.questdb.griffin.engine.functions.date.NanosOfMicrosFunctionFactory
 io.questdb.griffin.engine.functions.date.IsLeapYearFunctionFactory
+io.questdb.griffin.engine.functions.date.IsEndOfMonthFunctionFactory
 io.questdb.griffin.engine.functions.date.TimestampDiffFunctionFactory
 io.questdb.griffin.engine.functions.date.TimestampAddFunctionFactory
 io.questdb.griffin.engine.functions.date.TimestampAddWithTimezoneFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/date/IsEndOfMonthFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/date/IsEndOfMonthFunctionFactoryTest.java
@@ -28,10 +28,10 @@ import io.questdb.test.AbstractCairoTest;
 import org.junit.Test;
 
 public class IsEndOfMonthFunctionFactoryTest extends AbstractCairoTest {
+
     @Test
     public void testNull() throws Exception {
         assertQuery("select is_end_of_month(null)")
-                .ddl(null)
                 .expectSize()
                 .returns("""
                         is_end_of_month
@@ -42,7 +42,6 @@ public class IsEndOfMonthFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testTimestamp() throws Exception {
         assertQuery("select is_end_of_month('2024-02-29T00:00:00.000000Z'::timestamp)")
-                .ddl(null)
                 .expectSize()
                 .returns("""
                         is_end_of_month
@@ -50,7 +49,6 @@ public class IsEndOfMonthFunctionFactoryTest extends AbstractCairoTest {
                         """);
 
         assertQuery("select is_end_of_month('2024-02-28T00:00:00.000000Z'::timestamp)")
-                .ddl(null)
                 .expectSize()
                 .returns("""
                         is_end_of_month
@@ -58,7 +56,6 @@ public class IsEndOfMonthFunctionFactoryTest extends AbstractCairoTest {
                         """);
 
         assertQuery("select is_end_of_month('2023-02-28T00:00:00.000000Z'::timestamp)")
-                .ddl(null)
                 .expectSize()
                 .returns("""
                         is_end_of_month
@@ -66,7 +63,6 @@ public class IsEndOfMonthFunctionFactoryTest extends AbstractCairoTest {
                         """);
 
         assertQuery("select is_end_of_month('2026-04-30T00:00:00.000000Z'::timestamp)")
-                .ddl(null)
                 .expectSize()
                 .returns("""
                         is_end_of_month
@@ -74,7 +70,6 @@ public class IsEndOfMonthFunctionFactoryTest extends AbstractCairoTest {
                         """);
 
         assertQuery("select is_end_of_month('2026-04-29T00:00:00.000000Z'::timestamp)")
-                .ddl(null)
                 .expectSize()
                 .returns("""
                         is_end_of_month
@@ -82,7 +77,13 @@ public class IsEndOfMonthFunctionFactoryTest extends AbstractCairoTest {
                         """);
 
         assertQuery("select is_end_of_month('2026-01-31T00:00:00.000000Z'::timestamp)")
-                .ddl(null)
+                .expectSize()
+                .returns("""
+                        is_end_of_month
+                        true
+                        """);
+
+        assertQuery("select is_end_of_month('2025-12-31T00:00:00.000000Z'::timestamp)")
                 .expectSize()
                 .returns("""
                         is_end_of_month
@@ -91,9 +92,27 @@ public class IsEndOfMonthFunctionFactoryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testTimestampColumn() throws Exception {
+        execute("create table x (ts timestamp)");
+        execute("insert into x values ('2024-02-29T00:00:00.000000Z')");
+        execute("insert into x values ('2024-02-28T00:00:00.000000Z')");
+        execute("insert into x values (null)");
+        execute("insert into x values ('2025-12-31T00:00:00.000000Z')");
+
+        assertQuery("select ts, is_end_of_month(ts) from x")
+                .expectSize()
+                .returns("""
+                        ts\tis_end_of_month
+                        2024-02-29T00:00:00.000000Z\ttrue
+                        2024-02-28T00:00:00.000000Z\tfalse
+                        \tfalse
+                        2025-12-31T00:00:00.000000Z\ttrue
+                        """);
+    }
+
+    @Test
     public void testTimestampNs() throws Exception {
         assertQuery("select is_end_of_month('2024-02-29T00:00:00.000000123Z'::timestamp_ns)")
-                .ddl(null)
                 .expectSize()
                 .returns("""
                         is_end_of_month
@@ -101,11 +120,36 @@ public class IsEndOfMonthFunctionFactoryTest extends AbstractCairoTest {
                         """);
 
         assertQuery("select is_end_of_month('2024-02-28T00:00:00.000000123Z'::timestamp_ns)")
-                .ddl(null)
                 .expectSize()
                 .returns("""
                         is_end_of_month
                         false
+                        """);
+    }
+
+    @Test
+    public void testTimestampNsNull() throws Exception {
+        assertQuery("select is_end_of_month(null::timestamp_ns)")
+                .expectSize()
+                .returns("""
+                        is_end_of_month
+                        false
+                        """);
+    }
+
+    @Test
+    public void testTimestampColumnWhereClause() throws Exception {
+        execute("create table x (ts timestamp)");
+        execute("insert into x values ('2024-02-29T00:00:00.000000Z')");
+        execute("insert into x values ('2024-02-28T00:00:00.000000Z')");
+        execute("insert into x values (null)");
+        execute("insert into x values ('2025-12-31T00:00:00.000000Z')");
+
+        assertQuery("select ts from x where is_end_of_month(ts)")
+                .returns("""
+                        ts
+                        2024-02-29T00:00:00.000000Z
+                        2025-12-31T00:00:00.000000Z
                         """);
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/date/IsEndOfMonthFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/date/IsEndOfMonthFunctionFactoryTest.java
@@ -1,0 +1,111 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.date;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class IsEndOfMonthFunctionFactoryTest extends AbstractCairoTest {
+    @Test
+    public void testNull() throws Exception {
+        assertQuery("select is_end_of_month(null)")
+                .ddl(null)
+                .expectSize()
+                .returns("""
+                        is_end_of_month
+                        false
+                        """);
+    }
+
+    @Test
+    public void testTimestamp() throws Exception {
+        assertQuery("select is_end_of_month('2024-02-29T00:00:00.000000Z'::timestamp)")
+                .ddl(null)
+                .expectSize()
+                .returns("""
+                        is_end_of_month
+                        true
+                        """);
+
+        assertQuery("select is_end_of_month('2024-02-28T00:00:00.000000Z'::timestamp)")
+                .ddl(null)
+                .expectSize()
+                .returns("""
+                        is_end_of_month
+                        false
+                        """);
+
+        assertQuery("select is_end_of_month('2023-02-28T00:00:00.000000Z'::timestamp)")
+                .ddl(null)
+                .expectSize()
+                .returns("""
+                        is_end_of_month
+                        true
+                        """);
+
+        assertQuery("select is_end_of_month('2026-04-30T00:00:00.000000Z'::timestamp)")
+                .ddl(null)
+                .expectSize()
+                .returns("""
+                        is_end_of_month
+                        true
+                        """);
+
+        assertQuery("select is_end_of_month('2026-04-29T00:00:00.000000Z'::timestamp)")
+                .ddl(null)
+                .expectSize()
+                .returns("""
+                        is_end_of_month
+                        false
+                        """);
+
+        assertQuery("select is_end_of_month('2026-01-31T00:00:00.000000Z'::timestamp)")
+                .ddl(null)
+                .expectSize()
+                .returns("""
+                        is_end_of_month
+                        true
+                        """);
+    }
+
+    @Test
+    public void testTimestampNs() throws Exception {
+        assertQuery("select is_end_of_month('2024-02-29T00:00:00.000000123Z'::timestamp_ns)")
+                .ddl(null)
+                .expectSize()
+                .returns("""
+                        is_end_of_month
+                        true
+                        """);
+
+        assertQuery("select is_end_of_month('2024-02-28T00:00:00.000000123Z'::timestamp_ns)")
+                .ddl(null)
+                .expectSize()
+                .returns("""
+                        is_end_of_month
+                        false
+                        """);
+    }
+}


### PR DESCRIPTION
Adds a SQL helper function, is_end_of_month(timestamp), which returns true when the provided timestamp falls on the final calendar day of its month.

This is useful for monthly reports, billing-period logic, finance workflows, and calendar-based time-series analysis.

Includes tests for leap-year February, non-leap-year February, 30-day months, 31-day months, and timestamp_ns inputs.