### PR TITLE
test(core): stop ServerMainForeignTableTest SAMPLE BY assertions flaking on the RSS check

### DIFF
--- a/core/src/test/java/io/questdb/test/ServerMainForeignTableTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainForeignTableTest.java
@@ -208,6 +208,7 @@ public class ServerMainForeignTableTest extends AbstractBootstrapTest {
                 new QueryAssertion(context.getCairoEngine(), context, () -> {
                 }, "SELECT min(ts), max(ts), count() FROM " + tableName + " SAMPLE BY 1d ALIGN TO CALENDAR")
                         .noLeakCheck()
+                        .noMemoryUsageCheck()
                         .expectSize()
                         .returns(TABLE_START_CONTENT);
                 assertTableExists(tableToken, false, true);
@@ -362,6 +363,7 @@ public class ServerMainForeignTableTest extends AbstractBootstrapTest {
                 new QueryAssertion(context.getCairoEngine(), context, () -> {
                 }, "SELECT min(ts), max(ts), count() FROM " + tableName + " SAMPLE BY 1d ALIGN TO CALENDAR")
                         .noLeakCheck()
+                        .noMemoryUsageCheck()
                         .expectSize()
                         .returns(TABLE_START_CONTENT);
                 dropTable(context, tableToken);


### PR DESCRIPTION
## What

Add `.noMemoryUsageCheck()` to two live-`ServerMain` `SELECT ... SAMPLE BY 1d ALIGN TO CALENDAR` assertions in `ServerMainForeignTableTest`:
- the pre-symlink assertion in `testServerMainCreateTableMoveItsFolderAwayAndSoftLinkIt`
- the assertion in `testServerMainCreateWalTableInVolume`

## Why

`QueryAssertion.assertFactoryMemoryUsage()` measures process-global native memory (`getMemUsedByFactories()`) before and after the cursor closes and fails when more than 64 KiB is retained. Under a live `ServerMain`, background threads (WAL apply, query workers, async HTTP connections) allocate native memory concurrently, so that process-global figure is not attributable to the cursor under test. The `SAMPLE BY` query intermittently trips the bound (observed in CI as "cursor kept 256 KiB") even though the cursor itself releases its memory.

`#7307` already applied the same opt-out to the third, identical assertion in the same test (the post-symlink read). This change extends it to the two remaining siblings, which share the identical pattern and exposure.

## Tradeoff

These two assertions no longer verify per-cursor RSS retention. That coverage is low value here — the result is a single-row `SAMPLE BY` aggregate — and the check cannot measure reliably against the live server's concurrent allocation, which is the source of the flake. The assertions still verify query results (`.returns(...)`) and the reported size (`.expectSize()`). The third assertion in this file remains the only place these methods previously exercised the RSS check, and `#7307` already disabled it there.

## Test plan

- Ran `ServerMainForeignTableTest#testServerMainCreateTableMoveItsFolderAwayAndSoftLinkIt` and `#testServerMainCreateWalTableInVolume` locally on arm64 (JDK 25) — both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
