### PR TITLE
fix(sql): fix crash on incomplete expression after CASE ... END

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -1109,7 +1109,15 @@ public class ExpressionParser {
                             } else {
                                 // attach dot to existing literal or constant
                                 ExpressionNode en = opStack.peek();
-                                ((GenericLexer.FloatingSequence) en.token).setHi(lastPos + 1);
+                                if (en != null && en.token instanceof GenericLexer.FloatingSequence floatingToken) {
+                                    floatingToken.setHi(lastPos + 1);
+                                } else {
+                                    // The dot has no literal to glue to. This happens for a dangling
+                                    // member access right after a value-producing construct such as
+                                    // 'case ... end.col', whose result sits on the operand stack
+                                    // rather than as a gluable token on the op stack.
+                                    throw SqlException.$(lastPos, "'.' is unexpected here");
+                                }
                             }
                         }
                         if (prevBranch == BRANCH_DOT || prevBranch == BRANCH_DOT_DEREFERENCE) {

--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -1907,6 +1907,14 @@ public class ExpressionParser {
                                             argStackDepth = onNode(listener, node, argStackDepth, prevBranch);
                                         }
 
+                                        // The final branch's value is already accounted for in paramCount and is
+                                        // re-added below, so clear the local depth the flush loop left behind. This
+                                        // keeps argStackDepth in step with the listener's operand stack: a CASE
+                                        // expression yields exactly one value. An inflated depth here would let a
+                                        // trailing binary operator (e.g. 'case ... end &') pass the arity guard with a
+                                        // missing operand.
+                                        argStackDepth = 0;
+
                                         // 'when/else' have been clearing argStackDepth to ensure expressions between
                                         // 'when' and 'when' do not pick up arguments outside of scope now we need to
                                         // restore stack depth before 'case' entry

--- a/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
@@ -297,6 +297,24 @@ public class ExpressionParserTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCaseDanglingDotAfterEnd() {
+        assertFail(
+                "case x when 1 then 'a' when 2 then 'b' end.foo",
+                42,
+                "'.' is unexpected here"
+        );
+    }
+
+    @Test
+    public void testCaseDanglingDotAfterEndInExpression() {
+        assertFail(
+                "1 + case x when 1 then 'a' when 2 then 'b' end.foo",
+                46,
+                "'.' is unexpected here"
+        );
+    }
+
+    @Test
     public void testCaseDanglingOperatorAfterCase() {
         assertFail(
                 "1 + case *x when 1 then 'a' when 2 then 'b' end",

--- a/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
@@ -315,6 +315,24 @@ public class ExpressionParserTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCaseDanglingOperatorAfterEnd() {
+        assertFail(
+                "case x when 1 then 'a' when 2 then 'b' end &",
+                43,
+                "too few arguments for '&' [found=1,expected=2]"
+        );
+    }
+
+    @Test
+    public void testCaseDanglingOperatorAfterEndNested() {
+        assertFail(
+                "case x when 1 then case y when 2 then 'a' else 'b' end else 'c' end +",
+                68,
+                "too few arguments for '+' [found=1,expected=2]"
+        );
+    }
+
+    @Test
     public void testCaseDanglingOperatorAfterThen() {
         assertFail(
                 "1 + case x when 1 then +'a' when 2 then 'b' end",

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -1574,6 +1574,18 @@ public class SqlParserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testCaseDanglingDotAfterEnd() throws Exception {
+        // A dot right after 'end' has no literal to attach to: the CASE result sits on the
+        // operand stack rather than as a gluable token. It must produce a clean syntax error,
+        // not an NPE from dereferencing an empty operator stack.
+        assertSyntaxError(
+                "select case when true then 1 else 0 end.foo",
+                39,
+                "'.' is unexpected here"
+        );
+    }
+
+    @Test
     public void testCaseDanglingOperatorAfterEnd() throws Exception {
         // A binary operator with a missing right operand right after 'end' must produce
         // a clean syntax error, not an NPE from a malformed expression node.

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -1574,6 +1574,17 @@ public class SqlParserTest extends AbstractSqlParserTest {
     }
 
     @Test
+    public void testCaseDanglingOperatorAfterEnd() throws Exception {
+        // A binary operator with a missing right operand right after 'end' must produce
+        // a clean syntax error, not an NPE from a malformed expression node.
+        assertSyntaxError(
+                "select sum(case when true then 1 else 0 end & )",
+                44,
+                "too few arguments for '&'"
+        );
+    }
+
+    @Test
     public void testCaseImpossibleRewrite1() throws SqlException {
         // referenced columns in 'when' clauses are different
         assertQuery(


### PR DESCRIPTION
## Summary

Two malformed expressions involving `CASE ... END` crashed the query with an
internal error instead of returning a syntax error. Over HTTP/PGWire this
surfaced to the user as an internal error rather than a clear message about the
malformed SQL. Both stem from the expression parser mishandling a token that
immediately follows `END`. The two fixes are independent and each has its own
section below.

---

## Fix 1: dangling binary operator after `END`

### Problem

A binary operator with a missing right operand directly after a `CASE ... END`
expression crashed with a `NullPointerException`. For example:

```sql
select sum(case when true then 1 else 0 end & );
```

A simple operand in the same position (e.g. `1 & `) already reported a proper
error, so only the `CASE ... END` form was affected.

### Root cause

The expression parser's `end`-keyword handler flushes the final CASE branch's
value through the operator stack, which leaves the local `argStackDepth` counter
at 1. The code right after assumes that counter was already cleared (its own
comment says so) and adds the restored outer depth plus `paramCount` on top. The
stale 1 leaked through, so after every `CASE ... END` the parser's depth counter
ran one higher than the listener's real operand stack.

That surplus is harmless for valid queries, but it defeated the arity guard
`argStackDepth < node.paramCount` in `onNode`: a trailing binary operator (which
needs two operands) saw an inflated depth and passed the guard. The tree builder
then polled only the single real operand and assigned a null left-hand side,
which later dereferenced to an NPE during column-alias generation or function
construction.

### Fix

Reset `argStackDepth` to 0 after the flush loop so the counter stays in step
with the operand stack, since a `CASE` expression yields exactly one value. The
arity guard now fires and the query reports:

```
[44] too few arguments for '&' [found=1,expected=2]
```

with the position pointing at the offending operator.

---

## Fix 2: dangling dot after `END`

### Problem

A dot directly after `CASE ... END` crashed the parser. At the top level it
threw a `NullPointerException`:

```sql
select case when true then 1 else 0 end.foo
```

and inside a larger expression it threw a `ClassCastException`:

```sql
select 1 + case when true then 1 else 0 end.foo
```

### Root cause

The parser's dot handler peeks the operator stack and casts the top token to
`FloatingSequence` to glue the dot onto a preceding literal (the `a.b`
qualified-name case). A `CASE` result is not a gluable literal token: it sits on
the listener's operand stack, leaving either an empty operator stack (`peek()`
returns null -> NPE) or an unrelated pending operator whose `String` token fails
the cast (-> `ClassCastException`).

### Fix

Extend the token only when the stack top is a `FloatingSequence` literal;
otherwise raise a syntax error with the position on the dot:

```
[39] '.' is unexpected here
```

This mirrors the existing guard on the dot-dereference path.

---

## Scope and tradeoffs

- Fix 1 touches a core parser path exercised by every `CASE` expression. The
  adjustment only removes a previously-harmless over-count, so valid queries
  produce the same parse as before; the only behavioral change is that the
  malformed form now returns a syntax error instead of an NPE.
- Fix 2 touches the dot handler, exercised by every `table.column` reference. It
  adds a null/type check on a path that previously assumed a `FloatingSequence`
  was present. Valid qualified references are unaffected; only the
  previously-crashing inputs change behavior.
- No new functionality and no measurable performance impact. Neither fix adds a
  defensive null-check downstream; each prevents the malformed expression node
  from being built in the first place.

## Test plan

- `ExpressionParserTest`: added `testCaseDanglingOperatorAfterEnd` and
  `testCaseDanglingOperatorAfterEndNested` (Fix 1), plus `testCaseDanglingDotAfterEnd`
  and `testCaseDanglingDotAfterEndInExpression` (Fix 2), alongside the existing
  `testCaseDanglingOperatorAfter{Case,Else,Then,When}` family.
- `SqlParserTest`: added `testCaseDanglingOperatorAfterEnd` (Fix 1) and
  `testCaseDanglingDotAfterEnd` (Fix 2), covering the reported `select` scenarios
  end to end and asserting a clean error rather than a crash.
- Pre-fix, each new test fails by reproducing the original crash (NPE/CCE);
  post-fix all pass.
- Regression batch -- `SqlParserTest` (1083), `WhereClauseParserTest` (846),
  `FunctionParserTest` (120), `CaseFunctionFactoryTest` (64),
  `SwitchFunctionFactoryTest` (60): 2,173 tests, all passing, confirming valid
  `table.column` and `CASE` parsing is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
