### PR TITLE
fix(core): fix query cancellation being lost when it races query startup

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/NetworkSqlExecutionCircuitBreaker.java
+++ b/core/src/main/java/io/questdb/cairo/sql/NetworkSqlExecutionCircuitBreaker.java
@@ -147,6 +147,12 @@ public class NetworkSqlExecutionCircuitBreaker implements SqlExecutionCircuitBre
 
     @Override
     public int getState(long millis, long fd) {
+        // A cancelled breaker carries the powerUpTime == MIN_VALUE sentinel, which the overflow-safe
+        // timeout predicate below would otherwise report as STATE_TIMEOUT. Classify it as cancelled so
+        // callers reading getState() see an honest reason.
+        if (isCancelled()) {
+            return STATE_CANCELLED;
+        }
         if (clock.getTicks() - timeout > millis) {
             return STATE_TIMEOUT;
         }
@@ -267,7 +273,12 @@ public class NetworkSqlExecutionCircuitBreaker implements SqlExecutionCircuitBre
     }
 
     private void testCancelled() {
-        if ((cancelledFlag != null && cancelledFlag.get()) || engine.isClosing()) {
+        // isCancelled() (the powerUpTime == MIN_VALUE sentinel) must come first: cancel() sets the
+        // sentinel unconditionally but only flips cancelledFlag when it is already attached. A cancel
+        // that races QueryRegistry.register() before it binds the per-query flag leaves only the
+        // sentinel, and testTimeout()'s now - MIN_VALUE arithmetic overflows without tripping, so this
+        // is the single place that reliably turns such a cancel into a thrown queryCancelled().
+        if (isCancelled() || (cancelledFlag != null && cancelledFlag.get()) || engine.isClosing()) {
             throw CairoException.queryCancelled(fd);
         }
     }

--- a/core/src/main/java/io/questdb/cairo/sql/NetworkSqlExecutionCircuitBreaker.java
+++ b/core/src/main/java/io/questdb/cairo/sql/NetworkSqlExecutionCircuitBreaker.java
@@ -112,13 +112,10 @@ public class NetworkSqlExecutionCircuitBreaker implements SqlExecutionCircuitBre
     }
 
     public void clearCancelSentinel() {
-        // A cancel that raced QueryRegistry.register() before the per-query flag was attached leaves
-        // only the powerUpTime == MIN_VALUE sentinel. A guarded "if (!isTimerSet()) resetTimer()" cannot
-        // clear it (isTimerSet() is true for MIN_VALUE), so the connection clears it explicitly at the
-        // start of every query. Clearing only the sentinel, never a real running timer, keeps a
-        // query_timeout window intact for a named portal paginated across Sync.
-        if (powerUpTime == Long.MIN_VALUE) {
-            powerUpTime = Long.MAX_VALUE;
+        // Drop a cancel left by a prior, finished query so it cannot trip the next one on this reused
+        // breaker. Guarded per-query resets cannot clear it (isTimerSet() reports MIN_VALUE as "set").
+        if (isCancelled()) {
+            unsetTimer();
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/sql/NetworkSqlExecutionCircuitBreaker.java
+++ b/core/src/main/java/io/questdb/cairo/sql/NetworkSqlExecutionCircuitBreaker.java
@@ -111,6 +111,17 @@ public class NetworkSqlExecutionCircuitBreaker implements SqlExecutionCircuitBre
         timeout = defaultMaxTime;
     }
 
+    public void clearCancelSentinel() {
+        // A cancel that raced QueryRegistry.register() before the per-query flag was attached leaves
+        // only the powerUpTime == MIN_VALUE sentinel. A guarded "if (!isTimerSet()) resetTimer()" cannot
+        // clear it (isTimerSet() is true for MIN_VALUE), so the connection clears it explicitly at the
+        // start of every query. Clearing only the sentinel, never a real running timer, keeps a
+        // query_timeout window intact for a named portal paginated across Sync.
+        if (powerUpTime == Long.MIN_VALUE) {
+            powerUpTime = Long.MAX_VALUE;
+        }
+    }
+
     @Override
     public void close() {
         buffer = Unsafe.free(buffer, bufferSize, memoryTag);

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGConnectionContext.java
@@ -1281,6 +1281,11 @@ public class PGConnectionContext extends IOContext<PGConnectionContext> implemen
 
     private void prepareForNewQuery() {
         LOG.debug().$("prepare for new query").$();
+        // Bound the cancel sentinel to a single query: a cancel for a prior, already-finished query
+        // can leave powerUpTime == MIN_VALUE on this reused per-connection breaker, and the guarded
+        // per-query resets do not clear it. prepareForNewQuery() runs once before each query (every
+        // Sync, both protocols), at which point any sentinel belongs to a finished query.
+        circuitBreaker.clearCancelSentinel();
         Misc.clear(bindVariableService);
         freezeRecvBuffer = false;
         sqlExecutionContext.setCacheHit(false);

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/DefaultPGCircuitBreakerRegistryTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/DefaultPGCircuitBreakerRegistryTest.java
@@ -170,6 +170,48 @@ public class DefaultPGCircuitBreakerRegistryTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testClearCancelSentinelClearsStaleCancel() throws Exception {
+        // A guarded "if (!isTimerSet()) resetTimer()" cannot clear the sentinel because isTimerSet()
+        // is true for MIN_VALUE. clearCancelSentinel() is the unconditional per-query clear that bounds
+        // the sentinel to a single query.
+        assertMemoryLeak(() -> {
+            try (NetworkSqlExecutionCircuitBreaker cb = newCircuitBreaker()) {
+                cb.resetTimer();
+                cb.cancel();
+                // A guarded reset does NOT clear the sentinel (the breaker still reports the cancel):
+                if (!cb.isTimerSet()) {
+                    cb.resetTimer();
+                }
+                expectQueryCancelled(cb::statefulThrowExceptionIfTripped);
+
+                // The connection's per-query entry clears the stale sentinel:
+                cb.clearCancelSentinel();
+                // Now a guarded reset arms a fresh timer, and the breaker is OK:
+                if (!cb.isTimerSet()) {
+                    cb.resetTimer();
+                }
+                cb.statefulThrowExceptionIfTripped(); // must not throw
+                Assert.assertEquals(SqlExecutionCircuitBreaker.STATE_OK, cb.getState());
+            }
+        });
+    }
+
+    @Test
+    public void testClearCancelSentinelKeepsRunningTimer() throws Exception {
+        // clearCancelSentinel() must not disturb a legitimately running timer (e.g. a named portal
+        // paginated across Sync); it clears only the cancel sentinel.
+        assertMemoryLeak(() -> {
+            try (NetworkSqlExecutionCircuitBreaker cb = newCircuitBreaker()) {
+                cb.resetTimer();
+                cb.clearCancelSentinel(); // no-op: powerUpTime is a real timer, not the sentinel
+                Assert.assertTrue(cb.isTimerSet());
+                cb.statefulThrowExceptionIfTripped(); // must not throw
+                Assert.assertEquals(SqlExecutionCircuitBreaker.STATE_OK, cb.getState());
+            }
+        });
+    }
+
+    @Test
     public void testSentinelCancelReportedByGetState() throws Exception {
         // A cancel that lands before QueryRegistry binds the per-query flag leaves only the
         // powerUpTime == MIN_VALUE sentinel. getState() must report it as cancelled instead of

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/DefaultPGCircuitBreakerRegistryTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/DefaultPGCircuitBreakerRegistryTest.java
@@ -26,6 +26,7 @@ package io.questdb.test.cutlass.pgwire;
 
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.sql.NetworkSqlExecutionCircuitBreaker;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.cutlass.pgwire.DefaultPGCircuitBreakerRegistry;
 import io.questdb.cutlass.pgwire.DefaultPGConfiguration;
 import io.questdb.cutlass.pgwire.PGConfiguration;
@@ -34,6 +35,8 @@ import io.questdb.std.MemoryTag;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class DefaultPGCircuitBreakerRegistryTest extends AbstractCairoTest {
 
@@ -166,6 +169,49 @@ public class DefaultPGCircuitBreakerRegistryTest extends AbstractCairoTest {
         });
     }
 
+    @Test
+    public void testSentinelCancelReportedByGetState() throws Exception {
+        // A cancel that lands before QueryRegistry binds the per-query flag leaves only the
+        // powerUpTime == MIN_VALUE sentinel. getState() must report it as cancelled instead of
+        // mislabelling the sentinel as a timeout.
+        assertMemoryLeak(() -> {
+            try (NetworkSqlExecutionCircuitBreaker cb = newCircuitBreaker()) {
+                cb.resetTimer();
+                cb.cancel();
+                Assert.assertEquals(SqlExecutionCircuitBreaker.STATE_CANCELLED, cb.getState());
+            }
+        });
+    }
+
+    @Test
+    public void testSentinelCancelThrowsWhenFlagAttachedFalseAfterwards() throws Exception {
+        // Exact production race: cancel() runs before QueryRegistry.register() binds the per-query
+        // flag, so it only sets the sentinel; register() then binds a fresh flag whose value is
+        // false. The sentinel must still win, so the stateful throw path aborts as cancelled.
+        assertMemoryLeak(() -> {
+            try (NetworkSqlExecutionCircuitBreaker cb = newCircuitBreaker()) {
+                cb.resetTimer();
+                cb.cancel();
+                cb.setCancelledFlag(new AtomicBoolean(false));
+                expectQueryCancelled(cb::statefulThrowExceptionIfTripped);
+            }
+        });
+    }
+
+    @Test
+    public void testSentinelCancelThrowsWhenNoFlagAttached() throws Exception {
+        // cancel() arriving while cancelledFlag is still null sets only the sentinel. The stateful
+        // throw path used by virtually all query execution must honour it and abort as cancelled,
+        // even though testTimeout()'s now - MIN_VALUE arithmetic overflows and never trips.
+        assertMemoryLeak(() -> {
+            try (NetworkSqlExecutionCircuitBreaker cb = newCircuitBreaker()) {
+                cb.resetTimer();
+                cb.cancel();
+                expectQueryCancelled(cb::statefulThrowExceptionIfTripped);
+            }
+        });
+    }
+
     private static void expectCairoFailure(Runnable op, String expectedMessage) {
         try {
             op.run();
@@ -174,6 +220,21 @@ public class DefaultPGCircuitBreakerRegistryTest extends AbstractCairoTest {
             Assert.assertTrue(
                     "unexpected message: " + e.getFlyweightMessage(),
                     e.getFlyweightMessage().toString().contains(expectedMessage)
+            );
+        }
+    }
+
+    private static void expectQueryCancelled(Runnable op) {
+        try {
+            op.run();
+            Assert.fail("expected a CairoException signalling query cancellation, but nothing was thrown");
+        } catch (CairoException e) {
+            // queryCancelled() sets the cancellation flag while queryTimedOut() only sets
+            // interruption, so isCancellation() proves the breaker aborted as a cancel, not a timeout.
+            Assert.assertTrue("expected a cancellation, got: " + e.getFlyweightMessage(), e.isCancellation());
+            Assert.assertTrue(
+                    "expected 'cancelled by user', got: " + e.getFlyweightMessage(),
+                    e.getFlyweightMessage().toString().contains("cancelled by user")
             );
         }
     }

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/DefaultPGCircuitBreakerRegistryTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/DefaultPGCircuitBreakerRegistryTest.java
@@ -212,6 +212,27 @@ public class DefaultPGCircuitBreakerRegistryTest extends AbstractCairoTest {
         });
     }
 
+    @Test
+    public void testSentinelClearedByResetTimer() throws Exception {
+        // The cancel sentinel must not leak across queries. Once a sentinel-only cancel has been
+        // honoured, the next query's resetTimer() overwrites powerUpTime with a fresh value, so the
+        // fresh query neither throws nor reports cancelled. This pins the no-false-positive property
+        // that the sentinel check relies on for cross-query safety.
+        assertMemoryLeak(() -> {
+            try (NetworkSqlExecutionCircuitBreaker cb = newCircuitBreaker()) {
+                cb.resetTimer();
+                cb.cancel();
+                // The sentinel is honoured for the cancelled query.
+                expectQueryCancelled(cb::statefulThrowExceptionIfTripped);
+
+                // A fresh query starts: resetTimer() clears the stale sentinel, so the breaker is OK.
+                cb.resetTimer();
+                cb.statefulThrowExceptionIfTripped(); // must not throw
+                Assert.assertEquals(SqlExecutionCircuitBreaker.STATE_OK, cb.getState());
+            }
+        });
+    }
+
     private static void expectCairoFailure(Runnable op, String expectedMessage) {
         try {
             op.run();


### PR DESCRIPTION
Fixes a live production bug that affects any node serving the PostgreSQL wire protocol: a query cancellation can be silently lost, and the affected query's per-query timeout is defeated along with it, when the cancel races query startup. There is no GitHub issue; fixing directly.

## Root cause

`NetworkSqlExecutionCircuitBreaker.cancel()` always sets the `powerUpTime == Long.MIN_VALUE` sentinel but only flips the per-query cancelled flag when that flag is already attached. `QueryRegistry.register()` publishes the query and fires its listener *before* it binds the per-query flag. A `CancelRequest` landing in that window sets only the sentinel; `register()` then binds a fresh flag whose value is `false`, so the cancel survives only in the sentinel.

The stateful poll path used by essentially all query execution (`statefulThrowExceptionIfTripped*`) runs `testTimeout()` then `testCancelled()`, and neither consulted the sentinel:

- `testTimeout()` computes `now - powerUpTime`; `now - MIN_VALUE` overflows to a large negative runtime, so it never trips.
- `testCancelled()` only checked the flag, which is now `false`.

Net effect: the cancel is dropped, and because `powerUpTime` stays at `MIN_VALUE` the per-query timeout is defeated too. The query runs to natural completion ignoring both cancel and timeout, pinning a worker; async/parallel queries can pin several.

## Fix

- `testCancelled()` checks `isCancelled()` (the sentinel) first, so both stateful paths abort a racing cancel as `queryCancelled()`.
- `getState()` classifies the sentinel as `STATE_CANCELLED` instead of mislabelling it `STATE_TIMEOUT`.
- `PGConnectionContext.prepareForNewQuery()` clears the sentinel (via the new `clearCancelSentinel()`) before every query on a connection, bounding it to a single query.

The sentinel is unforgeable: only `cancel()` writes `MIN_VALUE`. Within a query it is honoured by `testCancelled()` / `getState()`; across queries it cannot leak because `prepareForNewQuery()` clears it before the next query consults the breaker. The *guarded* resets `if (!isTimerSet()) resetTimer()` do not clear it (`isTimerSet()` treats `MIN_VALUE` as set), which is why the explicit per-query clear exists; that clear is a no-op for a real running timer, so it leaves the `query_timeout` window intact.

## Scope and tradeoffs

The change is deliberately minimal: the `testCancelled()` sentinel check and the `getState()` label on the breaker, plus a new `clearCancelSentinel()` called once from `PGConnectionContext.prepareForNewQuery()` to bound the sentinel to a single query. It does not reorder `QueryRegistry.register()` (an alternative the design discussion floated; the sentinel fix subsumes the window without touching the hot registration path or the listener's registration-only contract), does not touch `cancel()` / lifecycle / error text, and does not alter throttling. The optional `testTimeout()` overflow guard is omitted because the `testCancelled()` fix makes it redundant; the pre-existing (now unreachable) `isCancelled()` branch inside `testTimeout()` is left as-is rather than broadening the diff. The `ServerMainSleepTest` cancel-fuzz oracle is left unchanged.

## Test plan

- New deterministic regressions in `DefaultPGCircuitBreakerRegistryTest` drive the race ordering directly on the breaker (no fuzz/timing): a sentinel-only cancel with no flag attached, a cancel followed by a fresh `false` flag (the exact production race), and the `getState()` label. On master all three fail for the expected reasons (nothing thrown / `STATE_TIMEOUT`). Two further tests pin the cross-query no-leak property: a guarded `if (!isTimerSet()) resetTimer()` does not clear the sentinel, `clearCancelSentinel()` does, and a real running timer is left untouched. The class is 13/13 green.
- `PGJobContextTest#testRunQueryAfterCancellingPreviousInTheSameConnection` and `#testCancelQueryThatReusesCircuitBreakerFromPreviousConnection` (same-connection and cross-connection breaker reuse) stay green with the per-query clear.
- `ServerMainSleepTest#testFuzzConcurrentSleeps`: `cancelAttempts=60, cancelObserved=60, cancelNormal=0, cancelNormalBeforeDeadline=0, failures=0` — every cancel observed, zero missed, zero runaways.
- `ServerMainSleepTest` full class: 7/7 green; the timeout and connection-drop paths are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

