### PR TITLE
fix(core): complete catalogue functions on startup; fix flaky covering-index fuzz op

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,23 @@ offending character, not the start of the expression.
   once", no rewording prior commits, no force pushes to clean up. Adding a
   fix-up commit on top is always fine. The squash flow folds the lot at merge
   time anyway.
+- **Bundle related fixes into one PR; do NOT propose splitting by logic.** This
+  is a high-throughput shop (~20 PRs/day) and CI is the bottleneck, not review:
+  a full run takes ~40 min and can go red on an unrelated flake. Splitting one
+  branch into N "logically clean" PRs multiplies that cost — N× CI time, N×
+  flake exposure, PRs failing on each other's flakes, and N× the babysitting to
+  shepherd them all to merge. The squash-merge collapses everything into one
+  tidy `master` commit anyway, so multiple fixes on a branch cost nothing at
+  merge time. Default to adding the change to the PR/branch already in flight,
+  especially when the fixes share a CI lineage (one change is what makes the
+  other's CI go green). When a branch carries more than one fix, give each its
+  own clearly-labeled section in the PR body instead of opening another PR. Only
+  split if the user explicitly asks, or if the changes must merge/revert
+  independently.
+- **When asked to "send a change to PR #N" / update PR metadata:** push the
+  commit(s) to that PR's branch (rebase onto the remote head first if it moved),
+  then update the PR title/body to cover everything the branch now contains.
+  Re-running CI on that branch is the validation; do not open a new PR.
 - **Do not create worktrees or `pr-*` checkout branches when reviewing or
   iterating on a PR.** All work belongs on `vi_api`. Even when a PR exists on a
   separate branch (e.g. `pr-7128`), the canonical state to review and modify is

--- a/core/src/main/java/io/questdb/cairo/AbstractPartitionFrameCursorFactory.java
+++ b/core/src/main/java/io/questdb/cairo/AbstractPartitionFrameCursorFactory.java
@@ -87,6 +87,11 @@ abstract class AbstractPartitionFrameCursorFactory implements PartitionFrameCurs
 
     @Override
     public boolean hasParquetFormatPartitions(SqlExecutionContext executionContext) {
+        // The token is resolved from the synchronously loaded registry, but the metadata
+        // cache is hydrated lazily; hydrate on demand so parquet row-group pruning is not
+        // silently skipped for a registered-but-not-yet-cached table during the startup
+        // hydration window.
+        executionContext.getCairoEngine().getMetadataCache().hydrateTableOnDemand(tableToken);
         try (MetadataCacheReader metadataRO = executionContext.getCairoEngine().getMetadataCache().readLock()) {
             CairoTable table = metadataRO.getTable(tableToken);
             return table != null && table.hasParquetPartitions();

--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -50,6 +50,7 @@ import io.questdb.std.str.Path;
 import io.questdb.tasks.TelemetryTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 import java.util.Comparator;
 
@@ -58,6 +59,17 @@ import java.util.Comparator;
  */
 public class MetadataCache implements QuietCloseable {
     private static final Log LOG = LogFactory.getLog(MetadataCache.class);
+    // Upper bound on the number of catalogue reconcile passes that may keep finding
+    // a table missing before {@link #hydrateAllTables()} stops retrying and latches
+    // {@code cacheComplete} anyway. Without this cap a table whose {@code _meta}
+    // cannot be read (corrupt, or transiently unavailable at startup) would be
+    // re-read - and logged as CRITICAL - on every single catalogue query, since a
+    // failed hydration never lands in the cache and so always looks "missing". The
+    // cap trades the (already master-equivalent) hiding of a genuinely unhydratable
+    // table for bounded work and log output, while still giving transient failures
+    // several passes to self-heal. A writer touching the table still re-hydrates it,
+    // and clearCache() resets the counter so a fresh epoch reconciles again.
+    private static final int MAX_INCOMPLETE_RECONCILE_PASSES = 8;
     private static final Comparator<CairoColumn> comparator = Comparator.comparingInt(CairoColumn::getPosition);
     private final MetadataCacheReaderImpl cacheReader = new MetadataCacheReaderImpl();
     private final MetadataCacheWriterImpl cacheWriter = new MetadataCacheWriterImpl();
@@ -65,13 +77,26 @@ public class MetadataCache implements QuietCloseable {
     private final SimpleReadWriteLock rwLock = new SimpleReadWriteLock();
     private final CharSequenceObjHashMap<CairoTable> tableMap = new CharSequenceObjHashMap<>();
     private ColumnVersionReader columnVersionReader;
+    // Counts consecutive catalogue reconcile passes that still found at least one
+    // table missing from the cache. Bounded by MAX_INCOMPLETE_RECONCILE_PASSES;
+    // reset by clearCache(). Only mutated under the write lock (by the give-up latch
+    // in hydrateAllTables() and by clearCache()), so it stays in step with
+    // cacheComplete and a concurrent clear cannot race the budgeted latch.
+    private int incompleteReconcilePasses;
     private MemoryCMR metaMem = Vm.getCMRInstance();
     // True once the cache is known to hold every registered (non-view) table. Set by
-    // the startup hydrator and by any catalogue reconcile that observes the cache as
-    // already complete; from then on writers keep the cache in sync incrementally, so
-    // hydrateAllTables() short-circuits. Reset by clearCache() so a wiped cache is
-    // reconciled afresh.
+    // the startup hydrator only when it actually hydrated every table, and by any
+    // catalogue reconcile that observes the cache as already complete (or that gives
+    // up after MAX_INCOMPLETE_RECONCILE_PASSES); from then on writers keep the cache
+    // in sync incrementally, so hydrateAllTables() short-circuits. Reset by
+    // clearCache() so a wiped cache is reconciled afresh.
     private volatile boolean cacheComplete;
+    // Test-only seam fired immediately before hydrateAllTables() publishes the
+    // completeness latch (see #latchCompleteTestHook). Lets a test deterministically
+    // race a clearCache() against the publish: because it sits right next to the
+    // publish, it stays inside whatever lock scope the publish lives in, so a
+    // regression that moved the publish back outside the read lock would expose it.
+    private volatile Runnable latchCompleteTestHook;
     private TxReader txReader;
     private long version;
 
@@ -106,14 +131,24 @@ public class MetadataCache implements QuietCloseable {
                 }
             }
 
+            // Verify completeness and publish the flag under a single read lock. The
+            // check-and-set is then mutually exclusive with clearCache() (write lock),
+            // so a concurrent clear cannot slip between observing completeness and
+            // latching the flag and leave an emptied cache marked complete.
+            //
+            // We latch only if every registered table is actually present: a per-table
+            // hydration can fail silently (hydrateTableStartup swallows it with
+            // throwError=false and evicts the table), and a swallowed failure must leave
+            // the flag unset so the catalogue reconcile (hydrateAllTables) keeps retrying
+            // - self-healing transient failures - until it succeeds or exhausts its
+            // retry budget. This mirrors the contract honoured by hydrateAllTables()'s
+            // second pass, which likewise never latches a flag it cannot back up. The
+            // flag is also left unset on an abnormal abort below (e.g. getTableTokens()/
+            // lock failure).
             try (MetadataCacheReader metadataRO = readLock()) {
                 LOG.info().$("metadata hydration completed [tables=").$(metadataRO.getTableCount()).I$();
+                latchCacheCompleteIfWarmed(tableTokens);
             }
-            // The startup pass completed: the cache now holds every table and from
-            // here writers keep it in sync incrementally, so hydrateAllTables() can
-            // skip its reconcile. Left unset on an abnormal abort below, so the
-            // reconcile keeps running as a self-healing fallback.
-            cacheComplete = true;
         } catch (CairoException e) {
             LogRecord l = e.isCritical() ? LOG.critical() : LOG.error();
             l.$safe(e.getFlyweightMessage()).$();
@@ -132,16 +167,21 @@ public class MetadataCache implements QuietCloseable {
      * contains tables that have already been hydrated. Without this
      * reconciliation those queries would race the async startup hydrator and
      * could return an incomplete catalogue immediately after a restart. Calling
-     * this first guarantees the complete set of tables is observed.
+     * this first observes the complete set of tables whenever every table can be
+     * hydrated. A table whose {@code _meta} cannot be read (corrupt, or transiently
+     * unavailable) cannot be hydrated and is omitted - the same outcome as on a
+     * release without this reconcile - until a writer next touches it or the process
+     * restarts; see {@link #MAX_INCOMPLETE_RECONCILE_PASSES}.
      * <p>
      * The reconcile is only needed until the cache is known to be complete. Once
-     * either {@link #onStartupAsyncHydrator()} finishes or a reconcile pass observes
-     * the cache already holding every registered table, writers keep the cache in
-     * sync incrementally, so this method short-circuits on a single volatile read and
-     * adds no per-query overhead (no allocation, no lock). This matters for embedded
-     * engines, which never run the startup hydrator: without it every catalogue query
-     * would reconcile forever. {@link MetadataCacheWriter#clearCache()} resets the
-     * state so a wiped cache is reconciled afresh.
+     * {@link #onStartupAsyncHydrator()} hydrates every table, a reconcile pass observes
+     * the cache already holding every registered table, or the reconcile gives up after
+     * {@link #MAX_INCOMPLETE_RECONCILE_PASSES} passes still find a table missing, writers
+     * keep the cache in sync incrementally, so this method short-circuits on a single
+     * volatile read and adds no per-query overhead (no allocation, no lock). This
+     * matters for embedded engines, which never run the startup hydrator: without it
+     * every catalogue query would reconcile forever. {@link MetadataCacheWriter#clearCache()}
+     * resets the state so a wiped cache is reconciled afresh.
      */
     public void hydrateAllTables() {
         // Fast path: once the cache is known complete it is kept current by writers,
@@ -171,28 +211,148 @@ public class MetadataCache implements QuietCloseable {
                     missing.add(token);
                 }
             }
+            if (missing == null) {
+                // Nothing missing: publish the flag while still under the read lock so
+                // the observation + latch are mutually exclusive with clearCache()
+                // (write lock); otherwise a concurrent clear could slip in after the
+                // scan and leave an emptied cache marked complete.
+                final Runnable hook = latchCompleteTestHook;
+                if (hook != null) {
+                    hook.run();
+                }
+                cacheComplete = true;
+            }
         }
 
         if (missing == null) {
-            // The cache already holds every registered table. From here writers keep
-            // it in sync incrementally, so future catalogue queries short-circuit on
-            // the fast path above. This is what spares embedded engines (which never
-            // run the startup hydrator) a per-query reconcile once warmed up; the flag
-            // is cleared by clearCache() so a wiped cache is reconciled again.
-            cacheComplete = true;
+            // The cache already holds every registered table; the flag was latched
+            // inside the read lock above (mutually exclusive with clearCache()). From
+            // here writers keep it in sync incrementally, so future catalogue queries
+            // short-circuit on the fast path above. This is what spares embedded engines
+            // (which never run the startup hydrator) a per-query reconcile once warmed
+            // up; the flag is cleared by clearCache() so a wiped cache is reconciled
+            // again.
             return;
         }
 
         // Second pass: hydrate the missing tables. Take the write lock per table
         // (matching onStartupAsyncHydrator) so we do not stall ongoing work.
-        // We deliberately do NOT set cacheComplete here: a per-table hydration can
-        // fail silently (throwError=false), so the next reconcile re-scans and only
-        // flips the flag once a pass observes nothing missing.
         for (int i = 0, n = missing.size(); i < n; i++) {
             try (MetadataCacheWriter ignore = writeLock()) {
                 hydrateTableStartup(missing.getQuick(i), false, true);
             }
         }
+
+        // We could not confirm completeness this pass (some tables were missing).
+        // A per-table hydration can fail silently (throwError=false), so normally we
+        // leave cacheComplete unset and let the next reconcile re-scan - that is how
+        // a transient failure self-heals. But a table whose _meta is genuinely
+        // unreadable would otherwise be re-read (and logged CRITICAL) on every
+        // catalogue query forever. Bound that: after MAX_INCOMPLETE_RECONCILE_PASSES
+        // passes still find something missing, give up and latch the flag, leaving the
+        // unhydratable table(s) to be picked up by a writer (hydrateTable/registerName)
+        // or the next clearCache() epoch.
+        //
+        // Do the budget bump + latch under the write lock, so they are mutually
+        // exclusive with clearCache() (which resets both the counter and the flag under
+        // the same lock). Otherwise a concurrent clear could slip between the budget
+        // check and the latch and leave an emptied cache marked complete.
+        final boolean gaveUp;
+        try (MetadataCacheWriter ignore = writeLock()) {
+            gaveUp = ++incompleteReconcilePasses >= MAX_INCOMPLETE_RECONCILE_PASSES;
+            if (gaveUp) {
+                cacheComplete = true;
+            }
+        }
+        if (gaveUp) {
+            LOG.error().$("catalogue reconcile giving up after repeated incomplete passes [passes=")
+                    .$(MAX_INCOMPLETE_RECONCILE_PASSES).$(", missing=").$(missing.size()).I$();
+        }
+    }
+
+    /**
+     * Ensures a single registered table is present in the cache, hydrating it on demand
+     * if it is missing. This is the point-lookup analogue of {@link #hydrateAllTables()}
+     * for callers that resolve a {@link TableToken} from the synchronously loaded table
+     * registry but then read the lazily hydrated cache - e.g. {@code SHOW COLUMNS},
+     * {@code SHOW CREATE TABLE}, {@code SHOW CREATE MATERIALIZED VIEW} and parquet
+     * partition-format probes. Without it those paths would report a registered table
+     * as non-existent (or skip parquet pruning) during the startup hydration window, or
+     * indefinitely for an embedded engine that never runs the startup hydrator and has
+     * not yet had its cache warmed by an enumerating catalogue query.
+     * <p>
+     * Best-effort: a per-table hydration failure is swallowed (mirrors
+     * {@link #hydrateAllTables()}), leaving the table absent so the caller reports it as
+     * missing rather than failing hard. Plain views are never cached (no {@code _meta}
+     * file) and are skipped. Once {@link #cacheComplete} is latched the cache is kept
+     * current by writers, so a still-absent table is genuinely gone (dropped) or was
+     * given up on as unhydratable; re-reading it on every point lookup would only add
+     * load and CRITICAL-log noise, so this short-circuits.
+     */
+    public void hydrateTableOnDemand(@Nullable TableToken token) {
+        if (token == null || token.isView()) {
+            return;
+        }
+        if (cacheComplete) {
+            return;
+        }
+        // Cheap check under the read lock first: skip the version-bumping write lock
+        // when the table is already cached (the common case once the cache is warm).
+        try (MetadataCacheReader ignore = readLock()) {
+            if (tableMap.get(token.getTableName()) != null) {
+                return;
+            }
+        }
+        try (MetadataCacheWriter ignore = writeLock()) {
+            // skipIfCached=true: another thread may have hydrated it between the two
+            // locks. throwError=false: swallow a per-table failure so the caller reports
+            // the table as missing rather than failing hard (mirrors hydrateAllTables()).
+            hydrateTableStartup(token, false, true);
+        }
+    }
+
+    /**
+     * Latches {@link #cacheComplete} iff every registered (non-view) table is already
+     * present in the cache. The caller must hold the read or write lock: performing
+     * the scan and the publish under that lock keeps the check-and-set mutually
+     * exclusive with {@link MetadataCacheWriter#clearCache()} (write lock), so a
+     * concurrent clear cannot interleave between observing completeness and setting
+     * the flag and leave an emptied cache marked complete.
+     */
+    private void latchCacheCompleteIfWarmed(ObjList<TableToken> tableTokens) {
+        for (int i = 0, n = tableTokens.size(); i < n; i++) {
+            final TableToken token = tableTokens.getQuick(i);
+            // views are never stored in the cache (they have no _meta file)
+            if (token.isView()) {
+                continue;
+            }
+            if (tableMap.get(token.getTableName()) == null) {
+                return;
+            }
+        }
+        cacheComplete = true;
+    }
+
+    /**
+     * Whether the cache is currently latched as holding every registered (non-view)
+     * table. Exposed for tests that assert the latch is only ever published while the
+     * cache is actually complete; production code uses the volatile fast path inside
+     * {@link #hydrateAllTables()} instead.
+     */
+    @TestOnly
+    public boolean isCacheComplete() {
+        return cacheComplete;
+    }
+
+    /**
+     * Installs (or clears, when {@code null}) a hook fired immediately before
+     * {@link #hydrateAllTables()} publishes the completeness latch. Tests use it to
+     * deterministically interleave a {@link MetadataCacheWriter#clearCache()} with the
+     * publish; production never sets it.
+     */
+    @TestOnly
+    public void setLatchCompleteTestHook(Runnable hook) {
+        this.latchCompleteTestHook = hook;
     }
 
     /**
@@ -739,7 +899,9 @@ public class MetadataCache implements QuietCloseable {
         public void clearCache() {
             tableMap.clear();
             // The cache is no longer complete; force the next catalogue reconcile to
-            // re-hydrate from the registry (see hydrateAllTables()).
+            // re-hydrate from the registry (see hydrateAllTables()) and give it a fresh
+            // retry budget for any table that fails to hydrate.
+            incompleteReconcilePasses = 0;
             cacheComplete = false;
         }
 

--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -252,6 +252,23 @@ public class MetadataCache implements QuietCloseable {
             Path.clearThreadLocals();
         }
 
+        // Confirm completeness immediately, reusing the token snapshot we already
+        // collected (no second getTableTokens() / ObjHashSet allocation): if every
+        // missing table was hydrated above, the cache now holds every registered table.
+        // Latch here - under the read lock, mutually exclusive with clearCache() (write
+        // lock), exactly like onStartupAsyncHydrator() - so the next catalogue query
+        // short-circuits on the fast path instead of repeating a full reconcile only to
+        // observe "nothing missing" and set the flag. A silently-failed hydration
+        // (throwError=false evicts the table) leaves a gap, so latchCacheCompleteIfWarmed()
+        // latches only when genuinely warm; otherwise we fall through to the bounded retry
+        // budget below.
+        try (MetadataCacheReader ignore = readLock()) {
+            latchCacheCompleteIfWarmed(tableTokens);
+        }
+        if (cacheComplete) {
+            return;
+        }
+
         // We could not confirm completeness this pass (some tables were missing).
         // A per-table hydration can fail silently (throwError=false), so normally we
         // leave cacheComplete unset and let the next reconcile re-scan - that is how

--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -112,6 +112,58 @@ public class MetadataCache implements QuietCloseable {
     }
 
     /**
+     * Ensures that every table currently registered with the engine is present
+     * in the cache, hydrating on demand any tables that the background startup
+     * hydrator ({@link #onStartupAsyncHydrator()}) has not processed yet.
+     * <p>
+     * Catalogue queries such as {@code tables()} and {@code all_tables()} read a
+     * {@link MetadataCacheReader#snapshot snapshot} of the cache, which only
+     * contains tables that have already been hydrated. Without this
+     * reconciliation those queries would race the async startup hydrator and
+     * could return an incomplete catalogue immediately after a restart. Calling
+     * this first guarantees the complete set of tables is observed.
+     * <p>
+     * In steady state (cache fully populated) this is a cheap read-only scan:
+     * no write lock is taken, so the {@link MetadataCacheReader#snapshot}
+     * version fast-path remains intact.
+     */
+    public void hydrateAllTables() {
+        final ObjHashSet<TableToken> tableTokensSet = new ObjHashSet<>();
+        engine.getTableTokens(tableTokensSet, false);
+        final ObjList<TableToken> tableTokens = tableTokensSet.getList();
+
+        // First pass: under a single read lock, collect tables that exist in the
+        // registry but are missing from the cache.
+        ObjList<TableToken> missing = null;
+        try (MetadataCacheReader ignore = readLock()) {
+            for (int i = 0, n = tableTokens.size(); i < n; i++) {
+                final TableToken token = tableTokens.getQuick(i);
+                // views are never stored in the cache (they have no _meta file),
+                // skip them so we don't take a write lock on every invocation
+                if (token.isView()) {
+                    continue;
+                }
+                if (tableMap.get(token.getTableName()) == null) {
+                    if (missing == null) {
+                        missing = new ObjList<>();
+                    }
+                    missing.add(token);
+                }
+            }
+        }
+
+        // Second pass: hydrate the missing tables. Take the write lock per table
+        // (matching onStartupAsyncHydrator) so we do not stall ongoing work.
+        if (missing != null) {
+            for (int i = 0, n = missing.size(); i < n; i++) {
+                try (MetadataCacheWriter ignore = writeLock()) {
+                    hydrateTableStartup(missing.getQuick(i), false);
+                }
+            }
+        }
+    }
+
+    /**
      * Begins the read-path by taking a read lock and acquiring a thread-local
      * {@link MetadataCacheReaderImpl}, an implementation of {@link MetadataCacheReader}.
      *

--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -59,15 +59,18 @@ import java.util.Comparator;
  */
 public class MetadataCache implements QuietCloseable {
     private static final Log LOG = LogFactory.getLog(MetadataCache.class);
-    // Upper bound on the number of catalogue reconcile passes that may keep finding
-    // a table missing before {@link #hydrateAllTables()} stops retrying and latches
-    // {@code cacheComplete} anyway. Without this cap a table whose {@code _meta}
-    // cannot be read (corrupt, or transiently unavailable at startup) would be
-    // re-read - and logged as CRITICAL - on every single catalogue query, since a
-    // failed hydration never lands in the cache and so always looks "missing". The
-    // cap trades the (already master-equivalent) hiding of a genuinely unhydratable
-    // table for bounded work and log output, while still giving transient failures
-    // several passes to self-heal. A writer touching the table still re-hydrates it,
+    // Upper bound on the number of consecutive zero-progress catalogue reconcile passes
+    // (a pass that still finds a table missing yet hydrates none of the missing tables)
+    // before {@link #hydrateAllTables()} stops retrying and latches {@code cacheComplete}
+    // anyway. Without this cap a table whose {@code _meta} cannot be read (corrupt, or
+    // transiently unavailable at startup) would be re-read - and logged as CRITICAL - on
+    // every single catalogue query, since a failed hydration never lands in the cache and
+    // so always looks "missing". The cap trades the (already master-equivalent) hiding of
+    // a genuinely unhydratable table for bounded work and log output, while still giving
+    // transient failures several passes to self-heal: any pass that hydrates at least one
+    // missing table resets the budget, so a post-restart storm making incremental
+    // progress (e.g. a PG-introspection burst racing the startup hydrator) cannot exhaust
+    // it in a single concurrent burst. A writer touching the table still re-hydrates it,
     // and clearCache() resets the counter so a fresh epoch reconciles again.
     private static final int MAX_INCOMPLETE_RECONCILE_PASSES = 8;
     private static final Comparator<CairoColumn> comparator = Comparator.comparingInt(CairoColumn::getPosition);
@@ -77,11 +80,14 @@ public class MetadataCache implements QuietCloseable {
     private final SimpleReadWriteLock rwLock = new SimpleReadWriteLock();
     private final CharSequenceObjHashMap<CairoTable> tableMap = new CharSequenceObjHashMap<>();
     private ColumnVersionReader columnVersionReader;
-    // Counts consecutive catalogue reconcile passes that still found at least one
-    // table missing from the cache. Bounded by MAX_INCOMPLETE_RECONCILE_PASSES;
-    // reset by clearCache(). Only mutated under the write lock (by the give-up latch
-    // in hydrateAllTables() and by clearCache()), so it stays in step with
-    // cacheComplete and a concurrent clear cannot race the budgeted latch.
+    // Counts consecutive catalogue reconcile passes that made no progress - i.e. that
+    // still found a table missing AND hydrated none of the previously-missing tables. A
+    // pass that hydrates at least one missing table resets it (the cache is self-healing),
+    // so it counts only genuinely-stuck rounds rather than every concurrent invocation.
+    // Bounded by MAX_INCOMPLETE_RECONCILE_PASSES; reset by clearCache(). Only mutated
+    // under the write lock (by the give-up logic in hydrateAllTables() and by
+    // clearCache()), so it stays in step with cacheComplete and a concurrent clear cannot
+    // race the budgeted latch.
     private int incompleteReconcilePasses;
     private MemoryCMR metaMem = Vm.getCMRInstance();
     // True once the cache is known to hold every registered (non-view) table. Set by
@@ -275,19 +281,40 @@ public class MetadataCache implements QuietCloseable {
         // a transient failure self-heals. But a table whose _meta is genuinely
         // unreadable would otherwise be re-read (and logged CRITICAL) on every
         // catalogue query forever. Bound that: after MAX_INCOMPLETE_RECONCILE_PASSES
-        // passes still find something missing, give up and latch the flag, leaving the
+        // consecutive zero-progress passes, give up and latch the flag, leaving the
         // unhydratable table(s) to be picked up by a writer (hydrateTable/registerName)
         // or the next clearCache() epoch.
         //
-        // Do the budget bump + latch under the write lock, so they are mutually
-        // exclusive with clearCache() (which resets both the counter and the flag under
-        // the same lock). Otherwise a concurrent clear could slip between the budget
+        // The budget counts only zero-progress rounds: if this pass hydrated at least one
+        // previously-missing table the cache is still self-healing, so reset the counter
+        // instead of spending it. This keeps the give-up budget a function of sequential
+        // stuck rounds rather than of the number of concurrent invocations - a burst of
+        // catalogue queries that each make progress (e.g. a post-restart introspection
+        // storm racing the startup hydrator) cannot exhaust it.
+        //
+        // Do the progress check + budget bump + latch under the write lock, so they are
+        // mutually exclusive with clearCache() (which resets both the counter and the flag
+        // under the same lock). Otherwise a concurrent clear could slip between the budget
         // check and the latch and leave an emptied cache marked complete.
         final boolean gaveUp;
         try (MetadataCacheWriter ignore = writeLock()) {
-            gaveUp = ++incompleteReconcilePasses >= MAX_INCOMPLETE_RECONCILE_PASSES;
-            if (gaveUp) {
-                cacheComplete = true;
+            boolean progressed = false;
+            for (int i = 0, n = missing.size(); i < n; i++) {
+                if (tableMap.get(missing.getQuick(i).getTableName()) != null) {
+                    progressed = true;
+                    break;
+                }
+            }
+            if (progressed) {
+                // Progress this round - the cache is self-healing, so do not spend the
+                // give-up budget; the next reconcile re-scans for whatever is still missing.
+                incompleteReconcilePasses = 0;
+                gaveUp = false;
+            } else {
+                gaveUp = ++incompleteReconcilePasses >= MAX_INCOMPLETE_RECONCILE_PASSES;
+                if (gaveUp) {
+                    cacheComplete = true;
+                }
             }
         }
         if (gaveUp) {

--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -237,10 +237,19 @@ public class MetadataCache implements QuietCloseable {
 
         // Second pass: hydrate the missing tables. Take the write lock per table
         // (matching onStartupAsyncHydrator) so we do not stall ongoing work.
-        for (int i = 0, n = missing.size(); i < n; i++) {
-            try (MetadataCacheWriter ignore = writeLock()) {
-                hydrateTableStartup(missing.getQuick(i), false, true);
+        try {
+            for (int i = 0, n = missing.size(); i < n; i++) {
+                try (MetadataCacheWriter ignore = writeLock()) {
+                    hydrateTableStartup(missing.getQuick(i), false, true);
+                }
             }
+        } finally {
+            // hydrateTableStartup() acquires a thread-local Path; release it so a caller
+            // running on a short-lived (non-pooled) thread does not leak the
+            // NATIVE_PATH_THREAD_LOCAL buffer when the thread terminates. Mirrors
+            // onStartupAsyncHydrator(). Only reached on the hydration slow path; once the
+            // cache is warm hydrateAllTables() short-circuits before allocating.
+            Path.clearThreadLocals();
         }
 
         // We could not confirm completeness this pass (some tables were missing).
@@ -308,6 +317,13 @@ public class MetadataCache implements QuietCloseable {
             // locks. throwError=false: swallow a per-table failure so the caller reports
             // the table as missing rather than failing hard (mirrors hydrateAllTables()).
             hydrateTableStartup(token, false, true);
+        } finally {
+            // hydrateTableStartup() acquires a thread-local Path; release it so a caller
+            // running on a short-lived (non-pooled) thread does not leak the
+            // NATIVE_PATH_THREAD_LOCAL buffer when the thread terminates. Mirrors
+            // onStartupAsyncHydrator(); only reached on the hydration slow path, since the
+            // cacheComplete / already-cached checks above short-circuit once warm.
+            Path.clearThreadLocals();
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -66,6 +66,7 @@ public class MetadataCache implements QuietCloseable {
     private final CharSequenceObjHashMap<CairoTable> tableMap = new CharSequenceObjHashMap<>();
     private ColumnVersionReader columnVersionReader;
     private MemoryCMR metaMem = Vm.getCMRInstance();
+    private volatile boolean startupHydrated;
     private TxReader txReader;
     private long version;
 
@@ -103,6 +104,11 @@ public class MetadataCache implements QuietCloseable {
             try (MetadataCacheReader metadataRO = readLock()) {
                 LOG.info().$("metadata hydration completed [tables=").$(metadataRO.getTableCount()).I$();
             }
+            // The startup pass completed: from here writers keep the cache in
+            // sync incrementally, so hydrateAllTables() can skip its reconcile.
+            // Left unset on an abnormal abort below, so the reconcile keeps
+            // running as a self-healing fallback.
+            startupHydrated = true;
         } catch (CairoException e) {
             LogRecord l = e.isCritical() ? LOG.critical() : LOG.error();
             l.$safe(e.getFlyweightMessage()).$();
@@ -123,11 +129,19 @@ public class MetadataCache implements QuietCloseable {
      * could return an incomplete catalogue immediately after a restart. Calling
      * this first guarantees the complete set of tables is observed.
      * <p>
-     * In steady state (cache fully populated) this is a cheap read-only scan:
-     * no write lock is taken, so the {@link MetadataCacheReader#snapshot}
-     * version fast-path remains intact.
+     * The reconcile is only needed while the one-shot startup hydration is in
+     * progress. Once {@link #onStartupAsyncHydrator()} finishes, writers keep
+     * the cache in sync incrementally, so this method short-circuits on a single
+     * volatile read and adds no per-query overhead (no allocation, no lock). If
+     * the startup pass aborts abnormally the flag stays unset and the reconcile
+     * keeps running as a self-healing fallback.
      */
     public void hydrateAllTables() {
+        // Fast path: after startup hydration the cache is authoritative and kept
+        // current by writers, so no reconcile (or allocation/lock) is needed.
+        if (startupHydrated) {
+            return;
+        }
         final ObjHashSet<TableToken> tableTokensSet = new ObjHashSet<>();
         engine.getTableTokens(tableTokensSet, false);
         final ObjList<TableToken> tableTokens = tableTokensSet.getList();

--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -66,7 +66,12 @@ public class MetadataCache implements QuietCloseable {
     private final CharSequenceObjHashMap<CairoTable> tableMap = new CharSequenceObjHashMap<>();
     private ColumnVersionReader columnVersionReader;
     private MemoryCMR metaMem = Vm.getCMRInstance();
-    private volatile boolean startupHydrated;
+    // True once the cache is known to hold every registered (non-view) table. Set by
+    // the startup hydrator and by any catalogue reconcile that observes the cache as
+    // already complete; from then on writers keep the cache in sync incrementally, so
+    // hydrateAllTables() short-circuits. Reset by clearCache() so a wiped cache is
+    // reconciled afresh.
+    private volatile boolean cacheComplete;
     private TxReader txReader;
     private long version;
 
@@ -97,18 +102,18 @@ public class MetadataCache implements QuietCloseable {
             for (int i = 0, n = tableTokens.size(); i < n; i++) {
                 // acquire a write lock for each table
                 try (MetadataCacheWriter ignore = writeLock()) {
-                    hydrateTableStartup(tableTokens.getQuick(i), false);
+                    hydrateTableStartup(tableTokens.getQuick(i), false, true);
                 }
             }
 
             try (MetadataCacheReader metadataRO = readLock()) {
                 LOG.info().$("metadata hydration completed [tables=").$(metadataRO.getTableCount()).I$();
             }
-            // The startup pass completed: from here writers keep the cache in
-            // sync incrementally, so hydrateAllTables() can skip its reconcile.
-            // Left unset on an abnormal abort below, so the reconcile keeps
-            // running as a self-healing fallback.
-            startupHydrated = true;
+            // The startup pass completed: the cache now holds every table and from
+            // here writers keep it in sync incrementally, so hydrateAllTables() can
+            // skip its reconcile. Left unset on an abnormal abort below, so the
+            // reconcile keeps running as a self-healing fallback.
+            cacheComplete = true;
         } catch (CairoException e) {
             LogRecord l = e.isCritical() ? LOG.critical() : LOG.error();
             l.$safe(e.getFlyweightMessage()).$();
@@ -129,17 +134,19 @@ public class MetadataCache implements QuietCloseable {
      * could return an incomplete catalogue immediately after a restart. Calling
      * this first guarantees the complete set of tables is observed.
      * <p>
-     * The reconcile is only needed while the one-shot startup hydration is in
-     * progress. Once {@link #onStartupAsyncHydrator()} finishes, writers keep
-     * the cache in sync incrementally, so this method short-circuits on a single
-     * volatile read and adds no per-query overhead (no allocation, no lock). If
-     * the startup pass aborts abnormally the flag stays unset and the reconcile
-     * keeps running as a self-healing fallback.
+     * The reconcile is only needed until the cache is known to be complete. Once
+     * either {@link #onStartupAsyncHydrator()} finishes or a reconcile pass observes
+     * the cache already holding every registered table, writers keep the cache in
+     * sync incrementally, so this method short-circuits on a single volatile read and
+     * adds no per-query overhead (no allocation, no lock). This matters for embedded
+     * engines, which never run the startup hydrator: without it every catalogue query
+     * would reconcile forever. {@link MetadataCacheWriter#clearCache()} resets the
+     * state so a wiped cache is reconciled afresh.
      */
     public void hydrateAllTables() {
-        // Fast path: after startup hydration the cache is authoritative and kept
-        // current by writers, so no reconcile (or allocation/lock) is needed.
-        if (startupHydrated) {
+        // Fast path: once the cache is known complete it is kept current by writers,
+        // so no reconcile (or allocation/lock) is needed.
+        if (cacheComplete) {
             return;
         }
         final ObjHashSet<TableToken> tableTokensSet = new ObjHashSet<>();
@@ -166,13 +173,24 @@ public class MetadataCache implements QuietCloseable {
             }
         }
 
+        if (missing == null) {
+            // The cache already holds every registered table. From here writers keep
+            // it in sync incrementally, so future catalogue queries short-circuit on
+            // the fast path above. This is what spares embedded engines (which never
+            // run the startup hydrator) a per-query reconcile once warmed up; the flag
+            // is cleared by clearCache() so a wiped cache is reconciled again.
+            cacheComplete = true;
+            return;
+        }
+
         // Second pass: hydrate the missing tables. Take the write lock per table
         // (matching onStartupAsyncHydrator) so we do not stall ongoing work.
-        if (missing != null) {
-            for (int i = 0, n = missing.size(); i < n; i++) {
-                try (MetadataCacheWriter ignore = writeLock()) {
-                    hydrateTableStartup(missing.getQuick(i), false);
-                }
+        // We deliberately do NOT set cacheComplete here: a per-table hydration can
+        // fail silently (throwError=false), so the next reconcile re-scans and only
+        // flips the flag once a pass observes nothing missing.
+        for (int i = 0, n = missing.size(); i < n; i++) {
+            try (MetadataCacheWriter ignore = writeLock()) {
+                hydrateTableStartup(missing.getQuick(i), false, true);
             }
         }
     }
@@ -239,7 +257,7 @@ public class MetadataCache implements QuietCloseable {
         return columnVersionReader = new ColumnVersionReader();
     }
 
-    private void hydrateTableStartup(@NotNull TableToken token, boolean throwError) {
+    private void hydrateTableStartup(@NotNull TableToken token, boolean throwError, boolean skipIfCached) {
         if (engine.isTableDropped(token)) {
             // Table writer can still process some transactions when DROP table has already
             // been executed, essentially updating dropped table. We should ignore such updates.
@@ -249,6 +267,18 @@ public class MetadataCache implements QuietCloseable {
         if (token.isView()) {
             // views do not have _meta file
             // view metadata will be added to the cache when the view is compiled
+            return;
+        }
+
+        // Exactly-once hydration per clearCache() epoch. The startup hydrator and
+        // the catalogue reconcile (hydrateAllTables) only need to ensure a table is
+        // present; both run under the write lock. If another pass already hydrated
+        // this table since the last clear, skip the redundant meta-file read. The
+        // write lock makes this check-and-hydrate atomic, so each table is read from
+        // disk exactly once between clears. The writer-driven refresh path
+        // (hydrateTable(TableToken)) passes skipIfCached=false and still re-reads to
+        // pick up newer on-disk metadata.
+        if (skipIfCached && tableMap.get(token.getTableName()) != null) {
             return;
         }
 
@@ -708,6 +738,9 @@ public class MetadataCache implements QuietCloseable {
         @Override
         public void clearCache() {
             tableMap.clear();
+            // The cache is no longer complete; force the next catalogue reconcile to
+            // re-hydrate from the registry (see hydrateAllTables()).
+            cacheComplete = false;
         }
 
         /**
@@ -849,7 +882,7 @@ public class MetadataCache implements QuietCloseable {
 
         @Override
         public void hydrateTable(@NotNull TableToken token) {
-            hydrateTableStartup(token, true);
+            hydrateTableStartup(token, true, false);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/cairo/MetadataCache.java
+++ b/core/src/main/java/io/questdb/cairo/MetadataCache.java
@@ -189,6 +189,32 @@ public class MetadataCache implements QuietCloseable {
     }
 
     /**
+     * Refreshes {@code localCache} with a complete, current view of the cache and
+     * returns the new snapshot version. This is the catalogue read-path used by
+     * {@code tables()}, {@code all_tables()}, {@code information_schema.columns()}
+     * and {@code pg_catalog.pg_attribute}: it first reconciles the cache against
+     * the table registry via {@link #hydrateAllTables()} (so the snapshot is
+     * complete even mid startup hydration), then snapshots under the read lock.
+     * <p>
+     * Prefer this over taking {@link #readLock()} and calling
+     * {@link MetadataCacheReader#snapshot} directly; the reader-level variant
+     * skips the reconcile and exists for callers that already hold the read lock
+     * or deliberately want the raw, possibly-incomplete cache contents.
+     *
+     * @param localCache   the snapshot to be refreshed
+     * @param priorVersion the version of the snapshot
+     * @return the current version of the snapshot
+     */
+    public long snapshot(CharSequenceObjMap<CairoTable> localCache, long priorVersion) {
+        // Reconcile first (cheap no-op once startup hydration has completed), then
+        // snapshot under a single read lock.
+        hydrateAllTables();
+        try (MetadataCacheReader metadataRO = readLock()) {
+            return metadataRO.snapshot(localCache, priorVersion);
+        }
+    }
+
+    /**
      * Begins the read-path by taking a write lock and acquiring a thread-local
      * {@link MetadataCacheWriterImpl}, an implementation of {@link MetadataCacheWriter}.
      * Also increments a version counter, used to invalidate the cache.

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/AllTablesFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/AllTablesFunctionFactory.java
@@ -92,6 +92,9 @@ public class AllTablesFunctionFactory implements FunctionFactory {
         @Override
         public RecordCursor getCursor(SqlExecutionContext executionContext) {
             final CairoEngine engine = executionContext.getCairoEngine();
+            // Make sure the catalogue is complete even if the background startup
+            // hydrator has not finished yet (see MetadataCache#hydrateAllTables).
+            engine.getMetadataCache().hydrateAllTables();
             try (MetadataCacheReader metadataRO = engine.getMetadataCache().readLock()) {
                 tableCacheVersion = metadataRO.snapshot(tableCache, tableCacheVersion);
             }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/AllTablesFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/AllTablesFunctionFactory.java
@@ -31,7 +31,6 @@ import io.questdb.cairo.CairoTable;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.DefaultLocalCacheSnapshotFactory;
 import io.questdb.cairo.GenericRecordMetadata;
-import io.questdb.cairo.MetadataCacheReader;
 import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.NoRandomAccessRecordCursor;
@@ -92,12 +91,9 @@ public class AllTablesFunctionFactory implements FunctionFactory {
         @Override
         public RecordCursor getCursor(SqlExecutionContext executionContext) {
             final CairoEngine engine = executionContext.getCairoEngine();
-            // Make sure the catalogue is complete even if the background startup
-            // hydrator has not finished yet (see MetadataCache#hydrateAllTables).
-            engine.getMetadataCache().hydrateAllTables();
-            try (MetadataCacheReader metadataRO = engine.getMetadataCache().readLock()) {
-                tableCacheVersion = metadataRO.snapshot(tableCache, tableCacheVersion);
-            }
+            // Reconciles against the table registry before snapshotting, so the
+            // catalogue is complete even mid startup hydration.
+            tableCacheVersion = engine.getMetadataCache().snapshot(tableCache, tableCacheVersion);
             cursor.toTop();
             return cursor;
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/InformationSchemaColumnsFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/InformationSchemaColumnsFunctionFactory.java
@@ -100,6 +100,9 @@ public class InformationSchemaColumnsFunctionFactory implements FunctionFactory 
         @Override
         public RecordCursor getCursor(SqlExecutionContext executionContext) {
             final CairoEngine engine = executionContext.getCairoEngine();
+            // Make sure the catalogue is complete even if the background startup
+            // hydrator has not finished yet (see MetadataCache#hydrateAllTables).
+            engine.getMetadataCache().hydrateAllTables();
             try (MetadataCacheReader metadataRO = engine.getMetadataCache().readLock()) {
                 tableCacheVersion = metadataRO.snapshot(tableCache, tableCacheVersion);
             }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/InformationSchemaColumnsFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/InformationSchemaColumnsFunctionFactory.java
@@ -32,7 +32,6 @@ import io.questdb.cairo.CairoTable;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.DefaultLocalCacheSnapshotFactory;
 import io.questdb.cairo.GenericRecordMetadata;
-import io.questdb.cairo.MetadataCacheReader;
 import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.Function;
@@ -100,12 +99,9 @@ public class InformationSchemaColumnsFunctionFactory implements FunctionFactory 
         @Override
         public RecordCursor getCursor(SqlExecutionContext executionContext) {
             final CairoEngine engine = executionContext.getCairoEngine();
-            // Make sure the catalogue is complete even if the background startup
-            // hydrator has not finished yet (see MetadataCache#hydrateAllTables).
-            engine.getMetadataCache().hydrateAllTables();
-            try (MetadataCacheReader metadataRO = engine.getMetadataCache().readLock()) {
-                tableCacheVersion = metadataRO.snapshot(tableCache, tableCacheVersion);
-            }
+            // Reconciles against the table registry before snapshotting, so the
+            // catalogue is complete even mid startup hydration.
+            tableCacheVersion = engine.getMetadataCache().snapshot(tableCache, tableCacheVersion);
             cursor.toTop();
             return cursor;
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgAttributeFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgAttributeFunctionFactory.java
@@ -107,6 +107,9 @@ public class PgAttributeFunctionFactory implements FunctionFactory {
         @Override
         public RecordCursor getCursor(SqlExecutionContext executionContext) {
             final CairoEngine engine = executionContext.getCairoEngine();
+            // Make sure the catalogue is complete even if the background startup
+            // hydrator has not finished yet (see MetadataCache#hydrateAllTables).
+            engine.getMetadataCache().hydrateAllTables();
             try (MetadataCacheReader metadataRO = engine.getMetadataCache().readLock()) {
                 tableCacheVersion = metadataRO.snapshot(tableCache, tableCacheVersion);
             }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgAttributeFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/PgAttributeFunctionFactory.java
@@ -32,7 +32,6 @@ import io.questdb.cairo.CairoTable;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.DefaultLocalCacheSnapshotFactory;
 import io.questdb.cairo.GenericRecordMetadata;
-import io.questdb.cairo.MetadataCacheReader;
 import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.Function;
@@ -107,12 +106,9 @@ public class PgAttributeFunctionFactory implements FunctionFactory {
         @Override
         public RecordCursor getCursor(SqlExecutionContext executionContext) {
             final CairoEngine engine = executionContext.getCairoEngine();
-            // Make sure the catalogue is complete even if the background startup
-            // hydrator has not finished yet (see MetadataCache#hydrateAllTables).
-            engine.getMetadataCache().hydrateAllTables();
-            try (MetadataCacheReader metadataRO = engine.getMetadataCache().readLock()) {
-                tableCacheVersion = metadataRO.snapshot(tableCache, tableCacheVersion);
-            }
+            // Reconciles against the table registry before snapshotting, so the
+            // catalogue is complete even mid startup hydration.
+            tableCacheVersion = engine.getMetadataCache().snapshot(tableCache, tableCacheVersion);
 
             cursor.toTop();
             return cursor;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TablesFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TablesFunctionFactory.java
@@ -31,7 +31,6 @@ import io.questdb.cairo.CairoTable;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.DefaultLocalCacheSnapshotFactory;
 import io.questdb.cairo.GenericRecordMetadata;
-import io.questdb.cairo.MetadataCacheReader;
 import io.questdb.cairo.TableColumnMetadata;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.TimestampDriver;
@@ -177,12 +176,9 @@ public class TablesFunctionFactory implements FunctionFactory {
         @Override
         public RecordCursor getCursor(SqlExecutionContext executionContext) {
             final CairoEngine engine = executionContext.getCairoEngine();
-            // Make sure the catalogue is complete even if the background startup
-            // hydrator has not finished yet (see MetadataCache#hydrateAllTables).
-            engine.getMetadataCache().hydrateAllTables();
-            try (MetadataCacheReader metadataRO = engine.getMetadataCache().readLock()) {
-                tableCacheVersion = metadataRO.snapshot(tableCache, tableCacheVersion);
-            }
+            // Reconciles against the table registry before snapshotting, so the
+            // catalogue is complete even mid startup hydration.
+            tableCacheVersion = engine.getMetadataCache().snapshot(tableCache, tableCacheVersion);
             cursor.of(engine.getRecentWriteTracker(), engine.getTableSequencerAPI());
             cursor.toTop();
             return cursor;

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TablesFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/TablesFunctionFactory.java
@@ -177,6 +177,9 @@ public class TablesFunctionFactory implements FunctionFactory {
         @Override
         public RecordCursor getCursor(SqlExecutionContext executionContext) {
             final CairoEngine engine = executionContext.getCairoEngine();
+            // Make sure the catalogue is complete even if the background startup
+            // hydrator has not finished yet (see MetadataCache#hydrateAllTables).
+            engine.getMetadataCache().hydrateAllTables();
             try (MetadataCacheReader metadataRO = engine.getMetadataCache().readLock()) {
                 tableCacheVersion = metadataRO.snapshot(tableCache, tableCacheVersion);
             }

--- a/core/src/main/java/io/questdb/griffin/engine/table/ShowColumnsRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/ShowColumnsRecordCursorFactory.java
@@ -145,6 +145,12 @@ public class ShowColumnsRecordCursorFactory extends AbstractRecordCursorFactory 
 
         public ShowColumnsCursor of(SqlExecutionContext executionContext, TableToken tableToken, int tokenPosition) {
             final CairoEngine engine = executionContext.getCairoEngine();
+            // The token is resolved from the synchronously loaded registry, but the
+            // metadata cache is hydrated lazily; hydrate this table on demand so we do
+            // not report a registered-but-not-yet-cached table as non-existent during
+            // the startup hydration window (or before any catalogue query has warmed an
+            // embedded engine).
+            engine.getMetadataCache().hydrateTableOnDemand(tableToken);
             try (MetadataCacheReader metadataRO = engine.getMetadataCache().readLock()) {
                 final CairoTable cairoTable = metadataRO.getTable(tableToken);
                 if (cairoTable != null) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/ShowCreateMatViewRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/ShowCreateMatViewRecordCursorFactory.java
@@ -135,6 +135,11 @@ public class ShowCreateMatViewRecordCursorFactory extends AbstractRecordCursorFa
             this.tableToken = tableToken;
             this.executionContext = executionContext;
 
+            // The token is resolved from the synchronously loaded registry, but the
+            // metadata cache is hydrated lazily; hydrate this materialized view on demand
+            // (matviews have a _meta file and are cached) so we do not report it as
+            // non-existent during the startup hydration window.
+            executionContext.getCairoEngine().getMetadataCache().hydrateTableOnDemand(tableToken);
             try (MetadataCacheReader metadataRO = executionContext.getCairoEngine().getMetadataCache().readLock()) {
                 this.table = metadataRO.getTable(tableToken);
                 if (table == null) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/ShowCreateTableRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/ShowCreateTableRecordCursorFactory.java
@@ -183,6 +183,12 @@ public class ShowCreateTableRecordCursorFactory extends AbstractRecordCursorFact
         ) throws SqlException {
             this.tableToken = tableToken;
             this.executionContext = executionContext;
+            // The token is resolved from the synchronously loaded registry, but the
+            // metadata cache is hydrated lazily; hydrate this table on demand so we do
+            // not report a registered-but-not-yet-cached table as non-existent during
+            // the startup hydration window (or before any catalogue query has warmed an
+            // embedded engine).
+            executionContext.getCairoEngine().getMetadataCache().hydrateTableOnDemand(tableToken);
             try (MetadataCacheReader metadataRO = executionContext.getCairoEngine().getMetadataCache().readLock()) {
                 this.table = metadataRO.getTable(tableToken);
                 if (this.table == null) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/ShowCreateViewRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/ShowCreateViewRecordCursorFactory.java
@@ -129,12 +129,18 @@ public class ShowCreateViewRecordCursorFactory extends AbstractRecordCursorFacto
         ) throws SqlException {
             this.viewToken = viewToken;
             this.executionContext = executionContext;
+            // The view token is resolved from the synchronously loaded table registry
+            // (SqlParserCallback.getViewToken), which already guarantees the view exists
+            // and is a view. Do NOT treat a metadata-cache miss as "view does not exist":
+            // plain views have no _meta file, are skipped by the startup hydrator, and
+            // hydrateTableOnDemand() no-ops on views, so only the async ViewCompilerJob
+            // ever caches them. Gating on the cache would report a registered view as
+            // missing during the startup / embedded window (the bug fixed for SHOW CREATE
+            // TABLE/MATERIALIZED VIEW). Read the cache best-effort to keep the staleness
+            // guard when the view is warm; the definition itself is read from disk below.
             try (MetadataCacheReader metadataRO = executionContext.getCairoEngine().getMetadataCache().readLock()) {
                 this.view = metadataRO.getTable(viewToken);
-                if (this.view == null) {
-                    throw SqlException.$(tokenPosition, "view does not exist [view=")
-                            .put(viewToken.getTableName()).put(']');
-                } else if (!viewToken.equals(view.getTableToken())) {
+                if (this.view != null && !viewToken.equals(view.getTableToken())) {
                     throw TableReferenceOutOfDateException.of(viewToken);
                 }
             }

--- a/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
@@ -848,11 +848,37 @@ public class MetadataCacheTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testHydrateAllTablesShortCircuitsAfterStartup() throws Exception {
-        // hydrateAllTables() backs the tables()/all_tables() startup-race fix, but
-        // it must be a no-op once the one-shot startup hydration has completed:
-        // from then on writers keep the cache current, so a per-query reconcile
-        // would be pure overhead. This pins that fast-path contract.
+    public void testClearCacheReenablesReconcile() throws Exception {
+        // clearCache() wipes the cache and must reset the fast-path flag so the next
+        // catalogue reconcile rebuilds the full set. Guards the checkpoint/restore
+        // style window where the registry is ahead of a freshly-cleared cache.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE a (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE b (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            drainWalQueue();
+
+            // Warm the cache and flip it into the fast path.
+            engine.getMetadataCache().onStartupAsyncHydrator();
+
+            // Wipe the cache. clearCache() must clear the completeness flag too.
+            try (MetadataCacheWriter w = engine.getMetadataCache().writeLock()) {
+                w.clearCache();
+            }
+
+            // The reconcile must run again and rebuild the complete set.
+            engine.getMetadataCache().hydrateAllTables();
+            try (MetadataCacheReader ro = engine.getMetadataCache().readLock()) {
+                Assert.assertEquals(2, ro.getTableCount());
+            }
+        });
+    }
+
+    @Test
+    public void testHydrateAllTablesShortCircuitsWhenCacheComplete() throws Exception {
+        // hydrateAllTables() backs the tables()/all_tables() startup-race fix, but it
+        // must be a no-op once the cache is known complete: from then on writers keep
+        // the cache current, so a per-query reconcile would be pure overhead. This pins
+        // that fast-path contract.
         assertMemoryLeak(() -> {
             execute("CREATE TABLE a (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
             execute("CREATE TABLE b (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
@@ -862,15 +888,77 @@ public class MetadataCacheTest extends AbstractCairoTest {
             // MetadataCache into its steady-state fast path.
             engine.getMetadataCache().onStartupAsyncHydrator();
 
-            // Empty the cache to mimic a missing entry post-startup. Because the
-            // startup pass has completed, hydrateAllTables() must short-circuit
-            // and leave the cache untouched (no reconcile, no repopulation).
+            // Evict a single still-registered table directly from the cache (not via
+            // clearCache(), which would reset the fast-path flag). Because the cache was
+            // marked complete, hydrateAllTables() must short-circuit and leave the gap.
+            TableToken a = engine.getTableTokenIfExists("a");
             try (MetadataCacheWriter w = engine.getMetadataCache().writeLock()) {
-                w.clearCache();
+                w.dropTable(a);
             }
             engine.getMetadataCache().hydrateAllTables();
             try (MetadataCacheReader ro = engine.getMetadataCache().readLock()) {
-                Assert.assertEquals(0, ro.getTableCount());
+                Assert.assertEquals(1, ro.getTableCount());
+                Assert.assertNull(ro.getTable(a));
+            }
+        });
+    }
+
+    @Test
+    public void testSnapshotHydratesEachTableExactlyOncePerClearEpoch() throws Exception {
+        // The catalogue read path (MetadataCache.snapshot()) reconciles via
+        // hydrateAllTables(), which reads each table's _meta exactly once per
+        // clearCache() epoch: a table already present in the cache is never re-read.
+        // We prove this through CairoTable object identity - a re-hydration would
+        // replace the instance.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE a (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE b (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            drainWalQueue();
+
+            final MetadataCache cache = engine.getMetadataCache();
+            final TableToken a = engine.getTableTokenIfExists("a");
+            final TableToken b = engine.getTableTokenIfExists("b");
+            final CharSequenceObjSortedHashMap<CairoTable> snap = new CharSequenceObjSortedHashMap<>();
+            long version = -1;
+
+            // Start from an empty cache to mimic the post-restart reconcile window.
+            try (MetadataCacheWriter w = cache.writeLock()) {
+                w.clearCache();
+            }
+
+            // First snapshot hydrates both tables from disk.
+            version = cache.snapshot(snap, version);
+            CairoTable a1, b1;
+            try (MetadataCacheReader ro = cache.readLock()) {
+                a1 = ro.getTable(a);
+                b1 = ro.getTable(b);
+            }
+            Assert.assertNotNull(a1);
+            Assert.assertNotNull(b1);
+
+            // Repeated snapshots within the same epoch must NOT re-read: the cached
+            // CairoTable instances stay identical.
+            for (int i = 0; i < 3; i++) {
+                version = cache.snapshot(snap, version);
+                try (MetadataCacheReader ro = cache.readLock()) {
+                    Assert.assertSame(a1, ro.getTable(a));
+                    Assert.assertSame(b1, ro.getTable(b));
+                }
+            }
+
+            // A clearCache() opens a new epoch: the next snapshot re-reads from disk,
+            // producing fresh CairoTable instances.
+            try (MetadataCacheWriter w = cache.writeLock()) {
+                w.clearCache();
+            }
+            cache.snapshot(snap, version);
+            try (MetadataCacheReader ro = cache.readLock()) {
+                CairoTable a2 = ro.getTable(a);
+                CairoTable b2 = ro.getTable(b);
+                Assert.assertNotNull(a2);
+                Assert.assertNotNull(b2);
+                Assert.assertNotSame(a1, a2);
+                Assert.assertNotSame(b1, b2);
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
@@ -988,6 +988,90 @@ public class MetadataCacheTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testReconcileBudgetCountsOnlyZeroProgressRounds() throws Exception {
+        // M2: the give-up budget must count consecutive reconcile rounds that make NO
+        // progress, not every reconcile that still finds something missing - otherwise a
+        // post-restart storm (>=MAX concurrent catalogue queries racing the startup
+        // hydrator) exhausts the 8-budget in one burst and latches cacheComplete with a
+        // transiently-unreadable table still absent. A reconcile that hydrates >=1
+        // previously-missing table is self-healing, so it resets the budget; only rounds
+        // that hydrate nothing spend it. Here we drive several progress rounds (tables
+        // becoming readable one round at a time, as a storm hydrates incrementally) and
+        // assert the budget is not consumed while progress continues - it is spent only by
+        // the genuinely-stuck table once progress stops.
+        final int maxIncompleteReconcilePasses = 8;
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE alpha (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE bravo (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE gamma (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE stuck (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            drainWalQueue();
+
+            final MetadataCache cache = engine.getMetadataCache();
+
+            final File bravoMeta = metaFile("bravo");
+            final File bravoHidden = new File(bravoMeta.getParentFile(), "_meta.hidden");
+            final File gammaMeta = metaFile("gamma");
+            final File gammaHidden = new File(gammaMeta.getParentFile(), "_meta.hidden");
+            final File stuckMeta = metaFile("stuck");
+            final File stuckHidden = new File(stuckMeta.getParentFile(), "_meta.hidden");
+
+            // Hide bravo, gamma and stuck so only alpha can hydrate initially; reveal
+            // bravo/gamma one round at a time to mimic a storm making incremental progress.
+            java.nio.file.Files.move(bravoMeta.toPath(), bravoHidden.toPath());
+            java.nio.file.Files.move(gammaMeta.toPath(), gammaHidden.toPath());
+            java.nio.file.Files.move(stuckMeta.toPath(), stuckHidden.toPath());
+            try {
+                try (MetadataCacheWriter w = cache.writeLock()) {
+                    w.clearCache();
+                }
+
+                // Round 1: only alpha hydrates (progress) - bravo/gamma/stuck still hidden.
+                cache.hydrateAllTables();
+                Assert.assertFalse(cache.isCacheComplete());
+
+                // Round 2: reveal bravo, it hydrates (progress).
+                java.nio.file.Files.move(bravoHidden.toPath(), bravoMeta.toPath());
+                cache.hydrateAllTables();
+                Assert.assertFalse(cache.isCacheComplete());
+
+                // Round 3: reveal gamma, it hydrates (progress).
+                java.nio.file.Files.move(gammaHidden.toPath(), gammaMeta.toPath());
+                cache.hydrateAllTables();
+                Assert.assertFalse(cache.isCacheComplete());
+
+                // Three progress rounds happened, yet the budget is untouched: now only the
+                // permanently-stuck table is missing, so the next rounds are zero-progress.
+                // MAX_INCOMPLETE_RECONCILE_PASSES - 1 of them must NOT yet latch (proving the
+                // earlier progress rounds were not counted; pre-fix the budget would already
+                // be spent here).
+                for (int i = 0; i < maxIncompleteReconcilePasses - 1; i++) {
+                    cache.hydrateAllTables();
+                    Assert.assertFalse(
+                            "give-up budget exhausted too early - progress rounds were counted",
+                            cache.isCacheComplete());
+                }
+
+                // One more zero-progress round tips the budget over MAX and gives up.
+                cache.hydrateAllTables();
+                Assert.assertTrue(cache.isCacheComplete());
+                try (MetadataCacheReader ro = cache.readLock()) {
+                    Assert.assertEquals(3, ro.getTableCount());
+                    Assert.assertNull(ro.getTable(engine.getTableTokenIfExists("stuck")));
+                }
+            } finally {
+                if (bravoHidden.exists()) {
+                    java.nio.file.Files.move(bravoHidden.toPath(), bravoMeta.toPath());
+                }
+                if (gammaHidden.exists()) {
+                    java.nio.file.Files.move(gammaHidden.toPath(), gammaMeta.toPath());
+                }
+                java.nio.file.Files.move(stuckHidden.toPath(), stuckMeta.toPath());
+            }
+        });
+    }
+
+    @Test
     public void testReconcileGivesUpAfterRepeatedHydrationFailures() throws Exception {
         // Mirror of MetadataCache.MAX_INCOMPLETE_RECONCILE_PASSES. A genuinely
         // unhydratable table would otherwise be re-read (and logged CRITICAL) on every
@@ -1012,8 +1096,18 @@ public class MetadataCacheTest extends AbstractCairoTest {
                     w.clearCache();
                 }
 
-                // Each reconcile re-reads charlie's (still missing) _meta and fails.
-                // After maxIncompleteReconcilePasses such passes the flag latches.
+                // First reconcile hydrates alpha+bravo (progress) and leaves charlie
+                // missing. A progress round does not spend the give-up budget, so do it
+                // up front; only the zero-progress rounds below count toward giving up.
+                cache.hydrateAllTables();
+                try (MetadataCacheReader ro = cache.readLock()) {
+                    Assert.assertEquals(2, ro.getTableCount());
+                }
+                Assert.assertFalse(cache.isCacheComplete());
+
+                // Now only charlie is missing and unhydratable: each reconcile re-reads
+                // its (still missing) _meta and fails, making zero progress. After
+                // maxIncompleteReconcilePasses such rounds the flag latches.
                 for (int i = 0; i < maxIncompleteReconcilePasses; i++) {
                     cache.hydrateAllTables();
                     try (MetadataCacheReader ro = cache.readLock()) {

--- a/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
@@ -32,6 +32,7 @@ import io.questdb.cairo.MetadataCache;
 import io.questdb.cairo.MetadataCacheReader;
 import io.questdb.cairo.MetadataCacheWriter;
 import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContextImpl;
@@ -46,7 +47,9 @@ import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.File;
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -904,6 +907,383 @@ public class MetadataCacheTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testStartupHydratorDoesNotLatchCompleteWhenATableFailsToHydrate() throws Exception {
+        // A table whose _meta cannot be read at startup (fd exhaustion, torn read during
+        // concurrent WAL apply, slow/NFS storage, mid-conversion) makes
+        // hydrateTableStartup() swallow the failure (throwError=false) and evict the
+        // table from the cache. onStartupAsyncHydrator() must NOT then latch
+        // cacheComplete: doing so would short-circuit every future catalogue reconcile
+        // and hide the table forever (until a writer touches it or the process
+        // restarts). Leaving the flag unset lets the reconcile self-heal once the
+        // _meta becomes readable again.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE alpha (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE bravo (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE charlie (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            drainWalQueue();
+
+            final MetadataCache cache = engine.getMetadataCache();
+            final File meta = metaFile("charlie");
+            final File hidden = new File(meta.getParentFile(), "_meta.hidden");
+
+            // Make charlie's _meta unreadable, then run the startup hydrator from an
+            // empty cache (mimics a fresh process whose hydrator races a transient fault).
+            java.nio.file.Files.move(meta.toPath(), hidden.toPath());
+            try {
+                try (MetadataCacheWriter w = cache.writeLock()) {
+                    w.clearCache();
+                }
+                cache.onStartupAsyncHydrator();
+
+                // alpha + bravo hydrated; charlie could not be read and is absent.
+                try (MetadataCacheReader ro = cache.readLock()) {
+                    Assert.assertEquals(2, ro.getTableCount());
+                    Assert.assertNull(ro.getTable(engine.getTableTokenIfExists("charlie")));
+                }
+            } finally {
+                // _meta is readable again (the transient fault cleared).
+                java.nio.file.Files.move(hidden.toPath(), meta.toPath());
+            }
+
+            // Self-heal: because the startup hydrator did NOT latch cacheComplete, the
+            // reconcile still runs and now picks charlie up. With the pre-fix
+            // unconditional latch this short-circuited and charlie stayed hidden.
+            cache.hydrateAllTables();
+            try (MetadataCacheReader ro = cache.readLock()) {
+                Assert.assertEquals(3, ro.getTableCount());
+                Assert.assertNotNull(ro.getTable(engine.getTableTokenIfExists("charlie")));
+            }
+        });
+    }
+
+    @Test
+    public void testReconcileGivesUpAfterRepeatedHydrationFailures() throws Exception {
+        // Mirror of MetadataCache.MAX_INCOMPLETE_RECONCILE_PASSES. A genuinely
+        // unhydratable table would otherwise be re-read (and logged CRITICAL) on every
+        // catalogue query forever, since a failed hydration never lands in the cache
+        // and so always looks "missing". After this many incomplete passes the
+        // reconcile must give up and latch cacheComplete, leaving the table for a
+        // writer or the next clearCache() epoch to pick up.
+        final int maxIncompleteReconcilePasses = 8;
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE alpha (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE bravo (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE charlie (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            drainWalQueue();
+
+            final MetadataCache cache = engine.getMetadataCache();
+            final File meta = metaFile("charlie");
+            final File hidden = new File(meta.getParentFile(), "_meta.hidden");
+
+            java.nio.file.Files.move(meta.toPath(), hidden.toPath());
+            try {
+                try (MetadataCacheWriter w = cache.writeLock()) {
+                    w.clearCache();
+                }
+
+                // Each reconcile re-reads charlie's (still missing) _meta and fails.
+                // After maxIncompleteReconcilePasses such passes the flag latches.
+                for (int i = 0; i < maxIncompleteReconcilePasses; i++) {
+                    cache.hydrateAllTables();
+                    try (MetadataCacheReader ro = cache.readLock()) {
+                        Assert.assertEquals(2, ro.getTableCount());
+                    }
+                }
+            } finally {
+                java.nio.file.Files.move(hidden.toPath(), meta.toPath());
+            }
+
+            // The retry budget is spent and cacheComplete latched, so the reconcile now
+            // short-circuits: charlie stays hidden even though its _meta is readable.
+            // This caps the CRITICAL-spam / per-query disk I/O path for corrupt tables.
+            cache.hydrateAllTables();
+            try (MetadataCacheReader ro = cache.readLock()) {
+                Assert.assertEquals(2, ro.getTableCount());
+                Assert.assertNull(ro.getTable(engine.getTableTokenIfExists("charlie")));
+            }
+
+            // clearCache() resets the budget, so a fresh epoch reconciles charlie back in.
+            try (MetadataCacheWriter w = cache.writeLock()) {
+                w.clearCache();
+            }
+            cache.hydrateAllTables();
+            try (MetadataCacheReader ro = cache.readLock()) {
+                Assert.assertEquals(3, ro.getTableCount());
+                Assert.assertNotNull(ro.getTable(engine.getTableTokenIfExists("charlie")));
+            }
+        });
+    }
+
+    @Test
+    public void testCompletenessLatchIsMutuallyExclusiveWithClearCache() throws Exception {
+        // M2 regression (deterministic): the completeness latch (cacheComplete=true) in
+        // hydrateAllTables() must be published under the read lock that observed the
+        // cache as complete, so it is mutually exclusive with clearCache() (write lock).
+        // We force the exact interleaving via a test hook fired right before the
+        // publish: while the hook runs, another thread tries to clearCache(). With the
+        // publish correctly inside the read lock, that clearCache() is blocked until we
+        // release, so the latch can never end up set on an emptied cache. Were the
+        // publish moved back outside the lock (the bug), the clearCache() would land
+        // between the scan and the publish and leave cacheComplete=true over an empty
+        // cache - which the post-condition below catches.
+        assertMemoryLeak(() -> {
+            final int tableCount = 3;
+            for (int i = 0; i < tableCount; i++) {
+                execute("CREATE TABLE t" + i + " (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            }
+            drainWalQueue();
+
+            final MetadataCache cache = engine.getMetadataCache();
+
+            // Start from a warm-but-unlatched state: full cache, cacheComplete=false.
+            // clearCache() empties + unlatches; the first reconcile refills via pass 2
+            // (which never latches), so the cache is complete but the flag is still off.
+            try (MetadataCacheWriter w = cache.writeLock()) {
+                w.clearCache();
+            }
+            cache.hydrateAllTables();
+            try (MetadataCacheReader ro = cache.readLock()) {
+                Assert.assertEquals(tableCount, ro.getTableCount());
+            }
+            Assert.assertFalse(cache.isCacheComplete());
+
+            // The hook fires once, on the next reconcile's missing==null publish. It
+            // kicks off a concurrent clearCache() and gives it ample time to run. In
+            // correct code that clearCache() is blocked on the write lock (we hold the
+            // read lock), so it cannot empty the cache before we publish.
+            final AtomicReference<Thread> clearer = new AtomicReference<>();
+            final AtomicReference<Throwable> clearError = new AtomicReference<>();
+            final AtomicBoolean fired = new AtomicBoolean(false);
+            cache.setLatchCompleteTestHook(() -> {
+                if (!fired.compareAndSet(false, true)) {
+                    return;
+                }
+                final Thread b = new Thread(() -> {
+                    try (MetadataCacheWriter w = cache.writeLock()) {
+                        w.clearCache();
+                    } catch (Throwable t) {
+                        clearError.compareAndSet(null, t);
+                    } finally {
+                        Path.clearThreadLocals();
+                    }
+                }, "clearer");
+                clearer.set(b);
+                b.start();
+                // Long enough that, were we NOT holding the read lock, the clearer would
+                // certainly have emptied the cache before we publish the latch.
+                Os.sleep(200);
+            });
+
+            try {
+                cache.hydrateAllTables();
+            } finally {
+                cache.setLatchCompleteTestHook(null);
+            }
+
+            final Thread b = clearer.get();
+            Assert.assertNotNull("hook did not fire - publish path changed?", b);
+            b.join();
+            if (clearError.get() != null) {
+                throw new RuntimeException(clearError.get());
+            }
+
+            // Invariant: cacheComplete must never be latched over an incomplete cache.
+            // Correct code ends here with the cache emptied by the clearer and the flag
+            // off (publish happened under the read lock while the cache was still full,
+            // then the clearer emptied + unlatched). The buggy code would end with
+            // cacheComplete=true over an empty cache.
+            try (MetadataCacheReader ro = cache.readLock()) {
+                if (cache.isCacheComplete()) {
+                    Assert.assertEquals(
+                            "cacheComplete latched on an incomplete cache",
+                            tableCount, ro.getTableCount());
+                }
+            }
+
+            // And the cache still self-heals to the full set.
+            cache.hydrateAllTables();
+            try (MetadataCacheReader ro = cache.readLock()) {
+                Assert.assertEquals(tableCount, ro.getTableCount());
+            }
+        });
+    }
+
+    @Test
+    public void testConcurrentReconcileAndClearCacheNeverMarksEmptyCacheComplete() throws Exception {
+        // M2 regression: the completeness latch (cacheComplete=true) in
+        // hydrateAllTables() / onStartupAsyncHydrator() must be published under a lock
+        // that excludes clearCache(). Set outside the lock, a clearCache() can
+        // interleave between observing the cache as complete and publishing the flag,
+        // leaving an emptied cache marked complete - catalogue queries then
+        // short-circuit forever with no self-healing. We hammer the reconcile path
+        // against concurrent clearCache() and assert the invariant "cacheComplete =>
+        // the cache holds every table" is never violated. The invariant is checked
+        // under the read lock, which excludes clearCache(), so the table set is stable
+        // for the duration of the check.
+        assertMemoryLeak(() -> {
+            final int tableCount = 4;
+            for (int i = 0; i < tableCount; i++) {
+                execute("CREATE TABLE t" + i + " (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            }
+            drainWalQueue();
+
+            final MetadataCache cache = engine.getMetadataCache();
+            final AtomicBoolean stop = new AtomicBoolean(false);
+            final AtomicReference<Throwable> error = new AtomicReference<>();
+            // Heavily oversubscribe so the scheduler frequently preempts a reconciler in
+            // the narrow window between releasing the pass-1 read lock and publishing the
+            // latch - that preemption is what widens the race the buggy (unlocked) latch
+            // exposes to clearCache(). Bounded by wall-clock so the test stays fast.
+            final int reconcilerCount = Math.max(8, 2 * Runtime.getRuntime().availableProcessors());
+            final long deadline = System.nanoTime() + 1_000_000_000L;
+
+            // Reconcilers: drive the completeness-latch path from multiple threads.
+            final Runnable reconciler = () -> {
+                try {
+                    while (!stop.get() && error.get() == null && System.nanoTime() < deadline) {
+                        cache.hydrateAllTables();
+                    }
+                } catch (Throwable t) {
+                    error.compareAndSet(null, t);
+                } finally {
+                    // hydrateTableStartup() allocates a thread-local Path; release it so
+                    // the surrounding assertMemoryLeak() does not flag native memory.
+                    Path.clearThreadLocals();
+                }
+            };
+            // Checker: a latched cacheComplete must imply a full cache. Read the count
+            // and the flag under the read lock, which excludes clearCache(), so the
+            // table set cannot change mid-check; only a buggy unlocked latch can flip
+            // cacheComplete while we hold the lock over an emptied cache.
+            final Runnable checker = () -> {
+                try {
+                    while (!stop.get() && error.get() == null && System.nanoTime() < deadline) {
+                        try (MetadataCacheReader ro = cache.readLock()) {
+                            final int count = ro.getTableCount();
+                            if (cache.isCacheComplete() && count != tableCount) {
+                                throw new AssertionError(
+                                        "cacheComplete latched on an incomplete cache: tableCount="
+                                                + count + " expected=" + tableCount);
+                            }
+                        }
+                    }
+                } catch (Throwable t) {
+                    error.compareAndSet(null, t);
+                } finally {
+                    Path.clearThreadLocals();
+                }
+            };
+
+            final Thread[] reconcilers = new Thread[reconcilerCount];
+            for (int i = 0; i < reconcilerCount; i++) {
+                reconcilers[i] = new Thread(reconciler, "reconciler-" + i);
+                reconcilers[i].start();
+            }
+            final Thread chk = new Thread(checker, "checker");
+            chk.start();
+            try {
+                while (error.get() == null && System.nanoTime() < deadline) {
+                    try (MetadataCacheWriter w = cache.writeLock()) {
+                        w.clearCache();
+                    }
+                    // Brief yield so reconcilers can refill and reach the vulnerable
+                    // missing==null publish, and so the checker can observe a latched
+                    // flag before the next clear resets it.
+                    Os.pause();
+                }
+            } finally {
+                stop.set(true);
+            }
+            for (Thread t : reconcilers) {
+                t.join();
+            }
+            chk.join();
+
+            if (error.get() != null) {
+                throw new RuntimeException(error.get());
+            }
+
+            // With clears stopped, the cache must converge back to the full set: had a
+            // racing clear latched an empty-complete cache, this reconcile would
+            // short-circuit and leave it short.
+            cache.hydrateAllTables();
+            try (MetadataCacheReader ro = cache.readLock()) {
+                Assert.assertEquals(tableCount, ro.getTableCount());
+            }
+        });
+    }
+
+    @Test
+    public void testHydrateTableOnDemandPopulatesMissingTable() throws Exception {
+        // M3: point-lookup catalogue paths (SHOW COLUMNS / SHOW CREATE TABLE / parquet
+        // partition probes) resolve the token from the registry but read the lazily
+        // hydrated cache. hydrateTableOnDemand() is their single-table reconcile: it must
+        // populate a registered-but-uncached table, and no-op once the cache is marked
+        // complete (a still-missing table is then genuinely gone / given up on).
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE a (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            drainWalQueue();
+
+            final MetadataCache cache = engine.getMetadataCache();
+            final TableToken a = engine.getTableTokenIfExists("a");
+
+            // Empty cache (post-restart window): the table is registered but not cached.
+            try (MetadataCacheWriter w = cache.writeLock()) {
+                w.clearCache();
+            }
+            try (MetadataCacheReader ro = cache.readLock()) {
+                Assert.assertNull(ro.getTable(a));
+            }
+
+            // A null token is a no-op (no exception).
+            cache.hydrateTableOnDemand(null);
+
+            // On-demand hydrate brings just this table into the cache.
+            cache.hydrateTableOnDemand(a);
+            try (MetadataCacheReader ro = cache.readLock()) {
+                Assert.assertNotNull(ro.getTable(a));
+                Assert.assertEquals(1, ro.getTableCount());
+            }
+
+            // Once the cache is marked complete, a still-missing table is treated as gone:
+            // hydrateTableOnDemand must short-circuit (no re-read) rather than re-read and
+            // log on every point lookup. Evict via dropTable(), which does not reset the
+            // completeness flag.
+            cache.hydrateAllTables();
+            Assert.assertTrue(cache.isCacheComplete());
+            try (MetadataCacheWriter w = cache.writeLock()) {
+                w.dropTable(a);
+            }
+            cache.hydrateTableOnDemand(a);
+            try (MetadataCacheReader ro = cache.readLock()) {
+                Assert.assertNull(ro.getTable(a));
+            }
+        });
+    }
+
+    @Test
+    public void testShowColumnsBeforeStartupHydration() throws Exception {
+        // M3 regression: SHOW COLUMNS resolves the token from the registry but reads the
+        // lazily hydrated cache; in the startup window it used to throw "table does not
+        // exist" for a registered table. It must hydrate the table on demand.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE foo (ts TIMESTAMP, a INT, b LONG) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            drainWalQueue();
+
+            // Simulate the window: registry knows the table, metadata cache is empty.
+            try (MetadataCacheWriter w = engine.getMetadataCache().writeLock()) {
+                w.clearCache();
+            }
+
+            printSql("show columns from foo");
+            final String out = sink.toString();
+            TestUtils.assertContains(out, "ts\tTIMESTAMP");
+            TestUtils.assertContains(out, "a\tINT");
+            TestUtils.assertContains(out, "b\tLONG");
+        });
+    }
+
+    @Test
     public void testSnapshotHydratesEachTableExactlyOncePerClearEpoch() throws Exception {
         // The catalogue read path (MetadataCache.snapshot()) reconciles via
         // hydrateAllTables(), which reads each table's _meta exactly once per
@@ -1209,6 +1589,15 @@ public class MetadataCacheTest extends AbstractCairoTest {
             Assert.assertEquals(timestampIndex, tsIndex);
             Assert.assertEquals("timestamp", table.getTimestampName());
         }
+    }
+
+    private File metaFile(String tableName) {
+        final TableToken token = engine.getTableTokenIfExists(tableName);
+        Assert.assertNotNull("table not found: " + tableName, token);
+        return new File(
+                new File(engine.getConfiguration().getDbRoot(), token.getDirName()),
+                TableUtils.META_FILE_NAME
+        );
     }
 
     private void createX() throws SqlException {

--- a/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
@@ -877,6 +877,37 @@ public class MetadataCacheTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testReconcileLatchesCompleteAfterHydratingMissingTables() throws Exception {
+        // M3 optimization: when one hydrateAllTables() reconcile successfully hydrates
+        // every missing table, it must latch cacheComplete in that same pass (reusing the
+        // token snapshot it already collected), not leave the flag off and force the next
+        // catalogue query to run a second, redundant full reconcile (getTableTokens +
+        // allocation + scan) just to observe "nothing missing".
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE a (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE b (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            drainWalQueue();
+
+            final MetadataCache cache = engine.getMetadataCache();
+
+            // Empty + unlatch: tables stay registered, cache is empty, cacheComplete=false.
+            try (MetadataCacheWriter w = cache.writeLock()) {
+                w.clearCache();
+            }
+            Assert.assertFalse(cache.isCacheComplete());
+
+            // A single reconcile hydrates both missing tables AND latches in the same
+            // pass. Pre-fix this latched only on a second reconcile, so the flag stayed
+            // off here.
+            cache.hydrateAllTables();
+            Assert.assertTrue(cache.isCacheComplete());
+            try (MetadataCacheReader ro = cache.readLock()) {
+                Assert.assertEquals(2, ro.getTableCount());
+            }
+        });
+    }
+
+    @Test
     public void testHydrateAllTablesShortCircuitsWhenCacheComplete() throws Exception {
         // hydrateAllTables() backs the tables()/all_tables() startup-race fix, but it
         // must be a no-op once the cache is known complete: from then on writers keep
@@ -1036,12 +1067,17 @@ public class MetadataCacheTest extends AbstractCairoTest {
             final MetadataCache cache = engine.getMetadataCache();
 
             // Start from a warm-but-unlatched state: full cache, cacheComplete=false.
-            // clearCache() empties + unlatches; the first reconcile refills via pass 2
-            // (which never latches), so the cache is complete but the flag is still off.
+            // clearCache() empties + unlatches; we then warm the cache table-by-table via
+            // the point-lookup path (hydrateTableOnDemand never latches cacheComplete), so
+            // the cache holds every table while the flag stays off. A full
+            // hydrateAllTables() reconcile cannot produce this state: once it hydrates
+            // every missing table it latches immediately (under the read lock).
             try (MetadataCacheWriter w = cache.writeLock()) {
                 w.clearCache();
             }
-            cache.hydrateAllTables();
+            for (int i = 0; i < tableCount; i++) {
+                cache.hydrateTableOnDemand(engine.getTableTokenIfExists("t" + i));
+            }
             try (MetadataCacheReader ro = cache.readLock()) {
                 Assert.assertEquals(tableCount, ro.getTableCount());
             }

--- a/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/MetadataCacheTest.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.CairoException;
 import io.questdb.cairo.CairoTable;
 import io.questdb.cairo.MetadataCache;
 import io.questdb.cairo.MetadataCacheReader;
+import io.questdb.cairo.MetadataCacheWriter;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.griffin.SqlException;
@@ -843,6 +844,34 @@ public class MetadataCacheTest extends AbstractCairoTest {
             assertQuery("table_columns('y')")
                     .noLeakCheck()
                     .fails(14, "table does not exist");
+        });
+    }
+
+    @Test
+    public void testHydrateAllTablesShortCircuitsAfterStartup() throws Exception {
+        // hydrateAllTables() backs the tables()/all_tables() startup-race fix, but
+        // it must be a no-op once the one-shot startup hydration has completed:
+        // from then on writers keep the cache current, so a per-query reconcile
+        // would be pure overhead. This pins that fast-path contract.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE a (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE b (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            drainWalQueue();
+
+            // Complete the one-shot startup hydration: fills the cache and flips
+            // MetadataCache into its steady-state fast path.
+            engine.getMetadataCache().onStartupAsyncHydrator();
+
+            // Empty the cache to mimic a missing entry post-startup. Because the
+            // startup pass has completed, hydrateAllTables() must short-circuit
+            // and leave the cache untouched (no reconcile, no repopulation).
+            try (MetadataCacheWriter w = engine.getMetadataCache().writeLock()) {
+                w.clearCache();
+            }
+            engine.getMetadataCache().hydrateAllTables();
+            try (MetadataCacheReader ro = engine.getMetadataCache().readLock()) {
+                Assert.assertEquals(0, ro.getTableCount());
+            }
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/view/ViewsFunctionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/view/ViewsFunctionTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.cairo.view;
 
+import io.questdb.cairo.MetadataCacheWriter;
 import org.junit.Test;
 
 public class ViewsFunctionTest extends AbstractViewTest {
@@ -53,6 +54,37 @@ public class ViewsFunctionTest extends AbstractViewTest {
             createTable(TABLE1);
             final String query = "select ts, v+v doubleV, avg(v) from " + TABLE1 + " sample by 30s";
             execute("create view test as (" + query + ")");
+            assertQuery("show create view test")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .returns("""
+                            ddl
+                            CREATE VIEW 'test' AS (\s
+                            select ts, v+v doubleV, avg(v) from table1 sample by 30s
+                            );
+                            """);
+        });
+    }
+
+    @Test
+    public void testShowCreateViewBeforeStartupHydration() throws Exception {
+        // Regression: SHOW CREATE VIEW resolves the token from the synchronously
+        // loaded table registry but reads the lazily hydrated metadata cache. Plain
+        // views have no _meta file, are skipped by the startup hydrator, and
+        // hydrateTableOnDemand() no-ops on views, so only the async ViewCompilerJob
+        // ever caches them. In the post-restart / embedded window (cache not yet
+        // (re)hydrated) the command must not report a registered view as missing.
+        assertMemoryLeak(() -> {
+            createTable(TABLE1);
+            final String query = "select ts, v+v doubleV, avg(v) from " + TABLE1 + " sample by 30s";
+            execute("create view test as (" + query + ")");
+            drainWalAndViewQueues();
+
+            // Simulate the window: registry knows the view, metadata cache is empty.
+            try (MetadataCacheWriter w = engine.getMetadataCache().writeLock()) {
+                w.clearCache();
+            }
+
             assertQuery("show create view test")
                     .noLeakCheck()
                     .noRandomAccess()

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzAddCoveringIndexOperation.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzAddCoveringIndexOperation.java
@@ -103,7 +103,13 @@ public class FuzzAddCoveringIndexOperation implements FuzzTransactionOperation {
                 if (Chars.contains(e.getMessage(), "already indexed")
                         || Chars.contains(e.getMessage(), "does not exist")
                         || Chars.contains(e.getMessage(), "column is already indexed")
-                        || Chars.contains(e.getMessage(), "table busy")) {
+                        || Chars.contains(e.getMessage(), "table busy")
+                        // The symbol check above is performed against getTableMetadata(), which for WAL
+                        // tables is the lagging applied metadata. The ALTER below is validated against the
+                        // fresh sequencer metadata, so a concurrent drop/re-add (column-name reuse) that
+                        // turned the column into a non-symbol type can legitimately surface here. Tolerate
+                        // it like the other transient races above.
+                        || Chars.contains(e.getMessage(), "indexes are only supported for symbol type")) {
                     return;
                 }
                 if (e instanceof CairoException ce && ce.isTableDropped()) {

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzAddCoveringIndexOperationTest.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzAddCoveringIndexOperationTest.java
@@ -1,0 +1,92 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.fuzz;
+
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.sql.TableMetadata;
+import io.questdb.std.IntList;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+/**
+ * Regression test for the {@link FuzzAddCoveringIndexOperation} flake observed in
+ * ReplicationFuzzTest.testPrimaryMigration (Azure build 241911):
+ * <pre>
+ *   io.questdb.griffin.SqlException: [48] indexes are only supported for symbol type
+ *       [column=new_col_12, type=BYTE]
+ *       at io.questdb.test.fuzz.FuzzAddCoveringIndexOperation.executePostDrain(...)
+ * </pre>
+ *
+ * <p>Root cause: {@code executePostDrain} validates that its target column is a SYMBOL by
+ * reading {@link io.questdb.cairo.CairoEngine#getTableMetadata}, which for WAL tables is the
+ * <b>lagging</b> applied metadata. It then issues an {@code ALTER TABLE ... ADD INDEX} which is
+ * validated against {@code getMetadataForWrite} → {@code getSequencerMetadata}, the <b>fresh</b>
+ * write-side metadata. When the table metadata lags behind a drop/re-add (column-name reuse) that
+ * changed the column from SYMBOL to a non-symbol type, the operation emits an ALTER on a name that
+ * now resolves to a non-symbol column, and the resulting {@code SqlException} is not in its
+ * swallowed-error set — so it propagates and fails the fuzz test.
+ *
+ * <p>This test reproduces the metadata skew deterministically (no fuzz seed, no concurrency) by
+ * issuing the structural change through the sequencer but not draining it to the table. It is RED
+ * against the current operation and should go GREEN once {@code executePostDrain} tolerates the
+ * column no longer being a symbol when resolved at execution time.
+ */
+public class FuzzAddCoveringIndexOperationTest extends AbstractCairoTest {
+
+    @Test
+    public void testExecutePostDrainToleratesStaleSymbolColumnTypeChange() throws Exception {
+        assertMemoryLeak(() -> {
+            final String tableName = "covering_idx_skew";
+
+            // WAL table with a SYMBOL column 's' at index 1 (index 0 is the designated timestamp).
+            execute("create table " + tableName + " (ts timestamp, s symbol) timestamp(ts) partition by day wal");
+            drainWalQueue();
+
+            final TableToken tableToken = engine.verifyTableName(tableName);
+            final int symbolColumnIndex;
+            try (TableMetadata metadata = engine.getTableMetadata(tableToken)) {
+                symbolColumnIndex = metadata.getColumnIndex("s");
+            }
+
+            // Drop 's' (SYMBOL) and re-add 's' as a non-symbol (BYTE) via the sequencer, reusing the name.
+            // Deliberately DO NOT drain the WAL queue: the applied table metadata read by
+            // executePostDrain still reports 's' as SYMBOL at symbolColumnIndex, while the
+            // sequencer metadata that ALTER ... ADD INDEX validates against already sees 's' as BYTE.
+            execute("alter table " + tableName + " drop column s");
+            execute("alter table " + tableName + " add column s byte");
+
+            // INCLUDE the designated timestamp column (index 0) so the covering index SQL is emitted.
+            final IntList includeColumnIndices = new IntList();
+            includeColumnIndices.add(0);
+
+            final FuzzAddCoveringIndexOperation op =
+                    new FuzzAddCoveringIndexOperation(symbolColumnIndex, includeColumnIndices);
+
+            // Must not surface "indexes are only supported for symbol type": the operation has to
+            // be resilient to the target column no longer being a symbol when the ALTER executes.
+            op.executePostDrain(engine, tableName);
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/ParquetRowGroupPruningTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParquetRowGroupPruningTest.java
@@ -27,6 +27,7 @@ package io.questdb.test.griffin;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.CairoTable;
 import io.questdb.cairo.MetadataCacheReader;
+import io.questdb.cairo.MetadataCacheWriter;
 import io.questdb.cairo.TableToken;
 import io.questdb.griffin.engine.table.ParquetRowGroupFilter;
 import io.questdb.test.AbstractCairoTest;
@@ -39,6 +40,56 @@ public class ParquetRowGroupPruningTest extends AbstractCairoTest {
     public void setUp() {
         ParquetRowGroupFilter.resetRowGroupsSkipped();
         super.setUp();
+    }
+
+    @Test
+    public void testRowGroupPruningSurvivesEmptyMetadataCacheWindow() throws Exception {
+        // Regression for the parquet pruning probe
+        // (AbstractPartitionFrameCursorFactory#hasParquetFormatPartitions). The table
+        // token is resolved from the synchronously loaded registry, but the metadata
+        // cache hydrates lazily (async at startup, or after a clearCache()). The probe
+        // must hydrate the table on demand before reading the cache; otherwise it sees
+        // the table as missing, returns false, and row-group pruning is silently skipped
+        // during the hydration window. Pruning is an optimization, not a correctness
+        // feature, so the regression does NOT change query results - it can only be
+        // caught by asserting on the pruning signal (rowGroupsSkipped).
+        setProperty(PropertyKey.CAIRO_PARTITION_ENCODER_PARQUET_ROW_GROUP_SIZE, 100);
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE x (val INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO x
+                    SELECT CAST(x AS INT), timestamp_sequence('2024-01-01', 100_000)
+                    FROM long_sequence(5000)
+                    """);
+            // Second partition makes 2024-01-01 a non-active partition so it converts.
+            execute("""
+                    INSERT INTO x VALUES
+                    (8000, '2024-01-02T02:00:00.000000Z')
+                    """);
+            execute("ALTER TABLE x CONVERT PARTITION TO PARQUET WHERE ts >= 0 WITH (bloom_filter_columns = 'val')");
+
+            // Reproduce the registered-but-not-yet-cached window: evict the table from
+            // the metadata cache so the query below is the first reader to need it.
+            try (MetadataCacheWriter metadataRW = engine.getMetadataCache().writeLock()) {
+                metadataRW.clearCache();
+            }
+            // Precondition: the table really is absent from the cache. getTable() reads
+            // the map without hydrating, so it stays null until the pruning probe
+            // hydrates on demand.
+            final TableToken token = engine.getTableTokenIfExists("x");
+            try (MetadataCacheReader metadataRO = engine.getMetadataCache().readLock()) {
+                Assert.assertNull(metadataRO.getTable(token));
+            }
+
+            // The filtered query must still skip row groups: hasParquetFormatPartitions()
+            // hydrates the table on demand, so pruning is applied even though the cache
+            // started empty. Without the on-demand hydrate this assertion fails (0 skipped).
+            ParquetRowGroupFilter.resetRowGroupsSkipped();
+            assertQuery("SELECT val FROM x WHERE val = -991 ORDER BY ts DESC")
+                    .noLeakCheck()
+                    .returns("val\n");
+            Assert.assertTrue(ParquetRowGroupFilter.getRowGroupsSkipped() > 1);
+        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/ShowCreateTableTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ShowCreateTableTest.java
@@ -252,6 +252,48 @@ public class ShowCreateTableTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testShowCreateMatViewBeforeStartupHydration() throws Exception {
+        // Regression (M3): SHOW CREATE MATERIALIZED VIEW resolves the token from the
+        // synchronously loaded registry but reads the lazily hydrated metadata cache.
+        // In the post-restart window (cache not yet hydrated) it must hydrate the matview
+        // on demand rather than report a registered matview as non-existent.
+        assertMemoryLeak(() -> {
+            execute("create table base (ts timestamp, v double) timestamp(ts) partition by day wal");
+            execute("create materialized view base_1h as (select ts, max(v) from base sample by 1h) partition by week");
+            drainWalAndViewQueues();
+
+            // Simulate the window: registry knows the matview, metadata cache is empty.
+            try (MetadataCacheWriter w = engine.getMetadataCache().writeLock()) {
+                w.clearCache();
+            }
+
+            printSql("show create materialized view base_1h");
+            TestUtils.assertContains(sink.toString(), "CREATE MATERIALIZED VIEW 'base_1h'");
+        });
+    }
+
+    @Test
+    public void testShowCreateTableBeforeStartupHydration() throws Exception {
+        // Regression (M3): SHOW CREATE TABLE resolves the token from the synchronously
+        // loaded registry but reads the lazily hydrated metadata cache. In the
+        // post-restart window (or for an embedded engine before any catalogue query has
+        // warmed the cache) the table is not cached yet, and the command used to report
+        // a registered table as non-existent. It must hydrate the table on demand.
+        assertMemoryLeak(() -> {
+            execute("create table foo (ts timestamp, a int) timestamp(ts) partition by day wal");
+            drainWalQueue();
+
+            // Simulate the window: registry knows the table, metadata cache is empty.
+            try (MetadataCacheWriter w = engine.getMetadataCache().writeLock()) {
+                w.clearCache();
+            }
+
+            printSql("show create table foo");
+            TestUtils.assertContains(sink.toString(), "CREATE TABLE 'foo'");
+        });
+    }
+
+    @Test
     public void testMissingNameReportsDoesNotExist() throws Exception {
         // the existence check must run before the view/matview check, so an unknown
         // name reports "does not exist" rather than the "got view" message

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/InformationSchemaColumnsFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/InformationSchemaColumnsFunctionFactoryTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin.engine.functions.catalogue;
 
+import io.questdb.cairo.MetadataCacheWriter;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Test;
 
@@ -50,6 +51,39 @@ public class InformationSchemaColumnsFunctionFactoryTest extends AbstractCairoTe
                             qdb\tpublic\tC\tcol0\t0\t\tyes\tdouble precision
                             qdb\tpublic\tC\tcol1\t1\t\tyes\tcharacter
                             qdb\tpublic\tC\tcol2\t2\t\tyes\tsmallint
+                            """);
+        });
+    }
+
+    @Test
+    public void testColumnsCompleteBeforeStartupHydration() throws Exception {
+        // Regression for the startup-hydration race shared with tables()/all_tables():
+        // information_schema.columns() (and the pg_catalog.pg_attribute it backs)
+        // snapshot MetadataCache, which the background onStartupAsyncHydrator() fills
+        // lazily. A query in the post-restart / post-backup-restore pre-hydration
+        // window used to omit tables and their columns, which breaks PostgreSQL
+        // driver introspection (the pg_class -> pg_attribute join renders existing
+        // tables with zero columns). getCursor() must reconcile first.
+        assertMemoryLeak(() -> {
+            execute("create table A(col0 int, col1 symbol)");
+            execute("create table B(col0 long, col1 string)");
+            drainWalQueue();
+
+            // Simulate the pre-hydration window: the registry knows the tables, but
+            // the metadata cache is empty (async hydrator has not run).
+            try (MetadataCacheWriter w = engine.getMetadataCache().writeLock()) {
+                w.clearCache();
+            }
+
+            assertQuery("SELECT table_name, column_name FROM information_schema.columns() ORDER BY table_name, column_name")
+                    .noLeakCheck()
+                    .ddl(null)
+                    .returns("""
+                            table_name	column_name
+                            A	col0
+                            A	col1
+                            B	col0
+                            B	col1
                             """);
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/TablesFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/catalogue/TablesFunctionFactoryTest.java
@@ -27,6 +27,7 @@ package io.questdb.test.griffin.engine.functions.catalogue;
 import io.questdb.PropertyKey;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.ErrorTag;
+import io.questdb.cairo.MetadataCacheWriter;
 import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.pool.RecentWriteTracker;
@@ -42,6 +43,52 @@ import org.junit.Test;
 import static io.questdb.cairo.TableUtils.META_FILE_NAME;
 
 public class TablesFunctionFactoryTest extends AbstractCairoTest {
+    @Test
+    public void testCatalogueIsCompleteBeforeStartupHydration() throws Exception {
+        // Regression: tables() and all_tables() snapshot the MetadataCache, which is
+        // populated lazily by the background onStartupAsyncHydrator(). A catalogue
+        // query that runs before hydration completes (e.g. right after a restart or a
+        // backup restore) used to observe an empty/partial list and silently miss
+        // tables. The catalogue functions must reconcile against the table registry
+        // and hydrate on demand so they always return the complete set.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE alpha (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE bravo (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE charlie (ts TIMESTAMP, x INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            drainWalQueue();
+
+            // Simulate the post-restart window before the async hydrator has run:
+            // the registry knows the tables, but the metadata cache is empty.
+            try (MetadataCacheWriter w = engine.getMetadataCache().writeLock()) {
+                w.clearCache();
+            }
+
+            // tables() must still return every table without onStartupAsyncHydrator().
+            assertQuery("select table_name from tables() order by table_name")
+                    .noLeakCheck()
+                    .expectSize()
+                    .returns("""
+                            table_name
+                            alpha
+                            bravo
+                            charlie
+                            """);
+
+            // Clear again and verify the sibling all_tables() function too.
+            try (MetadataCacheWriter w = engine.getMetadataCache().writeLock()) {
+                w.clearCache();
+            }
+            assertQuery("select table_name from all_tables() order by table_name")
+                    .noLeakCheck()
+                    .returns("""
+                            table_name
+                            alpha
+                            bravo
+                            charlie
+                            """);
+        });
+    }
+
     @Test
     public void testMemoryPressureColumn() throws Exception {
         assertMemoryLeak(() -> {


### PR DESCRIPTION
This PR carries two code fixes that both surfaced from CI on this branch, plus a small documentation change. Each is in its own clearly-labeled section below.

---

# 1. fix(core): complete catalogue & metadata lookups during startup hydration

## Problem

The catalogue functions return a `snapshot()` of `MetadataCache`. That cache is populated **lazily on a background thread** by `MetadataCache.onStartupAsyncHydrator()`. A catalogue query that runs *before* hydration finishes — right after a restart, or after a backup restore brings a server up — observes an **empty or partial** table list and silently misses tables (and their columns).

This was caught by the enterprise cross-repo CI for this PR: `BackupTest.testFailedRestoreParallelTaskFailure` ran `select table_name from tables` on a freshly-started server and got an empty result because the query beat the async hydrator by a few milliseconds (`metadata hydration completed` was logged ~6 ms *after* the query executed).

## Root cause

`MetadataCacheReader.snapshot()` only copies tables already present in the cache's `tableMap`. The startup hydrator fills that map entry-by-entry on a background thread, so until it completes the snapshot is incomplete. The catalogue functions did no on-demand reconciliation against the authoritative table registry.

## Fix — catalogue enumerators (`tables` / `all_tables` / `columns` / `pg_attribute`)

- Add `MetadataCache.hydrateAllTables()`: reconciles the cache against the table registry (`engine.getTableTokens`) and hydrates any missing tables on demand. Under a single read lock it collects tables that exist in the registry but are missing from the cache, then hydrates them with a per-table write lock (matching `onStartupAsyncHydrator`). Views are skipped (no `_meta`).
- Call it before snapshotting in **all four** `snapshot()` callers — `tables()`, `all_tables()`, `information_schema.columns()`, and `pg_catalog.pg_attribute` — which via cursor-factory reuse also covers `pg_attribute`'s prefixed variant and `information_schema.questdb_columns`.

## Fix — point-lookup paths (`SHOW COLUMNS` / `SHOW CREATE TABLE` / `SHOW CREATE MATERIALIZED VIEW` / parquet pruning)

The same root cause hits single-table lookups that resolve a `TableToken` from the synchronously-loaded registry but then read the lazily-hydrated cache.

- Add `MetadataCache.hydrateTableOnDemand(token)`, the point-lookup analogue of `hydrateAllTables()`: if the cache is not yet complete and the one table is missing, hydrate just that table under a write lock (best-effort; a per-table failure is swallowed so the caller reports it missing rather than failing hard).
- Wire it into the paths that resolve-then-read: `SHOW COLUMNS` (`ShowColumnsRecordCursorFactory`), `SHOW CREATE TABLE` (`ShowCreateTableRecordCursorFactory`), `SHOW CREATE MATERIALIZED VIEW` (`ShowCreateMatViewRecordCursorFactory`), and the parquet row-group-pruning probe `AbstractPartitionFrameCursorFactory.hasParquetFormatPartitions()`.
- Without this, during the hydration window those paths would report a registered table/matview as **non-existent**, or — for parquet — silently **skip row-group pruning** (a correctness-neutral but performance-relevant regression).

## Reconcile machinery: `cacheComplete` latch & concurrency

- `hydrateAllTables()`/`hydrateTableOnDemand()` short-circuit on a single volatile `cacheComplete` flag, so once the cache is known complete they add no per-query work. The flag is latched when a reconcile observes every registered table present, when the startup hydrator finishes hydrating every table, or when the give-up budget below is exhausted; it is reset by `clearCache()` (checkpoint/restore, tests).
- **Mutual exclusion with `clearCache()`:** the completeness latch is published under the read lock that observed the cache as complete, so it cannot interleave with `clearCache()` (write lock) and leave an emptied cache marked complete. Pinned by `MetadataCacheTest.testCompletenessLatchIsMutuallyExclusiveWithClearCache` and a concurrent stress test.
- **Same-pass latch:** when a reconcile hydrates the last missing table it latches `cacheComplete` in that same pass (re-checking the token snapshot it already collected, under the read lock) instead of leaving the flag off and forcing the next catalogue query to run a second, redundant full reconcile just to observe "nothing missing".

## Give-up budget and its tradeoff

A table whose `_meta` cannot be read (genuinely corrupt, or transiently unavailable at startup) never lands in the cache and so always looks "missing"; without a cap it would be re-read — and logged `CRITICAL` — on **every** catalogue query forever.

- `MAX_INCOMPLETE_RECONCILE_PASSES = 8`: after that many **consecutive zero-progress** reconcile rounds, `hydrateAllTables()` gives up and latches `cacheComplete` anyway.
- **Tradeoff:** a genuinely unhydratable table is then **hidden from the catalogue** until a writer touches it (`registerName`/`hydrateTable` re-hydrate it) or the next `clearCache()`/restart. This matches `master`'s worst case — `master` never reconciles, so such a table is hidden there too — in exchange for bounded work and log output.
- The budget counts **only zero-progress rounds**: any round that hydrates ≥1 previously-missing table resets it, so a post-restart introspection storm making incremental progress (e.g. catalogue queries racing the startup hydrator) cannot exhaust it in a burst.

## Native memory hygiene

The reconcile / on-demand paths hydrate on the **caller's** thread, acquiring a thread-local `Path` (`NATIVE_PATH_THREAD_LOCAL`). They release it via `Path.clearThreadLocals()` after hydrating — mirroring `onStartupAsyncHydrator()` — so a short-lived (non-pooled) caller thread does not leak the native buffer. (CI caught the leak via `ViewCompilerJobTest.testConcurrentEventProcessing`'s memory-leak assertion, which spawns and joins worker threads that hit these paths.)

## Steady-state cost

The reconcile is only needed while the one-shot startup hydration is in flight. Once it completes, writers keep the cache in sync incrementally, so `hydrateAllTables()` short-circuits on a single volatile flag — no allocation, no lock, the `snapshot()` version fast-path is untouched. If the startup pass aborts abnormally the flag stays unset and the reconcile keeps running as a self-healing fallback.

## Impact (Postgres Wire)

The column enumerators are the higher-impact path: PostgreSQL drivers and BI tools query them automatically on connect. `pg_class` enumerates tables straight from the registry, so during the window `pg_class` is complete while `pg_attribute` is not — the standard `pg_class -> pg_attribute` introspection join would render existing tables with zero columns, breaking driver schema views and autocomplete right after a restart.

## Regression tests

Catalogue enumerators:
- `TablesFunctionFactoryTest.testCatalogueIsCompleteBeforeStartupHydration` — `tables()` / `all_tables()` return the complete set in the pre-hydration window.
- `InformationSchemaColumnsFunctionFactoryTest.testColumnsCompleteBeforeStartupHydration` — same for `information_schema.columns()` (which also backs `pg_attribute`); verified it fails with a partial column list when the reconcile is removed.

Point-lookup paths:
- `MetadataCacheTest.testShowColumnsBeforeStartupHydration`, `MetadataCacheTest.testHydrateTableOnDemandPopulatesMissingTable`.
- `ShowCreateTableTest.testShowCreateTableBeforeStartupHydration`, `ShowCreateTableTest.testShowCreateMatViewBeforeStartupHydration` (materialized view).
- `ParquetRowGroupPruningTest.testRowGroupPruningSurvivesEmptyMetadataCacheWindow` — evicts the table from the cache, then asserts a filtered query still skips row groups (pruning is applied via on-demand hydrate).

Reconcile machinery / latch / budget:
- `MetadataCacheTest.testHydrateAllTablesShortCircuitsWhenCacheComplete` — pins the steady-state fast path (no-op once complete, even if the cache was cleared).
- `MetadataCacheTest.testReconcileLatchesCompleteAfterHydratingMissingTables` — one reconcile both hydrates and latches (no redundant second pass).
- `MetadataCacheTest.testReconcileBudgetCountsOnlyZeroProgressRounds` — progress rounds do not consume the give-up budget.
- `MetadataCacheTest.testReconcileGivesUpAfterRepeatedHydrationFailures` — give up after `MAX_INCOMPLETE_RECONCILE_PASSES` zero-progress rounds.
- `MetadataCacheTest.testStartupHydratorDoesNotLatchCompleteWhenATableFailsToHydrate`, `testCompletenessLatchIsMutuallyExclusiveWithClearCache`, `testConcurrentReconcileAndClearCacheNeverMarksEmptyCacheComplete` — never latch over an incomplete/emptied cache.

---

# 2. test(core): fix flaky covering-index fuzz op on stale WAL metadata

## Problem

`ReplicationFuzzTest.testPrimaryMigration` (and other fuzz tests that enable `addCoveringIndexProb`) intermittently fail with:

```
java.lang.RuntimeException: io.questdb.griffin.SqlException:
  [48] indexes are only supported for symbol type [column=new_col_12, type=BYTE]
    at io.questdb.test.fuzz.FuzzAddCoveringIndexOperation.executePostDrain(FuzzAddCoveringIndexOperation.java:112)
    at io.questdb.test.cairo.fuzz.FuzzRunner.executeCoveringIndexOps(FuzzRunner.java:1211)
Caused by: io.questdb.griffin.SqlException: [48] indexes are only supported for symbol type [column=new_col_12, type=BYTE]
    at io.questdb.griffin.SqlCompilerImpl.alterTableColumnAddIndex(SqlCompilerImpl.java:1176)
```

The SQL engine is behaving correctly here — you genuinely cannot index a non-symbol column. The bug is in the fuzz operation.

## Root cause

`FuzzAddCoveringIndexOperation.executePostDrain`:

1. reads `CairoEngine.getTableMetadata()` and validates the target column **by index** is a `SYMBOL`, then takes that column's **name**;
2. issues `ALTER TABLE ... ALTER COLUMN "<name>" ADD INDEX TYPE POSTING INCLUDE (...)`.

For WAL tables these two reads can see **different metadata versions**:

- `getTableMetadata()` is, by its own contract, the **lagging applied** metadata (not all WAL transactions have necessarily reached the table yet).
- `ALTER ... ADD INDEX` validates against `SqlExecutionContext.getMetadataForWrite()` → `getLegacyMetadata()` → `getSequencerMetadata()`, i.e. the **fresh** write-side metadata.

When the workload recycles a column name (drop a `SYMBOL` column / rename so a name is reused by a non-symbol column), the operation can observe the name as `SYMBOL` in the lagging metadata while the name already resolves to a non-symbol (e.g. `BYTE`) column in the sequencer metadata. The emitted `ALTER` then fails, and `"indexes are only supported for symbol type"` was **not** in the operation's swallowed-error set, so it propagated and failed the test.

This was seen on a CI run where the fuzz workload heavily renamed columns, recycling the name `new_col_12` onto a `BYTE` column before the covering-index op ran.

## Fix

Tolerate this transient metadata skew, consistent with the other races the operation already swallows (`already indexed` / `does not exist` / `table busy` / dropped table). Skipping the operation under this race is the established pattern for the fuzz infrastructure.

## Regression test

Added `FuzzAddCoveringIndexOperationTest` which reproduces the skew **deterministically** — no fuzz seed, no servers, no concurrency (~1s): create a WAL table with a `SYMBOL` column, drop + re-add it as `BYTE` through the sequencer **without draining**, then invoke `executePostDrain`. The applied metadata still reports the column as `SYMBOL` while the sequencer metadata sees `BYTE`, reproducing the exact failure.

- Before the fix: test errors with the exact CI exception (`executePostDrain:112` → `alterTableColumnAddIndex:1176`).
- After the fix: `Tests run: 1, Failures: 0, Errors: 0`.

---

# 3. docs: PR-bundling workflow guidance (`CLAUDE.md`)

Documentation-only; no code impact. Adds guidance to `CLAUDE.md` to bundle related fixes onto one branch/PR (CI is the throughput bottleneck, and the squash-merge collapses the branch into one `master` commit anyway), to give each fix its own clearly-labeled section in the PR body, and how to update a PR's branch/metadata when asked to "send a change to PR #N". Kept on this branch deliberately: it is small, merges/reverts with no code coupling, and it codifies the very multi-fix workflow this PR follows.
