### PR TITLE
fix(sql): fix SAMPLE BY rewrite for queries with prefixed designated timestamps

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -4672,13 +4672,17 @@ public class SqlOptimiser implements Mutable {
     private void fixTimestampAndCollectMissingTokens(
             ExpressionNode node,
             CharSequence timestampColumn,
+            int timestampDot,
+            int timestampLo,
+            int timestampHi,
             CharSequence timestampAlias,
+            IQueryModel model,
             CharSequenceHashSet missingTokens
     ) {
         sqlNodeStack.clear();
         while (node != null) {
             if (node.type == LITERAL) {
-                if (Chars.equalsIgnoreCase(node.token, timestampColumn)) {
+                if (referencesTimestampColumn(node.token, timestampColumn, timestampDot, timestampLo, timestampHi, model)) {
                     node.token = timestampAlias;
                 } else {
                     missingTokens.add(node.token);
@@ -5815,15 +5819,105 @@ public class SqlOptimiser implements Mutable {
         return nextLiteral(token, 0);
     }
 
-    private boolean nonAggregateFunctionDependsOn(ExpressionNode node, ExpressionNode timestampNode) {
-        if (timestampNode == null) {
+    private boolean referencesTimestampColumn(
+            CharSequence token,
+            CharSequence timestamp,
+            int timestampDot,
+            int timestampLo,
+            int timestampHi,
+            IQueryModel model
+    ) {
+        if (Chars.equalsIgnoreCase(token, timestamp)) {
+            return true;
+        }
+
+        final int tokenDot = Chars.indexOfLastUnquoted(token, '.');
+        final int tokenLo = tokenDot + 1;
+        final int tokenHi = token.length();
+        if (!equalsIgnoreCaseUnquoted(token, tokenLo, tokenHi, timestamp, timestampLo, timestampHi)) {
             return false;
         }
 
-        final CharSequence timestamp = timestampNode.token;
+        if (tokenDot == -1) {
+            return true;
+        }
+
+        if (timestampDot > -1) {
+            if (equalsIgnoreCaseUnquoted(timestamp, 0, timestampDot, token, 0, tokenDot)) {
+                return true;
+            }
+            if (model != null) {
+                final int tokenModelIndex = model.getModelAliasIndex(token, 0, tokenDot);
+                final int timestampModelIndex = model.getModelAliasIndex(timestamp, 0, timestampDot);
+                return tokenModelIndex > -1 && tokenModelIndex == timestampModelIndex;
+            }
+            return false;
+        }
+
+        if (model == null) {
+            return false;
+        }
+
+        final ExpressionNode alias = model.getAlias();
+        if (alias != null && equalsIgnoreCaseUnquoted(alias.token, 0, alias.token.length(), token, 0, tokenDot)) {
+            return true;
+        }
+
+        final CharSequence tableName = model.getTableName();
+        if (tableName != null && equalsIgnoreCaseUnquoted(tableName, 0, tableName.length(), token, 0, tokenDot)) {
+            return true;
+        }
+
+        final int modelIndex = model.getModelAliasIndex(token, 0, tokenDot);
+        if (modelIndex == -1) {
+            return false;
+        }
+        return model.getJoinModels().size() == 1 || modelIndex == 0;
+    }
+
+    private static boolean equalsIgnoreCaseUnquoted(CharSequence a, int aStart, int aEnd, CharSequence b, int bStart, int bEnd) {
+        if (a == null || b == null) {
+            return false;
+        }
+        
+        int aLen = aEnd - aStart;
+        if (aLen > 1 && a.charAt(aStart) == '"' && a.charAt(aEnd - 1) == '"') {
+            aStart++;
+            aEnd--;
+        }
+        
+        int bLen = bEnd - bStart;
+        if (bLen > 1 && b.charAt(bStart) == '"' && b.charAt(bEnd - 1) == '"') {
+            bStart++;
+            bEnd--;
+        }
+        
+        if (aEnd - aStart != bEnd - bStart) {
+            return false;
+        }
+        
+        for (int i = aStart, j = bStart; i < aEnd; i++, j++) {
+            char ca = a.charAt(i);
+            char cb = b.charAt(j);
+            if (ca != cb && Character.toLowerCase(ca) != Character.toLowerCase(cb)) {
+                return false;
+            }
+        }
+        
+        return true;
+    }
+
+    private boolean nonAggregateFunctionDependsOn(ExpressionNode node, CharSequence timestamp, IQueryModel model) {
+        if (timestamp == null) {
+            return false;
+        }
+
+        final int timestampDot = Chars.indexOfLastUnquoted(timestamp, '.');
+        final int timestampLo = timestampDot + 1;
+        final int timestampHi = timestamp.length();
         sqlNodeStack.clear();
         while (node != null) {
-            if (node.type == LITERAL && Chars.equalsIgnoreCase(node.token, timestamp)) {
+            if (node.type == LITERAL && referencesTimestampColumn(node.token, timestamp, timestampDot, timestampLo, timestampHi, model)) {
                 return true;
             }
 
@@ -5854,6 +5948,10 @@ public class SqlOptimiser implements Mutable {
         }
 
         return false;
+    }
+
+    private boolean nonAggregateFunctionDependsOn(ExpressionNode node, ExpressionNode timestampNode, IQueryModel model) {
+        return timestampNode != null && nonAggregateFunctionDependsOn(node, timestampNode.token, model);
     }
 
     private void normalizeWindowFrame(WindowExpression ac, SqlExecutionContext sqlExecutionContext) throws SqlException {
@@ -9020,16 +9118,19 @@ public class SqlOptimiser implements Mutable {
                 // columnToAlias map is lossy, it only stores "last" alias (non-deterministic)
                 // to find other aliases we have to loop thru all the columns. We are removing
                 // columns in this loop, that is why there is no auto-increment.
+                final int tsDot = Chars.indexOfLastUnquoted(timestampColumn, '.');
+                final int tsLo = tsDot + 1;
+                final int tsHi = timestampColumn.length();
                 for (int i = 0, k = 0, n = model.getBottomUpColumns().size(); i < n; k++) {
                     final QueryColumn qc = model.getBottomUpColumns().getQuick(i);
                     final boolean isFunctionWithTsColumn = (qc.getAst().type == FUNCTION || qc.getAst().type == OPERATION)
-                            && nonAggregateFunctionDependsOn(qc.getAst(), nested.getTimestamp());
+                            && nonAggregateFunctionDependsOn(qc.getAst(), timestampColumn, nested);
                     if (
                             isFunctionWithTsColumn ||
                                     // also check all literals that refer timestamp column, except the one
                                     // with our chosen timestamp alias
                                     (timestampAlias != null && qc.getAst().type == LITERAL
-                                            && Chars.equalsIgnoreCase(qc.getAst().token, timestampColumn)
+                                            && referencesTimestampColumn(qc.getAst().token, timestampColumn, tsDot, tsLo, tsHi, nested)
                                             && !Chars.equalsIgnoreCase(qc.getAlias(), timestampAlias))
                     ) {
                         model.removeColumn(i);
@@ -9053,7 +9154,7 @@ public class SqlOptimiser implements Mutable {
                             timestampOnly = false;
                         }
                     } else {
-                        if (!Chars.equalsIgnoreCase(qc.getAst().token, timestampColumn)) {
+                        if (!referencesTimestampColumn(qc.getAst().token, timestampColumn, tsDot, tsLo, tsHi, nested)) {
                             timestampOnly = false;
                         }
                         i++;
@@ -9188,7 +9289,7 @@ public class SqlOptimiser implements Mutable {
                 if ((wrapAction & SAMPLE_BY_REWRITE_WRAP_ADD_TIMESTAMP_COPIES) != 0) {
                     tempCharSequenceHashSet.clear();
                     for (int i = 0, n = tempColumns.size(); i < n; i++) {
-                        fixTimestampAndCollectMissingTokens(tempColumns.get(i).getAst(), timestampColumn, timestampAlias, tempCharSequenceHashSet);
+                        fixTimestampAndCollectMissingTokens(tempColumns.get(i).getAst(), timestampColumn, tsDot, tsLo, tsHi, timestampAlias, nested, tempCharSequenceHashSet);
                     }
                     for (int i = 0, size = tempCharSequenceHashSet.size(); i < size; i++) {
                         final CharSequence dependentToken = tempCharSequenceHashSet.get(i);
@@ -9646,7 +9747,7 @@ public class SqlOptimiser implements Mutable {
 
         IQueryModel aggModel = isWindowJoin ? windowJoinModel : (isHorizonJoin ? horizonJoinModel : groupByModel);
         final int beforeSplit = aggModel.getBottomUpColumns().size();
-        if (checkForChildAggregates(qc.getAst()) || (sampleBy != null && nonAggregateFunctionDependsOn(qc.getAst(), baseModel.getTimestamp()))) {
+        if (checkForChildAggregates(qc.getAst()) || (sampleBy != null && nonAggregateFunctionDependsOn(qc.getAst(), baseModel.getTimestamp(), baseModel))) {
             // push aggregates and literals outside aggregate functions
             emitAggregatesAndLiterals(
                     qc.getAst(),

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -518,6 +518,38 @@ public class SqlOptimiser implements Mutable {
         }
     }
 
+    private static boolean equalsIgnoreCaseUnquoted(CharSequence a, int aStart, int aEnd, CharSequence b, int bStart, int bEnd) {
+        if (a == null || b == null) {
+            return false;
+        }
+
+        int aLen = aEnd - aStart;
+        if (aLen > 1 && a.charAt(aStart) == '"' && a.charAt(aEnd - 1) == '"') {
+            aStart++;
+            aEnd--;
+        }
+
+        int bLen = bEnd - bStart;
+        if (bLen > 1 && b.charAt(bStart) == '"' && b.charAt(bEnd - 1) == '"') {
+            bStart++;
+            bEnd--;
+        }
+
+        if (aEnd - aStart != bEnd - bStart) {
+            return false;
+        }
+
+        for (int i = aStart, j = bStart; i < aEnd; i++, j++) {
+            char ca = a.charAt(i);
+            char cb = b.charAt(j);
+            if (ca != cb && Character.toLowerCase(ca) != Character.toLowerCase(cb)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private static void extractAndTerms(ExpressionNode node, ObjList<ExpressionNode> terms) {
         if (node.type == ExpressionNode.OPERATION && SqlKeywords.isAndKeyword(node.token)) {
             extractAndTerms(node.lhs, terms);
@@ -5873,38 +5905,6 @@ public class SqlOptimiser implements Mutable {
             return false;
         }
         return model.getJoinModels().size() == 1 || modelIndex == 0;
-    }
-
-    private static boolean equalsIgnoreCaseUnquoted(CharSequence a, int aStart, int aEnd, CharSequence b, int bStart, int bEnd) {
-        if (a == null || b == null) {
-            return false;
-        }
-        
-        int aLen = aEnd - aStart;
-        if (aLen > 1 && a.charAt(aStart) == '"' && a.charAt(aEnd - 1) == '"') {
-            aStart++;
-            aEnd--;
-        }
-        
-        int bLen = bEnd - bStart;
-        if (bLen > 1 && b.charAt(bStart) == '"' && b.charAt(bEnd - 1) == '"') {
-            bStart++;
-            bEnd--;
-        }
-        
-        if (aEnd - aStart != bEnd - bStart) {
-            return false;
-        }
-        
-        for (int i = aStart, j = bStart; i < aEnd; i++, j++) {
-            char ca = a.charAt(i);
-            char cb = b.charAt(j);
-            if (ca != cb && Character.toLowerCase(ca) != Character.toLowerCase(cb)) {
-                return false;
-            }
-        }
-        
-        return true;
     }
 
     private boolean nonAggregateFunctionDependsOn(ExpressionNode node, CharSequence timestamp, IQueryModel model) {

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -9438,6 +9438,98 @@ public class SampleByTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSampleByWithQuotedTablePrefixAndFunction() throws Exception {
+        assertMemoryLeak(() -> {
+            createSampleByPrefixTrades("\"trades.hist\"");
+
+            assertQuery("""
+                    SELECT dateadd('d', 1, "trades.hist".timestamp) AS time, sum(price)
+                    FROM "trades.hist"
+                    SAMPLE BY 5m
+                    """)
+                    .noLeakCheck()
+                    .expectSize()
+                    .returns("""
+                            time\tsum
+                            2026-04-01T02:00:00.000000Z\t201.0
+                            2026-04-01T02:05:00.000000Z\t102.0
+                            """);
+        });
+    }
+
+    @Test
+    public void testSampleByWithTableAliasAndFunction() throws Exception {
+        assertMemoryLeak(() -> {
+            createSampleByPrefixTrades("trades");
+
+            assertQuery("""
+                    SELECT dateadd('d', 1, t.timestamp) AS time, sum(price)
+                    FROM trades t
+                    SAMPLE BY 5m
+                    """)
+                    .noLeakCheck()
+                    .expectSize()
+                    .returns("""
+                            time\tsum
+                            2026-04-01T02:00:00.000000Z\t201.0
+                            2026-04-01T02:05:00.000000Z\t102.0
+                            """);
+        });
+    }
+
+    @Test
+    public void testSampleByWithTableAliasAndFunctionInJoin() throws Exception {
+        assertMemoryLeak(() -> {
+            createSampleByPrefixTrades("trades");
+            execute("""
+                    CREATE TABLE machines (
+                        host SYMBOL,
+                        grp SYMBOL
+                    )
+                    """);
+            execute("""
+                    INSERT INTO machines VALUES
+                        ('a', 'east'),
+                        ('b', 'west')
+                    """);
+
+            assertQuery("""
+                    SELECT dateadd('d', 1, t.timestamp) AS time, sum(t.price)
+                    FROM trades t
+                    JOIN machines m ON t.host = m.host
+                    WHERE m.grp = 'east'
+                    SAMPLE BY 5m
+                    """)
+                    .noLeakCheck()
+                    .expectSize()
+                    .returns("""
+                            time\tsum
+                            2026-04-01T02:00:00.000000Z\t201.0
+                            """);
+        });
+    }
+
+    @Test
+    public void testSampleByWithTablePrefixAndFunction() throws Exception {
+        assertMemoryLeak(() -> {
+            createSampleByPrefixTrades("trades");
+
+            assertQuery("""
+                    SELECT dateadd('d', 1, trades.timestamp) AS time, sum(price)
+                    FROM trades
+                    SAMPLE BY 5m
+                    """)
+                    .noLeakCheck()
+                    .expectSize()
+                    .returns("""
+                            time\tsum
+                            2026-04-01T02:00:00.000000Z\t201.0
+                            2026-04-01T02:05:00.000000Z\t102.0
+                            """);
+        });
+    }
+
+    @Test
     public void testSampleByWithoutTimestamp() throws Exception {
         assertQuery("SELECT * FROM ( SELECT null as x) SAMPLE BY 1d FROM '2021-01-02T00:00:00' " +
                 "TO dateadd('d', 1095, '2021-01-02T00:00:00');")
@@ -17804,6 +17896,19 @@ public class SampleByTest extends AbstractCairoTest {
                     .expectSize(expectSize)
                     .returns(expected);
         });
+    }
+
+    private void createSampleByPrefixTrades(String tableName) throws SqlException {
+        execute("CREATE TABLE " + tableName + " (" +
+                "  host SYMBOL," +
+                "  price DOUBLE," +
+                "  timestamp TIMESTAMP" +
+                ") TIMESTAMP(timestamp) PARTITION BY DAY");
+
+        execute("INSERT INTO " + tableName + " VALUES" +
+                "('a', 100.0, '2026-03-31T02:00:00.000000Z')," +
+                "('a', 101.0, '2026-03-31T02:03:00.000000Z')," +
+                "('b', 102.0, '2026-03-31T02:06:00.000000Z')");
     }
 
     @NotNull


### PR DESCRIPTION
Fixes #6189

### Problem

`SAMPLE BY` silently stops bucketing when the designated timestamp is passed
through a function using a table prefix or alias. This query returns one row per
input row instead of 5-minute buckets:

```sql
SELECT dateadd('d', 1, trades.timestamp), sum(price)
FROM trades
WHERE timestamp IN yesterday()
SAMPLE BY 5m;
```

Dropping the `trades.` prefix makes it sample correctly. The prefixed form is
unavoidable in joins, where columns must be qualified, so the user hitting this
in a Grafana join query had no practical workaround.

### Root cause

The SAMPLE BY rewrite detects which projected expressions reference the
designated timestamp so it can rewrite them against the sampled model. That
detection compared tokens with `Chars.equalsIgnoreCase(token, timestampColumn)`,
an exact match. A prefixed literal such as `trades.timestamp` or `t.timestamp`
never equals the bare `timestamp`, so the function expression was treated as an
ordinary column, the timestamp copy was not injected, and the rewrite produced a
non-sampling query.

### Fix

A new `referencesTimestampColumn(...)` replaces the exact-match checks on the
timestamp-detection paths (`nonAggregateFunctionDependsOn`,
`fixTimestampAndCollectMissingTokens`, and the projection scan in the SAMPLE BY
rewrite). It matches a literal against the designated timestamp when:

- the tokens are exactly equal (unchanged fast path), or
- the unquoted column parts match and the prefix resolves to the timestamp's
  own table via the table name, table alias, or model alias index.

Matching is case-insensitive and quote-aware on both operands, so quoted
identifiers like `"trades.hist".timestamp` resolve correctly. The comparison is
allocation-free (bounded `equalsIgnoreCaseUnquoted`, no substring copies), in
keeping with the zero-GC constraint on this path.

### Effects

- Prefixed and aliased timestamp functions under `SAMPLE BY` now bucket
  correctly, including in joins.
- Non-prefixed queries keep the original exact-match fast path and are
  unaffected.
- The prefix resolution adds a bounded per-literal comparison and, for prefixed
  literals, a model-alias lookup; no allocations and no I/O.

### Test plan

- New `SampleByTest` cases covering table prefix, table alias, quoted
  table prefix, and an aliased timestamp function inside a join; each asserts the
  bucketed result with `.returns(...)`.
- All `SampleByTest` cases pass.
