### PR TITLE
chore(core): allow ADD INDEX over a parquet partition where the column is absent

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -7208,18 +7208,23 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         final long partitionSize = txWriter.getPartitionRowCountByTimestamp(timestamp);
         final long columnTop = columnVersionWriter.getColumnTop(timestamp, columnIndex);
 
-        // Invariant: on a parquet partition the indexed SYMBOL's columnTop
-        // is either 0 (column has data from row 0) or partitionSize (column
-        // is all-NULL in this partition). zeroColumnTopsAfterParquetRewrite
-        // collapses every intermediate 0 < columnTop < partitionSize down
-        // to 0 at convert time, so the merged decode below can rely on
-        // columnTop == 0 whenever it executes. A future ATTACH PARQUET /
-        // restore path that bypasses that routine must restore this
-        // invariant before reaching here, or the rowLo formula at the
-        // decodeRowGroup call would truncate the covered columns.
-        assert columnTop == 0 || columnTop == partitionSize
+        // Invariant: on a parquet partition the indexed SYMBOL's columnTop is
+        // one of three values. 0 (column has data from row 0):
+        // zeroColumnTopsAfterParquetRewrite collapses every intermediate
+        // 0 < columnTop < partitionSize down to 0 at convert time, so the merged
+        // decode below can rely on columnTop == 0 whenever it executes.
+        // partitionSize (an explicit column-version record marks the column
+        // all-NULL in this partition). -1 (getColumnTop's "column does not exist
+        // in this partition" sentinel, returned when the column was added in a
+        // later partition and has no record here). The guard below skips both -1
+        // and partitionSize -- there is nothing to index -- so only 0 reaches the
+        // decode. A future ATTACH PARQUET / restore path that bypasses
+        // zeroColumnTopsAfterParquetRewrite must restore this invariant before
+        // reaching here, or the rowLo formula at the decodeRowGroup call would
+        // truncate the covered columns.
+        assert columnTop == -1 || columnTop == 0 || columnTop == partitionSize
                 : "parquet partition indexed SYMBOL columnTop=" + columnTop
-                + " is neither 0 nor partitionSize=" + partitionSize
+                + " is none of -1, 0 or partitionSize=" + partitionSize
                 + " (timestamp=" + timestamp + ", columnIndex=" + columnIndex + ")";
 
         if (columnTop > -1 && partitionSize > columnTop) {

--- a/core/src/test/java/io/questdb/test/griffin/ParquetTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParquetTest.java
@@ -284,8 +284,11 @@ public class ParquetTest extends AbstractCairoTest {
                     engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("x")));
 
             // The index is queryable: sym='a' returns the indexed rows in ts order.
+            // Pin the plan so a silently-degraded full scan cannot mask a broken
+            // index by returning the right answer for the wrong reason.
             assertQuery("x where sym = 'a'")
                     .noLeakCheck()
+                    .withPlanContaining("Index forward scan on: sym")
                     .timestamp("ts")
                     .returns("""
                             ts\tsym

--- a/core/src/test/java/io/questdb/test/griffin/ParquetTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParquetTest.java
@@ -241,6 +241,76 @@ public class ParquetTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAddIndexOverParquetPartitionWithAbsentColumn() throws Exception {
+        // ADD INDEX on a SYMBOL column must not suspend a WAL table when the column
+        // predates one of its parquet partitions. sym is added while 2024-01-02 is
+        // the last partition, so the older 2024-01-01 partition has no column-version
+        // record and getColumnTop returns -1 there (not 0, not partitionSize).
+        // 2024-01-01 is converted to parquet AFTER the column exists, so the parquet
+        // file physically carries sym (all-NULL) -- findParquetColumnIndex finds it and
+        // indexParquetColumn proceeds to the columnTop check. This previously tripped an
+        // over-strict assertion (it allowed only 0 or partitionSize) and suspended the
+        // table under -ea. The guard below skips the all-NULL column; nothing to index.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE x (ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            // 2024-01-02 must exist before ADD COLUMN so that 2024-01-01 predates sym.
+            execute("INSERT INTO x(ts) VALUES" +
+                    " ('2024-01-01T00:00:00.000000Z')," +
+                    " ('2024-01-01T01:00:00.000000Z')," +
+                    " ('2024-01-02T00:00:00.000000Z')");
+            drainWalQueue();
+
+            // Added at 2024-01-02 (then-last): getColumnTop('2024-01-01') is -1.
+            execute("ALTER TABLE x ADD COLUMN sym SYMBOL");
+            drainWalQueue();
+
+            // Convert AFTER ADD COLUMN: the parquet carries sym (all-NULL) while
+            // 2024-01-01's column-version record stays -1.
+            execute("ALTER TABLE x CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            drainWalQueue();
+
+            // Populate sym in a later partition so the index has real entries.
+            execute("INSERT INTO x(ts, sym) VALUES" +
+                    " ('2024-01-03T00:00:00.000000Z', 'a')," +
+                    " ('2024-01-03T01:00:00.000000Z', 'b')," +
+                    " ('2024-01-03T02:00:00.000000Z', 'a')");
+            drainWalQueue();
+
+            execute("ALTER TABLE x ALTER COLUMN sym ADD INDEX");
+            drainWalQueue();
+
+            Assert.assertFalse(
+                    "ADD INDEX over a parquet partition that predates the column must not suspend the table",
+                    engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("x")));
+
+            // The index is queryable: sym='a' returns the indexed rows in ts order.
+            assertQuery("x where sym = 'a'")
+                    .noLeakCheck()
+                    .timestamp("ts")
+                    .returns("""
+                            ts\tsym
+                            2024-01-03T00:00:00.000000Z\ta
+                            2024-01-03T02:00:00.000000Z\ta
+                            """);
+
+            // Full read: the parquet partition survives with NULL sym, later rows keep their values.
+            assertQuery("x")
+                    .noLeakCheck()
+                    .timestamp("ts")
+                    .expectSize()
+                    .returns("""
+                            ts\tsym
+                            2024-01-01T00:00:00.000000Z\t
+                            2024-01-01T01:00:00.000000Z\t
+                            2024-01-02T00:00:00.000000Z\t
+                            2024-01-03T00:00:00.000000Z\ta
+                            2024-01-03T01:00:00.000000Z\tb
+                            2024-01-03T02:00:00.000000Z\ta
+                            """);
+        });
+    }
+
+    @Test
     public void testArrayColTops() throws Exception {
         testArrayColTops(false);
     }


### PR DESCRIPTION
## Summary

`ALTER TABLE ... ADD INDEX` on a SYMBOL column can suspend a WAL table when the column is absent from one of the table's parquet partitions. The crash is an over-strict assertion in `TableWriter.indexParquetColumn`; the surrounding production code already handles the case correctly, so this only bites builds that run with assertions enabled (tests and CI).

## Root cause

`TableWriter.indexParquetColumn` reads the indexed column's columnTop and asserts it is either `0` or `partitionSize`:

```java
final long columnTop = columnVersionWriter.getColumnTop(timestamp, columnIndex);
assert columnTop == 0 || columnTop == partitionSize : ...;   // too strict
if (columnTop > -1 && partitionSize > columnTop) {           // already handles -1
    ...
}
```

`ColumnVersionReader.getColumnTop()` returns `-1` to mean "this column does not exist in the partition" (see its javadoc). That value occurs whenever the indexed column was added in a *later* partition than the one being indexed, so the older partition has no record for it. The `if (columnTop > -1 ...)` guard on the next line is written precisely to skip that case (there is nothing to index), but the assertion above it never allowed for `-1` and so trips.

The reproducing sequence (hit by the Enterprise backup parquet fuzz test):

1. add a SYMBOL column — the column-version record is written only on the then-last partition;
2. convert an *older* partition (which predates the column) to parquet;
3. `ADD INDEX` on that column.

When indexing reaches the older parquet partition, `getColumnTop` returns `-1`, the assertion fails inside `ApplyWal2TableJob`, and the WAL apply path suspends the table:

```
C ApplyWal2TableJob job failed, table suspended [seqTxn=10,
  error=java.lang.AssertionError: parquet partition indexed SYMBOL columnTop=-1
        is neither 0 nor partitionSize=1000 (columnIndex=9)]
  at TableWriter.indexParquetColumn(TableWriter.java:7220)
  at TableWriter.addIndex(TableWriter.java:858)
  at AlterOperation.applyAddIndex(...)
```

## Fix

Add `-1` to the permitted set in the assertion and update the comment to document all three legal columnTop values (`-1`, `0`, `partitionSize`). The runtime behavior is unchanged: the existing `if (columnTop > -1 && partitionSize > columnTop)` guard already skips both `-1` (column absent) and `partitionSize` (column all-NULL), indexing only when `0 <= columnTop < partitionSize`.

## Impact and scope

- This is an assertion-only defect. With assertions disabled (the default for production servers) the guard already does the right thing and the partition is correctly skipped, so there is no data-correctness change and no production behavior change.
- With assertions enabled (`-ea`, i.e. tests and CI) the assertion previously suspended the table. After this change `ADD INDEX` over such a parquet partition completes normally.
- The change does not touch the parquet metadata (`_pm`) read path, the convert-to-parquet path, or `ColumnVersion{Reader,Writer}`. It is a single assertion/comment edit.

## Test plan

- The Enterprise `BackupTest.testBackupFuzzyTableWithParquetPartitions` fuzz test surfaced this non-deterministically (failing seed: `10430439030179876L, 1781860299323L`); it passes once the assertion accepts the `-1` sentinel.
- `ParquetTest.testAddIndexOverParquetPartitionWithAbsentColumn` is a targeted, deterministic OSS regression test that reproduces the failure under `-ea`: it creates a WAL table, adds a SYMBOL column while a later partition is the last one (so an earlier partition predates the column), `CONVERT PARTITION TO PARQUET` on that earlier partition, then `ADD INDEX` on the column. It asserts the table is not suspended, that `sym = 'a'` returns the indexed rows through a pinned `Index forward scan on: sym` plan (so a silently-degraded full scan cannot mask a broken index by returning the right rows for the wrong reason), and that a full read keeps the parquet partition's NULL values alongside the later rows. The test fails on the parent commit and passes with the assertion fix.