### PR TITLE
feat(sql): add kurtosis and skewness aggregates

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractKurtosisGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractKurtosisGroupByFunction.java
@@ -1,0 +1,208 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.engine.functions.DoubleFunction;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.Numbers;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Streaming aggregation for the central moments needed to compute kurtosis.
+ * <p>
+ * The state holds five slots: mean, M2, M3, M4, and count, where
+ * Mk = sum((x - mean)^k). The per-row update uses Pebay's online algorithm
+ * (an extension of Welford's), and {@link #merge} uses the corresponding
+ * pairwise combine. Concrete subclasses turn these moments into a kurtosis
+ * value via {@code getDouble}.
+ *
+ * @see <a href="https://www.osti.gov/biblio/1028931">Pebay 2008, Formulas for Robust, One-Pass Parallel Computation of Covariances and Arbitrary-Order Statistical Moments</a>
+ */
+public abstract class AbstractKurtosisGroupByFunction extends DoubleFunction implements GroupByFunction, UnaryFunction {
+    protected final Function arg;
+    protected int valueIndex;
+
+    protected AbstractKurtosisGroupByFunction(@NotNull Function arg) {
+        this.arg = arg;
+    }
+
+    @Override
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        final double d = arg.getDouble(record);
+        mapValue.putDouble(valueIndex, 0);
+        mapValue.putDouble(valueIndex + 1, 0);
+        mapValue.putDouble(valueIndex + 2, 0);
+        mapValue.putDouble(valueIndex + 3, 0);
+        mapValue.putLong(valueIndex + 4, 0);
+        if (Numbers.isFinite(d)) {
+            aggregate(mapValue, d);
+        }
+    }
+
+    @Override
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        final double d = arg.getDouble(record);
+        if (Numbers.isFinite(d)) {
+            aggregate(mapValue, d);
+        }
+    }
+
+    @Override
+    public Function getArg() {
+        return arg;
+    }
+
+    @Override
+    public int getValueIndex() {
+        return valueIndex;
+    }
+
+    @Override
+    public void initValueIndex(int valueIndex) {
+        this.valueIndex = valueIndex;
+    }
+
+    @Override
+    public void initValueTypes(ArrayColumnTypes columnTypes) {
+        this.valueIndex = columnTypes.getColumnCount();
+        columnTypes.add(ColumnType.DOUBLE); // mean
+        columnTypes.add(ColumnType.DOUBLE); // M2 = sum((x - mean)^2)
+        columnTypes.add(ColumnType.DOUBLE); // M3 = sum((x - mean)^3)
+        columnTypes.add(ColumnType.DOUBLE); // M4 = sum((x - mean)^4)
+        columnTypes.add(ColumnType.LONG);   // count
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long nB = srcValue.getLong(valueIndex + 4);
+        if (nB == 0) {
+            return;
+        }
+        long nA = destValue.getLong(valueIndex + 4);
+        if (nA == 0) {
+            destValue.putDouble(valueIndex, srcValue.getDouble(valueIndex));
+            destValue.putDouble(valueIndex + 1, srcValue.getDouble(valueIndex + 1));
+            destValue.putDouble(valueIndex + 2, srcValue.getDouble(valueIndex + 2));
+            destValue.putDouble(valueIndex + 3, srcValue.getDouble(valueIndex + 3));
+            destValue.putLong(valueIndex + 4, nB);
+            return;
+        }
+
+        double meanA = destValue.getDouble(valueIndex);
+        double m2A = destValue.getDouble(valueIndex + 1);
+        double m3A = destValue.getDouble(valueIndex + 2);
+        double m4A = destValue.getDouble(valueIndex + 3);
+
+        double meanB = srcValue.getDouble(valueIndex);
+        double m2B = srcValue.getDouble(valueIndex + 1);
+        double m3B = srcValue.getDouble(valueIndex + 2);
+        double m4B = srcValue.getDouble(valueIndex + 3);
+
+        double nAd = nA;
+        double nBd = nB;
+        double nd = nAd + nBd;
+
+        double delta = meanB - meanA;
+        double delta2 = delta * delta;
+        double delta3 = delta2 * delta;
+        double delta4 = delta3 * delta;
+
+        double mean = (nAd * meanA + nBd * meanB) / nd;
+        double m2 = m2A + m2B + delta2 * nAd * nBd / nd;
+        double m3 = m3A + m3B
+                + delta3 * nAd * nBd * (nAd - nBd) / (nd * nd)
+                + 3 * delta * (nAd * m2B - nBd * m2A) / nd;
+        double m4 = m4A + m4B
+                + delta4 * nAd * nBd * (nAd * nAd - nAd * nBd + nBd * nBd) / (nd * nd * nd)
+                + 6 * delta2 * (nAd * nAd * m2B + nBd * nBd * m2A) / (nd * nd)
+                + 4 * delta * (nAd * m3B - nBd * m3A) / nd;
+
+        destValue.putDouble(valueIndex, mean);
+        destValue.putDouble(valueIndex + 1, m2);
+        destValue.putDouble(valueIndex + 2, m3);
+        destValue.putDouble(valueIndex + 3, m4);
+        destValue.putLong(valueIndex + 4, nA + nB);
+    }
+
+    @Override
+    public void setDouble(MapValue mapValue, double value) {
+        mapValue.putDouble(valueIndex, value);
+        mapValue.putDouble(valueIndex + 1, 0);
+        mapValue.putDouble(valueIndex + 2, 0);
+        mapValue.putDouble(valueIndex + 3, 0);
+        mapValue.putLong(valueIndex + 4, 1L);
+    }
+
+    @Override
+    public void setNull(MapValue mapValue) {
+        mapValue.putDouble(valueIndex, Double.NaN);
+        mapValue.putDouble(valueIndex + 1, Double.NaN);
+        mapValue.putDouble(valueIndex + 2, Double.NaN);
+        mapValue.putDouble(valueIndex + 3, Double.NaN);
+        mapValue.putLong(valueIndex + 4, 0);
+    }
+
+    @Override
+    public boolean supportsParallelism() {
+        return UnaryFunction.super.supportsParallelism();
+    }
+
+    protected void aggregate(MapValue mapValue, double value) {
+        double mean = mapValue.getDouble(valueIndex);
+        double m2 = mapValue.getDouble(valueIndex + 1);
+        double m3 = mapValue.getDouble(valueIndex + 2);
+        double m4 = mapValue.getDouble(valueIndex + 3);
+        long n = mapValue.getLong(valueIndex + 4) + 1;
+
+        double nd = n;
+        double delta = value - mean;
+        double deltaN = delta / nd;
+        double deltaN2 = deltaN * deltaN;
+        double term1 = delta * deltaN * (nd - 1);
+
+        // Update order matters: M4 reads the old M2 and M3, M3 reads the old M2.
+        double newM4 = m4 + term1 * deltaN2 * (nd * nd - 3 * nd + 3) + 6 * deltaN2 * m2 - 4 * deltaN * m3;
+        double newM3 = m3 + term1 * deltaN * (nd - 2) - 3 * deltaN * m2;
+        double newM2 = m2 + term1;
+        double newMean = mean + deltaN;
+
+        mapValue.putDouble(valueIndex, newMean);
+        mapValue.putDouble(valueIndex + 1, newM2);
+        mapValue.putDouble(valueIndex + 2, newM3);
+        mapValue.putDouble(valueIndex + 3, newM4);
+        mapValue.putLong(valueIndex + 4, n);
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractSkewnessGroupByFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/AbstractSkewnessGroupByFunction.java
@@ -1,0 +1,191 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.ArrayColumnTypes;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.map.MapValue;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.engine.functions.DoubleFunction;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.Numbers;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Streaming aggregation for the central moments needed to compute skewness.
+ * <p>
+ * The state holds four slots: mean, M2, M3, and count, where
+ * Mk = sum((x - mean)^k). The per-row update uses Pebay's online algorithm
+ * (an extension of Welford's), and {@link #merge} uses the corresponding
+ * pairwise combine. Concrete subclasses turn these moments into a skewness
+ * value via {@code getDouble}.
+ *
+ * @see <a href="https://www.osti.gov/biblio/1028931">Pebay 2008, Formulas for Robust, One-Pass Parallel Computation of Covariances and Arbitrary-Order Statistical Moments</a>
+ */
+public abstract class AbstractSkewnessGroupByFunction extends DoubleFunction implements GroupByFunction, UnaryFunction {
+    protected final Function arg;
+    protected int valueIndex;
+
+    protected AbstractSkewnessGroupByFunction(@NotNull Function arg) {
+        this.arg = arg;
+    }
+
+    @Override
+    public void computeFirst(MapValue mapValue, Record record, long rowId) {
+        final double d = arg.getDouble(record);
+        mapValue.putDouble(valueIndex, 0);
+        mapValue.putDouble(valueIndex + 1, 0);
+        mapValue.putDouble(valueIndex + 2, 0);
+        mapValue.putLong(valueIndex + 3, 0);
+        if (Numbers.isFinite(d)) {
+            aggregate(mapValue, d);
+        }
+    }
+
+    @Override
+    public void computeNext(MapValue mapValue, Record record, long rowId) {
+        final double d = arg.getDouble(record);
+        if (Numbers.isFinite(d)) {
+            aggregate(mapValue, d);
+        }
+    }
+
+    @Override
+    public Function getArg() {
+        return arg;
+    }
+
+    @Override
+    public int getValueIndex() {
+        return valueIndex;
+    }
+
+    @Override
+    public void initValueIndex(int valueIndex) {
+        this.valueIndex = valueIndex;
+    }
+
+    @Override
+    public void initValueTypes(ArrayColumnTypes columnTypes) {
+        this.valueIndex = columnTypes.getColumnCount();
+        columnTypes.add(ColumnType.DOUBLE); // mean
+        columnTypes.add(ColumnType.DOUBLE); // M2 = sum((x - mean)^2)
+        columnTypes.add(ColumnType.DOUBLE); // M3 = sum((x - mean)^3)
+        columnTypes.add(ColumnType.LONG);   // count
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
+    public void merge(MapValue destValue, MapValue srcValue) {
+        long nB = srcValue.getLong(valueIndex + 3);
+        if (nB == 0) {
+            return;
+        }
+        long nA = destValue.getLong(valueIndex + 3);
+        if (nA == 0) {
+            destValue.putDouble(valueIndex, srcValue.getDouble(valueIndex));
+            destValue.putDouble(valueIndex + 1, srcValue.getDouble(valueIndex + 1));
+            destValue.putDouble(valueIndex + 2, srcValue.getDouble(valueIndex + 2));
+            destValue.putLong(valueIndex + 3, nB);
+            return;
+        }
+
+        double meanA = destValue.getDouble(valueIndex);
+        double m2A = destValue.getDouble(valueIndex + 1);
+        double m3A = destValue.getDouble(valueIndex + 2);
+
+        double meanB = srcValue.getDouble(valueIndex);
+        double m2B = srcValue.getDouble(valueIndex + 1);
+        double m3B = srcValue.getDouble(valueIndex + 2);
+
+        double nAd = nA;
+        double nBd = nB;
+        double nd = nAd + nBd;
+
+        double delta = meanB - meanA;
+        double delta2 = delta * delta;
+        double delta3 = delta2 * delta;
+
+        double mean = (nAd * meanA + nBd * meanB) / nd;
+        double m2 = m2A + m2B + delta2 * nAd * nBd / nd;
+        double m3 = m3A + m3B
+                + delta3 * nAd * nBd * (nAd - nBd) / (nd * nd)
+                + 3 * delta * (nAd * m2B - nBd * m2A) / nd;
+
+        destValue.putDouble(valueIndex, mean);
+        destValue.putDouble(valueIndex + 1, m2);
+        destValue.putDouble(valueIndex + 2, m3);
+        destValue.putLong(valueIndex + 3, nA + nB);
+    }
+
+    @Override
+    public void setDouble(MapValue mapValue, double value) {
+        mapValue.putDouble(valueIndex, value);
+        mapValue.putDouble(valueIndex + 1, 0);
+        mapValue.putDouble(valueIndex + 2, 0);
+        mapValue.putLong(valueIndex + 3, 1L);
+    }
+
+    @Override
+    public void setNull(MapValue mapValue) {
+        mapValue.putDouble(valueIndex, Double.NaN);
+        mapValue.putDouble(valueIndex + 1, Double.NaN);
+        mapValue.putDouble(valueIndex + 2, Double.NaN);
+        mapValue.putLong(valueIndex + 3, 0);
+    }
+
+    @Override
+    public boolean supportsParallelism() {
+        return UnaryFunction.super.supportsParallelism();
+    }
+
+    protected void aggregate(MapValue mapValue, double value) {
+        double mean = mapValue.getDouble(valueIndex);
+        double m2 = mapValue.getDouble(valueIndex + 1);
+        double m3 = mapValue.getDouble(valueIndex + 2);
+        long n = mapValue.getLong(valueIndex + 3) + 1;
+
+        double nd = n;
+        double delta = value - mean;
+        double deltaN = delta / nd;
+        double term1 = delta * deltaN * (nd - 1);
+
+        // Update order matters: M3 reads the old M2.
+        double newM3 = m3 + term1 * deltaN * (nd - 2) - 3 * deltaN * m2;
+        double newM2 = m2 + term1;
+        double newMean = mean + deltaN;
+
+        mapValue.putDouble(valueIndex, newMean);
+        mapValue.putDouble(valueIndex + 1, newM2);
+        mapValue.putDouble(valueIndex + 2, newM3);
+        mapValue.putLong(valueIndex + 3, n);
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/KurtosisGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/KurtosisGroupByFunctionFactory.java
@@ -1,0 +1,33 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+public class KurtosisGroupByFunctionFactory extends KurtosisSampleGroupByFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "kurtosis(D)";
+    }
+
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/KurtosisGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/KurtosisGroupByFunctionFactory.java
@@ -29,5 +29,4 @@ public class KurtosisGroupByFunctionFactory extends KurtosisSampleGroupByFunctio
     public String getSignature() {
         return "kurtosis(D)";
     }
-
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/KurtosisPopGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/KurtosisPopGroupByFunctionFactory.java
@@ -1,0 +1,84 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import org.jetbrains.annotations.NotNull;
+
+public class KurtosisPopGroupByFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "kurtosis_pop(D)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new KurtosisPopGroupByFunction(args.getQuick(0));
+    }
+
+    private static class KurtosisPopGroupByFunction extends AbstractKurtosisGroupByFunction {
+
+        public KurtosisPopGroupByFunction(@NotNull Function arg) {
+            super(arg);
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            long n = rec.getLong(valueIndex + 4);
+            if (n < 1) {
+                return Double.NaN;
+            }
+            double m2 = rec.getDouble(valueIndex + 1);
+            if (m2 == 0.0) {
+                // all observations equal (or n == 1): kurtosis is undefined
+                return Double.NaN;
+            }
+            double m4 = rec.getDouble(valueIndex + 3);
+            return ((double) n) * m4 / (m2 * m2) - 3.0;
+        }
+
+        @Override
+        public String getName() {
+            return "kurtosis_pop";
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/KurtosisSampleGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/KurtosisSampleGroupByFunctionFactory.java
@@ -1,0 +1,93 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import org.jetbrains.annotations.NotNull;
+
+public class KurtosisSampleGroupByFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "kurtosis_samp(D)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new KurtosisSampleGroupByFunction(args.getQuick(0));
+    }
+
+    private static class KurtosisSampleGroupByFunction extends AbstractKurtosisGroupByFunction {
+
+        public KurtosisSampleGroupByFunction(@NotNull Function arg) {
+            super(arg);
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            long n = rec.getLong(valueIndex + 4);
+            if (n < 4) {
+                return Double.NaN;
+            }
+            double m2 = rec.getDouble(valueIndex + 1);
+            if (m2 == 0.0) {
+                // all observations equal: kurtosis is undefined
+                return Double.NaN;
+            }
+            double m4 = rec.getDouble(valueIndex + 3);
+            double nd = n;
+            // population excess kurtosis, then Fisher-Pearson bias correction
+            double g2 = nd * m4 / (m2 * m2) - 3.0;
+            return ((nd - 1) / ((nd - 2) * (nd - 3))) * ((nd + 1) * g2 + 6);
+        }
+
+        @Override
+        public String getName() {
+            return "kurtosis_samp";
+        }
+
+        @Override
+        public int getSampleByFlags() {
+            return GroupByFunction.SAMPLE_BY_FILL_ALL;
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SkewnessGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SkewnessGroupByFunctionFactory.java
@@ -1,0 +1,32 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+public class SkewnessGroupByFunctionFactory extends SkewnessSampleGroupByFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "skewness(D)";
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SkewnessPopGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SkewnessPopGroupByFunctionFactory.java
@@ -1,0 +1,85 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import org.jetbrains.annotations.NotNull;
+
+public class SkewnessPopGroupByFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "skewness_pop(D)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new SkewnessPopGroupByFunction(args.getQuick(0));
+    }
+
+    private static class SkewnessPopGroupByFunction extends AbstractSkewnessGroupByFunction {
+
+        public SkewnessPopGroupByFunction(@NotNull Function arg) {
+            super(arg);
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            long n = rec.getLong(valueIndex + 3);
+            if (n < 1) {
+                return Double.NaN;
+            }
+            double m2 = rec.getDouble(valueIndex + 1);
+            if (m2 == 0.0) {
+                // all observations equal (or n == 1): skewness is undefined
+                return Double.NaN;
+            }
+            double m3 = rec.getDouble(valueIndex + 2);
+            double nd = n;
+            return Math.sqrt(nd) * m3 / (m2 * Math.sqrt(m2));
+        }
+
+        @Override
+        public String getName() {
+            return "skewness_pop";
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SkewnessSampleGroupByFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/SkewnessSampleGroupByFunctionFactory.java
@@ -1,0 +1,92 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.GroupByFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import org.jetbrains.annotations.NotNull;
+
+public class SkewnessSampleGroupByFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "skewness_samp(D)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new SkewnessSampleGroupByFunction(args.getQuick(0));
+    }
+
+    private static class SkewnessSampleGroupByFunction extends AbstractSkewnessGroupByFunction {
+
+        public SkewnessSampleGroupByFunction(@NotNull Function arg) {
+            super(arg);
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            long n = rec.getLong(valueIndex + 3);
+            if (n < 3) {
+                return Double.NaN;
+            }
+            double m2 = rec.getDouble(valueIndex + 1);
+            if (m2 == 0.0) {
+                // all observations equal: skewness is undefined
+                return Double.NaN;
+            }
+            double m3 = rec.getDouble(valueIndex + 2);
+            double nd = n;
+            // sample skewness (Fisher-Pearson)
+            return (nd * Math.sqrt(nd - 1.0) / (nd - 2.0)) * m3 / (m2 * Math.sqrt(m2));
+        }
+
+        @Override
+        public String getName() {
+            return "skewness_samp";
+        }
+
+        @Override
+        public int getSampleByFlags() {
+            return GroupByFunction.SAMPLE_BY_FILL_ALL;
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/ParallelGroupByFuzzTest.java
@@ -311,6 +311,63 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testParallelApproxPercentileFuzz() throws Exception {
+        Assume.assumeTrue(enableParallelGroupBy);
+        assertMemoryLeak(() -> {
+            final Rnd rnd = TestUtils.generateRandom(LOG);
+            final double percentile = rnd.nextDouble();
+            final int precision = rnd.nextInt(6);
+            final int rowCount = rnd.nextInt(ROW_COUNT) + 1;
+            final int groupCount = rnd.nextInt(10) + 1;
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.execute(
+                    pool,
+                    (engine, compiler, sqlExecutionContext) -> {
+                        sqlExecutionContext.setJitMode(
+                                enableJitCompiler ? SqlJitMode.JIT_MODE_ENABLED : SqlJitMode.JIT_MODE_DISABLED);
+
+                        execute(
+                                compiler,
+                                "CREATE TABLE tab AS ("
+                                        + "SELECT CASE WHEN rnd_int() % 10 = 0 THEN NULL ELSE abs(rnd_long()) % 10_000_000 END AS x, rnd_int() % " + groupCount + " AS g "
+                                        + "FROM long_sequence(" + rowCount + "))",
+                                sqlExecutionContext);
+
+                        final String query = "SELECT g, approx_percentile(x, " + percentile + ", " + precision + ") FROM tab GROUP BY g ORDER BY g";
+
+                        sqlExecutionContext.setParallelGroupByEnabled(false);
+                        try {
+                            TestUtils.printSql(
+                                    engine,
+                                    sqlExecutionContext,
+                                    query,
+                                    sink);
+                        } finally {
+                            sqlExecutionContext.setParallelGroupByEnabled(
+                                    engine.getConfiguration().isSqlParallelGroupByEnabled());
+                        }
+
+                        sqlExecutionContext.setParallelGroupByEnabled(true);
+                        final StringSink parallelSink = new StringSink();
+                        try {
+                            TestUtils.printSql(
+                                    engine,
+                                    sqlExecutionContext,
+                                    query,
+                                    parallelSink);
+                        } finally {
+                            sqlExecutionContext.setParallelGroupByEnabled(
+                                    engine.getConfiguration().isSqlParallelGroupByEnabled());
+                        }
+
+                        TestUtils.assertEquals(sink, parallelSink);
+                    },
+                    configuration,
+                    LOG);
+        });
+    }
+
+    @Test
     public void testParallelAvgDecimal128RescaleOverflowFactoryReuse() throws Exception {
         // Regression: AvgDecimal128Rescale256GroupByFunction.merge's "both
         // shards overflowed into 256 bits" branch must add the running
@@ -1773,6 +1830,32 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testParallelGroupByKurtosis() throws Exception {
+        testParallelGroupByAllTypes(
+                "SELECT round(kurtosis_samp(adouble), 12) FROM tab", """
+                        round
+                        -1.173939788697
+                        """,
+                "SELECT round(kurtosis(adouble), 12) FROM tab", """
+                        round
+                        -1.173939788697
+                        """,
+                "SELECT round(kurtosis_pop(adouble), 12) FROM tab", """
+                        round
+                        -1.173979070703
+                        """,
+                "SELECT key, round(kurtosis_pop(adouble), 12) kp, round(kurtosis_samp(adouble), 12) ks FROM tab ORDER BY key", """
+                        key\tkp\tks
+                        k0\t-1.177368704151\t-1.177195920397
+                        k1\t-1.213464478728\t-1.2135590444339999
+                        k2\t-1.156658901168\t-1.156322164928
+                        k3\t-1.1266060077039999\t-1.126049103395
+                        k4\t-1.172914311098\t-1.172699075325
+                        """
+        );
+    }
+
+    @Test
     public void testParallelGroupByRegrIntercept() throws Exception {
         Assume.assumeTrue(enableParallelGroupBy);
         testParallelGroupByAllTypes("SELECT round(regr_intercept(adouble, along), 14) FROM tab", """
@@ -1794,6 +1877,32 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                 round
                 2.2694313961E-4
                 """);
+    }
+
+    @Test
+    public void testParallelGroupBySkewness() throws Exception {
+        testParallelGroupByAllTypes(
+                "SELECT round(skewness_samp(adouble), 12) FROM tab", """
+                        round
+                        0.006214510929
+                        """,
+                "SELECT round(skewness(adouble), 12) FROM tab", """
+                        round
+                        0.006214510929
+                        """,
+                "SELECT round(skewness_pop(adouble), 12) FROM tab", """
+                        round
+                        0.006211714609
+                        """,
+                "SELECT key, round(skewness_pop(adouble), 12) sp, round(skewness_samp(adouble), 12) ss FROM tab ORDER BY key", """
+                        key\tsp\tss
+                        k0\t0.092682517801\t0.092887845278
+                        k1\t-0.03876828558\t-0.038854299301999996
+                        k2\t-0.046932723408999996\t-0.047040025485999996
+                        k3\t-0.039550117182\t-0.039639049387
+                        k4\t0.064287112494\t0.06443590616099999
+                        """
+        );
     }
 
     @Test
@@ -2657,63 +2766,6 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
     @Test
     public void testParallelNonKeyedGroupByFaultTolerance() throws Exception {
         testParallelGroupByFaultTolerance("select vwap(price, quantity) from tab where npe();");
-    }
-
-    @Test
-    public void testParallelApproxPercentileFuzz() throws Exception {
-        Assume.assumeTrue(enableParallelGroupBy);
-        assertMemoryLeak(() -> {
-            final Rnd rnd = TestUtils.generateRandom(LOG);
-            final double percentile = rnd.nextDouble();
-            final int precision = rnd.nextInt(6);
-            final int rowCount = rnd.nextInt(ROW_COUNT) + 1;
-            final int groupCount = rnd.nextInt(10) + 1;
-            final WorkerPool pool = new WorkerPool(() -> 4);
-            TestUtils.execute(
-                    pool,
-                    (engine, compiler, sqlExecutionContext) -> {
-                        sqlExecutionContext.setJitMode(
-                                enableJitCompiler ? SqlJitMode.JIT_MODE_ENABLED : SqlJitMode.JIT_MODE_DISABLED);
-
-                        execute(
-                                compiler,
-                                "CREATE TABLE tab AS ("
-                                        + "SELECT CASE WHEN rnd_int() % 10 = 0 THEN NULL ELSE abs(rnd_long()) % 10_000_000 END AS x, rnd_int() % " + groupCount + " AS g "
-                                        + "FROM long_sequence(" + rowCount + "))",
-                                sqlExecutionContext);
-
-                        final String query = "SELECT g, approx_percentile(x, " + percentile + ", " + precision + ") FROM tab GROUP BY g ORDER BY g";
-
-                        sqlExecutionContext.setParallelGroupByEnabled(false);
-                        try {
-                            TestUtils.printSql(
-                                    engine,
-                                    sqlExecutionContext,
-                                    query,
-                                    sink);
-                        } finally {
-                            sqlExecutionContext.setParallelGroupByEnabled(
-                                    engine.getConfiguration().isSqlParallelGroupByEnabled());
-                        }
-
-                        sqlExecutionContext.setParallelGroupByEnabled(true);
-                        final StringSink parallelSink = new StringSink();
-                        try {
-                            TestUtils.printSql(
-                                    engine,
-                                    sqlExecutionContext,
-                                    query,
-                                    parallelSink);
-                        } finally {
-                            sqlExecutionContext.setParallelGroupByEnabled(
-                                    engine.getConfiguration().isSqlParallelGroupByEnabled());
-                        }
-
-                        TestUtils.assertEquals(sink, parallelSink);
-                    },
-                    configuration,
-                    LOG);
-        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/KurtosisParallelGroupByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/KurtosisParallelGroupByTest.java
@@ -1,0 +1,105 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.PropertyKey;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.mp.WorkerPool;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+public class KurtosisParallelGroupByTest extends AbstractCairoTest {
+
+    @Override
+    @Before
+    public void setUp() {
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_ENABLED, "true");
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_SHARDING_THRESHOLD, 1);
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_WORK_STEALING_THRESHOLD, 1);
+        setProperty(PropertyKey.CAIRO_SQL_PAGE_FRAME_MAX_ROWS, 64);
+        setProperty(PropertyKey.CAIRO_PAGE_FRAME_SHARD_COUNT, 2);
+        setProperty(PropertyKey.CAIRO_PAGE_FRAME_REDUCE_QUEUE_CAPACITY, 2);
+        super.setUp();
+    }
+
+    @Test
+    public void testParallelKurtosisPopSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            createSparseTable(compiler, ctx);
+            // arithmetic sequence {1500..1509}, n=10: g2_pop = 10*M4/M2^2 - 3 = -202/165
+            assertQuery("SELECT kurtosis_pop(x) FROM tbl")
+                    .noLeakCheck()
+                    .withCompiler(compiler)
+                    .withContext(ctx)
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_pop\n-1.2242424242424241\n");
+        });
+    }
+
+    @Test
+    public void testParallelKurtosisSampSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            createSparseTable(compiler, ctx);
+            // arithmetic sequence of any length >= 4 has Fisher-Pearson sample kurtosis exactly -6/5
+            assertQuery("SELECT kurtosis_samp(x) FROM tbl")
+                    .noLeakCheck()
+                    .withCompiler(compiler)
+                    .withContext(ctx)
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\n-1.1999999999999997\n");
+        });
+    }
+
+    private void createSparseTable(SqlCompiler compiler, SqlExecutionContext ctx) throws Exception {
+        execute(
+                compiler,
+                "CREATE TABLE tbl AS (" +
+                        "    SELECT" +
+                        "        CASE WHEN x BETWEEN 1500 AND 1509 THEN cast(x AS double) ELSE cast(null AS double) END x" +
+                        "    FROM long_sequence(4_000)" +
+                        ")",
+                ctx
+        );
+    }
+
+    private void runWithPool(PoolRunnable body) throws Exception {
+        assertMemoryLeak(() -> {
+            try (WorkerPool pool = new WorkerPool(() -> 4)) {
+                TestUtils.execute(pool, (_, compiler, sqlExecutionContext) ->
+                        body.run(compiler, sqlExecutionContext), configuration, LOG);
+            }
+        });
+    }
+
+    @FunctionalInterface
+    private interface PoolRunnable {
+        void run(SqlCompiler compiler, SqlExecutionContext ctx) throws Exception;
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/KurtosisPopGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/KurtosisPopGroupByFunctionFactoryTest.java
@@ -1,0 +1,207 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class KurtosisPopGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testKurtosisPopAllNull() throws Exception {
+        assertMemoryLeak(() -> assertQuery(
+                "select kurtosis_pop(x) from (select cast(null as double) x from long_sequence(100))")
+                .noLeakCheck()
+                .noRandomAccess()
+                .expectSize()
+                .returns("kurtosis_pop\nnull\n"));
+    }
+
+    @Test
+    public void testKurtosisPopAllSameValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT 1 x FROM long_sequence(100))");
+            assertQuery("SELECT kurtosis_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_pop\nnull\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisPopDoubleValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(4))");
+            assertQuery("SELECT kurtosis_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_pop\n-1.36\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisPopFirstNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 (x DOUBLE)");
+            execute("INSERT INTO tbl1 VALUES (null)");
+            execute("INSERT INTO tbl1 SELECT cast(x AS DOUBLE) FROM long_sequence(4)");
+            assertQuery("SELECT kurtosis_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_pop\n-1.36\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisPopFloatValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS FLOAT) x FROM long_sequence(4))");
+            assertQuery("SELECT kurtosis_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_pop\n-1.36\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisPopIntValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS INT) x FROM long_sequence(4))");
+            assertQuery("SELECT kurtosis_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_pop\n-1.36\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisPopLongValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT x FROM long_sequence(4))");
+            assertQuery("SELECT kurtosis_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_pop\n-1.36\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisPopMultiColumn() throws Exception {
+        // Verified with DuckDB
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE aggr (k INT, v INT, v2 INT)");
+            execute("""
+                    INSERT INTO aggr VALUES
+                        (1, 10, null),
+                        (2, 10, 11),
+                        (2, 10, 15),
+                        (2, 10, 18),
+                        (2, 20, 22),
+                        (2, 20, 25),
+                        (2, 25, null),
+                        (2, 30, 35),
+                        (2, 30, 40),
+                        (2, 30, 50),
+                        (2, 30, 51)""");
+            assertQuery("""
+                    SELECT round(kurtosis_pop(k), 6) k,
+                           round(kurtosis_pop(v), 6) v,
+                           round(kurtosis_pop(v2), 6) v2
+                    FROM aggr""")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("k\tv\tv2\n6.1\t-1.6768569999999998\t-1.358688\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisPopNoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 (x DOUBLE)");
+            assertQuery("SELECT kurtosis_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_pop\nnull\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisPopOneValue() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 (x DOUBLE)");
+            execute("INSERT INTO tbl1 VALUES (1)");
+            assertQuery("SELECT kurtosis_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_pop\nnull\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisPopSomeNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(4))");
+            execute("INSERT INTO tbl1 VALUES (null)");
+            assertQuery("SELECT kurtosis_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_pop\n-1.36\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisPopThreeValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(3))");
+            assertQuery("SELECT kurtosis_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_pop\n-1.5\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisPopTwoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(2))");
+            assertQuery("SELECT kurtosis_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_pop\n-2.0\n");
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/KurtosisPopGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/KurtosisPopGroupByFunctionFactoryTest.java
@@ -31,12 +31,11 @@ public class KurtosisPopGroupByFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testKurtosisPopAllNull() throws Exception {
-        assertMemoryLeak(() -> assertQuery(
+        assertQuery(
                 "select kurtosis_pop(x) from (select cast(null as double) x from long_sequence(100))")
-                .noLeakCheck()
                 .noRandomAccess()
                 .expectSize()
-                .returns("kurtosis_pop\nnull\n"));
+                .returns("kurtosis_pop\nnull\n");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/KurtosisSampleGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/KurtosisSampleGroupByFunctionFactoryTest.java
@@ -31,12 +31,11 @@ public class KurtosisSampleGroupByFunctionFactoryTest extends AbstractCairoTest 
 
     @Test
     public void testKurtosisSampAllNull() throws Exception {
-        assertMemoryLeak(() -> assertQuery(
+        assertQuery(
                 "select kurtosis_samp(x) from (select cast(null as double) x from long_sequence(100))")
-                .noLeakCheck()
                 .noRandomAccess()
                 .expectSize()
-                .returns("kurtosis_samp\nnull\n"));
+                .returns("kurtosis_samp\nnull\n");
     }
 
     @Test
@@ -86,6 +85,19 @@ public class KurtosisSampleGroupByFunctionFactoryTest extends AbstractCairoTest 
                     .noRandomAccess()
                     .expectSize()
                     .returns("kurtosis_samp\n-1.2\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisSampHugeValues() throws Exception {
+        // Arithmetic sequence: sample excess kurtosis is ~-1.2 at any scale, so huge values keep a known target.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT 100_000_000 * x x FROM long_sequence(1_000_000))");
+            assertQuery("SELECT kurtosis_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\n-1.2000000000000608\n");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/KurtosisSampleGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/KurtosisSampleGroupByFunctionFactoryTest.java
@@ -1,0 +1,208 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class KurtosisSampleGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testKurtosisSampAllNull() throws Exception {
+        assertMemoryLeak(() -> assertQuery(
+                "select kurtosis_samp(x) from (select cast(null as double) x from long_sequence(100))")
+                .noLeakCheck()
+                .noRandomAccess()
+                .expectSize()
+                .returns("kurtosis_samp\nnull\n"));
+    }
+
+    @Test
+    public void testKurtosisSampAllSameValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT 1 x FROM long_sequence(100))");
+            assertQuery("SELECT kurtosis_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\nnull\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisSampDoubleValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(4))");
+            assertQuery("SELECT round(kurtosis_samp(x), 6) kurtosis_samp FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\n-1.2\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisSampFirstNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 (x DOUBLE)");
+            execute("INSERT INTO tbl1 VALUES (null)");
+            execute("INSERT INTO tbl1 SELECT cast(x AS DOUBLE) FROM long_sequence(4)");
+            assertQuery("SELECT round(kurtosis_samp(x), 6) kurtosis_samp FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\n-1.2\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisSampFloatValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS FLOAT) x FROM long_sequence(4))");
+            assertQuery("SELECT round(kurtosis_samp(x), 6) kurtosis_samp FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\n-1.2\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisSampIntValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS INT) x FROM long_sequence(4))");
+            assertQuery("SELECT round(kurtosis_samp(x), 6) kurtosis_samp FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\n-1.2\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisSampLongValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT x FROM long_sequence(4))");
+            assertQuery("SELECT round(kurtosis_samp(x), 6) kurtosis_samp FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\n-1.2\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisSampMultiColumn() throws Exception {
+        // Verified with DuckDB
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE aggr (k INT, v INT, v2 INT)");
+            execute("""
+                    INSERT INTO aggr VALUES
+                        (1, 10, null),
+                        (2, 10, 11),
+                        (2, 10, 15),
+                        (2, 10, 18),
+                        (2, 20, 22),
+                        (2, 20, 25),
+                        (2, 25, null),
+                        (2, 30, 35),
+                        (2, 30, 40),
+                        (2, 30, 50),
+                        (2, 30, 51)""");
+            assertQuery("""
+                    SELECT round(kurtosis_samp(k), 6) k,
+                           round(kurtosis_samp(v), 6) v,
+                           round(kurtosis_samp(v2), 6) v2
+                    FROM aggr""")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("k\tv\tv2\n11.0\t-1.961428\t-1.44512\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisSampNoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 (x DOUBLE)");
+            assertQuery("SELECT kurtosis_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\nnull\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisSampOneValue() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 (x DOUBLE)");
+            execute("INSERT INTO tbl1 VALUES (1)");
+            assertQuery("SELECT kurtosis_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\nnull\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisSampSomeNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(4))");
+            execute("INSERT INTO tbl1 VALUES (null)");
+            assertQuery("SELECT round(kurtosis_samp(x), 6) kurtosis_samp FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\n-1.2\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisSampThreeValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(3))");
+            assertQuery("SELECT kurtosis_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\nnull\n");
+        });
+    }
+
+    @Test
+    public void testKurtosisSampTwoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(2))");
+            assertQuery("SELECT kurtosis_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("kurtosis_samp\nnull\n");
+        });
+    }
+
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/SkewnessParallelGroupByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/SkewnessParallelGroupByTest.java
@@ -1,0 +1,104 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.PropertyKey;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.mp.WorkerPool;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SkewnessParallelGroupByTest extends AbstractCairoTest {
+
+    @Override
+    @Before
+    public void setUp() {
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_ENABLED, "true");
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_GROUPBY_SHARDING_THRESHOLD, 1);
+        setProperty(PropertyKey.CAIRO_SQL_PARALLEL_WORK_STEALING_THRESHOLD, 1);
+        setProperty(PropertyKey.CAIRO_SQL_PAGE_FRAME_MAX_ROWS, 64);
+        setProperty(PropertyKey.CAIRO_PAGE_FRAME_SHARD_COUNT, 2);
+        setProperty(PropertyKey.CAIRO_PAGE_FRAME_REDUCE_QUEUE_CAPACITY, 2);
+        super.setUp();
+    }
+
+    @Test
+    public void testParallelSkewnessPopSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            createSparseTable(compiler, ctx);
+            // arithmetic sequence is symmetric -> M3=0 -> skewness=0
+            assertQuery("SELECT skewness_pop(x) FROM tbl")
+                    .noLeakCheck()
+                    .withCompiler(compiler)
+                    .withContext(ctx)
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_pop\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testParallelSkewnessSampSparseNulls() throws Exception {
+        runWithPool((compiler, ctx) -> {
+            createSparseTable(compiler, ctx);
+            assertQuery("SELECT skewness_samp(x) FROM tbl")
+                    .noLeakCheck()
+                    .withCompiler(compiler)
+                    .withContext(ctx)
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\n0.0\n");
+        });
+    }
+
+    private void createSparseTable(SqlCompiler compiler, SqlExecutionContext ctx) throws Exception {
+        execute(
+                compiler,
+                "CREATE TABLE tbl AS (" +
+                        "    SELECT" +
+                        "        CASE WHEN x BETWEEN 1500 AND 1509 THEN cast(x AS double) ELSE cast(null AS double) END x" +
+                        "    FROM long_sequence(4_000)" +
+                        ")",
+                ctx
+        );
+    }
+
+    private void runWithPool(PoolRunnable body) throws Exception {
+        assertMemoryLeak(() -> {
+            try (WorkerPool pool = new WorkerPool(() -> 4)) {
+                TestUtils.execute(pool, (_, compiler, sqlExecutionContext) ->
+                        body.run(compiler, sqlExecutionContext), configuration, LOG);
+            }
+        });
+    }
+
+    @FunctionalInterface
+    private interface PoolRunnable {
+        void run(SqlCompiler compiler, SqlExecutionContext ctx) throws Exception;
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/SkewnessPopGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/SkewnessPopGroupByFunctionFactoryTest.java
@@ -1,0 +1,206 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class SkewnessPopGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testSkewnessPopAllNull() throws Exception {
+        assertMemoryLeak(() -> assertQuery(
+                "select skewness_pop(x) from (select cast(null as double) x from long_sequence(100))")
+                .noLeakCheck()
+                .noRandomAccess()
+                .expectSize()
+                .returns("skewness_pop\nnull\n"));
+    }
+
+    @Test
+    public void testSkewnessPopAllSameValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT 1 x FROM long_sequence(100))");
+            assertQuery("SELECT skewness_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_pop\nnull\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessPopDoubleValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(4))");
+            assertQuery("SELECT skewness_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_pop\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessPopFirstNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 (x DOUBLE)");
+            execute("INSERT INTO tbl1 VALUES (null)");
+            execute("INSERT INTO tbl1 SELECT cast(x AS DOUBLE) FROM long_sequence(4)");
+            assertQuery("SELECT skewness_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_pop\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessPopFloatValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS FLOAT) x FROM long_sequence(4))");
+            assertQuery("SELECT skewness_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_pop\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessPopIntValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS INT) x FROM long_sequence(4))");
+            assertQuery("SELECT skewness_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_pop\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessPopLongValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT x FROM long_sequence(4))");
+            assertQuery("SELECT skewness_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_pop\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessPopMultiColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE aggr (k INT, v INT, v2 INT)");
+            execute("""
+                    INSERT INTO aggr VALUES
+                        (1, 10, null),
+                        (2, 10, 11),
+                        (2, 10, 15),
+                        (2, 10, 18),
+                        (2, 20, 22),
+                        (2, 20, 25),
+                        (2, 25, null),
+                        (2, 30, 35),
+                        (2, 30, 40),
+                        (2, 30, 50),
+                        (2, 30, 51)""");
+            assertQuery("""
+                    SELECT round(skewness_pop(k), 6) k,
+                           round(skewness_pop(v), 6) v,
+                           round(skewness_pop(v2), 6) v2
+                    FROM aggr""")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("k\tv\tv2\n-2.84605\t-0.140254\t0.30144\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessPopNoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 (x DOUBLE)");
+            assertQuery("SELECT skewness_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_pop\nnull\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessPopOneValue() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 (x DOUBLE)");
+            execute("INSERT INTO tbl1 VALUES (1)");
+            assertQuery("SELECT skewness_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_pop\nnull\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessPopSomeNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(4))");
+            execute("INSERT INTO tbl1 VALUES (null)");
+            assertQuery("SELECT skewness_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_pop\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessPopThreeValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(3))");
+            assertQuery("SELECT skewness_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_pop\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessPopTwoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(2))");
+            assertQuery("SELECT skewness_pop(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_pop\n0.0\n");
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/SkewnessPopGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/SkewnessPopGroupByFunctionFactoryTest.java
@@ -31,12 +31,11 @@ public class SkewnessPopGroupByFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testSkewnessPopAllNull() throws Exception {
-        assertMemoryLeak(() -> assertQuery(
+        assertQuery(
                 "select skewness_pop(x) from (select cast(null as double) x from long_sequence(100))")
-                .noLeakCheck()
                 .noRandomAccess()
                 .expectSize()
-                .returns("skewness_pop\nnull\n"));
+                .returns("skewness_pop\nnull\n");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/SkewnessSampleGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/SkewnessSampleGroupByFunctionFactoryTest.java
@@ -1,0 +1,207 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class SkewnessSampleGroupByFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testSkewnessSampAllNull() throws Exception {
+        assertMemoryLeak(() -> assertQuery(
+                "select skewness_samp(x) from (select cast(null as double) x from long_sequence(100))")
+                .noLeakCheck()
+                .noRandomAccess()
+                .expectSize()
+                .returns("skewness_samp\nnull\n"));
+    }
+
+    @Test
+    public void testSkewnessSampAllSameValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT 1 x FROM long_sequence(100))");
+            assertQuery("SELECT skewness_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\nnull\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessSampDoubleValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(4))");
+            assertQuery("SELECT skewness_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessSampFirstNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 (x DOUBLE)");
+            execute("INSERT INTO tbl1 VALUES (null)");
+            execute("INSERT INTO tbl1 SELECT cast(x AS DOUBLE) FROM long_sequence(4)");
+            assertQuery("SELECT skewness_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessSampFloatValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS FLOAT) x FROM long_sequence(4))");
+            assertQuery("SELECT skewness_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessSampIntValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS INT) x FROM long_sequence(4))");
+            assertQuery("SELECT skewness_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessSampLongValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT x FROM long_sequence(4))");
+            assertQuery("SELECT skewness_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessSampMultiColumn() throws Exception {
+        // Verified with DuckDB
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE aggr (k INT, v INT, v2 INT)");
+            execute("""
+                    INSERT INTO aggr VALUES
+                        (1, 10, null),
+                        (2, 10, 11),
+                        (2, 10, 15),
+                        (2, 10, 18),
+                        (2, 20, 22),
+                        (2, 20, 25),
+                        (2, 25, null),
+                        (2, 30, 35),
+                        (2, 30, 40),
+                        (2, 30, 50),
+                        (2, 30, 51)""");
+            assertQuery("""
+                    SELECT round(skewness_samp(k), 6) k,
+                           round(skewness_samp(v), 6) v,
+                           round(skewness_samp(v2), 6) v2
+                    FROM aggr""")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("k\tv\tv2\n-3.3166249999999997\t-0.163444\t0.365401\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessSampNoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 (x DOUBLE)");
+            assertQuery("SELECT skewness_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\nnull\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessSampOneValue() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 (x DOUBLE)");
+            execute("INSERT INTO tbl1 VALUES (1)");
+            assertQuery("SELECT skewness_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\nnull\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessSampSomeNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(4))");
+            execute("INSERT INTO tbl1 VALUES (null)");
+            assertQuery("SELECT skewness_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessSampThreeValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(3))");
+            assertQuery("SELECT skewness_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessSampTwoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT cast(x AS DOUBLE) x FROM long_sequence(2))");
+            assertQuery("SELECT skewness_samp(x) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\nnull\n");
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/SkewnessSampleGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/SkewnessSampleGroupByFunctionFactoryTest.java
@@ -31,12 +31,11 @@ public class SkewnessSampleGroupByFunctionFactoryTest extends AbstractCairoTest 
 
     @Test
     public void testSkewnessSampAllNull() throws Exception {
-        assertMemoryLeak(() -> assertQuery(
+        assertQuery(
                 "select skewness_samp(x) from (select cast(null as double) x from long_sequence(100))")
-                .noLeakCheck()
                 .noRandomAccess()
                 .expectSize()
-                .returns("skewness_samp\nnull\n"));
+                .returns("skewness_samp\nnull\n");
     }
 
     @Test
@@ -86,6 +85,19 @@ public class SkewnessSampleGroupByFunctionFactoryTest extends AbstractCairoTest 
                     .noRandomAccess()
                     .expectSize()
                     .returns("skewness_samp\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testSkewnessSampHugeValues() throws Exception {
+        // Right-skewed x^2: a symmetric set gives ~0, so we use a clear non-zero skew to anchor.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tbl1 AS (SELECT (x * x)::double val FROM long_sequence(1_000_000))");
+            assertQuery("SELECT skewness_samp(val) FROM tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("skewness_samp\n0.6388769842619288\n");
         });
     }
 


### PR DESCRIPTION
## Summary

Adds `kurtosis` and `skewness` methods addressing Gap 4 of https://github.com/questdb/roadmap/issues/120. To be precise, the following functions are added

  | Function | Description |
  | --- | --- |
  | `kurtosis` / `kurtosis_samp` | Sample excess kurtosis |
  | `kurtosis_pop` | Population excess kurtosis |
  | `skewness` / `skewness_samp` | Sample skewness |
  | `skewness_pop` | Population skewness |

**Example**
```sql
SELECT skewness(price), kurtosis(price)
FROM trades
WHERE symbol = 'BTC-USD'
SAMPLE BY 1h;
```
Documentation: https://github.com/questdb/documentation/pull/463

## Implementation details
- The state for each group keeps a running mean and the central moments M2, M3 (and M4 for kurtosis) plus a count, updated per row with [Pébay](https://www.osti.gov/biblio/1028931)'s one-pass online algorithm (an extension of Welford's)
- Partial aggregates merge with the matching pairwise-combine formulas, so the functions support parallel GROUP BY execution
- The streaming approach avoids a second pass over the data and is numerically more stable than the naive sum-of-powers formula.

**Conventions**
- Sample skewness returns `null` for fewer than 3 values; sample kurtosis for fewer than 4
- The sample variants apply the standard bias correction (Fisher's definition)
- Population variants return `null` for an empty group
- All variants return `null` when every observation is equal (zero variance), since the
  statistic is undefined

## Testing
- Unit tests using DuckDB as a reference
- A script outside this PR was used to compare the values we compute with this implementation and `scipy`