### PR TITLE
fix(sql): concurrent NPE in CoveringIndexRecordCursorFactory.getCursor (#7294)

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/table/CoveringIndexRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/CoveringIndexRecordCursorFactory.java
@@ -141,13 +141,18 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
         int[] requiredIncludeIndices = buildRequiredIncludeIndices(queryColToIncludeIdx);
 
         int[] symInclCols = findSymbolIncludeCols(queryColToIncludeIdx, metadata);
-        if (keyValueFuncs != null) {
-            this.resolvedKeys = new IntList(keyValueFuncs.size());
-            int multiKeyCapacity = keyValueFuncs.size();
+        // Read the owned defensive copy (this.keyValueFuncs), never the pooled parameter. The two are
+        // content-identical here (compiling thread owns the model exclusively during construction), but
+        // the copy is the reference this factory owns and frees in close(); using it consistently avoids
+        // a refactor hazard if the defensive copy above is ever changed or removed.
+        final ObjList<Function> keyValueFuncsCopy = this.keyValueFuncs;
+        if (keyValueFuncsCopy != null) {
+            this.resolvedKeys = new IntList(keyValueFuncsCopy.size());
+            int multiKeyCapacity = keyValueFuncsCopy.size();
             if (reader != null) {
                 SymbolMapReader smr = reader.getSymbolMapReader(indexColumnIndex);
-                for (int i = 0, n = keyValueFuncs.size(); i < n; i++) {
-                    Function f = keyValueFuncs.getQuick(i);
+                for (int i = 0, n = keyValueFuncsCopy.size(); i < n; i++) {
+                    Function f = keyValueFuncsCopy.getQuick(i);
                     int key = f.isRuntimeConstant() ? SymbolTable.VALUE_NOT_FOUND : smr.keyOf(f.getStrA(null));
                     resolvedKeys.add(key);
                 }

--- a/core/src/main/java/io/questdb/griffin/engine/table/CoveringIndexRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/CoveringIndexRecordCursorFactory.java
@@ -128,7 +128,16 @@ public class CoveringIndexRecordCursorFactory implements RecordCursorFactory {
         this.latestBy = latestBy;
         this.latestByFilter = latestByFilter;
         this.queryColToIncludeIdx = queryColToIncludeIdx;
-        this.keyValueFuncs = keyValueFuncs;
+        // Defensive copy. The caller passes intrinsicModel.keyValueFuncs, which is a
+        // POOLED ObjList owned by the compiler's WhereClauseParser (ObjectPool<IntrinsicModel>).
+        // SqlCompilers are pooled and shared across threads/connections, so when another
+        // thread borrows the same compiler and recompiles, models.next() -> IntrinsicModel.clear()
+        // -> keyValueFuncs.clear() nulls the backing array (Arrays.fill BEFORE pos=0). A concurrent
+        // getCursor() on this still-cached factory would then read a stale size() (> 0) and a null
+        // slot in Function.init(...), producing the intermittent NPE in issue #7294. We keep our own
+        // list of the same Function instances -- which this factory owns and frees in close() (the
+        // pooled model only clears references, never frees) -- to decouple from the model's lifecycle.
+        this.keyValueFuncs = keyValueFuncs != null ? new ObjList<>(keyValueFuncs) : null;
         int[] requiredIncludeIndices = buildRequiredIncludeIndices(queryColToIncludeIdx);
 
         int[] symInclCols = findSymbolIncludeCols(queryColToIncludeIdx, metadata);

--- a/core/src/test/java/io/questdb/test/cairo/covering/PostingIndexConcurrentQueryNpeTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/PostingIndexConcurrentQueryNpeTest.java
@@ -1,0 +1,172 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.covering;
+
+import io.questdb.cairo.security.AllowAllSecurityContext;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContextImpl;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Reproduces issue #7294: intermittent NullPointerException in
+ * CoveringIndexRecordCursorFactory.getCursor under concurrent queries.
+ * <p>
+ * Root cause: {@link io.questdb.griffin.engine.table.CoveringIndexRecordCursorFactory}
+ * keeps a <b>direct reference</b> to {@code IntrinsicModel.keyValueFuncs}, which is a
+ * <b>pooled</b> {@link io.questdb.std.ObjList} owned by the compiler's
+ * {@link io.questdb.griffin.WhereClauseParser} (an {@code ObjectPool<IntrinsicModel>}).
+ * SqlCompilers are pooled and shared across threads/connections. When another thread
+ * borrows the same pooled compiler and recompiles, {@code models.next()} calls
+ * {@code IntrinsicModel.clear()} -> {@code keyValueFuncs.clear()}, which runs
+ * {@code Arrays.fill(buffer, null)} <i>before</i> resetting {@code pos = 0}.
+ * <p>
+ * A concurrent {@code getCursor} on the still-cached factory calls
+ * {@code Function.init(keyValueFuncs, ...)} which reads {@code size()} (stale, &gt; 0)
+ * and then {@code getQuick(i)} (already nulled), producing exactly the reported:
+ * <pre>
+ * java.lang.NullPointerException: Cannot invoke
+ *   "io.questdb.cairo.sql.Function.init(...)" because the return value of
+ *   "io.questdb.std.ObjList.getQuick(int)" is null
+ * </pre>
+ * <p>
+ * The query mirrors the issue: a window function over a UNION ALL whose first branch
+ * is an IN-list scan served by the posting/covering index.
+ */
+public class PostingIndexConcurrentQueryNpeTest extends AbstractCairoTest {
+
+    // Window function over a UNION ALL whose first branch is an IN-list covering-index scan.
+    private static final String FAILING_QUERY = "SELECT ts, last_value(v) ignore nulls over (order by ts) AS lv\n" +
+            "FROM (\n" +
+            "  SELECT ts, 1 AS v\n" +
+            "  FROM signals_boolean\n" +
+            "  WHERE name IN ('signal.a','signal.b','signal.c','signal.d','signal.e')\n" +
+            "    AND ts <= cast(1781184000000000 as timestamp)\n" +
+            "  UNION ALL SELECT cast(1781042400000000 as timestamp), cast(null as int)\n" +
+            ")";
+
+    @Test(timeout = 120_000)
+    public void testConcurrentWindowOverUnionAllWithCoveringIndex() throws Exception {
+        assertMemoryLeak(() -> {
+            // Schema from the issue (TTL/DEDUP omitted -- irrelevant to the race; the
+            // posting/covering index with an INCLUDE list is what matters).
+            execute("CREATE TABLE signals_boolean (" +
+                    "  ts TIMESTAMP," +
+                    "  name SYMBOL INDEX TYPE POSTING INCLUDE (source, value, ts)," +
+                    "  source SYMBOL," +
+                    "  value BOOLEAN" +
+                    ") TIMESTAMP(ts) PARTITION BY DAY");
+
+            // ~250 rows across the 5 signal.* keys used by the IN list.
+            execute("INSERT INTO signals_boolean " +
+                    "SELECT (1781000000000000 + x * 100000000)::timestamp, " +
+                    "  'signal.' || CASE x % 5 WHEN 0 THEN 'a' WHEN 1 THEN 'b' WHEN 2 THEN 'c' WHEN 3 THEN 'd' ELSE 'e' END, " +
+                    "  'src' || (x % 3), " +
+                    "  x % 2 = 0 " +
+                    "FROM long_sequence(250)");
+
+            // Sanity: the query must actually be served by the covering index, otherwise
+            // we would not be exercising the buggy code path.
+            final String plan;
+            try (RecordCursorFactory factory = select(FAILING_QUERY)) {
+                planSink.clear();
+                factory.toPlan(planSink);
+                plan = planSink.getSink().toString();
+            }
+            Assert.assertTrue("expected a CoveringIndex plan, got:\n" + plan, plan.contains("CoveringIndex"));
+
+            // Correctness guard: the factory now holds its own copy of keyValueFuncs, so the
+            // multi-key IN-list covering scan must still return exactly the reference results.
+            assertSqlCursors(
+                    "SELECT /*+ no_covering */ ts, name, source, value FROM signals_boolean " +
+                            "WHERE name IN ('signal.a','signal.c','signal.e') ORDER BY ts",
+                    "SELECT ts, name, source, value FROM signals_boolean " +
+                            "WHERE name IN ('signal.a','signal.c','signal.e') ORDER BY ts"
+            );
+
+            // A modest amount of concurrent compile/execute overlap is enough: on the
+            // unfixed code this reproduces the NPE essentially every run. Threads borrow
+            // a compiler, compile, RETURN it to the pool, then execute -- so a sibling
+            // thread reuses the same pooled compiler and clears the keyValueFuncs list
+            // this factory still references, racing getCursor().
+            final int threads = 8;
+            final int iterations = 15;
+            final CyclicBarrier barrier = new CyclicBarrier(threads);
+            final CountDownLatch done = new CountDownLatch(threads);
+            final AtomicReference<Throwable> firstError = new AtomicReference<>();
+
+            for (int t = 0; t < threads; t++) {
+                new Thread(() -> {
+                    try (SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)) {
+                        ctx.with(AllowAllSecurityContext.INSTANCE);
+                        barrier.await();
+                        for (int i = 0; i < iterations && firstError.get() == null; i++) {
+                            // Mirror PG-wire: compile, RETURN the compiler to the pool,
+                            // then execute the cached factory. Another thread reuses the
+                            // same pooled compiler (and its WhereClauseParser
+                            // IntrinsicModel pool), clearing the keyValueFuncs list that
+                            // this factory still references -- racing this getCursor().
+                            final RecordCursorFactory factory;
+                            try (SqlCompiler compiler = engine.getSqlCompiler()) {
+                                factory = compiler.compile(FAILING_QUERY, ctx).getRecordCursorFactory();
+                            }
+                            try (RecordCursorFactory f = factory; RecordCursor cursor = f.getCursor(ctx)) {
+                                final Record record = cursor.getRecord();
+                                while (cursor.hasNext()) {
+                                    record.getTimestamp(0);
+                                    record.getInt(1);
+                                }
+                            }
+                        }
+                    } catch (Throwable th) {
+                        firstError.compareAndSet(null, th);
+                    } finally {
+                        done.countDown();
+                    }
+                }, "repro-7294-" + t).start();
+            }
+
+            done.await();
+            final Throwable err = firstError.get();
+            if (err != null) {
+                // Before the fix this is the intermittent NPE from issue #7294:
+                //   Function.init(...) <- ObjList.getQuick(int) returns null
+                // raised in CoveringIndexRecordCursorFactory.getCursor.
+                throw new AssertionError(
+                        "concurrent window-over-UNION-ALL covering-index query must not fail (issue #7294): " + err,
+                        err
+                );
+            }
+        });
+    }
+}


### PR DESCRIPTION
## What

Fixes #7294 — an intermittent `NullPointerException` in
`CoveringIndexRecordCursorFactory.getCursor` that occurs under concurrent queries.

```
java.lang.NullPointerException: Cannot invoke
  "io.questdb.cairo.sql.Function.init(io.questdb.cairo.sql.SymbolTableSource, io.questdb.griffin.SqlExecutionContext)"
  because the return value of "io.questdb.std.ObjList.getQuick(int)" is null
    at io.questdb.cairo.sql.Function.init(Function.java:100)
    at io.questdb.griffin.engine.table.CoveringIndexRecordCursorFactory.getCursor(...)
    at io.questdb.griffin.engine.table.VirtualRecordCursorFactory.getCursor(...)
    at io.questdb.griffin.engine.union.UnionAllRecordCursorFactory.getCursor(...)
    at io.questdb.griffin.engine.window.CachedWindowRecordCursorFactory.getCursor(...)
```

It reproduces for the query shape in the report: a **window function** over a
**`UNION ALL`** whose first branch is an **IN‑list scan served by the posting/covering
index** (`SYMBOL INDEX TYPE POSTING INCLUDE (...)`). It only manifests when several such
queries run concurrently (e.g. all panels of a Grafana dashboard firing at once over PG wire).

## Root cause

`CoveringIndexRecordCursorFactory` stored a **direct reference** to
`intrinsicModel.keyValueFuncs`:

```java
this.keyValueFuncs = keyValueFuncs; // intrinsicModel.keyValueFuncs
```

That `ObjList` is **pooled** — it belongs to the compiler's `WhereClauseParser`
(`ObjectPool<IntrinsicModel>`). `SqlCompiler`s are themselves pooled and shared across
threads/connections, so the lifecycle of that list is **not** tied to the factory:

1. Thread A compiles the query, borrows a pooled compiler, builds the covering factory
   (holding a reference to that compiler's pooled `keyValueFuncs`), and returns the
   compiler to the pool. The factory is cached (prepared statement / window operator).
2. Thread B borrows the **same** pooled compiler and recompiles. `models.next()` →
   `IntrinsicModel.clear()` → `keyValueFuncs.clear()`, and `ObjList.clear()` runs
   `Arrays.fill(buffer, null)` **before** resetting `pos = 0`.
3. Thread A's `getCursor()` calls `Function.init(keyValueFuncs, …)`, which reads a stale
   `size()` (> 0) and then `getQuick(i)` on an already‑nulled slot → **NPE**.

This is why it is intermittent and concurrency‑only: a single query run in isolation never
has another thread clear the shared list between compile and execute. The
window‑over‑`UNION ALL` shape simply widens the window between the factory being
built/cached and `getCursor()` running, so it surfaces there while a bare scan effectively never did.

## Fix

Keep our **own copy** of the list in the constructor:

```java
this.keyValueFuncs = keyValueFuncs != null ? new ObjList<>(keyValueFuncs) : null;
```

- The copy holds the **same `Function` instances**, which this factory already owns and
  frees in `close()` (`Misc.freeObjList`). The pooled `IntrinsicModel` only ever *clears*
  its list (`keyValueFuncs.clear()`), never frees the functions — so there is **no
  double‑free** and no change in ownership.
- This restores the contract already honored by `FilterOnValuesRecordCursorFactory`, whose
  key‑value list parameter is `@Transient` and is consumed at construction rather than retained.

Minimal, additive, non‑breaking: one logical line in production code plus a regression test.

## Test

`PostingIndexConcurrentQueryNpeTest` recreates the issue's schema (posting/covering index
with an `INCLUDE` list), inserts ~250 rows, and runs the reported window‑over‑`UNION ALL`
query concurrently. It also:

- asserts the query is actually served by the covering index (`CoveringIndex` in the plan),
  so the buggy path is genuinely exercised; and
- asserts the multi‑key IN‑list covering scan still matches the `/*+ no_covering */`
  reference results (proves the defensive copy preserves behavior).

### Verification (compiled against this tree)

| Code | Result |
| --- | --- |
| **before** the fix | reproduces the exact NPE on essentially every run (verified 9/9) |
| **after** the fix | passes reliably, ~1–2s (verified 11/11) |

Red before, green after.
