### PR TITLE
test(core): stabilize flaky TxnScoreboardTest.testHammer

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/TxnScoreboardTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TxnScoreboardTest.java
@@ -272,7 +272,10 @@ public class TxnScoreboardTest extends AbstractCairoTest {
     @Test
     public void testHammer() throws Exception {
         Rnd rnd = TestUtils.generateRandom(LOG);
-        testHammerScoreboard(rnd.nextInt(1000) + 1, 10000);
+        // Cap readers to available CPUs: the readers busy-spin, so a near-1000 draw oversubscribes
+        // a CI runner's few cores, starves the writer, and times the test out.
+        int maxReaders = 8 * Runtime.getRuntime().availableProcessors();
+        testHammerScoreboard(Math.min(rnd.nextInt(1000) + 1, maxReaders), 10000);
     }
 
     @Test
@@ -587,6 +590,9 @@ public class TxnScoreboardTest extends AbstractCairoTest {
                         }
                         scoreboard.releaseTxn(id, t);
                         LockSupport.parkNanos(10);
+                    } else {
+                        // Acquire lost a race with the writer; back off so readers don't starve it.
+                        Os.pause();
                     }
                 }
             } catch (Throwable e) {


### PR DESCRIPTION
## What

`TxnScoreboardTest.testHammer` intermittently times out and takes the whole `TxnScoreboardTest` class down with it (recently observed on `mac-cairo`).

## Root cause

The test picks its reader count from `rnd.nextInt(1000) + 1`, so an unlucky draw spawns close to 1000 reader threads. Each reader busy-spins in its acquire loop with no backoff when `acquireTxn` returns `false` (which happens constantly, as the writer keeps advancing the txn). On a CI runner with only a few cores this oversubscribes the CPU by roughly two orders of magnitude.

The single writer thread is then starved and cannot push the txn counter to 10000 within the 20-minute global test timeout. When JUnit's timeout rule fires it abandons the test but does **not** stop the spawned threads, so the still-spinning readers go on to starve every subsequent test in the class and trip the stuck-thread detector. In the failing run the writer did eventually finish (`writer done` was logged ~27 minutes in) and no scoreboard anomaly was ever reported, confirming this is a timeout under CPU starvation rather than a deadlock or a correctness bug
in the scoreboard itself.

This is a long-standing test fragility (the `nextInt(1000)` bound dates to #5444); the scoreboard production code is unchanged.

## Fix

- Cap the reader count at `8 * availableProcessors` so the stress stays proportional to the host instead of fixed at up to 1000 threads. The scoreboard's entry count is dominated by the iteration count (10000), so the smaller reader count does not reduce coverage.
- Add an `Os.pause()` backoff on the failed-acquire path in the reader loop, so a lost race no longer pins a core at full tilt.

## Tradeoffs

Capping the reader count lowers the maximum thread contention the test exercises on machines with few cores. On a 24-core dev box the cap is 192 readers, and on a typical CI runner it is far lower; in exchange the test runs deterministically in well under a second. Peak-contention behavior at ~1000 concurrent readers is no longer exercised, but that regime was producing CPU starvation rather than meaningful coverage.

## Test plan

- `mvn -pl core test -Dtest=TxnScoreboardTest#testHammer` passes across multiple random seeds (~0.7s each, previously ~21 min on timeout).
- `mvn -pl core test -Dtest=TxnScoreboardTest` runs the full class green in ~1.1s.