### PR TITLE
fix(core): regenerate _pm when restored data.parquet exceeds the committed size

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
+++ b/core/src/main/java/io/questdb/cairo/TableSnapshotRestore.java
@@ -699,21 +699,36 @@ public class TableSnapshotRestore implements QuietCloseable {
 
             tablePath.trimTo(partitionDirLen).concat(TableUtils.PARQUET_METADATA_FILE_NAME).$();
             if (ff.exists(tablePath.$())) {
-                if (isParquetMetaResolvable(tablePath, parquetFileSize)) {
+                // Trust an existing _pm only when data.parquet is EXACTLY the
+                // committed size. When the file is longer (onDiskSize >
+                // parquetFileSize), the snapshot captured the partition mid in-place
+                // O3 rewrite: a later generation appended row groups and a new
+                // footer past the committed point and rewrote _pm to describe that
+                // later generation, while _txn still records the earlier committed
+                // size. resolveFooter() can still resolve a footer at the committed
+                // size, so the stale sidecar would be silently kept and then
+                // mis-read at the committed size -- a column chunk of the later
+                // generation lies past parquetFileSize, surfacing as
+                // "File out of specification" on the first merge/read and suspending
+                // a replica that replays over the restored partition. Regenerate
+                // from data.parquet at the committed size, which the size check
+                // above has already validated.
+                if (onDiskSize == parquetFileSize && isParquetMetaResolvable(tablePath, parquetFileSize)) {
                     tablePath.trimTo(plen);
                     continue;
                 }
                 // The sidecar does not resolve a footer at the committed parquet
-                // size: a stale _pm paired with an in-place regenerated
-                // data.parquet, a torn copy, or a partial file left by a crashed
-                // restore. Trusting it would defer the failure to the first read
-                // of the partition, so remove it and regenerate from
-                // data.parquet, which the committed-size check above has already
-                // validated.
+                // size, or data.parquet is longer than the committed size (a stale
+                // _pm paired with an in-place regenerated data.parquet, a torn
+                // copy, or a partial file left by a crashed restore). Trusting it
+                // would defer the failure to the first read of the partition, so
+                // remove it and regenerate from data.parquet, which the
+                // committed-size check above has already validated.
                 if (!ff.removeQuiet(tablePath.$())) {
                     throw CairoException.critical(ff.errno()).put("cannot remove unresolvable _pm file [path=").put(tablePath).put(']');
                 }
-                LOG.info().$("removed unresolvable _pm of restored parquet partition for regeneration [path=").$(tablePath).I$();
+                LOG.info().$("removed stale/unresolvable _pm of restored parquet partition for regeneration [path=").$(tablePath)
+                        .$(", committed=").$(parquetFileSize).$(", onDisk=").$(onDiskSize).I$();
             }
 
             tablePath.trimTo(partitionDirLen).concat(TableUtils.PARQUET_PARTITION_NAME).$();


### PR DESCRIPTION
**Tandem PR:** https://github.com/questdb/questdb-enterprise/pull/1072 (Enterprise) — must merge together.

## Summary

A snapshot/checkpoint can capture a parquet partition whose on-disk `data.parquet`
is a **later generation** than the committed parquet size recorded in `_txn`. The
restore path trusted the partition's existing `_pm` sidecar in that state and left
it stale, so the first read/merge after restore decodes a column chunk that lies
past the committed size:

```
CairoException: error in ParquetPartitionDecoder.decodeRowGroup:
File out of specification: Column chunk range N..M exceeds data length N
```

On a replica that replays the WAL over the restored partition this is fatal: the
`ApplyWal2TableJob` apply fails and the table is **suspended**, breaking
replication. This is the failure seen in the enterprise
`ReplicationFuzzTest.testFuzzWithSnapshotDroppedTableReplica`.

## How a snapshot captures a torn partition

An in-place O3 update of a parquet partition (`partitionMutates=false`) grows
`data.parquet`/`_pm` to a new generation and only then advances the committed
parquet size in `_txn`. The data write and the `_txn` commit live in separate
files and cannot commit atomically, so a checkpoint that lands in between captures
`data.parquet` at the later generation (size `M`) paired with `_txn` still at the
earlier committed size `N` (`N < M`). For a replica the window is wider still: the
snapshot carries the earlier committed `_txn` while the replica's sequencer is
already ahead, so it **replays** the O3 update over the restored partition.

## Root cause

`TableSnapshotRestore.generateMissingParquetMetaFiles` validates `data.parquet`
against the committed size, then decides whether to trust the existing `_pm`:

```java
if (isParquetMetaResolvable(tablePath, parquetFileSize)) { continue; }
```

`isParquetMetaResolvable` only checks that the sidecar **resolves a footer** at the
committed size. A `_pm` from the later generation still resolves a footer at the
committed head, so the stale sidecar was kept — and then mis-read at the committed
size, where a later-generation column chunk lies past it. The existing guard
already rejects an *undersized* `data.parquet` (`onDiskSize < committed`); it had
no symmetric handling for an *oversized* one (`onDiskSize > committed`), which is
exactly the torn snapshot.

## The change

Only trust an existing `_pm` when `data.parquet` is **exactly** the committed size.
When the file is longer (`onDiskSize > parquetFileSize` — the snapshot captured the
partition mid in-place rewrite), regenerate `_pm` from the committed size, which
the size check above has already validated:

```java
if (onDiskSize == parquetFileSize && isParquetMetaResolvable(tablePath, parquetFileSize)) {
    continue;
}
// otherwise remove + regenerate _pm from the committed size
```

`onDiskSize == committed` is the normal consistent invariant, so regeneration fires
only for genuinely torn partitions; it is correctness-preserving (it rebuilds a
compact `_pm` for the committed footer).

## Testing

- Reproduced deterministically end-to-end in enterprise replication (paired PR):
  a primary snapshot of a parquet partition mid in-place O3 rewrite, restored on a
  replica that replays the update — **RED** (table suspended, `File out of
  specification`) before this change, **GREEN** after.
- `CheckpointTest` (107 tests, incl. the `_pm` regenerate / reject / stale-sidecar
  cases) and `ParquetMetaGenerateTest` — all green.

