### PR TITLE
fix(core): fix POSTING-indexed tables suspending WAL apply after out-of-order writes

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -7485,12 +7485,15 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     private void linkPartitionIndexFiles(long partitionTimestamp, long partitionNameTxn, int partitionDirLen, int newPartitionDirLen) {
         try {
             final int columnCount = metadata.getColumnCount();
+            final long partitionSize = txWriter.getPartitionRowCountByTimestamp(partitionTimestamp);
             for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
                 if (!ColumnType.isSymbol(metadata.getColumnType(columnIndex)) || !metadata.isIndexed(columnIndex)) {
                     continue;
                 }
-                // no data in partition for this column
-                if (columnVersionWriter.getColumnTop(partitionTimestamp, columnIndex) == -1) {
+                // Absent (columnTop == -1) or row-less (columnTop >= partition size) columns
+                // have no index files in this partition. Same guard as copyOrRebuildColumnIndexes.
+                final long columnTop = columnVersionWriter.getColumnTop(partitionTimestamp, columnIndex);
+                if (columnTop == -1 || columnTop >= partitionSize) {
                     continue;
                 }
                 linkColumnIndexFiles(
@@ -12349,10 +12352,11 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 }
                 // Absent (columnTop == -1) or row-less (columnTop >= partition size) columns
                 // have no .pk file here, so there is no index to restore. Same guard as
-                // sealPostingIndexForPartition.
+                // sealPostingIndexForPartition -- use getColumnTop (sentinel -1), not
+                // getColumnTopQuick (returns 0 for an absent column, so the -1 arm is dead).
                 long partitionSize = txWriter.getPartitionRowCountByTimestamp(lastOpenPartitionTs);
-                long columnTop = columnVersionWriter.getColumnTopQuick(lastOpenPartitionTs, colIdx);
-                if (columnTop < 0 || columnTop >= partitionSize) {
+                long columnTop = columnVersionWriter.getColumnTop(lastOpenPartitionTs, colIdx);
+                if (columnTop == -1 || columnTop >= partitionSize) {
                     continue;
                 }
                 CharSequence colName = metadata.getColumnName(colIdx);

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -12347,10 +12347,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 if (indexer == null) {
                     continue;
                 }
-                // columnTop == -1 means the column does not exist on this partition at
-                // all (no .pk file), so skip those.
+                // Absent (columnTop == -1) or row-less (columnTop >= partition size) columns
+                // have no .pk file here, so there is no index to restore. Same guard as
+                // sealPostingIndexForPartition.
+                long partitionSize = txWriter.getPartitionRowCountByTimestamp(lastOpenPartitionTs);
                 long columnTop = columnVersionWriter.getColumnTopQuick(lastOpenPartitionTs, colIdx);
-                if (columnTop < 0) {
+                if (columnTop < 0 || columnTop >= partitionSize) {
                     continue;
                 }
                 CharSequence colName = metadata.getColumnName(colIdx);

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -12340,6 +12340,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         path.trimTo(pathSize);
         setPathForNativePartition(path, timestampType, partitionBy, lastOpenPartitionTs, currentNameTxn);
         int plen = path.size();
+        long partitionSize = txWriter.getPartitionRowCountByTimestamp(lastOpenPartitionTs);
         try {
             for (int colIdx = 0; colIdx < columnCount; colIdx++) {
                 if (metadata.getColumnType(colIdx) <= 0 || !metadata.isColumnIndexed(colIdx)
@@ -12350,17 +12351,26 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 if (indexer == null) {
                     continue;
                 }
-                // Absent (columnTop == -1) or row-less (columnTop >= partition size) columns
-                // have no .pk file here, so there is no index to restore. Same guard as
-                // sealPostingIndexForPartition -- use getColumnTop (sentinel -1), not
-                // getColumnTopQuick (returns 0 for an absent column, so the -1 arm is dead).
-                long partitionSize = txWriter.getPartitionRowCountByTimestamp(lastOpenPartitionTs);
+                // A column added after this partition (columnTop == -1) has no .pk here.
                 long columnTop = columnVersionWriter.getColumnTop(lastOpenPartitionTs, colIdx);
-                if (columnTop == -1 || columnTop >= partitionSize) {
+                if (columnTop == -1) {
                     continue;
                 }
                 CharSequence colName = metadata.getColumnName(colIdx);
                 long colNameTxn = columnVersionWriter.getColumnNameTxn(lastOpenPartitionTs, colIdx);
+                // A row-less column (columnTop >= partition size) has a .pk only if ADD COLUMN
+                // INDEX TYPE POSTING built one here on the active partition; a split tail whose
+                // seal never built one has none. Discriminate on the .pk's presence: skipping a
+                // present .pk strands the indexer on an older partition (silent index loss),
+                // while opening an absent one throws "index does not exist".
+                if (columnTop >= partitionSize) {
+                    boolean keyFileExists = ff.exists(
+                            keyFileName(metadata.getColumnIndexType(colIdx), path.trimTo(plen), colName, colNameTxn));
+                    path.trimTo(plen);
+                    if (!keyFileExists) {
+                        continue;
+                    }
+                }
                 indexer.configureFollowerAndWriter(
                         path.trimTo(plen), colName, colNameTxn,
                         getPrimaryColumn(colIdx), columnTop,

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -12351,7 +12351,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 if (indexer == null) {
                     continue;
                 }
-                // A column added after this partition (columnTop == -1) has no .pk here.
+                // Defensive: columnTop == -1 means the column is absent on this partition
+                // (no .pk). Normally unreachable on the last partition; kept as a guard.
                 long columnTop = columnVersionWriter.getColumnTop(lastOpenPartitionTs, colIdx);
                 if (columnTop == -1) {
                     continue;

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -760,6 +760,54 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         });
     }
 
+    @Test
+    public void testO3SealRestoreSkipsRowlessPostingColumnWithoutKeyFile() throws Exception {
+        // A POSTING-indexed column with no rows in a partition (columnTop >= partition
+        // size) has no .pk key file there: the O3 seal sweep skips row-less columns
+        // (sealPostingIndexForPartition), so it never builds one. The seal-sweep tail
+        // restorePostingIndexersToLastPartition used to open that column's index anyway
+        // and threw "index does not exist", which suspends a WAL table mid-apply (here,
+        // BYPASS WAL, it surfaces as the INSERT throwing).
+        //
+        // A last-partition split shrinks 2024-01-01 while `extra` stays row-less there
+        // (columnTop above the shrunk row count). The FilesFacade reports `extra`'s key
+        // file as absent on the day partition the seal-sweep restores to -- the exact
+        // production state -- but only once ADD COLUMN has built it (so the legitimate
+        // openNewColumnFiles path during ADD COLUMN is unaffected), and only for the
+        // day partition (not the split tail, whose dir carries a "...T..." suffix).
+        node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
+        node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 20);
+        node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 20);
+        final AtomicBoolean keyFileHidden = new AtomicBoolean(false);
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public boolean exists(LPSZ path) {
+                if (keyFileHidden.get()
+                        && Utf8s.containsAscii(path, "extra.pk")
+                        && !Utf8s.containsAscii(path, "2024-01-01T")) {
+                    return false;
+                }
+                return super.exists(path);
+            }
+        };
+        assertMemoryLeak(ff, () -> {
+            execute("CREATE TABLE t_rowless (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, v LONG) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+            execute("INSERT INTO t_rowless(ts, sym, v) SELECT ('2024-01-01T00:00:00.000000Z'::timestamp + x * 3600000000L)::timestamp, 'a', x FROM long_sequence(20)");
+            // extra has no rows on 2024-01-01 (columnTop == partition size).
+            execute("ALTER TABLE t_rowless ADD COLUMN extra SYMBOL INDEX TYPE POSTING");
+
+            keyFileHidden.set(true);
+            // O3 insert forces a last-partition split; the seal sweep then restores the
+            // posting indexers to the shrunk 2024-01-01, where `extra` is row-less.
+            execute("INSERT INTO t_rowless(ts, sym, v) VALUES ('2024-01-01T18:30:00.000000Z', 'a', 999)");
+            keyFileHidden.set(false);
+
+            // The table survived: all rows present, and the `sym` posting index serves reads.
+            Assert.assertEquals(21, selectLong("SELECT count() FROM t_rowless"));
+            Assert.assertEquals(21, selectLong("SELECT count() FROM t_rowless WHERE sym = 'a'"));
+        });
+    }
+
     /**
      * Rollback reencode publishes a bumped sealTxn for the compacted
      * {@code .pv.N}; it must also stage a sealed {@code .pc0.N} sidecar so a

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -803,8 +803,70 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             keyFileHidden.set(false);
 
             // The table survived: all rows present, and the `sym` posting index serves reads.
-            Assert.assertEquals(21, selectLong("SELECT count() FROM t_rowless"));
-            Assert.assertEquals(21, selectLong("SELECT count() FROM t_rowless WHERE sym = 'a'"));
+            assertQuery("SELECT count() FROM t_rowless")
+                    .noLeakCheck().noRandomAccess().expectSize().returns("count\n21\n");
+            assertQuery("SELECT count() FROM t_rowless WHERE sym = 'a'")
+                    .noLeakCheck().noRandomAccess().expectSize().returns("count\n21\n");
+
+            // The row-less `extra` posting column stays queryable post-restore: an
+            // equality lookup matches nothing (extra is absent on every row).
+            assertQuery("SELECT count() FROM t_rowless WHERE extra = 'a'")
+                    .noLeakCheck().noRandomAccess().expectSize().returns("count\n0\n");
+            assertQuery("SELECT count() FROM t_rowless WHERE extra IS NULL")
+                    .noLeakCheck().noRandomAccess().expectSize().returns("count\n21\n");
+        });
+    }
+
+    @Test
+    public void testO3SealRestoreSkipStrandsRowlessIndexerWithKeyFile() throws Exception {
+        // Counterpart to testO3SealRestoreSkipsRowlessPostingColumnWithoutKeyFile.
+        // There the row-less last-partition column has NO .pk (split tail) so the
+        // restore skip is correct. Here the row-less column DOES have a .pk: c is
+        // POSTING-indexed, added by ALTER while day2 (L) is the last partition, so
+        // ADD COLUMN created an empty .pk for c on day2 and c is row-less there
+        // (columnTop == day2 size), absent on day1 (P).
+        //
+        // An O3 back-fill of c into day1 seals day1 and points c's posting writer at
+        // day1. A blanket row-less skip in restorePostingIndexersToLastPartition()
+        // would skip c (columnTop >= partitionSize on L) and leave its writer on day1;
+        // the next in-order append into day2 would then index day2 rows into day1's
+        // .pk/.pv, making the appended row invisible to "WHERE c = ..." while the base
+        // data stays intact. The existence-based skip re-points c to day2 instead.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t_probe (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, v LONG) " +
+                    "TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+            // day1 rows start at 12:00 so the O3 back-fill at 00:00 lands at rowid 0
+            // (columnTop for c on day1 becomes 0).
+            execute("INSERT INTO t_probe(ts, sym, v) SELECT " +
+                    "('2024-01-01T12:00:00.000000Z'::timestamp + (x-1) * 3600000000L)::timestamp, 'a', x " +
+                    "FROM long_sequence(5)");
+            // day2 (L): 3 rows.
+            execute("INSERT INTO t_probe(ts, sym, v) SELECT " +
+                    "('2024-01-02T00:00:00.000000Z'::timestamp + (x-1) * 3600000000L)::timestamp, 'a', 100+x " +
+                    "FROM long_sequence(3)");
+            // c row-less on day2 (columnTop == 3), absent on day1.
+            execute("ALTER TABLE t_probe ADD COLUMN c SYMBOL INDEX TYPE POSTING");
+
+            // O3 back-fill of c into day1 -> seals day1, points c at day1, restore skips c.
+            execute("INSERT INTO t_probe(ts, sym, c, v) VALUES ('2024-01-01T00:00:00.000000Z', 'a', 'X', 999)");
+
+            // In-order append into day2 with a c value: indexes through c's stranded writer.
+            execute("INSERT INTO t_probe(ts, sym, c, v) VALUES ('2024-01-02T03:00:00.000000Z', 'a', 'Y', 555)");
+
+            // Base table integrity (no index involved).
+            assertQuery("SELECT count() FROM t_probe")
+                    .noLeakCheck().noRandomAccess().expectSize().returns("count\n10\n");
+            // Control: sym is NOT row-less in day2, restore re-points it -> index correct.
+            assertQuery("SELECT count() FROM t_probe WHERE sym = 'a'")
+                    .noLeakCheck().noRandomAccess().expectSize().returns("count\n10\n");
+
+            // The day2 'Y' row must be found exactly once via c's index, with its real value.
+            assertQuery("SELECT count() FROM t_probe WHERE c = 'Y'")
+                    .noLeakCheck().noRandomAccess().expectSize().returns("count\n1\n");
+            assertQuery("SELECT v FROM t_probe WHERE c = 'Y'")
+                    .noLeakCheck().returns("v\n555\n");
+            assertQuery("SELECT v FROM t_probe WHERE c = 'X'")
+                    .noLeakCheck().returns("v\n999\n");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -792,7 +792,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         };
         assertMemoryLeak(ff, () -> {
             execute("CREATE TABLE t_rowless (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, v LONG) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
-            execute("INSERT INTO t_rowless(ts, sym, v) SELECT ('2024-01-01T00:00:00.000000Z'::timestamp + x * 3600000000L)::timestamp, 'a', x FROM long_sequence(20)");
+            execute("INSERT INTO t_rowless(ts, sym, v) SELECT ('2024-01-01T00:00:00.000000Z'::timestamp + x * 3_600_000_000L)::timestamp, 'a', x FROM long_sequence(20)");
             // extra has no rows on 2024-01-01 (columnTop == partition size).
             execute("ALTER TABLE t_rowless ADD COLUMN extra SYMBOL INDEX TYPE POSTING");
 
@@ -838,11 +838,11 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             // day1 rows start at 12:00 so the O3 back-fill at 00:00 lands at rowid 0
             // (columnTop for c on day1 becomes 0).
             execute("INSERT INTO t_probe(ts, sym, v) SELECT " +
-                    "('2024-01-01T12:00:00.000000Z'::timestamp + (x-1) * 3600000000L)::timestamp, 'a', x " +
+                    "('2024-01-01T12:00:00.000000Z'::timestamp + (x-1) * 3_600_000_000L)::timestamp, 'a', x " +
                     "FROM long_sequence(5)");
             // day2 (L): 3 rows.
             execute("INSERT INTO t_probe(ts, sym, v) SELECT " +
-                    "('2024-01-02T00:00:00.000000Z'::timestamp + (x-1) * 3600000000L)::timestamp, 'a', 100+x " +
+                    "('2024-01-02T00:00:00.000000Z'::timestamp + (x-1) * 3_600_000_000L)::timestamp, 'a', 100+x " +
                     "FROM long_sequence(3)");
             // c row-less on day2 (columnTop == 3), absent on day1.
             execute("ALTER TABLE t_probe ADD COLUMN c SYMBOL INDEX TYPE POSTING");
@@ -867,6 +867,63 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                     .noLeakCheck().returns("v\n555\n");
             assertQuery("SELECT v FROM t_probe WHERE c = 'X'")
                     .noLeakCheck().returns("v\n999\n");
+        });
+    }
+
+    @Test
+    public void testO3SealRestoreRowlessNoKeyFileDoesNotSuspendWalTable() throws Exception {
+        // WAL counterpart to testO3SealRestoreSkipsRowlessPostingColumnWithoutKeyFile.
+        // The headline symptom of the no-.pk bug is a WAL table suspending mid-apply:
+        // restorePostingIndexersToLastPartition throws "index does not exist",
+        // ApplyWal2TableJob catches it and suspends the table -- the commit lands but
+        // apply halts and the table needs a manual RESUME WAL. With the fix the seal
+        // restore skips the row-less keyless column, apply completes, the table stays live.
+        node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
+        node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 20);
+        node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 20);
+        final AtomicBoolean keyFileHidden = new AtomicBoolean(false);
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public boolean exists(LPSZ path) {
+                if (keyFileHidden.get()
+                        && Utf8s.containsAscii(path, "extra.pk")
+                        && !Utf8s.containsAscii(path, "2024-01-01T")) {
+                    return false;
+                }
+                return super.exists(path);
+            }
+        };
+        assertMemoryLeak(ff, () -> {
+            execute("CREATE TABLE t_rowless_wal (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, v LONG) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("INSERT INTO t_rowless_wal(ts, sym, v) SELECT ('2024-01-01T00:00:00.000000Z'::timestamp + x * 3_600_000_000L)::timestamp, 'a', x FROM long_sequence(20)");
+            // extra has no rows on 2024-01-01 (columnTop == partition size).
+            execute("ALTER TABLE t_rowless_wal ADD COLUMN extra SYMBOL INDEX TYPE POSTING");
+            // Apply everything while the .pk is visible, so ADD COLUMN builds extra's
+            // .pk on the active partition exactly as in production.
+            drainWalQueue();
+
+            final TableToken token = engine.verifyTableName("t_rowless_wal");
+            Assert.assertFalse("table must apply cleanly before the O3 split", engine.getTableSequencerAPI().isSuspended(token));
+
+            // O3 insert forces a last-partition split; the seal sweep then restores the
+            // posting indexers to the shrunk 2024-01-01, where extra is row-less and
+            // reports no .pk. On master the apply throws and suspends the table here.
+            execute("INSERT INTO t_rowless_wal(ts, sym, v) VALUES ('2024-01-01T18:30:00.000000Z', 'a', 999)");
+            keyFileHidden.set(true);
+            drainWalQueue();
+            keyFileHidden.set(false);
+
+            // The table kept applying: not suspended, all rows present, sym index serves reads.
+            Assert.assertFalse(
+                    "WAL apply must not suspend the table on a row-less keyless posting column",
+                    engine.getTableSequencerAPI().isSuspended(token)
+            );
+            assertQuery("SELECT count() FROM t_rowless_wal")
+                    .noLeakCheck().noRandomAccess().expectSize().returns("count\n21\n");
+            assertQuery("SELECT count() FROM t_rowless_wal WHERE sym = 'a'")
+                    .noLeakCheck().noRandomAccess().expectSize().returns("count\n21\n");
+            assertQuery("SELECT count() FROM t_rowless_wal WHERE extra IS NULL")
+                    .noLeakCheck().noRandomAccess().expectSize().returns("count\n21\n");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
@@ -3280,6 +3280,82 @@ public class TableWriterTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSwitchNativePartitionWithParquetSkipsRowlessPostingColumn() throws Exception {
+        // Regression: linkPartitionIndexFiles skipped only the absent case
+        // (columnTop == -1). A posting-indexed column that is row-less on the
+        // partition (columnTop >= partition size) also has no .pk / .pv files --
+        // the seal sweep never builds them -- yet the old guard did not skip it,
+        // so linkColumnIndexFiles threw "index files do not exist". The guard now
+        // mirrors copyOrRebuildColumnIndexes.
+        assertMemoryLeak(() -> {
+            final String tableName = "posting_switch_rowless";
+            TableModel model = new TableModel(configuration, tableName, PartitionBy.DAY)
+                    .col("sym", ColumnType.SYMBOL).symbolCapacity(16).indexed(true, 256, IndexType.POSTING)
+                    .timestamp("ts", timestampType);
+            AbstractCairoTest.create(model);
+
+            Rnd rnd = new Rnd();
+            long ts = timestampDriver.parseFloorLiteral("2013-03-04T00:00:00.000Z");
+            long interval = timestampDriver.fromMicros(60_000L * 1000L);
+
+            // Span two partitions so partition 0 is non-active when `extra` is added.
+            try (TableWriter writer = newOffPoolWriter(configuration, tableName)) {
+                for (int i = 0; i < 2_000; i++) {
+                    TableWriter.Row r = writer.newRow(ts += interval);
+                    r.putSym(0, rnd.nextString(4));
+                    r.append();
+                }
+                writer.commit();
+            }
+
+            long partitionTs;
+            try (TableWriter writer = newOffPoolWriter(configuration, tableName)) {
+                final TableToken token = writer.getTableToken();
+                TxWriter tx = writer.getTxWriter();
+
+                partitionTs = tx.getPartitionTimestampByIndex(0);
+                int partitionIndex = tx.getPartitionIndex(partitionTs);
+                long partitionNameTxn = tx.getPartitionNameTxn(partitionIndex);
+
+                // `extra` is added while partition 0 is historic, so it never gets
+                // a .pk on partition 0.
+                writer.addColumn("extra", ColumnType.SYMBOL, 16, false, IndexType.POSTING, 256, false, AllowAllSecurityContext.INSTANCE);
+
+                try (Path p = new Path()) {
+                    p.of(configuration.getDbRoot()).concat(token);
+                    TableUtils.setPathForParquetPartition(p, timestampType, PartitionBy.DAY, partitionTs, partitionNameTxn);
+                    Assert.assertTrue("failed to touch data.parquet", FF.touch(p.$()));
+
+                    p.of(configuration.getDbRoot()).concat(token);
+                    TableUtils.setPathForParquetPartitionMetadata(p, timestampType, PartitionBy.DAY, partitionTs, partitionNameTxn);
+                    Assert.assertTrue("failed to touch _pm", FF.touch(p.$()));
+                }
+
+                // Bump writer.txn past partition.nameTxn so the switch creates a
+                // distinct destination dir.
+                TableWriter.Row r = writer.newRow(tx.getMaxTimestamp() + interval);
+                r.putSym(0, rnd.nextString(4));
+                r.append();
+                writer.commit();
+
+                // Stamp `extra` row-less on partition 0 (columnTop == partition
+                // size): a column-version record with no .pk, the state an O3
+                // add-column race produces.
+                writer.upsertColumnVersion(partitionTs, writer.getColumnIndex("extra"), tx.getPartitionSize(partitionIndex));
+
+                tx.setPartitionParquetGenerated(partitionIndex, true);
+
+                int rc = writer.switchNativePartitionWithParquet(partitionTs, 0L);
+                Assert.assertEquals(TableWriter.SWITCH_OK, rc);
+                Assert.assertTrue(
+                        "partition must be parquet after the switch",
+                        writer.getTxWriter().isPartitionParquet(partitionIndex)
+                );
+            }
+        });
+    }
+
+    @Test
     public void testTableDoesNotExist() throws Exception {
         assertMemoryLeak(() -> {
             try {

--- a/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
@@ -44,6 +44,7 @@ import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.TimestampDriver;
 import io.questdb.cairo.TxWriter;
+import io.questdb.cairo.idx.IndexFactory;
 import io.questdb.cairo.idx.IndexReader;
 import io.questdb.cairo.security.AllowAllSecurityContext;
 import io.questdb.cairo.sql.Record;
@@ -3351,6 +3352,27 @@ public class TableWriterTest extends AbstractCairoTest {
                         "partition must be parquet after the switch",
                         writer.getTxWriter().isPartitionParquet(partitionIndex)
                 );
+
+                // linkPartitionIndexFiles must link sym's .pk (it has rows) and skip
+                // extra's (row-less, no .pk). The positive sym check pins the link arm:
+                // an over-broad guard that also dropped the live sym would link nothing
+                // yet still return SWITCH_OK, which rc alone cannot catch.
+                long symNameTxn = writer.getColumnNameTxn(partitionTs, writer.getColumnIndex("sym"));
+                long extraNameTxn = writer.getColumnNameTxn(partitionTs, writer.getColumnIndex("extra"));
+                long newNameTxn = writer.getTxWriter().getPartitionNameTxn(partitionIndex);
+                try (Path p = new Path()) {
+                    p.of(configuration.getDbRoot()).concat(token);
+                    TableUtils.setPathForNativePartition(p, timestampType, PartitionBy.DAY, partitionTs, newNameTxn);
+                    int dirLen = p.size();
+                    Assert.assertTrue(
+                            "sym .pk must be linked into the parquet partition dir",
+                            FF.exists(IndexFactory.keyFileName(IndexType.POSTING, p, "sym", symNameTxn))
+                    );
+                    Assert.assertFalse(
+                            "row-less extra must have no .pk in the parquet partition dir",
+                            FF.exists(IndexFactory.keyFileName(IndexType.POSTING, p.trimTo(dirLen), "extra", extraNameTxn))
+                    );
+                }
             }
         });
     }


### PR DESCRIPTION
## What this fixes

A POSTING-indexed column can carry a column-version record on a partition while having no rows there (`columnTop >= partition size`). Whether such a row-less column has a `.pk` key file depends on the partition: on a *historic* partition it has none (the seal sweep `sealPostingIndexForPartition` skips row-less columns and never builds one), while on the *active* partition `ADD COLUMN ... INDEX TYPE POSTING` builds an empty `.pk` even with no rows.

Several per-partition code paths iterate posting columns guarded only against the *absent* case (`columnTop == -1`), not the *row-less* case. Two distinct faults follow:

- Reaching a row-less column with no `.pk` and opening/linking it throws `CairoException: index does not exist` / `index files do not exist`. Both fixed sites hit this.
- Conversely, blanket-skipping *every* row-less column is wrong where one can legitimately have a `.pk`. `restorePostingIndexersToLastPartition` re-points indexers at the active partition, so skipping a row-less column that has a `.pk` there silently strands its index — rows stay in the base data but become invisible to indexed predicates, with no exception and no table suspension.

This branch fixes the two sites: `restorePostingIndexersToLastPartition` discriminates by `.pk` existence (so it skips the no-`.pk` case and re-points the `.pk`-present case), and the parquet-switch link mirrors its historic-partition sibling. It also aligns a third guard so it cannot silently rot.

## Fix 1 — restoring posting indexers after an O3 seal

`restorePostingIndexersToLastPartition()` re-points every posting indexer at the last open partition `L` after the O3 seal sweep, so later appends and rollbacks target `L`. Its guard only caught absent columns (`columnTop < 0`), so a row-less column with no key file fell through to `PostingIndexWriter.of(isInit=false)`, which fails at `!ff.exists(keyFile)` (`PostingIndexWriter.java:1093`):

```
CairoException: index does not exist [path=.../<col>.pk.<txn>]
```

User-visible impact of that crash:

- On a WAL table, `ApplyWal2TableJob` catches the exception and suspends the table mid-apply. The data is committed, but apply stops and the table needs manual resume.
- Under `BYPASS WAL`, the commit throws straight back to the caller (the INSERT fails).

A row-less column on `L` (`columnTop >= partition size`) may or may not have a `.pk`, and the two cases need opposite handling, so `columnTop` alone cannot decide:

- **No `.pk`** — e.g. a last-partition split tail the seal sweep never built a key file for. Re-pointing throws `index does not exist`, so restore must skip.
- **`.pk` present** — `ADD COLUMN ... INDEX TYPE POSTING` on the active partition `L` builds an empty `.pk` and stamps `columnTop == partition size`. Restore must re-point this indexer to `L`. Skipping it leaves the indexer where the seal sweep last pointed it — an older partition `P` that an O3 write back-filled `L`'s column into — and the next in-order append then reads `L`'s data but writes into `P`'s `.pk`/`.pv`. The row never reaches `L`'s index: invisible to `WHERE col = ...`, no exception, no suspension.

So restore discriminates on the key file's actual presence, not on row-less-ness — keep the `columnTop == -1` skip, and skip a row-less column only when its `.pk` is absent:

```java
long partitionSize = txWriter.getPartitionRowCountByTimestamp(lastOpenPartitionTs);
...
long columnTop = columnVersionWriter.getColumnTop(lastOpenPartitionTs, colIdx);
if (columnTop == -1) {
    continue;
}
...
if (columnTop >= partitionSize) {
    boolean keyFileExists = ff.exists(
            keyFileName(metadata.getColumnIndexType(colIdx), path.trimTo(plen), colName, colNameTxn));
    path.trimTo(plen);
    if (!keyFileExists) {
        continue;
    }
}
```

The accessor also moves from `getColumnTopQuick` to `getColumnTop`: `getColumnTopQuick` returns `0` (never `-1`) for an absent column, so the `columnTop == -1` arm was dead and an absent column — one whose home partition was dropped so it no longer exists on `L` — would have fallen through the same way. `getColumnTop` returns `-1` for that case. Restore reads `partitionSize` once above the loop (it is loop-invariant), matching the sibling sweeps.

The change is in the method body, so both callers benefit: the O3 seal sweep (`sealPostingIndexesForO3Partitions`) and the squash path.

## Fix 2 — linking index files when switching a partition to parquet

`linkPartitionIndexFiles()` (reached from the public `switchNativePartitionWithParquet()` API) hard-links each indexed column's index files from the source native partition into the new partition directory. Its guard was `getColumnTop(...) == -1` only — the comment said "no data in partition for this column", but a row-less column also has no data there while `getColumnTop` returns `partition size` (≥0, not `-1`), so it was not skipped. Control then reached `linkColumnIndexFiles()`, whose `linkFile(.pk)` throws when the key file was never built:

```
CairoException: index files do not exist [path=.../<partition>]
```

The guard now mirrors the parallel helper for the same feature, `copyOrRebuildColumnIndexes()` (which already carries the full `colTop == -1 || colTop >= partitionRowCount` guard):

```java
final long partitionSize = txWriter.getPartitionRowCountByTimestamp(partitionTimestamp);
...
final long columnTop = columnVersionWriter.getColumnTop(partitionTimestamp, columnIndex);
if (columnTop == -1 || columnTop >= partitionSize) {
    continue;
}
```

Unlike Fix 1, the blanket row-less skip is correct here: the switched partition is historic, where a row-less posting column never has a `.pk` (the seal sweep skips it and `ADD COLUMN ... INDEX` only builds a `.pk` on the active partition), so there is never a key file to link.

Severity note: the in-OSS `ALTER TABLE ... CONVERT PARTITION TO PARQUET` path goes through `convertPartitionNativeToParquet` → `copyOrRebuildColumnIndexes`, which was already guarded, so this site is reachable only through the public `switchNativePartitionWithParquet` API. It is the same absent-only guard gap as Fix 1's crash, but lower-severity within OSS than the WAL-suspend path.

## Root cause

Both fixed sites iterate posting columns and were guarded only against the absent case (`columnTop == -1`), not the row-less case (`columnTop >= partition size`). But the correct response to a row-less column differs by what the site does:

- **Fix 2 and the seal/copy siblings** (`sealPostingIndexForPartition`, `copyOrRebuildColumnIndexes`, `linkColumnIndexFiles`) operate on historic partitions, where a row-less posting column never has a `.pk`. There the row-less blanket skip is correct; Fix 2 simply brings `linkPartitionIndexFiles` into line with `copyOrRebuildColumnIndexes`.
- **Fix 1** re-points the live writer at the *active* last partition `L`, where a row-less posting column added via `ADD COLUMN ... INDEX` *does* have a `.pk`. A blanket row-less skip there is over-broad — it strands that indexer (silent index data loss) — so restore discriminates on the `.pk`'s presence instead.

The row-less-without-`.pk` state itself arises from a multi-partition, same-transaction O3 write interleaved with `ADD COLUMN`: the column-version bookkeeping stamps a `columnTop` onto a partition the column has no rows in, and the seal then skips building its `.pk`.

## Effects and tradeoffs

- Fix 2 only adds a skip; on the historic partition it touches, a row-less posting column has no `.pk` to link. Columns that have rows (and a key file) are unaffected.
- Fix 1 adds a skip for row-less columns with no `.pk`, and now correctly *re-points* row-less columns that do have one (added via `ADD COLUMN ... INDEX` on the active partition). Columns that have rows are unaffected. The re-point path is the same `configureFollowerAndWriter` call already used for every populated column.
- Fix 1's accessor change (`getColumnTopQuick` -> `getColumnTop`) is behavior-equivalent for every column present on the last partition (both return the same top); it differs only for an absent column, which previously fell through and now is correctly skipped.
- Cost: Fix 1 adds one `ff.exists(...)` per row-less posting column on the restore path (off the hot write path); both fixes add one `getPartitionRowCountByTimestamp(...)` lookup, now hoisted out of the per-column loop. Negligible.
- Narrow scope: no data migration, no format change. Outside the row-less/absent interleaving, behavior is unchanged.

## Audit

Beyond the observed failure, I swept every posting-index open/link/restore site to find siblings of the same family. Fix 2 came out of that sweep. The remaining `PostingIndexWriter.of(isInit=false)` and `configureFollowerAndWriter` sites are each protected by one of: the full two-arm guard, a preceding `createIndexFiles(...)` that materializes the `.pk`, an explicit `ff.exists` check, a `skipForPosting` gate, or the O3 worker's self-correcting `isInit = (row == 0)`. I investigated one adjacent lead — `mapCoveringColumnsForSeal` opening a covered column's `.d` without an absence skip — but left it out: it operates on a covered data file rather than a posting sidecar, and I could not show that a covering posting index ever has a covered column absent on a resealed partition.

## Test plan

- `PostingIndexCriticalIssuesTest#testO3SealRestoreSkipsRowlessPostingColumnWithoutKeyFile` (Fix 1, no-`.pk` arm). Builds a partition where a later-added POSTING column is row-less, forces a last-partition split so the seal sweep restores indexers there, and uses a scoped `FilesFacade` to report that column's `.pk` as absent — the production state. Fails before the fix with `index does not exist [.../extra.pk.1]` at `restorePostingIndexersToLastPartition`; passes after. It then reads the row-less column itself — `WHERE extra = 'a'` returns 0 and `WHERE extra IS NULL` returns 21 — confirming the recovered row-less posting column stays queryable.
- `PostingIndexCriticalIssuesTest#testO3SealRestoreRowlessNoKeyFileDoesNotSuspendWalTable` (Fix 1, no-`.pk` arm, WAL). The WAL counterpart of the test above: the same row-less keyless `extra` column and last-partition split, but on a `WAL` table applied through `drainWalQueue()`. Before the fix `ApplyWal2TableJob` catches the `index does not exist` throw and suspends the table mid-apply (error `.../2024-01-01/extra.pk.1`); after the fix apply completes, the table is not suspended, all 21 rows are present, and the `sym` index serves reads. This is the regression guard for the headline WAL-suspend symptom (proven to suspend-and-fail with the skip block neutralized, pass with it in place).
- `PostingIndexCriticalIssuesTest#testO3SealRestoreSkipStrandsRowlessIndexerWithKeyFile` (Fix 1, `.pk`-present arm). Plain SQL: adds a POSTING column on the active partition (row-less there, with a `.pk`), back-fills it into an older partition via an O3 write (which points its indexer at the older partition), then appends in order to the active partition. Asserts the appended row is visible to `WHERE c = ...`. With a blanket row-less skip the read returns 0 (silent data loss); with the existence-based skip it returns the row. The test also passes on master — master's `getColumnTopQuick` path already re-points the column — so it is not a before/after regression for the shipped diff; it is a forward guard pinning the existence-check arm against a future simplification to a blanket row-less skip.
- `TableWriterTest#testSwitchNativePartitionWithParquetSkipsRowlessPostingColumn` (Fix 2). Adds a posting column to a historic partition, stamps it row-less (`columnTop == partition size`, no `.pk`), and switches that partition to parquet. Fails before the fix with `index files do not exist [.../2013-03-04]` at `linkColumnIndexFiles`; passes after. Also asserts positively that the live `sym` column's `.pk` *was* linked into the new parquet partition dir while `extra`'s is absent — so an over-broad guard that dropped the live column too would be caught (it would link nothing yet still return `SWITCH_OK`).
- Regression sweep, all green: `PostingIndexCriticalIssuesTest` (118), `TableWriterTest` (157), `PostingSealPurgeTest` (22); plus `CoveringIndexTest` (398), `PostingIndexOracleTest` (16), `PostingIndexConcurrencyTest` (12), `PostingIndexNativeTest` (5), `PostingIndexO3ConcurrencyFuzzTest` (3). These counts are from the prior full sweep and predate the latest test additions/edits; I re-ran the four added/changed methods (`testO3SealRestoreSkipsRowlessPostingColumnWithoutKeyFile`, `testO3SealRestoreSkipStrandsRowlessIndexerWithKeyFile`, `testO3SealRestoreRowlessNoKeyFileDoesNotSuspendWalTable`, `testSwitchNativePartitionWithParquetSkipsRowlessPostingColumn`) green individually this round, but a confirming full re-run before merge is advisable.

Run the new/changed tests:

```bash
mvnd -pl core \
  -Dtest='PostingIndexCriticalIssuesTest#testO3SealRestoreSkipsRowlessPostingColumnWithoutKeyFile+testO3SealRestoreSkipStrandsRowlessIndexerWithKeyFile+testO3SealRestoreRowlessNoKeyFileDoesNotSuspendWalTable,TableWriterTest#testSwitchNativePartitionWithParquetSkipsRowlessPostingColumn' \
  -DfailIfNoTests=false test
```