### PR TITLE
test(core): fix data race in concurrent ParallelGroupByFuzzTest tests

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/fuzz/ParallelGroupByFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/ParallelGroupByFuzzTest.java
@@ -2596,9 +2596,12 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                         final int threadId = i;
                         new Thread(() -> {
                             TestUtils.await(barrier);
-                            try {
+                            // SqlExecutionContext is not thread-safe: its compilation state (e.g.
+                            // timestampRequiredStack) is mutated during code generation, so each
+                            // worker thread must run with its own execution context.
+                            try (SqlExecutionContext threadContext = TestUtils.createSqlExecutionCtx(engine, pool.getWorkerCount())) {
                                 for (int j = 0; j < numOfIterations; j++) {
-                                    assertQueries(engine, sqlExecutionContext, query, expected);
+                                    assertQueries(engine, threadContext, query, expected);
                                 }
                             } catch (Throwable th) {
                                 th.printStackTrace(System.out);
@@ -3770,9 +3773,12 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                         final int threadId = i;
                         new Thread(() -> {
                             TestUtils.await(barrier);
-                            try {
+                            // SqlExecutionContext is not thread-safe: its compilation state (e.g.
+                            // timestampRequiredStack) is mutated during code generation, so each
+                            // worker thread must run with its own execution context.
+                            try (SqlExecutionContext threadContext = TestUtils.createSqlExecutionCtx(engine, pool.getWorkerCount())) {
                                 for (int j = 0; j < numOfIterations; j++) {
-                                    assertQueries(engine, sqlExecutionContext, query, expected);
+                                    assertQueries(engine, threadContext, query, expected);
                                 }
                             } catch (Throwable th) {
                                 th.printStackTrace(System.out);
@@ -3833,10 +3839,11 @@ public class ParallelGroupByFuzzTest extends AbstractCairoTest {
                         final int threadId = i;
                         new Thread(() -> {
                             TestUtils.await(barrier);
-                            // We expect an NPE (work stealing) or a CairoException (NPE caught by a worker)
-                            try {
+                            // We expect an NPE (work stealing) or a CairoException (NPE caught by a worker).
+                            // SqlExecutionContext is not thread-safe, so each worker uses its own context.
+                            try (SqlExecutionContext threadContext = TestUtils.createSqlExecutionCtx(engine, pool.getWorkerCount())) {
                                 for (int j = 0; j < numOfIterations; j++) {
-                                    assertCairoException(engine, sqlExecutionContext);
+                                    assertCairoException(engine, threadContext);
                                 }
                             } catch (NullPointerException npe) {
                                 // NPE is expected


### PR DESCRIPTION
## Problem

The scheduled **Fuzz Tests** build intermittently fails in
`ParallelGroupByFuzzTest.testParallelStringKeyGroupByConcurrent` with:

```
java.lang.AssertionError: Error in threads
  at ParallelGroupByFuzzTest.testParallelStringKeyGroupByConcurrent(...:3795)
```

The underlying (per-worker) exception is:

```
java.lang.AssertionError
  at io.questdb.std.IntStack.doubleCapacity(IntStack.java:144)   // assert head == tail
  at io.questdb.std.IntStack.push(IntStack.java:112)
  at io.questdb.griffin.SqlExecutionContextImpl.pushTimestampRequiredFlag(SqlExecutionContextImpl.java:428)
  at io.questdb.griffin.SqlCodeGenerator.generateQuery0Inner(SqlCodeGenerator.java:7731)
  ... compiling: SELECT key, avg + sum from (SELECT key, avg(value), sum(colTop) FROM tab) ORDER BY key
```

## Root cause

These concurrent tests spawn 8 worker threads that **all share the single
`SqlExecutionContext`** passed into the `TestUtils.execute` lambda.

`SqlExecutionContext` is not thread-safe. During code generation the compiler
mutates per-context state — in particular the `timestampRequiredStack` (an
`IntStack`) via `pushTimestampRequiredFlag`/`popTimestampRequiredFlag`, which is
exercised here because the query has a nested `ORDER BY`. With several threads
compiling the same query at once, their `push()`/`pop()` calls race on the
stack's `head`/`tail`. `push()` calls `doubleCapacity()` exactly when
`head == tail`, and `doubleCapacity()` re-asserts `assert head == tail`; that
assertion is always true single-threaded, so it can **only** fail when another
thread mutates the stack in between — i.e. a data race.

This is a test-harness concurrency bug, not a product bug: the execution context
is a per-connection object and must not be shared across concurrently-compiling
threads. It is timing/seed-dependent because the fuzz `Rnd` drives the
configuration (parquet conversion, page-frame/shard/queue sizes, batch size,
etc.), which changes thread scheduling and the size of the race window.

## Fix

Give each worker thread its **own** `SqlExecutionContext`, created via
`TestUtils.createSqlExecutionCtx(engine, pool.getWorkerCount())` and auto-closed
with try-with-resources. No compilation state is shared across threads anymore.
The worker count matches the context the tests used before, so parallel GROUP BY
behaviour is unchanged.

Applied to all three tests that shared the same buggy pattern:
- `testParallelStringKeyGroupByConcurrent` (the failing one)
- `testParallelNonKeyedGroupByConcurrent`
- `testParallelStringKeyGroupByConcurrentNpeInReduce`

## Testing

- `core` test module compiles cleanly.
- The three affected tests pass (`Tests run: 3, Failures: 0`).
- Ran `testParallelStringKeyGroupByConcurrent` 5× under the failing run's frozen
  seed `(10671960832754732L, 1781343725232L)` → all pass.

Note: the race is timing/hardware-dependent and does not reliably reproduce
locally even with the frozen seed, so the fix is justified by construction
(it removes the shared mutable state the race operates on) rather than by a
local red→green reproduction.

Test-only change; no production code touched.