### PR TITLE
fix(sql): fix wrong SAMPLE BY first()/last() results when the time column is not selected

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFirstLastRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/SampleByFirstLastRecordCursorFactory.java
@@ -980,12 +980,15 @@ public class SampleByFirstLastRecordCursorFactory extends AbstractRecordCursorFa
                 public long getLong(int col) {
                     long pageAddress = pageAddresses[col];
                     if (pageAddress > 0) {
-                        if (col != timestampIndex) {
+                        if (col != groupByTimestampIndex) {
                             return Unsafe.getLong(pageAddress + (getRowId(firstLastIndexByCol[col]) << 3));
                         }
-                        // Special case - timestamp the sample by runs on
-                        // Take it from timestampOutBuff instead of column
-                        // It's the value of the beginning of the group, not where the first row found
+                        // Special case - the projected designated timestamp the sample by runs on.
+                        // Take it from the sample period buffer instead of the column, so it reports
+                        // the value of the beginning of the group, not where the first row was found.
+                        // groupByTimestampIndex is the projection-space index of that column (-1 when
+                        // it is not projected); comparing against the base-table timestampIndex would
+                        // alias an unrelated projected column whenever the two index spaces disagree.
                         return samplePeriodAddress.get(getRowId(TIMESTAMP_OUT_INDEX) - prevSamplePeriodOffset);
                     } else {
                         return Numbers.LONG_NULL;

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -6483,6 +6483,56 @@ public class SampleByTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSampleByFirstLastReturnsValuesWhenTimestampNotProjected() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (sym SYMBOL INDEX, val LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO t
+                    SELECT ('s' || (x % 5)::STRING)::SYMBOL AS sym,
+                           (x * 3)::LONG AS val,
+                           timestamp_sequence('2024-01-01T00:00:00.000000Z', 600_000_000) AS ts
+                    FROM long_sequence(60)""");
+
+            // Reference: with the designated timestamp projected, first()/last() are correct.
+            // This selects the same SampleByFirstLast factory.
+            assertQuery(
+                    "SELECT ts, sym, first(val) fv, last(val) lv FROM t WHERE sym = 's1' SAMPLE BY 1h ALIGN TO FIRST OBSERVATION"
+            ).timestamp("ts").noRandomAccess().returns("""
+                    ts\tsym\tfv\tlv
+                    2024-01-01T00:00:00.000000Z\ts1\t3\t18
+                    2024-01-01T01:00:00.000000Z\ts1\t33\t33
+                    2024-01-01T02:00:00.000000Z\ts1\t48\t48
+                    2024-01-01T03:00:00.000000Z\ts1\t63\t63
+                    2024-01-01T04:00:00.000000Z\ts1\t78\t78
+                    2024-01-01T05:00:00.000000Z\ts1\t93\t108
+                    2024-01-01T06:00:00.000000Z\ts1\t123\t123
+                    2024-01-01T07:00:00.000000Z\ts1\t138\t138
+                    2024-01-01T08:00:00.000000Z\ts1\t153\t153
+                    2024-01-01T09:00:00.000000Z\ts1\t168\t168
+                    """);
+
+            // Without the designated timestamp projected, the data-record path used to alias the
+            // trailing last(val) onto the bucket-start timestamp for the middle buckets. The first
+            // and final buckets travel through the cross-frame record and were always correct.
+            assertQuery(
+                    "SELECT sym, first(val) fv, last(val) lv FROM t WHERE sym = 's1' SAMPLE BY 1h ALIGN TO FIRST OBSERVATION"
+            ).noRandomAccess().returns("""
+                    sym\tfv\tlv
+                    s1\t3\t18
+                    s1\t33\t33
+                    s1\t48\t48
+                    s1\t63\t63
+                    s1\t78\t78
+                    s1\t93\t108
+                    s1\t123\t123
+                    s1\t138\t138
+                    s1\t153\t153
+                    s1\t168\t168
+                    """);
+        });
+    }
+
+    @Test
     public void testSampleByFirstLastWithNonTsOrFilteredSymbolColumn() throws Exception {
         Rnd rnd = TestUtils.generateRandom(LOG);
         setProperty(PropertyKey.DEBUG_CAIRO_COPIER_TYPE, rnd.nextInt(4));


### PR DESCRIPTION
## What changed

A `SAMPLE BY` query that aggregates with `first()` / `last()`, filters on an
indexed `SYMBOL` column, and uses `ALIGN TO FIRST OBSERVATION` could return a
bucket timestamp where an aggregated value was expected. After this change such
queries return the correct values.

The wrong results appeared only when the designated timestamp column was left
out of the `SELECT` list, and only for the buckets in the middle of the result.
The first and last buckets were always correct, which made the problem easy to
miss. There was no error and no crash, so an affected query silently produced a
plausible-looking timestamp in place of the value.

## Reproduction

```sql
CREATE TABLE t (sym SYMBOL INDEX, val LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY;
INSERT INTO t
SELECT ('s' || (x % 5)::STRING)::SYMBOL, (x * 3)::LONG,
       timestamp_sequence('2024-01-01T00:00:00.000000Z', 600_000_000)
FROM long_sequence(60);

SELECT sym, first(val) fv, last(val) lv
FROM t WHERE sym = 's1' SAMPLE BY 1h ALIGN TO FIRST OBSERVATION;
```

Before the fix, `lv` for the middle buckets came back as the bucket-start
timestamp (e.g. `1704070800000000`) instead of the aggregated value (e.g. `33`).
With the fix, every bucket reports the expected value.

Adding the timestamp to the projection, switching to `ALIGN TO CALENDAR`, or
dropping the indexed-symbol filter all avoided the problem, because each of
those routes the query away from the affected execution path.

## Root cause

`SampleByFirstLastRecordCursorFactory` emits the middle (non-boundary) rows
through its data record. The data record special-cased the bucket-timestamp
column using the base-table timestamp index, while the column it was handed is a
projection index. The two indexes coincide only when the timestamp is projected
at the same position it occupies in the base scan. When the timestamp was not
projected, the base index pointed at an unrelated projected column (the trailing
aggregate) and overwrote it with the bucket timestamp. The boundary rows, which
travel through a separate record that already used the projection index, were
unaffected, which is why the first and last buckets stayed correct.

The fix makes the data record use the same projection index as the boundary
record. When the timestamp is not projected, no column matches the special case
and every aggregate reports its stored value.

## Scope and risk

- The change is limited to one comparison on the read path of this factory; it
  is an index comparison only, with no extra work, so query performance is
  unchanged.
- Queries that already projected the designated timestamp were correct before
  and remain correct; their plans and results do not change.
- Factory selection is unchanged: the same queries route to this factory as
  before.

## Test plan

- Added `SampleByTest#testSampleByFirstLastReturnsValuesWhenTimestampNotProjected`,
  which fails on master and passes with the fix. It asserts both the
  timestamp-projected form (a regression guard that was already correct) and the
  timestamp-omitted form (the bug).
- Ran the `SampleByTest#testSampleByFirstLast*` and
  `ExplainPlanTest#testSampleByFirstLast*` suites to confirm factory selection
  and plans are unchanged.
- Ran the full `SampleByTest` (313 tests) and `SampleByNanoTimestampTest`
  (279 tests) classes; all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)