### PR TITLE
fix(core): fix out-of-order rows after a lag commit crosses a partition boundary

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TxWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TxWriter.java
@@ -47,6 +47,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
     private int lastRecordBaseOffset = -1;
     private long lastRecordStructureVersion = -1;
     private long lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
+    private long prevLastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
     private long prevMaxTimestamp;
     private long prevMinTimestamp;
     private long prevPartitionTableVersion = -1;
@@ -117,6 +118,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         if (transientRowCount == 1 && txPartitionCount > 1) {
             // we have to undo creation of partition
             txPartitionCount--;
+            lastSealedPartitionMaxTimestamp = prevLastSealedPartitionMaxTimestamp;
             fixedRowCount -= prevTransientRowCount;
             transientRowCount = prevTransientRowCount + 1; // When row cancel finishes 1 is subtracted. Add 1 to compensate.
             attachedPartitions.setPos(attachedPartitions.size() - LONGS_PER_TX_ATTACHED_PARTITION);
@@ -157,6 +159,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         lastRecordBaseOffset = -1;
         prevRecordBaseOffset = -2;
         lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
+        prevLastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
     }
 
     @Override
@@ -311,6 +314,8 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
     public void removeAllPartitions() {
         maxTimestamp = Long.MIN_VALUE;
         minTimestamp = Long.MAX_VALUE;
+        lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
+        prevLastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
         prevTransientRowCount = 0;
         transientRowCount = 0;
         fixedRowCount = 0;
@@ -387,6 +392,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
     public void resetTimestamp() {
         recordStructureVersion++;
         lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
+        prevLastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
         prevMaxTimestamp = Long.MIN_VALUE;
         prevMinTimestamp = Long.MAX_VALUE;
         maxTimestamp = prevMaxTimestamp;
@@ -503,6 +509,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
 
     public void switchPartitions(long timestamp) {
         recordStructureVersion++;
+        prevLastSealedPartitionMaxTimestamp = lastSealedPartitionMaxTimestamp;
         lastSealedPartitionMaxTimestamp = maxTimestamp;
         fixedRowCount += transientRowCount;
         prevTransientRowCount = transientRowCount;
@@ -523,7 +530,6 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
     }
 
     public void truncate(long columnVersion, ObjList<? extends SymbolCountProvider> symbolCountProviders) {
-        lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
         removeAllPartitions();
         if (!PartitionBy.isPartitioned(partitionBy)) {
             attachedPartitions.setPos(LONGS_PER_TX_ATTACHED_PARTITION);
@@ -555,6 +561,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         this.prevPartitionTableVersion = partitionTableVersion;
         this.txPartitionCount = 1;
         this.lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
+        this.prevLastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
         if (baseVersion >= 0) {
             this.readBaseOffset = getBaseOffset();
             this.readRecordSize = getRecordSize();
@@ -666,6 +673,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         prevMinTimestamp = minTimestamp;
         prevMaxTimestamp = maxTimestamp;
         lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
+        prevLastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
 
         prevRecordStructureVersion = lastRecordStructureVersion;
         lastRecordStructureVersion = recordStructureVersion;

--- a/core/src/main/java/io/questdb/cairo/TxWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TxWriter.java
@@ -46,6 +46,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
     private TableWriter.ExtensionListener extensionListener;
     private int lastRecordBaseOffset = -1;
     private long lastRecordStructureVersion = -1;
+    private long lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
     private long prevMaxTimestamp;
     private long prevMinTimestamp;
     private long prevPartitionTableVersion = -1;
@@ -155,6 +156,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         prevRecordStructureVersion = -2L;
         lastRecordBaseOffset = -1;
         prevRecordBaseOffset = -2;
+        lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
     }
 
     @Override
@@ -365,6 +367,10 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         resetLagAppliedRows();
     }
 
+    public void resetPartitionParquetFormat(long timestamp) {
+        setPartitionParquetFormat(timestamp, -1, false);
+    }
+
     public void resetPartitionParquetGenerated(int partitionIndex) {
         resetPartitionParquetGeneratedByRawIndex(partitionIndex * LONGS_PER_TX_ATTACHED_PARTITION);
     }
@@ -374,16 +380,13 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         attachedPartitions.setQuick(indexRaw + PARTITION_PARQUET_FILE_SIZE_OFFSET, -1L);
     }
 
-    public void resetPartitionParquetFormat(long timestamp) {
-        setPartitionParquetFormat(timestamp, -1, false);
-    }
-
     public void resetStructureVersionUnsafe() {
         txMemBase.putLong(readBaseOffset + TX_OFFSET_STRUCT_VERSION_64, 0);
     }
 
     public void resetTimestamp() {
         recordStructureVersion++;
+        lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
         prevMaxTimestamp = Long.MIN_VALUE;
         prevMinTimestamp = Long.MAX_VALUE;
         maxTimestamp = prevMaxTimestamp;
@@ -500,6 +503,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
 
     public void switchPartitions(long timestamp) {
         recordStructureVersion++;
+        lastSealedPartitionMaxTimestamp = maxTimestamp;
         fixedRowCount += transientRowCount;
         prevTransientRowCount = transientRowCount;
         long partitionTimestampLo = getPartitionTimestampByTimestamp(maxTimestamp);
@@ -519,6 +523,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
     }
 
     public void truncate(long columnVersion, ObjList<? extends SymbolCountProvider> symbolCountProviders) {
+        lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
         removeAllPartitions();
         if (!PartitionBy.isPartitioned(partitionBy)) {
             attachedPartitions.setPos(LONGS_PER_TX_ATTACHED_PARTITION);
@@ -549,6 +554,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         this.baseVersion = getVersion();
         this.prevPartitionTableVersion = partitionTableVersion;
         this.txPartitionCount = 1;
+        this.lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
         if (baseVersion >= 0) {
             this.readBaseOffset = getBaseOffset();
             this.readRecordSize = getRecordSize();
@@ -596,12 +602,12 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         return maskedSize;
     }
 
-    private static long updatePartitionHasParquetGenerated(long maskedSize, boolean parquetGenerated) {
-        return updatePartitionFlagAt(maskedSize, parquetGenerated, PARTITION_MASK_PARQUET_GENERATED_BIT_OFFSET);
-    }
-
     private static long updatePartitionHasParquetFormat(long maskedSize, boolean isParquetFormat) {
         return updatePartitionFlagAt(maskedSize, isParquetFormat, PARTITION_MASK_PARQUET_FORMAT_BIT_OFFSET);
+    }
+
+    private static long updatePartitionHasParquetGenerated(long maskedSize, boolean parquetGenerated) {
+        return updatePartitionFlagAt(maskedSize, parquetGenerated, PARTITION_MASK_PARQUET_GENERATED_BIT_OFFSET);
     }
 
     private static long updatePartitionIsReadOnly(long maskedSize, boolean isReadOnly) {
@@ -659,6 +665,7 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         prevTransientRowCount = transientRowCount;
         prevMinTimestamp = minTimestamp;
         prevMaxTimestamp = maxTimestamp;
+        lastSealedPartitionMaxTimestamp = Long.MIN_VALUE;
 
         prevRecordStructureVersion = lastRecordStructureVersion;
         lastRecordStructureVersion = recordStructureVersion;
@@ -830,7 +837,10 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
     }
 
     void resetToLastPartition(long committedTransientRowCount) {
-        resetToLastPartition(committedTransientRowCount, getLong(TX_OFFSET_MAX_TIMESTAMP_64));
+        resetToLastPartition(
+                committedTransientRowCount,
+                Math.max(getLong(TX_OFFSET_MAX_TIMESTAMP_64), lastSealedPartitionMaxTimestamp)
+        );
     }
 
     long unsafeCommittedFixedRowCount() {

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/O3MaxLagFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/O3MaxLagFuzzTest.java
@@ -26,11 +26,8 @@ package io.questdb.test.cairo.fuzz;
 
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.ColumnType;
-import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.TimestampDriver;
-import io.questdb.cairo.sql.Record;
-import io.questdb.test.cairo.TestTableReaderRecordCursor;
 import io.questdb.cairo.sql.TableRecordMetadata;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
@@ -66,7 +63,7 @@ public class O3MaxLagFuzzTest extends AbstractO3Test {
     @Test
     public void testRollbackLagPartitionSwitchRegression() throws Exception {
         // Regression test for https://github.com/questdb/questdb/issues/7278
-        // 57091 rows, partition by DAY. The in-order prefix crosses the 1970-01-01 -> 1970-01-02
+        // 57_091 rows, partition by DAY. The in-order prefix crosses the 1970-01-01 -> 1970-01-02
         // boundary, so a lag-commit + rollback leaves maxTimestamp below the committed data.
         executeWithPool(2, (engine, compiler, sqlExecutionContext, timestampTypeName) ->
                 testRollbackFuzz0(engine, compiler, sqlExecutionContext, 57_091, 151, 1_545_848));

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/O3MaxLagFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/O3MaxLagFuzzTest.java
@@ -26,8 +26,11 @@ package io.questdb.test.cairo.fuzz;
 
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.TimestampDriver;
+import io.questdb.cairo.sql.Record;
+import io.questdb.test.cairo.TestTableReaderRecordCursor;
 import io.questdb.cairo.sql.TableRecordMetadata;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
@@ -58,6 +61,15 @@ public class O3MaxLagFuzzTest extends AbstractO3Test {
     @Test
     public void testRollbackFuzzParallel() throws Exception {
         executeWithPool(2, this::testRollbackFuzz);
+    }
+
+    @Test
+    public void testRollbackLagPartitionSwitchRegression() throws Exception {
+        // Regression test for https://github.com/questdb/questdb/issues/7278
+        // 57091 rows, partition by DAY. The in-order prefix crosses the 1970-01-01 -> 1970-01-02
+        // boundary, so a lag-commit + rollback leaves maxTimestamp below the committed data.
+        executeWithPool(2, (engine, compiler, sqlExecutionContext, timestampTypeName) ->
+                testRollbackFuzz0(engine, compiler, sqlExecutionContext, 57_091, 151, 1_545_848));
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cairo/o3/O3MaxLagTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/o3/O3MaxLagTest.java
@@ -92,6 +92,37 @@ public class O3MaxLagTest extends AbstractO3Test {
         });
     }
 
+    // Cancelling a partition switch must leave the writer's maxTimestamp correct on the next O3
+    // lag commit. With the same data, the committed high-water mark comes from a different place
+    // depending on the lag: a shorter lag commits a second-partition row, so the max comes from
+    // the O3 buffer; a longer lag holds every second-partition row in lag, so the max comes from
+    // the sealed first partition the O3 commit never touches. Both must be reported exactly.
+    @Test
+    public void testCancelPartitionSwitchMaxTimestamp() throws Exception {
+        executeWithPool(0, (engine, compiler, sqlExecutionContext, timestampTypeName) -> {
+            final TimestampDriver driver = timestampType.getDriver();
+            final long o3Ts = driver.parseFloorLiteral("1970-01-01T12:00:00.000000Z");
+            final long firstPartitionMaxTs = driver.parseFloorLiteral("1970-01-01T23:00:00.000000Z");
+            final long secondPartitionLoTs = driver.parseFloorLiteral("1970-01-02T06:00:00.000000Z");
+            final long secondPartitionHiTs = driver.parseFloorLiteral("1970-01-02T22:00:00.000000Z");
+            final long cancelledThirdPartitionTs = driver.parseFloorLiteral("1970-01-03T00:00:00.000000Z");
+
+            // 12h lag: secondPartitionLoTs commits, so the max comes from the O3 buffer.
+            assertMaxTimestampAfterCancelledSwitch(
+                    engine, sqlExecutionContext, timestampTypeName, "x_buffer", 43_200,
+                    o3Ts, firstPartitionMaxTs, secondPartitionLoTs, secondPartitionHiTs, cancelledThirdPartitionTs,
+                    secondPartitionLoTs
+            );
+
+            // 18h lag: both second-partition rows stay in lag, so the max comes from the sealed partition.
+            assertMaxTimestampAfterCancelledSwitch(
+                    engine, sqlExecutionContext, timestampTypeName, "x_sealed", 64_800,
+                    o3Ts, firstPartitionMaxTs, secondPartitionLoTs, secondPartitionHiTs, cancelledThirdPartitionTs,
+                    firstPartitionMaxTs
+            );
+        });
+    }
+
     @Test
     public void testContinuousBatchedCommitContended() throws Exception {
         executeWithPool(0, this::testContinuousBatchedCommit0);
@@ -480,6 +511,51 @@ public class O3MaxLagTest extends AbstractO3Test {
             putVariantStr(metadata, row, 4, "dd");
             row.putLong(5, 444444L);
             row.append();
+        }
+    }
+
+    private void assertMaxTimestampAfterCancelledSwitch(
+            CairoEngine engine,
+            SqlExecutionContext sqlExecutionContext,
+            String timestampTypeName,
+            String tableName,
+            long o3MaxLagSeconds,
+            long o3Ts,
+            long firstPartitionMaxTs,
+            long secondPartitionLoTs,
+            long secondPartitionHiTs,
+            long cancelledThirdPartitionTs,
+            long expectedMaxTs
+    ) throws SqlException {
+        engine.execute(
+                "CREATE TABLE " + tableName + " (i INT, ts " + timestampTypeName + ") TIMESTAMP(ts) PARTITION BY DAY"
+                        + " WITH maxUncommittedRows=2, o3MaxLag=" + o3MaxLagSeconds + "s",
+                sqlExecutionContext
+        );
+        try (TableWriter writer = TestUtils.getWriter(engine, tableName)) {
+            Row row = writer.newRow(firstPartitionMaxTs);
+            row.putInt(0, 1);
+            row.append();
+
+            row = writer.newRow(secondPartitionLoTs);
+            row.putInt(0, 2);
+            row.append();
+
+            row = writer.newRow(secondPartitionHiTs);
+            row.putInt(0, 3);
+            row.append();
+
+            row = writer.newRow(cancelledThirdPartitionTs);
+            row.putInt(0, 4);
+            row.cancel();
+
+            row = writer.newRow(o3Ts);
+            row.putInt(0, 5);
+            row.append();
+
+            writer.ic();
+
+            Assert.assertEquals(expectedMaxTs, writer.getMaxTimestamp());
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/questdb/questdb/issues/7278

When a non-WAL writer ingests out of order and the in-order prefix crosses a partition boundary, the partition switch seals the earlier partition in memory but doesn't persist `_txn`. On the next lag commit, `o3MoveUncommitted` reclaims the active partition's uncommitted in-order tail into the O3 buffer and **resets `maxTimestamp` to the durable `_txn` value**. That value predates the switch, so the commit registers `maxTimestamp` from the committed O3-buffer rows only, even though the sealed partition holds a row with a higher timestamp. The high-water mark ends up below committed data: a rollback reloads it, and the next O3 commit reorders the partition tail.

## Fix

Make sure `maxTimestamp` resets to the max timestamp of the last sealed partition. We introduce a new variable to keep track of that information. Whenever a partition switch happens, we update that information. 

https://github.com/questdb/questdb/blob/870ff7ac5f16f9521eec3f46ded7f6c42e4adf05/core/src/main/java/io/questdb/cairo/TxWriter.java#L504-L506

https://github.com/questdb/questdb/blob/870ff7ac5f16f9521eec3f46ded7f6c42e4adf05/core/src/main/java/io/questdb/cairo/TxWriter.java#L839-L844

## Alternative solutions considered
- Make use of `prevMaxTimestamp`. Using it would make the regression test pass, but it would not be correct. There are cases where `prevMaxTimestamp` does not match the max timestamp of the last sealed partition.
- Whenever we reset `maxTimestamp` to the last partition, we read that value directly from the partition. It adds a disk read and is more complicated than simply having a variable


## Testing
- [`testRollbackLagPartitionSwitchRegression`](https://github.com/questdb/questdb/compare/master...brunocalza:questdb:bcalza/fix-o3-rollback?expand=1#diff-78da7596913cf1d05ef92b95e49917456fba0f6fb3d09b12270aa9de669c389eR67) that reproduces the bug is added, confirming the bug is fixed.