### PR TITLE
chore(build): migrate GitHub Actions workflows off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -9,9 +9,9 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # Only run on non-forked PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v5
       - name: Use Node.js 22.x
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v5
         with:
           node-version: 22.x
       - name: install danger

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       HAS_GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE != '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7

--- a/.github/workflows/glibc_smoke_test.yml
+++ b/.github/workflows/glibc_smoke_test.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           path: ~/.questdb/log/*
-          name: logs
+          name: logs-amd64
           retention-days: 5
   aarch64:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # Only run on non-forked PRs
@@ -161,5 +161,5 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           path: ~/.questdb/log/*
-          name: logs
+          name: logs-aarch64
           retention-days: 5

--- a/.github/workflows/glibc_smoke_test.yml
+++ b/.github/workflows/glibc_smoke_test.yml
@@ -25,7 +25,6 @@ jobs:
       image: amazonlinux:2
       volumes:
         - /nodeglibc217:/nodeglibc217
-        - /nodeglibc217:/__e/node20
         - /nodeglibc217:/__e/node24
     steps:
       - name: Install dependencies
@@ -38,8 +37,7 @@ jobs:
         # Q: Why do we need this hack at all? A: Many GitHub actions, e.g. actions/checkout, run on Node.js.
         # GitHub deprecated Node.js 20 and now forces actions onto its Node.js 24 build, which needs a newer glibc
         # than Amazon Linux 2 has. Node.js 24 has no glibc 2.17 build, so we install the newest glibc 2.17-compatible
-        # release (Node.js 22 LTS) and mount it over both /__e/node20 and /__e/node24, so it is used no matter which
-        # runtime the runner picks.
+        # release (Node.js 22 LTS) and mount it over /__e/node24, the path the runner now resolves every action to.
         run: |
           curl -LO https://unofficial-builds.nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-x64-glibc-217.tar.xz
           tar -xf node-v22.22.3-linux-x64-glibc-217.tar.xz --strip-components 1 -C /nodeglibc217

--- a/.github/workflows/glibc_smoke_test.yml
+++ b/.github/workflows/glibc_smoke_test.yml
@@ -24,36 +24,39 @@ jobs:
       # Use Amazon Linux 2 image - uses GLIBC 2.26
       image: amazonlinux:2
       volumes:
-        - /node20217:/node20217
-        - /node20217:/__e/node20
+        - /nodeglibc217:/nodeglibc217
+        - /nodeglibc217:/__e/node20
+        - /nodeglibc217:/__e/node24
     steps:
       - name: Install dependencies
         run: yum install -y curl git tar gunzip xz wget
       - name: Print GLIBC version
         run: ldd --version
-      - name: Install Node.js 20 glibc2.17
-        # A hack to override default nodejs 20 to a build compatible with older glibc.
+      - name: Install glibc 2.17-compatible Node.js
+        # A hack to override the runner's Node.js with a build compatible with older glibc.
         # Inspired by https://github.com/pytorch/test-infra/pull/5959 If it's good for pytorch, it's good for us too! :)
-        # Q: Why do we need this hack at all? A: Because many github actions, include action/checkout@v4, depend on nodejs 20.
-        # GitHub Actions runner provides a build of nodejs 20 that requires a newer glibc than Amazon Linux 2 has.
-        # Thus we download a build of nodejs 20 that is compatible with Amazon Linux 2 and override the default one.
+        # Q: Why do we need this hack at all? A: Many GitHub actions, e.g. actions/checkout, run on Node.js.
+        # GitHub deprecated Node.js 20 and now forces actions onto its Node.js 24 build, which needs a newer glibc
+        # than Amazon Linux 2 has. Node.js 24 has no glibc 2.17 build, so we install the newest glibc 2.17-compatible
+        # release (Node.js 22 LTS) and mount it over both /__e/node20 and /__e/node24, so it is used no matter which
+        # runtime the runner picks.
         run: |
-          curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
-          tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
-          ldd /__e/node20/bin/node
-      - uses: actions/checkout@v4
+          curl -LO https://unofficial-builds.nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-x64-glibc-217.tar.xz
+          tar -xf node-v22.22.3-linux-x64-glibc-217.tar.xz --strip-components 1 -C /nodeglibc217
+          ldd /__e/node24/bin/node
+      - uses: actions/checkout@v5
       - name: Cache JDK
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.tool_cache }}/Java_Temurin-Hotspot_jdk
           key: java-temurin-25-${{ runner.os }}-${{ runner.arch }}
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "25"
       - name: Cache Maven installation and repository
         id: maven-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /opt/apache-maven-3.9.9
@@ -90,7 +93,7 @@ jobs:
               http://localhost:9000/exp
       - name: Upload logs
         if: failure() # Only upload logs if the job failed
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: ~/.questdb/log/*
           name: logs
@@ -106,19 +109,19 @@ jobs:
         run: dnf install -y curl zip unzip git bash wget
       - name: Print GLIBC version
         run: ldd --version
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Cache JDK
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ runner.tool_cache }}/Java_Temurin-Hotspot_jdk
           key: java-temurin-25-${{ runner.os }}-${{ runner.arch }}
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "25"
       - name: Cache Maven installation and repository
         id: maven-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             /opt/apache-maven-3.9.9
@@ -155,7 +158,7 @@ jobs:
               http://localhost:9000/exp
       - name: Upload logs
         if: failure() # Only upload logs if the job failed
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: ~/.questdb/log/*
           name: logs

--- a/.github/workflows/parquet_compat.yml
+++ b/.github/workflows/parquet_compat.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         id: jdk25
         with:
           distribution: 'temurin'
           java-version: '25'
           cache: 'maven'
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         id: jdk17
         with:
           distribution: 'temurin'
@@ -37,7 +37,7 @@ jobs:
         env:
           JAVA_HOME: ${{ steps.jdk25.outputs.path }}
       - name: Setup Python version
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
       - name: Run parquet pyarrow22 tests
@@ -90,7 +90,7 @@ jobs:
           JAVA_HOME: ${{ steps.jdk25.outputs.path }}
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: ~/.questdb/log/*
           name: logs

--- a/.github/workflows/pgwire_latest.yml
+++ b/.github/workflows/pgwire_latest.yml
@@ -15,8 +15,8 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # Only run on non-forked PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -38,7 +38,7 @@ jobs:
           toolchain: 1.90.0
           cache-workspaces: compat/src/test/rust/scenarios
       - name: Setup Python version
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3
       - name: Run all scenarios

--- a/.github/workflows/pgwire_stable.yml
+++ b/.github/workflows/pgwire_stable.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup golang toolchain
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache-dependency-path: compat/src/test/golang/go.sum
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/pgwire_stable.yml
+++ b/.github/workflows/pgwire_stable.yml
@@ -12,8 +12,8 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # Only run on non-forked PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -40,20 +40,20 @@ jobs:
           toolchain: 1.90.0
           cache-workspaces: compat/src/test/rust/scenarios
       - name: Setup golang toolchain
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24'
           cache-dependency-path: compat/src/test/golang/go.sum
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '9.0.x'
       - name: Setup Python version
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.8
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
       - name: Run all scenarios
@@ -63,7 +63,7 @@ jobs:
         run: ./questdb-*bin/questdb.sh stop
       - name: Upload logs
         if: failure() # Only upload logs if the job failed
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: ~/.questdb/log/*
           name: logs

--- a/.github/workflows/r_test.yml
+++ b/.github/workflows/r_test.yml
@@ -10,8 +10,8 @@ jobs:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # Only run on non-forked PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload logs
         if: failure() # Only upload logs if the job failed
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: ~/.questdb/log/*
           name: logs

--- a/.github/workflows/rebuild_async_profiler.yml
+++ b/.github/workflows/rebuild_async_profiler.yml
@@ -55,7 +55,7 @@ jobs:
           apt-get install git file -y
 
       - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           fetch-depth: 0
@@ -110,7 +110,7 @@ jobs:
           file asprof jfrconv
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: asprof-${{ matrix.platform }}
           path: |
@@ -124,16 +124,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download x86-64 binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: asprof-linux-x86-64
           path: core/src/main/bin/linux-x86-64/
 
       - name: Download aarch64 binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: asprof-linux-aarch64
           path: core/src/main/bin/linux-aarch64/

--- a/.github/workflows/rebuild_native_libs.yml
+++ b/.github/workflows/rebuild_native_libs.yml
@@ -74,7 +74,6 @@ jobs:
       image: quay.io/pypa/manylinux2014_x86_64
       volumes:
         - /nodeglibc217:/nodeglibc217
-        - /nodeglibc217:/__e/node20
         - /nodeglibc217:/__e/node24
     steps:
       - name: Install tools, most are needed to build nasm
@@ -98,8 +97,7 @@ jobs:
         # Q: Why do we need this hack at all? A: Many GitHub actions, e.g. actions/checkout, run on Node.js.
         # GitHub deprecated Node.js 20 and now forces actions onto its Node.js 24 build, which needs a newer glibc
         # than manylinux2014 has. Node.js 24 has no glibc 2.17 build, so we install the newest glibc 2.17-compatible
-        # release (Node.js 22 LTS) and mount it over both /__e/node20 and /__e/node24, so it is used no matter which
-        # runtime the runner picks.
+        # release (Node.js 22 LTS) and mount it over /__e/node24, the path the runner now resolves every action to.
         run: |
           curl -LO https://unofficial-builds.nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-x64-glibc-217.tar.xz
           tar -xf node-v22.22.3-linux-x64-glibc-217.tar.xz --strip-components 1 -C /nodeglibc217

--- a/.github/workflows/rebuild_native_libs.yml
+++ b/.github/workflows/rebuild_native_libs.yml
@@ -25,7 +25,7 @@ jobs:
         os: [macos-14, macos-15-intel]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
       - name: Install toolchains (CXX/NASM)
@@ -54,14 +54,14 @@ jobs:
           cp core/target/classes/io/questdb/bin-local/libquestdb.dylib core/src/main/resources/io/questdb/bin/darwin-x86-64/
       - name: Save darwin-aarch64 Libraries to Cache
         if: ${{ matrix.os == 'macos-14' }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/darwin-aarch64/libquestdb.dylib
           key: nativelibs-armosx-${{ github.sha }}
       - name: Save darwin-x86-64 Libraries to Cache
         if: ${{ matrix.os == 'macos-15-intel' }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/darwin-x86-64/libquestdb.dylib
@@ -73,8 +73,9 @@ jobs:
     container:
       image: quay.io/pypa/manylinux2014_x86_64
       volumes:
-        - /node20217:/node20217
-        - /node20217:/__e/node20
+        - /nodeglibc217:/nodeglibc217
+        - /nodeglibc217:/__e/node20
+        - /nodeglibc217:/__e/node24
     steps:
       - name: Install tools, most are needed to build nasm
         run: |
@@ -91,17 +92,19 @@ jobs:
           wget https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/linux/nasm-2.16.03-0.fc39.src.rpm
           rpmbuild --rebuild ./nasm-2.16.03-0.fc39.src.rpm
           rpm -i ~/rpmbuild/RPMS/x86_64/nasm-2.16.03-0.el7.x86_64.rpm
-      - name: Install Node.js 20 glibc2.17
-        # A hack to override default nodejs 20 to a build compatible with older glibc.
+      - name: Install glibc 2.17-compatible Node.js
+        # A hack to override the runner's Node.js with a build compatible with older glibc.
         # Inspired by https://github.com/pytorch/test-infra/pull/5959 If it's good for pytorch, it's good for us too! :)
-        # Q: Why do we need this hack at all? A: Because many github actions, include action/checkout@v4, depend on nodejs 20.
-        # GitHub Actions runner provides a build of nodejs 20 that requires a newer glibc than manylinux2014 has.
-        # Thus we download a build of nodejs 20 that is compatible with manylinux2014 and override the default one.
+        # Q: Why do we need this hack at all? A: Many GitHub actions, e.g. actions/checkout, run on Node.js.
+        # GitHub deprecated Node.js 20 and now forces actions onto its Node.js 24 build, which needs a newer glibc
+        # than manylinux2014 has. Node.js 24 has no glibc 2.17 build, so we install the newest glibc 2.17-compatible
+        # release (Node.js 22 LTS) and mount it over both /__e/node20 and /__e/node24, so it is used no matter which
+        # runtime the runner picks.
         run: |
-          curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
-          tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
-          ldd /__e/node20/bin/node
-      - uses: actions/checkout@v4
+          curl -LO https://unofficial-builds.nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-x64-glibc-217.tar.xz
+          tar -xf node-v22.22.3-linux-x64-glibc-217.tar.xz --strip-components 1 -C /nodeglibc217
+          ldd /__e/node24/bin/node
+      - uses: actions/checkout@v5
         with:
           submodules: true
       - name: Install up-to-date CMake
@@ -128,7 +131,7 @@ jobs:
           cp target/classes/io/questdb/bin-local/libquestdb.so src/main/resources/io/questdb/bin/linux-x86-64/
           cp target/classes/io/questdb/bin-local/libjemalloc.so src/main/bin/linux-x86-64/
       - name: Save linux-x86-64 Libraries to Cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/linux-x86-64/libquestdb.so
@@ -139,7 +142,7 @@ jobs:
     container:
       image: quay.io/pypa/manylinux_2_28_aarch64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
       - name: Install tooling
@@ -168,7 +171,7 @@ jobs:
           git config --global --add safe.directory /__w/questdb/questdb
           git status
       - name: Save linux-aarch64 Libraries to Cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/linux-aarch64/libquestdb.so
@@ -177,7 +180,7 @@ jobs:
   build-cxx-windows:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
       - name: Increase file count and install tooling
@@ -210,7 +213,7 @@ jobs:
         run: |
           git status
       - name: Save Windows CXX Library to Cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/windows-x86-64/libquestdb.dll
@@ -225,7 +228,7 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Print file sizes before
         run: |
           mkdir -p ./core/src/main/resources/io/questdb/bin/
@@ -233,33 +236,33 @@ jobs:
           find ./core/src/main/resources/io/questdb/bin/ -type f -exec ls -l {} \;
           find ./core/src/main/bin/ -type f -exec ls -l {} \;
       - name: Restore darwin-aarch64 Libraries from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/darwin-aarch64/libquestdb.dylib
           key: nativelibs-armosx-${{ github.sha }}
       - name: Restore darwin-x86-64 Libraries from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/darwin-x86-64/libquestdb.dylib
           key: nativelibs-osx-${{ github.sha }}
       - name: Restore linux-x86-64 Libraries from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/linux-x86-64/libquestdb.so
             core/src/main/bin/linux-x86-64/libjemalloc.so
           key: nativelibs-linux-${{ github.sha }}
       - name: Restore linux-aarch64 Libraries from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/linux-aarch64/libquestdb.so
             core/src/main/bin/linux-aarch64/libjemalloc.so
           key: nativelibs-armlinux-${{ github.sha }}
       - name: Restore Windows CXX Library from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/windows-x86-64/libquestdb.dll

--- a/.github/workflows/rebuild_rust.yml
+++ b/.github/workflows/rebuild_rust.yml
@@ -19,7 +19,7 @@ jobs:
   build-rust-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: false
       - name: Build Rust Library
@@ -30,7 +30,7 @@ jobs:
         run: |
           cp core/rust/qdbr/target/release/questdbr.dll core/src/main/resources/io/questdb/bin/windows-x86-64/
       - name: Save Windows Rust Library to Cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/windows-x86-64/questdbr.dll
@@ -45,7 +45,7 @@ jobs:
         os: [ macos-14, macos-15-intel ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: false
       - name: Build Rust Library
@@ -66,14 +66,14 @@ jobs:
           cp core/rust/qdbr/target/release/libquestdbr.dylib core/src/main/resources/io/questdb/bin/darwin-x86-64/
       - name: Save darwin-aarch64 Libraries to Cache
         if: ${{ matrix.os == 'macos-14' }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/darwin-aarch64/libquestdbr.dylib
           key: nativelibs-armosx-${{ github.sha }}
       - name: Save darwin-x86-64 Libraries to Cache
         if: ${{ matrix.os == 'macos-15-intel' }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/darwin-x86-64/libquestdbr.dylib
@@ -86,25 +86,28 @@ jobs:
       image:
         quay.io/pypa/manylinux2014_x86_64
       volumes:
-        - /node20217:/node20217
-        - /node20217:/__e/node20
+        - /nodeglibc217:/nodeglibc217
+        - /nodeglibc217:/__e/node20
+        - /nodeglibc217:/__e/node24
     steps:
       - name: Install tools
         run: |
           ldd --version
           yum update -y
           yum install wget rpm-build zstd curl python3 -y
-      - name: Install Node.js 20 glibc2.17
-        # A hack to override default nodejs 20 to a build compatible with older glibc.
+      - name: Install glibc 2.17-compatible Node.js
+        # A hack to override the runner's Node.js with a build compatible with older glibc.
         # Inspired by https://github.com/pytorch/test-infra/pull/5959 If it's good for pytorch, it's good for us too! :)
-        # Q: Why do we need this hack at all? A: Because many github actions, include action/checkout@v4, depend on nodejs 20.
-        # GitHub Actions runner provides a build of nodejs 20 that requires a newer glibc than manylinux2014 has.
-        # Thus we download a build of nodejs 20 that is compatible with manylinux2014 and override the default one.
+        # Q: Why do we need this hack at all? A: Many GitHub actions, e.g. actions/checkout, run on Node.js.
+        # GitHub deprecated Node.js 20 and now forces actions onto its Node.js 24 build, which needs a newer glibc
+        # than manylinux2014 has. Node.js 24 has no glibc 2.17 build, so we install the newest glibc 2.17-compatible
+        # release (Node.js 22 LTS) and mount it over both /__e/node20 and /__e/node24, so it is used no matter which
+        # runtime the runner picks.
         run: |
-          curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
-          tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
-          ldd /__e/node20/bin/node
-      - uses: actions/checkout@v4
+          curl -LO https://unofficial-builds.nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-x64-glibc-217.tar.xz
+          tar -xf node-v22.22.3-linux-x64-glibc-217.tar.xz --strip-components 1 -C /nodeglibc217
+          ldd /__e/node24/bin/node
+      - uses: actions/checkout@v5
         with:
           submodules: false
       - name: Install toolchains (Rust)
@@ -119,7 +122,7 @@ jobs:
           mkdir -p ../../src/main/resources/io/questdb/bin/linux-x86-64/
           cp target/release/libquestdbr.so ../../src/main/resources/io/questdb/bin/linux-x86-64/
       - name: Save linux-x86-64 Libraries to Cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/linux-x86-64/libquestdbr.so
@@ -129,7 +132,7 @@ jobs:
     container:
       image: quay.io/pypa/manylinux_2_28_aarch64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: false
       - name: Install Tools
@@ -153,7 +156,7 @@ jobs:
           git config --global --add safe.directory /__w/questdb/questdb
           git status
       - name: Save linux-aarch64 Libraries to Cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/linux-aarch64/libquestdbr.so
@@ -162,7 +165,7 @@ jobs:
     needs: [ build-all-macos, build-rust-windows, build-all-linux-x86-64, build-all-linux-aarch64 ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Print file sizes before
         run: |
           mkdir -p ./core/src/main/resources/io/questdb/bin/
@@ -170,31 +173,31 @@ jobs:
           find ./core/src/main/resources/io/questdb/bin/ -type f -exec ls -l {} \;
           find ./core/src/main/bin/ -type f -exec ls -l {} \;
       - name: Restore darwin-aarch64 Libraries from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/darwin-aarch64/libquestdbr.dylib
           key: nativelibs-armosx-${{ github.sha }}
       - name: Restore darwin-x86-64 Libraries from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/darwin-x86-64/libquestdbr.dylib
           key: nativelibs-osx-${{ github.sha }}
       - name: Restore linux-x86-64 Libraries from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/linux-x86-64/libquestdbr.so
           key: nativelibs-linux-${{ github.sha }}
       - name: Restore linux-aarch64 Libraries from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/linux-aarch64/libquestdbr.so
           key: nativelibs-armlinux-${{ github.sha }}
       - name: Restore Windows Rust Library from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/main/resources/io/questdb/bin/windows-x86-64/questdbr.dll

--- a/.github/workflows/rebuild_rust.yml
+++ b/.github/workflows/rebuild_rust.yml
@@ -87,7 +87,6 @@ jobs:
         quay.io/pypa/manylinux2014_x86_64
       volumes:
         - /nodeglibc217:/nodeglibc217
-        - /nodeglibc217:/__e/node20
         - /nodeglibc217:/__e/node24
     steps:
       - name: Install tools
@@ -101,8 +100,7 @@ jobs:
         # Q: Why do we need this hack at all? A: Many GitHub actions, e.g. actions/checkout, run on Node.js.
         # GitHub deprecated Node.js 20 and now forces actions onto its Node.js 24 build, which needs a newer glibc
         # than manylinux2014 has. Node.js 24 has no glibc 2.17 build, so we install the newest glibc 2.17-compatible
-        # release (Node.js 22 LTS) and mount it over both /__e/node20 and /__e/node24, so it is used no matter which
-        # runtime the runner picks.
+        # release (Node.js 22 LTS) and mount it over /__e/node24, the path the runner now resolves every action to.
         run: |
           curl -LO https://unofficial-builds.nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-x64-glibc-217.tar.xz
           tar -xf node-v22.22.3-linux-x64-glibc-217.tar.xz --strip-components 1 -C /nodeglibc217

--- a/.github/workflows/rebuild_rust_test.yml
+++ b/.github/workflows/rebuild_rust_test.yml
@@ -19,7 +19,7 @@ jobs:
   build-rust-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: false
       - name: Build Rust Library
@@ -30,7 +30,7 @@ jobs:
         run: |
           cp core/rust/qdb-sqllogictest/target/release/qdbsqllogictest.dll core/src/test/resources/io/questdb/bin/windows-x86-64/
       - name: Save Windows Rust Library to Cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/test/resources/io/questdb/bin/windows-x86-64/qdbsqllogictest.dll
@@ -45,7 +45,7 @@ jobs:
         os: [ macos-14, macos-15-intel ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: false
       - name: Build Rust Library
@@ -65,14 +65,14 @@ jobs:
           cp core/rust/qdb-sqllogictest/target/release/libqdbsqllogictest.dylib core/src/test/resources/io/questdb/bin/darwin-x86-64/
       - name: Save darwin-aarch64 Libraries to Cache
         if: ${{ matrix.os == 'macos-14' }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/test/resources/io/questdb/bin/darwin-aarch64/libqdbsqllogictest.dylib
           key: nativelibs-armosx-${{ github.sha }}
       - name: Save darwin-x86-64 Libraries to Cache
         if: ${{ matrix.os == 'macos-15-intel' }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/test/resources/io/questdb/bin/darwin-x86-64/libqdbsqllogictest.dylib
@@ -93,7 +93,7 @@ jobs:
           ldd --version
           apt-get update -y
           apt install git python3 wget ca-certificates build-essential zstd -y
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: false
       - name: Install toolchains (Rust)
@@ -108,7 +108,7 @@ jobs:
           mkdir -p ../../src/test/resources/io/questdb/bin/linux-x86-64/
           cp target/release/libqdbsqllogictest.so ../../src/test/resources/io/questdb/bin/linux-x86-64/
       - name: Save linux-x86-64 Libraries to Cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/test/resources/io/questdb/bin/linux-x86-64/libqdbsqllogictest.so
@@ -116,7 +116,7 @@ jobs:
   build-all-linux-aarch64:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: false
       - name: Install rs-cross
@@ -133,7 +133,7 @@ jobs:
         run: |
           git status
       - name: Save linux-aarch64 Libraries to Cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v5
         with:
           path: |
             core/src/test/resources/io/questdb/bin/linux-aarch64/libqdbsqllogictest.so
@@ -142,7 +142,7 @@ jobs:
     needs: [ build-all-macos, build-rust-windows, build-all-linux-x86-64, build-all-linux-aarch64 ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Print file sizes before
         run: |
           mkdir -p ./core/src/test/resources/io/questdb/bin/
@@ -150,31 +150,31 @@ jobs:
           find ./core/src/test/resources/io/questdb/bin/ -type f -exec ls -l {} \;
           find ./core/src/main/bin/ -type f -exec ls -l {} \;
       - name: Restore darwin-aarch64 Libraries from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/test/resources/io/questdb/bin/darwin-aarch64/libqdbsqllogictest.dylib
           key: nativelibs-armosx-${{ github.sha }}
       - name: Restore darwin-x86-64 Libraries from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/test/resources/io/questdb/bin/darwin-x86-64/libqdbsqllogictest.dylib
           key: nativelibs-osx-${{ github.sha }}
       - name: Restore linux-x86-64 Libraries from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/test/resources/io/questdb/bin/linux-x86-64/libqdbsqllogictest.so
           key: nativelibs-linux-${{ github.sha }}
       - name: Restore linux-aarch64 Libraries from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/test/resources/io/questdb/bin/linux-aarch64/libqdbsqllogictest.so
           key: nativelibs-armlinux-${{ github.sha }}
       - name: Restore Windows Rust Library from Cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v5
         with:
           path: |
             core/src/test/resources/io/questdb/bin/windows-x86-64/qdbsqllogictest.dll

--- a/.github/workflows/rebuild_win64svc.yml
+++ b/.github/workflows/rebuild_win64svc.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/rust_license_check.yml
+++ b/.github/workflows/rust_license_check.yml
@@ -25,7 +25,7 @@ jobs:
           - { path: core/rust/qdbr, name: qdbr }
           - { path: core/rust/qdb-sqllogictest, name: qdb-sqllogictest }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: false
 

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1,7 +1,7 @@
 Third-party licenses for Rust dependencies of QuestDB
 ======================================================
 
-Generated on 2026-06-17 by cargo-deny
+Generated on 2026-06-15 by cargo-deny
 
 0BSD (1): adler2@2.0.1
 Apache-2.0 (75): adler2@2.0.1, alloc-checked@0.1.3, autocfg@1.5.0, bitflags@2.11.1, bytemuck@1.25.0, cc@1.2.60, cesu8@1.1.0, cfg-if@1.0.4, crc32fast@1.5.0, crossbeam-deque@0.8.6, crossbeam-epoch@0.9.18, crossbeam-utils@0.8.21, either@1.15.0, fallible-streaming-iterator@0.1.9, find-msvc-tools@0.1.9, flate2@1.1.9, getrandom@0.3.4, hashbrown@0.14.5, itoa@1.0.18, jni@0.21.1, jni-sys@0.3.1, jni-sys@0.4.1, jni-sys-macros@0.4.1, jobserver@0.1.34, libc@0.2.185, lock_api@0.4.14, log@0.4.29, memmap2@0.9.10, miniz_oxide@0.8.9, nonmax@0.5.5, num-traits@0.2.19, once_cell@1.21.4, parking_lot_core@0.9.12, parquet-format-safe@0.2.4, parquet2@0.17.2, pastey@0.1.1, pkg-config@0.3.33, proc-macro2@1.0.106, qdb-core@0.1.0, qdb-parquet-meta@0.1.0, qdbr@0.1.0, quote@1.0.45, r-efi@5.3.0, rapidhash@4.4.1, rayon@1.12.0, rayon-core@1.13.0, rustversion@1.0.22, scopeguard@1.2.0, seq-macro@0.3.6, serde@1.0.228, serde_core@1.0.228, serde_derive@1.0.228, serde_json@1.0.149, shlex@1.3.0, smallvec@1.15.1, streaming-decompression@0.1.2, syn@2.0.117, thiserror@1.0.69, thiserror-impl@1.0.69, unicode-ident@1.0.24, wasip2@1.0.2+wasi-0.2.9, windows-link@0.2.1, windows-sys@0.45.0, windows-sys@0.61.2, windows-targets@0.42.2, windows_aarch64_gnullvm@0.42.2, windows_aarch64_msvc@0.42.2, windows_i686_gnu@0.42.2, windows_i686_msvc@0.42.2, windows_x86_64_gnu@0.42.2, windows_x86_64_gnullvm@0.42.2, windows_x86_64_msvc@0.42.2, wit-bindgen@0.51.0, zstd-safe@7.2.4, zstd-sys@2.0.16+zstd.1.5.7

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -1,7 +1,7 @@
 Third-party licenses for Rust dependencies of QuestDB
 ======================================================
 
-Generated on 2026-06-15 by cargo-deny
+Generated on 2026-06-17 by cargo-deny
 
 0BSD (1): adler2@2.0.1
 Apache-2.0 (75): adler2@2.0.1, alloc-checked@0.1.3, autocfg@1.5.0, bitflags@2.11.1, bytemuck@1.25.0, cc@1.2.60, cesu8@1.1.0, cfg-if@1.0.4, crc32fast@1.5.0, crossbeam-deque@0.8.6, crossbeam-epoch@0.9.18, crossbeam-utils@0.8.21, either@1.15.0, fallible-streaming-iterator@0.1.9, find-msvc-tools@0.1.9, flate2@1.1.9, getrandom@0.3.4, hashbrown@0.14.5, itoa@1.0.18, jni@0.21.1, jni-sys@0.3.1, jni-sys@0.4.1, jni-sys-macros@0.4.1, jobserver@0.1.34, libc@0.2.185, lock_api@0.4.14, log@0.4.29, memmap2@0.9.10, miniz_oxide@0.8.9, nonmax@0.5.5, num-traits@0.2.19, once_cell@1.21.4, parking_lot_core@0.9.12, parquet-format-safe@0.2.4, parquet2@0.17.2, pastey@0.1.1, pkg-config@0.3.33, proc-macro2@1.0.106, qdb-core@0.1.0, qdb-parquet-meta@0.1.0, qdbr@0.1.0, quote@1.0.45, r-efi@5.3.0, rapidhash@4.4.1, rayon@1.12.0, rayon-core@1.13.0, rustversion@1.0.22, scopeguard@1.2.0, seq-macro@0.3.6, serde@1.0.228, serde_core@1.0.228, serde_derive@1.0.228, serde_json@1.0.149, shlex@1.3.0, smallvec@1.15.1, streaming-decompression@0.1.2, syn@2.0.117, thiserror@1.0.69, thiserror-impl@1.0.69, unicode-ident@1.0.24, wasip2@1.0.2+wasi-0.2.9, windows-link@0.2.1, windows-sys@0.45.0, windows-sys@0.61.2, windows-targets@0.42.2, windows_aarch64_gnullvm@0.42.2, windows_aarch64_msvc@0.42.2, windows_i686_gnu@0.42.2, windows_i686_msvc@0.42.2, windows_x86_64_gnu@0.42.2, windows_x86_64_gnullvm@0.42.2, windows_x86_64_msvc@0.42.2, wit-bindgen@0.51.0, zstd-safe@7.2.4, zstd-sys@2.0.16+zstd.1.5.7


### PR DESCRIPTION
## Background

GitHub is [deprecating Node.js 20 on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
During the current brownout the runner ignores an action's declared `node20` runtime and forces every JavaScript action onto its bundled Node.js 24. This has two distinct consequences for our workflows:

- Jobs that run inside a container with **old glibc** fail hard. The runner's Node.js 24 binary needs glibc >= 2.28, but these containers ship older glibc, so `actions/checkout` (and any other JS action) aborts before doing any work with `libc.so.6: version 'GLIBC_2.27' not found`.
- Every other workflow still runs, but each JS action now emits a Node.js 20 deprecation annotation. Those become hard failures once GitHub removes the Node.js 20 fallback entirely.

Two runs that surfaced this:

- `Build and Push Release Rust Libraries` (`rebuild_rust.yml`) - the `build-all-linux-x86-64` job failed at `Run actions/checkout@v4`.
- `GLIBC Smoke Test` (`glibc_smoke_test.yml`) on PR #7268 - the `amd64` job failed at the same step.

## What changed

### 1. Node runtime for old-glibc container jobs

Three jobs build portable binaries inside containers whose glibc predates the Node.js 24 requirement:

- `glibc_smoke_test.yml` - `amd64` (`amazonlinux:2`, glibc 2.26)
- `rebuild_rust.yml` - `build-all-linux-x86-64` (`manylinux2014_x86_64`, glibc 2.17)
- `rebuild_native_libs.yml` - `build-all-linux-x86-64` (`manylinux2014_x86_64`, glibc 2.17)

Each already carried a hack that downloaded a glibc 2.17-compatible Node.js 20 and mounted it over `/__e/node20`. The runner no longer looks there - it now uses `/__e/node24` - so the override stopped taking effect.

The fix follows the same mechanism, updated for the new runtime path:

- The container now mounts the override directory over both `/__e/node20` and `/__e/node24`, so the custom binary is used regardless of which path the runner selects.
- The install step downloads Node.js 22.22.3 instead of 20.9.0. Node.js 24 has no glibc 2.17 build on `unofficial-builds.nodejs.org`; the newest available glibc 2.17 build is Node.js 22 (the current LTS line). A single glibc 2.17 build covers both the glibc 2.17 and glibc 2.26 containers.

Tradeoff: JS actions in these three jobs run on Node.js 22 rather than 24. That is an intentional gap - it is the newest runtime with a glibc 2.17 build, and the actions we run there (`checkout`, `cache`) execute correctly on it. The jobs in glibc 2.28 containers (`almalinux:8`, `manylinux_2_28_aarch64`, `debian:buster`, the async-profiler builders) already run on the stock Node.js 24 and need no override.

### 2. Action version bumps

Every first-party action was bumped to the lowest major that ships a `node24` runtime, which clears the deprecation warnings while keeping the version jump as small as possible:

| Action                                         | Before        | After | Runtime |
| ---------------------------------------------- | ------------- | ----- | ------- |
| `actions/checkout`                             | v4 / `master` | v5    | node24  |
| `actions/cache`, `cache/save`, `cache/restore` | v4 / v3       | v5    | node24  |
| `actions/setup-java`                           | v4            | v5    | node24  |
| `actions/setup-python`                         | v5            | v6    | node24  |
| `actions/setup-node`                           | v3 / `master` | v5    | node24  |
| `actions/setup-go`                             | v4            | v6    | node24  |
| `actions/setup-dotnet`                         | v3            | v5    | node24  |
| `actions/upload-artifact`                      | v4            | v6    | node24  |
| `actions/download-artifact`                    | v4            | v7    | node24  |

Notes and tradeoffs:

- `cache/save@v3` and `cache/restore@v3` were the most outdated - they targeted Node.js 16, which GitHub removed earlier - so they were already at risk independent of the Node.js 20 deprecation.
- `upload-artifact` (v4 -> v6) and `download-artifact` (v4 -> v7) are larger jumps because v5/v6 of those actions kept Node.js 20 as the default. The intermediate releases carry no behavioral change for our usage: the only real break is `download-artifact` v5 changing the output path for single downloads **by ID**, and both call sites download **by name**. v6/v7 require Actions runner >= 2.327.1, which GitHub-hosted runners satisfy.
- `setup-go` moves v4 -> v6, and its `go-version` is raised from 1.24 to 1.25 in the same step (the PGWire stable Go client scenarios) so the Go toolchain stays on a maintained release alongside the action bump.
- `danger.yml` pinned `actions/checkout` and `actions/setup-node` to floating `@master`. Both are now pinned to `@v5`, which makes those runs reproducible and removes a moving dependency, at the cost of needing a manual bump for future majors.
- Third-party actions pinned by commit SHA (`ad-m/github-push-action`, `gitleaks/gitleaks-action`, `actions-rust-lang/setup-rust-toolchain`, `questdb/r-actions/setup-r`) were left untouched.

### 3. Distinct log artifact names in the GLIBC smoke test

The `amd64` and `aarch64` jobs in `glibc_smoke_test.yml` both uploaded their failure logs as an artifact named `logs`. `actions/upload-artifact` v4 and newer treat artifact names as immutable and unique within a run, so a run where both jobs failed would abort the second upload on a name collision. Each job now uploads under a distinct name (`logs-amd64`, `logs-aarch64`).

## Risks

- The three container jobs now depend on Node.js 22 staying available as a glibc 2.17 build on `unofficial-builds.nodejs.org`. This is the same external dependency the previous Node.js 20 hack relied on, not a new one.
- Running actions on Node.js 22 in those jobs is a deliberate compromise. Once a glibc 2.17 Node.js 24 build appears, or once the containers move to glibc 2.28+, the override can be dropped and the jobs can use the stock runtime.
- The bumps move several actions across multiple majors at once. The artifact-action changelogs were reviewed (above); the remaining bumps are runtime-only releases.

## Test plan

- Re-run the two workflows that failed and confirm the previously-failing
  container jobs now get past `Run actions/checkout` and complete:
  - `Build and Push Release Rust Libraries` (manual `workflow_dispatch`)
  - `GLIBC Smoke Test` (re-trigger on a PR that touches
    `core/src/main/resources/io/questdb/bin/**`)
- Confirm the Node.js 20 deprecation annotations no longer appear on the
  PR-triggered workflows: `pgwire_stable.yml`, `r_test.yml`,
  `parquet_compat.yml`, `danger.yml`, `gitleaks.yml`, `rust_license_check.yml`.
- Exercise the manually-triggered rebuild workflows on a throwaway branch to
  confirm the cache save/restore and artifact upload/download steps still pair
  up: `rebuild_native_libs.yml`, `rebuild_rust_test.yml`,
  `rebuild_async_profiler.yml`, `rebuild_win64svc.yml`.
- Already validated locally: every workflow file still parses as YAML, and each
  bumped tag exists and resolves to a `node24` runtime.