### PR TITLE
fix(core): add null checks on opStack.peek() in ExpressionParser

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -449,8 +449,10 @@ public class ExpressionParser {
             char c = lexer.getContent().charAt(lastPos - 1);
             if (c == 'e' || c == 'E') { // Incomplete scientific floating-point literal
                 ExpressionNode en = opStack.peek();
-                ((GenericLexer.FloatingSequence) en.token).setHi(lastPos + 1);
-                processDefaultBranch = false;
+                if (en != null && en.token instanceof GenericLexer.FloatingSequence) {
+                    ((GenericLexer.FloatingSequence) en.token).setHi(lastPos + 1);
+                    processDefaultBranch = false;
+                }
             }
         }
         return processDefaultBranch;
@@ -1666,7 +1668,7 @@ public class ExpressionParser {
                                     char prevChar = lexer.getContent().charAt(lastPos - 1);
                                     if (prevChar == '-' || prevChar == '+') {
                                         final ExpressionNode en = opStack.peek();
-                                        if (en.token instanceof GenericLexer.FloatingSequence) {
+                                        if (en != null && en.token instanceof GenericLexer.FloatingSequence) {
                                             ((GenericLexer.FloatingSequence) en.token).setHi(lexer.getTokenHi());
                                             break;
                                         } else {


### PR DESCRIPTION
Two places in ExpressionParser call opStack.peek() and access the result without a null check, while every other call site in the same file already guards against null. ObjStack.peek() can return null when the stack is empty, and the unchecked cast to FloatingSequence can also throw ClassCastException.

- parsePlus(): add null + instanceof check before cast
- Constant parsing in parseOperation(): add null check before instanceof