### PR TITLE
ci(build): retry Maven wagon transfers on cache connect failure

### DIFF
--- a/ci/test-fuzz.yml
+++ b/ci/test-fuzz.yml
@@ -17,7 +17,9 @@ variables:
   includeTests: "%regex[.*[^o].class]"
   MAVEN_CACHE_FOLDER: $(HOME)/.m2/repository
   MAVEN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Xmx3072m -XX:+UseParallelGC"
-  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30"
+  # Wagon retries the transfer on connect failure so a dropped SYN to the single-IP cache
+  # re-attempts instead of failing the build. See test-pipeline.yml for the full rationale.
+  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.count=3"
   MAVEN_VERSION: "version"
   MAVEN_VERSION_OPTION: "Default"
   # Full reactor (the fuzz regex spans core and compat), but no fuzz test serves the

--- a/ci/test-hosted-pipeline.yml
+++ b/ci/test-hosted-pipeline.yml
@@ -15,7 +15,10 @@ variables:
   includeTests: "%regex[.*[^o].class]"
   MAVEN_CACHE_FOLDER: $(HOME)/.m2/repository
   MAVEN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Xmx3g -XX:+UseParallelGC"
-  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 "
+  # Kept in sync with test-pipeline.yml. These hosted (mac/windows) agents resolve from
+  # Maven Central, not the cache, so the retry is a harmless no-op for them; keeping
+  # MAVEN_RUN_OPTS identical across pipelines avoids drift. See test-pipeline.yml for rationale.
+  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.count=3 "
   MAVEN_VERSION: "version"
   MAVEN_VERSION_OPTION: "Default"
   # Hosted mac/windows jobs (hosted-jobs.yml) override this to "-pl core -am" and

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -14,7 +14,15 @@ variables:
   includeTests: "%regex[.*[^o].class]"
   MAVEN_CACHE_FOLDER: $(HOME)/.m2/repository
   MAVEN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Xmx3g -XX:+UseParallelGC"
-  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 "
+  # retryHandler.count: the self-hosted Reposilite cache is a single IP reached over the
+  # Hetzner vSwitch; under the fleet's cold-build connection bursts a fraction of TCP SYNs
+  # to it are dropped, and the failover-less mirror turns one dropped SYN into a dead build
+  # ("Connect to maven.internal:8081 ... Connection timed out"). Wagon retries the transfer
+  # on connect failure, so the resolve re-attempts (typically succeeding, since the loss is
+  # intermittent) instead of failing the build. The root-cause cache-box fix (host
+  # networking + raised SYN backlog) addresses the drops directly; this is a client-side
+  # backstop for any residual lost SYN.
+  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.count=3 "
   MAVEN_VERSION: "version"
   MAVEN_VERSION_OPTION: "Default"
   # Full-reactor defaults for the self-hosted Linux jobs. The hosted mac/windows


### PR DESCRIPTION
## Problem
Since master moved onto the self-hosted Reposilite Maven cache, a large share of builds fail at dependency resolution with:
```
Could not transfer artifact ... from/to hetzner-reposilite (http://maven.internal:8081/releases/):
Connect to maven.internal:8081 [10.0.0.13] failed: Connection timed out
```
The cache is healthy and near-idle (the exact "timed-out" jar serves in 0.15s). The cache is a **single IP** reached over the Hetzner vSwitch; under the fleet's cold-build connection bursts a fraction of TCP **SYNs are dropped**, and because the mirror has no mid-build failover, one dropped SYN kills the whole build.

## This change (client-side backstop)
Add `-Dmaven.wagon.http.retryHandler.count=3` to `MAVEN_RUN_OPTS` so the wagon transport **re-attempts a transfer on connect failure** instead of failing outright. The loss is intermittent, so a retry typically succeeds.

Applied to all three wagon `MAVEN_RUN_OPTS` (`test-pipeline.yml`, `test-hosted-pipeline.yml`, `test-fuzz.yml`), kept identical to avoid drift. The hosted mac/windows agents resolve from Central, so it's a harmless no-op there.

> Note: `-Dmaven.wagon.http.connectionTimeout` was deliberately **not** added — testing showed it does not bound the TCP connect in this Maven/wagon version (a blackholed connect still waited out the OS default), so it would be misleading.

## Root-cause fix (separate, already applied on the cache box)
The real fix is on the cache box itself, via the `azure-ci-runners` maven-cache role:
- **Reposilite switched to host networking** — removes the docker-proxy/iptables-DNAT hop that every connection traversed.
- **Raised `net.ipv4.tcp_max_syn_backlog` (512→8192), `net.core.netdev_max_backlog` (1000→16384), `somaxconn` (→8192)** — so SYN bursts are absorbed instead of dropped.

This PR is the belt-and-suspenders client side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)