### PR TITLE
fix(sql): fix internal error when subtracting a literal from a timestamp

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/math/SubTimestampFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/math/SubTimestampFunctionFactory.java
@@ -73,8 +73,12 @@ public class SubTimestampFunctionFactory implements FunctionFactory {
 
         @Override
         public long getTimestamp(Record rec) {
+            // The right operand is a LONG (signature "-(Nl)"), so read it with getLong().
+            // Calling getTimestamp() here breaks for operands whose getTimestamp() is unsupported,
+            // e.g. a CHAR constant implicitly cast to LONG ("now() - '1'"), which threw
+            // UnsupportedOperationException. This mirrors AddLongToTimestampFunctionFactory.
             long l = left.getTimestamp(rec);
-            long r = right.getTimestamp(rec);
+            long r = right.getLong(rec);
 
             if (l != Numbers.LONG_NULL && r != Numbers.LONG_NULL) {
                 return l - r;

--- a/core/src/test/java/io/questdb/test/griffin/IntervalFilterTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/IntervalFilterTest.java
@@ -879,7 +879,7 @@ public class IntervalFilterTest extends AbstractCairoTest {
             assertException(
                     "select * from x where ts > now() - '3 day' order by ts desc",
                     0,
-                    "inconvertible value: `3 day` [STRING -> TIMESTAMP_NS]"
+                    "inconvertible value: `3 day` [STRING -> LONG]"
             );
         });
     }
@@ -899,7 +899,7 @@ public class IntervalFilterTest extends AbstractCairoTest {
             assertException(
                     "select * from x where ts > now() - '3 day'",
                     0,
-                    "inconvertible value: `3 day` [STRING -> TIMESTAMP_NS]"
+                    "inconvertible value: `3 day` [STRING -> LONG]"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/math/SubTimestampFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/math/SubTimestampFunctionFactoryTest.java
@@ -1,0 +1,106 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.math;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class SubTimestampFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testNonNumericCharThrows() throws Exception {
+        // A non-numeric CHAR cannot be converted to LONG; the user gets a typed cast error,
+        // not an internal UnsupportedOperationException.
+        assertMemoryLeak(() -> assertException(
+                "SELECT '2020-01-01T00:00:00.000000Z'::timestamp - 'a'",
+                0,
+                "inconvertible value"));
+    }
+
+    @Test
+    public void testNowMinusCharInIntervalScan() throws Exception {
+        // Reproduces the production crash: "WHERE ts > now() - '1'" pushed into the interval
+        // optimizer (RuntimeIntervalModel) evaluated the CHAR operand via getTimestamp() and
+        // threw UnsupportedOperationException. now() is fixed via setCurrentMicros() to keep
+        // the result deterministic.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE x (ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("INSERT INTO x VALUES (8::timestamp), (9::timestamp), (10::timestamp), (11::timestamp)");
+            setCurrentMicros(10);
+            // now() is 10 micros, now() - '1' is 9 micros, so ts > 9 keeps rows 10 and 11.
+            assertQuery("SELECT ts FROM x WHERE ts > now() - '1'")
+                    .timestamp("ts")
+                    .returns("ts\n" +
+                            "1970-01-01T00:00:00.000010Z\n" +
+                            "1970-01-01T00:00:00.000011Z\n");
+        });
+    }
+
+    @Test
+    public void testNowPlusCharInIntervalScan() throws Exception {
+        // The symmetric '+' operator already worked; assert it keeps working alongside the fix.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE x (ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("INSERT INTO x VALUES (8::timestamp), (9::timestamp), (10::timestamp), (11::timestamp)");
+            setCurrentMicros(10);
+            // now() is 10 micros, now() + '1' is 11 micros, so ts > 11 keeps nothing.
+            assertQuery("SELECT ts FROM x WHERE ts > now() + '1'")
+                    .timestamp("ts")
+                    .returns("ts\n");
+        });
+    }
+
+    @Test
+    public void testTimestampMinusCharConstant() throws Exception {
+        // A single-character literal is a CHAR. The '-' operator must accept it as the LONG
+        // operand and subtract its numeric value, mirroring the '+' operator.
+        assertMemoryLeak(() -> assertQuery("SELECT '2020-01-01T00:00:00.000000Z'::timestamp - '1'")
+                .expectSize()
+                .returns("column\n2019-12-31T23:59:59.999999Z\n"));
+    }
+
+    @Test
+    public void testTimestampMinusLongConstant() throws Exception {
+        // Regression: a plain numeric LONG operand keeps working.
+        assertMemoryLeak(() -> assertQuery("SELECT '2020-01-01T00:00:00.000000Z'::timestamp - 1000000")
+                .expectSize()
+                .returns("column\n2019-12-31T23:59:59.000000Z\n"));
+    }
+
+    @Test
+    public void testTimestampMinusNullChar() throws Exception {
+        assertMemoryLeak(() -> assertQuery("SELECT '2020-01-01T00:00:00.000000Z'::timestamp - null")
+                .expectSize()
+                .returns("column\n\n"));
+    }
+
+    @Test
+    public void testTimestampNanoMinusCharConstant() throws Exception {
+        // The nanosecond timestamp variant must subtract in nanoseconds.
+        assertMemoryLeak(() -> assertQuery("SELECT '2020-01-01T00:00:00.000000000Z'::timestamp_ns - '1'")
+                .expectSize()
+                .returns("column\n2019-12-31T23:59:59.999999999Z\n"));
+    }
+}


### PR DESCRIPTION
## Problem

Subtracting a `CHAR` or `STRING` literal from a timestamp, e.g.

```sql
SELECT * FROM t WHERE timestamp > now() - '1' LIMIT 1
```

failed with an internal error. `'1'` is a single-character `CHAR` literal; it was implicitly bound to the `LONG` operand slot of the `timestamp - long` operator (`SubTimestampFunctionFactory`, signature `-(Nl)`), but the factory
read the right operand with `getTimestamp()` instead of `getLong()`. Calling `getTimestamp()` on a `CharFunction` throws `UnsupportedOperationException`, which surfaced to users as an internal error. The crash also occurred on the interval-optimizer path (`RuntimeIntervalModel`), as in the production stack trace that motivated this change.

## Fix

`SubTimestampFunctionFactory.Func.getTimestamp()` now reads the right operand with `getLong()`, mirroring the symmetric `AddLongToTimestampFunctionFactory` (`+(NL)`), which already did this. The change is behaviour-preserving for every `LONG`-compatible operand: `TimestampFunction.getLong()` returns the timestamp, `IntFunction.getTimestamp()` returns the long, and so on. It only changes the outcome for operands whose `getTimestamp()` is unsupported.

The other timestamp arithmetic factories were audited and are already correct: `AddLongToTimestampFunctionFactory` reads its count via `getLong()`, and the `dateadd`/`datediff` factories read the stride via `getInt()` and the period via `getChar()`.

## Effects and tradeoffs

- Positive: `now() - '1'` and similar queries no longer crash; the result is now consistent with `now() + '1'` (subtracting the numeric value of the operand).
- Behaviour change: `-` and `+` now produce identical, well-typed cast errors for non-numeric literals. `now() - '3 day'` now reports `inconvertible value: '3 day' [STRING -> LONG]` instead of the previous `[STRING -> TIMESTAMP]`. This is the same message `+` has always produced.
- Bug exposure: the old `-` path silently produced a meaningless value for a valid timestamp string (e.g. `now() - '2020-01-01T00:00:00.000000Z'` computed `now_micros - parsed_micros` and reinterpreted it as a timestamp). That case is now a clean cast error, matching `+`. Any query relying on that accidental behaviour will now error instead.

## Test plan

- Added `SubTimestampFunctionFactoryTest` covering the char, string, long, null, nanosecond-timestamp, and interval-scan (`now() - '1'`) paths.
- Updated the two `IntervalFilterTest` leak tests to expect the new, consistent `STRING -> LONG` error message.
- Ran `SubTimestampFunctionFactoryTest`, `IntervalFilterTest`, `TimestampQueryTest`, `TimestampAddFunctionFactoryTest`, `TimestampDiffFunctionFactoryTest`, and `WhereClauseParserTest` locally; all
  pass.
