### PR TITLE
build: bump questdb-client to released 1.3.4

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -117,7 +117,7 @@
           -->
         <uberjar.name>benchmarks</uberjar.name>
 
-        <questdb.client.version>1.3.2</questdb.client.version>
+        <questdb.client.version>1.3.4</questdb.client.version>
     </properties>
 
     <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -45,7 +45,7 @@
         -->
         <qdbr.rustflags>-D warnings</qdbr.rustflags>
 
-        <questdb.client.version>1.3.3-SNAPSHOT</questdb.client.version>
+        <questdb.client.version>1.3.4</questdb.client.version>
     </properties>
 
     <version>9.4.3-SNAPSHOT</version>
@@ -236,7 +236,7 @@
         <profile>
             <id>local-client</id>
             <properties>
-                <questdb.client.version>1.3.3-SNAPSHOT</questdb.client.version>
+                <questdb.client.version>1.3.4</questdb.client.version>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
                 <module>java-questdb-client</module>
             </modules>
             <properties>
-                <questdb.client.version>1.3.3-SNAPSHOT</questdb.client.version>
+                <questdb.client.version>1.3.4</questdb.client.version>
             </properties>
         </profile>
     </profiles>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -40,7 +40,7 @@
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
 
-        <questdb.client.version>1.3.2</questdb.client.version>
+        <questdb.client.version>1.3.4</questdb.client.version>
     </properties>
 
     <dependencies>
@@ -144,7 +144,7 @@
         <profile>
             <id>local-client</id>
             <properties>
-                <questdb.client.version>1.3.2</questdb.client.version>
+                <questdb.client.version>1.3.4</questdb.client.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
## What

Move all `questdb-client` (java-questdb-client) references to the released **1.3.4** — currently the latest/release version on Maven Central.

Previously the OSS modules pointed at a mix of snapshot and older releases:

| Module | Before | After |
| --- | --- | --- |
| `core` | `1.3.3-SNAPSHOT` | `1.3.4` |
| `utils` | `1.3.2` | `1.3.4` |
| `benchmarks` | `1.3.2` | `1.3.4` |
| `local-client` profile (root + core) | `1.3.3-SNAPSHOT` | `1.3.4` |

## Why

- Stop depending on snapshot artifacts for the ILP client.
- Align every module on a single, released client version.

## Notes

- `1.3.4` is published on Maven Central (`org.questdb:questdb-client:1.3.4`), so the default build resolves it without the `local-client` profile.
- The `java-questdb-client` submodule pointer is intentionally **not** changed.

## Verification

`mvn -B package -DskipTests` builds successfully; the shaded jars now include `questdb-client-1.3.4.jar`.
