### PR TITLE
feat(sql): add opt-in filter pushdown for record cursor factories

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/RecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/cairo/sql/RecordCursorFactory.java
@@ -361,6 +361,18 @@ public interface RecordCursorFactory extends Closeable, Sinkable, Plannable {
     }
 
     /**
+     * Returns true if the factory opts in to having the post-filter pushed into it
+     * via {@link #setPushdownFilterCondition(ObjList)}, independently of parquet
+     * partition pruning. Table functions that can evaluate filter conditions
+     * themselves override this to return true.
+     *
+     * @return true if the factory supports generic filter pushdown
+     */
+    default boolean supportsFilterPushdown() {
+        return false;
+    }
+
+    /**
      * Returns true if the factory stands for nothing more but a filter, so that
      * the above factory (e.g. a parallel GROUP BY one) can steal the filter.
      *

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -4256,7 +4256,8 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         try {
             // This path applies only to the read_parquet() table function.
             // For native tables, generateTableQuery0() handles pushdown separately.
-            if (factory.mayHaveParquetPartitions(executionContext) && executionContext.isParquetRowGroupPruningEnabled()) {
+            if ((factory.mayHaveParquetPartitions(executionContext) && executionContext.isParquetRowGroupPruningEnabled())
+                    || factory.supportsFilterPushdown()) {
                 factory.setPushdownFilterCondition(pushdownFilterExtractor.extractAndCompile(
                         sqlNodeStack, sqlNodeStack2, filterExpr, factory.getMetadata(), functionParser, executionContext));
             }


### PR DESCRIPTION
## Summary

Adds a generic opt-in so a `RecordCursorFactory` can advertise that it accepts pushed-down filter conditions. `RecordCursorFactory.supportsFilterPushdown()` defaults to `false`; the filter code generator now also offers pushdown to any factory that returns `true`.

## Notes

- Purely additive: existing factories inherit the `false` default and are unaffected.
- The pushdown path previously gated only on Parquet row-group pruning now also activates for factories that opt in.

## Test plan

- Existing filter/pushdown tests pass (e.g. `FilterPushdownIntoUnionTest`).