### PR TITLE
fix(core): fix NATIVE_INDEX_READER leak when a posting-index row cursor is closed after its reader

### DIFF
--- a/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/AbstractPostingIndexReader.java
@@ -103,6 +103,9 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
     protected int genCount;
     protected int keyCount;
     protected RecordMetadata metadata;
+    // Assertion-only stamp of the thread that last checked out a cursor; see
+    // assertStampOperatingThread() / assertSameOperatingThread().
+    private long assertOperatingThreadId = -1L;
     // Last successfully observed seqlock value of the chain header's active
     // page. Used by reloadConditionally to detect any publish (appendNewEntry
     // or extendHead — both republish the header) and skip the picker walk
@@ -1075,6 +1078,27 @@ public abstract class AbstractPostingIndexReader implements IndexReader {
 
     protected static long varBlockOffsetsSize(int count, boolean longOffsets) {
         return (long) (count + 1) * (longOffsets ? Long.BYTES : Integer.BYTES);
+    }
+
+    // Single-owner tripwire (assertion-only). A posting reader and its pooled
+    // cursors are driven by exactly one thread at a time: the thread that owns the
+    // enclosing TableReader between pool acquire/release. getCursor() stamps that
+    // thread via assertStampOperatingThread() and every cursor close() checks it
+    // here. A posting cursor whose close() runs after the reader was released to the
+    // pool and re-acquired by another thread -- the lifecycle hazard that
+    // CoveringIndexRecordCursorFactory.CoveringCursor.close() avoids by freeing the
+    // row cursor BEFORE the frame cursor -- trips this assert instead of silently
+    // re-pooling into / racing a concurrently-reloaded reader. Never relied upon for
+    // correctness: the isOpen() guard in each cursor close() is the actual leak
+    // mitigation, and this stamp is only written under -ea.
+    protected boolean assertSameOperatingThread() {
+        final long owner = assertOperatingThreadId;
+        return owner == -1L || owner == Thread.currentThread().threadId();
+    }
+
+    protected boolean assertStampOperatingThread() {
+        assertOperatingThreadId = Thread.currentThread().threadId();
+        return true;
     }
 
     protected void ensureSidecarOpen(int c) {

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexBwdReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexBwdReader.java
@@ -177,7 +177,14 @@ public class PostingIndexBwdReader extends AbstractPostingIndexReader {
 
         @Override
         public void close() {
-            if (!isPooled && freeCursors.size() < MAX_CACHED_FREE_CURSORS) {
+            // Only return to the idle pool while the owning reader is still open.
+            // The pool retains blockBufferAddr (NATIVE_INDEX_READER) for reuse and
+            // relies on the reader's close() draining freeCursors to reclaim it; a
+            // cursor that re-pools after the reader was closed (e.g. a reader-thread
+            // cursor outliving a concurrent reseal/reload) would never be drained
+            // again and would leak its block buffer. When the reader is closed,
+            // release everything immediately instead.
+            if (!isPooled && isOpen() && freeCursors.size() < MAX_CACHED_FREE_CURSORS) {
                 isPooled = true;
                 closeCoveringResources();
                 if (efRankDirAddr != 0) {
@@ -920,7 +927,9 @@ public class PostingIndexBwdReader extends AbstractPostingIndexReader {
 
         @Override
         public void close() {
-            if (!isPooled && freeNullCursors.size() < MAX_CACHED_FREE_CURSORS) {
+            // See Cursor.close(): never re-pool into a closed reader, otherwise the
+            // retained blockBufferAddr (NATIVE_INDEX_READER) leaks.
+            if (!isPooled && isOpen() && freeNullCursors.size() < MAX_CACHED_FREE_CURSORS) {
                 isPooled = true;
                 closeCoveringResources();
                 if (efRankDirAddr != 0) {

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexBwdReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexBwdReader.java
@@ -92,6 +92,7 @@ public class PostingIndexBwdReader extends AbstractPostingIndexReader {
 
     @Override
     public RowCursor getCursor(int key, long minValue, long maxValue, int[] requiredCoverColumns) {
+        assert assertStampOperatingThread();
         reloadConditionally();
 
         // See PostingIndexFwdReader.getCursor: clamp the index-walked
@@ -177,13 +178,26 @@ public class PostingIndexBwdReader extends AbstractPostingIndexReader {
 
         @Override
         public void close() {
+            assert assertSameOperatingThread() : "posting index cursor closed off the reader's owning thread";
             // Only return to the idle pool while the owning reader is still open.
             // The pool retains blockBufferAddr (NATIVE_INDEX_READER) for reuse and
             // relies on the reader's close() draining freeCursors to reclaim it; a
-            // cursor that re-pools after the reader was closed (e.g. a reader-thread
-            // cursor outliving a concurrent reseal/reload) would never be drained
+            // cursor that re-pools after the reader was closed would never be drained
             // again and would leak its block buffer. When the reader is closed,
             // release everything immediately instead.
+            //
+            // NOTE: this isOpen() guard is a single-threaded leak mitigation
+            // (defense-in-depth), NOT a concurrency primitive. isOpen() reads a
+            // non-volatile fd and "check isOpen() then freeCursors.add(this)" is a
+            // non-atomic check-then-act on a plain (unsynchronized) ObjList, so it is
+            // only correct when this close() runs on the thread that owns the reader.
+            // Cross-thread safety comes from elsewhere: a TableReader is owned by a
+            // single thread between pool acquire/release and its reseal/reload
+            // (TableReader.reloadColumnAt) runs on that owner, while
+            // CoveringIndexRecordCursorFactory.CoveringCursor.close() frees the row
+            // cursor BEFORE the frame cursor -- i.e. before the TableReader is
+            // released back to the pool where another thread could reload it -- so
+            // this close() always runs intra-thread while the reader is still open.
             if (!isPooled && isOpen() && freeCursors.size() < MAX_CACHED_FREE_CURSORS) {
                 isPooled = true;
                 closeCoveringResources();
@@ -927,8 +941,12 @@ public class PostingIndexBwdReader extends AbstractPostingIndexReader {
 
         @Override
         public void close() {
-            // See Cursor.close(): never re-pool into a closed reader, otherwise the
-            // retained blockBufferAddr (NATIVE_INDEX_READER) leaks.
+            assert assertSameOperatingThread() : "posting index null cursor closed off the reader's owning thread";
+            // See Cursor.close(): the isOpen() guard is a single-threaded leak
+            // mitigation (it avoids re-pooling into a closed reader and leaking the
+            // retained blockBufferAddr, NATIVE_INDEX_READER), not a concurrency
+            // primitive. Cross-thread safety relies on single reader ownership +
+            // CoveringCursor.close() ordering, not on this guard.
             if (!isPooled && isOpen() && freeNullCursors.size() < MAX_CACHED_FREE_CURSORS) {
                 isPooled = true;
                 closeCoveringResources();

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexFwdReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexFwdReader.java
@@ -101,6 +101,7 @@ public class PostingIndexFwdReader extends AbstractPostingIndexReader {
 
     @Override
     public RowCursor getCursor(int key, long minValue, long maxValue, int[] requiredCoverColumns) {
+        assert assertStampOperatingThread();
         reloadConditionally();
 
         // Clamp the index-walked range to the picked chain entry's
@@ -193,10 +194,14 @@ public class PostingIndexFwdReader extends AbstractPostingIndexReader {
 
         @Override
         public void close() {
+            assert assertSameOperatingThread() : "posting index cursor closed off the reader's owning thread";
             // Never re-pool into a closed reader: the pool retains blockBufferAddr
             // (NATIVE_INDEX_READER) for reuse and only the reader's close() drains it,
             // so a cursor that re-pools after the reader closed would leak its block
-            // buffer. See PostingIndexBwdReader.Cursor.close().
+            // buffer. This isOpen() guard is a single-threaded leak mitigation, not a
+            // concurrency primitive; cross-thread safety comes from single reader
+            // ownership + CoveringCursor.close() ordering. See
+            // PostingIndexBwdReader.Cursor.close() for the full rationale.
             if (!isPooled && isOpen() && freeCursors.size() < MAX_CACHED_FREE_CURSORS) {
                 isPooled = true;
                 closeCoveringResources();
@@ -897,7 +902,9 @@ public class PostingIndexFwdReader extends AbstractPostingIndexReader {
 
         @Override
         public void close() {
-            // See Cursor.close(): never re-pool into a closed reader.
+            assert assertSameOperatingThread() : "posting index null cursor closed off the reader's owning thread";
+            // See Cursor.close(): the isOpen() guard is a single-threaded leak
+            // mitigation, not a concurrency primitive.
             if (!isPooled && isOpen() && freeNullCursors.size() < MAX_CACHED_FREE_CURSORS) {
                 isPooled = true;
                 closeCoveringResources();

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexFwdReader.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexFwdReader.java
@@ -193,7 +193,11 @@ public class PostingIndexFwdReader extends AbstractPostingIndexReader {
 
         @Override
         public void close() {
-            if (!isPooled && freeCursors.size() < MAX_CACHED_FREE_CURSORS) {
+            // Never re-pool into a closed reader: the pool retains blockBufferAddr
+            // (NATIVE_INDEX_READER) for reuse and only the reader's close() drains it,
+            // so a cursor that re-pools after the reader closed would leak its block
+            // buffer. See PostingIndexBwdReader.Cursor.close().
+            if (!isPooled && isOpen() && freeCursors.size() < MAX_CACHED_FREE_CURSORS) {
                 isPooled = true;
                 closeCoveringResources();
                 resetCoveringState();
@@ -893,7 +897,8 @@ public class PostingIndexFwdReader extends AbstractPostingIndexReader {
 
         @Override
         public void close() {
-            if (!isPooled && freeNullCursors.size() < MAX_CACHED_FREE_CURSORS) {
+            // See Cursor.close(): never re-pool into a closed reader.
+            if (!isPooled && isOpen() && freeNullCursors.size() < MAX_CACHED_FREE_CURSORS) {
                 isPooled = true;
                 closeCoveringResources();
                 resetCoveringState();

--- a/core/src/main/java/io/questdb/griffin/engine/table/CoveringIndexRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/CoveringIndexRecordCursorFactory.java
@@ -498,8 +498,16 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
 
         @Override
         public void close() {
-            frameCursor = Misc.free(frameCursor);
+            // Free the row cursor BEFORE the frame cursor. The frame cursor owns the
+            // TableReader and Misc.free(frameCursor) returns it to the pool; once pooled,
+            // another thread can acquire+reload the reader and close the per-partition
+            // PostingIndex*Reader that currentRowCursor was checked out from. Closing the
+            // row cursor first guarantees its owning reader is still open (this thread
+            // still holds it), so the cursor re-pools into a live reader rather than a
+            // stale/closed one. Mirrors CoveringPageFrameCursor.close() (closePendingCursor
+            // before freeing frameCursor).
             this.currentRowCursor = Misc.free(currentRowCursor);
+            frameCursor = Misc.free(frameCursor);
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -2242,6 +2242,77 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    /**
+     * Deterministic regression for the native-memory leak that the concurrent fuzz
+     * {@link #testMultiThreadedO3CoveringLatestByConcurrentReaderFuzz} surfaces
+     * non-deterministically as
+     * {@code Memory usage by tag: NATIVE_INDEX_READER, difference: 512 ... was:<512>}.
+     * The fuzz seed only fixes the data shape, not the thread interleaving, so it
+     * cannot reproduce the race on demand. This test exercises the underlying
+     * lifecycle hazard directly, single-threaded.
+     * <p>
+     * {@link PostingIndexBwdReader} pools idle row cursors in {@code freeCursors}.
+     * To reuse the decode scratch the pooling {@code close()} path RETAINS the
+     * cursor's {@code blockBufferAddr} (BLOCK_CAPACITY longs = 512 bytes, tagged
+     * NATIVE_INDEX_READER); that buffer is only ever reclaimed by the reader's own
+     * {@code close()}, which drains {@code freeCursors}. So if the reader is closed
+     * while a cursor is still checked out -- exactly what a concurrent reseal/reload
+     * does to a reader thread that is mid-query -- the later {@code cursor.close()}
+     * re-pools the cursor (with its block buffer) into a reader that is never
+     * drained again, leaking the block buffer.
+     */
+    @Test
+    public void testRowCursorClosedAfterReaderDoesNotLeakBlockBuffer() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_cursor_after_reader_close";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    // Single key with IRREGULAR gaps so the per-key value blocks
+                    // encode with a non-zero bit width (packed/EF/flat) -- the only
+                    // decode path that allocates blockBufferAddr. Consecutive rowids
+                    // would hit the bitWidth==0 constant-delta fast path and allocate
+                    // nothing, hiding the leak.
+                    long rowId = 0;
+                    for (int i = 0; i < 4096; i++) {
+                        writer.add(0, rowId);
+                        rowId += 1 + (i % 7); // varying delta -> non-constant blocks
+                    }
+                    writer.setMaxValue(rowId);
+                    writer.commit();
+                }
+
+                final PostingIndexBwdReader reader = new PostingIndexBwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0,
+                        /* metadata */ null, /* columnVersionReader */ null,
+                        /* partitionTimestamp */ 0);
+
+                // Check out a cursor and fully drive it so the decode block buffer
+                // (NATIVE_INDEX_READER) is allocated on this active, un-pooled cursor.
+                final RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE);
+                long count = 0;
+                while (cursor.hasNext()) {
+                    cursor.next();
+                    count++;
+                }
+                Assert.assertEquals(4096, count);
+
+                // Reseal/reload race: the owning reader is closed while the cursor is
+                // still checked out. reader.close() drains only the idle pool, so this
+                // active cursor's block buffer is NOT reclaimed here.
+                reader.close();
+
+                // The slow consumer now closes its cursor. The cursor is not yet
+                // pooled and the (closed) reader's freeCursors still has room, so
+                // close() re-pools it and keeps blockBufferAddr -- now unreachable and
+                // never freed. assertMemoryLeak fails with a NATIVE_INDEX_READER leak.
+                cursor.close();
+            }
+        });
+    }
+
     @Test
     public void testReaderHidesHeadEntryTailGensAbovePin() throws Exception {
         assertMemoryLeak(() -> {

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -2313,6 +2313,168 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    /**
+     * Forward-reader sibling of
+     * {@link #testRowCursorClosedAfterReaderDoesNotLeakBlockBuffer}. The PR guards
+     * four pooling {@code close()} paths with {@code isOpen()}; the backward-reader
+     * test above only pins {@link PostingIndexBwdReader.Cursor#close()}. The fuzz
+     * {@link #testMultiThreadedO3CoveringLatestByConcurrentReaderFuzz} is LATEST ON
+     * (covering BACKWARD reader, asserts {@code plan.contains("CoveringIndex")}), so
+     * the forward-reader fix otherwise has no regression coverage. This drives
+     * {@link PostingIndexFwdReader.Cursor#close()} the same way: allocate the decode
+     * block buffer (NATIVE_INDEX_READER, 512 bytes), close the reader while the
+     * cursor is still checked out, then close the cursor -- which without the
+     * {@code isOpen()} guard re-pools the live block buffer into a drained reader.
+     */
+    @Test
+    public void testFwdRowCursorClosedAfterReaderDoesNotLeakBlockBuffer() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_fwd_cursor_after_reader_close";
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    // Irregular gaps -> non-zero bit width blocks -> decode allocates
+                    // blockBufferAddr. See the backward-reader test for why constant
+                    // deltas would hide the leak.
+                    long rowId = 0;
+                    for (int i = 0; i < 4096; i++) {
+                        writer.add(0, rowId);
+                        rowId += 1 + (i % 7);
+                    }
+                    writer.setMaxValue(rowId);
+                    writer.commit();
+                }
+
+                // columnTop == 0 -> getCursor returns a plain Cursor (not NullCursor).
+                final PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, /* columnTop */ 0);
+
+                final RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE);
+                long count = 0;
+                while (cursor.hasNext()) {
+                    cursor.next();
+                    count++;
+                }
+                Assert.assertEquals(4096, count);
+
+                // Reseal/reload race: reader closed while the cursor is checked out;
+                // reader.close() drains only the idle pool.
+                reader.close();
+
+                // Slow consumer closes its cursor: without isOpen() this re-pools the
+                // retained block buffer into the drained (closed) reader -> leak.
+                cursor.close();
+            }
+        });
+    }
+
+    /**
+     * Null-cursor sibling of
+     * {@link #testRowCursorClosedAfterReaderDoesNotLeakBlockBuffer}. The pooling
+     * close on {@link PostingIndexBwdReader.NullCursor#close()} is a fourth patched
+     * path reachable only when {@code key == 0 && columnTop > 0 && minValue < columnTop}
+     * (see {@code getCursor}); the other regression tests use {@code columnTop == 0}
+     * and never hit it. Here {@code columnTop > 0} so {@code getCursor} returns a
+     * {@link PostingIndexBwdReader.NullCursor}, whose {@code hasNext()} first drains
+     * the real key-0 entries via {@code super.hasNext()} -- allocating the decode
+     * block buffer (NATIVE_INDEX_READER) -- before synthesising the implicit nulls.
+     * Closing the reader mid-iteration then closing the cursor re-pools that buffer
+     * into the drained reader unless the {@code isOpen()} guard short-circuits it.
+     */
+    @Test
+    public void testBwdNullCursorClosedAfterReaderDoesNotLeakBlockBuffer() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_null_cursor_after_reader_close";
+            final long columnTop = 256;
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    // Real key-0 entries live at/after columnTop with irregular gaps
+                    // so the NullCursor's super.hasNext() decode allocates the block
+                    // buffer; rows below columnTop are surfaced as implicit nulls.
+                    long rowId = columnTop;
+                    for (int i = 0; i < 4096; i++) {
+                        writer.add(0, rowId);
+                        rowId += 1 + (i % 7);
+                    }
+                    writer.setMaxValue(rowId);
+                    writer.commit();
+                }
+
+                // key==0 && columnTop>0 && minValue(0)<columnTop -> NullCursor path.
+                final PostingIndexBwdReader reader = new PostingIndexBwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, columnTop,
+                        /* metadata */ null, /* columnVersionReader */ null,
+                        /* partitionTimestamp */ 0);
+
+                final RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE);
+                long count = 0;
+                while (cursor.hasNext()) {
+                    cursor.next();
+                    count++;
+                }
+                // 4096 real entries + columnTop synthesised nulls (columnTop-1..0).
+                Assert.assertEquals(4096 + columnTop, count);
+
+                // Reseal/reload race, then the slow consumer closes its null cursor.
+                reader.close();
+                cursor.close();
+            }
+        });
+    }
+
+    /**
+     * Forward-reader counterpart of
+     * {@link #testBwdNullCursorClosedAfterReaderDoesNotLeakBlockBuffer}, pinning the
+     * fourth and last patched path: {@link PostingIndexFwdReader.NullCursor#close()}.
+     * Same reachability gate ({@code key == 0 && columnTop > 0 && minValue < columnTop}),
+     * but the forward NullCursor emits the synthesised nulls FIRST and then drains
+     * the real key-0 entries via {@code super.hasNext()} (which allocates the decode
+     * block buffer). Together with the three sibling tests this gives every
+     * isOpen()-guarded close() its own RED-on-revert regression.
+     */
+    @Test
+    public void testFwdNullCursorClosedAfterReaderDoesNotLeakBlockBuffer() throws Exception {
+        assertMemoryLeak(() -> {
+            final String name = "posting_fwd_null_cursor_after_reader_close";
+            final long columnTop = 256;
+            try (Path path = new Path().of(configuration.getDbRoot())) {
+                final int plen = path.size();
+                try (PostingIndexWriter writer = new PostingIndexWriter(
+                        configuration, path.trimTo(plen), name, COLUMN_NAME_TXN_NONE)) {
+                    long rowId = columnTop;
+                    for (int i = 0; i < 4096; i++) {
+                        writer.add(0, rowId);
+                        rowId += 1 + (i % 7);
+                    }
+                    writer.setMaxValue(rowId);
+                    writer.commit();
+                }
+
+                // key==0 && columnTop>0 && minValue(0)<columnTop -> Fwd NullCursor.
+                final PostingIndexFwdReader reader = new PostingIndexFwdReader(
+                        configuration, path.trimTo(plen), name,
+                        COLUMN_NAME_TXN_NONE, /* partitionTxn */ 0, columnTop);
+
+                final RowCursor cursor = reader.getCursor(0, 0L, Long.MAX_VALUE);
+                long count = 0;
+                while (cursor.hasNext()) {
+                    cursor.next();
+                    count++;
+                }
+                // columnTop synthesised nulls (0..columnTop-1) + 4096 real entries.
+                Assert.assertEquals(4096 + columnTop, count);
+
+                reader.close();
+                cursor.close();
+            }
+        });
+    }
+
     @Test
     public void testReaderHidesHeadEntryTailGensAbovePin() throws Exception {
         assertMemoryLeak(() -> {


### PR DESCRIPTION
## What

Fixes a native-memory leak (`NATIVE_INDEX_READER` tag) in the POSTING covering-index read path, and adds a deterministic regression test.

## Symptom

`PostingIndexCriticalIssuesTest.testMultiThreadedO3CoveringLatestByConcurrentReaderFuzz` fails **non-deterministically** with:

```
java.lang.AssertionError: Memory usage by tag: NATIVE_INDEX_READER, difference: 512 expected:<0> but was:<512>
	at io.questdb.test.tools.TestUtils$LeakCheck.close(TestUtils.java:2655)
	at io.questdb.test.cairo.PostingIndexCriticalIssuesTest.testMultiThreadedO3CoveringLatestByConcurrentReaderFuzz(...)
```

It is a fuzz/concurrency flake: the seed only fixes the data shape, not the thread interleaving, so it cannot be reproduced on demand from the seed alone.

## Root cause

`PostingIndexBwdReader` / `PostingIndexFwdReader` pool idle row cursors in `freeCursors` / `freeNullCursors`. To reuse the decode scratch, the pooling `close()` path frees the covering caches and the EF rank directory but **deliberately retains the cursor's `blockBufferAddr`** — a `NATIVE_INDEX_READER` allocation of up to `BLOCK_CAPACITY` longs (64 × 8 = **512 bytes**). That block buffer is only ever reclaimed when the **reader's** own `close()` drains the cursor pool (`releaseResources()` per pooled cursor).

So if a cursor returns to the pool **after** its owning reader was already closed — e.g. a reader-thread cursor that outlives a concurrent reseal/reload — `cursor.close()` re-pools it (with its retained block buffer) into a reader whose `freeCursors` list will never be drained again. The 512-byte block buffer leaks.

`blockBufferAddr` is only allocated on the non-constant-delta decode paths (packed/EF/flat), which is exactly why the leaked size is a clean 512 bytes.

## Fix

Guard the re-pool with the reader's `isOpen()` state in both readers' `Cursor.close()` and `NullCursor.close()`:

```java
if (!isPooled && isOpen() && free*Cursors.size() < MAX_CACHED_FREE_CURSORS) {
    ... // re-pool, retaining the block buffer for reuse
}
releaseResources(); // reader already closed -> free the block buffer now instead of leaking
```

When the owning reader is already closed, the cursor releases its native buffers immediately rather than pooling into a dead reader. The block-buffer reuse optimisation is preserved for the normal (reader-open) case.

## Test

Adds `testRowCursorClosedAfterReaderDoesNotLeakBlockBuffer` — a deterministic, single-threaded regression that:

1. builds a single key with irregular row-id gaps (forces a non-zero bit-width block that allocates `blockBufferAddr`),
2. drives a cursor to completion so the decode block buffer is allocated,
3. closes the reader while the cursor is still checked out,
4. then closes the cursor.

Before the fix this reproduces the **exact** CI signature (`NATIVE_INDEX_READER, difference: 512`) in ~60 ms with no threads.

## Verification

- New test: red before the fix, green after.
- Full `PostingIndexCriticalIssuesTest`: **96 tests, 0 failures** (including the concurrent fuzz tests).