### PR TITLE
fix(core): fix chained materialized views left stale after a parent view is invalidated

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -2503,41 +2503,47 @@ public class CairoEngine implements Closeable, WriterSource {
         return state.getViewMetadata();
     }
 
-    // Scans the base-table WAL gap (lastRefreshBaseTxn, baseTableLastTxn] for a TRUNCATE, using the
+    // Scans the base WAL gap (lastRefreshBaseTxn, baseTableLastTxn] for an invalidating barrier, using the
     // same range and loader an incremental refresh would use (so there is no off-by-one vs interval
-    // planning). A truncate in the gap means a resumed incremental refresh would keep stale
-    // pre-truncate rows, so the caller must invalidate the view instead. Runs only on the cold
-    // load/hydrate path, so a transient loader is fine.
-    private boolean hasBaseTableTruncateInWalGap(TableToken baseTableToken, long lastRefreshBaseTxn, long baseTableLastTxn) {
+    // planning). Returns the invalidation reason to record, or null when the gap holds no barrier. A base
+    // TRUNCATE and a base materialized view's own MAT_VIEW_INVALIDATE both carry no data interval, so a
+    // resumed incremental refresh would silently keep stale rows; either is a reason to invalidate the view
+    // instead. Runs only on the cold load/hydrate path, so a transient loader is fine.
+    private String baseGapInvalidationReason(TableToken baseTableToken, long lastRefreshBaseTxn, long baseTableLastTxn) {
         if (lastRefreshBaseTxn >= baseTableLastTxn) {
-            return false;
+            return null;
         }
-        // This load-time probe scans the same (lastRefreshBaseTxn, baseTableLastTxn] gap that the
-        // enqueued incremental refresh re-scans to build its intervals, so the no-truncate promote path
-        // reads the gap twice (and allocates a fresh loader per view). It is bounded to lagging views on
-        // the cold boot/promote path, so the redundant scan is a tracked optimization, not a steady-state
-        // cost.
+        // This load-time probe scans the same (lastRefreshBaseTxn, baseTableLastTxn] gap that the enqueued
+        // incremental refresh re-scans to build its intervals, so the no-barrier promote path reads the gap
+        // twice (and allocates a fresh loader per view). It is bounded to lagging views on the cold
+        // boot/promote path, so the redundant scan is a tracked optimization, not a steady-state cost.
         try (
                 Path path = new Path();
                 WalTxnRangeLoader loader = new WalTxnRangeLoader(configuration)
         ) {
             final LongList intervals = new LongList();
             loader.load(this, path, baseTableToken, intervals, lastRefreshBaseTxn, baseTableLastTxn);
-            return loader.hasTruncate();
+            if (loader.hasTruncate()) {
+                return "truncate operation";
+            }
+            if (loader.hasMatViewInvalidate()) {
+                return "base materialized view is invalidated";
+            }
+            return null;
         } catch (CairoException e) {
-            // Missing or purged WAL files in the gap. Treat as "no truncate found" so the caller
-            // still schedules the normal incremental refresh. The refresh path's own interval planning
-            // hits the same read failure and falls back to a full refresh; note that fallback is a
-            // REPLACE_RANGE over the current range, so if the purged gap held a truncate, pre-truncate
-            // buckets outside the current range can survive (a stale-valid view). That purge-during-the-
-            // pending-window residual is a known, tracked deferral. Letting the exception escape would
-            // cause loadMatViewIntoStore's logging-only catch to swallow it, skipping
-            // enqueueIncrementalRefresh and leaving the view silently unscheduled after a promote-hydrate.
-            LOG.info().$("could not scan base WAL gap for truncate, scheduling refresh [baseTable=").$(baseTableToken)
+            // Missing or purged WAL files in the gap. Treat as "no barrier found" so the caller still
+            // schedules the normal incremental refresh. The refresh path's own interval planning hits the
+            // same read failure and falls back to a full refresh; note that fallback is a REPLACE_RANGE over
+            // the current range, so if the purged gap held a barrier, pre-barrier buckets outside the current
+            // range can survive (a stale-valid view). That purge-during-the-pending-window residual is a
+            // known, tracked deferral. Letting the exception escape would cause loadMatViewIntoStore's
+            // logging-only catch to swallow it, skipping enqueueIncrementalRefresh and leaving the view
+            // silently unscheduled after a promote-hydrate.
+            LOG.info().$("could not scan base WAL gap for invalidating barrier, scheduling refresh [baseTable=").$(baseTableToken)
                     .$(", errno=").$(e.getErrno())
                     .$(", msg=").$safe(e.getFlyweightMessage())
                     .I$();
-            return false;
+            return null;
         }
     }
 
@@ -2628,20 +2634,25 @@ public class CairoEngine implements Closeable, WriterSource {
                             .$(", baseTableTxn=").$(baseTableLastTxn)
                             .I$();
                     matViewStateStore.enqueueInvalidate(tableToken, "materialized view is ahead of base table and cannot be synchronized");
-                } else if (state.getLastRefreshBaseTxn() > -1 && hasBaseTableTruncateInWalGap(baseTableToken, state.getLastRefreshBaseTxn(), baseTableLastTxn)) {
-                    // A truncate in the base WAL gap (lastRefreshBaseTxn, baseTableLastTxn] carries no
-                    // data interval, so resuming an incremental refresh would silently advance past it
-                    // and keep stale pre-truncate rows. Invalidate instead, the same way a primary
-                    // already invalidates dependents on a truncate. Only for a view that has refreshed
-                    // at least once (a never-refreshed view has nothing stale to retain).
-                    LOG.info().$("materialized view base table was truncated, invalidating on load [table=")
-                            .$safe(viewDefinition.getBaseTableName())
-                            .$(", view=").$(tableToken)
-                            .I$();
-                    matViewStateStore.enqueueInvalidate(tableToken, "truncate operation");
-                } else if (viewDefinition.getRefreshType() == MatViewDefinition.REFRESH_TYPE_IMMEDIATE) {
-                    // Kickstart immediate refresh.
-                    matViewStateStore.enqueueIncrementalRefresh(tableToken);
+                } else {
+                    final String gapInvalidationReason = state.getLastRefreshBaseTxn() > -1
+                            ? baseGapInvalidationReason(baseTableToken, state.getLastRefreshBaseTxn(), baseTableLastTxn)
+                            : null;
+                    if (gapInvalidationReason != null) {
+                        // A truncate or a base view's own invalidation in the base WAL gap carries no data
+                        // interval, so resuming an incremental refresh would silently keep stale rows.
+                        // Invalidate instead. Only for a view that has refreshed at least once (a
+                        // never-refreshed view has nothing stale to retain).
+                        LOG.info().$("materialized view base was invalidated, invalidating on load [table=")
+                                .$safe(viewDefinition.getBaseTableName())
+                                .$(", view=").$(tableToken)
+                                .$(", reason=").$(gapInvalidationReason)
+                                .I$();
+                        matViewStateStore.enqueueInvalidate(tableToken, gapInvalidationReason);
+                    } else if (viewDefinition.getRefreshType() == MatViewDefinition.REFRESH_TYPE_IMMEDIATE) {
+                        // Kickstart immediate refresh.
+                        matViewStateStore.enqueueIncrementalRefresh(tableToken);
+                    }
                 }
             }
         } catch (Throwable th) {

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -2623,6 +2623,13 @@ public class CairoEngine implements Closeable, WriterSource {
 
                 state.initFromReader(matViewStateReader);
                 if (state.isInvalid()) {
+                    // A parent that loads invalid must re-cascade to its dependents: a chained child that
+                    // resumed off this now-invalid parent would otherwise reload valid and serve stale rows.
+                    // Enqueue as a base-table invalidate so the refresh job enumerates dependents from the
+                    // fully-built graph at processing time (independent of view load order) and cascades
+                    // transitively. Invalidating an already-invalid child is a no-op, so this is safe even
+                    // when the load-time backstop already invalidated the child.
+                    matViewStateStore.enqueueInvalidateDependentViews(tableToken, "base materialized view is invalidated");
                     return;
                 }
                 long baseTableLastTxn = getTableSequencerAPI().lastTxn(baseTableToken);

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -2336,6 +2336,50 @@ public class CairoEngine implements Closeable, WriterSource {
         }
     }
 
+    // Scans the base WAL gap (lastRefreshBaseTxn, baseTableLastTxn] for an invalidating barrier, using the
+    // same range and loader an incremental refresh would use (so there is no off-by-one vs interval
+    // planning). Returns the invalidation reason to record, or null when the gap holds no barrier. A base
+    // TRUNCATE and a base materialized view's own MAT_VIEW_INVALIDATE both carry no data interval, so a
+    // resumed incremental refresh would silently keep stale rows; either is a reason to invalidate the view
+    // instead. Runs only on the cold load/hydrate path, so a transient loader is fine.
+    private String baseGapInvalidationReason(TableToken baseTableToken, long lastRefreshBaseTxn, long baseTableLastTxn) {
+        if (lastRefreshBaseTxn >= baseTableLastTxn) {
+            return null;
+        }
+        // This load-time probe scans the same (lastRefreshBaseTxn, baseTableLastTxn] gap that the enqueued
+        // incremental refresh re-scans to build its intervals, so the no-barrier promote path reads the gap
+        // twice (and allocates a fresh loader per view). It is bounded to lagging views on the cold
+        // boot/promote path, so the redundant scan is a tracked optimization, not a steady-state cost.
+        try (
+                Path path = new Path();
+                WalTxnRangeLoader loader = new WalTxnRangeLoader(configuration)
+        ) {
+            final LongList intervals = new LongList();
+            loader.load(this, path, baseTableToken, intervals, lastRefreshBaseTxn, baseTableLastTxn);
+            if (loader.hasTruncate()) {
+                return "truncate operation";
+            }
+            if (loader.hasMatViewInvalidate()) {
+                return "base materialized view is invalidated";
+            }
+            return null;
+        } catch (CairoException e) {
+            // Missing or purged WAL files in the gap. Treat as "no barrier found" so the caller still
+            // schedules the normal incremental refresh. The refresh path's own interval planning hits the
+            // same read failure and falls back to a full refresh; note that fallback is a REPLACE_RANGE over
+            // the current range, so if the purged gap held a barrier, pre-barrier buckets outside the current
+            // range can survive (a stale-valid view). That purge-during-the-pending-window residual is a
+            // known, tracked deferral. Letting the exception escape would cause loadMatViewIntoStore's
+            // logging-only catch to swallow it, skipping enqueueIncrementalRefresh and leaving the view
+            // silently unscheduled after a promote-hydrate.
+            LOG.info().$("could not scan base WAL gap for invalidating barrier, scheduling refresh [baseTable=").$(baseTableToken)
+                    .$(", errno=").$(e.getErrno())
+                    .$(", msg=").$safe(e.getFlyweightMessage())
+                    .I$();
+            return null;
+        }
+    }
+
     // caller has to acquire the lock before this method is called and release the lock after the call
     private void createTableOrMatViewInVolumeUnsafe(MemoryMARW mem, @Nullable BlockFileWriter blockFileWriter, Path path, TableStructure struct, TableToken tableToken) {
         if (TableUtils.TABLE_DOES_NOT_EXIST != TableUtils.existsInVolume(configuration.getFilesFacade(), path, tableToken.getDirName())) {
@@ -2501,50 +2545,6 @@ public class CairoEngine implements Closeable, WriterSource {
             throw CairoException.viewDoesNotExist(tableToken.getTableName());
         }
         return state.getViewMetadata();
-    }
-
-    // Scans the base WAL gap (lastRefreshBaseTxn, baseTableLastTxn] for an invalidating barrier, using the
-    // same range and loader an incremental refresh would use (so there is no off-by-one vs interval
-    // planning). Returns the invalidation reason to record, or null when the gap holds no barrier. A base
-    // TRUNCATE and a base materialized view's own MAT_VIEW_INVALIDATE both carry no data interval, so a
-    // resumed incremental refresh would silently keep stale rows; either is a reason to invalidate the view
-    // instead. Runs only on the cold load/hydrate path, so a transient loader is fine.
-    private String baseGapInvalidationReason(TableToken baseTableToken, long lastRefreshBaseTxn, long baseTableLastTxn) {
-        if (lastRefreshBaseTxn >= baseTableLastTxn) {
-            return null;
-        }
-        // This load-time probe scans the same (lastRefreshBaseTxn, baseTableLastTxn] gap that the enqueued
-        // incremental refresh re-scans to build its intervals, so the no-barrier promote path reads the gap
-        // twice (and allocates a fresh loader per view). It is bounded to lagging views on the cold
-        // boot/promote path, so the redundant scan is a tracked optimization, not a steady-state cost.
-        try (
-                Path path = new Path();
-                WalTxnRangeLoader loader = new WalTxnRangeLoader(configuration)
-        ) {
-            final LongList intervals = new LongList();
-            loader.load(this, path, baseTableToken, intervals, lastRefreshBaseTxn, baseTableLastTxn);
-            if (loader.hasTruncate()) {
-                return "truncate operation";
-            }
-            if (loader.hasMatViewInvalidate()) {
-                return "base materialized view is invalidated";
-            }
-            return null;
-        } catch (CairoException e) {
-            // Missing or purged WAL files in the gap. Treat as "no barrier found" so the caller still
-            // schedules the normal incremental refresh. The refresh path's own interval planning hits the
-            // same read failure and falls back to a full refresh; note that fallback is a REPLACE_RANGE over
-            // the current range, so if the purged gap held a barrier, pre-barrier buckets outside the current
-            // range can survive (a stale-valid view). That purge-during-the-pending-window residual is a
-            // known, tracked deferral. Letting the exception escape would cause loadMatViewIntoStore's
-            // logging-only catch to swallow it, skipping enqueueIncrementalRefresh and leaving the view
-            // silently unscheduled after a promote-hydrate.
-            LOG.info().$("could not scan base WAL gap for invalidating barrier, scheduling refresh [baseTable=").$(baseTableToken)
-                    .$(", errno=").$(e.getErrno())
-                    .$(", msg=").$safe(e.getFlyweightMessage())
-                    .I$();
-            return null;
-        }
     }
 
     /**

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
@@ -69,6 +69,7 @@ import io.questdb.std.str.Sinkable;
 import io.questdb.std.str.StringSink;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 import java.util.concurrent.locks.Lock;
 
@@ -91,6 +92,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
     private final MatViewGraph graph;
     private final LongList intervals = new LongList();
     private final MicrosecondClock microsecondClock;
+    private Runnable onRefreshHoldingLockForTest;
     private final RefreshContext refreshContext = new RefreshContext();
     private final MatViewRefreshSqlExecutionContext refreshSqlExecutionContext;
     private final MatViewRefreshTask refreshTask = new MatViewRefreshTask();
@@ -174,6 +176,11 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
     @Override
     public boolean run(@NotNull WorkerContext workerContext) {
         return processNotifications();
+    }
+
+    @TestOnly
+    public void setOnRefreshHoldingLockForTest(Runnable onRefreshHoldingLockForTest) {
+        this.onRefreshHoldingLockForTest = onRefreshHoldingLockForTest;
     }
 
     private static long approxStepDuration(long step, long approxBucketSize) {
@@ -473,6 +480,30 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
         for (int v = 0, n = childViewSink2.size(); v < n; v++) {
             stateStore.enqueueInvalidate(childViewSink2.get(v), invalidationReason);
         }
+    }
+
+    private void finalizeDeferredInvalidation(TableToken viewToken, MatViewState viewState) {
+        // A refresh just completed while holding this view's lock. If a concurrent INVALIDATE deferred in
+        // that window it called markAsPendingInvalidation() and re-enqueued a task that the invalidateView
+        // top guard then swallowed (the guard skips a view that is already pending), so nothing else would
+        // finalize it and the view would stay valid on disk with stale rows. Clear the pending marker and
+        // re-enqueue a fresh INVALIDATE: with the marker cleared the guard no longer swallows it, and the
+        // lock is now free, so it mints durably through the normal path. A null reason marks a full-refresh
+        // reschedule (see fullRefresh), not an invalidation, so leave it for the queued full refresh. Skip
+        // while read-only: a demote rebuilds derived state from disk on promote, and re-enqueueing here
+        // would self-feed the demote quiesce drain. Mirrors invalidateView's own
+        // force || getLastRefreshBaseTxn() != -1 gate: a base-scoped (non-forced) invalidate does not mint
+        // for a view that never had an incremental/full refresh (e.g. range-only-populated), so such a view
+        // is not base-invalidated even without contention; finalize intentionally matches that.
+        if (!viewState.isPendingInvalidation() || viewState.isInvalid() || viewState.isDropped()) {
+            return;
+        }
+        final String invalidationReason = viewState.getPendingInvalidationReason();
+        if (invalidationReason == null || engine.isReadOnlyMode() || viewState.getLastRefreshBaseTxn() == -1) {
+            return;
+        }
+        viewState.markAsValid();
+        stateStore.enqueueInvalidate(viewToken, invalidationReason);
     }
 
     private RefreshContext findRefreshIntervals(
@@ -1378,12 +1409,15 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
 
     private void invalidateView(TableToken viewToken, String invalidationReason, boolean force) {
         final MatViewState viewState = stateStore.getViewState(viewToken);
-        // Known limitation (tracked follow-up): the pendingInvalidation term skips a view whose earlier
-        // invalidation deferred (read-only node, or the lock was held by a concurrent refresh) and was
-        // re-enqueued -- so a deferred enqueued INVALIDATE that loses the lock race can leave the view
-        // pending in memory while its on-disk state stays valid until a restart, REFRESH FULL, or role
-        // switch rebuilds the store. The truncate barrier no longer relies on this path (it invalidates
-        // inline while holding the lock + writer); the residual is the apply-time INVALIDATE race.
+        // The pendingInvalidation guard skips a re-enqueued INVALIDATE when an earlier deferral marked the
+        // view pending (read-only node, or the lock was held by a concurrent refresh). Incremental, range,
+        // and interval-update refresh holders now finalize a deferred invalidation on completion, clearing
+        // this guard for re-delivery. Residuals: a read-only deferral rebuilds from disk on promote; a
+        // fullRefresh-holder deferral self-resolves only for a pending set before the full refresh's reader
+        // snapshot (markAsValid clears pending at truncateSoft time), but an invalidation deferring after
+        // that snapshot is a tracked residual (fullRefresh does not call finalizeDeferredInvalidation); and
+        // the narrow window between a holder's finalize check and its unlock where a concurrent INVALIDATE
+        // can defer again.
         if (viewState != null && !viewState.isDropped() && !viewState.isInvalid() && !viewState.isPendingInvalidation()) {
             if (engine.isReadOnlyMode()) {
                 // The node is, or just became, a replica: marking the view invalid acquires a WalWriter
@@ -1392,7 +1426,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                 // halt-on-error pool would stop). Defer instead -- mark the view pending and re-enqueue so
                 // the invalidation retries after a re-promote, mirroring the refresh face's read-only
                 // deferral. A materialized view is derived state.
-                viewState.markAsPendingInvalidation();
+                viewState.markAsPendingInvalidation(invalidationReason);
                 stateStore.enqueueInvalidate(viewToken, invalidationReason);
                 return;
             }
@@ -1407,7 +1441,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             }
             if (!viewState.tryLock()) {
                 LOG.debug().$("skipping materialized view invalidation, locked by another refresh run [view=").$(viewToken).I$();
-                viewState.markAsPendingInvalidation();
+                viewState.markAsPendingInvalidation(invalidationReason);
                 stateStore.enqueueInvalidate(viewToken, invalidationReason);
                 return;
             }
@@ -1452,7 +1486,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                                 // (its in-memory start would otherwise sit ahead of the persisted finish).
                                 viewState.markAsValid();
                                 viewState.setLastRefreshStartTimestampUs(prevRefreshStartTimestampUs);
-                                viewState.markAsPendingInvalidation();
+                                viewState.markAsPendingInvalidation(invalidationReason);
                                 stateStore.enqueueInvalidate(viewToken, invalidationReason);
                                 return;
                             }
@@ -1555,6 +1589,10 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             return false;
         }
 
+        if (onRefreshHoldingLockForTest != null) {
+            onRefreshHoldingLockForTest.run();
+        }
+
         try (WalWriter walWriter = engine.getWalWriter(viewToken)) {
             final TableToken baseTableToken;
             final String baseTableName = viewDefinition.getBaseTableName();
@@ -1628,6 +1666,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             refreshFailState(viewDefinition, viewState, null, th);
             return false;
         } finally {
+            finalizeDeferredInvalidation(viewToken, viewState);
             viewState.unlock();
             viewState.tryCloseIfDropped();
             viewState.tryCloseIfClosed();
@@ -1717,6 +1756,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                             .I$();
                     refreshFailState(viewDefinition, viewState, null, th);
                 } finally {
+                    finalizeDeferredInvalidation(viewToken, viewState);
                     viewState.incrementRefreshSeq();
                     viewState.unlock();
                     viewState.tryCloseIfDropped();
@@ -1859,6 +1899,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             refreshFailState(viewDefinition, viewState, null, th);
             return false;
         } finally {
+            finalizeDeferredInvalidation(viewToken, viewState);
             viewState.incrementRefreshSeq();
             viewState.unlock();
             viewState.tryCloseIfDropped();
@@ -1879,6 +1920,9 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             long refreshTriggerTimestamp
     ) throws SqlException {
         assert viewState.isLocked();
+        if (onRefreshHoldingLockForTest != null) {
+            onRefreshHoldingLockForTest.run();
+        }
 
         // Steps:
         // - compile view and execute with timestamp ranges from the unprocessed commits
@@ -2012,6 +2056,10 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                 return;
             }
 
+            if (onRefreshHoldingLockForTest != null) {
+                onRefreshHoldingLockForTest.run();
+            }
+
             final MatViewDefinition viewDefinition = viewState.getViewDefinition();
             try (WalWriter walWriter = engine.getWalWriter(viewToken)) {
                 final TableToken baseTableToken = verifyBaseTableToken(viewDefinition, viewState, walWriter);
@@ -2046,6 +2094,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                         .I$();
                 refreshFailState(viewDefinition, viewState, null, th);
             } finally {
+                finalizeDeferredInvalidation(viewToken, viewState);
                 viewState.unlock();
                 viewState.tryCloseIfDropped();
                 viewState.tryCloseIfClosed();

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
@@ -92,7 +92,6 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
     private final MatViewGraph graph;
     private final LongList intervals = new LongList();
     private final MicrosecondClock microsecondClock;
-    private Runnable onRefreshHoldingLockForTest;
     private final RefreshContext refreshContext = new RefreshContext();
     private final MatViewRefreshSqlExecutionContext refreshSqlExecutionContext;
     private final MatViewRefreshTask refreshTask = new MatViewRefreshTask();
@@ -100,6 +99,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
     private final MatViewStateStore stateStore;
     private final TimeZoneIntervalIterator timeZoneIterator = new TimeZoneIntervalIterator();
     private final WalTxnRangeLoader txnRangeLoader;
+    private Runnable onRefreshHoldingLockForTest;
 
     public MatViewRefreshJob(int workerId, CairoEngine engine, int sharedQueryWorkerCount) {
         // workerId is accepted for source-compatibility; the rotation framework
@@ -491,18 +491,25 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
         // lock is now free, so it mints durably through the normal path. A null reason marks a full-refresh
         // reschedule (see fullRefresh), not an invalidation, so leave it for the queued full refresh. Skip
         // while read-only: a demote rebuilds derived state from disk on promote, and re-enqueueing here
-        // would self-feed the demote quiesce drain. Mirrors invalidateView's own
-        // force || getLastRefreshBaseTxn() != -1 gate: a base-scoped (non-forced) invalidate does not mint
-        // for a view that never had an incremental/full refresh (e.g. range-only-populated), so such a view
-        // is not base-invalidated even without contention; finalize intentionally matches that.
+        // would self-feed the demote quiesce drain.
+        //
+        // The marker clears regardless of getLastRefreshBaseTxn(): the re-enqueued view task re-delivers as
+        // force=true (see invalidate()), which mints regardless of lastRefreshBaseTxn, so a range-only view
+        // (lastRefreshBaseTxn == -1) ends cleanly invalid -- visible, REFRESH ... FULL recovers it. That is
+        // stricter than the no-contention path, where invalidateView's own force || getLastRefreshBaseTxn()
+        // != -1 gate declines a base-scoped (non-forced) invalidate for a never-incrementally-refreshed view
+        // and leaves it valid. Finalize cannot replicate that here -- the deferral already queued a force=true
+        // retry -- and minting invalid is the safe terminal state (the rows are in fact stale). It beats the
+        // alternative of leaving the marker set, which freezes the view: silently stale, still reporting valid
+        // (getViewStatus reads the persisted invalid flag, not the in-memory pending marker), never recovering.
         if (!viewState.isPendingInvalidation() || viewState.isInvalid() || viewState.isDropped()) {
             return;
         }
         final String invalidationReason = viewState.getPendingInvalidationReason();
-        if (invalidationReason == null || engine.isReadOnlyMode() || viewState.getLastRefreshBaseTxn() == -1) {
+        if (invalidationReason == null || engine.isReadOnlyMode()) {
             return;
         }
-        viewState.markAsValid();
+        viewState.clearPendingInvalidation();
         stateStore.enqueueInvalidate(viewToken, invalidationReason);
     }
 
@@ -823,6 +830,12 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                     fencedMatViewCommit(walWriter::truncateSoft);
                     resetInvalidState(viewState, walWriter);
 
+                    // Seam fires after resetInvalidState cleared the marker, modelling an INVALIDATE that
+                    // defers during the pump (the lock is held for the whole insert-as-select).
+                    if (onRefreshHoldingLockForTest != null) {
+                        onRefreshHoldingLockForTest.run();
+                    }
+
                     final RefreshContext refreshContext = findRefreshIntervals(baseTableReader, viewDefinition, viewState, walWriter, Numbers.LONG_NULL);
                     insertAsSelect(viewDefinition, viewState, walWriter, refreshContext, refreshTriggerTimestamp);
                 } finally {
@@ -859,6 +872,11 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             refreshFailState(viewDefinition, viewState, null, th);
             return false;
         } finally {
+            // A base invalidation that defers after resetInvalidState() cleared the marker (i.e. during the
+            // full-table pump, which snapshots the base at lock time) sets pending again; finalize it here so
+            // the view does not end frozen-pending. Without this, the lone lock-holding path that skips
+            // finalize is fullRefresh, and that window is the entire pump -- far wider than a tight race.
+            finalizeDeferredInvalidation(viewToken, viewState);
             viewState.incrementRefreshSeq();
             viewState.unlock();
             viewState.tryCloseIfDropped();
@@ -1411,13 +1429,13 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
         final MatViewState viewState = stateStore.getViewState(viewToken);
         // The pendingInvalidation guard skips a re-enqueued INVALIDATE when an earlier deferral marked the
         // view pending (read-only node, or the lock was held by a concurrent refresh). Incremental, range,
-        // and interval-update refresh holders now finalize a deferred invalidation on completion, clearing
-        // this guard for re-delivery. Residuals: a read-only deferral rebuilds from disk on promote; a
-        // fullRefresh-holder deferral self-resolves only for a pending set before the full refresh's reader
-        // snapshot (markAsValid clears pending at truncateSoft time), but an invalidation deferring after
-        // that snapshot is a tracked residual (fullRefresh does not call finalizeDeferredInvalidation); and
-        // the narrow window between a holder's finalize check and its unlock where a concurrent INVALIDATE
-        // can defer again.
+        // interval-update, and full-refresh holders all finalize a deferred invalidation on completion,
+        // clearing this guard for re-delivery so the view ends invalid rather than frozen. Residuals: a
+        // read-only deferral rebuilds from disk on promote; and the narrow window between a holder's finalize
+        // (which clears the marker and re-enqueues, both still under the latch) and its unlock -- a second
+        // worker that defers in that window re-sets the marker, and once the holder unlocks every queued
+        // INVALIDATE is swallowed again. When hit, that is a permanent silent freeze, not a self-healing
+        // retry: far narrower than the pre-fix always-lost deferral, but, unlike it, terminal.
         if (viewState != null && !viewState.isDropped() && !viewState.isInvalid() && !viewState.isPendingInvalidation()) {
             if (engine.isReadOnlyMode()) {
                 // The node is, or just became, a replica: marking the view invalid acquires a WalWriter

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
@@ -99,7 +99,8 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
     private final MatViewStateStore stateStore;
     private final TimeZoneIntervalIterator timeZoneIterator = new TimeZoneIntervalIterator();
     private final WalTxnRangeLoader txnRangeLoader;
-    private Runnable onRefreshHoldingLockForTest;
+    @TestOnly
+    private volatile Runnable onHoldingLockForTesting;
 
     public MatViewRefreshJob(int workerId, CairoEngine engine, int sharedQueryWorkerCount) {
         // workerId is accepted for source-compatibility; the rotation framework
@@ -178,9 +179,15 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
         return processNotifications();
     }
 
+    /**
+     * Test seam: runs while a lock-holder (a refresh, or {@code invalidateView} itself) holds the view lock,
+     * letting a test mark the view pending mid-hold exactly as a losing concurrent {@code invalidateView}
+     * would, so the holder's completion must finalize it. Production never sets it and {@code cloneInstance}
+     * does not copy it, so pool workers read {@code null}; {@code volatile} only matches the house seam idiom.
+     */
     @TestOnly
-    public void setOnRefreshHoldingLockForTest(Runnable onRefreshHoldingLockForTest) {
-        this.onRefreshHoldingLockForTest = onRefreshHoldingLockForTest;
+    public void setOnHoldingLockForTesting(Runnable onHoldingLockForTesting) {
+        this.onHoldingLockForTesting = onHoldingLockForTesting;
     }
 
     private static long approxStepDuration(long step, long approxBucketSize) {
@@ -482,13 +489,31 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
         }
     }
 
+    private void finalizeAndUnlock(TableToken viewToken, MatViewState viewState, boolean incrementRefreshSeq) {
+        // Only an OutOfMemoryError can throw out of finalizeDeferredInvalidation, but if one does, unlock()
+        // must still run: a skipped unlock wedges the latch forever and leaks the parked cursorFactory at
+        // teardown (close/tryCloseIf* all need the latch). Finalize stays under the latch, in the inner try,
+        // so the finalize->unlock race window stays narrow.
+        try {
+            finalizeDeferredInvalidation(viewToken, viewState);
+        } finally {
+            if (incrementRefreshSeq) {
+                viewState.incrementRefreshSeq();
+            }
+            viewState.unlock();
+            viewState.tryCloseIfDropped();
+            viewState.tryCloseIfClosed();
+        }
+    }
+
     private void finalizeDeferredInvalidation(TableToken viewToken, MatViewState viewState) {
         // A refresh just completed while holding this view's lock. If a concurrent INVALIDATE deferred in
         // that window it called markAsPendingInvalidation() and re-enqueued a task that the invalidateView
         // top guard then swallowed (the guard skips a view that is already pending), so nothing else would
         // finalize it and the view would stay valid on disk with stale rows. Clear the pending marker and
-        // re-enqueue a fresh INVALIDATE: with the marker cleared the guard no longer swallows it, and the
-        // lock is now free, so it mints durably through the normal path. A null reason marks a full-refresh
+        // re-enqueue a fresh INVALIDATE: the re-enqueue runs here under the latch, but with the marker
+        // cleared the guard no longer swallows the re-delivered task, so once this holder unlocks a later
+        // worker mints invalid durably through the normal path. A null reason marks a full-refresh
         // reschedule (see fullRefresh), not an invalidation, so leave it for the queued full refresh. Skip
         // while read-only: a demote rebuilds derived state from disk on promote, and re-enqueueing here
         // would self-feed the demote quiesce drain.
@@ -832,8 +857,9 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
 
                     // Seam fires after resetInvalidState cleared the marker, modelling an INVALIDATE that
                     // defers during the pump (the lock is held for the whole insert-as-select).
-                    if (onRefreshHoldingLockForTest != null) {
-                        onRefreshHoldingLockForTest.run();
+                    final Runnable seam = onHoldingLockForTesting;
+                    if (seam != null) {
+                        seam.run();
                     }
 
                     final RefreshContext refreshContext = findRefreshIntervals(baseTableReader, viewDefinition, viewState, walWriter, Numbers.LONG_NULL);
@@ -876,11 +902,14 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             // full-table pump, which snapshots the base at lock time) sets pending again; finalize it here so
             // the view does not end frozen-pending. Without this, the lone lock-holding path that skips
             // finalize is fullRefresh, and that window is the entire pump -- far wider than a tight race.
-            finalizeDeferredInvalidation(viewToken, viewState);
-            viewState.incrementRefreshSeq();
-            viewState.unlock();
-            viewState.tryCloseIfDropped();
-            viewState.tryCloseIfClosed();
+            //
+            // Tradeoff: if this full refresh won the lock race, its snapshot already incorporated the base
+            // change and rebuilt the view, yet finalize still re-enqueues the deferral force=true and ends the
+            // view invalid (cascading to dependents) -- a spurious-looking valid->invalid flip under the
+            // "UPDATE then REFRESH FULL" race. It is conservatively safe (invalid is visible, REFRESH ... FULL
+            // recovers it) and better than dropping finalize, which re-exposes the silent frozen-pending freeze
+            // across the whole pump. finalize is reason-blind; gating on the trigger txn is a tracked follow-up.
+            finalizeAndUnlock(viewToken, viewState, true);
         }
 
         if (viewDefinition.getRefreshType() == MatViewDefinition.REFRESH_TYPE_IMMEDIATE) {
@@ -1427,15 +1456,16 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
 
     private void invalidateView(TableToken viewToken, String invalidationReason, boolean force) {
         final MatViewState viewState = stateStore.getViewState(viewToken);
-        // The pendingInvalidation guard skips a re-enqueued INVALIDATE when an earlier deferral marked the
-        // view pending (read-only node, or the lock was held by a concurrent refresh). Incremental, range,
-        // interval-update, and full-refresh holders all finalize a deferred invalidation on completion,
-        // clearing this guard for re-delivery so the view ends invalid rather than frozen. Residuals: a
-        // read-only deferral rebuilds from disk on promote; and the narrow window between a holder's finalize
-        // (which clears the marker and re-enqueues, both still under the latch) and its unlock -- a second
-        // worker that defers in that window re-sets the marker, and once the holder unlocks every queued
-        // INVALIDATE is swallowed again. When hit, that is a permanent silent freeze, not a self-healing
-        // retry: far narrower than the pre-fix always-lost deferral, but, unlike it, terminal.
+        // The pendingInvalidation guard swallows a re-enqueued INVALIDATE for an already-pending view. Every
+        // lock-holder finalizes a deferral on completion -- the incremental, range, interval-update and
+        // full-refresh holders, plus invalidateView's own force=false decline below (a never-refreshed view it
+        // holds without minting) -- clearing the guard so the view ends invalid, not frozen. Residuals: a
+        // read-only deferral rebuilds from disk on promote; and the window between a holder's finalize and its
+        // unlock, where a second deferral re-sets the marker (a torn (pending, reason) write lands here too --
+        // the defer writers hold no latch and write the two volatile fields in opposite orders, so reason can
+        // tear to null and route a real deferral down finalize's no-op marker branch) and is then swallowed
+        // for good. When hit that is a terminal silent freeze -- far narrower than the pre-fix always-lost
+        // deferral, but, unlike it, not self-healing.
         if (viewState != null && !viewState.isDropped() && !viewState.isInvalid() && !viewState.isPendingInvalidation()) {
             if (engine.isReadOnlyMode()) {
                 // The node is, or just became, a replica: marking the view invalid acquires a WalWriter
@@ -1444,6 +1474,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                 // halt-on-error pool would stop). Defer instead -- mark the view pending and re-enqueue so
                 // the invalidation retries after a re-promote, mirroring the refresh face's read-only
                 // deferral. A materialized view is derived state.
+                assert invalidationReason != null : "a deferred invalidation must carry a reason (null is the full-refresh marker)";
                 viewState.markAsPendingInvalidation(invalidationReason);
                 stateStore.enqueueInvalidate(viewToken, invalidationReason);
                 return;
@@ -1459,9 +1490,17 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             }
             if (!viewState.tryLock()) {
                 LOG.debug().$("skipping materialized view invalidation, locked by another refresh run [view=").$(viewToken).I$();
+                assert invalidationReason != null : "a deferred invalidation must carry a reason (null is the full-refresh marker)";
                 viewState.markAsPendingInvalidation(invalidationReason);
                 stateStore.enqueueInvalidate(viewToken, invalidationReason);
                 return;
+            }
+
+            // Seam: a concurrent INVALIDATE deferring while THIS invalidateView holds the lock (see the
+            // method-top comment); the finally must finalize it.
+            final Runnable seam = onHoldingLockForTesting;
+            if (seam != null) {
+                seam.run();
             }
 
             try {
@@ -1504,6 +1543,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                                 // (its in-memory start would otherwise sit ahead of the persisted finish).
                                 viewState.markAsValid();
                                 viewState.setLastRefreshStartTimestampUs(prevRefreshStartTimestampUs);
+                                assert invalidationReason != null : "a deferred invalidation must carry a reason (null is the full-refresh marker)";
                                 viewState.markAsPendingInvalidation(invalidationReason);
                                 stateStore.enqueueInvalidate(viewToken, invalidationReason);
                                 return;
@@ -1515,9 +1555,12 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                     }
                 }
             } finally {
-                viewState.unlock();
-                viewState.tryCloseIfDropped();
-                viewState.tryCloseIfClosed();
+                // Finalize the decline path's own lock-hold (see the method-top comment). No-op on the mint
+                // path (isInvalid short-circuits) and on the auth-rollback defer above while still read-only
+                // (finalize's isReadOnlyMode check); if the role flipped back to writable in between, finalize
+                // just re-delivers the invalidation the rollback already queued -- the first mints, the
+                // duplicate then no-ops on isInvalid.
+                finalizeAndUnlock(viewToken, viewState, false);
             }
             // Invalidate dependent views recursively.
             enqueueInvalidateDependentViews(viewToken, "base materialized view is invalidated");
@@ -1607,8 +1650,9 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             return false;
         }
 
-        if (onRefreshHoldingLockForTest != null) {
-            onRefreshHoldingLockForTest.run();
+        final Runnable seam = onHoldingLockForTesting;
+        if (seam != null) {
+            seam.run();
         }
 
         try (WalWriter walWriter = engine.getWalWriter(viewToken)) {
@@ -1684,10 +1728,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             refreshFailState(viewDefinition, viewState, null, th);
             return false;
         } finally {
-            finalizeDeferredInvalidation(viewToken, viewState);
-            viewState.unlock();
-            viewState.tryCloseIfDropped();
-            viewState.tryCloseIfClosed();
+            finalizeAndUnlock(viewToken, viewState, false);
         }
 
         return true;
@@ -1774,11 +1815,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                             .I$();
                     refreshFailState(viewDefinition, viewState, null, th);
                 } finally {
-                    finalizeDeferredInvalidation(viewToken, viewState);
-                    viewState.incrementRefreshSeq();
-                    viewState.unlock();
-                    viewState.tryCloseIfDropped();
-                    viewState.tryCloseIfClosed();
+                    finalizeAndUnlock(viewToken, viewState, true);
                 }
             }
         }
@@ -1917,11 +1954,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             refreshFailState(viewDefinition, viewState, null, th);
             return false;
         } finally {
-            finalizeDeferredInvalidation(viewToken, viewState);
-            viewState.incrementRefreshSeq();
-            viewState.unlock();
-            viewState.tryCloseIfDropped();
-            viewState.tryCloseIfClosed();
+            finalizeAndUnlock(viewToken, viewState, true);
         }
     }
 
@@ -1938,8 +1971,9 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
             long refreshTriggerTimestamp
     ) throws SqlException {
         assert viewState.isLocked();
-        if (onRefreshHoldingLockForTest != null) {
-            onRefreshHoldingLockForTest.run();
+        final Runnable seam = onHoldingLockForTesting;
+        if (seam != null) {
+            seam.run();
         }
 
         // Steps:
@@ -2074,8 +2108,9 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                 return;
             }
 
-            if (onRefreshHoldingLockForTest != null) {
-                onRefreshHoldingLockForTest.run();
+            final Runnable seam = onHoldingLockForTesting;
+            if (seam != null) {
+                seam.run();
             }
 
             final MatViewDefinition viewDefinition = viewState.getViewDefinition();
@@ -2112,10 +2147,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                         .I$();
                 refreshFailState(viewDefinition, viewState, null, th);
             } finally {
-                finalizeDeferredInvalidation(viewToken, viewState);
-                viewState.unlock();
-                viewState.tryCloseIfDropped();
-                viewState.tryCloseIfClosed();
+                finalizeAndUnlock(viewToken, viewState, false);
             }
         }
     }

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
@@ -1595,6 +1595,8 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                 seam.run();
             }
 
+            // True once the auth-rollback branch below defers this invalidate itself (see the finally).
+            boolean selfDeferred = false;
             try {
                 // Mark the view invalid only if the operation is forced or the view was never refreshed.
                 if (force || viewState.getLastRefreshBaseTxn() != -1) {
@@ -1638,6 +1640,7 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                                 assert invalidationReason != null : "a deferred invalidation must carry a reason (null is the full-refresh marker)";
                                 viewState.markAsPendingInvalidation(invalidationReason);
                                 stateStore.enqueueInvalidate(viewToken, invalidationReason);
+                                selfDeferred = true;
                                 return;
                             }
                             if (!handleErrorRetryRefresh(ex, viewToken, null, null)) {
@@ -1647,12 +1650,18 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
                     }
                 }
             } finally {
-                // Finalize the decline path's own lock-hold (see the method-top comment). No-op on the mint
-                // path (isInvalid short-circuits) and on the auth-rollback defer above while still read-only
-                // (finalize's isReadOnlyMode check); if the role flipped back to writable in between, finalize
-                // just re-delivers the invalidation the rollback already queued -- the first mints, the
-                // duplicate then no-ops on isInvalid.
-                finalizeAndUnlock(viewToken, viewState, false);
+                // Skip finalize for the auth-rollback path's own deferral: finalizeDeferredInvalidation would
+                // clear the marker it just set and re-enqueue. With the writer refusal sticky until a
+                // re-promote, clearing the marker lets the retry back past the top guard every pass -- a busy
+                // spin. The else branch still finalizes a deferral a concurrent invalidate left while this one
+                // held the lock.
+                if (selfDeferred) {
+                    viewState.unlock();
+                    viewState.tryCloseIfDropped();
+                    viewState.tryCloseIfClosed();
+                } else {
+                    finalizeAndUnlock(viewToken, viewState, false);
+                }
             }
             // Invalidate dependent views recursively.
             enqueueInvalidateDependentViews(viewToken, "base materialized view is invalidated");

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewState.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewState.java
@@ -127,6 +127,7 @@ public class MatViewState implements QuietCloseable {
     private volatile long lastRefreshFinishTimestampUs = Numbers.LONG_NULL;
     private volatile long lastRefreshStartTimestampUs = Numbers.LONG_NULL;
     private volatile boolean pendingInvalidation;
+    private volatile String pendingInvalidationReason;
     // Protected by this.latch.
     private long recordRowCopierMetadataVersion;
     // Protected by this.latch.
@@ -423,6 +424,10 @@ public class MatViewState implements QuietCloseable {
         return lastRefreshStartTimestampUs;
     }
 
+    public String getPendingInvalidationReason() {
+        return pendingInvalidationReason;
+    }
+
     public long getRecordRowCopierMetadataVersion() {
         return recordRowCopierMetadataVersion;
     }
@@ -508,12 +513,18 @@ public class MatViewState implements QuietCloseable {
     }
 
     public void markAsPendingInvalidation() {
+        markAsPendingInvalidation(null);
+    }
+
+    public void markAsPendingInvalidation(String invalidationReason) {
+        pendingInvalidationReason = invalidationReason;
         pendingInvalidation = true;
     }
 
     public void markAsValid() {
         this.invalid = false;
         this.pendingInvalidation = false;
+        this.pendingInvalidationReason = null;
     }
 
     public void rangeRefreshSuccess(

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewState.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewState.java
@@ -46,8 +46,11 @@ import static io.questdb.TelemetryEvent.*;
  * Mat view refresh state serves the purpose of synchronizing and coordinating
  * {@link MatViewRefreshJob}s.
  * <p>
- * Unlike {@link MatViewStateReader}, it doesn't include invalidation reason
- * string as that field is not needed for refresh jobs.
+ * Unlike {@link MatViewStateReader}, it does not carry a persisted invalidation
+ * reason string. The only reason it holds, {@link #pendingInvalidationReason}, is a
+ * transient in-memory marker for an invalidation that deferred behind the view lock;
+ * it is distinct from the reader's durable invalidationReason and is cleared once the
+ * lock-holding refresh finalizes the deferral.
  */
 public class MatViewState implements QuietCloseable {
     // Cold-start gap-width threshold used when no scan/commit samples have
@@ -320,6 +323,19 @@ public class MatViewState implements QuietCloseable {
         RecordCursorFactory factory = cursorFactory;
         cursorFactory = null;
         return factory;
+    }
+
+    /**
+     * Clears the pending-invalidation marker (and its reason) without touching the
+     * {@link #invalid} flag. {@code finalizeDeferredInvalidation} uses this to release a
+     * deferred invalidation it is about to re-enqueue: only the marker must drop so the
+     * re-delivered INVALIDATE is no longer swallowed by the pending guard, while a
+     * genuinely invalid view (a separate flag) stays invalid. Unlike {@link #markAsValid()},
+     * it never resurrects an invalid view.
+     */
+    public void clearPendingInvalidation() {
+        this.pendingInvalidation = false;
+        this.pendingInvalidationReason = null;
     }
 
     @Override

--- a/core/src/main/java/io/questdb/cairo/mv/WalTxnRangeLoader.java
+++ b/core/src/main/java/io/questdb/cairo/mv/WalTxnRangeLoader.java
@@ -46,6 +46,7 @@ import static io.questdb.cairo.wal.WalUtils.*;
 
 public class WalTxnRangeLoader implements QuietCloseable {
     private final WalEventReader walEventReader;
+    private boolean hasMatViewInvalidate;
     private boolean hasTruncate;
     private long maxTimestamp;
     private long minTimestamp;
@@ -66,6 +67,14 @@ public class WalTxnRangeLoader implements QuietCloseable {
 
     public long getMinTimestamp() {
         return minTimestamp;
+    }
+
+    // True when the last load() scan saw a base materialized view's own MAT_VIEW_INVALIDATE (with
+    // invalid=true) in the scanned (txnLo, txnHi] range. Like a truncate it carries no data interval but
+    // is an invalidating barrier: a child mat-view must not resume an incremental refresh past its base
+    // view's invalidation. A reset-to-valid (invalid=false) shares the txn type and does not set this flag.
+    public boolean hasMatViewInvalidate() {
+        return hasMatViewInvalidate;
     }
 
     // True when the last load() scan saw a base-table TRUNCATE in the scanned (txnLo, txnHi] range.
@@ -105,6 +114,7 @@ public class WalTxnRangeLoader implements QuietCloseable {
 
         minTimestamp = Long.MAX_VALUE;
         maxTimestamp = Long.MIN_VALUE;
+        hasMatViewInvalidate = false;
         hasTruncate = false;
 
         try (WalEventReader eventReader = walEventReader) {
@@ -156,6 +166,14 @@ public class WalTxnRangeLoader implements QuietCloseable {
                             // invalidating non-data txn in the gap as a barrier is a tracked follow-up.
                             if (walEventCursor.getType() == WalTxnType.TRUNCATE) {
                                 hasTruncate = true;
+                            } else if (walEventCursor.getType() == WalTxnType.MAT_VIEW_INVALIDATE
+                                    && walEventCursor.getMatViewInvalidationInfo().isInvalid()) {
+                                // A base materialized view recorded its own invalidation in this gap. Like a
+                                // truncate it carries no data interval, but a child resuming an incremental
+                                // refresh past it would keep stale rows derived from the now-invalid parent.
+                                // Flag it so the load-time backstop invalidates the child. A reset-to-valid
+                                // (invalid=false) shares this txn type and must NOT trip the flag.
+                                hasMatViewInvalidate = true;
                             }
                             continue;
                         }

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewPendingInvalidationTrapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewPendingInvalidationTrapTest.java
@@ -6,7 +6,7 @@
  *    \__\_\\__,_|\___||___/\__|____/|____/
  *
  *  Copyright (c) 2014-2019 Appsicle
- *  Copyright (c) 2019-2024 QuestDB
+ *  Copyright (c) 2019-2026 QuestDB
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -36,18 +36,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Pins the MV-2 pending-invalidation trap (see
- * {@code .planning/diagnosis/2026-06-25-matview-pending-invalidation-trap-mv2.md}) on a PLAIN PRIMARY,
- * with no role switch involved.
+ * Pins the pending-invalidation trap on a plain primary (no role switch): an apply-time {@code INVALIDATE}
+ * that defers because a concurrent refresh holds the view lock sets {@code pendingInvalidation} and
+ * re-enqueues, the re-dequeued task is then swallowed by {@code invalidateView}'s top guard, and pre-fix
+ * nothing finalized it -- the view stayed {@code valid} on disk with stale rows. The fix finalizes the
+ * deferral when the lock-holder completes, so the view ends {@code invalid} (visible, recoverable) instead.
  * <p>
- * When an apply-time {@code INVALIDATE} defers because a concurrent refresh holds the view lock, it sets
- * {@code pendingInvalidation} and re-enqueues; the {@code invalidateView} top guard then swallows the
- * re-dequeued task. Nothing finalized it -- the view stayed {@code valid} on disk with stale rows. The
- * fix finalizes it when the lock-holding refresh completes.
+ * Each test drives the race deterministically with a {@code @TestOnly} seam that fires while a lock-holder
+ * (a refresh, or {@code invalidateView} itself) holds the view lock and marks the view pending, exactly as
+ * a losing concurrent {@code invalidateView} would; the holder's completion must finalize it.
  * <p>
- * The concurrent deferral is simulated deterministically: a {@code @TestOnly} seam fires once while a
- * real refresh holds the view lock and marks the view pending, exactly as a losing {@code invalidateView}
- * would. The refresh then completes, and its completion must finalize the deferred invalidation.
+ * One branch is left uncovered here: {@code finalizeDeferredInvalidation}'s read-only early-return. It needs
+ * {@code engine.isReadOnlyMode()} true at finalize time, which in OSS requires a custom read-only engine that
+ * cannot run this write-heavy setup; the demote/promote path that exercises it lives in the enterprise suite.
  */
 public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
 
@@ -92,7 +93,7 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
             // survive and freeze the view (silently stale, reporting valid). The finally must finalize it.
             final AtomicBoolean fired = new AtomicBoolean();
             try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
-                job.setOnRefreshHoldingLockForTest(() -> {
+                job.setOnHoldingLockForTesting(() -> {
                     if (fired.compareAndSet(false, true)) {
                         state.markAsPendingInvalidation("truncate operation");
                     }
@@ -110,8 +111,70 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
             assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views")
                     .noRandomAccess()
                     .noLeakCheck()
-                    .returns("view_name\tbase_table_name\tview_status\tinvalidation_reason\n" +
-                            "price_1h\tbase_price\tinvalid\ttruncate operation\n");
+                    .returns("""
+                            view_name\tbase_table_name\tview_status\tinvalidation_reason
+                            price_1h\tbase_price\tinvalid\ttruncate operation
+                            """);
+        });
+    }
+
+    @Test
+    public void testInvalidateViewHoldingLockFinalizesDeferredInvalidation() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base_price (" +
+                    "sym varchar, price double, amount int, ts timestamp" +
+                    ") timestamp(ts) partition by DAY WAL");
+            // MANUAL DEFERRED never refreshes incrementally, so a force=false base-cascade INVALIDATE on it
+            // hits invalidateView's gate-false decline (lastRefreshBaseTxn == -1): invalidateView holds the
+            // lock without minting -- the sixth lock-holder that, pre-fix, never finalized a deferral landing
+            // in that window.
+            execute("create materialized view price_1h refresh manual deferred as (" +
+                    "select sym, last(price) as price, ts from base_price sample by 1h" +
+                    ") partition by DAY");
+            execute("insert into base_price (sym, price, ts) values" +
+                    "('gbpusd', 1.320, '2024-09-10T12:01')" +
+                    ",('gbpusd', 1.323, '2024-09-10T12:02')" +
+                    ",('jpyusd', 103.21, '2024-09-10T12:02')");
+            drainWalQueue();
+
+            final TableToken viewToken = engine.verifyTableName("price_1h");
+            final MatViewState state = engine.getMatViewStateStore().getViewState(viewToken);
+            Assert.assertNotNull("expected a real (non-no-op) state store to hold the view state", state);
+
+            // Populate via RANGE (no seam armed) so the view is valid with rows, lastRefreshBaseTxn still -1.
+            engine.getMatViewStateStore().enqueueRangeRefresh(viewToken, 1L, Long.MAX_VALUE - 1);
+            drainMatViewQueue(engine);
+            drainWalQueue();
+            Assert.assertEquals("precondition: the view has never been incrementally refreshed", -1, state.getLastRefreshBaseTxn());
+            Assert.assertFalse("precondition: the view is valid before the cascade", state.isInvalid());
+
+            // The seam fires inside invalidateView's gate-false lock-hold and marks the view pending, modelling
+            // a second INVALIDATE deferring against it. invalidateView's finally must finalize that deferral so
+            // the view ends invalid, not frozen-pending-and-valid.
+            final AtomicBoolean fired = new AtomicBoolean();
+            try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
+                job.setOnHoldingLockForTesting(() -> {
+                    if (fired.compareAndSet(false, true)) {
+                        state.markAsPendingInvalidation("truncate operation");
+                    }
+                });
+
+                // A rows-affected base UPDATE enqueues a force=false base-cascade INVALIDATE for the view.
+                execute("update base_price set amount = 7;");
+                drainWalQueue();
+                drainMatViewQueue(job);
+                drainWalQueue();
+            }
+
+            Assert.assertTrue("the seam must have fired inside invalidateView", fired.get());
+
+            assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("""
+                            view_name\tbase_table_name\tview_status\tinvalidation_reason
+                            price_1h\tbase_price\tinvalid\ttruncate operation
+                            """);
         });
     }
 
@@ -155,6 +218,64 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testMultipleDependentViewsEachFinalizeDeferredInvalidation() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base_price (" +
+                    "sym varchar, price double, amount int, ts timestamp" +
+                    ") timestamp(ts) partition by DAY WAL");
+            execute("create materialized view price_1h as (" +
+                    "select sym, last(price) as price, ts from base_price sample by 1h" +
+                    ") partition by DAY");
+            execute("create materialized view price_30m as (" +
+                    "select sym, last(price) as price, ts from base_price sample by 30m" +
+                    ") partition by DAY");
+            execute("insert into base_price (sym, price, ts) values" +
+                    "('gbpusd', 1.320, '2024-09-10T12:01')" +
+                    ",('gbpusd', 1.323, '2024-09-10T12:02')" +
+                    ",('jpyusd', 103.21, '2024-09-10T12:02')");
+            drainWalAndMatViewQueues();
+
+            final MatViewState state1h = engine.getMatViewStateStore().getViewState(engine.verifyTableName("price_1h"));
+            final MatViewState state30m = engine.getMatViewStateStore().getViewState(engine.verifyTableName("price_30m"));
+            Assert.assertNotNull(state1h);
+            Assert.assertNotNull(state30m);
+
+            // Two dependents on one base drive refreshDependentViewsIncremental's loop with N > 1. The seam
+            // runs inside refreshIncremental0, once per locked view, and marks whichever view currently holds
+            // its lock pending (one-shot per view), modelling an INVALIDATE deferring against each in turn.
+            // Each loop iteration's finally must finalize its own deferral independently.
+            final AtomicBoolean fired1h = new AtomicBoolean();
+            final AtomicBoolean fired30m = new AtomicBoolean();
+            try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
+                job.setOnHoldingLockForTesting(() -> {
+                    if (state1h.isLocked() && fired1h.compareAndSet(false, true)) {
+                        state1h.markAsPendingInvalidation("update operation");
+                    } else if (state30m.isLocked() && fired30m.compareAndSet(false, true)) {
+                        state30m.markAsPendingInvalidation("update operation");
+                    }
+                });
+
+                execute("insert into base_price (sym, price, ts) values('gbpusd', 1.500, '2024-09-10T14:00')");
+                drainWalQueue();
+                drainMatViewQueue(job);
+                drainWalQueue();
+            }
+
+            Assert.assertTrue("the seam must have fired for price_1h", fired1h.get());
+            Assert.assertTrue("the seam must have fired for price_30m", fired30m.get());
+
+            // Both dependents finalize independently: each ends invalid, not frozen.
+            assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views order by view_name")
+                    .noLeakCheck()
+                    .returns("""
+                            view_name\tbase_table_name\tview_status\tinvalidation_reason
+                            price_1h\tbase_price\tinvalid\tupdate operation
+                            price_30m\tbase_price\tinvalid\tupdate operation
+                            """);
+        });
+    }
+
+    @Test
     public void testNullReasonMarkerIsNotFinalizedAsInvalidation() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table base_price (" +
@@ -178,7 +299,7 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
             // the queued FULL refresh -- and must not mint the view invalid.
             final AtomicBoolean fired = new AtomicBoolean();
             try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
-                job.setOnRefreshHoldingLockForTest(() -> {
+                job.setOnHoldingLockForTesting(() -> {
                     if (fired.compareAndSet(false, true)) {
                         state.markAsPendingInvalidation(); // no reason -> full-refresh reschedule marker
                     }
@@ -237,7 +358,7 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
             final AtomicBoolean fired = new AtomicBoolean();
             final AtomicLong baseTxnAtSeam = new AtomicLong(Long.MIN_VALUE);
             try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
-                job.setOnRefreshHoldingLockForTest(() -> {
+                job.setOnHoldingLockForTesting(() -> {
                     if (fired.compareAndSet(false, true)) {
                         baseTxnAtSeam.set(state.getLastRefreshBaseTxn());
                         state.markAsPendingInvalidation("truncate operation");
@@ -259,8 +380,10 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
             assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views")
                     .noRandomAccess()
                     .noLeakCheck()
-                    .returns("view_name\tbase_table_name\tview_status\tinvalidation_reason\n" +
-                            "price_1h\tbase_price\tinvalid\ttruncate operation\n");
+                    .returns("""
+                            view_name\tbase_table_name\tview_status\tinvalidation_reason
+                            price_1h\tbase_price\tinvalid\ttruncate operation
+                            """);
         });
     }
 
@@ -297,7 +420,7 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
             // would. The range-refresh completion must finalize the deferred invalidation.
             final AtomicBoolean fired = new AtomicBoolean();
             try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
-                job.setOnRefreshHoldingLockForTest(() -> {
+                job.setOnHoldingLockForTesting(() -> {
                     if (fired.compareAndSet(false, true)) {
                         state.markAsPendingInvalidation("update operation");
                     }
@@ -318,8 +441,10 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
             assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views")
                     .noRandomAccess()
                     .noLeakCheck()
-                    .returns("view_name\tbase_table_name\tview_status\tinvalidation_reason\n" +
-                            "price_1h\tbase_price\tinvalid\tupdate operation\n");
+                    .returns("""
+                            view_name\tbase_table_name\tview_status\tinvalidation_reason
+                            price_1h\tbase_price\tinvalid\tupdate operation
+                            """);
         });
     }
 
@@ -356,7 +481,7 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
             // would (markAsPendingInvalidation + the re-enqueued task swallowed by the guard).
             final AtomicBoolean fired = new AtomicBoolean();
             try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
-                job.setOnRefreshHoldingLockForTest(() -> {
+                job.setOnHoldingLockForTesting(() -> {
                     if (fired.compareAndSet(false, true)) {
                         state.markAsPendingInvalidation("update operation");
                     }
@@ -377,8 +502,57 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
             assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views")
                     .noRandomAccess()
                     .noLeakCheck()
-                    .returns("view_name\tbase_table_name\tview_status\tinvalidation_reason\n" +
-                            "price_1h\tbase_price\tinvalid\tupdate operation\n");
+                    .returns("""
+                            view_name\tbase_table_name\tview_status\tinvalidation_reason
+                            price_1h\tbase_price\tinvalid\tupdate operation
+                            """);
+        });
+    }
+
+    @Test
+    public void testSingleViewIncrementalRefreshHoldingLockFinalizesDeferredInvalidation() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base_price (" +
+                    "sym varchar, price double, amount int, ts timestamp" +
+                    ") timestamp(ts) partition by DAY WAL");
+            execute("create materialized view price_1h as (" +
+                    "select sym, last(price) as price, ts from base_price sample by 1h" +
+                    ") partition by DAY");
+            execute("insert into base_price (sym, price, ts) values" +
+                    "('gbpusd', 1.320, '2024-09-10T12:01')" +
+                    ",('gbpusd', 1.323, '2024-09-10T12:02')" +
+                    ",('jpyusd', 103.21, '2024-09-10T12:02')");
+            drainWalAndMatViewQueues();
+
+            final TableToken viewToken = engine.verifyTableName("price_1h");
+            final MatViewState state = engine.getMatViewStateStore().getViewState(viewToken);
+            Assert.assertNotNull("expected a real (non-no-op) state store to hold the view state", state);
+
+            // A base insert routes through the base-keyed refreshDependentViewsIncremental loop. A VIEW-keyed
+            // enqueueIncrementalRefresh instead drives the single-view refreshIncremental holder, whose own
+            // finally must finalize a deferral too. The seam fires in the shared refreshIncremental0.
+            final AtomicBoolean fired = new AtomicBoolean();
+            try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
+                job.setOnHoldingLockForTesting(() -> {
+                    if (fired.compareAndSet(false, true)) {
+                        state.markAsPendingInvalidation("update operation");
+                    }
+                });
+
+                engine.getMatViewStateStore().enqueueIncrementalRefresh(viewToken);
+                drainMatViewQueue(job);
+                drainWalQueue();
+            }
+
+            Assert.assertTrue("the seam must have fired during a single-view incremental refresh", fired.get());
+
+            assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("""
+                            view_name\tbase_table_name\tview_status\tinvalidation_reason
+                            price_1h\tbase_price\tinvalid\tupdate operation
+                            """);
         });
     }
 
@@ -416,7 +590,7 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
             // deferred invalidation.
             final AtomicBoolean fired = new AtomicBoolean();
             try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
-                job.setOnRefreshHoldingLockForTest(() -> {
+                job.setOnHoldingLockForTesting(() -> {
                     if (fired.compareAndSet(false, true)) {
                         state.markAsPendingInvalidation("update operation");
                     }
@@ -434,8 +608,10 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
             assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views")
                     .noRandomAccess()
                     .noLeakCheck()
-                    .returns("view_name\tbase_table_name\tview_status\tinvalidation_reason\n" +
-                            "price_1h\tbase_price\tinvalid\tupdate operation\n");
+                    .returns("""
+                            view_name\tbase_table_name\tview_status\tinvalidation_reason
+                            price_1h\tbase_price\tinvalid\tupdate operation
+                            """);
         });
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewPendingInvalidationTrapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewPendingInvalidationTrapTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*+*****************************************************************************
  *     ___                  _   ____  ____
  *    / _ \ _   _  ___  ___| |_|  _ \| __ )
  *   | | | | | | |/ _ \/ __| __| | | |  _ \
@@ -33,6 +33,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Pins the MV-2 pending-invalidation trap (see
@@ -55,6 +56,63 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
         super.setUp();
         // Materialized views require dev mode; without it the engine installs a no-op state store.
         setProperty(PropertyKey.DEV_MODE_ENABLED, "true");
+    }
+
+    @Test
+    public void testFullRefreshHoldingLockFinalizesDeferredInvalidation() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base_price (" +
+                    "sym varchar, price double, amount int, ts timestamp" +
+                    ") timestamp(ts) partition by DAY WAL");
+            execute("create materialized view price_1h as (" +
+                    "select sym, last(price) as price, ts from base_price sample by 1h" +
+                    ") partition by DAY");
+            execute("insert into base_price (sym, price, ts) values" +
+                    "('gbpusd', 1.320, '2024-09-10T12:01')" +
+                    ",('gbpusd', 1.323, '2024-09-10T12:02')" +
+                    ",('jpyusd', 103.21, '2024-09-10T12:02')");
+            drainWalAndMatViewQueues();
+
+            // Baseline: the view refreshed and is valid.
+            assertQuery("select view_name, base_table_name, view_status from materialized_views")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("""
+                            view_name\tbase_table_name\tview_status
+                            price_1h\tbase_price\tvalid
+                            """);
+
+            final TableToken viewToken = engine.verifyTableName("price_1h");
+            final MatViewState state = engine.getMatViewStateStore().getViewState(viewToken);
+            Assert.assertNotNull("expected a real (non-no-op) state store to hold the view state", state);
+
+            // A base-cascade INVALIDATE deferring during the full-refresh pump: the seam fires once, after
+            // resetInvalidState cleared the marker, while fullRefresh holds the view lock. fullRefresh has no
+            // success-path markAsValid after the pump, so without a finalize in its finally the marker would
+            // survive and freeze the view (silently stale, reporting valid). The finally must finalize it.
+            final AtomicBoolean fired = new AtomicBoolean();
+            try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
+                job.setOnRefreshHoldingLockForTest(() -> {
+                    if (fired.compareAndSet(false, true)) {
+                        state.markAsPendingInvalidation("truncate operation");
+                    }
+                });
+
+                engine.getMatViewStateStore().enqueueFullRefresh(viewToken);
+                drainMatViewQueue(job);
+                drainWalQueue();
+            }
+
+            Assert.assertTrue("the seam must have fired during a full refresh", fired.get());
+
+            // The deferred invalidation must be finalized: the view ends invalid (not valid-with-stale),
+            // carrying the deferral's reason.
+            assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("view_name\tbase_table_name\tview_status\tinvalidation_reason\n" +
+                            "price_1h\tbase_price\tinvalid\ttruncate operation\n");
+        });
     }
 
     @Test
@@ -93,6 +151,116 @@ public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
             } finally {
                 state.unlock();
             }
+        });
+    }
+
+    @Test
+    public void testNullReasonMarkerIsNotFinalizedAsInvalidation() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base_price (" +
+                    "sym varchar, price double, amount int, ts timestamp" +
+                    ") timestamp(ts) partition by DAY WAL");
+            execute("create materialized view price_1h as (" +
+                    "select sym, last(price) as price, ts from base_price sample by 1h" +
+                    ") partition by DAY");
+            execute("insert into base_price (sym, price, ts) values" +
+                    "('gbpusd', 1.320, '2024-09-10T12:01')" +
+                    ",('gbpusd', 1.323, '2024-09-10T12:02')" +
+                    ",('jpyusd', 103.21, '2024-09-10T12:02')");
+            drainWalAndMatViewQueues();
+
+            final TableToken viewToken = engine.verifyTableName("price_1h");
+            final MatViewState state = engine.getMatViewStateStore().getViewState(viewToken);
+            Assert.assertNotNull("expected a real (non-no-op) state store to hold the view state", state);
+
+            // A null-reason marker is the full-refresh reschedule (markAsPendingInvalidation() with no reason,
+            // see fullRefresh), NOT a deferred invalidation. finalize must leave it untouched -- it belongs to
+            // the queued FULL refresh -- and must not mint the view invalid.
+            final AtomicBoolean fired = new AtomicBoolean();
+            try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
+                job.setOnRefreshHoldingLockForTest(() -> {
+                    if (fired.compareAndSet(false, true)) {
+                        state.markAsPendingInvalidation(); // no reason -> full-refresh reschedule marker
+                    }
+                });
+
+                execute("insert into base_price (sym, price, ts) values('gbpusd', 1.500, '2024-09-10T14:00')");
+                drainWalQueue();
+                drainMatViewQueue(job);
+                drainWalQueue();
+            }
+
+            Assert.assertTrue("the seam must have fired during a refresh", fired.get());
+
+            // finalize saw a null reason and returned early: the marker is left for the full refresh and the
+            // view stays valid, not spuriously invalidated.
+            Assert.assertTrue("finalize must leave the full-refresh marker in place", state.isPendingInvalidation());
+            Assert.assertNull("the full-refresh marker carries no invalidation reason", state.getPendingInvalidationReason());
+            assertQuery("select view_name, base_table_name, view_status from materialized_views")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("""
+                            view_name\tbase_table_name\tview_status
+                            price_1h\tbase_price\tvalid
+                            """);
+        });
+    }
+
+    @Test
+    public void testRangeOnlyPopulatedViewFinalizesDeferredInvalidationToInvalid() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base_price (" +
+                    "sym varchar, price double, amount int, ts timestamp" +
+                    ") timestamp(ts) partition by DAY WAL");
+            // A MANUAL view never auto-refreshes incrementally, so lastRefreshBaseTxn stays -1 even after a
+            // user RANGE refresh populates rows (rangeRefreshSuccess does not advance lastRefreshBaseTxn).
+            // This is the frozen-branch class: finalize used to early-return on lastRefreshBaseTxn == -1 and
+            // leave the view pending forever (silently stale while reporting valid).
+            execute("create materialized view price_1h refresh manual deferred as (" +
+                    "select sym, last(price) as price, ts from base_price sample by 1h" +
+                    ") partition by DAY");
+            execute("insert into base_price (sym, price, ts) values" +
+                    "('gbpusd', 1.320, '2024-09-10T12:01')" +
+                    ",('gbpusd', 1.323, '2024-09-10T12:02')" +
+                    ",('jpyusd', 103.21, '2024-09-10T12:02')");
+            drainWalQueue(); // apply the base rows; a MANUAL view does not refresh on base writes
+
+            final TableToken viewToken = engine.verifyTableName("price_1h");
+            final MatViewState state = engine.getMatViewStateStore().getViewState(viewToken);
+            Assert.assertNotNull("expected a real (non-no-op) state store to hold the view state", state);
+            Assert.assertEquals("precondition: the view has never been incrementally refreshed", -1, state.getLastRefreshBaseTxn());
+
+            // Simulate a base-cascade INVALIDATE deferring while a user RANGE refresh holds the lock on this
+            // range-only view. The range refresh completes (lastRefreshBaseTxn stays -1) and its finally must
+            // finalize the deferral. The re-enqueued INVALIDATE re-delivers force=true and mints, so the view
+            // ends cleanly invalid, not frozen-pending-and-valid.
+            final AtomicBoolean fired = new AtomicBoolean();
+            final AtomicLong baseTxnAtSeam = new AtomicLong(Long.MIN_VALUE);
+            try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
+                job.setOnRefreshHoldingLockForTest(() -> {
+                    if (fired.compareAndSet(false, true)) {
+                        baseTxnAtSeam.set(state.getLastRefreshBaseTxn());
+                        state.markAsPendingInvalidation("truncate operation");
+                    }
+                });
+
+                engine.getMatViewStateStore().enqueueRangeRefresh(viewToken, 1L, Long.MAX_VALUE - 1);
+                drainMatViewQueue(job);
+                drainWalQueue();
+            }
+
+            Assert.assertTrue("the seam must have fired during a range refresh", fired.get());
+            // The seam fired inside rangeRefresh while the view had never been incrementally refreshed, so
+            // finalize ran on the lastRefreshBaseTxn == -1 branch (rangeRefreshSuccess never advances it).
+            Assert.assertEquals("seam must fire while lastRefreshBaseTxn is still -1", -1, baseTxnAtSeam.get());
+
+            // The deferred invalidation is finalized even on the lastRefreshBaseTxn == -1 branch: the view
+            // ends invalid (not frozen-pending), carrying the deferral's reason.
+            assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("view_name\tbase_table_name\tview_status\tinvalidation_reason\n" +
+                            "price_1h\tbase_price\tinvalid\ttruncate operation\n");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewPendingInvalidationTrapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewPendingInvalidationTrapTest.java
@@ -1,0 +1,273 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.mv;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.mv.MatViewRefreshJob;
+import io.questdb.cairo.mv.MatViewState;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Pins the MV-2 pending-invalidation trap (see
+ * {@code .planning/diagnosis/2026-06-25-matview-pending-invalidation-trap-mv2.md}) on a PLAIN PRIMARY,
+ * with no role switch involved.
+ * <p>
+ * When an apply-time {@code INVALIDATE} defers because a concurrent refresh holds the view lock, it sets
+ * {@code pendingInvalidation} and re-enqueues; the {@code invalidateView} top guard then swallows the
+ * re-dequeued task. Nothing finalized it -- the view stayed {@code valid} on disk with stale rows. The
+ * fix finalizes it when the lock-holding refresh completes.
+ * <p>
+ * The concurrent deferral is simulated deterministically: a {@code @TestOnly} seam fires once while a
+ * real refresh holds the view lock and marks the view pending, exactly as a losing {@code invalidateView}
+ * would. The refresh then completes, and its completion must finalize the deferred invalidation.
+ */
+public class MatViewPendingInvalidationTrapTest extends AbstractCairoTest {
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        // Materialized views require dev mode; without it the engine installs a no-op state store.
+        setProperty(PropertyKey.DEV_MODE_ENABLED, "true");
+    }
+
+    @Test
+    public void testLockContendedInvalidationDefersWithReason() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base_price (" +
+                    "sym varchar, price double, amount int, ts timestamp" +
+                    ") timestamp(ts) partition by DAY WAL");
+            execute("create materialized view price_1h as (" +
+                    "select sym, last(price) as price, ts from base_price sample by 1h" +
+                    ") partition by DAY");
+            execute("insert into base_price (sym, price, ts) values" +
+                    "('gbpusd', 1.320, '2024-09-10T12:01')" +
+                    ",('gbpusd', 1.323, '2024-09-10T12:02')" +
+                    ",('jpyusd', 103.21, '2024-09-10T12:02')");
+            drainWalAndMatViewQueues();
+
+            final TableToken viewToken = engine.verifyTableName("price_1h");
+            final MatViewState state = engine.getMatViewStateStore().getViewState(viewToken);
+            Assert.assertNotNull(state);
+
+            // Hold the view lock from the test thread to simulate a concurrent refresh worker. The latch
+            // is a non-reentrant AtomicBoolean, so the refresh job's invalidateView tryLock() fails exactly
+            // as it would against a real second worker.
+            Assert.assertTrue(state.tryLock());
+            try {
+                execute("update base_price set amount = 42;"); // rows-affected UPDATE -> apply-time INVALIDATE
+                drainWalQueue();           // apply the UPDATE -> enqueue the INVALIDATE
+                drainMatViewQueue(engine); // process it: invalidateView defers (we hold the lock) + guard swallow
+
+                // The real defer site must record the cause so a later finalize can mint with it.
+                Assert.assertTrue("invalidation should have deferred", state.isPendingInvalidation());
+                Assert.assertEquals("update operation", state.getPendingInvalidationReason());
+                // The deferral alone must not mint: the view is still valid on disk while pending in memory.
+                Assert.assertFalse("deferral alone must not mark the view invalid", state.isInvalid());
+            } finally {
+                state.unlock();
+            }
+        });
+    }
+
+    @Test
+    public void testRangeRefreshHoldingLockFinalizesDeferredInvalidation() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base_price (" +
+                    "sym varchar, price double, amount int, ts timestamp" +
+                    ") timestamp(ts) partition by DAY WAL");
+            execute("create materialized view price_1h as (" +
+                    "select sym, last(price) as price, ts from base_price sample by 1h" +
+                    ") partition by DAY");
+            execute("insert into base_price (sym, price, ts) values" +
+                    "('gbpusd', 1.320, '2024-09-10T12:01')" +
+                    ",('gbpusd', 1.323, '2024-09-10T12:02')" +
+                    ",('jpyusd', 103.21, '2024-09-10T12:02')");
+            drainWalAndMatViewQueues();
+
+            // Baseline: the view refreshed and is valid.
+            assertQuery("select view_name, base_table_name, view_status from materialized_views")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("""
+                            view_name\tbase_table_name\tview_status
+                            price_1h\tbase_price\tvalid
+                            """);
+
+            final TableToken viewToken = engine.verifyTableName("price_1h");
+            final MatViewState state = engine.getMatViewStateStore().getViewState(viewToken);
+            Assert.assertNotNull("expected a real (non-no-op) state store to hold the view state", state);
+
+            // Simulate a concurrent INVALIDATE deferring mid-range-refresh: the seam fires once while
+            // rangeRefresh holds the view lock and marks the view pending, exactly as a losing invalidateView
+            // would. The range-refresh completion must finalize the deferred invalidation.
+            final AtomicBoolean fired = new AtomicBoolean();
+            try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
+                job.setOnRefreshHoldingLockForTest(() -> {
+                    if (fired.compareAndSet(false, true)) {
+                        state.markAsPendingInvalidation("update operation");
+                    }
+                });
+
+                // Enqueue a range refresh covering all base table data. The seam fires inside
+                // rangeRefresh (while holding the lock) and marks the view pending; the refresh
+                // then completes and the finally block must finalize the deferred invalidation.
+                engine.getMatViewStateStore().enqueueRangeRefresh(viewToken, 1L, Long.MAX_VALUE - 1);
+                drainMatViewQueue(job);
+                drainWalQueue();
+            }
+
+            Assert.assertTrue("the seam must have fired during a range refresh", fired.get());
+
+            // The deferred invalidation must be finalized: the view ends invalid (not valid-with-stale),
+            // carrying the deferral's reason.
+            assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("view_name\tbase_table_name\tview_status\tinvalidation_reason\n" +
+                            "price_1h\tbase_price\tinvalid\tupdate operation\n");
+        });
+    }
+
+    @Test
+    public void testRefreshHoldingLockFinalizesDeferredInvalidation() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base_price (" +
+                    "sym varchar, price double, amount int, ts timestamp" +
+                    ") timestamp(ts) partition by DAY WAL");
+            execute("create materialized view price_1h as (" +
+                    "select sym, last(price) as price, ts from base_price sample by 1h" +
+                    ") partition by DAY");
+            execute("insert into base_price (sym, price, ts) values" +
+                    "('gbpusd', 1.320, '2024-09-10T12:01')" +
+                    ",('gbpusd', 1.323, '2024-09-10T12:02')" +
+                    ",('jpyusd', 103.21, '2024-09-10T12:02')");
+            drainWalAndMatViewQueues();
+
+            // Baseline: the view refreshed and is valid.
+            assertQuery("select view_name, base_table_name, view_status from materialized_views")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("""
+                            view_name\tbase_table_name\tview_status
+                            price_1h\tbase_price\tvalid
+                            """);
+
+            final TableToken viewToken = engine.verifyTableName("price_1h");
+            final MatViewState state = engine.getMatViewStateStore().getViewState(viewToken);
+            Assert.assertNotNull("expected a real (non-no-op) state store to hold the view state", state);
+
+            // A concurrent apply-time INVALIDATE deferring mid-refresh: the seam fires once, while the
+            // refresh holds the view lock, and marks the view pending exactly as a losing invalidateView
+            // would (markAsPendingInvalidation + the re-enqueued task swallowed by the guard).
+            final AtomicBoolean fired = new AtomicBoolean();
+            try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
+                job.setOnRefreshHoldingLockForTest(() -> {
+                    if (fired.compareAndSet(false, true)) {
+                        state.markAsPendingInvalidation("update operation");
+                    }
+                });
+
+                // A base write triggers an incremental refresh of the view; the seam marks it pending
+                // mid-refresh, and the refresh completion must finalize that deferred invalidation.
+                execute("insert into base_price (sym, price, ts) values('gbpusd', 1.500, '2024-09-10T14:00')");
+                drainWalQueue();
+                drainMatViewQueue(job);
+                drainWalQueue();
+            }
+
+            Assert.assertTrue("the seam must have fired during a refresh", fired.get());
+
+            // The deferred invalidation must be finalized: the view ends invalid (not valid-with-stale),
+            // carrying the deferral's reason.
+            assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("view_name\tbase_table_name\tview_status\tinvalidation_reason\n" +
+                            "price_1h\tbase_price\tinvalid\tupdate operation\n");
+        });
+    }
+
+    @Test
+    public void testUpdateRefreshIntervalsHoldingLockFinalizesDeferredInvalidation() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table base_price (" +
+                    "sym varchar, price double, amount int, ts timestamp" +
+                    ") timestamp(ts) partition by DAY WAL");
+            execute("create materialized view price_1h as (" +
+                    "select sym, last(price) as price, ts from base_price sample by 1h" +
+                    ") partition by DAY");
+            execute("insert into base_price (sym, price, ts) values" +
+                    "('gbpusd', 1.320, '2024-09-10T12:01')" +
+                    ",('gbpusd', 1.323, '2024-09-10T12:02')" +
+                    ",('jpyusd', 103.21, '2024-09-10T12:02')");
+            drainWalAndMatViewQueues();
+
+            // Baseline: the view refreshed and is valid.
+            assertQuery("select view_name, base_table_name, view_status from materialized_views")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("""
+                            view_name\tbase_table_name\tview_status
+                            price_1h\tbase_price\tvalid
+                            """);
+
+            final TableToken viewToken = engine.verifyTableName("price_1h");
+            final MatViewState state = engine.getMatViewStateStore().getViewState(viewToken);
+            Assert.assertNotNull("expected a real (non-no-op) state store to hold the view state", state);
+
+            // Simulate a concurrent INVALIDATE deferring while an interval-update task holds the view lock:
+            // the seam fires once (updateRefreshIntervals holds the lock) and marks the view pending,
+            // exactly as a losing invalidateView would. The interval-update completion must finalize the
+            // deferred invalidation.
+            final AtomicBoolean fired = new AtomicBoolean();
+            try (MatViewRefreshJob job = createMatViewRefreshJob(engine)) {
+                job.setOnRefreshHoldingLockForTest(() -> {
+                    if (fired.compareAndSet(false, true)) {
+                        state.markAsPendingInvalidation("update operation");
+                    }
+                });
+
+                engine.getMatViewStateStore().enqueueUpdateRefreshIntervals(viewToken);
+                drainMatViewQueue(job);
+                drainWalQueue();
+            }
+
+            Assert.assertTrue("the seam must have fired during an interval-update task", fired.get());
+
+            // The deferred invalidation must be finalized: the view ends invalid (not valid-with-stale),
+            // carrying the deferral's reason.
+            assertQuery("select view_name, base_table_name, view_status, invalidation_reason from materialized_views")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("view_name\tbase_table_name\tview_status\tinvalidation_reason\n" +
+                            "price_1h\tbase_price\tinvalid\tupdate operation\n");
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewReloadOnRestartTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewReloadOnRestartTest.java
@@ -31,6 +31,7 @@ import io.questdb.cairo.*;
 import io.questdb.cairo.mv.MatViewDefinition;
 import io.questdb.cairo.mv.MatViewRefreshJob;
 import io.questdb.cairo.mv.MatViewState;
+import io.questdb.cairo.mv.MatViewStateStoreImpl;
 import io.questdb.cairo.mv.MatViewTimerJob;
 import io.questdb.cairo.wal.WalPurgeJob;
 import io.questdb.client.Sender;
@@ -205,6 +206,57 @@ public class MatViewReloadOnRestartTest extends AbstractBootstrapTest {
         capture.stop();
         super.tearDown();
         LogFactory.disableGuaranteedLogging(LineHttpProcessorState.class);
+    }
+
+    @Test
+    public void testBootInvalidatesChainedMatViewOnParentInvalidation() throws Exception {
+        // Boot-path (buildViewGraphs) sibling of the truncate boot test: a chained mat-view B whose base
+        // mat-view A is durably invalid (type-4 in A's WAL) but whose cascade INVALIDATE was lost (here:
+        // severed by holding B's lock) must reload INVALID after a restart -- proving the fix self-heals across
+        // a restart, not only on a promote.
+        TestUtils.assertMemoryLeak(() -> {
+            try (final TestServerMain main1 = startMainPortsDisabled()) {
+                execute(main1, "create table base (sym symbol, val double, ts timestamp) timestamp(ts) partition by DAY WAL");
+                execute(main1, "create materialized view mv_a as (select ts, count() cnt from base sample by 1h) partition by DAY");
+                execute(main1, "create materialized view mv_b as (select ts, sum(cnt) cnt from mv_a sample by 1d) partition by DAY");
+                execute(main1, "insert into base values ('a', 1.0, '2024-09-10T12:00'), ('a', 2.0, '2024-09-10T12:30')");
+                try (var refreshJob = createMatViewRefreshJob(main1.getEngine())) {
+                    drainWalAndMatViewQueues(refreshJob, main1.getEngine());
+                }
+
+                final CairoEngine engine = main1.getEngine();
+                final TableToken viewA = engine.verifyTableName("mv_a");
+                final MatViewStateStoreImpl store = (MatViewStateStoreImpl) engine.getMatViewStateStore();
+                final MatViewState stateB = store.getViewState(engine.verifyTableName("mv_b"));
+
+                // Durably invalidate A while keeping B valid on disk: hold B's lock so its cascade defers.
+                Assert.assertTrue(stateB.tryLock());
+                try {
+                    store.enqueueInvalidate(viewA, "forced for test");
+                    try (var refreshJob = createMatViewRefreshJob(engine)) {
+                        drainWalAndMatViewQueues(refreshJob, engine);
+                    }
+                } finally {
+                    stateB.markAsValid();
+                    stateB.unlock();
+                }
+                Assert.assertTrue("precondition: parent durably invalid", store.getViewState(viewA).isInvalid());
+                Assert.assertFalse("precondition: child still valid on disk", stateB.isInvalid());
+            }
+
+            // Restart: main2's boot runs buildViewGraphs, detects A's type-4 in B's base WAL gap (and/or
+            // re-cascades from invalid A), and invalidates B with reason "base materialized view is invalidated".
+            try (final TestServerMain main2 = startMainPortsDisabled()) {
+                try (var refreshJob = createMatViewRefreshJob(main2.getEngine())) {
+                    drainWalAndMatViewQueues(refreshJob, main2.getEngine());
+                }
+                assertSql(
+                        main2,
+                        "view_status\tinvalidation_reason\ninvalid\tbase materialized view is invalidated\n",
+                        "select view_status, invalidation_reason from materialized_views where view_name = 'mv_b'"
+                );
+            }
+        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -45,6 +45,7 @@ import io.questdb.cairo.mv.WalTxnRangeLoader;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cairo.wal.WalPurgeJob;
 import io.questdb.cairo.wal.WalUtils;
 import io.questdb.cairo.wal.WalWriter;
 import io.questdb.griffin.SqlCompiler;
@@ -2607,6 +2608,54 @@ public class MatViewTest extends AbstractCairoTest {
 
             Assert.assertTrue(
                     "a chained mat-view must reload INVALID when its base mat-view is durably invalid",
+                    store.getViewState(viewB).isInvalid()
+            );
+        });
+    }
+
+    @Test
+    public void testChainedMatViewReCascadesWhenParentGapPurged() throws Exception {
+        // Isolates the hydrate re-cascade fallback (a). After the sever, engine.clear() drops the
+        // matViewStateStore so the purge job no longer sees B's lastRefreshBaseTxn and removes
+        // A's wal1 (the data segment containing txn 1). The backstop (b) scans A's WAL from txn 1
+        // but wal1 is gone; the scan throws CairoException and reports no invalidating barrier.
+        // With DEBUG_MAT_VIEW_REFRESH_MISSING_WAL_FILES_FATAL=false the subsequent refresh falls
+        // back to a full table read instead of failing, so B reloads VALID without the re-cascade
+        // fix. Only fix (a) -- re-cascade on invalid parent load -- can invalidate B here.
+        setProperty(PropertyKey.DEBUG_MAT_VIEW_REFRESH_MISSING_WAL_FILES_FATAL, "false");
+        assertMemoryLeak(() -> {
+            execute("create table base (sym symbol, val double, ts timestamp) timestamp(ts) partition by DAY WAL");
+            createMatView("mv_a", "select ts, count() cnt from base sample by 1h");
+            createMatView("mv_b", "select ts, sum(cnt) cnt from mv_a sample by 1d");
+            execute("insert into base values ('a', 1.0, '2024-09-10T12:00'), ('a', 2.0, '2024-09-10T12:30')");
+            drainQueues();
+
+            final TableToken viewA = engine.verifyTableName("mv_a");
+            final TableToken viewB = engine.verifyTableName("mv_b");
+            final MatViewStateStoreImpl store = (MatViewStateStoreImpl) engine.getMatViewStateStore();
+            severCascadeLeavingParentInvalidChildValid(store, viewA, store.getViewState(viewB));
+            Assert.assertTrue("precondition: parent durably invalid", store.getViewState(viewA).isInvalid());
+            Assert.assertFalse("precondition: child still valid on disk", store.getViewState(viewB).isInvalid());
+
+            // engine.clear() drops the in-memory state store so WalPurgeJob no longer sees
+            // B's lastRefreshBaseTxn=1 that would otherwise cap safeToPurgeTxn and keep wal1.
+            engine.clear();
+            try (WalPurgeJob purgeJob = new WalPurgeJob(engine)) {
+                purgeJob.drain(0);
+            }
+            // Confirm wal1 (A's data segment for txn 1) is gone so the backstop (b) scan from
+            // txn 1 throws and returns null. If this assertion fires the test setup has changed
+            // and the RED step may pass spuriously because fix (b) can still see the type-4.
+            try (Path path = new Path()) {
+                path.of(configuration.getDbRoot()).concat(viewA).concat(WAL_NAME_BASE).put(1);
+                Assert.assertFalse("A's wal1 must be purged to blind fix (b)", Files.exists(path.$()));
+            }
+
+            engine.hydrateMatViewStateStore();
+            drainWalAndMatViewQueues();
+
+            Assert.assertTrue(
+                    "the hydrate re-cascade must invalidate a chained mat-view even when the parent WAL gap is unreadable",
                     store.getViewState(viewB).isInvalid()
             );
         });

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -2578,6 +2578,41 @@ public class MatViewTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testChainedMatViewInvalidatedOnHydrateAfterParentInvalidation() throws Exception {
+        // Repro of the demote->promote stale-chained-view bug. Parent A is durably invalidated (type-4 in A's
+        // WAL) while child B's cascade INVALIDATE is discarded (severed here by holding B's lock). On the
+        // promote hydrate path (hydrateMatViewStateStore), B must end INVALID: the load-time backstop detects
+        // A's type-4 in B's base WAL gap. Before the fix, B reloads VALID and serves stale rows.
+        assertMemoryLeak(() -> {
+            execute("create table base (sym symbol, val double, ts timestamp) timestamp(ts) partition by DAY WAL");
+            createMatView("mv_a", "select ts, count() cnt from base sample by 1h");
+            createMatView("mv_b", "select ts, sum(cnt) cnt from mv_a sample by 1d");
+            execute("insert into base values ('a', 1.0, '2024-09-10T12:00'), ('a', 2.0, '2024-09-10T12:30')");
+            drainQueues();
+
+            final TableToken viewA = engine.verifyTableName("mv_a");
+            final TableToken viewB = engine.verifyTableName("mv_b");
+            final MatViewStateStoreImpl store = (MatViewStateStoreImpl) engine.getMatViewStateStore();
+            Assert.assertFalse(store.getViewState(viewA).isInvalid());
+            Assert.assertFalse(store.getViewState(viewB).isInvalid());
+            Assert.assertTrue("precondition: child refreshed off parent", store.getViewState(viewB).getLastRefreshBaseTxn() > -1);
+
+            severCascadeLeavingParentInvalidChildValid(store, viewA, store.getViewState(viewB));
+            Assert.assertTrue("precondition: parent durably invalid", store.getViewState(viewA).isInvalid());
+            Assert.assertFalse("precondition: child still valid on disk", store.getViewState(viewB).isInvalid());
+
+            // Promote hydrate: rebuilds state from disk and re-runs the load-time backstop.
+            engine.hydrateMatViewStateStore();
+            drainWalAndMatViewQueues();
+
+            Assert.assertTrue(
+                    "a chained mat-view must reload INVALID when its base mat-view is durably invalid",
+                    store.getViewState(viewB).isInvalid()
+            );
+        });
+    }
+
+    @Test
     public void testCheckMatViewModification() throws Exception {
         assertMemoryLeak(() -> {
             executeWithRewriteTimestamp(
@@ -3420,7 +3455,7 @@ public class MatViewTest extends AbstractCairoTest {
             drainWalQueue();
 
             // Delete segment 5's event file so loader.load() throws a CairoException when
-            // hasBaseTableTruncateInWalGap tries to open it during the next hydrateMatViewStateStore call.
+            // baseGapInvalidationReason tries to open it during the next hydrateMatViewStateStore call.
             final TableToken baseTableToken = engine.getTableTokenIfExists("base");
             Assert.assertNotNull(baseTableToken);
             try (Path path = new Path()) {
@@ -3456,7 +3491,7 @@ public class MatViewTest extends AbstractCairoTest {
 
             // Simulate the role-promote hydrate path. The truncate scan's load() will throw because
             // the WAL segment file is missing. The fix catches the exception inside
-            // hasBaseTableTruncateInWalGap and returns false, allowing enqueueIncrementalRefresh to
+            // baseGapInvalidationReason and returns null, allowing enqueueIncrementalRefresh to
             // run. Without the fix the view is silently left unscheduled.
             engine.hydrateMatViewStateStore();
 
@@ -9105,6 +9140,22 @@ public class MatViewTest extends AbstractCairoTest {
 
     private String replaceExpectedTimestamp(String expected) {
         return ColumnType.isTimestampMicro(timestampType.getTimestampType()) ? expected : expected.replaceAll(".000000Z", ".000000000Z");
+    }
+
+    // Drives parent view A to a durable INVALID state while leaving child view B durably VALID -- the
+    // on-disk shape a demote leaves behind after discarding B's in-memory cascade. Holding B's state lock
+    // forces A's cascade INVALIDATE for B onto the deferral path (mark pending + re-enqueue), so B's _mv
+    // state on disk stays valid. The pending marker is then cleared and the lock released so the in-memory
+    // state matches disk.
+    private void severCascadeLeavingParentInvalidChildValid(MatViewStateStoreImpl store, TableToken viewA, MatViewState stateB) {
+        Assert.assertTrue("test must acquire child state lock to block its cascade", stateB.tryLock());
+        try {
+            store.enqueueInvalidate(viewA, "forced for test");
+            drainWalAndMatViewQueues();
+        } finally {
+            stateB.markAsValid();
+            stateB.unlock();
+        }
     }
 
     private void testAlignToCalendarTimezoneOffset() throws Exception {

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -8644,6 +8644,62 @@ public class MatViewTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testWalTxnRangeLoaderDetectsMatViewInvalidate() throws Exception {
+        // Direct unit coverage for the type-4 detection the chained-view backstop rests on: a range holding a
+        // MAT_VIEW_INVALIDATE (invalid=true) reports hasMatViewInvalidate()==true; a data-only range and a
+        // range whose only type-4 is a reset-to-valid (invalid=false) both report false; and a clean reload
+        // resets the flag (no stale carry-over on a reused loader).
+        assertMemoryLeak(() -> {
+            execute("create table base (sym symbol, val double, ts timestamp) timestamp(ts) partition by DAY WAL");
+            createMatView("mv_a", "select ts, count() cnt from base sample by 1h");
+            execute("insert into base values ('a', 1.0, '2024-09-10T12:00')");
+            drainQueues();
+
+            final TableToken viewA = engine.verifyTableName("mv_a");
+            final MatViewStateStoreImpl store = (MatViewStateStoreImpl) engine.getMatViewStateStore();
+            final long txnAfterRefresh = engine.getTableSequencerAPI().getTxnTracker(viewA).getWriterTxn();
+
+            // Durably invalidate A: writes a MAT_VIEW_INVALIDATE (invalid=true) txn into A's own WAL.
+            store.enqueueInvalidate(viewA, "forced for test");
+            drainWalAndMatViewQueues();
+            Assert.assertTrue("precondition: A invalidated", store.getViewState(viewA).isInvalid());
+            final long txnAfterInvalidate = engine.getTableSequencerAPI().getTxnTracker(viewA).getWriterTxn();
+
+            // Re-validate A with a full refresh: resetInvalidState writes a MAT_VIEW_INVALIDATE (invalid=false).
+            execute("refresh materialized view mv_a full");
+            drainQueues();
+            Assert.assertFalse("precondition: A re-validated", store.getViewState(viewA).isInvalid());
+            final long txnAfterRevalidate = engine.getTableSequencerAPI().getTxnTracker(viewA).getWriterTxn();
+
+            try (
+                    WalTxnRangeLoader loader = new WalTxnRangeLoader(engine.getConfiguration());
+                    Path path = new Path()
+            ) {
+                final LongList intervals = new LongList();
+
+                // Data-only range (the initial refresh): no type-4 invalidation.
+                loader.load(engine, path, viewA, intervals, 0, txnAfterRefresh);
+                Assert.assertFalse("a data-only range must not report a mat-view invalidate", loader.hasMatViewInvalidate());
+
+                // Range spanning the invalidate: detected.
+                intervals.clear();
+                loader.load(engine, path, viewA, intervals, txnAfterRefresh, txnAfterInvalidate);
+                Assert.assertTrue("a range containing a MAT_VIEW_INVALIDATE (invalid=true) must report it", loader.hasMatViewInvalidate());
+
+                // Range whose only type-4 is the reset-to-valid (invalid=false): must NOT trip the flag.
+                intervals.clear();
+                loader.load(engine, path, viewA, intervals, txnAfterInvalidate, txnAfterRevalidate);
+                Assert.assertFalse("a reset-to-valid (invalid=false) must not report a mat-view invalidate", loader.hasMatViewInvalidate());
+
+                // A second clean (data-only) load must reset the flag, proving no stale carry-over.
+                intervals.clear();
+                loader.load(engine, path, viewA, intervals, 0, txnAfterRefresh);
+                Assert.assertFalse("a clean reload must reset the mat-view invalidate flag to false", loader.hasMatViewInvalidate());
+            }
+        });
+    }
+
+    @Test
     public void testWalTxnRangeLoaderDetectsTruncate() throws Exception {
         // Direct unit coverage for the detection primitive the whole truncate barrier rests on:
         // a range with a TRUNCATE reports hasTruncate()==true; a data-only range reports false; and a


### PR DESCRIPTION
Stacked on #7330 (`sm_matview_pending_invalidation_finalize`). The diff here is scoped to this fix's 5 commits; once #7330 merges, GitHub retargets this PR to `master`.

## Problem

A chained materialized view (a view `B` whose base is another view `A`) could serve silently stale results after a demote->promote, and did not self-heal even across a restart.

When parent `A` is durably invalidated while primary (e.g. its base table is truncated), `A` records a `MAT_VIEW_INVALIDATE` transaction in its own WAL, but the cascade that invalidates child `B` is only enqueued in memory. A demote before `B` is processed discards that pending cascade. On promote (or restart) the cold-load backstop scanned `A`'s WAL gap only for a base-table `TRUNCATE`, so it missed `A`'s own invalidation, and `B` reloaded VALID — returning stale rows from a view that reported itself valid. Recovery previously required `REFRESH ... FULL` on the parent first.

## Fix

Two changes on the shared cold-load path (`CairoEngine.loadMatViewIntoStore`, used by both boot `buildViewGraphs` and promote `hydrateMatViewStateStore`). Both read durable on-disk state, so they are immune to the in-memory discard and self-heal on restart:

- The WAL-gap backstop now treats a base view's own `MAT_VIEW_INVALIDATE` (with `invalid=true`) as an invalidating barrier, alongside a base-table `TRUNCATE`. A reset-to-valid (which shares the same transaction type) does not trip it.
- When a parent view itself loads invalid, its invalidation re-cascades to its dependents — covering the case where the parent's WAL gap is purged or unreadable so the backstop scan cannot see it. The cascade is transitive, so deeper chains converge too.

## Tradeoffs and notes

- The re-cascade enqueues one dependent-invalidate per invalid parent on every boot/hydrate, even when the child is already invalid on disk; each resolves to a no-op at the child (the invalidate path skips an already-invalid view). The cost is bounded to the number of invalid views, once per cold load.
- The backstop performs one extra WAL-gap scan per lagging view on the cold path. This is a known pattern already shared with the truncate backstop and is bounded to boot/promote, not steady state.
- Scope is OSS only; no enterprise changes.

## Test plan

- New loader unit test: a parent view's `MAT_VIEW_INVALIDATE` (`invalid=true`) is detected, a reset-to-valid (`invalid=false`) is not, and the flag resets per scan.
- New promote-hydrate integration test: parent durably invalid with the child's cascade discarded -> the child reloads invalid.
- New isolation test for the re-cascade: with the parent's WAL gap purged (backstop blinded), the child is still invalidated by the re-cascade alone.
- New boot/restart regression test proving the fix self-heals across a server restart.
- Full sweep: `MatViewTest` 205/205 and `MatViewReloadOnRestartTest` 26/26 passing.

## TODO

- Timer lifecycle across role switches (surfaced by the questdb/questdb-enterprise#1109 review; pre-existing): `MatViewTimerJob`'s internal timer heap belongs to the boot-constructed job and survives role switches, and `addTimers` is not idempotent. A demote frees the mat-view state store without emitting timer REMOVE events, and every promote's hydration re-emits ADD per timed view, so each demote->promote cycle stacks one more timer generation per view — an unbounded heap leak over node lifetime plus redundant wakeups on a primary (the `knownSeq` dedup keeps the extra enqueues idempotent) and per-tick log noise on a replica (state lookups hit the no-op store). Candidate fixes: (a) OSS-only — dedupe `addTimers` by view token + timer type so a re-ADD replaces the stale generation, bounding the heap at O(views); (b) full — additionally emit REMOVE for live views on the enterprise demote path before the store swap (needs an enterprise tandem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

