### PR TITLE
fix(http): prevent HTTP context reuse crashes and tighten multipart upload parsing

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/http/HttpHeaderParser.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpHeaderParser.java
@@ -120,6 +120,7 @@ public class HttpHeaderParser implements Mutable, QuietCloseable, HttpRequestHea
         this.query = null;
         this.headerName = null;
         this.contentType = null;
+        this.charset = null;
         this.boundary = null;
         this.contentDisposition = null;
         this.contentDispositionName = null;
@@ -139,7 +140,9 @@ public class HttpHeaderParser implements Mutable, QuietCloseable, HttpRequestHea
         this.contentLength = -1;
         this.cookieList.clear();
         this.cookiePool.clear();
+        this.cookies.clear();
         this.ignoredCookieCount = 0;
+        this.sink.clear();
         // do not clear the pool
         // this.pool.clear();
     }
@@ -347,6 +350,7 @@ public class HttpHeaderParser implements Mutable, QuietCloseable, HttpRequestHea
             this.hi = headerPtr + bufferSize;
         }
         boundaryAugmenter.reopen();
+        sink.reopen();
     }
 
     public int size() {

--- a/core/src/main/java/io/questdb/cutlass/http/HttpHeaderParser.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpHeaderParser.java
@@ -629,6 +629,9 @@ public class HttpHeaderParser implements Mutable, QuietCloseable, HttpRequestHea
 
         boolean expectFormData = true;
         boolean swallowSpace = true;
+        boolean valueQuoted = false;
+        boolean valueEscaped = false;
+        boolean valueStart = false;
 
         DirectUtf8String name = null;
 
@@ -640,7 +643,31 @@ public class HttpHeaderParser implements Mutable, QuietCloseable, HttpRequestHea
                 continue;
             }
 
-            if (p > hi || b == ';') {
+            if (name != null && valueStart) {
+                valueStart = false;
+                if (b == '"') {
+                    valueQuoted = true;
+                    valueEscaped = false;
+                    continue;
+                }
+            }
+
+            if (valueQuoted) {
+                if (valueEscaped) {
+                    valueEscaped = false;
+                    continue;
+                }
+                if (b == '\\') {
+                    valueEscaped = true;
+                    continue;
+                }
+                if (b == '"') {
+                    valueQuoted = false;
+                    continue;
+                }
+            }
+
+            if (p > hi || (b == ';' && !valueQuoted)) {
                 if (expectFormData) {
                     this.contentDisposition = csPool.next().of(_lo, p - 1);
                     _lo = p;
@@ -654,26 +681,27 @@ public class HttpHeaderParser implements Mutable, QuietCloseable, HttpRequestHea
 
                 if (Utf8s.equalsAscii("name", name)) {
                     this.contentDispositionName = unquote("name", csPool.next().of(_lo, p - 1));
-                    swallowSpace = true;
-                    _lo = p;
-                    name = null;
-                    continue;
+                } else if (Utf8s.equalsAscii("filename", name)) {
+                    this.contentDispositionFilename = unquote("filename", csPool.next().of(_lo, p - 1));
                 }
 
-                if (Utf8s.equalsAscii("filename", name)) {
-                    this.contentDispositionFilename = unquote("filename", csPool.next().of(_lo, p - 1));
-                    _lo = p;
-                    name = null;
-                    continue;
-                }
+                swallowSpace = true;
+                valueQuoted = false;
+                valueEscaped = false;
+                valueStart = false;
+                _lo = p;
+                name = null;
 
                 if (p > hi) {
                     break;
                 }
-            } else if (b == '=') {
+            } else if (b == '=' && !valueQuoted) {
                 name = name == null ? csPool.next().of(_lo, p - 1) : name.of(_lo, p - 1);
                 _lo = p;
                 swallowSpace = false;
+                valueQuoted = false;
+                valueEscaped = false;
+                valueStart = true;
             }
         }
     }

--- a/core/src/main/java/io/questdb/cutlass/http/HttpMultipartContentParser.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpMultipartContentParser.java
@@ -40,7 +40,8 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
 
     private static final int BODY = 6;
     private static final int BODY_BROKEN = 8;
-    private static final int BODY_REPLAY_BOUNDARY_SUFFIX = 14;
+    private static final int BODY_REPLAY_BOUNDARY_AFTER_CR = 14;
+    private static final int BODY_REPLAY_BOUNDARY_AFTER_DASH = 15;
     private static final int BOUNDARY_INCOMPLETE = 3;
     private static final int BOUNDARY_MATCH = 1;
     private static final int BOUNDARY_NO_MATCH = 2;
@@ -50,16 +51,17 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
     private static final int PARTIAL_START_BOUNDARY = 3;
     private static final int POTENTIAL_BOUNDARY = 9;
     private static final int PRE_HEADERS = 10;
-    private static final int START_BOUNDARY = 2;
+    private static final int PRE_HEADERS_AFTER_CR = 16;
+    private static final int PRE_HEADERS_AFTER_DASH = 17;
     private static final int START_HEADERS = 12;
     private static final int START_PARSING = 1;
     private static final int START_PRE_HEADERS = 11;
+    private static final int START_PRE_HEADERS_AFTER_DASH = 18;
     private final HttpHeaderParser headerParser;
     private DirectUtf8Sequence boundary;
     private byte boundaryByte;
     private int boundaryLen;
     private int boundaryPtr;
-    private byte boundarySuffix;
     private int consumedBoundaryLen;
     private long resumePtr;
     private int state;
@@ -75,7 +77,6 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
         this.boundaryPtr = 0;
         this.boundaryByte = 0;
         this.boundary = null;
-        this.boundarySuffix = 0;
         this.consumedBoundaryLen = 0;
         this.headerParser.clear();
     }
@@ -114,20 +115,13 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
                     _lo = ptr;
                     state = BODY;
                     break;
-                case BODY_REPLAY_BOUNDARY_SUFFIX:
-                    long suffixLo = getBoundarySuffixLo();
-                    try {
-                        ptr = onChunkWithRetryHandle(processor, suffixLo, suffixLo + 1, BODY_BROKEN, ptr, ptr, true);
-                        boundarySuffix = 0;
-                    } catch (RetryOperationException e) {
-                        boundarySuffix = 0;
-                        throw e;
-                    }
+                case BODY_REPLAY_BOUNDARY_AFTER_CR:
+                    ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.lo() + 1, BODY_BROKEN, ptr, ptr, true);
+                    break;
+                case BODY_REPLAY_BOUNDARY_AFTER_DASH:
+                    ptr = onChunkWithRetryHandle(processor, boundary.lo() + 2, boundary.lo() + 3, BODY_BROKEN, ptr, ptr, true);
                     break;
                 case START_PARSING:
-                    state = START_BOUNDARY;
-                    // fall through
-                case START_BOUNDARY:
                     boundaryPtr = 2;
                     // fall through
                 case PARTIAL_START_BOUNDARY:
@@ -145,55 +139,42 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
                     break;
                 case PRE_HEADERS:
                     byte preHeaderByte = Unsafe.getByte(ptr);
-                    switch (boundarySuffix) {
+                    switch (preHeaderByte) {
+                        case '\n':
+                            state = HEADERS;
+                            ptr++;
+                            break;
                         case '\r':
-                            if (preHeaderByte == '\n') {
-                                boundarySuffix = 0;
-                                state = HEADERS;
-                                ptr++;
-                                break;
-                            }
-                            ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_REPLAY_BOUNDARY_SUFFIX, ptr, ptr, true);
+                            state = PRE_HEADERS_AFTER_CR;
+                            ptr++;
                             break;
                         case '-':
-                            if (preHeaderByte == '-') {
-                                boundarySuffix = 0;
-                                processor.onPartEnd();
-                                state = DONE;
-                                return true;
-                            }
-                            ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_REPLAY_BOUNDARY_SUFFIX, ptr, ptr, true);
+                            state = PRE_HEADERS_AFTER_DASH;
+                            ptr++;
                             break;
                         default:
-                            switch (preHeaderByte) {
-                                case '\n':
-                                    state = HEADERS;
-                                    ptr++;
-                                    break;
-                                case '\r':
-                                    boundarySuffix = '\r';
-                                    ptr++;
-                                    break;
-                                case '-':
-                                    boundarySuffix = '-';
-                                    ptr++;
-                                    break;
-                                default:
-                                    ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_BROKEN, ptr, ptr, true);
-                                    break;
-                            }
+                            ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_BROKEN, ptr, ptr, true);
                             break;
                     }
                     break;
+                case PRE_HEADERS_AFTER_CR:
+                    if (Unsafe.getByte(ptr) == '\n') {
+                        state = HEADERS;
+                        ptr++;
+                    } else {
+                        ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_REPLAY_BOUNDARY_AFTER_CR, ptr, ptr, true);
+                    }
+                    break;
+                case PRE_HEADERS_AFTER_DASH:
+                    if (Unsafe.getByte(ptr) == '-') {
+                        processor.onPartEnd();
+                        state = DONE;
+                        return true;
+                    }
+                    ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_REPLAY_BOUNDARY_AFTER_DASH, ptr, ptr, true);
+                    break;
                 case START_PRE_HEADERS:
                     byte startPreHeaderByte = Unsafe.getByte(ptr);
-                    if (boundarySuffix == '-') {
-                        if (startPreHeaderByte == '-') {
-                            boundarySuffix = 0;
-                            return true;
-                        }
-                        throw HttpException.instance("Malformed start boundary");
-                    }
                     switch (startPreHeaderByte) {
                         case '\n':
                             state = START_HEADERS;
@@ -203,13 +184,19 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
                             ptr++;
                             break;
                         case '-':
-                            boundarySuffix = '-';
+                            state = START_PRE_HEADERS_AFTER_DASH;
                             ptr++;
                             break;
                         default:
                             throw HttpException.instance("Malformed start boundary");
                     }
                     break;
+                case START_PRE_HEADERS_AFTER_DASH:
+                    if (Unsafe.getByte(ptr) == '-') {
+                        state = DONE;
+                        return true;
+                    }
+                    throw HttpException.instance("Malformed start boundary");
                 case HEADERS:
                     processor.onPartEnd();
                     state = HEADERS;
@@ -270,10 +257,6 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
         }
 
         return false;
-    }
-
-    private long getBoundarySuffixLo() {
-        return boundarySuffix == '\r' ? boundary.lo() : boundary.lo() + 2;
     }
 
     private int matchBoundary(long lo, long hi) {

--- a/core/src/main/java/io/questdb/cutlass/http/HttpMultipartContentParser.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpMultipartContentParser.java
@@ -116,10 +116,10 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
                     state = BODY;
                     break;
                 case BODY_REPLAY_BOUNDARY_AFTER_CR:
-                    ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.lo() + 1, BODY_BROKEN, ptr, ptr, true);
+                    ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.lo() + 1, BODY_BROKEN, ptr, false);
                     break;
                 case BODY_REPLAY_BOUNDARY_AFTER_DASH:
-                    ptr = onChunkWithRetryHandle(processor, boundary.lo() + 2, boundary.lo() + 3, BODY_BROKEN, ptr, ptr, true);
+                    ptr = onChunkWithRetryHandle(processor, boundary.lo() + 2, boundary.lo() + 3, BODY_BROKEN, ptr, false);
                     break;
                 case START_PARSING:
                     boundaryPtr = 2;
@@ -153,7 +153,7 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
                             ptr++;
                             break;
                         default:
-                            ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_BROKEN, ptr, ptr, true);
+                            ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_BROKEN, ptr, false);
                             break;
                     }
                     break;
@@ -162,7 +162,7 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
                         state = HEADERS;
                         ptr++;
                     } else {
-                        ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_REPLAY_BOUNDARY_AFTER_CR, ptr, ptr, true);
+                        ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_REPLAY_BOUNDARY_AFTER_CR, ptr, false);
                     }
                     break;
                 case PRE_HEADERS_AFTER_DASH:
@@ -171,7 +171,7 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
                         state = DONE;
                         return true;
                     }
-                    ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_REPLAY_BOUNDARY_AFTER_DASH, ptr, ptr, true);
+                    ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_REPLAY_BOUNDARY_AFTER_DASH, ptr, false);
                     break;
                 case START_PRE_HEADERS:
                     byte startPreHeaderByte = Unsafe.getByte(ptr);
@@ -242,7 +242,7 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
                             break;
                         default:
                             // can only be BOUNDARY_NO_MATCH:
-                            onChunkWithRetryHandle(processor, boundary.lo(), boundary.lo() + p, BODY_BROKEN, ptr, ptr, true);
+                            onChunkWithRetryHandle(processor, boundary.lo(), boundary.lo() + p, BODY_BROKEN, ptr, false);
                             break;
                     }
                     break;
@@ -287,18 +287,6 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
             long resumePtr,
             boolean handleIncomplete
     ) throws PeerIsSlowToReadException, PeerDisconnectedException, ServerDisconnectException {
-        return onChunkWithRetryHandle(processor, lo, hi, state, resumePtr, lo, handleIncomplete);
-    }
-
-    private long onChunkWithRetryHandle(
-            HttpMultipartContentProcessor processor,
-            long lo,
-            long hi,
-            int state,
-            long resumePtr,
-            long tooFewBytesResumePtr,
-            boolean handleIncomplete
-    ) throws PeerIsSlowToReadException, PeerDisconnectedException, ServerDisconnectException {
         RetryOperationException needsRetry = null;
         try {
             processor.onChunk(lo, hi);
@@ -307,7 +295,7 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
             needsRetry = e;
         } catch (NotEnoughLinesException e) {
             if (handleIncomplete) {
-                this.resumePtr = tooFewBytesResumePtr;
+                this.resumePtr = lo;
                 throw TooFewBytesReceivedException.INSTANCE;
             } else {
                 throw e;

--- a/core/src/main/java/io/questdb/cutlass/http/HttpMultipartContentParser.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpMultipartContentParser.java
@@ -40,6 +40,7 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
 
     private static final int BODY = 6;
     private static final int BODY_BROKEN = 8;
+    private static final int BODY_REPLAY_BOUNDARY_SUFFIX = 14;
     private static final int BOUNDARY_INCOMPLETE = 3;
     private static final int BOUNDARY_MATCH = 1;
     private static final int BOUNDARY_NO_MATCH = 2;
@@ -58,8 +59,8 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
     private byte boundaryByte;
     private int boundaryLen;
     private int boundaryPtr;
+    private byte boundarySuffix;
     private int consumedBoundaryLen;
-    private boolean firstDashRead;
     private long resumePtr;
     private int state;
 
@@ -74,8 +75,8 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
         this.boundaryPtr = 0;
         this.boundaryByte = 0;
         this.boundary = null;
+        this.boundarySuffix = 0;
         this.consumedBoundaryLen = 0;
-        this.firstDashRead = false;
         this.headerParser.clear();
     }
 
@@ -113,6 +114,16 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
                     _lo = ptr;
                     state = BODY;
                     break;
+                case BODY_REPLAY_BOUNDARY_SUFFIX:
+                    long suffixLo = getBoundarySuffixLo();
+                    try {
+                        ptr = onChunkWithRetryHandle(processor, suffixLo, suffixLo + 1, BODY_BROKEN, ptr, ptr, true);
+                        boundarySuffix = 0;
+                    } catch (RetryOperationException e) {
+                        boundarySuffix = 0;
+                        throw e;
+                    }
+                    break;
                 case START_PARSING:
                     state = START_BOUNDARY;
                     // fall through
@@ -133,41 +144,68 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
                     }
                     break;
                 case PRE_HEADERS:
-                    switch (Unsafe.getByte(ptr)) {
-                        case '\n':
-                            state = HEADERS;
-                            // fall through
+                    byte preHeaderByte = Unsafe.getByte(ptr);
+                    switch (boundarySuffix) {
                         case '\r':
-                            ptr++;
-                            break;
-                        case '-':
-                            // make sure that we set the status to DONE only after we read the second '-'
-                            if (!firstDashRead) {
-                                firstDashRead = true;
-                                // on the first '-' we just need to read the next byte
+                            if (preHeaderByte == '\n') {
+                                boundarySuffix = 0;
+                                state = HEADERS;
                                 ptr++;
                                 break;
                             }
-                            processor.onPartEnd();
-                            state = DONE;
-                            return true;
+                            ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_REPLAY_BOUNDARY_SUFFIX, ptr, ptr, true);
+                            break;
+                        case '-':
+                            if (preHeaderByte == '-') {
+                                boundarySuffix = 0;
+                                processor.onPartEnd();
+                                state = DONE;
+                                return true;
+                            }
+                            ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_REPLAY_BOUNDARY_SUFFIX, ptr, ptr, true);
+                            break;
                         default:
-                            processor.onChunk(boundary.lo(), boundary.hi());
-                            _lo = ptr;
-                            state = BODY;
+                            switch (preHeaderByte) {
+                                case '\n':
+                                    state = HEADERS;
+                                    ptr++;
+                                    break;
+                                case '\r':
+                                    boundarySuffix = '\r';
+                                    ptr++;
+                                    break;
+                                case '-':
+                                    boundarySuffix = '-';
+                                    ptr++;
+                                    break;
+                                default:
+                                    ptr = onChunkWithRetryHandle(processor, boundary.lo(), boundary.hi(), BODY_BROKEN, ptr, ptr, true);
+                                    break;
+                            }
                             break;
                     }
                     break;
                 case START_PRE_HEADERS:
-                    switch (Unsafe.getByte(ptr)) {
+                    byte startPreHeaderByte = Unsafe.getByte(ptr);
+                    if (boundarySuffix == '-') {
+                        if (startPreHeaderByte == '-') {
+                            boundarySuffix = 0;
+                            return true;
+                        }
+                        throw HttpException.instance("Malformed start boundary");
+                    }
+                    switch (startPreHeaderByte) {
                         case '\n':
                             state = START_HEADERS;
-                            // fall through
+                            ptr++;
+                            break;
                         case '\r':
                             ptr++;
                             break;
                         case '-':
-                            return true;
+                            boundarySuffix = '-';
+                            ptr++;
+                            break;
                         default:
                             throw HttpException.instance("Malformed start boundary");
                     }
@@ -217,7 +255,7 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
                             break;
                         default:
                             // can only be BOUNDARY_NO_MATCH:
-                            onChunkWithRetryHandle(processor, boundary.lo(), boundary.lo() + p, BODY_BROKEN, ptr, true);
+                            onChunkWithRetryHandle(processor, boundary.lo(), boundary.lo() + p, BODY_BROKEN, ptr, ptr, true);
                             break;
                     }
                     break;
@@ -232,6 +270,10 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
         }
 
         return false;
+    }
+
+    private long getBoundarySuffixLo() {
+        return boundarySuffix == '\r' ? boundary.lo() : boundary.lo() + 2;
     }
 
     private int matchBoundary(long lo, long hi) {
@@ -262,6 +304,18 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
             long resumePtr,
             boolean handleIncomplete
     ) throws PeerIsSlowToReadException, PeerDisconnectedException, ServerDisconnectException {
+        return onChunkWithRetryHandle(processor, lo, hi, state, resumePtr, lo, handleIncomplete);
+    }
+
+    private long onChunkWithRetryHandle(
+            HttpMultipartContentProcessor processor,
+            long lo,
+            long hi,
+            int state,
+            long resumePtr,
+            long tooFewBytesResumePtr,
+            boolean handleIncomplete
+    ) throws PeerIsSlowToReadException, PeerDisconnectedException, ServerDisconnectException {
         RetryOperationException needsRetry = null;
         try {
             processor.onChunk(lo, hi);
@@ -270,7 +324,7 @@ public class HttpMultipartContentParser implements Closeable, Mutable {
             needsRetry = e;
         } catch (NotEnoughLinesException e) {
             if (handleIncomplete) {
-                this.resumePtr = lo;
+                this.resumePtr = tooFewBytesResumePtr;
                 throw TooFewBytesReceivedException.INSTANCE;
             } else {
                 throw e;

--- a/core/src/main/java/io/questdb/cutlass/http/HttpResponseSink.java
+++ b/core/src/main/java/io/questdb/cutlass/http/HttpResponseSink.java
@@ -115,6 +115,7 @@ public class HttpResponseSink implements Closeable, Mutable {
         totalBytesSent = 0;
         headersSent = false;
         chunkedRequestDone = false;
+        deflateBeforeSend = false;
         simpleResponse.clear();
         resetZip();
     }

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpHeaderParserTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpHeaderParserTest.java
@@ -279,6 +279,19 @@ public class HttpHeaderParserTest {
     }
 
     @Test
+    public void testContentTypeReuseClearsCharset() {
+        try (HttpHeaderParser hp = new HttpHeaderParser(1024, pool)) {
+            parse(hp, "Content-Type: text/html; charset=utf-8\r\n\r\n", false, false);
+            TestUtils.assertEquals("utf-8", hp.getCharset());
+
+            hp.clear();
+            parse(hp, "Content-Type: text/plain\r\n\r\n", false, false);
+            TestUtils.assertEquals("text/plain", hp.getContentType());
+            Assert.assertNull(hp.getCharset());
+        }
+    }
+
+    @Test
     public void testCookieError() {
         assertMalformedCookieIgnored(
                 "Set-Cookie: =123; Domain=hello.com; Path=/; Secure; Partitioned; HttpOnly; Max-Age=1234545; SameSite=strict; Expires=Wed, 21 Oct 2015 07:28:00 GMT\r\n"
@@ -533,6 +546,27 @@ public class HttpHeaderParserTest {
 
         } finally {
             Unsafe.free(p, v.length(), MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
+    public void testCookiesReuseClearsMappedCookies() {
+        final Utf8String cookieName = new Utf8String("id");
+
+        try (HttpHeaderParser hp = new HttpHeaderParser(1024, pool)) {
+            parse(
+                    hp,
+                    "GET /ok HTTP/1.1\r\n" +
+                            "Set-Cookie: id=123; Path=/\r\n" +
+                            "\r\n",
+                    true,
+                    false
+            );
+            Assert.assertNotNull(hp.getCookie(cookieName));
+
+            hp.clear();
+            parse(hp, "GET /ok HTTP/1.1\r\n\r\n", true, false);
+            Assert.assertNull(hp.getCookie(cookieName));
         }
     }
 
@@ -1015,6 +1049,15 @@ public class HttpHeaderParserTest {
 
         } finally {
             Unsafe.free(p, v.length(), MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    private static void parse(HttpHeaderParser hp, String headers, boolean request, boolean protocol) {
+        long p = TestUtils.toMemory(headers);
+        try {
+            hp.parse(p, p + headers.length(), request, protocol);
+        } finally {
+            Unsafe.free(p, headers.length(), MemoryTag.NATIVE_DEFAULT);
         }
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpHeaderParserTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpHeaderParserTest.java
@@ -97,6 +97,118 @@ public class HttpHeaderParserTest {
     }
 
     @Test
+    public void testContentDispositionQuotedFilenameWithSemicolon() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            String v = "Content-Disposition: form-data; name=\"data\"; filename=\"a;b.csv\"\r\n" +
+                    "\r\n";
+            long p = TestUtils.toMemory(v);
+            try (HttpHeaderParser hp = new HttpHeaderParser(1024, pool)) {
+                hp.parse(p, p + v.length(), false, false);
+                TestUtils.assertEquals("data", hp.getContentDispositionName());
+                TestUtils.assertEquals("a;b.csv", hp.getContentDispositionFilename());
+            } finally {
+                Unsafe.free(p, v.length(), MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testContentDispositionQuotedFilenameWithEqualsAndSemicolon() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            String v = "Content-Disposition: form-data; name=\"data\"; filename=\"a=b;c.csv\"\r\n" +
+                    "\r\n";
+            long p = TestUtils.toMemory(v);
+            try (HttpHeaderParser hp = new HttpHeaderParser(1024, pool)) {
+                hp.parse(p, p + v.length(), false, false);
+                TestUtils.assertEquals("data", hp.getContentDispositionName());
+                TestUtils.assertEquals("a=b;c.csv", hp.getContentDispositionFilename());
+            } finally {
+                Unsafe.free(p, v.length(), MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testContentDispositionQuotedFilenameWithSemicolonAndEscapedQuote() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            String v = "Content-Disposition: form-data; name=\"data\"; filename=\"a\\\";b.csv\"\r\n" +
+                    "\r\n";
+            long p = TestUtils.toMemory(v);
+            try (HttpHeaderParser hp = new HttpHeaderParser(1024, pool)) {
+                hp.parse(p, p + v.length(), false, false);
+                TestUtils.assertEquals("data", hp.getContentDispositionName());
+                TestUtils.assertEquals("a\\\";b.csv", hp.getContentDispositionFilename());
+            } finally {
+                Unsafe.free(p, v.length(), MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testContentDispositionFilenameBeforeName() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            String v = "Content-Disposition: form-data; filename=\"x.csv\"; name=\"data\"\r\n" +
+                    "\r\n";
+            long p = TestUtils.toMemory(v);
+            try (HttpHeaderParser hp = new HttpHeaderParser(1024, pool)) {
+                hp.parse(p, p + v.length(), false, false);
+                TestUtils.assertEquals("data", hp.getContentDispositionName());
+                TestUtils.assertEquals("x.csv", hp.getContentDispositionFilename());
+            } finally {
+                Unsafe.free(p, v.length(), MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testContentDispositionQuotedNameWithSemicolonBeforeFilename() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            String v = "Content-Disposition: form-data; name=\"da;ta\"; filename=\"x.csv\"\r\n" +
+                    "\r\n";
+            long p = TestUtils.toMemory(v);
+            try (HttpHeaderParser hp = new HttpHeaderParser(1024, pool)) {
+                hp.parse(p, p + v.length(), false, false);
+                TestUtils.assertEquals("da;ta", hp.getContentDispositionName());
+                TestUtils.assertEquals("x.csv", hp.getContentDispositionFilename());
+            } finally {
+                Unsafe.free(p, v.length(), MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testContentDispositionUnknownParameterBeforeFilename() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            String v = "Content-Disposition: form-data; name=\"data\"; tag=xyz; filename=\"a;b.csv\"\r\n" +
+                    "\r\n";
+            long p = TestUtils.toMemory(v);
+            try (HttpHeaderParser hp = new HttpHeaderParser(1024, pool)) {
+                hp.parse(p, p + v.length(), false, false);
+                TestUtils.assertEquals("data", hp.getContentDispositionName());
+                TestUtils.assertEquals("a;b.csv", hp.getContentDispositionFilename());
+            } finally {
+                Unsafe.free(p, v.length(), MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testContentDispositionUnquotedQuoteDoesNotHideFollowingFilename() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            String v = "Content-Disposition: form-data; name=abc\"; filename=\"x.csv\"\r\n" +
+                    "\r\n";
+            long p = TestUtils.toMemory(v);
+            try (HttpHeaderParser hp = new HttpHeaderParser(1024, pool)) {
+                hp.parse(p, p + v.length(), false, false);
+                TestUtils.assertEquals("abc\"", hp.getContentDispositionName());
+                TestUtils.assertEquals("x.csv", hp.getContentDispositionFilename());
+            } finally {
+                Unsafe.free(p, v.length(), MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
     public void testContentDispositionDangling() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             String v = "Content-Disposition: form-data; name=\"hello\";\r\n" +

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpMultipartContentParserTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpMultipartContentParserTest.java
@@ -29,7 +29,9 @@ import io.questdb.cutlass.http.HttpHeaderParser;
 import io.questdb.cutlass.http.HttpMultipartContentParser;
 import io.questdb.cutlass.http.HttpMultipartContentProcessor;
 import io.questdb.cutlass.http.HttpRequestHeader;
+import io.questdb.cutlass.http.ex.NotEnoughLinesException;
 import io.questdb.cutlass.http.ex.RetryOperationException;
+import io.questdb.cutlass.http.ex.TooFewBytesReceivedException;
 import io.questdb.network.PeerDisconnectedException;
 import io.questdb.network.PeerIsSlowToReadException;
 import io.questdb.network.ServerDisconnectException;
@@ -113,6 +115,150 @@ public class HttpMultipartContentParserTest {
     }
 
     @Test
+    public void testFalseBoundaryReplayKeepsReceiveBufferResumePointerOnTooFewBytes() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
+                final String content = "--AaB03x\r\n" +
+                        "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "value\r\n" +
+                        "--AaB03xZ\r\n" +
+                        "next\r\n" +
+                        "--AaB03x--";
+                final String expected = "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "value\r\n" +
+                        "--AaB03xZ\r\n" +
+                        "next\r\n" +
+                        "-----------------------------\r\n";
+
+                int len = content.length();
+                long p = TestUtils.toMemory(content);
+                try {
+                    String boundary = "\r\n--AaB03x";
+                    long pBoundary = TestUtils.toMemory(boundary);
+                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
+                    try {
+                        multipartContentParser.of(boundaryCs);
+                        NotEnoughLinesOnChunkProcessor listener = new NotEnoughLinesOnChunkProcessor(2);
+                        try {
+                            multipartContentParser.parse(p, p + len, listener);
+                            Assert.fail();
+                        } catch (TooFewBytesReceivedException e) {
+                            Assert.assertEquals(p + content.indexOf('Z'), multipartContentParser.getResumePtr());
+                        }
+
+                        Assert.assertTrue(multipartContentParser.parse(multipartContentParser.getResumePtr(), p + len, listener));
+                        TestUtils.assertEquals(expected, sink);
+                    } finally {
+                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
+                    }
+                } finally {
+                    Unsafe.free(p, len, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testFalseBoundaryWithCarriageReturnDoesNotDropCarriageReturn() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
+                // A matched boundary followed by '\r' and then a non-'\n' is body data; the '\r' must survive.
+                final String content = "--AaB03x\r\n" +
+                        "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "value\r\n" +
+                        "--AaB03x\rX\r\n" +
+                        "next\r\n" +
+                        "--AaB03x--";
+                final String expected = "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "value\r\n" +
+                        "--AaB03x\rX\r\n" +
+                        "next\r\n" +
+                        "-----------------------------\r\n";
+
+                int len = content.length();
+                long p = TestUtils.toMemory(content);
+                try {
+                    String boundary = "\r\n--AaB03x";
+                    long pBoundary = TestUtils.toMemory(boundary);
+                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
+                    try {
+                        for (int i = 0; i < len; i++) {
+                            sink.clear();
+                            multipartContentParser.clear();
+                            multipartContentParser.of(boundaryCs);
+                            boolean complete = multipartContentParser.parse(p, p + i, LISTENER);
+                            if (!complete) {
+                                complete = multipartContentParser.parse(p + i, p + i + 1, LISTENER);
+                            }
+                            if (!complete && len > i + 1) {
+                                complete = multipartContentParser.parse(p + i + 1, p + len, LISTENER);
+                            }
+                            Assert.assertTrue("Break at " + i, complete);
+                            Assert.assertEquals("Break at " + i, expected, sink.toString());
+                        }
+                    } finally {
+                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
+                    }
+                } finally {
+                    Unsafe.free(p, len, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testFalseBoundaryWithSingleDashDoesNotDropDashOrCompleteNextSingleDash() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
+                // A matched boundary followed by '-' and then a non-'-' is body data, not a final boundary.
+                final String content = "--AaB03x\r\n" +
+                        "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "value\r\n" +
+                        "--AaB03x-x\r\n" +
+                        "next\r\n" +
+                        "--AaB03x-";
+                final String expected = "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "value\r\n" +
+                        "--AaB03x-x\r\n" +
+                        "next";
+
+                long p = TestUtils.toMemory(content);
+                try {
+                    String boundary = "\r\n--AaB03x";
+                    long pBoundary = TestUtils.toMemory(boundary);
+                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
+                    try {
+                        for (int i = 0, len = content.length(); i < len; i++) {
+                            sink.clear();
+                            multipartContentParser.clear();
+                            multipartContentParser.of(boundaryCs);
+                            boolean complete = multipartContentParser.parse(p, p + i, LISTENER);
+                            if (!complete) {
+                                complete = multipartContentParser.parse(p + i, p + i + 1, LISTENER);
+                            }
+                            if (!complete && len > i + 1) {
+                                complete = multipartContentParser.parse(p + i + 1, p + len, LISTENER);
+                            }
+                            Assert.assertFalse("Break at " + i, complete);
+                            Assert.assertEquals("Break at " + i, expected, sink.toString());
+                        }
+                    } finally {
+                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
+                    }
+                } finally {
+                    Unsafe.free(p, content.length(), MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
     public void testMalformedAtEnd() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
@@ -129,6 +275,53 @@ public class HttpMultipartContentParserTest {
                         Assert.fail();
                     } catch (HttpException e) {
                         TestUtils.assertContains(e.getFlyweightMessage(), "Malformed start boundary");
+                    } finally {
+                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
+                    }
+                } finally {
+                    Unsafe.free(p, len, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testQuotedBoundary() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
+                final String content = """
+                        ------gc0pJq0M:08jU5"34c0p\r
+                        Content-Disposition: form-data; name="textline"\r
+                        \r
+                        value1\
+                        \r
+                        ------gc0pJq0M:08jU534c0p""";
+
+                String expected = """
+                        Content-Disposition: form-data; name="textline"\r
+                        \r
+                        value1\
+                        \r
+                        ------gc0pJq0M:08jU534c0p""";
+
+                int len = content.length();
+                long p = TestUtils.toMemory(content);
+                try {
+                    String boundary = "\r\n------gc0pJq0M:08jU5\"34c0p";
+                    long pBoundary = TestUtils.toMemory(boundary);
+                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
+                    try {
+                        for (int i = 0; i < len; i++) {
+                            sink.clear();
+                            multipartContentParser.clear();
+                            multipartContentParser.of(boundaryCs);
+                            multipartContentParser.parse(p, p + i, LISTENER);
+                            multipartContentParser.parse(p + i, p + i + 1, LISTENER);
+                            if (len > i + 1) {
+                                multipartContentParser.parse(p + i + 1, p + len, LISTENER);
+                            }
+                            TestUtils.assertEquals(expected, sink);
+                        }
                     } finally {
                         Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
                     }
@@ -223,6 +416,40 @@ public class HttpMultipartContentParserTest {
     }
 
     @Test
+    public void testStartBoundaryWithSingleDashDoesNotComplete() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
+                final String content = "--AaB03x-";
+                int len = content.length();
+                long p = TestUtils.toMemory(content);
+                try {
+                    String boundary = "\r\n--AaB03x";
+                    long pBoundary = TestUtils.toMemory(boundary);
+                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
+                    try {
+                        for (int i = 0; i < len; i++) {
+                            multipartContentParser.clear();
+                            multipartContentParser.of(boundaryCs);
+                            boolean complete = multipartContentParser.parse(p, p + i, LISTENER);
+                            if (!complete) {
+                                complete = multipartContentParser.parse(p + i, p + i + 1, LISTENER);
+                            }
+                            if (!complete && len > i + 1) {
+                                complete = multipartContentParser.parse(p + i + 1, p + len, LISTENER);
+                            }
+                            Assert.assertFalse("Break at " + i, complete);
+                        }
+                    } finally {
+                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
+                    }
+                } finally {
+                    Unsafe.free(p, len, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
     public void testWrongStartBoundary() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
@@ -248,54 +475,6 @@ public class HttpMultipartContentParserTest {
             }
         });
     }
-
-    @Test
-    public void testQuotedBoundary() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
-                final String content = """
-                        ------gc0pJq0M:08jU5"34c0p\r
-                        Content-Disposition: form-data; name="textline"\r
-                        \r
-                        value1\
-                        \r
-                        ------gc0pJq0M:08jU534c0p""";
-
-                String expected = """
-                        Content-Disposition: form-data; name="textline"\r
-                        \r
-                        value1\
-                        \r
-                        ------gc0pJq0M:08jU534c0p""";
-
-                int len = content.length();
-                long p = TestUtils.toMemory(content);
-                try {
-                    String boundary = "\r\n------gc0pJq0M:08jU5\"34c0p";
-                    long pBoundary = TestUtils.toMemory(boundary);
-                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
-                    try {
-                        for (int i = 0; i < len; i++) {
-                            sink.clear();
-                            multipartContentParser.clear();
-                            multipartContentParser.of(boundaryCs);
-                            multipartContentParser.parse(p, p + i, LISTENER);
-                            multipartContentParser.parse(p + i, p + i + 1, LISTENER);
-                            if (len > i + 1) {
-                                multipartContentParser.parse(p + i + 1, p + len, LISTENER);
-                            }
-                            TestUtils.assertEquals(expected, sink);
-                        }
-                    } finally {
-                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
-                    }
-                } finally {
-                    Unsafe.free(p, len, MemoryTag.NATIVE_DEFAULT);
-                }
-            }
-        });
-    }
-
 
     private boolean parseWithRetry(TestHttpMultipartContentProcessor listener, HttpMultipartContentParser multipartContentParser, long breakPoint, long hi) throws PeerDisconnectedException, PeerIsSlowToReadException, ServerDisconnectException {
         boolean result;
@@ -352,6 +531,25 @@ public class HttpMultipartContentParserTest {
                 }
             }
         });
+    }
+
+    private static class NotEnoughLinesOnChunkProcessor extends TestHttpMultipartContentProcessor {
+        private final int chunk;
+        private int onChunkCount;
+        private boolean thrown;
+
+        private NotEnoughLinesOnChunkProcessor(int chunk) {
+            this.chunk = chunk;
+        }
+
+        @Override
+        public void onChunk(long lo, long hi) {
+            if (++onChunkCount == chunk && !thrown) {
+                thrown = true;
+                throw NotEnoughLinesException.$("not enough lines");
+            }
+            super.onChunk(lo, hi);
+        }
     }
 
     private static class TestHttpMultipartContentProcessor implements HttpMultipartContentProcessor {

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpMultipartContentParserTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpMultipartContentParserTest.java
@@ -80,6 +80,59 @@ public class HttpMultipartContentParserTest {
     }
 
     @Test
+    public void testBoundaryWithLineFeedStartsNextPart() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
+                final String content = "--AaB03x\r\n" +
+                        "Content-Disposition: form-data; name=\"one\"\r\n" +
+                        "\r\n" +
+                        "one\r\n" +
+                        "--AaB03x\n" +
+                        "Content-Disposition: form-data; name=\"two\"\r\n" +
+                        "\r\n" +
+                        "two\r\n" +
+                        "--AaB03x--";
+                final String expected = "Content-Disposition: form-data; name=\"one\"\r\n" +
+                        "\r\n" +
+                        "one\r\n" +
+                        "-----------------------------\r\n" +
+                        "Content-Disposition: form-data; name=\"two\"\r\n" +
+                        "\r\n" +
+                        "two\r\n" +
+                        "-----------------------------\r\n";
+
+                int len = content.length();
+                long p = TestUtils.toMemory(content);
+                try {
+                    String boundary = "\r\n--AaB03x";
+                    long pBoundary = TestUtils.toMemory(boundary);
+                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
+                    try {
+                        for (int i = 0; i < len; i++) {
+                            sink.clear();
+                            multipartContentParser.clear();
+                            multipartContentParser.of(boundaryCs);
+                            boolean complete = multipartContentParser.parse(p, p + i, LISTENER);
+                            if (!complete) {
+                                complete = multipartContentParser.parse(p + i, p + i + 1, LISTENER);
+                            }
+                            if (!complete && len > i + 1) {
+                                complete = multipartContentParser.parse(p + i + 1, p + len, LISTENER);
+                            }
+                            Assert.assertTrue("Break at " + i, complete);
+                            Assert.assertEquals("Break at " + i, expected, sink.toString());
+                        }
+                    } finally {
+                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
+                    }
+                } finally {
+                    Unsafe.free(p, len, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
     public void testEmpty() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
@@ -383,6 +436,65 @@ public class HttpMultipartContentParserTest {
                         Assert.fail();
                     } catch (HttpException e) {
                         TestUtils.assertContains(e.getFlyweightMessage(), "Malformed start boundary");
+                    } finally {
+                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
+                    }
+                } finally {
+                    Unsafe.free(p, len, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testMalformedStartBoundaryAfterSingleDash() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
+                final String content = "--AaB03x-X";
+                int len = content.length();
+                long p = TestUtils.toMemory(content);
+                try {
+                    String boundary = "\r\n--AaB03x";
+                    long pBoundary = TestUtils.toMemory(boundary);
+                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
+                    try {
+                        multipartContentParser.of(boundaryCs);
+                        multipartContentParser.parse(p, p + len, LISTENER);
+                        Assert.fail();
+                    } catch (HttpException e) {
+                        TestUtils.assertContains(e.getFlyweightMessage(), "Malformed start boundary");
+                    } finally {
+                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
+                    }
+                } finally {
+                    Unsafe.free(p, len, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testNotEnoughLinesFromBodyChunkIsRethrown() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
+                final String content = "--AaB03x\r\n" +
+                        "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "value\r\n" +
+                        "--AaB03x--";
+
+                int len = content.length();
+                long p = TestUtils.toMemory(content);
+                try {
+                    String boundary = "\r\n--AaB03x";
+                    long pBoundary = TestUtils.toMemory(boundary);
+                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
+                    try {
+                        multipartContentParser.of(boundaryCs);
+                        multipartContentParser.parse(p, p + len, new NotEnoughLinesOnChunkProcessor(1));
+                        Assert.fail();
+                    } catch (NotEnoughLinesException e) {
+                        TestUtils.assertContains(e.getFlyweightMessage(), "not enough lines");
                     } finally {
                         Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
                     }

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpMultipartContentParserTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpMultipartContentParserTest.java
@@ -133,6 +133,39 @@ public class HttpMultipartContentParserTest {
     }
 
     @Test
+    public void testBodyChunkKeepsReceiveBufferResumePointerOnTooFewBytes() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
+                final String content = "--AaB03x\r\n" +
+                        "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "value";
+
+                int len = content.length();
+                long p = TestUtils.toMemory(content);
+                try {
+                    String boundary = "\r\n--AaB03x";
+                    long pBoundary = TestUtils.toMemory(boundary);
+                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
+                    try {
+                        multipartContentParser.of(boundaryCs);
+                        try {
+                            multipartContentParser.parse(p, p + len, new NotEnoughLinesOnChunkProcessor(1));
+                            Assert.fail();
+                        } catch (TooFewBytesReceivedException e) {
+                            Assert.assertEquals(p + content.indexOf("value"), multipartContentParser.getResumePtr());
+                        }
+                    } finally {
+                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
+                    }
+                } finally {
+                    Unsafe.free(p, len, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
     public void testEmpty() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
@@ -168,7 +201,7 @@ public class HttpMultipartContentParserTest {
     }
 
     @Test
-    public void testFalseBoundaryReplayKeepsReceiveBufferResumePointerOnTooFewBytes() throws Exception {
+    public void testFalseBoundaryReplayRethrowsNotEnoughLines() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
                 final String content = "--AaB03x\r\n" +
@@ -178,12 +211,6 @@ public class HttpMultipartContentParserTest {
                         "--AaB03xZ\r\n" +
                         "next\r\n" +
                         "--AaB03x--";
-                final String expected = "Content-Disposition: form-data; name=\"data\"\r\n" +
-                        "\r\n" +
-                        "value\r\n" +
-                        "--AaB03xZ\r\n" +
-                        "next\r\n" +
-                        "-----------------------------\r\n";
 
                 int len = content.length();
                 long p = TestUtils.toMemory(content);
@@ -197,12 +224,9 @@ public class HttpMultipartContentParserTest {
                         try {
                             multipartContentParser.parse(p, p + len, listener);
                             Assert.fail();
-                        } catch (TooFewBytesReceivedException e) {
-                            Assert.assertEquals(p + content.indexOf('Z'), multipartContentParser.getResumePtr());
+                        } catch (NotEnoughLinesException e) {
+                            TestUtils.assertContains(e.getFlyweightMessage(), "not enough lines");
                         }
-
-                        Assert.assertTrue(multipartContentParser.parse(multipartContentParser.getResumePtr(), p + len, listener));
-                        TestUtils.assertEquals(expected, sink);
                     } finally {
                         Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
                     }
@@ -214,7 +238,7 @@ public class HttpMultipartContentParserTest {
     }
 
     @Test
-    public void testFalseBoundaryReplayKeepsReceiveBufferResumePointerOnTooFewBytesAfterBoundarySplit() throws Exception {
+    public void testFalseBoundaryReplayRethrowsNotEnoughLinesAfterBoundarySplit() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
                 final String content = "--AaB03x\r\n" +
@@ -224,12 +248,6 @@ public class HttpMultipartContentParserTest {
                         "--AX03x\r\n" +
                         "next\r\n" +
                         "--AaB03x--";
-                final String expected = "Content-Disposition: form-data; name=\"data\"\r\n" +
-                        "\r\n" +
-                        "value\r\n" +
-                        "--AX03x\r\n" +
-                        "next\r\n" +
-                        "-----------------------------\r\n";
 
                 int len = content.length();
                 long p = TestUtils.toMemory(content);
@@ -247,12 +265,45 @@ public class HttpMultipartContentParserTest {
                         try {
                             multipartContentParser.parse(splitPtr, p + len, listener);
                             Assert.fail();
-                        } catch (TooFewBytesReceivedException e) {
-                            Assert.assertEquals(splitPtr, multipartContentParser.getResumePtr());
+                        } catch (NotEnoughLinesException e) {
+                            TestUtils.assertContains(e.getFlyweightMessage(), "not enough lines");
                         }
+                    } finally {
+                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
+                    }
+                } finally {
+                    Unsafe.free(p, len, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
 
-                        Assert.assertTrue(multipartContentParser.parse(multipartContentParser.getResumePtr(), p + len, listener));
-                        TestUtils.assertEquals(expected, sink);
+    @Test
+    public void testFalseBoundaryReplayRethrowsRepeatedNotEnoughLines() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
+                final String content = "--AaB03x\r\n" +
+                        "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "\r\n--AaB03xZ\n" +
+                        "a,b\n" +
+                        "1,2\n" +
+                        "--AaB03x--";
+
+                int len = content.length();
+                long p = TestUtils.toMemory(content);
+                try {
+                    String boundary = "\r\n--AaB03x";
+                    long pBoundary = TestUtils.toMemory(boundary);
+                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
+                    try {
+                        multipartContentParser.of(boundaryCs);
+                        try {
+                            multipartContentParser.parse(p, p + len, new NotEnoughLinesOnShortChunkProcessor());
+                            Assert.fail();
+                        } catch (NotEnoughLinesException e) {
+                            TestUtils.assertContains(e.getFlyweightMessage(), "not enough lines");
+                        }
                     } finally {
                         Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
                     }
@@ -784,6 +835,22 @@ public class HttpMultipartContentParserTest {
         public void onChunk(long lo, long hi) {
             if (lo == replayLo && !thrown) {
                 thrown = true;
+                throw NotEnoughLinesException.$("not enough lines");
+            }
+            super.onChunk(lo, hi);
+        }
+    }
+
+    private static class NotEnoughLinesOnShortChunkProcessor extends TestHttpMultipartContentProcessor {
+        @Override
+        public void onChunk(long lo, long hi) {
+            int lines = 0;
+            for (long p = lo; p < hi; p++) {
+                if (Unsafe.getByte(p) == '\n') {
+                    lines++;
+                }
+            }
+            if (hi > lo && lines < 2) {
                 throw NotEnoughLinesException.$("not enough lines");
             }
             super.onChunk(lo, hi);

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpMultipartContentParserTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpMultipartContentParserTest.java
@@ -161,6 +161,56 @@ public class HttpMultipartContentParserTest {
     }
 
     @Test
+    public void testFalseBoundaryReplayKeepsReceiveBufferResumePointerOnTooFewBytesAfterBoundarySplit() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
+                final String content = "--AaB03x\r\n" +
+                        "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "value\r\n" +
+                        "--AX03x\r\n" +
+                        "next\r\n" +
+                        "--AaB03x--";
+                final String expected = "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "value\r\n" +
+                        "--AX03x\r\n" +
+                        "next\r\n" +
+                        "-----------------------------\r\n";
+
+                int len = content.length();
+                long p = TestUtils.toMemory(content);
+                try {
+                    String boundary = "\r\n--AaB03x";
+                    long pBoundary = TestUtils.toMemory(boundary);
+                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
+                    try {
+                        multipartContentParser.of(boundaryCs);
+                        NotEnoughLinesOnReplayProcessor listener = new NotEnoughLinesOnReplayProcessor(pBoundary);
+                        int falseBoundaryStart = content.indexOf("\r\n--AX03x");
+                        long splitPtr = p + falseBoundaryStart + 5;
+
+                        Assert.assertFalse(multipartContentParser.parse(p, splitPtr, listener));
+                        try {
+                            multipartContentParser.parse(splitPtr, p + len, listener);
+                            Assert.fail();
+                        } catch (TooFewBytesReceivedException e) {
+                            Assert.assertEquals(splitPtr, multipartContentParser.getResumePtr());
+                        }
+
+                        Assert.assertTrue(multipartContentParser.parse(multipartContentParser.getResumePtr(), p + len, listener));
+                        TestUtils.assertEquals(expected, sink);
+                    } finally {
+                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
+                    }
+                } finally {
+                    Unsafe.free(p, len, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    @Test
     public void testFalseBoundaryWithCarriageReturnDoesNotDropCarriageReturn() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
@@ -211,6 +261,18 @@ public class HttpMultipartContentParserTest {
     }
 
     @Test
+    public void testFalseBoundarySuffixReplayRetry() throws Exception {
+        assertFalseBoundarySuffixReplayRetry(
+                "--AaB03x\rX\r\n",
+                "--AaB03x\rX\r\n"
+        );
+        assertFalseBoundarySuffixReplayRetry(
+                "--AaB03x-X\r\n",
+                "--AaB03x-X\r\n"
+        );
+    }
+
+    @Test
     public void testFalseBoundaryWithSingleDashDoesNotDropDashOrCompleteNextSingleDash() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
@@ -253,6 +315,52 @@ public class HttpMultipartContentParserTest {
                     }
                 } finally {
                     Unsafe.free(p, content.length(), MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    private void assertFalseBoundarySuffixReplayRetry(String falseBoundary, String expectedFalseBoundary) throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (HttpMultipartContentParser multipartContentParser = new HttpMultipartContentParser(new HttpHeaderParser(1024, pool))) {
+                sink.clear();
+                final String content = "--AaB03x\r\n" +
+                        "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "value\r\n" +
+                        falseBoundary +
+                        "next\r\n" +
+                        "--AaB03x--";
+                final String expected = "Content-Disposition: form-data; name=\"data\"\r\n" +
+                        "\r\n" +
+                        "value\r\n" +
+                        expectedFalseBoundary +
+                        "next\r\n" +
+                        "-----------------------------\r\n";
+
+                int len = content.length();
+                long p = TestUtils.toMemory(content);
+                try {
+                    String boundary = "\r\n--AaB03x";
+                    long pBoundary = TestUtils.toMemory(boundary);
+                    DirectUtf8String boundaryCs = new DirectUtf8String().of(pBoundary, pBoundary + boundary.length());
+                    try {
+                        multipartContentParser.of(boundaryCs);
+                        RetryOnChunkProcessor listener = new RetryOnChunkProcessor(3);
+                        try {
+                            multipartContentParser.parse(p, p + len, listener);
+                            Assert.fail();
+                        } catch (RetryOperationException e) {
+                            Assert.assertEquals(p + content.indexOf('X'), multipartContentParser.getResumePtr());
+                        }
+
+                        Assert.assertTrue(multipartContentParser.parse(multipartContentParser.getResumePtr(), p + len, listener));
+                        TestUtils.assertEquals(expected, sink);
+                    } finally {
+                        Unsafe.free(pBoundary, boundary.length(), MemoryTag.NATIVE_DEFAULT);
+                    }
+                } finally {
+                    Unsafe.free(p, len, MemoryTag.NATIVE_DEFAULT);
                 }
             }
         });
@@ -549,6 +657,43 @@ public class HttpMultipartContentParserTest {
                 throw NotEnoughLinesException.$("not enough lines");
             }
             super.onChunk(lo, hi);
+        }
+    }
+
+    private static class NotEnoughLinesOnReplayProcessor extends TestHttpMultipartContentProcessor {
+        private final long replayLo;
+        private boolean thrown;
+
+        private NotEnoughLinesOnReplayProcessor(long replayLo) {
+            this.replayLo = replayLo;
+        }
+
+        @Override
+        public void onChunk(long lo, long hi) {
+            if (lo == replayLo && !thrown) {
+                thrown = true;
+                throw NotEnoughLinesException.$("not enough lines");
+            }
+            super.onChunk(lo, hi);
+        }
+    }
+
+    private static class RetryOnChunkProcessor extends TestHttpMultipartContentProcessor {
+        private final int chunk;
+        private int onChunkCount;
+        private boolean thrown;
+
+        private RetryOnChunkProcessor(int chunk) {
+            this.chunk = chunk;
+        }
+
+        @Override
+        public void onChunk(long lo, long hi) {
+            super.onChunk(lo, hi);
+            if (++onChunkCount == chunk && !thrown) {
+                thrown = true;
+                throw RetryOperationException.INSTANCE;
+            }
         }
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/HttpQueryTestBuilder.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/HttpQueryTestBuilder.java
@@ -229,6 +229,7 @@ public class HttpQueryTestBuilder {
                 @Override
                 public ObjHashSet<String> getUrls() {
                     return new ObjHashSet<>() {{
+                        add("/imp");
                         add("/upload");
                     }};
                 }

--- a/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/IODispatcherTest.java
@@ -61,6 +61,8 @@ import io.questdb.cutlass.http.HttpRequestProcessor;
 import io.questdb.cutlass.http.HttpRequestProcessorSelector;
 import io.questdb.cutlass.http.HttpServer;
 import io.questdb.cutlass.http.RescheduleContext;
+import io.questdb.cutlass.http.client.HttpClient;
+import io.questdb.cutlass.http.client.HttpClientFactory;
 import io.questdb.cutlass.http.processors.JsonQueryProcessor;
 import io.questdb.cutlass.http.processors.StaticContentProcessorFactory;
 import io.questdb.cutlass.http.processors.TextImportProcessor;
@@ -122,6 +124,7 @@ import io.questdb.std.str.AbstractCharSequence;
 import io.questdb.std.str.Path;
 import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8Sequence;
+import io.questdb.std.str.Utf8String;
 import io.questdb.std.str.Utf8s;
 import io.questdb.tasks.TelemetryTask;
 import io.questdb.test.AbstractTest;
@@ -4557,6 +4560,88 @@ public class IODispatcherTest extends AbstractTest {
                 }
             }
         });
+    }
+
+    @Test
+    public void testPooledHttpContextParsesQuotedContentTypeParameter() throws Exception {
+        final String expectedResponse = """
+                HTTP/1.1 200 OK\r
+                Server: questDB/1.0\r
+                Date: Thu, 1 Jan 1970 00:00:00 GMT\r
+                Transfer-Encoding: chunked\r
+                Content-Type: text/plain\r
+                Connection: close\r
+                \r
+                0f\r
+                Status: Healthy\r
+                00\r
+                \r
+                """;
+        final String warmupRequest = """
+                GET /status HTTP/1.1\r
+                Host: localhost:9001\r
+                Connection: keep-alive\r
+                Accept: */*\r
+                \r
+                """;
+        final String quotedContentTypeRequest = """
+                GET /status HTTP/1.1\r
+                Host: localhost:9001\r
+                Connection: keep-alive\r
+                Content-Type: application/json; charset="utf-8"\r
+                Accept: */*\r
+                \r
+                """;
+
+        new HttpQueryTestBuilder()
+                .withTempFolder(root)
+                .withWorkerCount(1)
+                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder().withServerKeepAlive(false))
+                .run((engine, sqlExecutionContext) -> {
+                    sendAndReceive(NetworkFacadeImpl.INSTANCE, warmupRequest, expectedResponse, 1, 0, false, true);
+                    sendAndReceive(NetworkFacadeImpl.INSTANCE, quotedContentTypeRequest, expectedResponse, 1, 0, false, true);
+                });
+    }
+
+    @Test
+    public void testResponseCompressionDoesNotLeakAcrossKeepAliveRequests() throws Exception {
+        final Utf8String contentEncodingHeader = new Utf8String("Content-Encoding");
+        final StringSink sink = new StringSink();
+
+        new HttpQueryTestBuilder()
+                .withTempFolder(root)
+                .withWorkerCount(1)
+                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder()
+                        .withAllowDeflateBeforeSend(true)
+                        .withServerKeepAlive(true)
+                )
+                .run((engine, sqlExecutionContext) -> {
+                    try (HttpClient client = HttpClientFactory.newPlainTextInstance()) {
+                        HttpClient.Request gzipRequest = client.newRequest("localhost", 9001);
+                        gzipRequest.GET()
+                                .url("/exec")
+                                .query("query", "select 1")
+                                .header("Accept-Encoding", "gzip");
+                        HttpClient.ResponseHeaders headers = gzipRequest.send();
+                        headers.await();
+                        TestUtils.assertEquals("gzip", headers.getHeader(contentEncodingHeader));
+                        headers.getResponse().discard();
+
+                        HttpClient.Request plainRequest = client.newRequest("localhost", 9001);
+                        plainRequest.GET()
+                                .url("/exec")
+                                .query("query", "select 2");
+                        headers = plainRequest.send();
+                        headers.await();
+                        Assert.assertNull(headers.getHeader(contentEncodingHeader));
+                        sink.clear();
+                        headers.getResponse().copyTextTo(sink);
+                        TestUtils.assertEquals(
+                                "{\"query\":\"select 2\",\"columns\":[{\"name\":\"2\",\"type\":\"INT\"}],\"timestamp\":-1,\"dataset\":[[2]],\"count\":1}",
+                                sink
+                        );
+                    }
+                });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cutlass/http/ImportIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/ImportIODispatcherTest.java
@@ -967,6 +967,56 @@ public class ImportIODispatcherTest extends AbstractTest {
     }
 
     @Test
+    public void testImportUsesQuotedMultipartFilenameWithSemicolon() throws Exception {
+        new HttpQueryTestBuilder()
+                .withTempFolder(root)
+                .withWorkerCount(1)
+                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
+                .withTelemetry(false)
+                .run((engine, sqlExecutionContext) -> {
+                    new SendAndReceiveRequestBuilder().execute("""
+                            POST /imp?fmt=json&forceHeader=true&delimiter=%2C HTTP/1.1\r
+                            Host: localhost:9001\r
+                            User-Agent: curl/7.64.0\r
+                            Accept: */*\r
+                            Content-Length: 437760673\r
+                            Content-Type: multipart/form-data; boundary=------------------------27d997ca93d2689d\r
+                            Expect: 100-continue\r
+                            \r
+                            --------------------------27d997ca93d2689d\r
+                            Content-Disposition: form-data; name="schema"; filename="schema.json"\r
+                            Content-Type: application/octet-stream\r
+                            \r
+                            [{"name":"x","type":"INT"}]\r
+                            --------------------------27d997ca93d2689d\r
+                            Content-Disposition: form-data; name="data"; filename="a;b.csv"\r
+                            Content-Type: application/octet-stream\r
+                            \r
+                            x\r
+                            1\r
+                            --------------------------27d997ca93d2689d--""", """
+                            HTTP/1.1 200 OK\r
+                            Server: questDB/1.0\r
+                            Date: Thu, 1 Jan 1970 00:00:00 GMT\r
+                            Transfer-Encoding: chunked\r
+                            Content-Type: application/json; charset=utf-8\r
+                            \r
+                            a3\r
+                            {"status":"OK","location":"a;b.csv","rowsRejected":0,"rowsImported":1,"header":true,"partitionBy":"NONE","columns":[{"name":"x","type":"INT","size":4,"errors":0}]}\r
+                            00\r
+                            \r
+                            """);
+
+                    drainWalQueue(engine);
+                    assertQuery("select x from \"a;b.csv\"")
+                            .withEngine(engine)
+                            .withContext(sqlExecutionContext)
+                            .noLeakCheck()
+                            .returnsOnce("x\n1\n");
+                });
+    }
+
+    @Test
     public void testImportWithDedupEnabled() throws Exception {
         new HttpQueryTestBuilder()
                 .withTempFolder(root)

--- a/core/src/test/java/io/questdb/test/cutlass/http/ImportIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/ImportIODispatcherTest.java
@@ -929,44 +929,6 @@ public class ImportIODispatcherTest extends AbstractTest {
     }
 
     @Test
-    public void testImportWitNocacheSymbolsLoop() throws Exception {
-        for (int i = 0; i < 2; i++) {
-            System.out.println("*************************************************************************************");
-            System.out.println("**************************         Run " + i + "            ********************************");
-            System.out.println("*************************************************************************************");
-            testImportWithNoCacheSymbols();
-            TestUtils.removeTestPath(root);
-            TestUtils.createTestPath(root);
-        }
-    }
-
-    @Test
-    public void testImportWithCreateFalseAndNoTable() throws Exception {
-        new HttpQueryTestBuilder()
-                .withTempFolder(root).withWorkerCount(2)
-                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
-                .withTelemetry(false)
-                .run((_, _) -> new SendAndReceiveRequestBuilder().withExpectSendDisconnect(true).execute(ImportCreateParamRequestFalse, ImportCreateParamResponse));
-    }
-
-    @Test()
-    public void testImportWithCreateTrueAndNoTable() throws Exception {
-        new HttpQueryTestBuilder()
-                .withTempFolder(root).withWorkerCount(2)
-                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
-                .withTelemetry(false)
-                .run((engine, sqlExecutionContext) -> {
-                    new SendAndReceiveRequestBuilder().execute(ImportCreateParamRequestTrue, ImportCreateParamResponse);
-                    drainWalQueue(engine);
-                    assertQuery("select count() from trips")
-                            .withEngine(engine)
-                            .withContext(sqlExecutionContext)
-                            .noLeakCheck()
-                            .returnsOnce("count\n24\n");
-                });
-    }
-
-    @Test
     public void testImportUsesQuotedMultipartFilenameWithSemicolon() throws Exception {
         new HttpQueryTestBuilder()
                 .withTempFolder(root)
@@ -1012,7 +974,47 @@ public class ImportIODispatcherTest extends AbstractTest {
                             .withEngine(engine)
                             .withContext(sqlExecutionContext)
                             .noLeakCheck()
-                            .returnsOnce("x\n1\n");
+                            .expectSize()
+                            .returns("x\n1\n");
+                });
+    }
+
+    @Test
+    public void testImportWitNocacheSymbolsLoop() throws Exception {
+        for (int i = 0; i < 2; i++) {
+            System.out.println("*************************************************************************************");
+            System.out.println("**************************         Run " + i + "            ********************************");
+            System.out.println("*************************************************************************************");
+            testImportWithNoCacheSymbols();
+            TestUtils.removeTestPath(root);
+            TestUtils.createTestPath(root);
+        }
+    }
+
+    @Test
+    public void testImportWithCreateFalseAndNoTable() throws Exception {
+        new HttpQueryTestBuilder()
+                .withTempFolder(root).withWorkerCount(2)
+                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
+                .withTelemetry(false)
+                .run((_, _) -> new SendAndReceiveRequestBuilder().withExpectSendDisconnect(true).execute(ImportCreateParamRequestFalse, ImportCreateParamResponse));
+    }
+
+    @Test()
+    public void testImportWithCreateTrueAndNoTable() throws Exception {
+        new HttpQueryTestBuilder()
+                .withTempFolder(root).withWorkerCount(2)
+                .withHttpServerConfigBuilder(new HttpServerConfigurationBuilder())
+                .withTelemetry(false)
+                .run((engine, sqlExecutionContext) -> {
+                    new SendAndReceiveRequestBuilder().execute(ImportCreateParamRequestTrue, ImportCreateParamResponse);
+                    drainWalQueue(engine);
+                    assertQuery("select count() from trips")
+                            .withEngine(engine)
+                            .withContext(sqlExecutionContext)
+                            .expectSize()
+                            .noRandomAccess()
+                            .returns("count\n24\n");
                 });
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/http/ImportIODispatcherTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/http/ImportIODispatcherTest.java
@@ -1012,6 +1012,7 @@ public class ImportIODispatcherTest extends AbstractTest {
                     assertQuery("select count() from trips")
                             .withEngine(engine)
                             .withContext(sqlExecutionContext)
+                            .noLeakCheck()
                             .expectSize()
                             .noRandomAccess()
                             .returns("count\n24\n");


### PR DESCRIPTION
HTTP connections and contexts are reused across requests. Several HTTP parser/response objects were not fully resetting or reopening their per-request state, which could make a later request inherit stale state from an earlier one. In the worst case, a reused context could hit closed native parsing/compression buffers and crash the server when handling otherwise valid requests.

This PR fixes the reusable HTTP lifecycle state and hardens multipart upload parsing around boundary and `Content-Disposition` edge cases.

**User Impact**
- Prevents server crashes during HTTP context reuse when later requests parse quoted header parameters such as `charset="utf-8"`.
- Prevents gzip response state from leaking across keep-alive requests, so clients only receive gzip responses when the current request advertises gzip support.
- Prevents stale parsed charset and cookie metadata from being observed on reused header parsers.
- Prevents multipart upload bodies from losing bytes when body data resembles a multipart boundary but is not one.
- Allows uploaded filenames such as `a;b.csv` and `a=b;c.csv` to parse correctly.

**What Changed**
- Reopen the header parser’s quoted-value sink when pooled HTTP contexts are reused.
- Clear per-request gzip negotiation state in `HttpResponseSink`.
- Clear `charset` and mapped cookie state in `HttpHeaderParser.clear()`.
- Fix multipart false-boundary replay so body bytes are preserved when a boundary-like sequence is followed by non-boundary suffixes.
- Keep multipart resume pointers anchored to the receive buffer during retry paths.
- Parse `Content-Disposition` parameters with quote-aware delimiter handling, including semicolons and equals signs inside quoted values.
- Reset `Content-Disposition` parameter state consistently after known and unknown parameters.