### PR TITLE
fix(sql): fix internal error when a dotted name follows an operator

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -2013,10 +2013,17 @@ public class ExpressionParser {
                                 cse.put(en.token).put(GenericLexer.unquoteIfNoDots(tok));
                                 opStack.push(expressionNodePool.next().of(
                                         ExpressionNode.LITERAL, cse.toImmutable(), Integer.MIN_VALUE, en.position));
-                            } else {
+                            } else if (en.token instanceof GenericLexer.FloatingSequence) {
                                 final GenericLexer.FloatingSequence fsA = (GenericLexer.FloatingSequence) en.token;
                                 // vanilla 'a.b', just concat tokens efficiently
                                 fsA.setHi(lexer.getTokenHi());
+                            } else {
+                                // 'en' is not a valid qualifier for a dotted name. This happens for
+                                // malformed input such as "tables()/.env", where the top of the stack
+                                // is a pending operator ('/') rather than an identifier. Reject it
+                                // cleanly instead of letting the cast above fail with an internal
+                                // ClassCastException (which would surface as a 500/critical error).
+                                throw SqlException.$(lastPos, "'.' is unexpected here");
                             }
                         } else if (prevBranch == BRANCH_DOT_DEREFERENCE) {
                             argStackDepth++;

--- a/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
@@ -901,6 +901,18 @@ public class ExpressionParserTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testDottedNameAfterOperatorFailsCleanly() {
+        // A dotted name whose qualifier is a pending operator (not an identifier) used to
+        // blow up with an internal ClassCastException, e.g. the demo-box scanner probes
+        // "tables()/.env" and "tables()/.git/HEAD" (parsed as the division tables() / .env).
+        // It must now fail with a clean SqlException instead.
+        assertFail("tables()/.env", 10, "'.' is unexpected here");
+        assertFail("tables()/.git/HEAD", 10, "'.' is unexpected here");
+        assertFail("tables() / .env", 12, "'.' is unexpected here");
+        assertFail("1/.env", 3, "'.' is unexpected here");
+    }
+
+    @Test
     public void testDotDereferenceFunction() throws SqlException {
         x("a.b 1 2 3 f .", "(a.b).f(1,2,3)");
     }


### PR DESCRIPTION
## Problem

Our demo box was being probed by vulnerability scanners with requests like:

```
tables()/.env
tables()/.git/HEAD
```

These are sent to `/exec?query=...` and reach the SQL compiler. `tables()/.env` is **not** a path lookup — the parser reads it as the division expression `tables() / .env` in the FROM clause.

While building the AST, the expression parser handles the `.env` dotted name by peeking the operator stack and casting the qualifier node's token to `GenericLexer.FloatingSequence`:

```java
final GenericLexer.FloatingSequence fsA = (GenericLexer.FloatingSequence) en.token;
```

When the stack top is a **pending operator** (`/`), its token is a plain `java.lang.String`, so the unchecked cast throws a raw **`ClassCastException`** instead of a `SqlException`. The result is that a malformed scanner probe surfaces as an **internal/critical error** (500-class, stack-traced in the logs) rather than an ordinary "bad query" `400`.

Reproduced directly against the compiler:

| query | before | after |
|---|---|---|
| `tables()/.env` | `ClassCastException` | `SqlException: '.' is unexpected here` |
| `tables()/.git/HEAD` | `ClassCastException` | `SqlException: '.' is unexpected here` |
| `tables() / .env` | `ClassCastException` | `SqlException: '.' is unexpected here` |
| `select 1/.env from long_sequence(1)` | `ClassCastException` | `SqlException: '.' is unexpected here` |

(The crash-vs-clean behavior even varied with pooled parser state across queries, which is why some variants happened to look fine.)

## Fix

`ExpressionParser` — guard the fast-path concat so it only runs when the qualifier token is actually a `FloatingSequence`; otherwise reject cleanly with `'.' is unexpected here`. This is general: it fixes **every** malformed `<expr> / .name` shape, not just the specific names scanners use.

## Tests

- New regression test `ExpressionParserTest#testDottedNameAfterOperatorFailsCleanly`. It fails with the original `ClassCastException` when the fix is reverted (verified), and passes with the fix.
- Full parser suites green: `ExpressionParserTest` (296), `SqlParserTest` (1081), `ExpressionParserFuzzTest`, `SqlParserUpdateTest` — **1410 tests, 0 failures**.
- Valid dotted names are unaffected: `(a.b).c`, `"x".y`, `tables().f(...)`, qualified columns/tables, etc.
