### PR TITLE
fix(qwp): fix unresponsive network I/O under heavy QWP ingestion

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -238,6 +238,15 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
         LOG.debug().$("closed [fd=").$(fd).I$();
     }
 
+    public void drainRecvBuffer() {
+        try {
+            while (socket.recv(recvBuffer, recvBufferSize) > 0) {
+                // discard
+            }
+        } catch (Throwable ignored) {
+        }
+    }
+
     @Override
     public void fail(HttpRequestProcessorSelector selector, HttpException e) throws PeerIsSlowToReadException, ServerDisconnectException {
         LOG.info().$("failed to retry query [fd=").$(getFd()).I$();
@@ -439,15 +448,6 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
 
     public void resumeResponseSend() throws PeerIsSlowToReadException, PeerDisconnectedException {
         responseSink.resumeSend();
-    }
-
-    public void drainRecvBuffer() {
-        try {
-            while (socket.recv(recvBuffer, recvBufferSize) > 0) {
-                // discard
-            }
-        } catch (Throwable ignored) {
-        }
     }
 
     public void scheduleRetry(HttpRequestProcessor processor, RescheduleContext rescheduleContext) throws PeerIsSlowToReadException, ServerDisconnectException {
@@ -1157,8 +1157,12 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
         final HttpRequestProcessor processor = resolveResumeProcessor(selector);
         try {
             processor.resumeRecv(this);
-            // resumeRecv is not designed to complete normally (has a while-true loop). This line is unreachable.
-            return true;
+
+            // resumeRecv() returned normally -> the processor is ready to read from a websocket again.
+            // We don't return true, because that would make the infrastructure to call as immediately again
+            // and we would monopolize the thread. Instead, we use PeerIsSlowToWriteException as a signal
+            // to be registered for reading this gives the Worker thread a chance to run other processors.
+            throw PeerIsSlowToWriteException.INSTANCE;
         } catch (PeerIsSlowToReadException | PeerIsSlowToWriteException e) {
             // Need more data from/to peer
             throw e;

--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -1162,7 +1162,7 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
             // We don't return true, because that would make the infrastructure call us immediately again
             // and we would monopolize the thread. Instead, we use PeerIsSlowToWriteException as a signal
             // to be registered for reading. This gives the worker thread a chance to run other processors.
-            throw PeerIsSlowToWriteException.INSTANCE;
+            throw registerDispatcherRead();
         } catch (PeerIsSlowToReadException | PeerIsSlowToWriteException e) {
             // Need more data from/to peer
             throw e;

--- a/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpConnectionContext.java
@@ -1159,9 +1159,9 @@ public class HttpConnectionContext extends IOContext<HttpConnectionContext> impl
             processor.resumeRecv(this);
 
             // resumeRecv() returned normally -> the processor is ready to read from a websocket again.
-            // We don't return true, because that would make the infrastructure to call as immediately again
+            // We don't return true, because that would make the infrastructure call us immediately again
             // and we would monopolize the thread. Instead, we use PeerIsSlowToWriteException as a signal
-            // to be registered for reading this gives the Worker thread a chance to run other processors.
+            // to be registered for reading. This gives the worker thread a chance to run other processors.
             throw PeerIsSlowToWriteException.INSTANCE;
         } catch (PeerIsSlowToReadException | PeerIsSlowToWriteException e) {
             // Need more data from/to peer


### PR DESCRIPTION
A client streaming data fast over a QWP WebSocket could pin an HTTP worker thread, stalling other connections: REST queries and other WebSocket sessions saw elevated latency until the stream paused. this could also delay responsiveness to a shutdown signal.

The connection now returns to the dispatcher after each recv chunk instead of looping until the socket drains, so each worker rotates across all ready connections. Also: the HTTP keep-alive check no longer applies to upgraded connections on the receive path. 