### PR TITLE
fix(core): fix unexpected logout during HTTP session rotation

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/HttpSessionStore.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpSessionStore.java
@@ -1,6 +1,7 @@
 package io.questdb.cutlass.http;
 
 import io.questdb.cairo.security.PrincipalContext;
+import io.questdb.std.Chars;
 import io.questdb.std.ConcurrentHashMap;
 import io.questdb.std.Misc;
 import io.questdb.std.ObjList;
@@ -89,16 +90,14 @@ public interface HttpSessionStore {
         private final String principal;
         private volatile long expiresAt;
         private volatile boolean invalid = false;
-        private volatile long rotateAt;
-        private volatile String sessionId;
+        private volatile RotationInfo rotationInfo;
 
         public SessionInfo(@NotNull String sessionId, String principal, @NotNull ConcurrentHashMap<ReadOnlyObjList<CharSequence>> groupsByEntity, byte authType, long expiresAt, long rotateAt) {
-            this.sessionId = sessionId;
+            this.rotationInfo = new RotationInfo(sessionId, rotateAt);
             this.principal = principal;
             this.groupsByEntity = groupsByEntity;
             this.authType = authType;
             this.expiresAt = expiresAt;
-            this.rotateAt = rotateAt;
         }
 
         @Override
@@ -122,11 +121,11 @@ public interface HttpSessionStore {
         }
 
         public long getRotateAt() {
-            return rotateAt;
+            return rotationInfo.rotateAt;
         }
 
         public String getSessionId() {
-            return sessionId;
+            return rotationInfo.sessionId;
         }
 
         public void invalidate() {
@@ -143,21 +142,27 @@ public interface HttpSessionStore {
 
         @Override
         public String toString() {
+            final RotationInfo rotationInfo = this.rotationInfo;
             final StringSink sink = Misc.getThreadLocalSink();
             sink.put("SessionInfo [principal=").put(principal)
                     .put(", groups=").put(getGroups())
                     .put(", authType=").put(authType)
                     .put(", expiresAt=").put(expiresAt)
-                    .put(", rotateAt=").put(rotateAt)
-                    .put(", sessionId=").put(sessionId)
+                    .put(", rotateAt=").put(rotationInfo.rotateAt)
+                    .put(", sessionId=").put(rotationInfo.sessionId)
                     .put(", invalid=").put(invalid)
                     .put("]");
             return sink.toString();
         }
 
+        boolean isEvictableOldSessionId(@NotNull CharSequence mappedSessionId, long evictionGracePeriod, long currentMicros) {
+            final RotationInfo rotationInfo = this.rotationInfo;
+            return !Chars.equals(mappedSessionId, rotationInfo.sessionId)
+                    && rotationInfo.rotateAt - evictionGracePeriod < currentMicros;
+        }
+
         void rotate(String newSessionId, long nextRotationAt) {
-            this.sessionId = newSessionId;
-            this.rotateAt = nextRotationAt;
+            rotationInfo = new RotationInfo(newSessionId, nextRotationAt);
         }
 
         boolean tryLock() {
@@ -166,6 +171,14 @@ public interface HttpSessionStore {
 
         void unlock() {
             lock.set(false);
+        }
+
+        /**
+         * Immutable (sessionId, rotateAt) pair. The two values are logically coupled:
+         * rotation must replace them in a single volatile store, so concurrent readers
+         * never observe the id of one rotation generation with the deadline of another.
+         */
+        private record RotationInfo(String sessionId, long rotateAt) {
         }
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpSessionStoreImpl.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpSessionStoreImpl.java
@@ -198,7 +198,9 @@ public class HttpSessionStoreImpl implements HttpSessionStore {
      *       still pointing to a rotated session), and grace period has expired</li>
      * </ol>
      *
-     * <p>For old rotated IDs, the eviction time is calculated as:
+     * <p>For old rotated IDs, {@link SessionInfo#isEvictableOldSessionId(CharSequence, long, long)}
+     * makes the decision over an atomic snapshot of the (sessionId, rotateAt) pair, with the
+     * eviction time calculated as:
      * {@code evictRotatedAt = sessionInfo.rotateAt - rotatedSessionEvictionTime}
      * <p>
      * This works because {@code rotateAt} stores when the <i>next</i> rotation should occur.
@@ -225,15 +227,9 @@ public class HttpSessionStoreImpl implements HttpSessionStore {
                 // expired session
                 iterator.remove();
                 LOG.info().$("expired session evicted [principal=").$(sessionInfo.getPrincipal()).$(']').$();
-            } else if (!Chars.equals(sessionId, sessionInfo.getSessionId())) {
-                // Old rotated session ID - the map key doesn't match the current session ID
-                // Calculate when this old ID should be evicted by working backwards from next rotation
-                final long evictRotatedAt = sessionInfo.getRotateAt() - rotatedSessionEvictionTime;
-                if (evictRotatedAt < currentMicros) {
-                    // Grace period expired, remove old ID from map
-                    iterator.remove();
-                    LOG.info().$("rotated session id evicted [principal=").$(sessionInfo.getPrincipal()).$(']').$();
-                }
+            } else if (sessionInfo.isEvictableOldSessionId(sessionId, rotatedSessionEvictionTime, currentMicros)) {
+                iterator.remove();
+                LOG.info().$("rotated session id evicted [principal=").$(sessionInfo.getPrincipal()).$(']').$();
             }
         }
     }

--- a/core/src/test/java/io/questdb/test/cutlass/http/BaseHttpCookieTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/BaseHttpCookieTest.java
@@ -86,6 +86,106 @@ public abstract class BaseHttpCookieTest extends AbstractBootstrapTest {
         });
     }
 
+    protected void testIdleSessionEvictedBySweep(Supplier<ServerMain> serverMainSupplier, Supplier<HttpClient> httpClientSupplier, AtomicLong currentMicros) throws Exception {
+        assertMemoryLeak(() -> {
+            try (final ServerMain questdb = serverMainSupplier.get()) {
+                questdb.start();
+
+                final HttpSessionStore sessionStore = questdb.getConfiguration().getFactoryProvider().getHttpSessionStore();
+                final long sessionTimeout = questdb.getConfiguration().getHttpServerConfiguration().getHttpContextConfiguration().getSessionTimeout();
+
+                final String idleSessionId;
+
+                // authenticate with username + pwd, and pass 'session=true'
+                try (HttpClient httpClient = httpClientSupplier.get()) {
+                    HttpClient.ResponseHeaders responseHeaders = newHttpRequest(httpClient, HTTP_PORT, "SELECT x FROM long_sequence(3)", USER, PASSWORD, "true");
+
+                    // successful authentication with username + pwd
+                    awaitStatusCode(responseHeaders, "200");
+
+                    // assert that session cookie is set
+                    idleSessionId = assertSessionCookie(responseHeaders, isSecure());
+
+                    assertChunkedBody(responseHeaders, "{" +
+                            "\"query\":\"SELECT x FROM long_sequence(3)\"," +
+                            "\"columns\":[{\"name\":\"x\",\"type\":\"LONG\"}]," +
+                            "\"timestamp\":-1," +
+                            "\"dataset\":[[1],[2],[3]]," +
+                            "\"count\":3" +
+                            "}");
+                }
+
+                final HttpSessionStore.SessionInfo idleSession = assertSession(sessionStore, idleSessionId, currentMicros.get(), sessionTimeout);
+
+                // move the clock forward, but not past the idle session's expiry yet,
+                // and open a second session; the login request carries no cookie,
+                // so it does not run an eviction sweep
+                currentMicros.addAndGet(3 * sessionTimeout / 4);
+
+                final String activeSessionId;
+
+                // authenticate again with username + pwd, and pass 'session=true'
+                try (HttpClient httpClient = httpClientSupplier.get()) {
+                    HttpClient.ResponseHeaders responseHeaders = newHttpRequest(httpClient, HTTP_PORT, "SELECT x FROM long_sequence(3)", USER, PASSWORD, "true");
+
+                    // successful authentication with username + pwd
+                    awaitStatusCode(responseHeaders, "200");
+
+                    // assert that a separate session is created
+                    activeSessionId = assertSessionCookie(responseHeaders, isSecure());
+                    assertNotEquals(idleSessionId, activeSessionId);
+
+                    assertChunkedBody(responseHeaders, "{" +
+                            "\"query\":\"SELECT x FROM long_sequence(3)\"," +
+                            "\"columns\":[{\"name\":\"x\",\"type\":\"LONG\"}]," +
+                            "\"timestamp\":-1," +
+                            "\"dataset\":[[1],[2],[3]]," +
+                            "\"count\":3" +
+                            "}");
+                }
+
+                assertSession(sessionStore, activeSessionId, currentMicros.get(), sessionTimeout);
+
+                // move the clock past the idle session's expiry; the active session
+                // is neither expired nor due to rotate at this point
+                currentMicros.addAndGet(sessionTimeout / 4 + sessionTimeout / 8);
+
+                // the expired idle session stays in the store until a sweep collects it
+                assertNotNull(sessionStore.getSession(idleSessionId));
+
+                // a request on the active session piggybacks the eviction sweep
+                try (HttpClient httpClient = httpClientSupplier.get()) {
+                    HttpClient.ResponseHeaders responseHeaders = newHttpRequest(httpClient, HTTP_PORT, "SELECT x FROM long_sequence(2)", SESSION_COOKIE_NAME, activeSessionId);
+
+                    // successful authentication with the session cookie
+                    awaitStatusCode(responseHeaders, "200");
+
+                    // no rotation is due, no new cookie is issued
+                    assertNoSessionCookie(responseHeaders);
+
+                    assertChunkedBody(responseHeaders, "{" +
+                            "\"query\":\"SELECT x FROM long_sequence(2)\"," +
+                            "\"columns\":[{\"name\":\"x\",\"type\":\"LONG\"}]," +
+                            "\"timestamp\":-1," +
+                            "\"dataset\":[[1],[2]]," +
+                            "\"count\":2" +
+                            "}");
+                }
+
+                // the sweep removed the idle session from the store
+                assertNull(sessionStore.getSession(idleSessionId));
+
+                // sweep eviction removes the map entry without invalidating the session object
+                assertFalse(idleSession.isInvalid());
+
+                // the active session survived the sweep, and its lifetime was extended
+                final HttpSessionStore.SessionInfo activeSession = sessionStore.getSession(activeSessionId);
+                assertNotNull(activeSession);
+                assertEquals(currentMicros.get() + sessionTimeout, activeSession.getExpiresAt());
+            }
+        });
+    }
+
     protected void testRotatedSessionDestroyed(Supplier<ServerMain> serverMainSupplier, Supplier<HttpClient> httpClientSupplier, AtomicLong currentMicros, boolean closeWithNewSessionId) throws Exception {
         assertMemoryLeak(() -> {
             try (final ServerMain questdb = serverMainSupplier.get()) {

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpCookieTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpCookieTest.java
@@ -34,6 +34,13 @@ public class HttpCookieTest extends BaseHttpCookieTest {
     }
 
     @Test
+    public void testIdleSessionEvictedBySweep() throws Exception {
+        final AtomicLong currentMicros = new AtomicLong(1760743438000000L);
+        final Bootstrap bootstrap = getBootstrapWithMockClock(currentMicros);
+        testIdleSessionEvictedBySweep(() -> new ServerMain(bootstrap), HttpClientFactory::newPlainTextInstance, currentMicros);
+    }
+
+    @Test
     public void testRotatedSessionDestroyedWithNewSessionId() throws Exception {
         testRotatedSessionDestroyed(true);
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/questdb/questdb/issues/7235

During session id rotation, `SessionInfo.rotate()` updates the coupled sessionId and rotateAt fields in sequence, while the eviction sweep reads them under a different lock. An eviction that interleaves between the two writes observes the new sessionId together with the stale rotateAt, computes an eviction time in the past, and drops the old session id immediately instead of keeping it valid through the grace period. A request still in flight on the old cookie is then rejected with HTTP 401, so the user's Web Console session appears to log out.

## Implementation
I opted for a more robust fix than the one suggested by the issue. The issue suggests swapping the order of the writes. Although that can resolve the issue, it is not an explicit fix. I opted for adding a new record [`RotationInfo`](https://github.com/questdb/questdb/compare/master...brunocalza:questdb:bcalza/fix-session-rotation-concurrency?expand=1#diff-d43384907da08c7628215dfe16746478d1ffb07517296d5a0ff6f99c064e3a20R181). `rotate()` uses `RotationInfo` to do a single write of both sessionId and rotateAt. The sweep reads that record as one snapshot. 

## Testing
- Existing HttpCookieTest and HttpCookieConcurrentTest pass
- I set up a [Fray](https://github.com/cmu-pasta/fray) test outside this PR, and it confirmed the fix resolves the issue
- I manually tested using the web console, setting the session timeout to 1m, and checked the [log](https://github.com/questdb/questdb/compare/master...brunocalza:questdb:bcalza/fix-session-rotation-concurrency?expand=1#diff-29c1fdffd4b97dd6edb034d242c0e0ae4ed38dd395aae25d7db3ee31bc7bf2d1R232) to confirm the flow the code is triggered
- I added a unit [test](https://github.com/questdb/questdb/compare/master...brunocalza:questdb:bcalza/fix-session-rotation-concurrency?expand=1#diff-092a994df764052c78a97b13c48dadfa08f82104aae2407cf09cca9fbc3d3b30R89). It is not related to this fix. It is just to make sure [these](https://github.com/questdb/questdb/compare/master...brunocalza:questdb:bcalza/fix-session-rotation-concurrency?expand=1#diff-29c1fdffd4b97dd6edb034d242c0e0ae4ed38dd395aae25d7db3ee31bc7bf2d1R228-R229) lines are covered.