### PR TITLE
chore(core): stop returning a reader to the pool when its refresh fails

### DIFF
--- a/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
+++ b/core/src/main/java/io/questdb/cairo/pool/ReaderPool.java
@@ -259,23 +259,17 @@ public class ReaderPool extends AbstractMultiTenantPool<ReaderPool.R> {
         @Override
         public void refresh(ResourcePoolSupervisor<R> supervisor) {
             this.supervisor = supervisor;
-            try {
-                goActive();
-            } catch (Throwable ex) {
-                close();
-                throw ex;
-            }
+            // Do NOT close() here on failure: get0() owns disposal via goodbye()+close().
+            // Closing here returnToPool()'s the reader (slot released, tenant still assigned)
+            // before get0() disposes it, letting a concurrent get() acquire a torn-down reader.
+            goActive();
         }
 
         @Override
         public void refreshAt(@Nullable ResourcePoolSupervisor<R> supervisor, R srcReader) {
             this.supervisor = supervisor;
-            try {
-                goActiveAtTxn(srcReader);
-            } catch (Throwable ex) {
-                close();
-                throw ex;
-            }
+            // See refresh(): get0() owns disposal on failure; closing here re-publishes the reader.
+            goActiveAtTxn(srcReader);
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/cairo/pool/ReaderPoolTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/pool/ReaderPoolTest.java
@@ -368,6 +368,197 @@ public class ReaderPoolTest extends AbstractCairoTest {
         });
     }
 
+    // Covers the refreshAt()/getCopyOf() half of the same fix as
+    // testConcurrentGetRefreshFailureDoesNotHandOutDisposedReader. PR #7251 removed the failure-path
+    // close() from BOTH R.refresh() and R.refreshAt(); this exercises the refreshAt() branch.
+    //
+    // getCopyOf(src) requires src to be a pooled R holding its own slot, and get0()'s copyOf branch
+    // only calls tenant.refreshAt(supervisor, copyOfTenant) when the CAS-acquired slot already holds a
+    // returned tenant. So this uses a 2-slot pool: src holds slot 0 (kept checked out for the whole
+    // test) while a second reader R1 - opened at a newer txn and returned to the pool - holds slot 1.
+    // getCopyOf(src) lands on slot 1, sees R1.txn > src.txn, takes goActiveAtTxn()'s downgrade branch
+    // (init() -> openSymbolMaps()), and the injected fault makes the symbol-offset (.o) open throw. If
+    // refreshAt() were to close() on that failure it would returnToPool() the half-dead reader before
+    // get0() disposes it, letting a concurrent get() acquire a reader whose _txn mapping is already
+    // gone and dereference it - the "roTxMemBase is null" NPE. A correct pool keeps the slot owned by
+    // the disposing thread until it is fully gone, so the contender only ever sees
+    // EntryUnavailableException and never an NPE.
+    @Test
+    public void testConcurrentGetCopyOfRefreshFailureDoesNotHandOutDisposedReader() throws Exception {
+        final AtomicReference<TableReader> pooledReader = new AtomicReference<>();
+        final AtomicLong disposingThreadId = new AtomicLong(-1);
+        final AtomicBoolean faultSymbol = new AtomicBoolean();
+        final AtomicBoolean gateFired = new AtomicBoolean();
+        final AtomicReference<Throwable> refreshError = new AtomicReference<>();
+        final AtomicReference<Throwable> contenderError = new AtomicReference<>();
+        final CountDownLatch readerReleased = new CountDownLatch(1);
+        final CountDownLatch contenderDone = new CountDownLatch(1);
+
+        final TestFilesFacade ff = new TestFilesFacade() {
+            boolean isCalled = false;
+
+            @Override
+            public void munmap(long address, long size, int memoryTag) {
+                final TableReader r = pooledReader.get();
+                // The disposing thread frees _txn (nulling roTxMemBase) before it stops being open.
+                // The first munmap once isOpen() is false (the _cv unmap) is past that point: park
+                // here so the contender grabs a reader whose _txn mapping is already gone.
+                if (r != null
+                        && Thread.currentThread().threadId() == disposingThreadId.get()
+                        && !r.isOpen()
+                        && gateFired.compareAndSet(false, true)) {
+                    readerReleased.countDown();
+                    try {
+                        contenderDone.await(10, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                super.munmap(address, size, memoryTag);
+            }
+
+            @Override
+            public long openRO(LPSZ name) {
+                // Fault only the open of the symbol-offset (.o) file on the disposing thread, reached
+                // via init() -> openSymbolMaps() inside goActiveAtTxn()'s downgrade. exists() is left
+                // to pass so only a real file's open fails.
+                if (faultSymbol.get()
+                        && Thread.currentThread().threadId() == disposingThreadId.get()
+                        && Utf8s.endsWithAscii(name, ".o")) {
+                    isCalled = true;
+                    return -1;
+                }
+                return super.openRO(name);
+            }
+
+            @Override
+            public boolean wasCalled() {
+                return isCalled;
+            }
+        };
+
+        final CairoConfiguration poolConfig = new DefaultTestCairoConfiguration(root) {
+            @Override
+            public @NotNull FilesFacade getFilesFacade() {
+                return ff;
+            }
+
+            @Override
+            public int getPoolSegmentSize() {
+                return 2;
+            }
+
+            @Override
+            public int getReaderPoolMaxSegments() {
+                return 1;
+            }
+
+            @Override
+            public long getSpinLockTimeout() {
+                return 250;
+            }
+        };
+
+        assertWithPool(pool -> {
+            final String tableName = "copyOfRefreshFailure";
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
+                    .col("sym", ColumnType.SYMBOL)
+                    .timestamp("ts");
+            AbstractCairoTest.create(model);
+            final TableToken tableToken = engine.verifyTableName(tableName);
+
+            // Keep the table's scoreboard memory alive across the disposal so the contender's
+            // acquireTxn() reads a live scoreboard and fails on the null _txn, not a freed scoreboard.
+            final TxnScoreboard scoreboardHold = engine.getTxnScoreboardPool().getTxnScoreboard(tableToken);
+            TableReader src = null;
+            try {
+                // T1: one row in the first partition.
+                try (TableWriter w = newOffPoolWriter(configuration, tableName)) {
+                    TableWriter.Row r = w.newRow(1);
+                    r.putSym(0, "foo");
+                    r.append();
+                    w.commit();
+                }
+
+                // src opens at T1 and takes slot 0; keep it checked out for the whole test so the
+                // contender is forced onto slot 1 and never onto slot 0.
+                src = pool.get(tableToken);
+
+                // T2: a second row in a NEW partition, so a copyOf onto a T2 reader must downgrade.
+                try (TableWriter w = newOffPoolWriter(configuration, tableName)) {
+                    TableWriter.Row r = w.newRow(Micros.DAY_MICROS + 1);
+                    r.putSym(0, "bar");
+                    r.append();
+                    w.commit();
+                }
+
+                // R1 opens at T2 and takes slot 1, then returns to the pool (stays open, R1.txn == T2).
+                final TableReader r1 = pool.get(tableToken);
+                pooledReader.set(r1);
+                r1.close();
+
+                final Thread contender = new Thread(() -> {
+                    try {
+                        if (!readerReleased.await(10, TimeUnit.SECONDS)) {
+                            return;
+                        }
+                        final long deadline = configuration.getMillisecondClock().getTicks() + 2000;
+                        while (configuration.getMillisecondClock().getTicks() < deadline) {
+                            try (TableReader r = pool.get(tableToken)) {
+                                Assert.assertTrue(r.isOpen());
+                                break;
+                            } catch (EntryUnavailableException retry) {
+                                Os.pause();
+                            }
+                        }
+                    } catch (Throwable th) {
+                        contenderError.set(th);
+                    } finally {
+                        Path.clearThreadLocals();
+                        contenderDone.countDown();
+                    }
+                });
+                contender.start();
+
+                final TableReader srcRef = src;
+                final Thread disposer = new Thread(() -> {
+                    disposingThreadId.set(Thread.currentThread().threadId());
+                    faultSymbol.set(true);
+                    // getCopyOf(src) lands on slot 1's R1 (R1.txn T2 > src.txn T1), downgrades via
+                    // init() -> openSymbolMaps(), and the faulted .o open throws out of refreshAt().
+                    try (TableReader ignore = pool.getCopyOf(srcRef)) {
+                        Assert.fail("getCopyOf refresh should have failed");
+                    } catch (Throwable th) {
+                        refreshError.set(th);
+                    } finally {
+                        faultSymbol.set(false);
+                        Path.clearThreadLocals();
+                        // Safety net so the contender never blocks if the disposal misses the gate.
+                        readerReleased.countDown();
+                    }
+                });
+                disposer.start();
+
+                disposer.join();
+                contender.join();
+
+                Assert.assertTrue("injected symbol fault never fired", ff.wasCalled());
+                Assert.assertTrue("reader disposal never reached the parked munmap", gateFired.get());
+                Assert.assertNotNull("the getCopyOf refresh should have failed", refreshError.get());
+
+                final Throwable contenderErr = contenderError.get();
+                if (contenderErr != null) {
+                    throw new AssertionError(
+                            "ReaderPool handed a being-disposed reader to a concurrent get()", contenderErr);
+                }
+            } finally {
+                // src (slot 0) is held for the whole window; close it only after both threads join.
+                Misc.free(src);
+                Misc.free(scoreboardHold);
+            }
+        }, poolConfig);
+    }
+
     // When goActive()/reload() throws while a pooled reader is being refreshed, ReaderPool.R.refresh()
     // catches it and calls close(), which returnToPool()'s the reader: its slot is released while the
     // reader is still assigned and still open. get0()'s own catch then disposes the same reader via
@@ -393,7 +584,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
         final CountDownLatch contenderDone = new CountDownLatch(1);
 
         final TestFilesFacade ff = new TestFilesFacade() {
-            boolean called = false;
+            boolean isCalled = false;
 
             @Override
             public void munmap(long address, long size, int memoryTag) {
@@ -420,7 +611,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
                 if (faultMeta.get()
                         && Thread.currentThread().threadId() == disposingThreadId.get()
                         && Utf8s.endsWithAscii(name, TableUtils.META_FILE_NAME)) {
-                    called = true;
+                    isCalled = true;
                     return -1;
                 }
                 return super.openRO(name);
@@ -428,7 +619,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
 
             @Override
             public boolean wasCalled() {
-                return called;
+                return isCalled;
             }
         };
 

--- a/core/src/test/java/io/questdb/test/cairo/pool/ReaderPoolTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/pool/ReaderPoolTest.java
@@ -34,6 +34,7 @@ import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.TxnScoreboard;
 import io.questdb.cairo.pool.PoolListener;
 import io.questdb.cairo.pool.ReaderPool;
 import io.questdb.cairo.pool.ex.EntryLockedException;
@@ -71,7 +72,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.fail;
@@ -363,6 +366,165 @@ public class ReaderPoolTest extends AbstractCairoTest {
             Assert.assertEquals(0, halt.getCount());
             Assert.assertEquals(0, errors.get());
         });
+    }
+
+    // When goActive()/reload() throws while a pooled reader is being refreshed, ReaderPool.R.refresh()
+    // catches it and calls close(), which returnToPool()'s the reader: its slot is released while the
+    // reader is still assigned and still open. get0()'s own catch then disposes the same reader via
+    // goodbye()+close(). Between the release and the dispose a concurrent get() can acquire the
+    // half-dead reader and dereference its already-freed _txn mapping, producing the
+    // "roTxMemBase is null" NPE. This drives that exact interleaving deterministically.
+    //
+    // A single-slot pool forces both threads onto the same reader. The injected fault makes the
+    // refreshing thread's metadata reload throw; the FilesFacade then parks that thread inside its
+    // disposal - at the first munmap after the reader stops reporting open, i.e. after _txn was
+    // freed - and releases the second thread to contend for the just-released slot. A correct pool
+    // keeps the slot owned by the disposing thread until it is fully gone, so the second thread only
+    // ever sees EntryUnavailableException and never an NPE.
+    @Test
+    public void testConcurrentGetRefreshFailureDoesNotHandOutDisposedReader() throws Exception {
+        final AtomicReference<TableReader> pooledReader = new AtomicReference<>();
+        final AtomicLong disposingThreadId = new AtomicLong(-1);
+        final AtomicBoolean faultMeta = new AtomicBoolean();
+        final AtomicBoolean gateFired = new AtomicBoolean();
+        final AtomicReference<Throwable> refreshError = new AtomicReference<>();
+        final AtomicReference<Throwable> contenderError = new AtomicReference<>();
+        final CountDownLatch readerReleased = new CountDownLatch(1);
+        final CountDownLatch contenderDone = new CountDownLatch(1);
+
+        final TestFilesFacade ff = new TestFilesFacade() {
+            boolean called = false;
+
+            @Override
+            public void munmap(long address, long size, int memoryTag) {
+                final TableReader r = pooledReader.get();
+                // The disposing thread frees _txn (nulling roTxMemBase) before it stops being open.
+                // The first munmap once isOpen() is false (the _cv unmap) is past that point: park
+                // here so the contender grabs a reader whose _txn mapping is already gone.
+                if (r != null
+                        && Thread.currentThread().threadId() == disposingThreadId.get()
+                        && !r.isOpen()
+                        && gateFired.compareAndSet(false, true)) {
+                    readerReleased.countDown();
+                    try {
+                        contenderDone.await(10, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                super.munmap(address, size, memoryTag);
+            }
+
+            @Override
+            public long openRO(LPSZ name) {
+                if (faultMeta.get()
+                        && Thread.currentThread().threadId() == disposingThreadId.get()
+                        && Utf8s.endsWithAscii(name, TableUtils.META_FILE_NAME)) {
+                    called = true;
+                    return -1;
+                }
+                return super.openRO(name);
+            }
+
+            @Override
+            public boolean wasCalled() {
+                return called;
+            }
+        };
+
+        final CairoConfiguration poolConfig = new DefaultTestCairoConfiguration(root) {
+            @Override
+            public @NotNull FilesFacade getFilesFacade() {
+                return ff;
+            }
+
+            @Override
+            public int getPoolSegmentSize() {
+                return 1;
+            }
+
+            @Override
+            public int getReaderPoolMaxSegments() {
+                return 1;
+            }
+
+            @Override
+            public long getSpinLockTimeout() {
+                return 250;
+            }
+        };
+
+        assertWithPool(pool -> {
+            // Keep the table's scoreboard memory alive across the disposal so the contender's
+            // acquireTxn() reads a live scoreboard and fails on the null _txn, not a freed scoreboard.
+            final TxnScoreboard scoreboardHold = engine.getTxnScoreboardPool().getTxnScoreboard(uTableToken);
+            try {
+                // Prime the single slot: open a reader and return it; it stays open in the pool.
+                final TableReader primed = pool.get(uTableToken);
+                pooledReader.set(primed);
+                primed.close();
+
+                // Bump the metadata version so the refresh takes the slow metadata-reload path, where
+                // the injected _meta fault makes goActive() throw. Written via the unfaulted config.
+                try (TableWriter w = newOffPoolWriter(configuration, "u")) {
+                    w.addColumn("x", ColumnType.INT, AllowAllSecurityContext.INSTANCE);
+                }
+
+                final Thread contender = new Thread(() -> {
+                    try {
+                        if (!readerReleased.await(10, TimeUnit.SECONDS)) {
+                            return;
+                        }
+                        final long deadline = configuration.getMillisecondClock().getTicks() + 2000;
+                        while (configuration.getMillisecondClock().getTicks() < deadline) {
+                            try (TableReader r = pool.get(uTableToken)) {
+                                Assert.assertTrue(r.isOpen());
+                                break;
+                            } catch (EntryUnavailableException retry) {
+                                Os.pause();
+                            }
+                        }
+                    } catch (Throwable th) {
+                        contenderError.set(th);
+                    } finally {
+                        Path.clearThreadLocals();
+                        contenderDone.countDown();
+                    }
+                });
+                contender.start();
+
+                final Thread refresher = new Thread(() -> {
+                    disposingThreadId.set(Thread.currentThread().threadId());
+                    faultMeta.set(true);
+                    try (TableReader ignore = pool.get(uTableToken)) {
+                        Assert.fail("refresh-get should have failed");
+                    } catch (Throwable th) {
+                        refreshError.set(th);
+                    } finally {
+                        faultMeta.set(false);
+                        Path.clearThreadLocals();
+                        // Safety net so the contender never blocks if the disposal misses the gate.
+                        readerReleased.countDown();
+                    }
+                });
+                refresher.start();
+
+                refresher.join();
+                contender.join();
+
+                Assert.assertTrue("injected metadata fault never fired", ff.wasCalled());
+                Assert.assertTrue("reader disposal never reached the parked munmap", gateFired.get());
+                Assert.assertNotNull("the refresh-get should have failed", refreshError.get());
+
+                final Throwable contenderErr = contenderError.get();
+                if (contenderErr != null) {
+                    throw new AssertionError(
+                            "ReaderPool handed a being-disposed reader to a concurrent get()", contenderErr);
+                }
+            } finally {
+                Misc.free(scoreboardHold);
+            }
+        }, poolConfig);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cairo/pool/ReaderPoolTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/pool/ReaderPoolTest.java
@@ -387,8 +387,8 @@ public class ReaderPoolTest extends AbstractCairoTest {
     public void testConcurrentGetCopyOfRefreshFailureDoesNotHandOutDisposedReader() throws Exception {
         final AtomicReference<TableReader> pooledReader = new AtomicReference<>();
         final AtomicLong disposingThreadId = new AtomicLong(-1);
-        final AtomicBoolean faultSymbol = new AtomicBoolean();
-        final AtomicBoolean gateFired = new AtomicBoolean();
+        final AtomicBoolean isSymbolFaultEnabled = new AtomicBoolean();
+        final AtomicBoolean hasGateFired = new AtomicBoolean();
         final AtomicReference<Throwable> refreshError = new AtomicReference<>();
         final AtomicReference<Throwable> contenderError = new AtomicReference<>();
         final CountDownLatch readerReleased = new CountDownLatch(1);
@@ -406,7 +406,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
                 if (r != null
                         && Thread.currentThread().threadId() == disposingThreadId.get()
                         && !r.isOpen()
-                        && gateFired.compareAndSet(false, true)) {
+                        && hasGateFired.compareAndSet(false, true)) {
                     readerReleased.countDown();
                     try {
                         contenderDone.await(10, TimeUnit.SECONDS);
@@ -422,7 +422,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
                 // Fault only the open of the symbol-offset (.o) file on the disposing thread, reached
                 // via init() -> openSymbolMaps() inside goActiveAtTxn()'s downgrade. exists() is left
                 // to pass so only a real file's open fails.
-                if (faultSymbol.get()
+                if (isSymbolFaultEnabled.get()
                         && Thread.currentThread().threadId() == disposingThreadId.get()
                         && Utf8s.endsWithAscii(name, ".o")) {
                     isCalled = true;
@@ -502,7 +502,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
                         if (!readerReleased.await(10, TimeUnit.SECONDS)) {
                             return;
                         }
-                        final long deadline = configuration.getMillisecondClock().getTicks() + 2000;
+                        final long deadline = configuration.getMillisecondClock().getTicks() + 1000;
                         while (configuration.getMillisecondClock().getTicks() < deadline) {
                             try (TableReader r = pool.get(tableToken)) {
                                 Assert.assertTrue(r.isOpen());
@@ -523,7 +523,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
                 final TableReader srcRef = src;
                 final Thread disposer = new Thread(() -> {
                     disposingThreadId.set(Thread.currentThread().threadId());
-                    faultSymbol.set(true);
+                    isSymbolFaultEnabled.set(true);
                     // getCopyOf(src) lands on slot 1's R1 (R1.txn T2 > src.txn T1), downgrades via
                     // init() -> openSymbolMaps(), and the faulted .o open throws out of refreshAt().
                     try (TableReader ignore = pool.getCopyOf(srcRef)) {
@@ -531,7 +531,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
                     } catch (Throwable th) {
                         refreshError.set(th);
                     } finally {
-                        faultSymbol.set(false);
+                        isSymbolFaultEnabled.set(false);
                         Path.clearThreadLocals();
                         // Safety net so the contender never blocks if the disposal misses the gate.
                         readerReleased.countDown();
@@ -543,13 +543,19 @@ public class ReaderPoolTest extends AbstractCairoTest {
                 contender.join();
 
                 Assert.assertTrue("injected symbol fault never fired", ff.wasCalled());
-                Assert.assertTrue("reader disposal never reached the parked munmap", gateFired.get());
+                Assert.assertTrue("reader disposal never reached the parked munmap", hasGateFired.get());
                 Assert.assertNotNull("the getCopyOf refresh should have failed", refreshError.get());
 
                 final Throwable contenderErr = contenderError.get();
                 if (contenderErr != null) {
                     throw new AssertionError(
                             "ReaderPool handed a being-disposed reader to a concurrent get()", contenderErr);
+                }
+
+                // The disposing thread must leave the slot cleanly reclaimable: once it is gone,
+                // a fresh get() returns a usable, open reader rather than a leaked or stuck slot.
+                try (TableReader reclaimed = pool.get(tableToken)) {
+                    Assert.assertTrue("pool slot was not cleanly reclaimed after disposal", reclaimed.isOpen());
                 }
             } finally {
                 // src (slot 0) is held for the whole window; close it only after both threads join.
@@ -576,8 +582,8 @@ public class ReaderPoolTest extends AbstractCairoTest {
     public void testConcurrentGetRefreshFailureDoesNotHandOutDisposedReader() throws Exception {
         final AtomicReference<TableReader> pooledReader = new AtomicReference<>();
         final AtomicLong disposingThreadId = new AtomicLong(-1);
-        final AtomicBoolean faultMeta = new AtomicBoolean();
-        final AtomicBoolean gateFired = new AtomicBoolean();
+        final AtomicBoolean isMetaFaultEnabled = new AtomicBoolean();
+        final AtomicBoolean hasGateFired = new AtomicBoolean();
         final AtomicReference<Throwable> refreshError = new AtomicReference<>();
         final AtomicReference<Throwable> contenderError = new AtomicReference<>();
         final CountDownLatch readerReleased = new CountDownLatch(1);
@@ -595,7 +601,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
                 if (r != null
                         && Thread.currentThread().threadId() == disposingThreadId.get()
                         && !r.isOpen()
-                        && gateFired.compareAndSet(false, true)) {
+                        && hasGateFired.compareAndSet(false, true)) {
                     readerReleased.countDown();
                     try {
                         contenderDone.await(10, TimeUnit.SECONDS);
@@ -608,7 +614,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
 
             @Override
             public long openRO(LPSZ name) {
-                if (faultMeta.get()
+                if (isMetaFaultEnabled.get()
                         && Thread.currentThread().threadId() == disposingThreadId.get()
                         && Utf8s.endsWithAscii(name, TableUtils.META_FILE_NAME)) {
                     isCalled = true;
@@ -666,7 +672,7 @@ public class ReaderPoolTest extends AbstractCairoTest {
                         if (!readerReleased.await(10, TimeUnit.SECONDS)) {
                             return;
                         }
-                        final long deadline = configuration.getMillisecondClock().getTicks() + 2000;
+                        final long deadline = configuration.getMillisecondClock().getTicks() + 1000;
                         while (configuration.getMillisecondClock().getTicks() < deadline) {
                             try (TableReader r = pool.get(uTableToken)) {
                                 Assert.assertTrue(r.isOpen());
@@ -686,13 +692,13 @@ public class ReaderPoolTest extends AbstractCairoTest {
 
                 final Thread refresher = new Thread(() -> {
                     disposingThreadId.set(Thread.currentThread().threadId());
-                    faultMeta.set(true);
+                    isMetaFaultEnabled.set(true);
                     try (TableReader ignore = pool.get(uTableToken)) {
                         Assert.fail("refresh-get should have failed");
                     } catch (Throwable th) {
                         refreshError.set(th);
                     } finally {
-                        faultMeta.set(false);
+                        isMetaFaultEnabled.set(false);
                         Path.clearThreadLocals();
                         // Safety net so the contender never blocks if the disposal misses the gate.
                         readerReleased.countDown();
@@ -704,13 +710,19 @@ public class ReaderPoolTest extends AbstractCairoTest {
                 contender.join();
 
                 Assert.assertTrue("injected metadata fault never fired", ff.wasCalled());
-                Assert.assertTrue("reader disposal never reached the parked munmap", gateFired.get());
+                Assert.assertTrue("reader disposal never reached the parked munmap", hasGateFired.get());
                 Assert.assertNotNull("the refresh-get should have failed", refreshError.get());
 
                 final Throwable contenderErr = contenderError.get();
                 if (contenderErr != null) {
                     throw new AssertionError(
                             "ReaderPool handed a being-disposed reader to a concurrent get()", contenderErr);
+                }
+
+                // The disposing thread must leave the slot cleanly reclaimable: once it is gone,
+                // a fresh get() returns a usable, open reader rather than a leaked or stuck slot.
+                try (TableReader reclaimed = pool.get(uTableToken)) {
+                    Assert.assertTrue("pool slot was not cleanly reclaimed after disposal", reclaimed.isOpen());
                 }
             } finally {
                 Misc.free(scoreboardHold);


### PR DESCRIPTION
## Summary

Under concurrent table reads, a reader pulled from the pool occasionally fails with `NullPointerException: ... roTxMemBase is null`, and the run can finish holding leaked reader file descriptors. It shows up when many threads acquire readers for the same table while that table is being written to or altered, so pooled readers are frequently refreshed and a refresh sometimes fails. This change closes the race that causes both symptoms.

## Root cause

The cleanup for a failed reader refresh is split across two methods, and the first one returns the reader to the pool instead of disposing it.

When `ReaderPool.R.refresh()` (or `refreshAt()`) sees `goActive()` throw, its `catch` calls `close()`:

```java
public void refresh(ResourcePoolSupervisor<R> supervisor) {
    this.supervisor = supervisor;
    try {
        goActive();
    } catch (Throwable ex) {
        close();    // R.close() -> goPassive() + returnToPool()
        throw ex;
    }
}
```

For a still-pooled reader, `R.close()` is not a dispose: it calls `goPassive()` then `returnToPool(this)`, which sets `allocations[i] = UNALLOCATED` and returns `true`, leaving the reader open and still referenced at `entry.getTenant(i)`.

`AbstractMultiTenantPool.get0()` then runs its own cleanup on the rethrow:

```java
} catch (Throwable th) {
    tenant.goodbye();           // pool = null, entry = null
    tenant.close();             // pool == null now -> super.close() disposes the reader
    e.assignTenant(i, null);    // slot finally cleared here
    Unsafe.arrayPutOrdered(e.allocations, i, UNALLOCATED);
    throw th;
}
```

So `close()` runs twice on a failed refresh. The first call re-publishes the slot as available; the second tears the reader down. In between — for the whole duration of `super.close()` — `allocations[i]` is `UNALLOCATED` while `entry.getTenant(i)` still points at the reader being freed.

A concurrent `get0()` that CAS-acquires that slot reads the still-assigned tenant and calls `refresh()` on it. `TableReader.close()` frees `txFile` (nulling `roTxMemBase`) several statements before `freeTempMem()` flips `isOpen()` to `false`, so the reader still reports open while its `_txn` mapping is already gone, and the reload dereferences it:

```
java.lang.NullPointerException: Cannot invoke "...MemoryMR.getLong(long)" because "this.roTxMemBase" is null
    at io.questdb.cairo.TxReader.unsafeReadVersion(TxReader.java:715)
    at io.questdb.cairo.TableReader.readTxnSlow(TableReader.java:1569)
    at io.questdb.cairo.TableReader.goActive(TableReader.java:593)
    at io.questdb.cairo.pool.ReaderPool$R.refresh(ReaderPool.java:263)
    at io.questdb.cairo.pool.AbstractMultiTenantPool.get0(AbstractMultiTenantPool.java:316)
```

The same double-ownership corrupts the allocation/tenant bookkeeping (a reader can be assigned to a slot the pool considers free, or trip the `"double close"` guard on return), which orphans open readers and leaks their file descriptors.

## The fix

Make `get0()` the sole disposer on a failed refresh: drop the failure-path `close()` from `R.refresh()` and `R.refreshAt()`.

```java
public void refresh(ResourcePoolSupervisor<R> supervisor) {
    this.supervisor = supervisor;
    goActive();
}
```

Because `get0()`'s `catch` calls `goodbye()` before `close()`, that `close()` goes straight to `super.close()` (it does not call `returnToPool()`), and `allocations[i]` stays owned by the failing thread until the slot is cleared. There is no interval in which the reader is both released and still assigned, so a concurrent `get()` can no longer acquire a reader that is being torn down.

`refresh()` and `refreshAt()` are called only from `get0()`, which already disposes the tenant on any throw, so the removed `close()` was redundant. `supervisor.onResourceReturned(...)` is still invoked (inside the `close()` that `get0()` runs), so reader leak tracking is unchanged.

## Behavior change and risks

- Happy path (refresh succeeds) is unchanged.
- The only behavioral difference is on the refresh-failure path, where disposal now happens once, in `get0()`, instead of a return-to-pool followed by a dispose.
- The change deletes a cleanup branch, so the risk is a caller that depended on `refresh()`/`refreshAt()` self-disposing on failure. Both are invoked only from `get0()`, which owns that cleanup, so no such caller exists in the tree.
- This is a concurrency fix; the timing window is small, which is why it surfaced only under heavy concurrent load. A full CI run is worthwhile before merge.

## Scope: the same shape in `WalWriterPool`

`WalWriterPool.WalWriterTenant.refresh()` has the same textual shape this PR removes — `try { goActive(); } catch (Throwable ex) { close(); throw ex; }` — and `WalWriterPool` extends the same `AbstractMultiTenantPool`, so `get0()` is already its disposer too. It is left unchanged here because, unlike the reader, it is not a reachable race:

- `WalWriterTenant.close()` returns the writer to the pool only on its `!isDistressed()` branch. A distressed writer is disposed in place via `super.close()` + `expelFromPool()`, and `expelFromPool()` clears the tenant before releasing the slot, so there is no released-but-still-assigned window.
- `WalWriter.goActive()` marks the writer distressed on every `CairoException` (file/mmap errors, metadata validation, sequencer reads, version mismatch). `EntryUnavailableException` extends `CairoException`, so it is covered too. The only declared non-Cairo exception on that path, `AlterTableContextException`, is thrown solely under `if (!contextAllowsAnyStructureChanges)`, and the WAL replay calls `apply(metaWriterSvc, true)`, so it is unreachable.

So every normal failure of a WAL writer refresh sets `distressed` and takes the race-free disposal path. The reader has no such guard — `R.close()` always returns to the pool on failure — which is exactly why the race is reachable for readers and not for WAL writers. Dropping the `close()` from `WalWriterPool.refresh()` would be defense-in-depth against an unexpected non-`CairoException` (a bug or `Error`) reopening the window, not a bug fix, so it stays out of scope for this PR.

## Test plan

- Adds `ReaderPoolTest.testConcurrentGetRefreshFailureDoesNotHandOutDisposedReader`, a deterministic reproduction of the `refresh()`/`get()` path. It uses a single-slot pool so two threads contend for the same reader, an injected `openRO(_meta)` failure to make one thread's refresh throw, and a `FilesFacade` that parks that thread inside its disposal (after `_txn` is freed) and releases the second thread to contend for the just-released slot. The test fails on the current code with the NPE above and passes with this change.
- Adds `ReaderPoolTest.testConcurrentGetCopyOfRefreshFailureDoesNotHandOutDisposedReader`, the matching reproduction for the `refreshAt()`/`getCopyOf()` path, which this PR changes identically. It uses a two-slot pool — a checked-out source reader holds one slot while a newer-txn reader returned to the other slot is the refresh target — so `getCopyOf()` takes `goActiveAtTxn()`'s downgrade path; an injected `openRO` failure on the symbol-offset (`.o`) file makes `refreshAt()` throw, and the same disposal gate lets a concurrent `get()` contend for the slot. It fails on the unfixed `refreshAt()` with the same NPE and passes with this change.
- The full `ReaderPoolTest` suite passes (33 tests), including the failure-path and race tests `testGetReaderFailure`, `testGetAndCloseRace`, and `testReaderDoubleClose`.
- Reverting only the `ReaderPool.java` change reproduces both failures, confirming the tests are tied to this fix. Each test pins its own half — re-adding the failure-path `close()` to `refreshAt()` alone reproduces the second test's NPE, leaving the first test green.