### PR TITLE
fix(sql): fix wrong results in splice, right and full outer joins with a left-table filter

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -582,6 +582,32 @@ public class SqlOptimiser implements Mutable {
         model.getJoinModels().getQuick(parent).addDependency(child);
     }
 
+    /**
+     * Returns the join-model index of the outermost SPLICE, FULL OUTER or RIGHT OUTER join
+     * that NULL-extends the master (left) side table at {@code tableIndex}, or -1 when no
+     * such join follows it. Each of these joins emits rows in which the master table's
+     * columns are all NULL: slave-only timestamps for SPLICE, unmatched right rows for FULL
+     * and RIGHT OUTER. A WHERE predicate that references only such a table must therefore be
+     * applied as a post-join filter rather than pushed into the table's own sub-query.
+     * Pushing it leaves those NULL-master rows unfiltered (e.g. {@code a RIGHT JOIN b WHERE
+     * a.k = 'v'} would keep unmatched b rows whose a.k is NULL); for SPLICE it also changes
+     * which master row prevails at each slave timestamp. LEFT OUTER, ASOF and LT keep every
+     * master row, so their master-side predicates remain safe to push down and are excluded.
+     */
+    private static int masterNullingJoinIndex(IQueryModel parent, int tableIndex) {
+        final ObjList<IQueryModel> joinModels = parent.getJoinModels();
+        int result = -1;
+        for (int i = tableIndex + 1, n = joinModels.size(); i < n; i++) {
+            final int joinType = joinModels.getQuick(i).getJoinType();
+            if (joinType == IQueryModel.JOIN_SPLICE
+                    || joinType == IQueryModel.JOIN_FULL_OUTER
+                    || joinType == IQueryModel.JOIN_RIGHT_OUTER) {
+                result = i;
+            }
+        }
+        return result;
+    }
+
     private static boolean matchesModelAlias(CharSequence prefix, IQueryModel model) {
         if (model.getAlias() != null && Chars.equalsIgnoreCase(model.getAlias().token, prefix)) {
             return true;
@@ -1632,6 +1658,8 @@ public class SqlOptimiser implements Mutable {
                         && literalCollector.nullCount == 0
                         // the table must not be OUTER or ASOF joined
                         && joinBarriers.excludes(parent.getJoinModels().get(literalCollectorBIndexes.get(0)).getJoinType())
+                        // and must not sit on the master side of a downstream SPLICE/FULL/RIGHT OUTER join
+                        && masterNullingJoinIndex(parent, literalCollectorBIndexes.get(0)) < 0
                 ) {
                     // single table reference + constant
                     jc = contextPool.next();
@@ -1710,7 +1738,9 @@ public class SqlOptimiser implements Mutable {
                     }
                 } else if (bSize == 0
                         && literalCollector.nullCount == 0
-                        && joinBarriers.excludes(parent.getJoinModels().get(literalCollectorAIndexes.get(0)).getJoinType())) {
+                        && joinBarriers.excludes(parent.getJoinModels().get(literalCollectorAIndexes.get(0)).getJoinType())
+                        // and must not sit on the master side of a downstream SPLICE/FULL/RIGHT OUTER join
+                        && masterNullingJoinIndex(parent, literalCollectorAIndexes.get(0)) < 0) {
                     // single table reference + constant
                     if (!canMovePredicate) {
                         addOuterJoinExpression(parent, joinModel, joinIndex, node);
@@ -1829,9 +1859,17 @@ public class SqlOptimiser implements Mutable {
                     parent.setConstWhereClause(concatFilters(configuration.getCairoSqlLegacyOperatorPrecedence(), expressionNodePool, parent.getConstWhereClause(), node));
                 } else if (rs == 1 && // single table reference and this table is not joined via OUTER or ASOF
                         joinBarriers.excludes(parent.getJoinModels().getQuick(refs.get(0)).getJoinType())) {
-                    // get single table reference out of the way right away
-                    // we don't have to wait until "our" table comes along
-                    addWhereNode(parent, refs.get(0), node);
+                    final int nullingJoinIndex = masterNullingJoinIndex(parent, refs.get(0));
+                    if (nullingJoinIndex < 0) {
+                        // get single table reference out of the way right away
+                        // we don't have to wait until "our" table comes along
+                        addWhereNode(parent, refs.get(0), node);
+                    } else {
+                        // the table sits on the master side of a downstream SPLICE/FULL/RIGHT OUTER
+                        // join, which NULL-extends it; keep the predicate as a post-join filter so
+                        // NULL-master rows are removed rather than pushing it into the sub-query
+                        addPostJoinWhereClause(parent.getJoinModels().getQuick(nullingJoinIndex), node);
+                    }
                     postFilterRemoved.add(k);
                 } else {
                     boolean qualifies = true;

--- a/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExplainPlanTest.java
@@ -5006,20 +5006,29 @@ public class ExplainPlanTest extends AbstractCairoTest {
                         .noLeakCheck()
                         .assertsPlan("Count\n" + "    Filter filter: T2.value!=1\n" + "        " + factoryType + "\n" + (i < 3 ? "          condition: T2.created=T1.created\n" : "") + "            PageFrame\n" + "                Row forward scan\n" + "                Frame forward scan on: tab\n" + (i < 3 ? "            Hash\n" : "") + (i < 3 ? "    " : "") + "            PageFrame\n" + (i < 3 ? "    " : "") + "                Row forward scan\n" + (i < 3 ? "    " : "") + "                Frame forward scan on: tab\n");
 
-                // push down predicate to the 'left' table of left join
+                // Push the predicate down to the 'left' table for joins that keep every left
+                // row (LEFT OUTER, LT, ASOF). RIGHT and FULL OUTER NULL-extend the left table,
+                // so the predicate must stay a post-join filter there instead.
+                boolean leftNulled = "RIGHT".equals(joinType) || "FULL".equals(joinType);
                 assertQuery("SELECT count(1) " + "FROM tab as T1 " + joinType + " JOIN tab as T2 " + (i < 3 ? " ON T1.created=T2.created " : "") + "WHERE not T1.value=1")
                         .noLeakCheck()
-                        .assertsPlan("Count\n" + "    " + factoryType + "\n" + (i < 3 ? "      condition: T2.created=T1.created\n" : "") + "        Async JIT Filter workers: 1\n" + "          filter: value!=1\n" + "            PageFrame\n" + "                Row forward scan\n" + "                Frame forward scan on: tab\n" + (i < 3 ? "        Hash\n" : "") + (i < 3 ? "    " : "") + "        PageFrame\n" + (i < 3 ? "    " : "") + "            Row forward scan\n" + (i < 3 ? "    " : "") + "            Frame forward scan on: tab\n");
+                        .assertsPlan(leftNulled
+                                ? "Count\n" + "    Filter filter: T1.value!=1\n" + "        " + factoryType + "\n" + "          condition: T2.created=T1.created\n" + "            PageFrame\n" + "                Row forward scan\n" + "                Frame forward scan on: tab\n" + "            Hash\n" + "                PageFrame\n" + "                    Row forward scan\n" + "                    Frame forward scan on: tab\n"
+                                : "Count\n" + "    " + factoryType + "\n" + (i < 3 ? "      condition: T2.created=T1.created\n" : "") + "        Async JIT Filter workers: 1\n" + "          filter: value!=1\n" + "            PageFrame\n" + "                Row forward scan\n" + "                Frame forward scan on: tab\n" + (i < 3 ? "        Hash\n" : "") + (i < 3 ? "    " : "") + "        PageFrame\n" + (i < 3 ? "    " : "") + "            Row forward scan\n" + (i < 3 ? "    " : "") + "            Frame forward scan on: tab\n");
             }
 
             // two joins
             for (int i = 0; i < 3; i++) {
                 String joinType = joinTypes[i];
                 String factoryType = joinFactoryTypes[i];
+                // RIGHT and FULL OUTER NULL-extend T1, so a T1 predicate stays a post-join filter.
+                boolean leftNulled = "RIGHT".equals(joinType) || "FULL".equals(joinType);
 
                 assertQuery("SELECT count(1) " + "FROM tab as T1 " + joinType + " JOIN tab as T2 ON T1.created=T2.created " + "JOIN tab as T3 ON T2.created=T3.created " + "WHERE T1.value=1")
                         .noLeakCheck()
-                        .assertsPlan("Count\n" + "    Hash Join Light\n" + "      condition: T3.created=T2.created\n" + "        " + factoryType + "\n" + "          condition: T2.created=T1.created\n" + "            Async JIT Filter workers: 1\n" + "              filter: value=1\n" + "                PageFrame\n" + "                    Row forward scan\n" + "                    Frame forward scan on: tab\n" + "            Hash\n" + "                PageFrame\n" + "                    Row forward scan\n" + "                    Frame forward scan on: tab\n" + "        Hash\n" + "            PageFrame\n" + "                Row forward scan\n" + "                Frame forward scan on: tab\n");
+                        .assertsPlan(leftNulled
+                                ? "Count\n" + "    Hash Join Light\n" + "      condition: T3.created=T2.created\n" + "        Filter filter: T1.value=1\n" + "            " + factoryType + "\n" + "              condition: T2.created=T1.created\n" + "                PageFrame\n" + "                    Row forward scan\n" + "                    Frame forward scan on: tab\n" + "                Hash\n" + "                    PageFrame\n" + "                        Row forward scan\n" + "                        Frame forward scan on: tab\n" + "        Hash\n" + "            PageFrame\n" + "                Row forward scan\n" + "                Frame forward scan on: tab\n"
+                                : "Count\n" + "    Hash Join Light\n" + "      condition: T3.created=T2.created\n" + "        " + factoryType + "\n" + "          condition: T2.created=T1.created\n" + "            Async JIT Filter workers: 1\n" + "              filter: value=1\n" + "                PageFrame\n" + "                    Row forward scan\n" + "                    Frame forward scan on: tab\n" + "            Hash\n" + "                PageFrame\n" + "                    Row forward scan\n" + "                    Frame forward scan on: tab\n" + "        Hash\n" + "            PageFrame\n" + "                Row forward scan\n" + "                Frame forward scan on: tab\n");
 
                 assertQuery("SELECT count(1) " + "FROM tab as T1 " + joinType + " JOIN tab as T2 ON T1.created=T2.created " + "JOIN tab as T3 ON T2.created=T3.created " + "WHERE T2.created=1")
                         .noLeakCheck()

--- a/core/src/test/java/io/questdb/test/griffin/SqlOptimiserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlOptimiserTest.java
@@ -1444,21 +1444,24 @@ public class SqlOptimiserTest extends AbstractSqlParserTest {
                     .assertsPlan("""
                             VirtualRecord
                               functions: [1]
-                                Hash Right Outer Join Light
-                                  condition: ep.WorkflowEventId=el.Id and ep.CreateDate=el.CreateDate
-                                  filter: ep.ActionTypeId=8
+                                Filter filter: ((el.UserId=19 and el.TenantId=24024 and el.EventTypeId=1 and el.CreateDate>=) and >=el.CreateDate)
                                     Hash Right Outer Join Light
-                                      condition: ep0.WorkflowEventId=el.Id and ep0.CreateDate=el.CreateDate
-                                      filter: (ep0.ActionTypeId=13 and ep0.Message='2')
-                                        Empty table
+                                      condition: ep.WorkflowEventId=el.Id and ep.CreateDate=el.CreateDate
+                                      filter: ep.ActionTypeId=8
+                                        Hash Right Outer Join Light
+                                          condition: ep0.WorkflowEventId=el.Id and ep0.CreateDate=el.CreateDate
+                                          filter: (ep0.ActionTypeId=13 and ep0.Message='2')
+                                            PageFrame
+                                                Row forward scan
+                                                Frame forward scan on: WorkflowEvent
+                                            Hash
+                                                PageFrame
+                                                    Row forward scan
+                                                    Frame forward scan on: WorkflowEventAction
                                         Hash
                                             PageFrame
                                                 Row forward scan
                                                 Frame forward scan on: WorkflowEventAction
-                                    Hash
-                                        PageFrame
-                                            Row forward scan
-                                            Frame forward scan on: WorkflowEventAction
                             """);
 
             assertQuery("""
@@ -1485,21 +1488,24 @@ public class SqlOptimiserTest extends AbstractSqlParserTest {
                     .assertsPlan("""
                             VirtualRecord
                               functions: [1]
-                                Hash Full Outer Join Light
-                                  condition: ep.WorkflowEventId=el.Id and ep.CreateDate=el.CreateDate
-                                  filter: ep.ActionTypeId=8
+                                Filter filter: ((el.UserId=19 and el.TenantId=24024 and el.EventTypeId=1 and el.CreateDate>=) and >=el.CreateDate)
                                     Hash Full Outer Join Light
-                                      condition: ep0.WorkflowEventId=el.Id and ep0.CreateDate=el.CreateDate
-                                      filter: (ep0.ActionTypeId=13 and ep0.Message='2')
-                                        Empty table
+                                      condition: ep.WorkflowEventId=el.Id and ep.CreateDate=el.CreateDate
+                                      filter: ep.ActionTypeId=8
+                                        Hash Full Outer Join Light
+                                          condition: ep0.WorkflowEventId=el.Id and ep0.CreateDate=el.CreateDate
+                                          filter: (ep0.ActionTypeId=13 and ep0.Message='2')
+                                            PageFrame
+                                                Row forward scan
+                                                Frame forward scan on: WorkflowEvent
+                                            Hash
+                                                PageFrame
+                                                    Row forward scan
+                                                    Frame forward scan on: WorkflowEventAction
                                         Hash
                                             PageFrame
                                                 Row forward scan
                                                 Frame forward scan on: WorkflowEventAction
-                                    Hash
-                                        PageFrame
-                                            Row forward scan
-                                            Frame forward scan on: WorkflowEventAction
                             """);
 
             assertQuery("select-virtual 1 1 from (select [Id, CreateDate, UserId, TenantId, EventTypeId] from WorkflowEvent el timestamp (CreateDate) join (select [WorkflowEventId, CreateDate, ActionTypeId, Message] from WorkflowEventAction ep0 timestamp (CreateDate) where ActionTypeId = 13 and Message = '2') ep0 on ep0.WorkflowEventId = el.Id and ep0.CreateDate = el.CreateDate join (select [WorkflowEventId, CreateDate, ActionTypeId] from WorkflowEventAction ep timestamp (CreateDate) where ActionTypeId = 8) ep on ep.WorkflowEventId = el.Id and ep.CreateDate = el.CreateDate where UserId = 19 and TenantId = 24024 and EventTypeId = 1 and CreateDate >= to_timestamp('2024-01-26T18:26:14.000000Z', 'yyyy-MM-ddTHH:mm:ss.SSSUUUZ') and CreateDate <= to_timestamp('2024-01-26T18:47:49.994262Z', 'yyyy-MM-ddTHH:mm:ss.SSSUUUZ')) el", """

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -899,6 +899,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testAliasTopJoinTable() throws SqlException {
         assertQueryWithOuterJoinType(
                 "select-choose tx.a a, tx.b b from (select [a, b, xid] from x tx #OUTER_JOIN_TYPE join select [yid] from y ty on yid = xid where a = 1 or b = 2) tx",
+                "select-choose tx.a a, tx.b b from (select [a, b, xid] from x tx #OUTER_JOIN_TYPE join select [yid] from y ty on yid = xid post-join-where tx.a = 1 or tx.b = 2) tx",
                 "select tx.a, tx.b from x as tx #OUTER_JOIN_TYPE join y as ty on xid = yid where tx.a = 1 or tx.b=2",
                 modelOf("x").col("xid", ColumnType.INT).col("a", ColumnType.INT).col("b", ColumnType.INT),
                 modelOf("y").col("yid", ColumnType.INT).col("a", ColumnType.INT).col("b", ColumnType.INT)
@@ -5393,6 +5394,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testEqualsConstantTransitivityLhs() throws Exception {
         assertQueryWithOuterJoinType(
                 "select-choose c.customerId customerId, o.customerId customerId1 from (select [customerId] from customers c #OUTER_JOIN_TYPE join (select [customerId] from orders o where customerId = 100) o on o.customerId = c.customerId where 100 = customerId) c",
+                "select-choose c.customerId customerId, o.customerId customerId1 from (select [customerId] from customers c #OUTER_JOIN_TYPE join select [customerId] from orders o on o.customerId = c.customerId post-join-where 100 = c.customerId) c",
                 "customers c" +
                         " #OUTER_JOIN_TYPE join orders o on c.customerId = o.customerId" +
                         " where 100 = c.customerId",
@@ -5405,6 +5407,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testEqualsConstantTransitivityRhs() throws Exception {
         assertQueryWithOuterJoinType(
                 "select-choose c.customerId customerId, o.customerId customerId1 from (select [customerId] from customers c #OUTER_JOIN_TYPE join (select [customerId] from orders o where customerId = 100) o on o.customerId = c.customerId where customerId = 100) c",
+                "select-choose c.customerId customerId, o.customerId customerId1 from (select [customerId] from customers c #OUTER_JOIN_TYPE join select [customerId] from orders o on o.customerId = c.customerId post-join-where c.customerId = 100) c",
                 "customers c" +
                         " #OUTER_JOIN_TYPE join orders o on c.customerId = o.customerId" +
                         " where c.customerId = 100",
@@ -5426,6 +5429,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testEraseColumnPrefixInJoin() throws Exception {
         assertQueryWithOuterJoinType(
                 "select-choose c.customerId customerId, o.customerId customerId1, o.x x from (select [customerId] from customers c #OUTER_JOIN_TYPE join select [customerId, x] from (select-choose [customerId, x] customerId, x from (select [customerId, x] from orders o where x = 10 and customerId = 100) o) o on customerId = c.customerId where customerId = 100) c",
+                "select-choose c.customerId customerId, o.customerId customerId1, o.x x from (select [customerId] from customers c #OUTER_JOIN_TYPE join select [customerId, x] from (select-choose [customerId, x] customerId, x from (select [customerId, x] from orders o where x = 10) o) o on o.customerId = c.customerId post-join-where c.customerId = 100) c",
                 "customers c" +
                         " #OUTER_JOIN_TYPE join (orders o where o.x = 10) o on c.customerId = o.customerId" +
                         " where c.customerId = 100",
@@ -5440,6 +5444,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testEraseColumnPrefixInJoinWithNestedUnion() throws Exception {
         assertQueryWithOuterJoinType(
                 "select-choose c.customerId customerId, o.customerId customerId1, o.x x from (select [customerId] from customers c #OUTER_JOIN_TYPE join select [customerId, x] from (select-choose [customerId, x] customerId, x from (select [customerId, x] from (select-choose [customerId, x] customerId, x from (select [customerId, x] from orders) union select-choose [customerId, x] customerId, x from (select [customerId, x] from orders)) o where x = 10 and customerId = 100) o) o on customerId = c.customerId where customerId = 100) c",
+                "select-choose c.customerId customerId, o.customerId customerId1, o.x x from (select [customerId] from customers c #OUTER_JOIN_TYPE join select [customerId, x] from (select-choose [customerId, x] customerId, x from (select [customerId, x] from (select-choose [customerId, x] customerId, x from (select [customerId, x] from orders) union select-choose [customerId, x] customerId, x from (select [customerId, x] from orders)) o where x = 10) o) o on o.customerId = c.customerId post-join-where c.customerId = 100) c",
                 "customers c" +
                         " #OUTER_JOIN_TYPE join ((orders union orders) o where o.x = 10) o on c.customerId = o.customerId" +
                         " where c.customerId = 100",
@@ -5456,6 +5461,9 @@ public class SqlParserTest extends AbstractSqlParserTest {
                 "select-choose customerId from (select-choose [c.customerId customerId] c.customerId customerId from (select [customerId] from customers c #OUTER_JOIN_TYPE join select [customerId] from (select-choose [customerId] customerId, x from (select [customerId, x] from orders o where x = 10 and customerId = 100) o) o on customerId = c.customerId where customerId = 100) c)" +
                         " union all" +
                         " select-choose customerId from (select-choose [c.customerId customerId] c.customerId customerId from (select [customerId] from customers c #OUTER_JOIN_TYPE join (select [customerId] from orders o where customerId = 100) o on o.customerId = c.customerId where customerId = 100) c)",
+                "select-choose customerId from (select-choose [c.customerId customerId] c.customerId customerId from (select [customerId] from customers c #OUTER_JOIN_TYPE join select [customerId] from (select-choose [customerId] customerId, x from (select [customerId, x] from orders o where x = 10) o) o on o.customerId = c.customerId post-join-where c.customerId = 100) c)" +
+                        " union all" +
+                        " select-choose customerId from (select-choose [c.customerId customerId] c.customerId customerId from (select [customerId] from customers c #OUTER_JOIN_TYPE join select [customerId] from orders o on o.customerId = c.customerId post-join-where c.customerId = 100) c)",
                 "(select c.customerId" +
                         " from customers c" +
                         " #OUTER_JOIN_TYPE join (orders o where o.x = 10) o on c.customerId = o.customerId" +
@@ -5872,6 +5880,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testFilterOnSubQuery() throws Exception {
         assertQueryWithOuterJoinType(
                 "select-choose c.customerId customerId, c.customerName customerName, c.count count, o.orderId orderId, o.customerId customerId1 from (select [customerId, customerName, count] from (select-group-by [customerId, customerName, count() count] customerId, customerName, count() count from (select [customerId, customerName] from customers where customerId > 400 and customerId < 1200) where count > 1) c #OUTER_JOIN_TYPE join select [orderId, customerId] from orders o on o.customerId = c.customerId post-join-where o.orderId = NaN) c order by customerId",
+                "select-choose c.customerId customerId, c.customerName customerName, c.count count, o.orderId orderId, o.customerId customerId1 from (select [customerId, customerName, count] from (select-group-by [customerId, customerName, count() count] customerId, customerName, count() count from (select [customerId, customerName] from customers)) c #OUTER_JOIN_TYPE join select [orderId, customerId] from orders o on o.customerId = c.customerId post-join-where c.customerId > 400 and c.customerId < 1200 and count > 1 and o.orderId = NaN) c order by customerId",
                 "(select customerId, customerName, count() count from customers) c" +
                         " #OUTER_JOIN_TYPE join orders o on c.customerId = o.customerId " +
                         " where o.orderId = NaN and c.customerId > 400 and c.customerId < 1200 and count > 1 order by c.customerId",
@@ -7345,6 +7354,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testJoinClauseAlignmentBug() throws SqlException {
         assertQueryWithOuterJoinType(
                 "select-virtual NULL TABLE_CAT, TABLE_SCHEM, TABLE_NAME, switch(TABLE_SCHEM ~ '^pg_' or TABLE_SCHEM = 'information_schema', true, case when TABLE_SCHEM = 'pg_catalog' or TABLE_SCHEM = 'information_schema' then switch(relkind, 'r', 'SYSTEM TABLE', 'v', 'SYSTEM VIEW', 'i', 'SYSTEM INDEX', NULL) when TABLE_SCHEM = 'pg_toast' then switch(relkind, 'r', 'SYSTEM TOAST TABLE', 'i', 'SYSTEM TOAST INDEX', NULL) else switch(relkind, 'r', 'TEMPORARY TABLE', 'p', 'TEMPORARY TABLE', 'i', 'TEMPORARY INDEX', 'S', 'TEMPORARY SEQUENCE', 'v', 'TEMPORARY VIEW', NULL) end, false, switch(relkind, 'r', 'TABLE', 'p', 'PARTITIONED TABLE', 'i', 'INDEX', 'S', 'SEQUENCE', 'v', 'VIEW', 'c', 'TYPE', 'f', 'FOREIGN TABLE', 'm', 'MATERIALIZED VIEW', NULL), NULL) TABLE_TYPE, REMARKS, '' TYPE_CAT, '' TYPE_SCHEM, '' TYPE_NAME, '' SELF_REFERENCING_COL_NAME, '' REF_GENERATION from (select-choose [n.nspname TABLE_SCHEM, c.relname TABLE_NAME, c.relkind relkind, d.description REMARKS] n.nspname TABLE_SCHEM, c.relname TABLE_NAME, c.relkind relkind, d.description REMARKS from (select [nspname, oid] from pg_catalog.pg_namespace() n join (select [relname, relkind, relnamespace, oid] from pg_catalog.pg_class() c where relname like 'quickstart-events2') c on c.relnamespace = n.oid post-join-where false or c.relkind = 'r' and n.nspname !~ '^pg_' and n.nspname != 'information_schema' #OUTER_JOIN_TYPE join select [description, objoid, objsubid, classoid] from pg_catalog.pg_description() d on d.objoid = c.oid outer-join-expression d.objsubid = 0 #OUTER_JOIN_TYPE join select [oid, relname, relnamespace] from pg_catalog.pg_class() dc on dc.oid = d.classoid outer-join-expression dc.relname = 'pg_class' #OUTER_JOIN_TYPE join select [oid, nspname] from pg_catalog.pg_namespace() dn on dn.oid = dc.relnamespace outer-join-expression dn.nspname = 'pg_catalog') n) n order by TABLE_TYPE, TABLE_SCHEM, TABLE_NAME",
+                "select-virtual NULL TABLE_CAT, TABLE_SCHEM, TABLE_NAME, switch(TABLE_SCHEM ~ '^pg_' or TABLE_SCHEM = 'information_schema', true, case when TABLE_SCHEM = 'pg_catalog' or TABLE_SCHEM = 'information_schema' then switch(relkind, 'r', 'SYSTEM TABLE', 'v', 'SYSTEM VIEW', 'i', 'SYSTEM INDEX', NULL) when TABLE_SCHEM = 'pg_toast' then switch(relkind, 'r', 'SYSTEM TOAST TABLE', 'i', 'SYSTEM TOAST INDEX', NULL) else switch(relkind, 'r', 'TEMPORARY TABLE', 'p', 'TEMPORARY TABLE', 'i', 'TEMPORARY INDEX', 'S', 'TEMPORARY SEQUENCE', 'v', 'TEMPORARY VIEW', NULL) end, false, switch(relkind, 'r', 'TABLE', 'p', 'PARTITIONED TABLE', 'i', 'INDEX', 'S', 'SEQUENCE', 'v', 'VIEW', 'c', 'TYPE', 'f', 'FOREIGN TABLE', 'm', 'MATERIALIZED VIEW', NULL), NULL) TABLE_TYPE, REMARKS, '' TYPE_CAT, '' TYPE_SCHEM, '' TYPE_NAME, '' SELF_REFERENCING_COL_NAME, '' REF_GENERATION from (select-choose [n.nspname TABLE_SCHEM, c.relname TABLE_NAME, c.relkind relkind, d.description REMARKS] n.nspname TABLE_SCHEM, c.relname TABLE_NAME, c.relkind relkind, d.description REMARKS from (select [nspname, oid] from pg_catalog.pg_namespace() n join select [relname, relkind, relnamespace, oid] from pg_catalog.pg_class() c on c.relnamespace = n.oid post-join-where false or c.relkind = 'r' and n.nspname !~ '^pg_' and n.nspname != 'information_schema' #OUTER_JOIN_TYPE join select [description, objoid, objsubid, classoid] from pg_catalog.pg_description() d on d.objoid = c.oid outer-join-expression d.objsubid = 0 #OUTER_JOIN_TYPE join select [oid, relname, relnamespace] from pg_catalog.pg_class() dc on dc.oid = d.classoid outer-join-expression dc.relname = 'pg_class' #OUTER_JOIN_TYPE join select [oid, nspname] from pg_catalog.pg_namespace() dn on dn.oid = dc.relnamespace outer-join-expression dn.nspname = 'pg_catalog' post-join-where c.relname like 'quickstart-events2') n) n order by TABLE_TYPE, TABLE_SCHEM, TABLE_NAME",
                 """
                         SELECT\s
                              NULL AS TABLE_CAT,\s
@@ -7894,6 +7904,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testJoinSubQueryConstantWhere() throws Exception {
         assertQueryWithOuterJoinType(
                 "select-choose o.customerId customerId from (select [cid] from (select-choose [customerId cid] customerId cid from (select [customerId] from customers where 100 = customerId)) c #OUTER_JOIN_TYPE join (select [customerId] from orders o where customerId = 100) o on o.customerId = c.cid const-where 10 = 9) c",
+                "select-choose o.customerId customerId from (select [cid] from (select-choose [customerId cid] customerId cid from (select [customerId] from customers)) c #OUTER_JOIN_TYPE join select [customerId] from orders o on o.customerId = c.cid post-join-where 100 = c.cid const-where 10 = 9) c",
                 "select o.customerId from (select customerId cid from customers) c" +
                         " #OUTER_JOIN_TYPE join orders o on c.cid = o.customerId" +
                         " where 100 = c.cid and 10=9",
@@ -7906,6 +7917,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testJoinSubQueryWherePosition() throws Exception {
         assertQueryWithOuterJoinType(
                 "select-choose o.customerId customerId from (select [cid] from (select-choose [customerId cid] customerId cid from (select [customerId] from customers where 100 = customerId)) c #OUTER_JOIN_TYPE join (select [customerId] from orders o where customerId = 100) o on o.customerId = c.cid) c",
+                "select-choose o.customerId customerId from (select [cid] from (select-choose [customerId cid] customerId cid from (select [customerId] from customers)) c #OUTER_JOIN_TYPE join select [customerId] from orders o on o.customerId = c.cid post-join-where 100 = c.cid) c",
                 "select o.customerId from (select customerId cid from customers) c" +
                         " #OUTER_JOIN_TYPE join orders o on c.cid = o.customerId" +
                         " where 100 = c.cid",
@@ -9803,6 +9815,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testPGTableListQuery() throws SqlException {
         assertQueryWithOuterJoinType(
                 "select-virtual Schema, Name, switch(relkind, 'r', 'table', 'v', 'view', 'm', 'materialized view', 'i', 'index', 'S', 'sequence', 's', 'special', 'f', 'foreign table', 'p', 'table', 'I', 'index') Type, pg_catalog.pg_get_userbyid(relowner) Owner from (select-choose [n.nspname Schema, c.relname Name, c.relkind relkind, c.relowner relowner] n.nspname Schema, c.relname Name, c.relkind relkind, c.relowner relowner from (select [relname, relkind, relowner, relnamespace, oid] from pg_catalog.pg_class() c #OUTER_JOIN_TYPE join select [nspname, oid] from pg_catalog.pg_namespace() n on n.oid = c.relnamespace post-join-where n.nspname != 'pg_catalog' and n.nspname != 'information_schema' and n.nspname !~ '^pg_toast' where relkind in ('r', 'p', 'v', 'm', 'S', 'f', '') and pg_catalog.pg_table_is_visible(oid)) c) c order by Schema, Name",
+                "select-virtual Schema, Name, switch(relkind, 'r', 'table', 'v', 'view', 'm', 'materialized view', 'i', 'index', 'S', 'sequence', 's', 'special', 'f', 'foreign table', 'p', 'table', 'I', 'index') Type, pg_catalog.pg_get_userbyid(relowner) Owner from (select-choose [n.nspname Schema, c.relname Name, c.relkind relkind, c.relowner relowner] n.nspname Schema, c.relname Name, c.relkind relkind, c.relowner relowner from (select [relname, relkind, relowner, relnamespace, oid] from pg_catalog.pg_class() c #OUTER_JOIN_TYPE join select [nspname, oid] from pg_catalog.pg_namespace() n on n.oid = c.relnamespace post-join-where c.relkind in ('r', 'p', 'v', 'm', 'S', 'f', '') and pg_catalog.pg_table_is_visible(c.oid) and n.nspname != 'pg_catalog' and n.nspname != 'information_schema' and n.nspname !~ '^pg_toast') c) c order by Schema, Name",
                 """
                         SELECT n.nspname                              as "Schema",
                                c.relname                              as "Name",
@@ -11948,6 +11961,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testSelectAfterOrderBy() throws SqlException {
         assertQueryWithOuterJoinType(
                 "select-choose Schema from (select-group-by [Schema] Schema, count() count from (select-virtual [Schema, Name] Schema, Name, switch(relkind, 'r', 'table', 'v', 'view', 'm', 'materialized view', 'i', 'index', 'S', 'sequence', 's', 'special', 'f', 'foreign table', 'p', 'table', 'I', 'index') Type, pg_catalog.pg_get_userbyid(relowner) Owner from (select-choose [n.nspname Schema, c.relname Name] n.nspname Schema, c.relname Name, c.relkind relkind, c.relowner relowner from (select [relname, relnamespace, relkind, oid] from pg_catalog.pg_class() c #OUTER_JOIN_TYPE join select [nspname, oid] from pg_catalog.pg_namespace() n on n.oid = c.relnamespace post-join-where n.nspname != 'pg_catalog' and n.nspname != 'information_schema' and n.nspname !~ '^pg_toast' where relkind in ('r', 'p', 'v', 'm', 'S', 'f', '') and pg_catalog.pg_table_is_visible(oid)) c) c order by Schema, Name))",
+                "select-choose Schema from (select-group-by [Schema] Schema, count() count from (select-virtual [Schema, Name] Schema, Name, switch(relkind, 'r', 'table', 'v', 'view', 'm', 'materialized view', 'i', 'index', 'S', 'sequence', 's', 'special', 'f', 'foreign table', 'p', 'table', 'I', 'index') Type, pg_catalog.pg_get_userbyid(relowner) Owner from (select-choose [n.nspname Schema, c.relname Name] n.nspname Schema, c.relname Name, c.relkind relkind, c.relowner relowner from (select [relname, relnamespace, relkind, oid] from pg_catalog.pg_class() c #OUTER_JOIN_TYPE join select [nspname, oid] from pg_catalog.pg_namespace() n on n.oid = c.relnamespace post-join-where c.relkind in ('r', 'p', 'v', 'm', 'S', 'f', '') and pg_catalog.pg_table_is_visible(c.oid) and n.nspname != 'pg_catalog' and n.nspname != 'information_schema' and n.nspname !~ '^pg_toast') c) c order by Schema, Name))",
                 """
                         select distinct Schema from\s
                         (SELECT n.nspname                              as "Schema",
@@ -12740,7 +12754,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     @Test
     public void testSpliceJoin() throws SqlException {
         assertQuery(
-                "select-choose t.timestamp timestamp, t.tag tag, q.timestamp timestamp1 from (select [timestamp, tag] from trades t timestamp (timestamp) splice join select [timestamp] from quotes q timestamp (timestamp) where tag = null) t",
+                "select-choose t.timestamp timestamp, t.tag tag, q.timestamp timestamp1 from (select [timestamp, tag] from trades t timestamp (timestamp) splice join select [timestamp] from quotes q timestamp (timestamp) post-join-where tag = null) t",
                 "trades t splice join quotes q where tag = null",
                 modelOf("trades").timestamp().col("tag", ColumnType.SYMBOL),
                 modelOf("quotes").timestamp()
@@ -13658,6 +13672,12 @@ public class SqlParserTest extends AbstractSqlParserTest {
                         "(select [customerId] from customers c #OUTER_JOIN_TYPE join " +
                         "select [customerId, x] from (select-choose [customerId, x] customerId, x from " +
                         "(select [customerId, x] from orders o where x = 10 and customerId = 100) o) o on customerId = c.customerId where customerId = 100) c",
+                "select-virtual [1 1, 2 2, 3 3] 1 1, 2 2, 3 3 from (long_sequence(1)) " +
+                        "union " +
+                        "select-choose [c.customerId customerId, o.customerId customerId1, o.x x] c.customerId customerId, o.customerId customerId1, o.x x from " +
+                        "(select [customerId] from customers c #OUTER_JOIN_TYPE join " +
+                        "select [customerId, x] from (select-choose [customerId, x] customerId, x from " +
+                        "(select [customerId, x] from orders o where x = 10) o) o on o.customerId = c.customerId post-join-where c.customerId = 100) c",
                 "select 1, 2, 3 from long_sequence(1)" +
                         " union " +
                         "customers c" +
@@ -14024,6 +14044,7 @@ public class SqlParserTest extends AbstractSqlParserTest {
     public void testWhereNotSelectedColumn() throws Exception {
         assertQueryWithOuterJoinType(
                 "select-choose c.customerId customerId, c.weight weight, o.customerId customerId1, o.x x from (select [customerId, weight] from customers c #OUTER_JOIN_TYPE join select [customerId, x] from (select-choose [customerId, x] customerId, x from (select [customerId, x] from orders o where x = 10) o) o on o.customerId = c.customerId where weight = 100) c",
+                "select-choose c.customerId customerId, c.weight weight, o.customerId customerId1, o.x x from (select [customerId, weight] from customers c #OUTER_JOIN_TYPE join select [customerId, x] from (select-choose [customerId, x] customerId, x from (select [customerId, x] from orders o where x = 10) o) o on o.customerId = c.customerId post-join-where c.weight = 100) c",
                 "customers c" +
                         " #OUTER_JOIN_TYPE join (orders o where o.x = 10) o on c.customerId = o.customerId" +
                         " where c.weight = 100",
@@ -14982,6 +15003,22 @@ public class SqlParserTest extends AbstractSqlParserTest {
 
     private void assertQueryWithOuterJoinType(String expected, String query, TableModel... tableModels) throws SqlException {
         for (String outerJoinType : outerJoinTypes) {
+            assertQuery(
+                    expected.replaceAll("#OUTER_JOIN_TYPE", outerJoinType),
+                    query.replaceAll("#OUTER_JOIN_TYPE", outerJoinType),
+                    tableModels
+            );
+        }
+    }
+
+    // LEFT OUTER keeps every master (left) row, so a master-side WHERE predicate pushes
+    // down into the master sub-query. RIGHT and FULL OUTER NULL-extend the master, so such
+    // a predicate must stay a post-join filter (otherwise the NULL-master rows leak). A
+    // query that carries a master-side predicate therefore optimises to a different model
+    // for LEFT than for RIGHT/FULL, so the two are asserted separately.
+    private void assertQueryWithOuterJoinType(String expectedLeft, String expectedRightFull, String query, TableModel... tableModels) throws SqlException {
+        for (String outerJoinType : outerJoinTypes) {
+            final String expected = "left".equals(outerJoinType) ? expectedLeft : expectedRightFull;
             assertQuery(
                     expected.replaceAll("#OUTER_JOIN_TYPE", outerJoinType),
                     query.replaceAll("#OUTER_JOIN_TYPE", outerJoinType),

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/JoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/JoinTest.java
@@ -5851,6 +5851,37 @@ public class JoinTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testOuterJoinMasterFilterStaysPostJoin() throws Exception {
+        // Regression for a query-fuzzer bind-variable divergence. RIGHT and FULL OUTER joins
+        // NULL-extend the master (left) table, so a WHERE predicate that references only the
+        // master used to be pushed into the master sub-query, leaving the unmatched right
+        // rows (with a NULL master) unfiltered. Here the master has no 's2' row, so the
+        // slave's 's2' row has no match; WHERE a.sym = 's2' must return no rows because the
+        // master symbol is NULL. The literal form leaked one such row and the bind-variable
+        // form two; both now correctly return nothing because the predicate stays post-join.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE m (sym SYMBOL, c1 INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("INSERT INTO m VALUES ('x', 200, 4)");
+            execute("CREATE TABLE s (sym SYMBOL, v INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("INSERT INTO s VALUES ('s2', 10, 1), ('x', 50, 5)");
+
+            final String empty = "e0\te1\n";
+            for (String joinType : new String[]{"RIGHT OUTER", "FULL OUTER"}) {
+                final String literal = "SELECT a.sym AS e0, a.c1 AS e1 FROM m a " + joinType + " JOIN s b ON a.sym = b.sym WHERE a.sym = 's2'";
+                final String bind = "SELECT a.sym AS e0, a.c1 AS e1 FROM m a " + joinType + " JOIN s b ON a.sym = b.sym WHERE a.sym = :sym::SYMBOL";
+
+                bindVariableService.clear();
+                assertQuery(literal).noLeakCheck().noRandomAccess().returns(empty);
+
+                bindVariableService.clear();
+                bindVariableService.setStr("sym", "s2");
+                printSql(bind);
+                TestUtils.assertEquals(empty, sink);
+            }
+        });
+    }
+
+    @Test
     public void testSelectAliasTest() throws Exception {
         assertMemoryLeak(() -> {
             execute(
@@ -6448,6 +6479,46 @@ public class JoinTest extends AbstractCairoTest {
             assertQuery("select x.i, x.sym, x.amt, price, x.timestamp, y.timestamp from (x order by timestamp desc) x splice join y on y.sym2 = x.sym")
                     .noLeakCheck()
                     .fails(93, "left");
+        });
+    }
+
+    @Test
+    public void testSpliceJoinMasterFilterStaysPostJoin() throws Exception {
+        // Regression for a query-fuzzer bind-variable divergence. A WHERE predicate that
+        // references only the master (left) table of a SPLICE join used to be pushed into
+        // the master sub-query. SPLICE is a full outer temporal join, so it emits rows in
+        // which the master columns are all NULL (slave-only timestamps); pushing the
+        // predicate left those NULL-master rows unfiltered, and for the literal form it was
+        // also propagated to the slave through the join key, so the literal and
+        // bind-variable forms of the same query diverged (here 3 vs 4 rows). The predicate
+        // now stays a post-join filter, so both forms agree and NULL-master rows are removed.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE m (sym SYMBOL, c1 INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("INSERT INTO m VALUES ('s2', 100, 2), ('s2', 200, 4)");
+            execute("CREATE TABLE s (sym SYMBOL, v INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+            // s2@1 leads the first master row (would be a NULL-master splice row); x@3 never
+            // has a master match (another NULL-master splice row). Both must be filtered out.
+            execute("INSERT INTO s VALUES ('s2', 10, 1), ('x', 50, 3)");
+
+            final String query = "SELECT a.sym AS e0, a.c1 AS e1 FROM m a SPLICE JOIN s b ON (sym) WHERE a.sym = 's2' ORDER BY e1";
+            final String expected = """
+                    e0\te1
+                    s2\t100
+                    s2\t200
+                    """;
+
+            // Literal form: correct result and a post-join Filter over a full master scan
+            // (no predicate pushed into the master sub-query).
+            assertQuery(query)
+                    .noLeakCheck()
+                    .withPlanContaining("Filter filter: a.sym='s2'")
+                    .returns(expected);
+
+            // Bind-variable form must produce the identical result.
+            bindVariableService.clear();
+            bindVariableService.setStr("sym", "s2");
+            printSql("SELECT a.sym AS e0, a.c1 AS e1 FROM m a SPLICE JOIN s b ON (sym) WHERE a.sym = :sym::SYMBOL ORDER BY e1");
+            TestUtils.assertEquals(expected, sink);
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/EmptyTableRecordCursorFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/EmptyTableRecordCursorFactoryTest.java
@@ -54,13 +54,14 @@ public class EmptyTableRecordCursorFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testFoldedFalseFilterAllowsSpliceJoin() throws Exception {
-        // The literal filter ((c0 + null))::TIMESTAMP < '2024-...'::TIMESTAMP folds
-        // through AddIntFunctionFactory's null short-circuit and the timestamp
-        // comparator to constant FALSE. SqlCodeGenerator then substitutes the master
-        // side of the splice join with EmptyTableRecordCursorFactory. The splice join
-        // must compile because the empty cursor supports random access; the bind-form
-        // equivalent compiles via a regular filter, and both forms must agree on the
-        // row count produced.
+        // The filter ((c0 + null))::TIMESTAMP < '2024-...'::TIMESTAMP evaluates to NULL,
+        // hence FALSE, for every row: AddIntFunctionFactory short-circuits the null and the
+        // timestamp comparator yields NULL. The filter references only the master (left)
+        // side of the SPLICE join, which is a full outer temporal join that NULL-extends the
+        // master, so the optimiser keeps it as a post-join filter rather than pushing it into
+        // the master sub-query (which would empty the master and leak one NULL-master row per
+        // slave row). A WHERE that is always FALSE therefore produces no rows, and the
+        // literal and bind-variable forms must agree.
         assertMemoryLeak(() -> {
             execute("CREATE TABLE t1 (c0 SHORT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
             execute("CREATE TABLE t0 (c0 INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
@@ -85,8 +86,8 @@ public class EmptyTableRecordCursorFactoryTest extends AbstractCairoTest {
             int bindRows = countRows(bindSql);
 
             Assert.assertEquals("literal and bind splice forms must agree", bindRows, literalRows);
-            // SPLICE JOIN with empty master pairs each slave row with a null master.
-            Assert.assertEquals(3, literalRows);
+            // The post-join WHERE folds to FALSE, so the splice produces no rows.
+            Assert.assertEquals(0, literalRows);
         });
     }
 


### PR DESCRIPTION
## Summary

SPLICE, FULL OUTER and RIGHT OUTER joins NULL-extend the master (left) side: SPLICE emits slave-only timestamps paired with a NULL master, while FULL and RIGHT OUTER emit unmatched right rows with a NULL master. The optimizer pushed a WHERE predicate that referenced only the master table down into that table's
sub-query, because it gated the push solely on the referenced table's own join type (the base table is an inner join) and ignored any downstream NULL-extending join.

The pushed predicate then left those NULL-master rows unfiltered, and for SPLICE it also changed which master row prevailed at each slave timestamp. As a result any of these three joins could return wrong results when a filter referenced only the master table.

The query fuzzer surfaced this as a literal-vs-bind divergence: with a literal constant the optimiser could also propagate it to the slave through the join key, while the bind-variable form could not, so the two forms disagreed on the row count. The literal form looked correct only when the master happened to contain the key.

## Fix

`masterNullingJoinIndex()` reports the outermost downstream SPLICE, FULL OUTER or RIGHT OUTER join that NULL-extends a given table. `analyseEquals()` and`assignFilters()` consult it and keep such a predicate as a post-join filter (`addPostJoinWhereClause`) instead of pushing it into the table's sub-query. LEFT OUTER, ASOF and LT joins keep every master row, so their master-side predicates still push down unchanged.

## Tradeoff

Because the predicate now runs after the join rather than inside the master sub-query, a master-side filter on these three join types can no longer use an index or interval scan on the master table; the query runs as a full scan plus a post-join filter. This is the cost of correctness for these joins - the previous index/interval-scan plan produced wrong results.

## Test plan

- Adds `JoinTest#testSpliceJoinMasterFilterStaysPostJoin` - splice join with a master-side filter; asserts the results and that the filter stays post-join (`Filter filter: ...`), plus literal-vs-bind parity.
- Adds `JoinTest#testOuterJoinMasterFilterStaysPostJoin` - right/full outer join where the master lacks the key; asserts 0 rows (the previously leaked NULL-master rows are gone) for both the literal and bind forms.
- Updates `SqlParserTest` splice and outer-join model assertions to the post-join model, and adds a two-argument `assertQueryWithOuterJoinType` overload so LEFT keeps the pushed-down filter while RIGHT/FULL expect the post-join filter.
- Updates `ExplainPlanTest#testLeftJoinWithPostJoinFilter` and `SqlOptimiserTest#testOrderByAdviceWithMultipleJoinsAndFilters` for the new plan.
- Corrects `EmptyTableRecordCursorFactoryTest#testFoldedFalseFilterAllowsSpliceJoin`: a splice whose master WHERE folds to FALSE must produce 0 rows, not 3.