### PR TITLE
feat(sql): add normalised_perf() function for performance normalisation

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/finance/NormalisedPerfFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/finance/NormalisedPerfFunctionFactory.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.finance;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.SymbolTableSource;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.griffin.engine.functions.DoubleFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.Numbers;
+import io.questdb.std.ObjList;
+
+public class NormalisedPerfFunctionFactory implements FunctionFactory {
+
+    @Override
+    public String getSignature() {
+        return "normalised_perf(DD)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new NormalisedPerfFunction(args.getQuick(0), args.getQuick(1));
+    }
+
+    private static class NormalisedPerfFunction extends DoubleFunction implements BinaryFunction {
+        private final Function baseValue;
+        private final Function column;
+        private double firstValue;
+        private boolean isFirstRow;
+
+        public NormalisedPerfFunction(Function column, Function baseValue) {
+            this.baseValue = baseValue;
+            this.column = column;
+            this.firstValue = Double.NaN;
+            this.isFirstRow = true;
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+            column.init(symbolTableSource, executionContext);
+            baseValue.init(symbolTableSource, executionContext);
+            firstValue = Double.NaN;
+            isFirstRow = true;
+        }
+
+        @Override
+        public void toTop() {
+            column.toTop();
+            baseValue.toTop();
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            if (isFirstRow) {
+                firstValue = column.getDouble(rec);
+                isFirstRow = false;
+            }
+
+            if (Numbers.isNull(firstValue) || firstValue == 0.0) {
+                return Double.NaN;
+            }
+
+            final double colVal = column.getDouble(rec);
+            if (Numbers.isNull(colVal)) {
+                return Double.NaN;
+            }
+
+            final double bv = baseValue.getDouble(rec);
+            if (Numbers.isNull(bv)) {
+                return Double.NaN;
+            }
+
+            return bv * colVal / firstValue;
+        }
+
+        @Override
+        public Function getLeft() {
+            return column;
+        }
+
+        @Override
+        public String getName() {
+            return "normalised_perf";
+        }
+
+        @Override
+        public Function getRight() {
+            return baseValue;
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/finance/NormalisedPerfFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/finance/NormalisedPerfFunctionFactoryTest.java
@@ -1,0 +1,153 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.finance;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class NormalisedPerfFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testNormalisedPerfBasic() throws Exception {
+        assertMemoryLeak(() ->
+                assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
+                        .ddl("CREATE TABLE trades AS " +
+                                "(SELECT x * 10.0 AS price FROM long_sequence(5))")
+                        .returns(
+                                "normalised_perf\n" +
+                                        "100.0\n" +
+                                        "200.0\n" +
+                                        "300.0\n" +
+                                        "400.0\n" +
+                                        "500.0\n"
+                        )
+        );
+    }
+
+    @Test
+    public void testNormalisedPerfSingleRow() throws Exception {
+        assertMemoryLeak(() ->
+                assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
+                        .ddl("CREATE TABLE trades AS " +
+                                "(SELECT 42.0 AS price FROM long_sequence(1))")
+                        .returns("normalised_perf\n100.0\n")
+        );
+    }
+
+    @Test
+    public void testNormalisedPerfFirstRowZero() throws Exception {
+        assertMemoryLeak(() ->
+                assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
+                        .ddl("CREATE TABLE trades AS " +
+                                "(SELECT (x - 1) * 10.0 AS price FROM long_sequence(5))")
+                        .returns(
+                                "normalised_perf\n" +
+                                        "null\n" +
+                                        "null\n" +
+                                        "null\n" +
+                                        "null\n" +
+                                        "null\n"
+                        )
+        );
+    }
+
+    @Test
+    public void testNormalisedPerfFirstRowNull() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE trades (price DOUBLE)");
+            execute("INSERT INTO trades VALUES (null), (10.0), (20.0)");
+            assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
+                    .returns(
+                            "normalised_perf\n" +
+                                    "null\n" +
+                                    "null\n" +
+                                    "null\n"
+                    );
+        });
+    }
+
+    @Test
+    public void testNormalisedPerfNullInLaterRow() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE trades (price DOUBLE)");
+            execute("INSERT INTO trades VALUES (10.0), (null), (30.0)");
+            assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
+                    .returns(
+                            "normalised_perf\n" +
+                                    "100.0\n" +
+                                    "null\n" +
+                                    "300.0\n"
+                    );
+        });
+    }
+
+    @Test
+    public void testNormalisedPerfNullBaseValue() throws Exception {
+        assertMemoryLeak(() ->
+                assertQuery("SELECT normalised_perf(price, null::double) FROM trades")
+                        .ddl("CREATE TABLE trades AS " +
+                                "(SELECT x * 10.0 AS price FROM long_sequence(3))")
+                        .returns(
+                                "normalised_perf\n" +
+                                        "null\n" +
+                                        "null\n" +
+                                        "null\n"
+                        )
+        );
+    }
+
+    @Test
+    public void testNormalisedPerfBaseValueColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE trades (price DOUBLE, base DOUBLE)");
+            execute("INSERT INTO trades VALUES (10.0, 100.0), (20.0, 200.0), (30.0, 50.0)");
+            assertQuery("SELECT normalised_perf(price, base) FROM trades")
+                    .returns(
+                            "normalised_perf\n" +
+                                    "100.0\n" +
+                                    "400.0\n" +
+                                    "150.0\n"
+                    );
+        });
+    }
+
+    @Test
+    public void testNormalisedPerfCursorRewind() throws Exception {
+        // Runs the query via .returns(), which internally rewinds and re-reads
+        // the cursor a second time. If toTop() does not reset isFirstRow, the
+        // second pass will skip capturing column[0] and produce wrong results.
+        assertMemoryLeak(() ->
+                assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
+                        .ddl("CREATE TABLE trades AS " +
+                                "(SELECT x * 5.0 AS price FROM long_sequence(3))")
+                        .returns(
+                                "normalised_perf\n" +
+                                        "100.0\n" +
+                                        "200.0\n" +
+                                        "300.0\n"
+                        )
+        );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/finance/NormalisedPerfFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/finance/NormalisedPerfFunctionFactoryTest.java
@@ -27,127 +27,91 @@ package io.questdb.test.griffin.engine.functions.finance;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.Test;
 
-public class NormalisedPerfFunctionFactoryTest extends AbstractCairoTest {
+        public class NormalisedPerfFunctionFactoryTest extends AbstractCairoTest {
 
-    @Test
-    public void testNormalisedPerfBasic() throws Exception {
-        assertMemoryLeak(() ->
-                assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
-                        .ddl("CREATE TABLE trades AS " +
-                                "(SELECT x * 10.0 AS price FROM long_sequence(5))")
-                        .returns(
-                                "normalised_perf\n" +
-                                        "100.0\n" +
-                                        "200.0\n" +
-                                        "300.0\n" +
-                                        "400.0\n" +
-                                        "500.0\n"
-                        )
-        );
-    }
+            @Test
+            public void testNormalisedPerfBasic() throws Exception {
+                assertMemoryLeak(() ->
+                        assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
+                                .ddl("CREATE TABLE trades AS (SELECT x * 10.0 AS price FROM long_sequence(5))")
+                                .expectSize()
+                                .returns(
+                                        "normalised_perf\n" +
+                                                "100.0\n200.0\n300.0\n400.0\n500.0\n"
+                                )
+                );
+            }
 
-    @Test
-    public void testNormalisedPerfSingleRow() throws Exception {
-        assertMemoryLeak(() ->
-                assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
-                        .ddl("CREATE TABLE trades AS " +
-                                "(SELECT 42.0 AS price FROM long_sequence(1))")
-                        .returns("normalised_perf\n100.0\n")
-        );
-    }
+            @Test
+            public void testNormalisedPerfSingleRow() throws Exception {
+                assertMemoryLeak(() ->
+                        assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
+                                .ddl("CREATE TABLE trades AS (SELECT 42.0 AS price FROM long_sequence(1))")
+                                .expectSize()
+                                .returns("normalised_perf\n100.0\n")
+                );
+            }
 
-    @Test
-    public void testNormalisedPerfFirstRowZero() throws Exception {
-        assertMemoryLeak(() ->
-                assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
-                        .ddl("CREATE TABLE trades AS " +
-                                "(SELECT (x - 1) * 10.0 AS price FROM long_sequence(5))")
-                        .returns(
-                                "normalised_perf\n" +
-                                        "null\n" +
-                                        "null\n" +
-                                        "null\n" +
-                                        "null\n" +
-                                        "null\n"
-                        )
-        );
-    }
+            @Test
+            public void testNormalisedPerfFirstRowZero() throws Exception {
+                assertMemoryLeak(() ->
+                        assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
+                                .ddl("CREATE TABLE trades AS (SELECT (x - 1) * 10.0 AS price FROM long_sequence(5))")
+                                .expectSize()
+                                .returns("normalised_perf\nnull\nnull\nnull\nnull\nnull\n")
+                );
+            }
 
-    @Test
-    public void testNormalisedPerfFirstRowNull() throws Exception {
-        assertMemoryLeak(() -> {
-            execute("CREATE TABLE trades (price DOUBLE)");
-            execute("INSERT INTO trades VALUES (null), (10.0), (20.0)");
-            assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
-                    .returns(
-                            "normalised_perf\n" +
-                                    "null\n" +
-                                    "null\n" +
-                                    "null\n"
-                    );
-        });
-    }
+            @Test
+            public void testNormalisedPerfFirstRowNull() throws Exception {
+                assertMemoryLeak(() -> {
+                    execute("CREATE TABLE trades (price DOUBLE)");
+                    execute("INSERT INTO trades VALUES (null), (10.0), (20.0)");
+                    assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
+                            .expectSize()
+                            .returns("normalised_perf\nnull\nnull\nnull\n");
+                });
+            }
 
-    @Test
-    public void testNormalisedPerfNullInLaterRow() throws Exception {
-        assertMemoryLeak(() -> {
-            execute("CREATE TABLE trades (price DOUBLE)");
-            execute("INSERT INTO trades VALUES (10.0), (null), (30.0)");
-            assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
-                    .returns(
-                            "normalised_perf\n" +
-                                    "100.0\n" +
-                                    "null\n" +
-                                    "300.0\n"
-                    );
-        });
-    }
+            @Test
+            public void testNormalisedPerfNullInLaterRow() throws Exception {
+                assertMemoryLeak(() -> {
+                    execute("CREATE TABLE trades (price DOUBLE)");
+                    execute("INSERT INTO trades VALUES (10.0), (null), (30.0)");
+                    assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
+                            .expectSize()
+                            .returns("normalised_perf\n100.0\nnull\n300.0\n");
+                });
+            }
 
-    @Test
-    public void testNormalisedPerfNullBaseValue() throws Exception {
-        assertMemoryLeak(() ->
-                assertQuery("SELECT normalised_perf(price, null::double) FROM trades")
-                        .ddl("CREATE TABLE trades AS " +
-                                "(SELECT x * 10.0 AS price FROM long_sequence(3))")
-                        .returns(
-                                "normalised_perf\n" +
-                                        "null\n" +
-                                        "null\n" +
-                                        "null\n"
-                        )
-        );
-    }
+            @Test
+            public void testNormalisedPerfNullBaseValue() throws Exception {
+                assertMemoryLeak(() ->
+                        assertQuery("SELECT normalised_perf(price, null::double) FROM trades")
+                                .ddl("CREATE TABLE trades AS (SELECT x * 10.0 AS price FROM long_sequence(3))")
+                                .expectSize()
+                                .returns("normalised_perf\nnull\nnull\nnull\n")
+                );
+            }
 
-    @Test
-    public void testNormalisedPerfBaseValueColumn() throws Exception {
-        assertMemoryLeak(() -> {
-            execute("CREATE TABLE trades (price DOUBLE, base DOUBLE)");
-            execute("INSERT INTO trades VALUES (10.0, 100.0), (20.0, 200.0), (30.0, 50.0)");
-            assertQuery("SELECT normalised_perf(price, base) FROM trades")
-                    .returns(
-                            "normalised_perf\n" +
-                                    "100.0\n" +
-                                    "400.0\n" +
-                                    "150.0\n"
-                    );
-        });
-    }
+            @Test
+            public void testNormalisedPerfBaseValueColumn() throws Exception {
+                assertMemoryLeak(() -> {
+                    execute("CREATE TABLE trades (price DOUBLE, base DOUBLE)");
+                    execute("INSERT INTO trades VALUES (10.0, 100.0), (20.0, 200.0), (30.0, 50.0)");
+                    assertQuery("SELECT normalised_perf(price, base) FROM trades")
+                            .expectSize()
+                            .returns("normalised_perf\n100.0\n400.0\n150.0\n");
+                });
+            }
 
-    @Test
-    public void testNormalisedPerfCursorRewind() throws Exception {
-        // Runs the query via .returns(), which internally rewinds and re-reads
-        // the cursor a second time. If toTop() does not reset isFirstRow, the
-        // second pass will skip capturing column[0] and produce wrong results.
-        assertMemoryLeak(() ->
-                assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
-                        .ddl("CREATE TABLE trades AS " +
-                                "(SELECT x * 5.0 AS price FROM long_sequence(3))")
-                        .returns(
-                                "normalised_perf\n" +
-                                        "100.0\n" +
-                                        "200.0\n" +
-                                        "300.0\n"
-                        )
-        );
-    }
-}
+            @Test
+            public void testNormalisedPerfCursorRewind() throws Exception {
+                assertMemoryLeak(() ->
+                        assertQuery("SELECT normalised_perf(price, 100.0) FROM trades")
+                                .ddl("CREATE TABLE trades AS (SELECT x * 5.0 AS price FROM long_sequence(3))")
+                                .expectSize()
+                                .returns("normalised_perf\n100.0\n200.0\n300.0\n")
+                );
+            }
+        }


### PR DESCRIPTION
Fixes #4620

## What

Adds `normalised_perf(column, base_value)` as a scalar SQL function in the
finance package. The formula is:

  normalised_perf(column, base_value) = base_value * column[i] / column[0]

where `column[0]` is the value of `column` on the first row the cursor visits.
`base_value` is re-evaluated per row and can be a constant or a column.

## Example

```sql
SELECT ts, price, normalised_perf(price, 100.0) AS perf
FROM trades
ORDER BY ts;

