### PR TITLE
test(core): stop posting-index fuzz from mixing replace commits with Parquet

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/fuzz/PostingIndexO3ConcurrencyFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/PostingIndexO3ConcurrencyFuzzTest.java
@@ -134,7 +134,16 @@ public class PostingIndexO3ConcurrencyFuzzTest extends AbstractFuzzTest {
                 0.1,
                 0.0,
                 0.8,
-                0.1,   // replaceProb
+                0.0,   // replaceProb -- DISABLED: replace-range commits are a mat-view-only
+                       //   operation in production (WalWriter.commitMatView via
+                       //   MatViewRefreshJob); they are never issued against a regular WAL
+                       //   table. With partitionToParquetProb>0 above, enabling replace here
+                       //   makes the fuzz apply a replace commit onto a Parquet partition --
+                       //   an unsupported, production-unreachable state that suspends the
+                       //   table ("commit replace mode is not supported for Parquet
+                       //   partitions"). Replace and Parquet must stay mutually exclusive;
+                       //   native-partition replace coverage lives in
+                       //   testCoveringPostingO3NativeSpillFuzz and testCoveringPostingSquashSpillFuzz.
                 0.0,
                 0.01,
                 0.1,   // setParquetEncodingProb

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/PostingIndexO3ConcurrencyFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/PostingIndexO3ConcurrencyFuzzTest.java
@@ -135,15 +135,15 @@ public class PostingIndexO3ConcurrencyFuzzTest extends AbstractFuzzTest {
                 0.0,
                 0.8,
                 0.0,   // replaceProb -- DISABLED: replace-range commits are a mat-view-only
-                       //   operation in production (WalWriter.commitMatView via
-                       //   MatViewRefreshJob); they are never issued against a regular WAL
-                       //   table. With partitionToParquetProb>0 above, enabling replace here
-                       //   makes the fuzz apply a replace commit onto a Parquet partition --
-                       //   an unsupported, production-unreachable state that suspends the
-                       //   table ("commit replace mode is not supported for Parquet
-                       //   partitions"). Replace and Parquet must stay mutually exclusive;
-                       //   native-partition replace coverage lives in
-                       //   testCoveringPostingO3NativeSpillFuzz and testCoveringPostingSquashSpillFuzz.
+                //   operation in production (WalWriter.commitMatView via
+                //   MatViewRefreshJob); they are never issued against a regular WAL
+                //   table. With partitionToParquetProb>0 above, enabling replace here
+                //   makes the fuzz apply a replace commit onto a Parquet partition --
+                //   an unsupported, production-unreachable state that suspends the
+                //   table ("commit replace mode is not supported for Parquet
+                //   partitions"). Replace and Parquet must stay mutually exclusive;
+                //   native-partition replace coverage lives in
+                //   testCoveringPostingO3NativeSpillFuzz and testCoveringPostingSquashSpillFuzz.
                 0.0,
                 0.01,
                 0.1,   // setParquetEncodingProb


### PR DESCRIPTION
## What

Disable `replaceProb` in `PostingIndexO3ConcurrencyFuzzTest.testCoveringPostingParquetO3SpillFuzz` so the fuzz never combines **replace-range commits** with **Parquet partitions**.

## Why

That test was the only one enabling both `partitionToParquetProb` (0.5) and `replaceProb` (0.1).

Replace-range commits (`WAL_DEDUP_MODE_REPLACE_RANGE`) are a **materialized-view-only** operation in production: they are issued exclusively through `WalWriter.commitMatView` from `MatViewRefreshJob`, and are **never** applied to a regular WAL table. The fuzz harness simulates them on plain WAL tables via the test-only `WalWriter.commitWithParams` entry point (`FuzzRunner` lines ~392 and ~1155).

When the fuzz combined replace with Parquet conversion, a generated replace commit eventually landed on a partition that had been converted to Parquet. `TableWriter` correctly rejects this:

```
[0] commit replace mode is not supported for Parquet partitions
    at io.questdb.cairo.TableWriter.processO3Block(TableWriter.java:9457)
```

which suspends the table and trips `FuzzRunner.applyWal`:

```
java.lang.AssertionError: Table is suspended
    at io.questdb.test.cairo.fuzz.FuzzRunner.applyWal(FuzzRunner.java:414)
```

This is a **seed-dependent, flaky** failure for a state that cannot occur in production (regular tables never receive replace commits; the replace+Parquet combination is unreachable). The `TableWriter` guard is behaving correctly — the issue is purely that the fuzz models a non-production scenario.

Observed on a CI run (build 244219) of an unrelated PR:
`PostingIndexO3ConcurrencyFuzzTest.testCoveringPostingParquetO3SpillFuzz` → `AssertionError: Table is suspended`.

## Change

`replaceProb`: `0.1` → `0.0` in the Parquet test only. Replace and Parquet are now mutually exclusive across the suite:

| Test | partitionToParquetProb | replaceProb |
|------|------------------------|-------------|
| `testCoveringPostingO3NativeSpillFuzz` | 0.0 | 0.15 |
| `testCoveringPostingParquetO3SpillFuzz` | 0.5 | **0.0** (was 0.1) |
| `testCoveringPostingSquashSpillFuzz` | 0.0 | 0.2 |

Native-partition replace coverage is fully retained in the two native tests. No production code changed.
