### PR TITLE
feat(sql): experimental native (Rust/FFM) regex backend for ~ over VARCHAR

### DIFF
--- a/benchmarks/src/main/java/org/questdb/MatchVarcharRegexQueryBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/MatchVarcharRegexQueryBenchmark.java
@@ -1,0 +1,178 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.questdb;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.DefaultCairoConfiguration;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlCompilerImpl;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContextImpl;
+import io.questdb.log.LogFactory;
+import io.questdb.std.Os;
+import io.questdb.std.Rnd;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.lang.foreign.SymbolLookup;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * End-to-end SQL benchmark for the {@code ~} regex operator over a 1,000,000-row VARCHAR column,
+ * comparing the {@code old} JDK {@code java.util.regex} engine against the {@code new} native
+ * (Rust {@code regex} crate via JDK 25 FFM) backend.
+ * <p>
+ * Both arms run the same query, {@code select count(*) from vt where name ~ '<pattern>'}, over the
+ * same on-disk table (created once, deterministically, in {@link #main}). The only difference is
+ * the per-engine flag {@code cairo.sql.varchar.regex.native.enabled}, read by
+ * {@code MatchVarcharFunctionFactory} at query-compile time.
+ * <p>
+ * The count query forces the predicate to be evaluated on every row, so the measurement is
+ * dominated by regex matching (plus, for the JDK arm, the UTF-8&rarr;UTF-16 transcode that the
+ * {@code getStrA} path performs per row — which the native UTF-8 path avoids).
+ * <p>
+ * NOTE: for the {@code NATIVE} arm to actually use the native engine, {@code libquestdbr} must be
+ * built with the {@code qdb_regex_*} symbols; otherwise the factory silently falls back to JDK and
+ * the two arms will measure the same thing. {@link #main} prints which case applies.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 1, jvmArgsAppend = {"--enable-native-access=ALL-UNNAMED", "--enable-native-access=io.questdb.benchmarks"})
+public class MatchVarcharRegexQueryBenchmark {
+
+    private static final int NUM_ROWS = 1_000_000;
+    private static final String TABLE = "vt";
+    private static final String TMP = System.getProperty("java.io.tmpdir");
+
+    @Param({"JDK", "NATIVE"})
+    public Backend backend;
+    @Param({"abc", "[a-f][0-9]", "[a-z]+[0-9]+[a-z]+"})
+    public String pattern;
+
+    private SqlCompilerImpl compiler;
+    private RecordCursorFactory countFactory;
+    private SqlExecutionContextImpl ctx;
+    private CairoEngine engine;
+
+    public static void main(String[] args) throws RunnerException {
+        System.out.println("native regex backend available: " + nativeRegexAvailable());
+
+        // Build the 1M-row table once. It lives on disk under java.io.tmpdir, so the forked
+        // benchmark JVM sees it. Seeded RNG keeps the data identical across runs.
+        final CairoConfiguration cfg = config(false);
+        try (CairoEngine engine = new CairoEngine(cfg)) {
+            final SqlExecutionContextImpl ctx = newCtx(engine, cfg);
+            ctx.setRandom(new Rnd(0x4d4154434856L, 0x5243484152L));
+            engine.execute("drop table if exists " + TABLE, ctx);
+            engine.execute(
+                    "create table " + TABLE + " as (select rnd_varchar(8, 32, 20) name from long_sequence(" + NUM_ROWS + "))",
+                    ctx
+            );
+        } catch (SqlException e) {
+            e.printStackTrace(System.out);
+        }
+
+        Options opt = new OptionsBuilder()
+                .include(MatchVarcharRegexQueryBenchmark.class.getSimpleName())
+                .warmupIterations(3)
+                .measurementIterations(10)
+                .build();
+        new Runner(opt).run();
+
+        LogFactory.haltInstance();
+    }
+
+    @Benchmark
+    public long countMatches() throws SqlException {
+        long count = 0;
+        try (RecordCursor cursor = countFactory.getCursor(ctx)) {
+            if (cursor.hasNext()) {
+                count = cursor.getRecord().getLong(0);
+            }
+        }
+        return count;
+    }
+
+    @Setup(Level.Iteration)
+    public void setup() throws Exception {
+        final CairoConfiguration cfg = config(backend == Backend.NATIVE);
+        engine = new CairoEngine(cfg);
+        ctx = newCtx(engine, cfg);
+        compiler = new SqlCompilerImpl(engine);
+        final String q = "select count(*) from " + TABLE + " where name ~ '" + pattern + "'";
+        countFactory = compiler.compile(q, ctx).getRecordCursorFactory();
+    }
+
+    @TearDown(Level.Iteration)
+    public void tearDown() {
+        countFactory.close();
+        compiler.close();
+        engine.close();
+    }
+
+    private static CairoConfiguration config(boolean nativeRegex) {
+        return new DefaultCairoConfiguration(TMP) {
+            @Override
+            public boolean isVarcharRegexNativeEnabled() {
+                return nativeRegex;
+            }
+        };
+    }
+
+    private static boolean nativeRegexAvailable() {
+        try {
+            Os.init();
+            return SymbolLookup.loaderLookup().find("qdb_regex_compile").isPresent();
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    private static SqlExecutionContextImpl newCtx(CairoEngine engine, CairoConfiguration cfg) {
+        final SqlExecutionContextImpl c = new SqlExecutionContextImpl(engine, 1);
+        c.with(cfg.getFactoryProvider().getSecurityContextFactory().getRootContext(), null, null, -1, null);
+        return c;
+    }
+
+    public enum Backend {
+        JDK, NATIVE
+    }
+}

--- a/benchmarks/src/main/java/org/questdb/NativeRegexMatchBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/NativeRegexMatchBenchmark.java
@@ -1,0 +1,243 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.questdb;
+
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Os;
+import io.questdb.std.Unsafe;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Compares regex match throughput for the {@code ~} operator over VARCHAR:
+ * <ul>
+ *   <li>{@code jdk} — {@code java.util.regex.Matcher#find()} over a UTF-16 {@code String}
+ *       (models today's inherited {@code MatchStr} path);</li>
+ *   <li>{@code nativeZeroCopy} — Rust {@code regex} crate via a JDK 25 FFM {@code critical}
+ *       downcall, matching directly over the column's native UTF-8 bytes (the prototype fast path);</li>
+ *   <li>{@code nativeCopyThenMatch} — same downcall but first copying the bytes into a scratch
+ *       buffer (models the on-heap / non-contiguous fallback, to isolate the copy cost).</li>
+ * </ul>
+ * <p>
+ * Self-contained: it binds the {@code qdb_regex_*} symbols exported by {@code libquestdbr}
+ * itself (the production binding lives in the package-private
+ * {@code io.questdb.griffin.engine.functions.regex.NativeRegex}, not visible to this module).
+ * <p>
+ * Run (the native library must be built and on the path, and FFM native access granted):
+ * <pre>
+ * mvn -pl benchmarks compile
+ * java --enable-native-access=ALL-UNNAMED -cp ... org.questdb.NativeRegexMatchBenchmark
+ * </pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(value = 1, jvmArgsAppend = {"--enable-native-access=ALL-UNNAMED", "--enable-native-access=io.questdb.benchmarks"})
+public class NativeRegexMatchBenchmark {
+
+    private static final int N = 4096;
+    private static final String PATTERN = "[a-f][0-9]{2,4}x";
+
+    @Param({"8", "32", "128"})
+    private int len;
+
+    private long dataBase;
+    private long dataSize;
+    private long handle;
+    private Matcher jdkMatcher;
+    private int[] lens;
+    private MethodHandle mhFind;
+    private MethodHandle mhFree;
+    private long[] ptrs;
+    private long scratch;
+    private long scratchCap;
+    private String[] samples;
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(NativeRegexMatchBenchmark.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    public void jdk(Blackhole bh) {
+        final String[] s = samples;
+        final Matcher m = jdkMatcher;
+        for (int i = 0; i < N; i++) {
+            bh.consume(m.reset(s[i]).find());
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    public void nativeCopyThenMatch(Blackhole bh) throws Throwable {
+        final long h = handle;
+        final long dst = scratch;
+        for (int i = 0; i < N; i++) {
+            final int n = lens[i];
+            Unsafe.copyMemory(ptrs[i], dst, n);
+            bh.consume((int) mhFind.invokeExact(h, dst, (long) n) != 0);
+        }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(N)
+    public void nativeZeroCopy(Blackhole bh) throws Throwable {
+        final long h = handle;
+        for (int i = 0; i < N; i++) {
+            bh.consume((int) mhFind.invokeExact(h, ptrs[i], (long) lens[i]) != 0);
+        }
+    }
+
+    @Setup(Level.Trial)
+    public void setup() throws Throwable {
+        Os.init(); // ensure libquestdbr is loaded before loaderLookup()
+        final Linker linker = Linker.nativeLinker();
+        final SymbolLookup lookup = SymbolLookup.loaderLookup();
+        final MethodHandle mhCompile = linker.downcallHandle(
+                lookup.find("qdb_regex_compile").orElseThrow(),
+                FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+        );
+        mhFind = linker.downcallHandle(
+                lookup.find("qdb_regex_find").orElseThrow(),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG),
+                Linker.Option.critical(false)
+        );
+        mhFree = linker.downcallHandle(
+                lookup.find("qdb_regex_free").orElseThrow(),
+                FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
+        );
+
+        // compile the pattern with both engines
+        final byte[] pb = PATTERN.getBytes(StandardCharsets.UTF_8);
+        final long pp = Unsafe.malloc(pb.length, MemoryTag.NATIVE_DEFAULT);
+        for (int i = 0; i < pb.length; i++) {
+            Unsafe.getUnsafe().putByte(pp + i, pb[i]);
+        }
+        handle = (long) mhCompile.invokeExact(pp, (long) pb.length);
+        Unsafe.free(pp, pb.length, MemoryTag.NATIVE_DEFAULT);
+        if (handle == 0) {
+            throw new IllegalStateException("native regex unavailable or pattern unsupported");
+        }
+        jdkMatcher = Pattern.compile(PATTERN).matcher("");
+
+        // generate sample data and lay UTF-8 bytes out contiguously in native memory
+        final Random rnd = new Random(42);
+        samples = new String[N];
+        lens = new int[N];
+        final byte[][] enc = new byte[N][];
+        long total = 0;
+        int maxLen = 1;
+        for (int i = 0; i < N; i++) {
+            final String s = randomSample(rnd, len);
+            samples[i] = s;
+            final byte[] b = s.getBytes(StandardCharsets.UTF_8);
+            enc[i] = b;
+            lens[i] = b.length;
+            total += b.length;
+            maxLen = Math.max(maxLen, b.length);
+        }
+        dataSize = total;
+        dataBase = Unsafe.malloc(total, MemoryTag.NATIVE_DEFAULT);
+        ptrs = new long[N];
+        long off = dataBase;
+        for (int i = 0; i < N; i++) {
+            final byte[] b = enc[i];
+            for (int j = 0; j < b.length; j++) {
+                Unsafe.getUnsafe().putByte(off + j, b[j]);
+            }
+            ptrs[i] = off;
+            off += b.length;
+        }
+        scratchCap = maxLen;
+        scratch = Unsafe.malloc(scratchCap, MemoryTag.NATIVE_DEFAULT);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() throws Throwable {
+        if (handle != 0) {
+            mhFree.invokeExact(handle);
+            handle = 0;
+        }
+        if (dataBase != 0) {
+            Unsafe.free(dataBase, dataSize, MemoryTag.NATIVE_DEFAULT);
+            dataBase = 0;
+        }
+        if (scratch != 0) {
+            Unsafe.free(scratch, scratchCap, MemoryTag.NATIVE_DEFAULT);
+            scratch = 0;
+        }
+    }
+
+    private static String randomSample(Random rnd, int len) {
+        // mostly lowercase letters/digits; ~50% of rows are seeded to contain a match
+        final char[] c = new char[len];
+        for (int i = 0; i < len; i++) {
+            final int r = rnd.nextInt(36);
+            c[i] = (char) (r < 26 ? 'a' + r : '0' + (r - 26));
+        }
+        if (len >= 6 && rnd.nextBoolean()) {
+            final int p = rnd.nextInt(len - 5);
+            c[p] = (char) ('a' + rnd.nextInt(6)); // [a-f]
+            c[p + 1] = (char) ('0' + rnd.nextInt(10));
+            c[p + 2] = (char) ('0' + rnd.nextInt(10));
+            c[p + 3] = (char) ('0' + rnd.nextInt(10));
+            c[p + 4] = 'x';
+        }
+        return new String(c);
+    }
+}

--- a/core/rust/qdbr/Cargo.lock
+++ b/core/rust/qdbr/Cargo.lock
@@ -1385,6 +1385,7 @@ dependencies = [
  "rand",
  "rapidhash",
  "rayon",
+ "regex",
  "seq-macro",
  "serde",
  "serde_json",

--- a/core/rust/qdbr/Cargo.toml
+++ b/core/rust/qdbr/Cargo.toml
@@ -16,6 +16,7 @@ qdb-core = { path = "../qdb-core" }
 qdb-parquet-meta = { path = "../qdb-parquet-meta" }
 jni = "0.21.1"
 num-traits = "0.2.18"
+regex = "1.11"
 parquet2 = { path = "../parquet2" }
 parquet-format-safe = { path = "../parquet-format-safe" }
 libc = "0.2.155"

--- a/core/rust/qdbr/src/lib.rs
+++ b/core/rust/qdbr/src/lib.rs
@@ -34,6 +34,7 @@ pub mod parquet_metadata;
 pub mod parquet_read;
 pub mod parquet_write;
 pub mod qwp_zstd;
+pub mod regex_match;
 mod wal_lock;
 
 use jni::sys::jlong;

--- a/core/rust/qdbr/src/regex_match/mod.rs
+++ b/core/rust/qdbr/src/regex_match/mod.rs
@@ -1,0 +1,135 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+//! Experimental native regex backend for the SQL `~` operator over VARCHAR columns.
+//!
+//! Exposed over a flat C ABI (not JNI) so the JVM side can bind it through the
+//! JDK 25 Foreign Function & Memory API with low-overhead `critical` downcalls.
+//! VARCHAR payloads are already UTF-8 in native memory, so matching runs against
+//! raw byte slices with zero transcoding.
+//!
+//! The Rust `regex` crate is linear-time and intentionally does NOT support
+//! backreferences or lookaround. `qdb_regex_compile` therefore returns 0 for any
+//! pattern it cannot handle; the Java caller is expected to fall back to the JDK
+//! `java.util.regex` engine in that case, so no SQL surface loses functionality.
+
+use regex::bytes::Regex;
+use std::slice;
+
+/// Compiles a UTF-8 regex `pattern`. The pattern is passed as a raw native
+/// address plus a length in bytes.
+///
+/// Returns an opaque handle (a leaked `Box<Regex>` pointer) as an `i64`, or `0`
+/// when the pattern is not valid UTF-8 or is rejected by the engine. A non-zero
+/// handle MUST be released exactly once via [`qdb_regex_free`].
+#[no_mangle]
+pub extern "C" fn qdb_regex_compile(pattern_ptr: i64, pattern_len: i64) -> i64 {
+    if pattern_ptr == 0 || pattern_len < 0 {
+        return 0;
+    }
+    let bytes = unsafe { slice::from_raw_parts(pattern_ptr as *const u8, pattern_len as usize) };
+    let pattern = match std::str::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => return 0,
+    };
+    match Regex::new(pattern) {
+        Ok(re) => Box::into_raw(Box::new(re)) as i64,
+        Err(_) => 0,
+    }
+}
+
+/// Unanchored search over `text`, mirroring `java.util.regex.Matcher#find()`:
+/// returns `1` if the pattern matches anywhere in the input, `0` otherwise.
+///
+/// Designed to be invoked as a `critical` FFM downcall: it performs no
+/// allocation, never calls back into the JVM, and returns promptly.
+///
+/// # Safety
+/// `handle` must be a live value previously returned by [`qdb_regex_compile`]
+/// and `text_ptr`/`text_len` must describe a readable region of `text_len` bytes.
+#[no_mangle]
+pub extern "C" fn qdb_regex_find(handle: i64, text_ptr: i64, text_len: i64) -> i32 {
+    if handle == 0 || text_len < 0 {
+        return 0;
+    }
+    let re = unsafe { &*(handle as *const Regex) };
+    let text: &[u8] = if text_len == 0 {
+        &[]
+    } else {
+        unsafe { slice::from_raw_parts(text_ptr as *const u8, text_len as usize) }
+    };
+    re.is_match(text) as i32
+}
+
+/// Releases a handle returned by [`qdb_regex_compile`]. Passing `0` is a no-op.
+///
+/// # Safety
+/// `handle` must not be used after this call and must be freed at most once.
+#[no_mangle]
+pub extern "C" fn qdb_regex_free(handle: i64) {
+    if handle != 0 {
+        unsafe {
+            drop(Box::from_raw(handle as *mut Regex));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compile(p: &str) -> i64 {
+        qdb_regex_compile(p.as_ptr() as i64, p.len() as i64)
+    }
+
+    fn find(h: i64, t: &str) -> i32 {
+        qdb_regex_find(h, t.as_ptr() as i64, t.len() as i64)
+    }
+
+    #[test]
+    fn match_and_free() {
+        let h = compile("a.c");
+        assert_ne!(h, 0);
+        assert_eq!(find(h, "xxabcyy"), 1);
+        assert_eq!(find(h, "xxabdyy"), 0);
+        assert_eq!(find(h, ""), 0);
+        qdb_regex_free(h);
+    }
+
+    #[test]
+    fn unicode_payload() {
+        let h = compile("é+");
+        assert_ne!(h, 0);
+        assert_eq!(find(h, "caféé"), 1);
+        qdb_regex_free(h);
+    }
+
+    #[test]
+    fn unsupported_pattern_returns_zero() {
+        // backreference: rejected by the linear-time engine -> caller falls back to JDK
+        assert_eq!(compile(r"(a)\1"), 0);
+        // invalid syntax
+        assert_eq!(compile("a("), 0);
+    }
+}

--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -519,6 +519,7 @@ public class PropServerConfiguration implements ServerConfiguration {
     private final int sqlPageFrameMinRows;
     private final int sqlParallelFilterDispatchLimit;
     private final boolean sqlParallelFilterEnabled;
+    private final boolean sqlVarcharRegexNativeEnabled;
     private final double sqlParallelFilterPreTouchThreshold;
     private final boolean sqlParallelGroupByEnabled;
     private final boolean sqlParallelHorizonJoinEnabled;
@@ -2179,6 +2180,7 @@ public class PropServerConfiguration implements ServerConfiguration {
 
             final boolean defaultParallelSqlEnabled = queryWorkers > 0;
             this.sqlParallelFilterEnabled = getBoolean(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_FILTER_ENABLED, defaultParallelSqlEnabled);
+            this.sqlVarcharRegexNativeEnabled = getBoolean(properties, env, PropertyKey.CAIRO_SQL_VARCHAR_REGEX_NATIVE_ENABLED, false);
             this.sqlParallelTopKEnabled = getBoolean(properties, env, PropertyKey.CAIRO_SQL_PARALLEL_TOP_K_ENABLED, defaultParallelSqlEnabled);
             this.sqlHorizonJoinBwdScanAbsoluteThreshold = getLong(properties, env, PropertyKey.CAIRO_SQL_HORIZON_JOIN_BWD_SCAN_ABSOLUTE_THRESHOLD, 131_072);
             this.sqlHorizonJoinBwdScanMinGap = getLong(properties, env, PropertyKey.CAIRO_SQL_HORIZON_JOIN_BWD_SCAN_MIN_GAP, 1_024);
@@ -5226,6 +5228,11 @@ public class PropServerConfiguration implements ServerConfiguration {
         @Override
         public boolean isSqlParallelFilterEnabled() {
             return sqlParallelFilterEnabled;
+        }
+
+        @Override
+        public boolean isVarcharRegexNativeEnabled() {
+            return sqlVarcharRegexNativeEnabled;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/PropertyKey.java
+++ b/core/src/main/java/io/questdb/PropertyKey.java
@@ -110,6 +110,7 @@ public enum PropertyKey implements ConfigPropertyKey {
     CAIRO_PAGE_FRAME_REDUCE_QUEUE_CAPACITY("cairo.page.frame.reduce.queue.capacity"),
     CAIRO_PAGE_FRAME_ROWID_LIST_CAPACITY("cairo.page.frame.rowid.list.capacity"),
     CAIRO_PAGE_FRAME_COLUMN_LIST_CAPACITY("cairo.page.frame.column.list.capacity"),
+    CAIRO_SQL_VARCHAR_REGEX_NATIVE_ENABLED("cairo.sql.varchar.regex.native.enabled"),
     CAIRO_SQL_PARALLEL_FILTER_ENABLED("cairo.sql.parallel.filter.enabled"),
     CAIRO_SQL_PARALLEL_FILTER_PRETOUCH_ENABLED("cairo.sql.parallel.filter.pretouch.enabled"),
     CAIRO_SQL_PARALLEL_FILTER_PRETOUCH_THRESHOLD("cairo.sql.parallel.filter.pretouch.threshold"),

--- a/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfiguration.java
@@ -1071,6 +1071,19 @@ public interface CairoConfiguration {
         return true;
     }
 
+    /**
+     * Experimental: route the {@code ~} regex operator over VARCHAR through the native
+     * (Rust {@code regex} crate) backend bound via the JDK FFM API, instead of
+     * {@code java.util.regex}. Controlled by {@code cairo.sql.varchar.regex.native.enabled}
+     * (default off). When on but a pattern is unsupported by the native engine
+     * (e.g. backreferences/lookaround) the operator falls back to {@code java.util.regex}.
+     *
+     * @return true if the native VARCHAR regex backend should be used when available
+     */
+    default boolean isVarcharRegexNativeEnabled() {
+        return false;
+    }
+
     boolean isWalApplyEnabled();
 
     boolean isWalApplyParallelSqlEnabled();

--- a/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
+++ b/core/src/main/java/io/questdb/cairo/CairoConfigurationWrapper.java
@@ -1663,6 +1663,11 @@ public class CairoConfigurationWrapper implements CairoConfiguration {
     }
 
     @Override
+    public boolean isVarcharRegexNativeEnabled() {
+        return getDelegate().isVarcharRegexNativeEnabled();
+    }
+
+    @Override
     public boolean isSqlParallelGroupByEnabled() {
         return getDelegate().isSqlParallelGroupByEnabled();
     }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/MatchVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/MatchVarcharFunctionFactory.java
@@ -24,13 +24,267 @@
 
 package io.questdb.griffin.engine.functions.regex;
 
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.SymbolTableSource;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.engine.functions.constants.BooleanConstant;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.std.str.DirectUtf8Sink;
+import io.questdb.std.str.StringSink;
+import io.questdb.std.str.Utf8Sequence;
+import io.questdb.std.str.Utf8s;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Matcher;
+
 /**
- * This is tactical implementation of regex match over varchar column.
- * It exploits the ability of a varchar column to return a CharSequence view of the sequence.
+ * Regex match ({@code ~}) over a VARCHAR column.
+ * <p>
+ * VARCHAR is stored as UTF-8 in native memory, so the primary implementation matches the column's
+ * bytes directly: it reads {@link Function#getVarcharA} and hands the native pointer to the Rust
+ * {@code regex} engine via FFM (see {@link NativeRegex}), with no UTF-8&rarr;UTF-16 step.
+ * <p>
+ * This factory does not depend on {@link MatchStrFunctionFactory} at all. The {@code java.util.regex}
+ * fallback (used when the native backend is disabled/unavailable, for runtime/dynamic patterns, or
+ * for patterns the Rust engine cannot compile) is implemented here as dedicated VARCHAR functions
+ * that read {@link Function#getVarcharA} and perform the UTF-8&rarr;{@link CharSequence} bridge
+ * inline only at the matcher boundary &mdash; zero-copy {@code asAsciiCharSequence()} for ASCII,
+ * reusable-sink transcode otherwise &mdash; because {@code java.util.regex} can only consume a
+ * {@link CharSequence}.
  */
-public class MatchVarcharFunctionFactory extends MatchStrFunctionFactory {
+public class MatchVarcharFunctionFactory implements FunctionFactory {
+
     @Override
     public String getSignature() {
         return "~(ØS)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        final Function value = args.getQuick(0);
+        final Function pattern = args.getQuick(1);
+        final int patternPosition = argPositions.getQuick(1);
+
+        if (pattern.isConstant()) {
+            if (configuration.isVarcharRegexNativeEnabled() && NativeRegex.AVAILABLE) {
+                final CharSequence regex = pattern.getStrA(null);
+                if (regex == null) {
+                    return BooleanConstant.FALSE;
+                }
+                final long handle = NativeRegex.compile(regex);
+                if (handle != 0) {
+                    return new MatchVarcharFunction(value, handle, regex);
+                }
+                // handle == 0: pattern unsupported/invalid for the Rust engine -> JDK fallback below.
+            }
+            final Matcher matcher = RegexUtils.createMatcher(pattern, patternPosition);
+            if (matcher == null) {
+                return BooleanConstant.FALSE;
+            }
+            return new MatchVarcharConstFunction(value, matcher);
+        } else if (pattern.isRuntimeConstant()) {
+            return new MatchVarcharRuntimeConstFunction(value, pattern, patternPosition);
+        }
+        throw SqlException.$(patternPosition, "not implemented: dynamic pattern would be very slow to execute");
+    }
+
+    /**
+     * UTF-8 -> CharSequence bridge for the JDK fallback, identical in spirit to
+     * {@code VarcharFunction.getStrA}: zero-copy for ASCII, transcode into {@code utf16Sink} otherwise.
+     */
+    private static CharSequence asCharSequence(@NotNull Utf8Sequence us, StringSink utf16Sink) {
+        if (us.isAscii()) {
+            return us.asAsciiCharSequence();
+        }
+        utf16Sink.clear();
+        Utf8s.utf8ToUtf16(us, utf16Sink);
+        return utf16Sink;
+    }
+
+    /**
+     * Native (Rust {@code regex} via FFM) matcher over the column's UTF-8 bytes.
+     */
+    private static class MatchVarcharFunction extends BooleanFunction implements UnaryFunction {
+        private final String patternStr;
+        private final DirectUtf8Sink utf8Sink;
+        private final Function value;
+        private long handle;
+
+        private MatchVarcharFunction(Function value, long handle, @NotNull CharSequence pattern) {
+            this.value = value;
+            this.handle = handle;
+            this.patternStr = pattern.toString();
+            this.utf8Sink = new DirectUtf8Sink(32);
+        }
+
+        @Override
+        public void close() {
+            UnaryFunction.super.close();
+            utf8Sink.close();
+            if (handle != 0) {
+                NativeRegex.free(handle);
+                handle = 0;
+            }
+        }
+
+        @Override
+        public Function getArg() {
+            return value;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            final Utf8Sequence us = value.getVarcharA(rec);
+            if (us == null) {
+                return false;
+            }
+            final int size = us.size();
+            if (size == 0) {
+                return NativeRegex.find(handle, 0, 0);
+            }
+            final long ptr = us.ptr();
+            if (ptr != -1) {
+                // Zero-copy fast path: off-heap varchars expose `size` contiguous UTF-8 bytes at
+                // `ptr`, valid for the duration of this synchronous `critical` downcall (the pointer
+                // is not retained, so the sequence need not be `isStable()`).
+                return NativeRegex.find(handle, ptr, size);
+            }
+            // On-heap sequence (ptr == -1): materialise into a reusable native buffer.
+            utf8Sink.clear();
+            utf8Sink.put(us);
+            return NativeRegex.find(handle, utf8Sink.ptr(), size);
+        }
+
+        @Override
+        public int getComplexity() {
+            return Function.addComplexity(COMPLEXITY_REGEX, UnaryFunction.super.getComplexity());
+        }
+
+        @Override
+        public boolean isThreadSafe() {
+            return false;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(value).val(" ~ ").val(patternStr);
+        }
+    }
+
+    /**
+     * java.util.regex fallback for a constant pattern.
+     */
+    private static class MatchVarcharConstFunction extends BooleanFunction implements UnaryFunction {
+        private final Matcher matcher;
+        private final StringSink utf16Sink = new StringSink();
+        private final Function value;
+
+        private MatchVarcharConstFunction(Function value, @NotNull Matcher matcher) {
+            this.value = value;
+            this.matcher = matcher;
+        }
+
+        @Override
+        public Function getArg() {
+            return value;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            final Utf8Sequence us = value.getVarcharA(rec);
+            return us != null && matcher.reset(asCharSequence(us, utf16Sink)).find();
+        }
+
+        @Override
+        public int getComplexity() {
+            return Function.addComplexity(COMPLEXITY_REGEX, UnaryFunction.super.getComplexity());
+        }
+
+        @Override
+        public boolean isThreadSafe() {
+            return false;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(value).val(" ~ ").val(matcher.pattern().toString());
+        }
+    }
+
+    /**
+     * java.util.regex fallback for a runtime-constant pattern (matcher compiled in {@link #init}).
+     */
+    private static class MatchVarcharRuntimeConstFunction extends BooleanFunction implements UnaryFunction {
+        private final Function pattern;
+        private final int patternPosition;
+        private final StringSink utf16Sink = new StringSink();
+        private final Function value;
+        private Matcher matcher;
+
+        private MatchVarcharRuntimeConstFunction(Function value, Function pattern, int patternPosition) {
+            this.value = value;
+            this.pattern = pattern;
+            this.patternPosition = patternPosition;
+        }
+
+        @Override
+        public Function getArg() {
+            return value;
+        }
+
+        @Override
+        public boolean getBool(Record rec) {
+            if (matcher != null) {
+                final Utf8Sequence us = value.getVarcharA(rec);
+                return us != null && matcher.reset(asCharSequence(us, utf16Sink)).find();
+            }
+            return false;
+        }
+
+        @Override
+        public int getComplexity() {
+            return Function.addComplexity(COMPLEXITY_REGEX, UnaryFunction.super.getComplexity());
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+            UnaryFunction.super.init(symbolTableSource, executionContext);
+            pattern.init(symbolTableSource, executionContext);
+            this.matcher = RegexUtils.createMatcher(pattern, patternPosition);
+        }
+
+        @Override
+        public boolean isConstant() {
+            return false;
+        }
+
+        @Override
+        public boolean isRuntimeConstant() {
+            return false;
+        }
+
+        @Override
+        public boolean isThreadSafe() {
+            return false;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val(value).val(" ~ ").val(pattern.toString());
+        }
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/regex/NativeRegex.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/regex/NativeRegex.java
@@ -1,0 +1,140 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.regex;
+
+import io.questdb.log.Log;
+import io.questdb.log.LogFactory;
+import io.questdb.std.Os;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Experimental JDK 25 Foreign Function &amp; Memory (Panama) binding to the native
+ * regex backend exported by {@code libquestdbr} (see {@code core/rust/qdbr/src/regex_match}).
+ * <p>
+ * This is a prototype gated behind {@link io.questdb.cairo.CairoConfiguration#isVarcharRegexNativeEnabled()};
+ * for now it backs only the {@code ~} operator over VARCHAR. The hot {@code find} downcall is
+ * linked with {@link Linker.Option#critical(boolean)} so it skips the Java&rarr;native thread-state
+ * transition: matching a short native UTF-8 slice costs close to a regular JIT-compiled call.
+ * <p>
+ * If linking fails for any reason (older native library without the symbols, FFM lookup
+ * failure, ...) {@link #AVAILABLE} stays {@code false} and callers transparently fall back
+ * to the JDK {@code java.util.regex} engine.
+ */
+final class NativeRegex {
+    static final boolean AVAILABLE;
+    private static final Log LOG = LogFactory.getLog(NativeRegex.class);
+    private static final MethodHandle MH_COMPILE;
+    private static final MethodHandle MH_FIND;
+    private static final MethodHandle MH_FREE;
+
+    private NativeRegex() {
+    }
+
+    /**
+     * Compiles a regex pattern using the native engine.
+     *
+     * @return a non-zero opaque handle on success, or {@code 0} if the engine is unavailable or
+     * the pattern is unsupported (e.g. backreferences/lookaround) or invalid. A {@code 0} result
+     * is the signal for the caller to fall back to the JDK engine.
+     */
+    static long compile(CharSequence pattern) {
+        if (!AVAILABLE || pattern == null) {
+            return 0;
+        }
+        final byte[] utf8 = pattern.toString().getBytes(StandardCharsets.UTF_8);
+        try (Arena arena = Arena.ofConfined()) {
+            final MemorySegment seg = arena.allocate(Math.max(1, utf8.length));
+            MemorySegment.copy(utf8, 0, seg, ValueLayout.JAVA_BYTE, 0, utf8.length);
+            return (long) MH_COMPILE.invokeExact(seg.address(), (long) utf8.length);
+        } catch (Throwable t) {
+            return 0;
+        }
+    }
+
+    /**
+     * Unanchored match, equivalent to {@code Matcher#find()}. {@code textPtr} must address
+     * {@code textLen} contiguous native UTF-8 bytes (or be {@code 0} when {@code textLen == 0}).
+     */
+    static boolean find(long handle, long textPtr, int textLen) {
+        try {
+            return (int) MH_FIND.invokeExact(handle, textPtr, (long) textLen) != 0;
+        } catch (Throwable t) {
+            throw new RuntimeException("native regex find failed", t);
+        }
+    }
+
+    static void free(long handle) {
+        if (handle == 0) {
+            return;
+        }
+        try {
+            MH_FREE.invokeExact(handle);
+        } catch (Throwable t) {
+            throw new RuntimeException("native regex free failed", t);
+        }
+    }
+
+    static {
+        boolean available = false;
+        MethodHandle compile = null;
+        MethodHandle find = null;
+        MethodHandle free = null;
+        try {
+            Os.init(); // make sure libquestdbr has been System.load()-ed before loaderLookup()
+            final Linker linker = Linker.nativeLinker();
+            final SymbolLookup lookup = SymbolLookup.loaderLookup();
+            compile = linker.downcallHandle(
+                    lookup.find("qdb_regex_compile").orElseThrow(),
+                    FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG)
+            );
+            find = linker.downcallHandle(
+                    lookup.find("qdb_regex_find").orElseThrow(),
+                    FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG),
+                    // hot path: no JVM callbacks, no heap access, returns promptly
+                    Linker.Option.critical(false)
+            );
+            free = linker.downcallHandle(
+                    lookup.find("qdb_regex_free").orElseThrow(),
+                    FunctionDescriptor.ofVoid(ValueLayout.JAVA_LONG)
+            );
+            available = true;
+            LOG.info().$("native regex backend enabled (FFM)").$();
+        } catch (Throwable t) {
+            LOG.info().$("native regex backend unavailable, using JDK java.util.regex [reason=").$(t.getMessage()).$(']').$();
+        }
+        MH_COMPILE = compile;
+        MH_FIND = find;
+        MH_FREE = free;
+        AVAILABLE = available;
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/regex/MatchVarcharNativeRegexTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/regex/MatchVarcharNativeRegexTest.java
@@ -1,0 +1,129 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.regex;
+
+import io.questdb.PropertyKey;
+import io.questdb.griffin.SqlException;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Exercises the experimental native (JDK FFM + Rust {@code regex}) backend for the {@code ~}
+ * operator over VARCHAR, enabled via {@code cairo.sql.varchar.regex.native.enabled}.
+ * <p>
+ * Parity is asserted by comparing the VARCHAR operator ({@code name ~ p}, signature {@code ~(ØS)},
+ * native when available) against the STRING operator over the same data
+ * ({@code cast(name as string) ~ p}, signature {@code ~(SS)}, always {@code java.util.regex}).
+ * Both must return identical rows.
+ * <p>
+ * These assertions hold whether or not {@code libquestdbr} actually exposes the native symbols:
+ * when it does not, {@code MatchVarcharFunctionFactory} transparently falls back to
+ * {@code java.util.regex}, so parity is trivially preserved. When it does, the test pins the
+ * native engine to JDK semantics.
+ */
+public class MatchVarcharNativeRegexTest extends AbstractCairoTest {
+
+    @Override
+    public void setUp() {
+        node1.setProperty(PropertyKey.CAIRO_SQL_VARCHAR_REGEX_NATIVE_ENABLED, true);
+        super.setUp();
+    }
+
+    @Test
+    public void testNullRegex() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table x as (select rnd_varchar() name from long_sequence(2000))");
+            assertQuery("select * from x where name ~ null")
+                    .noLeakCheck()
+                    .expectSize()
+                    .returns("name\n");
+        });
+    }
+
+    @Test
+    public void testParityWithJdkOnRandomData() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table x as (select rnd_varchar() name from long_sequence(5000))");
+            // ASCII-only patterns with engine-independent semantics (no anchors / dot, whose
+            // newline handling differs subtly between java.util.regex and the Rust engine).
+            assertParity("[a-f][0-9]");
+            assertParity("[0-9][0-9][0-9]");
+            assertParity("[A-Za-z]");
+            assertParity("[^0-9]");
+            assertParity("abc");
+        });
+    }
+
+    @Test
+    public void testSimple() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table x (name varchar)");
+            execute("insert into x values ('apple123x'),('banana'),('h3ll0'),(null),('A12'),('zf9')");
+            // [a-f][0-9]: 'apple123x' -> "e1", 'zf9' -> "f9"; 'h3ll0' has no a-f char before a digit
+            assertQuery("select name from x where name ~ '[a-f][0-9]'")
+                    .noLeakCheck()
+                    .returns("name\napple123x\nzf9\n");
+        });
+    }
+
+    @Test
+    public void testSyntaxError() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table x as (select rnd_varchar() name from long_sequence(10))");
+            try {
+                // invalid for both engines; native compile returns no handle, so we fall back to
+                // java.util.regex which reports the precise syntax error and SQL position.
+                assertExceptionNoLeakCheck("select * from x where name ~ 'XJ**'");
+            } catch (SqlException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "Dangling meta");
+            }
+        });
+    }
+
+    @Test
+    public void testUnsupportedPatternFallsBackToJdk() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table x (name varchar)");
+            execute("insert into x values ('abab'),('abc'),('xyababy'),(null),('aba')");
+            // Backreferences are unsupported by the Rust engine: MatchVarcharFunctionFactory must
+            // fall back to java.util.regex rather than failing or silently mismatching.
+            final String jdkPredicate = "select name from x where cast(name as string) ~ '(ab)\\1'";
+            final String varcharPredicate = "select name from x where name ~ '(ab)\\1'";
+            assertSqlCursors(jdkPredicate, varcharPredicate);
+            assertQuery("select name from x where name ~ '(ab)\\1'")
+                    .noLeakCheck()
+                    .returns("name\nabab\nxyababy\n");
+        });
+    }
+
+    private static void assertParity(String regex) throws Exception {
+        assertSqlCursors(
+                "select name from x where cast(name as string) ~ '" + regex + "'",
+                "select name from x where name ~ '" + regex + "'"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Opt-in native regex engine for the `~` operator on **VARCHAR** columns, behind `cairo.sql.varchar.regex.native.enabled` (**default: off**). The match runs in the Rust `regex` crate, bound from Java via the **JDK 25 Foreign Function & Memory (Panama) API**, directly over the column's native UTF-8 bytes.

## Motivation

VARCHAR is UTF-8 in native memory, but today `~(ØS)` rides the STRING matcher (`MatchVarcharFunctionFactory extends MatchStrFunctionFactory`), which feeds `java.util.regex` a UTF-16 `CharSequence` via `getStrA`. The JDK engine cannot match UTF-8 directly, so it forces a CharSequence adapter (and a transcode for non-ASCII). A UTF-8-native engine removes that and adds linear-time matching (no catastrophic backtracking).

## What's in here

- **Rust C-ABI module** `core/rust/qdbr/src/regex_match`: `qdb_regex_compile` / `qdb_regex_find` (unanchored, = `Matcher.find()`) / `qdb_regex_free` over `regex::bytes::Regex`. Flat `extern "C"` (no JNI).
- **FFM binding** `NativeRegex`: `SymbolLookup.loaderLookup()` on the already-loaded `libquestdbr`; the hot `find` downcall uses `Linker.Option.critical` to skip the Java→native thread-state transition. Linking failure ⇒ `AVAILABLE=false` ⇒ transparent JDK fallback.
- **`MatchVarcharFunctionFactory` is now standalone** (no longer extends the string factory):
  - **Native path** — reads `getVarcharA`, matches the UTF-8 bytes **zero-copy via the native pointer** (`us.ptr()`), copying only the rare on-heap fallback.
  - **JDK fallback** — dedicated VARCHAR functions that bridge UTF-8→`CharSequence` inline **only at the matcher boundary** (zero-copy `asAsciiCharSequence()` for ASCII, reusable-sink transcode otherwise). Used when native is disabled/unavailable, for runtime/dynamic patterns, or for patterns the Rust engine cannot compile.
- **Config key** `cairo.sql.varchar.regex.native.enabled` wired through `PropertyKey` / `PropServerConfiguration` / `CairoConfigurationWrapper` / `CairoConfiguration` (default off).

## Semantics & safety

The Rust `regex` engine is linear-time and rejects **backreferences/lookaround**. Such patterns produce no handle and **fall back to `java.util.regex`**, so no SQL surface loses functionality. When the flag is off (default) behaviour is byte-for-byte the current implementation.

## Tests

- `MatchVarcharNativeRegexTest`: asserts **native ≡ JDK parity** by comparing `name ~ p` against `cast(name as string) ~ p` over 5000 `rnd_varchar()` rows (engine-safe patterns), plus null-pattern, syntax-error (`Dangling meta` position preserved), and unsupported-pattern (backreference) fallback cases.
- Rust unit tests: compile/find/free, Unicode payload, unsupported-pattern rejection.

## Benchmarks

- `NativeRegexMatchBenchmark` (micro: zero-copy vs copy vs JDK at the call level).
- `MatchVarcharRegexQueryBenchmark` (1M-row SQL, `JDK` vs `NATIVE` arm over the same on-disk table).

Indicative 1M-row run against the **real `getStrA` path** (Apple Silicon, release Rust, best-of-7; isolates engine + bridge, excludes shared cursor overhead):

| Pattern | ASCII data | Mixed (30% multibyte) |
|---|--:|--:|
| `abc` | ~2.2× | ~4.3× |
| `[a-f][0-9]` | ~1.5× | ~1.7× |
| `[a-z]+[0-9]+[a-z]+` | ~1.9× | ~2.4× |

ASCII = pure engine (no transcode on either side); the larger non-ASCII wins come from the transcode the native UTF-8 path avoids. All runs report identical match counts (parity).

## Scope / follow-ups

- **Prototype**: native handles **constant patterns over VARCHAR only**; runtime-const and every other regex surface (`~(SS)`, `~(KS)`, `!~`, `regexp_replace`, LIKE/ILIKE) keep using `java.util.regex`.
- Possible next steps: runtime-const patterns; apply the same split to `!~(Øs)`; a documented `^`/`$`/`.` divergence test before considering native as a default; extend to `regexp_replace(ØSS)`.

## Notes for reviewers / CI

- Requires JDK 25 (FFM is GA; `--enable-native-access` is already in the build's argLine) and a `libquestdbr` built with the new symbols.
- Local validation was per-file `javac`/`cargo` (the working tree's `core/target/classes` was stale); please rely on CI for the full `core` build + test + bench compile.