### PR TITLE
ci(build): bound cache connect timeout and retry connect failures

### DIFF
--- a/ci/maven-settings-hetzner.xml
+++ b/ci/maven-settings-hetzner.xml
@@ -26,4 +26,27 @@
     </mirror>
   </mirrors>
 
+  <servers>
+    <!--
+      Bound the connect/read timeouts for the cache mirror. The cache is a single private
+      IP fronted by nginx; under the CI fleet's connection bursts a fresh TCP connect can
+      occasionally have its SYN dropped and retransmitted. Wagon's default connect timeout
+      inherits the OS SYN-retransmit budget (~127s with tcp_syn_retries=6), so a single
+      black-holed connect rides that full window and kills the build. A short connectionTimeout
+      makes a stuck connect fail fast (in seconds) so the wagon retry handler can reconnect
+      on a fresh source port instead of hanging. The server id MUST match the mirror id above.
+    -->
+    <server>
+      <id>hetzner-reposilite</id>
+      <configuration>
+        <httpConfiguration>
+          <all>
+            <connectionTimeout>10000</connectionTimeout>
+            <readTimeout>120000</readTimeout>
+          </all>
+        </httpConfiguration>
+      </configuration>
+    </server>
+  </servers>
+
 </settings>

--- a/ci/test-fuzz.yml
+++ b/ci/test-fuzz.yml
@@ -17,9 +17,11 @@ variables:
   includeTests: "%regex[.*[^o].class]"
   MAVEN_CACHE_FOLDER: $(HOME)/.m2/repository
   MAVEN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Xmx3072m -XX:+UseParallelGC"
-  # Wagon retries the transfer on connect failure so a dropped SYN to the single-IP cache
-  # re-attempts instead of failing the build. See test-pipeline.yml for the full rationale.
-  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.count=3"
+  # Wagon retries a dropped connect to the single-IP cache (count + nonRetryableClasses,
+  # which re-enables retry on ConnectException) instead of failing the build; the connect
+  # timeout in maven-settings-hetzner.xml bounds each attempt. See test-pipeline.yml for the
+  # full rationale.
+  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.NotSerializableException"
   MAVEN_VERSION: "version"
   MAVEN_VERSION_OPTION: "Default"
   # Full reactor (the fuzz regex spans core and compat), but no fuzz test serves the

--- a/ci/test-hosted-pipeline.yml
+++ b/ci/test-hosted-pipeline.yml
@@ -18,7 +18,7 @@ variables:
   # Kept in sync with test-pipeline.yml. These hosted (mac/windows) agents resolve from
   # Maven Central, not the cache, so the retry is a harmless no-op for them; keeping
   # MAVEN_RUN_OPTS identical across pipelines avoids drift. See test-pipeline.yml for rationale.
-  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.count=3 "
+  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.NotSerializableException "
   MAVEN_VERSION: "version"
   MAVEN_VERSION_OPTION: "Default"
   # Hosted mac/windows jobs (hosted-jobs.yml) override this to "-pl core -am" and

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -14,15 +14,20 @@ variables:
   includeTests: "%regex[.*[^o].class]"
   MAVEN_CACHE_FOLDER: $(HOME)/.m2/repository
   MAVEN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Xmx3g -XX:+UseParallelGC"
-  # retryHandler.count: the self-hosted Reposilite cache is a single IP reached over the
-  # Hetzner vSwitch; under the fleet's cold-build connection bursts a fraction of TCP SYNs
-  # to it are dropped, and the failover-less mirror turns one dropped SYN into a dead build
-  # ("Connect to maven.internal:8081 ... Connection timed out"). Wagon retries the transfer
-  # on connect failure, so the resolve re-attempts (typically succeeding, since the loss is
-  # intermittent) instead of failing the build. The root-cause cache-box fix (host
-  # networking + raised SYN backlog) addresses the drops directly; this is a client-side
-  # backstop for any residual lost SYN.
-  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.count=3 "
+  # Cache connect resilience. The self-hosted Reposilite cache is a single IP reached over
+  # the Hetzner vSwitch; under the fleet's cold-build connection bursts a fraction of TCP
+  # SYNs to it are dropped, and the failover-less mirror turns one black-holed connect into
+  # a dead build ("Connect to maven.internal:8081 ... Connection timed out").
+  #   * retryHandler.count=3 retries failed resolves, BUT wagon's default retry handler puts
+  #     ConnectException (and other connect-phase errors) on its non-retryable list, so a
+  #     connect-phase failure was NOT actually retried. nonRetryableClasses overrides that
+  #     default set with a single never-thrown class, which re-enables retry on connect
+  #     failures (the case we actually hit). connectionTimeout (in maven-settings-hetzner.xml)
+  #     bounds each connect attempt to ~10s instead of the ~127s OS SYN-retransmit budget, so
+  #     a retried connect re-attempts on a fresh source port instead of hanging out the build.
+  # The cache-box fix (nginx front-end + enlarged upstream keepalive pool) reduces the drop
+  # rate at the source; these client flags are the backstop for any residual lost SYN.
+  MAVEN_RUN_OPTS: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.NotSerializableException "
   MAVEN_VERSION: "version"
   MAVEN_VERSION_OPTION: "Default"
   # Full-reactor defaults for the self-hosted Linux jobs. The hosted mac/windows


### PR DESCRIPTION
## Problem

Self-hosted CI builds still intermittently fail with `Connect to maven.internal:8081 ... Connection timed out`, even after the cache was fronted by nginx. Diagnosis on the cache box and a runner container showed the failure is a **connect-phase** event: under the CI fleet's burst (a single PR fans out ~24 self-hosted jobs that resolve the Maven tree at once), an occasional fresh TCP connect to the single-IP cache has its SYN dropped and retransmitted, riding the OS SYN-retransmit budget (`tcp_syn_retries=6` → **~127s**) into a dead build.

Two things made this fatal rather than self-healing:

1. **No connect timeout** — wagon inherited the ~127s OS default, so a black-holed connect hung out the whole build.
2. **`retryHandler.count=3` did not retry it** — Apache HttpClient's `DefaultHttpRequestRetryHandler` puts `ConnectException` on its built-in non-retryable list (`{InterruptedIOException, UnknownHostException, ConnectException, SSLException}`), so connect-phase failures were never retried.

## Fix

- **`ci/maven-settings-hetzner.xml`** — add a `<server>` `<httpConfiguration>` for the cache mirror with `connectionTimeout=10000` (and `readTimeout=120000`), so a stuck connect fails fast (~10s) instead of ~127s. Scoped to the cache mirror only.
- **`MAVEN_RUN_OPTS`** (test-pipeline / test-fuzz / test-hosted) — add `-Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.NotSerializableException`, which overrides HttpClient's default non-retryable set so `ConnectException` **is** retried. A retried connect uses a fresh source port and almost always succeeds.

Net effect: a black-holed connect becomes a ~10s fast-fail + retry instead of a ~127s fatal hang.

## Validation

Verified empirically in a throwaway runner container (Maven 3.8.7, same as CI) against a black-holed mirror IP: with the default handler the connect failure was **not** retried; with `nonRetryableClasses` overridden it **was** retried, and `connectionTimeout` bounded each attempt to ~10s. (See PR thread for the before/after wagon `-X` output.)

This is the client-side half of the fix. The cache-side half (enlarged nginx upstream keepalive pool + `proxy_next_upstream` retry) ships separately in the infra repo and reduces the drop rate at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
