### PR TITLE
Enhance error messaging for invalid field values

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/LineHttpProcessorState.java
@@ -49,6 +49,7 @@ import io.questdb.std.Zip;
 import io.questdb.std.str.DirectUtf8Sink;
 import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8Sink;
+import io.questdb.std.str.DirectUtf8Sequence;
 
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -398,10 +399,28 @@ public class LineHttpProcessorState implements QuietCloseable, ConnectionAware {
             case INVALID_TIMESTAMP:
                 error.put(": Could not parse timestamp: ").put(parser.getErrorTimestampValue());
                 break;
-            case INVALID_FIELD_VALUE:
+            case INVALID_FIELD_VALUE: {
+                DirectUtf8Sequence val = parser.getErrorFieldValue();
+                DirectUtf8Sequence name = parser.getLastEntityName();
+                // Provide more specific guidance when possible, e.g. trailing 'u' (unsigned)
+                if (val != null && val.size() > 0) {
+                    byte last = val.byteAt(val.size() - 1);
+                    if (last == 'u' || last == 'U') {
+                        error.put(": Invalid integer value: ");
+                        error.put(val);
+                        error.put("; Expected signed integer, long, double, boolean, or string");
+                        if (name != null) {
+                            error.put(". Field: ").put(name);
+                        }
+                        break;
+                    }
+                }
+
+                // Fallback: keep the original informative message
                 error.put(": Could not parse entire line, field value is invalid. Field: ")
-                        .put(parser.getLastEntityName()).put("; value: ").put(parser.getErrorFieldValue());
+                        .put(name).put("; value: ").put(val);
                 break;
+            }
             case INVALID_TAG_VALUE:
                 error.put(": Could not parse entire line, tag value is invalid. Tag: ")
                         .put(parser.getLastEntityName()).put("; value: ").put(parser.getErrorFieldValue());


### PR DESCRIPTION
Added more detailed error messages for line protocol error reporting for when a user submits an invalid field value ending in u or U. This case commonly occurs when a user sends an unsigned integer value such as 8u, which is valid in some line protocol implementations but unsupported by QuestDB.

Previously, QuestDB reported this as a generic invalid field value error, which made it harder for users to understand what was wrong. I updated the error-handling logic for the INVALID_FIELD_VALUE case so that it checks the rejected value returned by the parser. If the value ends in u or U, the system now returns a more specific message explaining that the value is invalid and listing the supported field types.

The new behavior behaves like this:
`Invalid integer value: 8u; Expected signed integer, long, double, boolean, or string. Field: value`



