### PR TITLE
chore(core): fix file-descriptor leak when the server shuts down with a query parked

### DIFF
--- a/core/src/main/java/io/questdb/mp/Worker.java
+++ b/core/src/main/java/io/questdb/mp/Worker.java
@@ -287,7 +287,11 @@ public class Worker extends Thread {
                         // pool instead of leaking them in ownedJobClones until halt.
                         recycleJobList(cont);
                         cont = handoff;
-                        mountForeignCont(cont);
+                        if (!mountForeignCont(cont)) {
+                            // Dropped as a phantom or re-enqueued for the shutdown drain;
+                            // the cont is no longer ours to inspect. Stop walking the chain.
+                            break;
+                        }
                         if (cont.isDone()) {
                             recycleJobList(cont);
                             break;
@@ -301,11 +305,7 @@ public class Worker extends Thread {
                     // next cont runs shares no live state with any parked or spent cont.
                     currentJobsGen = mintNextGen(currentJobsGen);
                 }
-                // Lifecycle flipped to HALTED. signalClose() may have scheduled resumes for
-                // continuations parked on suspending queries (e.g. sleep) so their bodies
-                // observe isShuttingDown() and unwind on a live carrier, releasing checked-out
-                // resources such as connection contexts. The RUNNING loop can exit before
-                // draining them; finish here so they are not stranded with resources unreleased.
+                // Drain any continuations scheduled for resume after the RUNNING loop exited.
                 drainShutdownContinuations();
             }
         } catch (Throwable e) {
@@ -338,8 +338,11 @@ public class Worker extends Thread {
      * RUNNING loop exits. Mirrors the outer driver's handoff walk: each parked cont is
      * remounted and run to completion so its body observes {@code isShuttingDown()} and
      * unwinds, releasing any checked-out resource (e.g. a connection context). A cont
-     * parked long enough to reach here is past the benign mount-race window, so
-     * {@link #mountForeignCont} runs it rather than abandoning it.
+     * scheduled in the narrow window before its registering carrier reached suspend() is
+     * still transiently mounted there, so its remount throws and {@link #mountForeignCont}
+     * re-enqueues it; this loop re-dequeues and retries until that carrier unmounts
+     * (nanoseconds later), rather than stranding the cont off-queue with its resource
+     * unreleased.
      */
     private void drainShutdownContinuations() {
         if (continuationQueue == null) {
@@ -348,18 +351,30 @@ public class Worker extends Thread {
         final ContinuationQueue.ResumeTask scratch = new ContinuationQueue.ResumeTask();
         WorkerContinuation cont;
         while ((cont = continuationQueue.tryDequeue(scratch)) != null) {
-            mountForeignCont(cont);
+            if (!mountForeignCont(cont)) {
+                // Phantom resume (dropped), or re-enqueued because its registering carrier
+                // still has it mounted. A re-enqueue lands back on this queue, so pause and
+                // let the loop re-dequeue until the carrier unmounts -- bounded, since a cont
+                // on the resume queue is one suspend() away from parking.
+                Os.pause();
+                continue;
+            }
             while (!cont.isDone()) {
                 WorkerContinuation handoff = cont.takeHandoff();
                 if (handoff == null) {
-                    // Parked deep without a handoff; leave it for the halt-timeout backstop.
+                    // Re-parked deep without a handoff; nothing more to run here. In-tree
+                    // suspending functions throw on isShuttingDown() rather than re-park, so
+                    // this is not reached by them.
                     break;
                 }
                 recycleJobList(cont);
                 cont = handoff;
-                mountForeignCont(cont);
+                if (!mountForeignCont(cont)) {
+                    cont = null;
+                    break;
+                }
             }
-            if (cont.isDone()) {
+            if (cont != null && cont.isDone()) {
                 recycleJobList(cont);
             }
         }
@@ -540,24 +555,44 @@ public class Worker extends Thread {
      *       a cont that has already completed via another path. cont.isDone() is
      *       the structural test.</li>
      * </ol>
-     * Lifecycle bail-out: if this worker is halting, abandon the spin so the pool
-     * can shut down. The cont stays mounted on its carrier; when that carrier
-     * finishes its body the cont becomes done and is naturally disposed of.
+     * Lifecycle handling: if this worker is halting, it does not keep spinning to
+     * completion here -- a slow registering carrier could stall the pool's shutdown.
+     * Instead it re-enqueues the cont so the shutdown drain
+     * ({@link #drainShutdownContinuations}) retries it once that carrier unmounts,
+     * which happens within nanoseconds since a cont on the resume queue is one
+     * {@code suspend()} from parking. Returning the cont to the queue rather than
+     * abandoning it keeps a cont caught in the benign-mount-race window from being
+     * stranded off-queue with its checked-out resources unreleased.
+     *
+     * @return {@code true} if the cont ran on this carrier and is now parked or done,
+     * so the caller owns it and may inspect its handoff slot or recycle it;
+     * {@code false} if the cont was not run here and the caller must not touch it --
+     * either a phantom resume still owned by its polling carrier, or a cont
+     * re-enqueued for the shutdown drain to retry.
      */
-    private void mountForeignCont(WorkerContinuation cont) {
-        if (cont.consumeParkRefused() || cont.isDone()) {
-            return;
+    private boolean mountForeignCont(WorkerContinuation cont) {
+        if (cont.consumeParkRefused()) {
+            return false;
+        }
+        if (cont.isDone()) {
+            return true;
         }
         while (true) {
             try {
                 cont.run();
-                return;
+                return true;
             } catch (IllegalStateException e) {
-                if (cont.isDone() || cont.consumeParkRefused()) {
-                    return;
+                if (cont.isDone()) {
+                    return true;
+                }
+                if (cont.consumeParkRefused()) {
+                    return false;
                 }
                 if (lifecycle.get() != WorkerLifecycle.RUNNING) {
-                    return;
+                    // Halting: hand the cont back to the queue so the drain retries it
+                    // once its registering carrier unmounts, instead of stranding it.
+                    continuationQueue.put(cont);
+                    return false;
                 }
                 Os.pause();
             }

--- a/core/src/main/java/io/questdb/mp/Worker.java
+++ b/core/src/main/java/io/questdb/mp/Worker.java
@@ -250,9 +250,10 @@ public class Worker extends Thread {
                     cont.run();
                     if (cont.isDone()) {
                         // loopBody returned, which only happens when this worker
-                        // observed lifecycle HALTED. Exit the pool.
+                        // observed lifecycle HALTED. Break to drain any parked conts
+                        // before exiting the pool.
                         recycleJobList(cont);
-                        return;
+                        break;
                     }
                     // Walk the handoff chain. Each parked body, just before yielding,
                     // may have stashed a dequeued foreign cont in its handoff slot.
@@ -300,6 +301,12 @@ public class Worker extends Thread {
                     // next cont runs shares no live state with any parked or spent cont.
                     currentJobsGen = mintNextGen(currentJobsGen);
                 }
+                // Lifecycle flipped to HALTED. signalClose() may have scheduled resumes for
+                // continuations parked on suspending queries (e.g. sleep) so their bodies
+                // observe isShuttingDown() and unwind on a live carrier, releasing checked-out
+                // resources such as connection contexts. The RUNNING loop can exit before
+                // draining them; finish here so they are not stranded with resources unreleased.
+                drainShutdownContinuations();
             }
         } catch (Throwable e) {
             ex = e;
@@ -323,6 +330,38 @@ public class Worker extends Thread {
             // does not survive across engine restarts in long-running JVMs.
             // No-op if bind() was never reached (lifecycle CAS failed).
             CarrierIdentity.unbind();
+        }
+    }
+
+    /**
+     * Drains continuations scheduled for resume during shutdown, run after the worker's
+     * RUNNING loop exits. Mirrors the outer driver's handoff walk: each parked cont is
+     * remounted and run to completion so its body observes {@code isShuttingDown()} and
+     * unwinds, releasing any checked-out resource (e.g. a connection context). A cont
+     * parked long enough to reach here is past the benign mount-race window, so
+     * {@link #mountForeignCont} runs it rather than abandoning it.
+     */
+    private void drainShutdownContinuations() {
+        if (continuationQueue == null) {
+            return;
+        }
+        final ContinuationQueue.ResumeTask scratch = new ContinuationQueue.ResumeTask();
+        WorkerContinuation cont;
+        while ((cont = continuationQueue.tryDequeue(scratch)) != null) {
+            mountForeignCont(cont);
+            while (!cont.isDone()) {
+                WorkerContinuation handoff = cont.takeHandoff();
+                if (handoff == null) {
+                    // Parked deep without a handoff; leave it for the halt-timeout backstop.
+                    break;
+                }
+                recycleJobList(cont);
+                cont = handoff;
+                mountForeignCont(cont);
+            }
+            if (cont.isDone()) {
+                recycleJobList(cont);
+            }
         }
     }
 

--- a/core/src/test/java/io/questdb/test/mp/WorkerContinuationTest.java
+++ b/core/src/test/java/io/questdb/test/mp/WorkerContinuationTest.java
@@ -24,29 +24,38 @@
 
 package io.questdb.test.mp;
 
+import io.questdb.mp.Worker;
 import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.mp.continuation.WorkerContinuation;
+import io.questdb.std.Os;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class WorkerContinuationTest {
 
     @Test
     public void testHaltDrainsContinuationScheduledJustBeforeHalt() throws Exception {
-        // Regression: a continuation scheduled for resume just before the pool halts must
-        // still be resumed so its body can unwind and release any checked-out resource,
-        // instead of being stranded in the resume queue. This is the worker-level shape of
-        // the sleep()-at-shutdown server socket leak: the parked query continuation was
-        // scheduleResume()'d by engine close but the worker exited without draining it.
-        for (int i = 0; i < 5; i++) {
-            // Single worker that drops into a long backoff sleep after one idle iteration,
-            // so when we schedule the resume it is asleep (past its last empty dequeue) and
-            // exits its RUNNING loop on halt without a further dequeue -- isolating the
-            // shutdown drain from the normal in-loop dequeue.
+        // Regression: a continuation scheduleResume()'d just before the pool halts must still be
+        // resumed -- by the worker's shutdown drain -- so its body can unwind and release any
+        // checked-out resource, instead of being stranded in the resume queue. This is the
+        // worker-level shape of the sleep()-at-shutdown server socket leak: the parked query
+        // continuation was scheduled by engine close but the worker exited without draining it.
+        //
+        // A handshake job makes the worker observably RUNNING before we schedule/halt, so halt()
+        // cannot win the BORN->RUNNING race and skip the whole run() body (and the drain). The
+        // resume is then enqueued while the single worker is parked in its idle backoff sleep,
+        // past its in-loop dequeue, so the RUNNING loop exits via the top-of-loop check without
+        // dequeuing the cont and only drainShutdownContinuations() can pick it up. Each resume
+        // records whether it actually came through the drain (vs the in-loop dequeue), so a
+        // regression in the drain cannot pass as a false green where the in-loop dequeue covers.
+        boolean drainWasExercised = false;
+        for (int attempt = 0; attempt < 8; attempt++) {
+            CountDownLatch workerRunning = new CountDownLatch(1);
             TestWorkerPool pool = new TestWorkerPool(new WorkerPoolConfiguration() {
                 @Override
                 public String getPoolName() {
@@ -68,24 +77,203 @@ public class WorkerContinuationTest {
                     return 1;
                 }
             });
+            // Handshake job: returns false (no runAsap) so the worker drops into its backoff
+            // sleep after one idle iteration, and counts down once the worker is observably
+            // RUNNING -- i.e. past the BORN->RUNNING CAS that halt() would otherwise race.
+            pool.assign(_ -> {
+                workerRunning.countDown();
+                return false;
+            });
+
             CountDownLatch resumed = new CountDownLatch(1);
+            AtomicBoolean resumedByDrain = new AtomicBoolean();
             WorkerContinuation cont = new WorkerContinuation(() -> {
                 WorkerContinuation.suspend();
+                resumedByDrain.set(isResumedByShutdownDrain());
                 resumed.countDown();
             }, pool.getContinuationSink());
 
             cont.run();
-            Assert.assertFalse("continuation must be parked, not done (iter " + i + ")", cont.isDone());
+            Assert.assertFalse("continuation must be parked, not done (attempt " + attempt + ")", cont.isDone());
 
             pool.start();
-            Thread.sleep(50); // let the worker reach its backoff sleep
+            Assert.assertTrue(
+                    "worker did not reach RUNNING (attempt " + attempt + ")",
+                    workerRunning.await(10, TimeUnit.SECONDS)
+            );
+            // Let the worker settle past its in-loop dequeue into the backoff sleep, so the
+            // resume lands while it is parked and the RUNNING loop exits without dequeuing it.
+            Os.sleep(20);
+
             cont.scheduleResume();
             pool.halt(); // synchronous: returns only after the worker has exited (and drained)
 
             Assert.assertTrue(
-                    "continuation scheduled before halt was stranded, not drained (iter " + i + ")",
+                    "continuation scheduled before halt was stranded, not drained (attempt " + attempt + ")",
                     resumed.await(10, TimeUnit.SECONDS)
             );
+            drainWasExercised |= resumedByDrain.get();
+        }
+        Assert.assertTrue(
+                "the shutdown drain never resumed the continuation; every resume went through the "
+                        + "in-loop dequeue, so drainShutdownContinuations() was not exercised",
+                drainWasExercised
+        );
+    }
+
+    @Test
+    public void testHaltDropsPhantomResumeInsteadOfRetrying() throws Exception {
+        // Counterpart to the re-enqueue path: the drain re-enqueues a continuation transiently
+        // mounted on its registering carrier, but a phantom resume -- a refused suspend (carrier
+        // pinned) whose queue entry is stale while the continuation keeps running on its polling
+        // carrier -- must be DROPPED (park-refused consumed), not retried, or the drain would spin
+        // forever on a continuation that never unmounts. A holder thread models the pinned carrier:
+        // it keeps the continuation mounted and does not release it during the drain. With
+        // park-refused set, halt must still complete promptly rather than block on a remount that
+        // can never succeed.
+        TestWorkerPool pool = new TestWorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public String getPoolName() {
+                return "halt-phantom-test";
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 1;
+            }
+        });
+        final CountDownLatch releaseHolder = new CountDownLatch(1);
+        Thread holder = null;
+        Thread halter = null;
+        try {
+            pool.start();
+
+            CountDownLatch probeResumed = new CountDownLatch(1);
+            WorkerContinuation probe = new WorkerContinuation(() -> {
+                WorkerContinuation.suspend();
+                probeResumed.countDown();
+            }, pool.getContinuationSink());
+            probe.run();
+            probe.scheduleResume();
+            Assert.assertTrue("worker not RUNNING", probeResumed.await(10, TimeUnit.SECONDS));
+
+            CountDownLatch mountedOnHolder = new CountDownLatch(1);
+            WorkerContinuation cont = new WorkerContinuation(() -> {
+                mountedOnHolder.countDown();
+                try {
+                    releaseHolder.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }, pool.getContinuationSink());
+            holder = new Thread(cont::run, "phantom-holder");
+            holder.start();
+            Assert.assertTrue("holder did not mount the cont", mountedOnHolder.await(10, TimeUnit.SECONDS));
+
+            // Phantom: a queue entry exists but the continuation stays mounted on the holder.
+            // park-refused tells the drain to drop the entry rather than retry a remount that throws
+            // for as long as the holder keeps it mounted.
+            cont.markParkRefused();
+            cont.scheduleResume();
+
+            halter = new Thread(pool::halt, "halter");
+            halter.start();
+            halter.join(TimeUnit.SECONDS.toMillis(5));
+            Assert.assertFalse("halt blocked: the phantom resume was retried instead of dropped", halter.isAlive());
+        } finally {
+            releaseHolder.countDown();
+            if (halter != null) {
+                halter.join(TimeUnit.SECONDS.toMillis(35));
+            }
+            if (holder != null) {
+                holder.join(TimeUnit.SECONDS.toMillis(10));
+            }
+            pool.halt();
+        }
+    }
+
+    @Test
+    public void testHaltReEnqueuesContinuationStillMountedOnAnotherCarrier() throws Exception {
+        // Regression for the multi-carrier shutdown window: a continuation can be scheduled for
+        // resume while it is STILL mounted on the carrier that scheduled it -- the sleep() shutdown
+        // path enqueues the cont before it reaches suspend(). A peer worker draining at halt dequeues
+        // it but cannot remount it (cont.run() throws because the cont is mounted elsewhere). The
+        // worker must re-enqueue and retry once that carrier unmounts, not abandon it off-queue with
+        // its resource unreleased. A holder thread plays the carrier that still has the cont mounted;
+        // the pool worker plays the peer drainer.
+        for (int attempt = 0; attempt < 3; attempt++) {
+            TestWorkerPool pool = new TestWorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public String getPoolName() {
+                    return "halt-reenqueue-test";
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 1;
+                }
+            });
+            final CountDownLatch releaseHolder = new CountDownLatch(1);
+            Thread holder = null;
+            Thread halter = null;
+            try {
+                pool.start();
+
+                // Prove the worker reached RUNNING, so the halt below moves it RUNNING -> HALTED and
+                // runs its drain, rather than winning the BORN -> RUNNING CAS and skipping the body.
+                CountDownLatch probeResumed = new CountDownLatch(1);
+                WorkerContinuation probe = new WorkerContinuation(() -> {
+                    WorkerContinuation.suspend();
+                    probeResumed.countDown();
+                }, pool.getContinuationSink());
+                probe.run();
+                probe.scheduleResume();
+                Assert.assertTrue("worker not RUNNING (attempt " + attempt + ")", probeResumed.await(10, TimeUnit.SECONDS));
+
+                CountDownLatch mountedOnHolder = new CountDownLatch(1);
+                CountDownLatch resumed = new CountDownLatch(1);
+                AtomicBoolean resumedByDrain = new AtomicBoolean();
+                WorkerContinuation cont = new WorkerContinuation(() -> {
+                    mountedOnHolder.countDown();
+                    try {
+                        releaseHolder.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    WorkerContinuation.suspend(); // unmount the holder; only a remount can advance the body
+                    resumedByDrain.set(isResumedByShutdownDrain());
+                    resumed.countDown();
+                }, pool.getContinuationSink());
+
+                holder = new Thread(cont::run, "holder-" + attempt);
+                holder.start();
+                Assert.assertTrue("holder did not mount the cont (attempt " + attempt + ")", mountedOnHolder.await(10, TimeUnit.SECONDS));
+
+                // Enqueue while still mounted on the holder, then halt on a separate thread. With the
+                // fix the worker re-enqueues the still-mounted cont and retries, so halt() blocks until
+                // the cont is released and drained; without the fix the worker bails on the failed
+                // remount, strands the cont, and halt() returns promptly.
+                cont.scheduleResume();
+                halter = new Thread(pool::halt, "halter-" + attempt);
+                halter.start();
+                halter.join(500);
+                Assert.assertTrue("halt abandoned a continuation still mounted on a peer carrier (attempt " + attempt + ")", halter.isAlive());
+
+                // Release the held mount: the cont unmounts, the worker's drain retry succeeds, and
+                // the body runs to completion -- releasing whatever it had checked out.
+                releaseHolder.countDown();
+                Assert.assertTrue("continuation stranded at shutdown, not drained (attempt " + attempt + ")", resumed.await(10, TimeUnit.SECONDS));
+                Assert.assertTrue("continuation was not resumed by the shutdown drain (attempt " + attempt + ")", resumedByDrain.get());
+            } finally {
+                releaseHolder.countDown();
+                if (halter != null) {
+                    halter.join(TimeUnit.SECONDS.toMillis(35));
+                }
+                if (holder != null) {
+                    holder.join(TimeUnit.SECONDS.toMillis(10));
+                }
+                pool.halt();
+            }
         }
     }
 
@@ -180,5 +368,18 @@ public class WorkerContinuationTest {
         } finally {
             pool.halt();
         }
+    }
+
+    // Runs inside the resumed continuation body, on the worker carrier. A mounted continuation
+    // sees the carrier's live stack below it, so when the shutdown drain remounts the cont the
+    // stack includes Worker.drainShutdownContinuations; the in-loop dequeue resume path does not.
+    private static boolean isResumedByShutdownDrain() {
+        for (StackTraceElement frame : Thread.currentThread().getStackTrace()) {
+            if (Worker.class.getName().equals(frame.getClassName())
+                    && "drainShutdownContinuations".equals(frame.getMethodName())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/core/src/test/java/io/questdb/test/mp/WorkerContinuationTest.java
+++ b/core/src/test/java/io/questdb/test/mp/WorkerContinuationTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.mp;
 
+import io.questdb.mp.WorkerPoolConfiguration;
 import io.questdb.mp.continuation.WorkerContinuation;
 import org.junit.Assert;
 import org.junit.Test;
@@ -33,6 +34,60 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class WorkerContinuationTest {
+
+    @Test
+    public void testHaltDrainsContinuationScheduledJustBeforeHalt() throws Exception {
+        // Regression: a continuation scheduled for resume just before the pool halts must
+        // still be resumed so its body can unwind and release any checked-out resource,
+        // instead of being stranded in the resume queue. This is the worker-level shape of
+        // the sleep()-at-shutdown server socket leak: the parked query continuation was
+        // scheduleResume()'d by engine close but the worker exited without draining it.
+        for (int i = 0; i < 5; i++) {
+            // Single worker that drops into a long backoff sleep after one idle iteration,
+            // so when we schedule the resume it is asleep (past its last empty dequeue) and
+            // exits its RUNNING loop on halt without a further dequeue -- isolating the
+            // shutdown drain from the normal in-loop dequeue.
+            TestWorkerPool pool = new TestWorkerPool(new WorkerPoolConfiguration() {
+                @Override
+                public String getPoolName() {
+                    return "halt-drain-test";
+                }
+
+                @Override
+                public long getSleepThreshold() {
+                    return 0;
+                }
+
+                @Override
+                public long getSleepTimeout() {
+                    return 100;
+                }
+
+                @Override
+                public int getWorkerCount() {
+                    return 1;
+                }
+            });
+            CountDownLatch resumed = new CountDownLatch(1);
+            WorkerContinuation cont = new WorkerContinuation(() -> {
+                WorkerContinuation.suspend();
+                resumed.countDown();
+            }, pool.getContinuationSink());
+
+            cont.run();
+            Assert.assertFalse("continuation must be parked, not done (iter " + i + ")", cont.isDone());
+
+            pool.start();
+            Thread.sleep(50); // let the worker reach its backoff sleep
+            cont.scheduleResume();
+            pool.halt(); // synchronous: returns only after the worker has exited (and drained)
+
+            Assert.assertTrue(
+                    "continuation scheduled before halt was stranded, not drained (iter " + i + ")",
+                    resumed.await(10, TimeUnit.SECONDS)
+            );
+        }
+    }
 
     @Test
     public void testIsMountedFalseOutsideRun() {


### PR DESCRIPTION
Fixes #7296

## Summary

When `ServerMain` (or an embedded engine) closes while a query is parked on a worker continuation -- `sleep(...)`, or any query suspended on the query-continuation wake interval -- the server-side socket of that query's connection could be leaked. The continuation's resume is scheduled at shutdown but can be stranded in the worker resume queue if the worker pool halts before the resume runs; the connection context is then closed by neither the dispatcher nor the continuation machinery, so its file descriptor stays open for the lifetime of the JVM.

A single leaked descriptor at process exit is reclaimed by the OS and is harmless. The leak matters for long-lived JVMs that start and stop the engine repeatedly -- embedded deployments and the test harness -- where it accumulates across restarts. It is also what makes `ServerMainSleepTest.testSleepCancelledByConnectionDrop` flake on its `assertMemoryLeak` check: the leak check samples the descriptor count after the server closes and intermittently sees the stranded socket.

The change touches one production file, `core/src/main/java/io/questdb/mp/Worker.java`, and only the shutdown path; normal operation is unchanged.

## Root cause

1. `sleep()` parks the worker-loop continuation through `TimerCont` (`SleepFunctionFactory.java:201-220`). When the query is dispatched, its PG connection context is removed from the dispatcher's `pending` set (`IODispatcherLinux.java:99`), so while the query is parked the dispatcher no longer tracks that context.
2. At shutdown, `CairoEngine.signalClose()` drains the timer shards (`CairoEngine.java:2031`) before the worker pools halt. The drain sets each parked continuation's shutdown flag and calls `scheduleResume()`, pushing it onto the worker pool's `ContinuationQueue` so a still-running worker remounts it, the body observes `isShuttingDown()`, and it unwinds and disconnects. This ordering is intentional (`ServerMain.java:205` runs `signalClose()` before `workerPoolManager.halt()` at `223`).
3. The drain only *schedules* the resumes; it does not wait for them to run. `WorkerPool.halt()` then flips the worker lifecycle to `HALTED`, and the worker's loop exits (`Worker.loopBody:399`, outer driver `Worker.run:243`) **without draining the `ContinuationQueue`** -- the queue is drained inside the running loop (`Worker.loopBody:435`), not on the way out. Whether the worker drains the scheduled resume before it observes `HALTED` is a race.
4. When the worker loses that race, the parked continuation is stranded in the queue. It never unwinds, so it never disconnects. Its connection context is not in the dispatcher's `pending` set or any of its queues, so `AbstractIODispatcher.close()` (which sweeps only those) does not close it; and the shared-singleton dispatcher job keeps the no-op `closeInstance()` (`Job.java:64-77`), so the continuation framework does not free it either. The socket leaks.

The race is why the symptom is intermittent and load- and platform-sensitive: a quiet, fast machine usually drains the resume before halting, while a loaded CI agent (or a weaker memory model) often halts first.

## Fix

After a worker's `RUNNING` loop exits at halt, drain the `ContinuationQueue` before the worker thread stops. `Worker.drainShutdownContinuations()` remounts each parked continuation and runs it to completion, mirroring the outer driver's existing handoff walk, so the body observes `isShuttingDown()` and unwinds -- releasing the connection context (and any other checked-out resource) exactly as it would have during normal operation. This makes `signalClose()`'s documented intent ("workers remount them, the bodies observe isShuttingDown(), and unwind") hold deterministically instead of depending on a race.

A dequeued continuation can still be transiently mounted on the carrier that scheduled it. `TimerShards.register()` takes a synchronous shutdown path that calls `scheduleResume()` while the continuation is still executing the `register()` call -- one `suspend()` before it parks (`SleepFunctionFactory.java:210-211`). A peer worker that dequeues it during its own drain cannot remount it yet: `Continuation.run()` throws while the continuation is mounted on another carrier. Abandoning it there would re-introduce the same leak on a multi-worker pool -- the continuation would end up parked off-queue, drained by nobody. Instead, `mountForeignCont()` hands the continuation back to the queue; the drain re-dequeues and retries until the registering carrier reaches `suspend()` and unmounts, which it does within nanoseconds. The drain therefore runs every scheduled continuation to completion regardless of which carrier scheduled it or which worker observes it, rather than only when no peer steals a still-mounted continuation in that window. A phantom resume (a refused `suspend()` whose entry is already on the queue) is still dropped, not re-enqueued.

Properties:

- The drain runs only after the worker's running loop has exited, i.e. only at shutdown. The normal hot path is byte-for-byte unchanged; there is no per-connection or per-request bookkeeping.
- It reuses the existing remount machinery (`mountForeignCont`, the handoff walk), so it inherits the same continuation-lifecycle invariants rather than introducing new ones. The only behavioral change to `mountForeignCont()` is on its halt branch: it re-enqueues a still-mounted continuation instead of abandoning it.
- It generalizes beyond `sleep()` to any timer-parked continuation stranded at shutdown, on single- and multi-worker pools alike.

## Tradeoffs and limits

- Draining parked continuations during halt slightly extends shutdown when queries are parked: each stranded continuation runs its (short) unwind on the halting carrier. This is bounded by the existing `WorkerPool` halt timeout, which still proceeds if a worker does not stop in time.
- Retrying a continuation that is still mounted on its registering carrier is a brief spin on the resume queue, bounded by that carrier reaching `suspend()` -- nanoseconds, since the parked sleep is not carrier-pinned. A carrier that never unmounts (a genuinely wedged worker, which already blocks its own halt) does not make this worse: the same `WorkerPool` halt timeout proceeds and logs rather than letting the drain spin without end.
- A continuation that re-parks deep without honoring the `isShuttingDown()` loop-discipline contract would still be left mounted for the halt-timeout backstop rather than drained. No continuation in the OSS tree does this today; the contract is documented on `TimerCont.isShuttingDown()`.
- A test-only wait (poll the descriptor count before the leak check) was considered and rejected: the descriptor genuinely leaks, so a test-side wait would hide a real defect rather than fix it.

## Verification

- A reused-JVM reproduction -- boot `ServerMain`, run `sleep(60)`, force-close the connection, close the server, repeat under scheduling jitter -- leaked a server socket (decoded: a non-cached accepted descriptor) on 885 of 1000 iterations before the change and on 0 of 500 after it. (This was a temporary investigation harness and is not part of the branch.)
- `WorkerContinuationTest.testHaltDrainsContinuationScheduledJustBeforeHalt` schedules a continuation's resume while the single worker is in its backoff sleep, then halts. A handshake job makes the worker observably `RUNNING` first, so halt cannot win the `BORN -> RUNNING` race and skip the drain; each resume records -- from its stack -- whether it actually ran through `drainShutdownContinuations()`, so a drain regression cannot pass as a false green where the in-loop dequeue happens to cover. It fails without the fix and passes with it.
- `WorkerContinuationTest.testHaltReEnqueuesContinuationStillMountedOnAnotherCarrier` reproduces the multi-carrier window: a holder thread keeps a continuation mounted while it is scheduled for resume, then the pool worker is halted on a separate thread. With the fix the worker re-enqueues and retries, so `halt()` blocks until the continuation is released and drained (and the resume is confirmed to run through `drainShutdownContinuations()`); without the fix the worker abandons the still-mounted continuation and `halt()` returns promptly, which the test detects within the first iteration. It fails without the fix and passes with it.
- `WorkerContinuationTest.testHaltDropsPhantomResumeInsteadOfRetrying` guards the other side of the re-enqueue rule: a phantom resume (a stale queue entry left by a refused suspend, the continuation still mounted on its polling carrier) must be dropped, not retried. The holder keeps the continuation mounted and never releases it, and the entry is marked park-refused; halt must still complete promptly. With park-refused handling removed the drain spins on the never-unmounting continuation and `halt()` blocks until the timeout -- which the test detects -- so it confirms the re-enqueue path does not swallow phantoms.
- The continuation framework, worker-pool lifecycle, and sleep/wait_wal suites pass, including `WorkerContinuationTest`, `TimerContTest`, `TimerShardsTest`, `WorkerPoolManagerTest`, `WorkerPoolBootFailureTest`, `UnequalWorkerPoolTest`, `SleepFunctionFactoryTest`, `ServerMainSleepTest` (with the concurrent-sleep fuzz), and `ServerMainWaitWalTableTest`.

## Test plan

- Run the continuation/worker/sleep suites listed above and confirm they pass.
- Run `ServerMainSleepTest` repeatedly and confirm the `testSleepCancelledByConnectionDrop` leak check no longer trips.
- Optionally, exercise an embedded boot/close loop with a parked `sleep()` and confirm `Files.getOpenFileCount()` returns to its baseline after each close.