### PR TITLE
feat(qwp): add a connect timeout and tolerant client startup

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -146,7 +146,7 @@ Every agent receives:
 
 Launch the following agents in parallel.
 
-**Agent 1 — Correctness & bugs:** NULL handling, edge cases, logic errors, off-by-one, operator precedence, error paths. Cross-reference every changed symbol against its callsite inventory and verify the new behavior is correct at each callsite.
+**Agent 1 — Correctness & bugs:** NULL handling, edge cases, logic errors, off-by-one, operator precedence, error paths. Cross-reference every changed symbol against its callsite inventory and verify the new behavior is correct at each callsite. When the diff touches the QWP ingress / role-gating path, an in-place switch or failover, a `java-questdb-client` submodule bump, or store-and-forward test suites, also verify the "Store-and-forward & pool startup invariants" checklist — a change that lets a running SF drainer surface transport errors to the producer, imposes a reconnect time budget on it, or hard-fails it on a transient outage is a Critical (data-loss) finding.
 
 **Agent 2 — Concurrency:** Race conditions, shared mutable state, missing volatile, lock ordering, thread-safety of data structures. Use the implicit contract list (lock order, thread-affinity) and check every callsite from 2.5b for violations of the new contract.
 
@@ -371,6 +371,82 @@ For each new or changed allocation site, verify:
 - **Same tracker for malloc and its matching free.** A site that allocates with a tracker but frees with `null` (or vice versa) desyncs the counter and trips the live `recordPerQueryMemAlloc` balance assert. Trace every free / close path — error paths and `toTop()` / `clear()` / cursor-close reuse included — and confirm the identical tracker is used on both ends.
 - **Nested SQL inherits the outer tracker.** Subqueries, the mat-view refresh inner SELECT, and WAL apply inner SQL must inherit the tracker already bound on the context, not acquire their own. A new acquisition site that acquires unconditionally (instead of only when no outer tracker is present) double-counts — flag it.
 - **Coverage has a test.** A newly wired allocator needs a `*MemoryTrackerTest` proving (a) a breach throws the per-query out-of-memory message, (b) an under-limit run succeeds, and (c) a `getCursor()`-to-close leak loop stays balanced. Missing tracker tests for a newly wired site is a high-priority finding; so is a factory-class routing guard that no longer pins the test to the intended plan.
+
+### Store-and-forward & pool startup invariants (QWP client contract)
+Apply this whenever the diff touches the QWP ingress path (upgrade/role
+gating, in-place demote / lifecycle switch, connection handling on role
+change), replication failover, a `java-questdb-client` submodule bump, or
+tests that drive a producer through a failover/switch window. These are the
+CLIENT's store-and-forward guarantees (the client code lives in the
+`java-questdb-client` submodule); server-side changes and tests in this repo
+must be reviewed against them. A violation here is a **Critical** finding:
+the whole point of store-and-forward is that a running producer never loses
+data and never hard-fails on a transient outage.
+
+**Drainer (steady state — once the pool is running).**
+- Once the pool is running, an async drainer thread ships buffered SF data to
+  the server. It MUST NOT propagate server / transport errors back to the
+  client (`Sender` producer calls, `flush()`, the pooled handle). The ONLY
+  error a running drainer may surface to the caller is **SF out of space** (the
+  on-disk / backing buffer is full and can accept no more rows). Flag any other
+  failure class (connect-refused, DNS, unreachable/black-hole, TLS/cert, auth,
+  role-reject, upgrade/protocol timeout, reset) that can escape the drainer
+  onto a producer or borrow call.
+- Primary reconnect MUST be fully contained inside the drainer thread and MUST
+  have **no time limit** — no `reconnect_max_duration_millis`-style budget, no
+  deadline, no "give up and latch terminal after N ms". A budget that latches
+  the sender terminal on a long outage is a Critical violation: it drops a
+  producer that store-and-forward promised to keep alive. Flag any bounded
+  reconnect loop, `deadlineNanos` / `while (now < deadline)`, or terminal
+  `SenderError` reachable from the running drainer's reconnect path.
+- The drainer must retry with **exponential backoff** and handle every connect
+  failure class gracefully, without a hard fail — it keeps buffering and keeps
+  retrying until the wire is back. The per-attempt backoff may be capped (a max
+  delay between attempts), but the RETRY LOOP ITSELF must be unbounded. Flag a
+  capped total retry duration or an attempt-count cap on the steady-state
+  drainer.
+- **Sanctioned terminals (orphan-slot drainer only).** The orphan drainer
+  (`BackgroundDrainer`) MAY quarantine its slot (`.failed` sentinel,
+  human-in-the-loop) on conditions that are terminal by design: auth failure,
+  a non-421 upgrade reject, and a genuine cluster-wide durable-ack capability
+  gap that exhausted its documented settle budget (16 consecutive
+  capability-gap sweeps, or a wall-clock budget anchored at the FIRST
+  capability-gap error of the episode — whichever is hit first). These are
+  NOT violations of the no-budget rule above. The settle budget applies ONLY
+  to consecutive capability-gap attempts: transient classes (role reject,
+  transport error) must never increment it or burn its wall clock — a
+  transient state consuming the terminal budget (shared attempt counter,
+  entry-anchored deadline) IS a Critical violation of this checklist.
+
+**Pool startup — two modes; the mode decides who sees connectivity errors.**
+- `lazy_connect=true`: `build()` MUST succeed with **no server present**. The
+  producing `Sender` must work immediately (writes buffer via SF), and once the
+  server comes up the read side must also connect and read (reads are deferred,
+  not disabled).
+- `lazy_connect=false` (default): `build()` / the initial connect MUST expose
+  connectivity problems to the caller — DNS errors, connect-refused /
+  unreachable, TLS/cert, authentication/authorization, and connect/upgrade
+  timeouts must all surface as a thrown exception at startup, not be swallowed.
+- **In BOTH modes the boundary is the same:** connectivity errors are only
+  ever the caller's problem DURING initialization. Once the client has
+  connected and is past initialization, the running drainer reverts to the
+  steady-state contract above — it must NEVER expose transport problems, NEVER
+  impose a reconnect time budget, and NEVER hard-fail on a transient outage.
+
+**Server-side & test application (this repo).**
+- The server MUST NOT rely on producer-visible role errors: an in-place
+  demote CLOSES QWP ingress connections (no per-write SECURITY_ERROR to an SF
+  sender). A server change that reintroduces per-write role errors on the QWP
+  ingress path breaks the containment contract above.
+- Flag any test (unit, integration, or e2e) that uses QWP producer-visible
+  role errors as evidence of the REPLICA write gate — under the containment
+  contract the producer is silent by design. Write-gate evidence belongs on
+  pg-wire probes, frozen commit counts on the settled replica, and
+  post-promotion SF drain (durable-ack await barriers + dense oracles).
+- Dense/count oracles over rows produced through an SF sender must account
+  for at-least-once replay: durably ack (await) seed rows before the
+  disturbance, or use a DEDUP table — otherwise the oracle reports replay
+  duplicates as data corruption.
 
 ### SQL conventions (if tests or SQL involved)
 - Keywords in UPPERCASE

--- a/.pi/skills/review-pr/SKILL.md
+++ b/.pi/skills/review-pr/SKILL.md
@@ -192,7 +192,7 @@ Every agent receives:
 
 Launch the following agents in parallel (in pi, via `subagent(...)` fresh-context `reviewer` tasks — see "Spawning review agents in pi").
 
-**Agent 1 — Correctness & bugs:** NULL handling, edge cases, logic errors, off-by-one, operator precedence, error paths. Cross-reference every changed symbol against its callsite inventory and verify the new behavior is correct at each callsite.
+**Agent 1 — Correctness & bugs:** NULL handling, edge cases, logic errors, off-by-one, operator precedence, error paths. Cross-reference every changed symbol against its callsite inventory and verify the new behavior is correct at each callsite. When the diff touches the QWP ingress / role-gating path, an in-place switch or failover, a `java-questdb-client` submodule bump, or store-and-forward test suites, also verify the "Store-and-forward & pool startup invariants" checklist — a change that lets a running SF drainer surface transport errors to the producer, imposes a reconnect time budget on it, or hard-fails it on a transient outage is a Critical (data-loss) finding.
 
 **Agent 2 — Concurrency:** Race conditions, shared mutable state, missing volatile, lock ordering, thread-safety of data structures. Use the implicit contract list (lock order, thread-affinity) and check every callsite from 2.5b for violations of the new contract.
 
@@ -402,6 +402,82 @@ Every new loop, traversal, data structure choice, and computation must be justif
 - Resources properly closed in all code paths (especially error paths)
 - try-with-resources used where applicable
 - Native memory freed correctly
+
+### Store-and-forward & pool startup invariants (QWP client contract)
+Apply this whenever the diff touches the QWP ingress path (upgrade/role
+gating, in-place demote / lifecycle switch, connection handling on role
+change), replication failover, a `java-questdb-client` submodule bump, or
+tests that drive a producer through a failover/switch window. These are the
+CLIENT's store-and-forward guarantees (the client code lives in the
+`java-questdb-client` submodule); server-side changes and tests in this repo
+must be reviewed against them. A violation here is a **Critical** finding:
+the whole point of store-and-forward is that a running producer never loses
+data and never hard-fails on a transient outage.
+
+**Drainer (steady state — once the pool is running).**
+- Once the pool is running, an async drainer thread ships buffered SF data to
+  the server. It MUST NOT propagate server / transport errors back to the
+  client (`Sender` producer calls, `flush()`, the pooled handle). The ONLY
+  error a running drainer may surface to the caller is **SF out of space** (the
+  on-disk / backing buffer is full and can accept no more rows). Flag any other
+  failure class (connect-refused, DNS, unreachable/black-hole, TLS/cert, auth,
+  role-reject, upgrade/protocol timeout, reset) that can escape the drainer
+  onto a producer or borrow call.
+- Primary reconnect MUST be fully contained inside the drainer thread and MUST
+  have **no time limit** — no `reconnect_max_duration_millis`-style budget, no
+  deadline, no "give up and latch terminal after N ms". A budget that latches
+  the sender terminal on a long outage is a Critical violation: it drops a
+  producer that store-and-forward promised to keep alive. Flag any bounded
+  reconnect loop, `deadlineNanos` / `while (now < deadline)`, or terminal
+  `SenderError` reachable from the running drainer's reconnect path.
+- The drainer must retry with **exponential backoff** and handle every connect
+  failure class gracefully, without a hard fail — it keeps buffering and keeps
+  retrying until the wire is back. The per-attempt backoff may be capped (a max
+  delay between attempts), but the RETRY LOOP ITSELF must be unbounded. Flag a
+  capped total retry duration or an attempt-count cap on the steady-state
+  drainer.
+- **Sanctioned terminals (orphan-slot drainer only).** The orphan drainer
+  (`BackgroundDrainer`) MAY quarantine its slot (`.failed` sentinel,
+  human-in-the-loop) on conditions that are terminal by design: auth failure,
+  a non-421 upgrade reject, and a genuine cluster-wide durable-ack capability
+  gap that exhausted its documented settle budget (16 consecutive
+  capability-gap sweeps, or a wall-clock budget anchored at the FIRST
+  capability-gap error of the episode — whichever is hit first). These are
+  NOT violations of the no-budget rule above. The settle budget applies ONLY
+  to consecutive capability-gap attempts: transient classes (role reject,
+  transport error) must never increment it or burn its wall clock — a
+  transient state consuming the terminal budget (shared attempt counter,
+  entry-anchored deadline) IS a Critical violation of this checklist.
+
+**Pool startup — two modes; the mode decides who sees connectivity errors.**
+- `lazy_connect=true`: `build()` MUST succeed with **no server present**. The
+  producing `Sender` must work immediately (writes buffer via SF), and once the
+  server comes up the read side must also connect and read (reads are deferred,
+  not disabled).
+- `lazy_connect=false` (default): `build()` / the initial connect MUST expose
+  connectivity problems to the caller — DNS errors, connect-refused /
+  unreachable, TLS/cert, authentication/authorization, and connect/upgrade
+  timeouts must all surface as a thrown exception at startup, not be swallowed.
+- **In BOTH modes the boundary is the same:** connectivity errors are only
+  ever the caller's problem DURING initialization. Once the client has
+  connected and is past initialization, the running drainer reverts to the
+  steady-state contract above — it must NEVER expose transport problems, NEVER
+  impose a reconnect time budget, and NEVER hard-fail on a transient outage.
+
+**Server-side & test application (this repo).**
+- The server MUST NOT rely on producer-visible role errors: an in-place
+  demote CLOSES QWP ingress connections (no per-write SECURITY_ERROR to an SF
+  sender). A server change that reintroduces per-write role errors on the QWP
+  ingress path breaks the containment contract above.
+- Flag any test (unit, integration, or e2e) that uses QWP producer-visible
+  role errors as evidence of the REPLICA write gate — under the containment
+  contract the producer is silent by design. Write-gate evidence belongs on
+  pg-wire probes, frozen commit counts on the settled replica, and
+  post-promotion SF drain (durable-ack await barriers + dense oracles).
+- Dense/count oracles over rows produced through an SF sender must account
+  for at-least-once replay: durably ack (await) seed rows before the
+  disturbance, or use a DEDUP table — otherwise the oracle reports replay
+  duplicates as data corruption.
 
 ### SQL conventions (if tests or SQL involved)
 - Keywords in UPPERCASE

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -117,7 +117,7 @@
           -->
         <uberjar.name>benchmarks</uberjar.name>
 
-        <questdb.client.version>1.3.5-SNAPSHOT</questdb.client.version>
+        <questdb.client.version>1.3.6-SNAPSHOT</questdb.client.version>
     </properties>
 
     <build>

--- a/ci/templates/build-client-native.yml
+++ b/ci/templates/build-client-native.yml
@@ -1,0 +1,90 @@
+# Build the java-questdb-client native library from source when the local-client
+# profile is active.
+#
+# The client submodule no longer commits its compiled native libraries
+# (libquestdb.so / .dylib / .dll). When core/pom.xml references a -SNAPSHOT
+# client, detect-local-client.yml sets CLIENT_PROFILE to "-P local-client" and
+# the reactor builds the client from source, so CI must also compile its native
+# library -- otherwise every client-dependent test fails at class load with:
+#   FatalError: cannot find /io/questdb/client/bin/<platform>/libquestdb.so
+# A Maven-Central client (release version) ships the binaries inside its jar, so
+# CLIENT_PROFILE is empty in that case and every step below is skipped.
+#
+# CMake writes the library into core/target/classes/.../bin-local/, which the
+# subsequent `mvn clean` would wipe before the test phase runs. We copy it into
+# the client's source resources (src/main/resources/io/questdb/client/bin/
+# <platform>/) so it survives the clean and lands on the production resource
+# path the loader checks first (see io.questdb.client.std.Os).
+#
+# These steps run after the JDK activation steps so $JAVA_HOME points at the JDK
+# whose jni.h CMake compiles against.
+steps:
+  - bash: |
+      set -eux
+      # zstd is a submodule of the client and is required by its CMake build.
+      git submodule update --init --recursive java-questdb-client
+      # gcc is already present (the core and Rust builds need it); add cmake and
+      # nasm (the x86-64 asmlib) only when missing.
+      if ! command -v cmake >/dev/null 2>&1 || ! command -v nasm >/dev/null 2>&1; then
+        sudo apt-get update
+        sudo apt-get install -y cmake nasm build-essential
+      fi
+      export JAVA_HOME="${JAVA_HOME:-$(dirname "$(dirname "$(readlink -f "$(command -v java)")")")}"
+      cd java-questdb-client/core
+      cmake -DCMAKE_BUILD_TYPE=Release -B cmake-build-release -S.
+      cmake --build cmake-build-release --config Release --parallel
+      case "$(uname -m)" in
+        aarch64|arm64) plat=linux-aarch64 ;;
+        *)             plat=linux-x86-64 ;;
+      esac
+      mkdir -p "src/main/resources/io/questdb/client/bin/$plat"
+      cp target/classes/io/questdb/client/bin-local/libquestdb.so \
+         "src/main/resources/io/questdb/client/bin/$plat/libquestdb.so"
+    displayName: "Build client native library (local-client, Linux)"
+    condition: and(contains(variables['CLIENT_PROFILE'], 'local-client'), eq(variables['os'], 'Linux'))
+
+  - bash: |
+      set -eux
+      git submodule update --init --recursive java-questdb-client
+      # macos-14 agents are arm64: that CMake path uses neither nasm nor asmlib,
+      # and cmake/clang ship with the image. Install nasm only on the x86-64 leg,
+      # which still assembles asmlib.
+      if [ "$(uname -m)" = "x86_64" ] && ! command -v nasm >/dev/null 2>&1; then
+        brew install nasm
+      fi
+      export JAVA_HOME="${JAVA_HOME:-${JAVA_HOME_25_ARM64:-${JAVA_HOME_25_X64:-$(/usr/libexec/java_home)}}}"
+      export MACOSX_DEPLOYMENT_TARGET=13.0
+      cd java-questdb-client/core
+      cmake -DCMAKE_BUILD_TYPE=Release -B cmake-build-release -S.
+      cmake --build cmake-build-release --config Release --parallel
+      case "$(uname -m)" in
+        arm64|aarch64) plat=darwin-aarch64 ;;
+        *)             plat=darwin-x86-64 ;;
+      esac
+      mkdir -p "src/main/resources/io/questdb/client/bin/$plat"
+      cp target/classes/io/questdb/client/bin-local/libquestdb.dylib \
+         "src/main/resources/io/questdb/client/bin/$plat/libquestdb.dylib"
+    displayName: "Build client native library (local-client, macOS)"
+    condition: and(contains(variables['CLIENT_PROFILE'], 'local-client'), eq(variables['os'], 'macOS'))
+
+  - pwsh: |
+      $ErrorActionPreference = "Stop"
+      git submodule update --init --recursive java-questdb-client
+      if ($LASTEXITCODE -ne 0) { throw "submodule update failed" }
+      # The client distributes a mingw-built Windows .dll; reproduce that here.
+      # Ninja avoids the MinGW-Makefiles "sh.exe found in PATH" failure and the
+      # mingw32-make dependency. choco shims land on the machine PATH, which we
+      # refresh into this session before invoking cmake.
+      choco install -y --no-progress ninja nasm mingw
+      $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" +
+                  [System.Environment]::GetEnvironmentVariable("Path", "User")
+      Set-Location java-questdb-client/core
+      cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -B cmake-build-release -S .
+      if ($LASTEXITCODE -ne 0) { throw "cmake configure failed" }
+      cmake --build cmake-build-release --config Release
+      if ($LASTEXITCODE -ne 0) { throw "cmake build failed" }
+      New-Item -ItemType Directory -Force -Path src/main/resources/io/questdb/client/bin/windows-x86-64 | Out-Null
+      Copy-Item target/classes/io/questdb/client/bin-local/libquestdb.dll `
+                src/main/resources/io/questdb/client/bin/windows-x86-64/libquestdb.dll
+    displayName: "Build client native library (local-client, Windows)"
+    condition: and(contains(variables['CLIENT_PROFILE'], 'local-client'), eq(variables['os'], 'Windows'))

--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -82,6 +82,11 @@ steps:
     displayName: "Activate GraalVM 25"
     condition: |
       eq(variables['System.JobName'], 'linux_x64_graal')
+  # Compile the client's native library from source when building it as a
+  # -SNAPSHOT (local-client). A Maven-Central client ships the binaries in its
+  # jar, so this is a no-op there. Runs after JDK activation so $JAVA_HOME points
+  # at the JDK whose jni.h CMake builds against.
+  - template: build-client-native.yml
   - task: Cache@2
     displayName: "Cache non-default Maven"
     continueOnError: true

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -45,7 +45,7 @@
         -->
         <qdbr.rustflags>-D warnings</qdbr.rustflags>
 
-        <questdb.client.version>1.3.5-SNAPSHOT</questdb.client.version>
+        <questdb.client.version>1.3.6-SNAPSHOT</questdb.client.version>
     </properties>
 
     <version>9.4.4-SNAPSHOT</version>
@@ -264,7 +264,7 @@
         <profile>
             <id>local-client</id>
             <properties>
-                <questdb.client.version>1.3.5-SNAPSHOT</questdb.client.version>
+                <questdb.client.version>1.3.6-SNAPSHOT</questdb.client.version>
             </properties>
         </profile>
         <profile>

--- a/core/src/main/java/io/questdb/cairo/CairoException.java
+++ b/core/src/main/java/io/questdb/cairo/CairoException.java
@@ -80,9 +80,32 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
     private int messagePosition;
     private boolean outOfMemory;
     private boolean preferencesOutOfDateError = false;
+    private boolean readOnlyAccessRefusal = false;
 
     public static CairoException authorization() {
         return nonCritical().setAuthorizationError();
+    }
+
+    /**
+     * A write refused BECAUSE the node is read-only -- statically
+     * ({@code readonly=true} in the server configuration) or dynamically (the
+     * role-derived read-only of an enterprise replica, including a demote in
+     * flight). Carries the authorization flag, the canonical
+     * {@link #READ_ONLY_ACCESS_MESSAGE} and the read-only-refusal marker
+     * ({@link #isReadOnlyAccessRefusal()}) in lockstep, so the refusal's CAUSE
+     * travels with the exception.
+     * <p>
+     * Protocol layers that must tell a transient role-demote refusal apart from
+     * a genuine ACL denial (e.g. the QWP NACK classification) key on the marker.
+     * They must NOT re-read live engine state at catch time -- that races with a
+     * demote revert (the drain-timeout PRIMARY restore can land between the
+     * throw and the catch; nothing fences the propagation) -- and must NOT match
+     * the message text, which is brittle. Every "node is read-only" refusal site
+     * uses this factory so the marker is correct by construction; sites must not
+     * hand-roll {@code authorization().put(READ_ONLY_ACCESS_MESSAGE)}.
+     */
+    public static CairoException readOnlyAccess() {
+        return authorization().setReadOnlyAccessRefusal().put(READ_ONLY_ACCESS_MESSAGE);
     }
 
     public static CairoException critical(int errno) {
@@ -323,6 +346,15 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
         return outOfMemory;
     }
 
+    /**
+     * Whether this refusal was raised BECAUSE the node is read-only (set only by
+     * {@link #readOnlyAccess()}). Implies {@link #isAuthorizationError()}. False
+     * for genuine ACL denials.
+     */
+    public boolean isReadOnlyAccessRefusal() {
+        return readOnlyAccessRefusal;
+    }
+
     public boolean isPreferencesOutOfDateError() {
         return preferencesOutOfDateError;
     }
@@ -466,6 +498,11 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
         return this;
     }
 
+    private CairoException setReadOnlyAccessRefusal() {
+        this.readOnlyAccessRefusal = true;
+        return this;
+    }
+
     private CairoException setPreferencesOutOfDateError() {
         this.preferencesOutOfDateError = true;
         return this;
@@ -485,6 +522,7 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
         cancellation = false;
         preferencesOutOfDateError = false;
         authorizationError = false;
+        readOnlyAccessRefusal = false;
         messagePosition = 0;
         outOfMemory = false;
         housekeeping = false;

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewRefreshJob.java
@@ -456,13 +456,13 @@ public class MatViewRefreshJob implements Job, QuietCloseable {
     // deployments: the read lock is uncontended and the read-only flag is static.
     private void fencedMatViewCommit(Runnable commit) {
         if (engine.isReadOnlyMode()) {
-            throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+            throw CairoException.readOnlyAccess();
         }
         final Lock lock = engine.getRoleSwitchReadLock();
         lock.lock();
         try {
             if (engine.isReadOnlyMode()) {
-                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                throw CairoException.readOnlyAccess();
             }
             engine.fireRoleSwitchMintObserver();
             commit.run();

--- a/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/http/processors/JsonQueryProcessor.java
@@ -496,7 +496,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, HttpRequestHand
                     // covers CREATE/DROP operation subtypes.
                     cc.closeAllButSelect();
                     Misc.free(cc.getOperation());
-                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                    throw CairoException.readOnlyAccess();
                 }
                 // todo: reconsider whether we need to keep the SqlCompiler instance open while executing the query
                 // the problem is the each instance of the compiler has just a single instance of the CompilerQuery object.
@@ -658,7 +658,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, HttpRequestHand
     ) throws SqlException {
         if (engine.isReadOnlyMode()
                 && ReadOnlyStatementGate.isRefusedOnReadOnly(sqlType, op, engine.getConfiguration())) {
-            throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+            throw CairoException.readOnlyAccess();
         }
         final Lock lock = engine.getRoleSwitchReadLock();
         lock.lock();
@@ -668,7 +668,7 @@ public class JsonQueryProcessor implements HttpRequestProcessor, HttpRequestHand
             // cannot interleave (its write acquire waits), while other commits share the read side.
             if (engine.isReadOnlyMode()
                     && ReadOnlyStatementGate.isRefusedOnReadOnly(sqlType, op, engine.getConfiguration())) {
-                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                throw CairoException.readOnlyAccess();
             }
             try (OperationFuture fut = op.execute(sqlExecutionContext, eventSubSequence)) {
                 return fut.await(awaitTimeout);

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/TableUpdateDetails.java
@@ -236,7 +236,7 @@ public class TableUpdateDetails implements Closeable {
             // acquire the lock, skip the lock acquire entirely. This is NOT the
             // authoritative refusal -- the in-lock re-check below is.
             if (engine.isReadOnlyMode()) {
-                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                throw CairoException.readOnlyAccess();
             }
             // Hold the role-switch lock across the authoritative re-check and the
             // actual commit. The role-flip path in EntCairoEngine acquires the same
@@ -256,7 +256,7 @@ public class TableUpdateDetails implements Closeable {
                 // authorizeCommit(): a real authorization failure must still roll back the writer
                 // and surface as a wrapped CommitFailedException, exactly as before this gate existed.
                 if (engine.isReadOnlyMode()) {
-                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                    throw CairoException.readOnlyAccess();
                 }
                 try {
                     authorizeCommit();

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGPipelineEntry.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGPipelineEntry.java
@@ -402,7 +402,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
         // the lock entirely. This is NOT the authoritative refusal -- the in-lock re-check below is.
         if (engine.isReadOnlyMode()) {
             rollback(pendingWriters);
-            throw kaput().put((Throwable) CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE));
+            throw kaput().put((Throwable) CairoException.readOnlyAccess());
         }
         // Hold the role-switch READ lock across the authoritative re-check and the actual commit. The
         // role-flip path in EntCairoEngine acquires the WRITE side of this lock around the REPLICA flag
@@ -421,7 +421,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
             // unaffected. The parked writers are rolled back so nothing lands on the demoting node.
             if (engine.isReadOnlyMode()) {
                 rollback(pendingWriters);
-                throw kaput().put((Throwable) CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE));
+                throw kaput().put((Throwable) CairoException.readOnlyAccess());
             }
             try {
                 for (ObjObjHashMap.Entry<TableToken, TableWriterAPI> pendingWriter : pendingWriters) {
@@ -702,7 +702,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
             // BEGIN/INSERT that parks a writer and straddles the demote.
             if (engine.isReadOnlyMode()
                     && ReadOnlyStatementGate.isRefusedOnReadOnly(this.sqlType, operation, engine.getConfiguration())) {
-                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                throw CairoException.readOnlyAccess();
             }
             switch (this.sqlType) {
                 case CompiledQuery.EXPLAIN:
@@ -1456,7 +1456,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
     ) throws SqlException {
         if (engine.isReadOnlyMode()
                 && ReadOnlyStatementGate.isRefusedOnReadOnly(sqlType, operation, engine.getConfiguration())) {
-            throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+            throw CairoException.readOnlyAccess();
         }
         long affectedRowCount = 0;
         engine.getMetrics().pgWireMetrics().markStart();
@@ -1468,7 +1468,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
             // cannot interleave (its write acquire waits), while other commits share the read side.
             if (engine.isReadOnlyMode()
                     && ReadOnlyStatementGate.isRefusedOnReadOnly(sqlType, operation, engine.getConfiguration())) {
-                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                throw CairoException.readOnlyAccess();
             }
             try (OperationFuture fut = operation.execute(sqlExecutionContext, tempSequence)) {
                 fut.await();
@@ -1505,7 +1505,7 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
         try {
             if (engine.isReadOnlyMode()
                     && ReadOnlyStatementGate.isRefusedOnReadOnly(sqlType, operation, engine.getConfiguration())) {
-                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                throw CairoException.readOnlyAccess();
             }
             engine.execute(sqlText, sqlExecutionContext);
         } finally {
@@ -1728,14 +1728,14 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
                             // runs fully as PRIMARY while the flip's write acquire waits for the read hold.
                             if (engine.isReadOnlyMode()) {
                                 rollback(pendingWriters);
-                                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                                throw CairoException.readOnlyAccess();
                             }
                             final Lock lock = engine.getRoleSwitchReadLock();
                             lock.lock();
                             try {
                                 if (engine.isReadOnlyMode()) {
                                     rollback(pendingWriters);
-                                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                                    throw CairoException.readOnlyAccess();
                                 }
                                 // Update implicitly commits. WAL table cannot do 2 commits in 1 call and require commits to be made upfront.
                                 fireParkedUpdateMintObserver();

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpConstants.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpConstants.java
@@ -160,6 +160,16 @@ public final class QwpConstants {
      */
     public static final byte STATUS_LIMIT_EXCEEDED = 0x0B;
     /**
+     * Status: Reserved. Node cannot accept writes (read-only replica /
+     * demoting primary). Servers currently signal this state with a
+     * reconnect-eligible {@code NORMAL_CLOSURE} close instead of a NACK (see
+     * the role-change close in {@code QwpIngressProcessorState}); the byte is
+     * reserved so a future server can NACK it mid-stream once deployed client
+     * fleets classify it as retriable-with-endpoint-rotation rather than
+     * unknown/terminal.
+     */
+    public static final byte STATUS_NOT_WRITABLE = 0x0C;
+    /**
      * Status: Batch accepted successfully.
      */
     public static final byte STATUS_OK = 0x00;

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -706,7 +706,7 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
             rejectCommitError(e.getReason());
         } catch (CairoException e) {
             LOG.error().$('[').$(fd).$("] cairo error: ").$(e.getFlyweightMessage()).$();
-            reject(cairoExceptionStatus(e), e.getFlyweightMessage(), fd);
+            rejectCairoError(e);
         } catch (Throwable e) {
             LOG.critical().$('[').$(fd).$("] unexpected error: ").$(e).$();
             tudCache.setDistressed();
@@ -836,9 +836,37 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
         }
     }
 
+    /**
+     * Rejects a batch that failed with a {@link CairoException}, with Invariant B
+     * containment for the in-place demote race.
+     * <p>
+     * The {@code engine.isReadOnlyMode()} gate at the top of
+     * {@link #processMessage()} re-checks the live role per batch, but the flag
+     * can flip BETWEEN that check and the WAL writer acquisition (or the commit)
+     * within the same batch. The deeper engine gates then refuse with
+     * {@code CairoException.authorization()} ("replica access is read-only"),
+     * which {@link #cairoExceptionStatus} would map to
+     * {@link Status#SECURITY_ERROR} -- a status a store-and-forward client
+     * latches as a terminal HALT and surfaces to its producer. Re-checking the
+     * live flag at catch time closes that window: if the node is (now)
+     * read-only, the refusal is the transient demote, so the connection is
+     * flagged for the same reconnect-eligible close as the top-gate path (the
+     * client reconnects, hits the 421 role reject on the now-replica endpoint,
+     * and retries from SF until a primary is reachable). A genuine ACL denial on
+     * a writable node (isReadOnlyMode() == false) still maps to SECURITY_ERROR.
+     */
+    private void rejectCairoError(CairoException e) {
+        if (e.isAuthorizationError() && engine.isReadOnlyMode()) {
+            roleChangeClosePending = true;
+            reject(Status.NOT_ACCEPTING_WRITES, e.getFlyweightMessage(), fd);
+            return;
+        }
+        reject(cairoExceptionStatus(e), e.getFlyweightMessage(), fd);
+    }
+
     private void rejectCommitError(Throwable th) {
         if (th instanceof CairoException e) {
-            reject(cairoExceptionStatus(e), e.getFlyweightMessage(), fd);
+            rejectCairoError(e);
             return;
         }
 

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -112,6 +112,12 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
     private int pendingHandshakeBytes;
     private int recvBufferLen;
     private long resumeAckSequence = -1;
+    // Set when a batch is refused because the node just flipped to a read-only
+    // replica (an in-place PRIMARY->REPLICA demote). A TRANSIENT failover, not a
+    // permanent auth failure -- the upgrade processor closes the connection with a
+    // reconnect-eligible code instead of sending a SECURITY_ERROR that a
+    // store-and-forward client would treat as a terminal HALT.
+    private boolean roleChangeClosePending;
     private SecurityContext securityContext;
     private int sendState = SEND_STATE_READY;
     private QwpStreamingDecoder streamingDecoder;
@@ -186,6 +192,7 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
         streamingDecoder.reset();
         handshakeFlushPending = false;
         pendingHandshakeBytes = 0;
+        roleChangeClosePending = false;
     }
 
     /**
@@ -198,6 +205,7 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
         currentStatus = Status.OK;
         bufferPosition = 0;
         streamingDecoder.reset();
+        roleChangeClosePending = false;
     }
 
     @Override
@@ -356,6 +364,10 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
 
     public boolean isOk() {
         return currentStatus == Status.OK;
+    }
+
+    public boolean isRoleChangeClosePending() {
+        return roleChangeClosePending;
     }
 
     public boolean isSendReady() {
@@ -618,7 +630,17 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
             // read-only-replica flag flips FIRST in the switch cascade), the whole batch is
             // rejected as an authorization error, which maps to Status.SECURITY_ERROR below.
             if (engine.isReadOnlyMode()) {
-                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                // INVARIANT B: an in-place PRIMARY-to-REPLICA demote is a TRANSIENT
+                // failover (the node can be promoted back / a sibling primary may
+                // exist), NOT a permanent auth failure. Do not reject the batch as an
+                // authorization error (which maps to SECURITY_ERROR and a store-and-
+                // forward client treats as a terminal HALT). Flag the connection for a
+                // reconnect-eligible close instead: the client reconnects, hits the
+                // 421 role reject on the now-replica endpoint, and retries from SF
+                // until a primary is reachable.
+                roleChangeClosePending = true;
+                reject(Status.NOT_ACCEPTING_WRITES, CairoException.READ_ONLY_ACCESS_MESSAGE, fd);
+                return;
             }
 
             // Verify the message version matches what was negotiated during the upgrade

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -69,6 +69,7 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
     static final int SEND_STATE_RESUME_ACK_THEN_CLOSE = 7;
     static final int SEND_STATE_RESUME_ACK_THEN_ERROR = 3;
     static final int SEND_STATE_RESUME_CLOSE = 6;
+    static final int SEND_STATE_RESUME_DRAIN_THEN_CLOSE = 10;
     static final int SEND_STATE_RESUME_DURABLE_ACK = 4;
     static final int SEND_STATE_RESUME_DURABLE_ACK_THEN_CLOSE = 8;
     static final int SEND_STATE_RESUME_DURABLE_ACK_THEN_ERROR = 5;
@@ -668,12 +669,23 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
                 || sendState == SEND_STATE_RESUME_DURABLE_ACK_THEN_ERROR
                 || sendState == SEND_STATE_RESUME_DURABLE_ACK_THEN_CLOSE) {
             sendState = SEND_STATE_RESUME_DURABLE_ACK_THEN_CLOSE;
+        } else if (sendState == SEND_STATE_RESUME_CLOSE) {
+            // The parked bytes ARE a CLOSE frame (a previous fatal close was
+            // partially flushed). The resume path finishes that flush and
+            // disconnects; the just-stored code/reason are redundant.
+            clearDeferredClose();
         } else {
-            // RESUME_ERROR collapses to RESUME_CLOSE — the app-level error
-            // would have followed the same disconnect anyway, and the CLOSE
-            // frame is a stronger protocol-level signal.
+            // RESUME_PONG / RESUME_ERROR (or a re-entered DRAIN_THEN_CLOSE):
+            // some non-ack response is parked. Drain it on resume, then flush
+            // final ack/durable-ack progress and emit the stored CLOSE frame.
+            // The previous collapse to RESUME_CLOSE was wrong on two counts:
+            // RESUME_CLOSE assumes the parked bytes are the CLOSE frame
+            // itself, so the deferred CLOSE was never written (the client saw
+            // a bare FIN with no close code), and the final durable ack was
+            // dropped with it, leaving a durable-ack client's replay
+            // watermark stale (reconnect-replay duplicates).
             clearDeferredError();
-            sendState = SEND_STATE_RESUME_CLOSE;
+            sendState = SEND_STATE_RESUME_DRAIN_THEN_CLOSE;
         }
     }
 
@@ -693,6 +705,16 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
         lastAckedSequence = resumeAckSequence;
         resumeAckSequence = -1;
         resumeAckSeqTxns.clear();
+        sendState = SEND_STATE_READY;
+    }
+
+    /**
+     * Completes the drain of a parked non-ack response (pong or error
+     * response) that a deferred fatal CLOSE was queued behind. Returns to
+     * READY so the caller can flush final ack/durable-ack progress and emit
+     * the deferred CLOSE frame.
+     */
+    public void onResumeDrainComplete() {
         sendState = SEND_STATE_READY;
     }
 
@@ -832,6 +854,26 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
             rejectMsg.clear();
             rejectMsg.put("unexpected error: ").put(e.getMessage());
             reject(Status.INTERNAL_ERROR, rejectMsg, fd);
+        }
+    }
+
+    /**
+     * Re-parks a deferred fatal CLOSE behind an ack/durable-ack send that
+     * blocked during the resume path's pre-close flush
+     * ({@code QwpIngressUpgradeProcessor#finishDeferredFatalClose}). The
+     * deferred close code/reason are already stored from the original
+     * {@link #onFatalCloseBlocked} call, so this performs only the state
+     * transition. Routing the stored reason back through onFatalCloseBlocked
+     * would clear the reason sink and then append it to itself, losing the
+     * reason.
+     */
+    public void reArmDeferredFatalClose() {
+        assert sendState == SEND_STATE_RESUME_ACK || sendState == SEND_STATE_RESUME_DURABLE_ACK
+                : "reArmDeferredFatalClose called in wrong state: " + sendState;
+        if (sendState == SEND_STATE_RESUME_ACK) {
+            sendState = SEND_STATE_RESUME_ACK_THEN_CLOSE;
+        } else if (sendState == SEND_STATE_RESUME_DURABLE_ACK) {
+            sendState = SEND_STATE_RESUME_DURABLE_ACK_THEN_CLOSE;
         }
     }
 

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -1015,22 +1015,39 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
      * {@link #processMessage()} re-checks the live role per batch, but the flag
      * can flip BETWEEN that check and the WAL writer acquisition (or the commit)
      * within the same batch. The deeper engine gates then refuse with
-     * {@code CairoException.authorization()} ("replica access is read-only"),
-     * which {@link #cairoExceptionStatus} would map to
-     * {@link Status#SECURITY_ERROR} -- a status a store-and-forward client
-     * latches as a terminal HALT and surfaces to its producer. Re-checking the
-     * live flag at catch time closes that window: if the node is (now)
-     * read-only BECAUSE OF ITS ROLE, the refusal is the transient demote, so the
-     * connection is flagged for the same reconnect-eligible close as the
-     * top-gate path (the client reconnects, hits the 421 role reject on the
-     * now-replica endpoint, and retries from SF until a primary is reachable).
-     * A genuine ACL denial on a writable node (isReadOnlyMode() == false) still
-     * maps to SECURITY_ERROR -- and so does any refusal on a STATICALLY
-     * read-only node ({@link #isStaticReadOnlyInstance()}), where the
-     * role-change close has no 421 backstop and would loop the client forever.
+     * {@code CairoException.readOnlyAccess()}, which
+     * {@link #cairoExceptionStatus} would map to {@link Status#SECURITY_ERROR}
+     * -- a status a store-and-forward client latches as a terminal HALT and
+     * surfaces to its producer.
+     * <p>
+     * Classification keys on {@link CairoException#isReadOnlyAccessRefusal()}
+     * -- the marker every read-only gate stamps at the THROW site -- never on
+     * live engine state at catch time. A live {@code engine.isReadOnlyMode()}
+     * re-read here races with a demote REVERT: when the demote fails between
+     * the throw and the catch (real path:
+     * {@code EntCairoEngine.drainWriterPool(restorePrimaryOnTimeout=true)}
+     * restores PRIMARY on drain-budget expiry, and nothing fences the
+     * throw-to-catch propagation -- the commit path releases the role-switch
+     * READ lock as the exception unwinds), the re-read would see writable and
+     * leak the transient refusal as a terminal SECURITY_ERROR for a
+     * milliseconds-long condition on a node that ended up writable PRIMARY.
+     * The marker records the refusal's CAUSE, which no later state flip can
+     * rewrite.
+     * <p>
+     * Shape decision for a marked refusal: role-derived read-only takes the
+     * reconnect-eligible close (the client reconnects, hits the 421 role reject
+     * on the now-replica endpoint, and retries from SF until a primary is
+     * reachable); a STATICALLY read-only node
+     * ({@link #isStaticReadOnlyInstance()}, an immutable config flag -- no
+     * TOCTOU) keeps the terminal SECURITY_ERROR, because the role-change close
+     * has no 421 backstop there and would loop the client forever. A genuine
+     * ACL denial (unmarked authorization error) maps to SECURITY_ERROR
+     * regardless of the node's role at catch time: ACL state is
+     * role-independent, so the terminal NACK is truthful even when the denial
+     * lands mid-demote.
      */
     private void rejectCairoError(CairoException e) {
-        if (e.isAuthorizationError() && engine.isReadOnlyMode() && !isStaticReadOnlyInstance()) {
+        if (e.isReadOnlyAccessRefusal() && !isStaticReadOnlyInstance()) {
             roleChangeClosePending = true;
             reject(Status.NOT_ACCEPTING_WRITES, e.getFlyweightMessage(), fd);
             return;

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -705,16 +705,32 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
             // bypasses per-write authorization entirely. Consulting engine.isReadOnlyMode() here
             // closes that boundary race: the instant the node starts demoting (the dynamic
             // read-only-replica flag flips FIRST in the switch cascade), the whole batch is
-            // rejected as an authorization error, which maps to Status.SECURITY_ERROR below.
+            // refused. HOW it is refused depends on WHY the node is read-only -- see
+            // isStaticReadOnlyInstance() for the contract.
             if (engine.isReadOnlyMode()) {
-                // INVARIANT B: an in-place PRIMARY-to-REPLICA demote is a TRANSIENT
-                // failover (the node can be promoted back / a sibling primary may
-                // exist), NOT a permanent auth failure. Do not reject the batch as an
-                // authorization error (which maps to SECURITY_ERROR and a store-and-
-                // forward client treats as a terminal HALT). Flag the connection for a
-                // reconnect-eligible close instead: the client reconnects, hits the
-                // 421 role reject on the now-replica endpoint, and retries from SF
-                // until a primary is reachable.
+                if (isStaticReadOnlyInstance()) {
+                    // Statically read-only (readonly=true in the server config): a permanent
+                    // property of this process, not a role transition. The role-change close
+                    // is WRONG here because its 421 backstop does not exist -- the upgrade
+                    // gate rejects only ROLE_REPLICA / ROLE_PRIMARY_CATCHUP, and a statically
+                    // read-only node keeps reporting its upgrade-eligible role (STANDALONE on
+                    // OSS) forever. A store-and-forward client treats the resulting
+                    // NORMAL_CLOSURE as orderly (no NACK, no poison strike, no typed
+                    // terminal) and would reconnect-replay in a silent infinite loop, its
+                    // producer never learning of the misconfiguration. Answer with the typed
+                    // SECURITY_ERROR NACK instead: the client latches it as terminal and
+                    // surfaces it loudly.
+                    reject(Status.SECURITY_ERROR, CairoException.READ_ONLY_ACCESS_MESSAGE, fd);
+                    return;
+                }
+                // INVARIANT B: role-derived read-only means an in-place PRIMARY-to-REPLICA
+                // demote is underway -- a TRANSIENT failover (the node can be promoted
+                // back / a sibling primary may exist), NOT a permanent auth failure. Do
+                // not reject the batch as an authorization error (which maps to
+                // SECURITY_ERROR and a store-and-forward client treats as a terminal
+                // HALT). Flag the connection for a reconnect-eligible close instead: the
+                // client reconnects, hits the 421 role reject on the now-replica
+                // endpoint, and retries from SF until a primary is reachable.
                 roleChangeClosePending = true;
                 reject(Status.NOT_ACCEPTING_WRITES, CairoException.READ_ONLY_ACCESS_MESSAGE, fd);
                 return;
@@ -914,6 +930,39 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
     }
 
     /**
+     * Whether this node is read-only STATICALLY -- {@code readonly=true}
+     * ({@code READ_ONLY_INSTANCE}) in the server configuration -- as opposed to
+     * DYNAMICALLY through the role an enterprise engine reports. The distinction
+     * decides the refusal shape for write batches on a read-only node:
+     * <ul>
+     * <li>Role-derived read-only ({@code engine.isReadOnlyMode()} true while this
+     * flag is false; only reachable where an enterprise engine widens
+     * {@code isReadOnlyMode()} with the replica leg) is TRANSIENT. Refusals take
+     * the reconnect-eligible role-change close, and the reconnecting client is
+     * handed over to the 421 role reject of the now-replica endpoint.</li>
+     * <li>Static read-only is PERMANENT. The node's role never changes on account
+     * of it, so the 421 backstop never materialises, and a role-change close
+     * would send a store-and-forward client into a silent infinite
+     * reconnect-replay loop. Refusals must stay the typed, terminal
+     * {@link Status#SECURITY_ERROR} NACK.</li>
+     * </ul>
+     * When BOTH legs hold (an enterprise replica that is also statically
+     * read-only) the static answer wins: the node refuses writes regardless of
+     * any future promote, so the terminal NACK is the truthful signal. (The
+     * combination is unreachable mid-connection anyway -- a statically read-only
+     * node refuses the very first batch, before any role flip can land.)
+     * <p>
+     * The flag is immutable for the process lifetime (a {@code final} field of
+     * the server configuration; the dynamic replica leg is a SEPARATE
+     * configuration method), so consulting it after a live
+     * {@code engine.isReadOnlyMode()} read opens no TOCTOU window: the shape
+     * decision cannot flip between the two reads.
+     */
+    private boolean isStaticReadOnlyInstance() {
+        return engine.getConfiguration().isReadOnlyInstance();
+    }
+
+    /**
      * Rejects a batch that failed with a {@link CairoException}, with Invariant B
      * containment for the in-place demote race.
      * <p>
@@ -926,14 +975,17 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
      * {@link Status#SECURITY_ERROR} -- a status a store-and-forward client
      * latches as a terminal HALT and surfaces to its producer. Re-checking the
      * live flag at catch time closes that window: if the node is (now)
-     * read-only, the refusal is the transient demote, so the connection is
-     * flagged for the same reconnect-eligible close as the top-gate path (the
-     * client reconnects, hits the 421 role reject on the now-replica endpoint,
-     * and retries from SF until a primary is reachable). A genuine ACL denial on
-     * a writable node (isReadOnlyMode() == false) still maps to SECURITY_ERROR.
+     * read-only BECAUSE OF ITS ROLE, the refusal is the transient demote, so the
+     * connection is flagged for the same reconnect-eligible close as the
+     * top-gate path (the client reconnects, hits the 421 role reject on the
+     * now-replica endpoint, and retries from SF until a primary is reachable).
+     * A genuine ACL denial on a writable node (isReadOnlyMode() == false) still
+     * maps to SECURITY_ERROR -- and so does any refusal on a STATICALLY
+     * read-only node ({@link #isStaticReadOnlyInstance()}), where the
+     * role-change close has no 421 backstop and would loop the client forever.
      */
     private void rejectCairoError(CairoException e) {
-        if (e.isAuthorizationError() && engine.isReadOnlyMode()) {
+        if (e.isAuthorizationError() && engine.isReadOnlyMode() && !isStaticReadOnlyInstance()) {
             roleChangeClosePending = true;
             reject(Status.NOT_ACCEPTING_WRITES, e.getFlyweightMessage(), fd);
             return;

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -134,6 +134,19 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
     // events (gate-rejected frames, keepalive PINGs) until the durable-upload
     // registry covers pendingDurableSeqTxns or the grace budget expires.
     private long roleChangeCloseDeferredDeadline = -1;
+    // Lowest sequence number consumed from the wire but neither committed nor
+    // answered with an error response. Only the role-change close path can
+    // leave a sequence in this limbo: it consumes the sequence, then either
+    // closes the connection or defers the close -- in both cases without an
+    // error response, because the refusal is TRANSIENT and the client is
+    // expected to replay from its acked watermark after the reconnect-eligible
+    // close. Cleared only on disconnect: once a sequence is unresolved, the
+    // connection's sole legitimate exit is that close. The cumulative-ack
+    // watermark must never reach this sequence -- a cumulative OK ack confirms
+    // every sequence up to and including its value, so an ack at or past an
+    // unresolved sequence would make a store-and-forward client trim rows the
+    // server never wrote. Enforced in setHighestProcessedSequence.
+    private long firstUnresolvedSequence = -1;
     private SecurityContext securityContext;
     private int sendState = SEND_STATE_READY;
     private QwpStreamingDecoder streamingDecoder;
@@ -457,6 +470,18 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
         return wsHandshakeSent;
     }
 
+    /**
+     * Records a sequence number that was consumed from the wire but will get
+     * neither a commit nor an error response -- the role-change close paths.
+     * Keeps the minimum across calls; {@link #setHighestProcessedSequence}
+     * refuses to advance the cumulative-ack watermark to or past it.
+     */
+    public void markSequenceUnresolved(long seq) {
+        if (firstUnresolvedSequence == -1 || seq < firstUnresolvedSequence) {
+            firstUnresolvedSequence = seq;
+        }
+    }
+
     public long nextMessageSequence() {
         return messageSequence++;
     }
@@ -559,6 +584,7 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
         clearDeferredClose();
         roleChangeCloseDeferredDeadline = -1;
         roleChangeCloseReason.clear();
+        firstUnresolvedSequence = -1;
         wsHandshakeSent = false;
 
         // Drop any durable-ack state; the connection is going away, so even if
@@ -830,6 +856,25 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
     }
 
     public void setHighestProcessedSequence(long highestProcessedSequence) {
+        // LAST-RESORT CONTAINMENT for the cumulative-ack leapfrog: a sequence
+        // flagged by markSequenceUnresolved was refused without an error
+        // response, so no cumulative OK ack may ever cover it -- the client
+        // would trim its store-and-forward slot for rows the server never
+        // wrote. The deferral gate in the upgrade processor's
+        // handleBinaryMessage must prevent any commit after such a refusal;
+        // if the watermark still tries to advance past the unresolved
+        // sequence, that gate has regressed. Clamp and scream: the client
+        // stalls on acks and replays after the close -- an availability hit,
+        // never data loss.
+        if (firstUnresolvedSequence != -1 && highestProcessedSequence >= firstUnresolvedSequence) {
+            LOG.critical().$('[').$(fd)
+                    .$("] cumulative-ack watermark tried to leapfrog an unresolved sequence; clamping [requested=")
+                    .$(highestProcessedSequence)
+                    .$(", firstUnresolved=").$(firstUnresolvedSequence)
+                    .$(']').$();
+            this.highestProcessedSequence = Math.max(this.highestProcessedSequence, firstUnresolvedSequence - 1);
+            return;
+        }
         this.highestProcessedSequence = highestProcessedSequence;
     }
 

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -56,6 +56,15 @@ import io.questdb.std.str.Utf8s;
  */
 public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware {
     static final int SEND_STATE_READY = 0;
+    // Bounded grace (MicrosecondClock ticks) a role-change close may be deferred
+    // while committed-but-not-yet-durably-uploaded work drains. The demote cascade
+    // flips the engine read-only FIRST and completes pending WAL uploads AFTERWARDS,
+    // so at gate-reject time the durable-ack watermark can lag this connection's
+    // committed work by the in-flight upload latency; closing inside that lag loses
+    // the final durable ack forever and forces a duplicate-producing client replay.
+    // Uploads the demote drain is completing land in milliseconds; 10s is a stall
+    // guard, not an expected wait.
+    public static final long ROLE_CHANGE_CLOSE_UPLOAD_GRACE_MICROS = 10_000_000;
     static final int SEND_STATE_RESUME_ACK = 1;
     static final int SEND_STATE_RESUME_ACK_THEN_CLOSE = 7;
     static final int SEND_STATE_RESUME_ACK_THEN_ERROR = 3;
@@ -82,6 +91,7 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
     private final CharSequenceObjHashMap<String> pendingDurableDirNames = new CharSequenceObjHashMap<>();
     private final CharSequenceLongHashMap pendingDurableSeqTxns = new CharSequenceLongHashMap();
     private final StringSink rejectMsg = new StringSink();
+    private final StringSink roleChangeCloseReason = new StringSink();
     private final CharSequenceLongHashMap resumeAckSeqTxns = new CharSequenceLongHashMap();
     private final ConnectionSymbolCache symbolCache = new ConnectionSymbolCache();
     private final CharSequenceObjHashMap<String> tableDirNames = new CharSequenceObjHashMap<>();
@@ -118,6 +128,12 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
     // reconnect-eligible code instead of sending a SECURITY_ERROR that a
     // store-and-forward client would treat as a terminal HALT.
     private boolean roleChangeClosePending;
+    // Deadline (MicrosecondClock ticks) for a deferred role-change close, or -1
+    // when no deferral is in progress. Unlike roleChangeClosePending this survives
+    // per-message clear()/clearMessageState(): the deferral spans multiple inbound
+    // events (gate-rejected frames, keepalive PINGs) until the durable-upload
+    // registry covers pendingDurableSeqTxns or the grace budget expires.
+    private long roleChangeCloseDeferredDeadline = -1;
     private SecurityContext securityContext;
     private int sendState = SEND_STATE_READY;
     private QwpStreamingDecoder streamingDecoder;
@@ -370,6 +386,65 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
         return roleChangeClosePending;
     }
 
+    /**
+     * Starts (or keeps, if already started) the bounded deferral of a role-change
+     * close, stashing {@code reason} for the eventual CLOSE frame. No-op when a
+     * deferral is already in progress so the deadline is never extended by
+     * follow-on gate-rejected frames.
+     */
+    public void deferRoleChangeClose(CharSequence reason) {
+        if (roleChangeCloseDeferredDeadline == -1) {
+            roleChangeCloseDeferredDeadline = configuration.getMicrosecondClock().getTicks()
+                    + ROLE_CHANGE_CLOSE_UPLOAD_GRACE_MICROS;
+            roleChangeCloseReason.clear();
+            if (reason != null) {
+                roleChangeCloseReason.put(reason);
+            }
+        }
+    }
+
+    public CharSequence getRoleChangeCloseReason() {
+        return roleChangeCloseReason;
+    }
+
+    /**
+     * True while a role-change close is deferred awaiting durable-upload coverage
+     * of this connection's committed work.
+     */
+    public boolean isRoleChangeCloseDeferred() {
+        return roleChangeCloseDeferredDeadline != -1;
+    }
+
+    /**
+     * True when a deferred role-change close has exhausted its grace budget and
+     * must proceed even with un-acked durable work (availability over the
+     * duplicate guard). Always false when no deferral is in progress.
+     */
+    public boolean isRoleChangeCloseGraceExpired() {
+        return roleChangeCloseDeferredDeadline != -1
+                && configuration.getMicrosecondClock().getTicks() >= roleChangeCloseDeferredDeadline;
+    }
+
+    /**
+     * True when every seqTxn this connection has committed but not yet durably
+     * acked is covered by the registry's durable-upload watermark -- i.e. a
+     * durable ack flushed right now would advance the client's replay watermark
+     * past ALL of this connection's committed work, leaving no replay window.
+     * Trivially true when nothing is pending (or durable ack is disabled:
+     * {@code pendingDurableSeqTxns} is only populated when enabled).
+     */
+    public boolean isDurableWorkFullyUploaded(DurableAckRegistry registry) {
+        ObjList<CharSequence> tableNames = pendingDurableSeqTxns.keys();
+        for (int i = 0, n = tableNames.size(); i < n; i++) {
+            CharSequence tableName = tableNames.getQuick(i);
+            String dirName = pendingDurableDirNames.get(tableName);
+            if (dirName == null || registry.getDurablyUploadedSeqTxn(dirName) < pendingDurableSeqTxns.get(tableName)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public boolean isSendReady() {
         return sendState == SEND_STATE_READY;
     }
@@ -482,6 +557,8 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
         sendState = SEND_STATE_READY;
         clearDeferredError();
         clearDeferredClose();
+        roleChangeCloseDeferredDeadline = -1;
+        roleChangeCloseReason.clear();
         wsHandshakeSent = false;
 
         // Drop any durable-ack state; the connection is going away, so even if

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -159,6 +159,20 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
     // server never wrote. Enforced in setHighestProcessedSequence.
     private long firstUnresolvedSequence = -1;
     private SecurityContext securityContext;
+    // True while WAL rows appended by FLAG_DEFER_COMMIT frames remain
+    // uncommitted. Set when a deferred frame's rows are buffered, cleared when
+    // commitAll() succeeds (the group-closing commit frame) or when clear()
+    // rolls the rows back. While true, the cumulative-ack watermark must not
+    // advance: a cumulative OK ack confirms every sequence up to and including
+    // its value, so covering an uncommitted deferred frame would let a
+    // store-and-forward client trim slots whose rows the server can still roll
+    // back -- silent data loss. This is the contract stated (but previously not
+    // enforced) by the deferred-commit feature (#7144): "the client's
+    // store-and-forward replays all unacknowledged messages on reconnect" --
+    // deferred frames must therefore stay unacknowledged until their group
+    // commits. Enforced in setHighestProcessedSequence as a last resort; the
+    // upgrade processor's ack path must not attempt the advance to begin with.
+    private boolean uncommittedDeferredRows;
     private int sendState = SEND_STATE_READY;
     private QwpStreamingDecoder streamingDecoder;
     private QwpTudCache tudCache;
@@ -233,6 +247,10 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
         handshakeFlushPending = false;
         pendingHandshakeBytes = 0;
         roleChangeClosePending = false;
+        // tudCache.clear() above rolled back any uncommitted deferred rows;
+        // the deferred group is gone, its frames were never acked, and the
+        // client replays them from its acked watermark.
+        uncommittedDeferredRows = false;
     }
 
     /**
@@ -291,6 +309,11 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
     public void commit() {
         try {
             tudCache.commitAll(committedTxnConsumer);
+            // commitAll covers every table this connection buffered rows for,
+            // including rows accumulated by FLAG_DEFER_COMMIT frames -- the
+            // deferred group (if any) is now durable in the WAL and the
+            // cumulative-ack watermark may advance over it.
+            uncommittedDeferredRows = false;
         } catch (Throwable th) {
             tudCache.setDistressed();
             LOG.error().$('[').$(fd).$("] commit error: ").$(th).$();
@@ -384,6 +407,15 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
      */
     public boolean hasPendingAck() {
         return sendState == SEND_STATE_READY && highestProcessedSequence > lastAckedSequence;
+    }
+
+    /**
+     * True while WAL rows appended by FLAG_DEFER_COMMIT frames remain
+     * uncommitted. While true, no cumulative OK ack may cover the deferred
+     * frames' sequences -- see {@link #setHighestProcessedSequence}.
+     */
+    public boolean hasUncommittedDeferredRows() {
+        return uncommittedDeferredRows;
     }
 
     public boolean isDeferCommit() {
@@ -491,6 +523,18 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
         if (firstUnresolvedSequence == -1 || seq < firstUnresolvedSequence) {
             firstUnresolvedSequence = seq;
         }
+    }
+
+    /**
+     * Records that a FLAG_DEFER_COMMIT frame buffered rows into WAL writers
+     * without a covering commit. Cleared by {@link #commit()} (successful
+     * commitAll) or {@link #clear()} (rollback). The per-table force-commit
+     * at the max-uncommitted-rows cap does NOT clear this: it commits single
+     * tables and gives no full-coverage guarantee, so the watermark stays put
+     * and those rows are simply replayed (at-least-once) after a reconnect.
+     */
+    public void markUncommittedDeferredRows() {
+        uncommittedDeferredRows = true;
     }
 
     public long nextMessageSequence() {
@@ -925,6 +969,22 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
                     .$(", firstUnresolved=").$(firstUnresolvedSequence)
                     .$(']').$();
             this.highestProcessedSequence = Math.max(this.highestProcessedSequence, firstUnresolvedSequence - 1);
+            return;
+        }
+        // LAST-RESORT CONTAINMENT for the deferred-commit ack hole (#7144): while
+        // FLAG_DEFER_COMMIT rows sit uncommitted in WAL writers, a cumulative OK
+        // ack covering their frames would let the client trim slots the server
+        // can still roll back. The upgrade processor's ack path skips the
+        // advance for deferred frames entirely; if the watermark still tries to
+        // move while deferred rows are uncommitted, that path has regressed.
+        // Clamp and scream: the client stalls on acks and replays after the
+        // close -- an availability hit, never data loss.
+        if (uncommittedDeferredRows && highestProcessedSequence > this.highestProcessedSequence) {
+            LOG.critical().$('[').$(fd)
+                    .$("] cumulative-ack watermark tried to advance over uncommitted deferred rows; clamping [requested=")
+                    .$(highestProcessedSequence)
+                    .$(", current=").$(this.highestProcessedSequence)
+                    .$(']').$();
             return;
         }
         this.highestProcessedSequence = highestProcessedSequence;

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -525,6 +525,11 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
         }
     }
 
+    // Survives per-message clear(); reset only on onDisconnected().
+    public boolean hasUnresolvedSequence() {
+        return firstUnresolvedSequence != -1;
+    }
+
     /**
      * Records that a FLAG_DEFER_COMMIT frame buffered rows into WAL writers
      * without a covering commit. Cleared by {@link #commit()} (successful

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -56,14 +56,24 @@ import io.questdb.std.str.Utf8s;
  */
 public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware {
     static final int SEND_STATE_READY = 0;
-    // Bounded grace (MicrosecondClock ticks) a role-change close may be deferred
-    // while committed-but-not-yet-durably-uploaded work drains. The demote cascade
+    // Bounded grace a role-change close may be deferred while
+    // committed-but-not-yet-durably-uploaded work drains. The demote cascade
     // flips the engine read-only FIRST and completes pending WAL uploads AFTERWARDS,
     // so at gate-reject time the durable-ack watermark can lag this connection's
     // committed work by the in-flight upload latency; closing inside that lag loses
     // the final durable ack forever and forces a duplicate-producing client replay.
-    // Uploads the demote drain is completing land in milliseconds; 10s is a stall
-    // guard, not an expected wait.
+    //
+    // NOTE: this budget is NOT a wall-clock teardown bound. Completion -- coverage
+    // OR expiry -- is evaluated ONLY on inbound, recv-driven re-entry: a gate-refused
+    // data frame (handleBinaryMessage) or the client's durable-ack keepalive PING
+    // (handlePing). There is no server-side timer and resumeSend does not re-poll, so
+    // the deadline is measured in MicrosecondClock ticks but enforced only while the
+    // client is live enough to poll. A conformant durable-ack client PINGs and
+    // completes in milliseconds (the demote drain's uploads land that fast); a fully
+    // silent client lingers deferred until the transport idle reaper tears the
+    // connection down via onConnectionClosed (best-effort final durable-ack flush,
+    // no CLOSE frame). 10s is a stall guard for the live-client path, not a
+    // guaranteed deadline.
     public static final long ROLE_CHANGE_CLOSE_UPLOAD_GRACE_MICROS = 10_000_000;
     static final int SEND_STATE_RESUME_ACK = 1;
     static final int SEND_STATE_RESUME_ACK_THEN_CLOSE = 7;

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
@@ -821,7 +821,6 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
 
             // Process the QWP v1 message
             state.processMessage();
-            roleChangeClose = state.isRoleChangeClosePending();
 
             if (state.isOk() && !deferCommit) {
                 state.commit();
@@ -829,6 +828,12 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
             if (state.isOk() && deferCommit) {
                 state.commitIfMaxUncommittedRowsReached();
             }
+            // Read AFTER the commit calls: processMessage's read-only gate AND the
+            // commit path's authorization-refusal containment (rejectCairoError)
+            // can both flag the role-change close; reading before commit() would
+            // miss the latter and send a client-visible error status instead of
+            // the graceful reconnect-eligible close.
+            roleChangeClose = state.isRoleChangeClosePending();
             // commit() swallows exceptions internally
             if (state.isOk()) {
                 if (deferCommit) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
@@ -796,7 +796,7 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
     }
 
     private void handleBinaryMessage(HttpConnectionContext context, QwpIngressProcessorState state, long payload, int length)
-            throws PeerDisconnectedException, PeerIsSlowToReadException {
+            throws PeerDisconnectedException, PeerIsSlowToReadException, ServerDisconnectException {
         long seq = state.nextMessageSequence();
         LOG.debug().$("WebSocket binary message [fd=").$(context.getFd())
                 .$(", len=").$(length)
@@ -810,6 +810,7 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
 
         byte responseStatus = STATUS_OK;
         String errorMessage = null;
+        boolean roleChangeClose = false;
 
         boolean deferCommit = false;
         try {
@@ -820,6 +821,7 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
 
             // Process the QWP v1 message
             state.processMessage();
+            roleChangeClose = state.isRoleChangeClosePending();
 
             if (state.isOk() && !deferCommit) {
                 state.commit();
@@ -863,6 +865,17 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
                 // Reset state for next message (but preserve connectionSymbolDict for delta encoding)
                 state.clear();
             }
+        }
+
+        // INVARIANT B: an in-place PRIMARY->REPLICA demote is TRANSIENT. Close the
+        // connection with a reconnect-eligible code instead of sending a
+        // SECURITY_ERROR that a store-and-forward client treats as a terminal HALT.
+        // sendFatalClose first flushes any pending ACK (so the client learns what
+        // committed); the client then reconnects, hits the 421 role reject on the
+        // now-replica endpoint, and retries from SF.
+        if (roleChangeClose) {
+            sendFatalClose(context, state, WebSocketCloseCode.NORMAL_CLOSURE, errorMessage);
+            return;
         }
 
         // Send response using cumulative ACK strategy

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
@@ -802,6 +802,26 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
                 .$(", len=").$(length)
                 .$(", seq=").$(seq).I$();
 
+        // INVARIANT B enforcement: while a role-change close deferral is armed,
+        // the connection exists ONLY to deliver the final durable ack before
+        // the CLOSE frame. Data frames arriving in this window must not touch
+        // the engine: the demote can revert within the grace period (in-place
+        // re-promote), and a frame that slipped past the live read-only gate
+        // would commit and advance the cumulative-ack watermark PAST the
+        // silently refused frame that armed the deferral -- the client would
+        // trim that frame's store-and-forward slot and its rows would be lost.
+        // Treat every data frame in this window exactly like the refused frame
+        // that armed the deferral: consume its sequence (the client replays it
+        // after the reconnect-eligible close), record it as unresolved for the
+        // ack clamp, and re-poll the deferral for coverage/expiry.
+        if (state.isRoleChangeCloseDeferred()) {
+            LOG.debug().$("WebSocket data frame refused, role-change close deferral armed [fd=").$(context.getFd())
+                    .$(", seq=").$(seq).I$();
+            state.markSequenceUnresolved(seq);
+            roleChangeCloseWithUploadGrace(context, state, state.getRoleChangeCloseReason());
+            return;
+        }
+
         if (!state.isOk()) {
             LOG.debug().$("WebSocket ignoring message, state is in error [fd=").$(context.getFd()).I$();
             sendErrorResponse(context, state, seq, STATUS_INTERNAL_ERROR, "Previous message failed");
@@ -880,6 +900,11 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
         // final durable ack is delivered BEFORE the CLOSE frame and the client's
         // replay window is empty -- see roleChangeCloseWithUploadGrace.
         if (roleChangeClose) {
+            // No error response goes out for this frame -- the refusal is
+            // transient and the client replays from its acked watermark after
+            // the reconnect-eligible close. Until that close, no cumulative
+            // OK ack may cover this sequence.
+            state.markSequenceUnresolved(seq);
             roleChangeCloseWithUploadGrace(context, state, errorMessage);
             return;
         }
@@ -1059,8 +1084,12 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
      * So: while committed work remains un-uploaded, DEFER the close (bounded by
      * {@link QwpIngressProcessorState#ROLE_CHANGE_CLOSE_UPLOAD_GRACE_MICROS})
      * and keep flushing ack progress. Re-entry points during the deferral are
-     * further gate-rejected data frames (this method) and the client's
-     * durable-ack keepalive PINGs ({@link #handlePing}). Once the registry
+     * further data frames (refused by the deferral gate at the top of
+     * {@code handleBinaryMessage} BEFORE they can touch the engine -- the live
+     * read-only gate alone is not sufficient, because an in-place re-promote
+     * within the grace window would let a frame commit and advance the
+     * cumulative ack past the silently refused frame that armed the deferral)
+     * and the client's durable-ack keepalive PINGs ({@link #handlePing}). Once the registry
      * covers the connection's pending seqTxns, sendFatalClose flushes the final
      * durable ack and only then emits NORMAL_CLOSURE: the replay window is
      * empty and every in-flight batch lands exactly once. If uploads stall past

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
@@ -597,13 +597,19 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
                 state.onResumeAckComplete();
                 LOG.debug().$("Resumed ACK sent before fatal close [fd=").$(context.getFd())
                         .$(", upTo=").$(state.getLastAckedSequence()).I$();
-                sendDeferredFatalClose(context, state);
+                finishDeferredFatalClose(context, state);
             }
             case QwpIngressProcessorState.SEND_STATE_RESUME_DURABLE_ACK_THEN_CLOSE -> {
                 context.resumeResponseSend();
                 state.onResumeDurableAckComplete();
                 LOG.debug().$("Resumed durable ACK sent before fatal close [fd=").$(context.getFd()).I$();
-                sendDeferredFatalClose(context, state);
+                finishDeferredFatalClose(context, state);
+            }
+            case QwpIngressProcessorState.SEND_STATE_RESUME_DRAIN_THEN_CLOSE -> {
+                context.resumeResponseSend();
+                state.onResumeDrainComplete();
+                LOG.debug().$("Resumed parked response drained before fatal close [fd=").$(context.getFd()).I$();
+                finishDeferredFatalClose(context, state);
             }
             case QwpIngressProcessorState.SEND_STATE_RESUME_CLOSE -> {
                 context.resumeResponseSend();
@@ -747,6 +753,7 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
             }
             case QwpIngressProcessorState.SEND_STATE_RESUME_ACK_THEN_CLOSE,
                  QwpIngressProcessorState.SEND_STATE_RESUME_DURABLE_ACK_THEN_CLOSE,
+                 QwpIngressProcessorState.SEND_STATE_RESUME_DRAIN_THEN_CLOSE,
                  QwpIngressProcessorState.SEND_STATE_RESUME_CLOSE -> // The peer is voluntarily closing, but we have a fatal CLOSE
                 // queued. The pending response will be torn down anyway, so
                 // there is no value in attempting to flush the deferred CLOSE
@@ -763,6 +770,39 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
                 throw PeerDisconnectedException.INSTANCE;
             }
         }
+    }
+
+    /**
+     * Resume-path completion of a deferred fatal CLOSE: flushes pending
+     * cumulative/durable ack progress first, then emits the CLOSE frame — the
+     * same ordering {@link #sendFatalClose} guarantees on the happy path.
+     * <p>
+     * This ordering carries the role-change close deferral's invariant
+     * ({@link #roleChangeCloseWithUploadGrace}): the final durable ack must
+     * precede the CLOSE frame, because a durable-ack store-and-forward client
+     * advances its replay/trim watermark only on STATUS_DURABLE_ACK frames.
+     * Emitting the CLOSE without it leaves the watermark stale, and on
+     * reconnect the client replays batches this server (or the promoted
+     * replica, via replication) already owns — duplicates on tables without
+     * DEDUP UPSERT KEYS, precisely under send backpressure at demote time.
+     * The pre-fix resume branches called {@link #sendDeferredFatalClose}
+     * directly, so any CLOSE that was ever deferred behind a blocked send
+     * skipped the final durable ack entirely.
+     * <p>
+     * If the flush blocks again, the CLOSE is re-parked behind the newly
+     * blocked ack frame and the dispatcher resumes us; every resume drains
+     * one parked frame, so the sequence terminates.
+     */
+    private void finishDeferredFatalClose(HttpConnectionContext context, QwpIngressProcessorState state)
+            throws PeerDisconnectedException, PeerIsSlowToReadException, ServerDisconnectException {
+        try {
+            flushPendingAck(context, state);
+        } catch (PeerIsSlowToReadException e) {
+            state.reArmDeferredFatalClose();
+            LOG.debug().$("Pre-close ack flush blocked, re-deferring fatal CLOSE [fd=").$(context.getFd()).I$();
+            throw e;
+        }
+        sendDeferredFatalClose(context, state);
     }
 
     private void flushPendingAck(HttpConnectionContext context, QwpIngressProcessorState state)

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
@@ -1057,11 +1057,14 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
         // keepalive PING is the recv-driven poll that observes upload completion
         // (durable acks are only ever flushed on inbound events). The flush above
         // already delivered any newly-covered durable ack; once coverage is full
-        // (or the grace budget is exhausted) emit the reconnect-eligible close.
-        if (state.isRoleChangeCloseDeferred()
-                && (state.isDurableWorkFullyUploaded(engine.getDurableAckRegistry())
-                || state.isRoleChangeCloseGraceExpired())) {
-            sendFatalClose(context, state, WebSocketCloseCode.NORMAL_CLOSURE, state.getRoleChangeCloseReason());
+        // (or the grace budget is exhausted) the close is routed through
+        // roleChangeCloseWithUploadGrace -- the same exit the gate-refused
+        // data-frame re-entry takes -- so close behaviour and diagnostics
+        // cannot drift between the two polls (a grace-expired close observed
+        // by PING used to proceed silently, skipping the un-acked-durable-work
+        // alarm). While the deferral holds, fall through to the pong keepalive.
+        if (state.isRoleChangeCloseDeferred() && isRoleChangeCloseCompletable(state)) {
+            roleChangeCloseWithUploadGrace(context, state, state.getRoleChangeCloseReason());
             return;
         }
 
@@ -1107,6 +1110,20 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
     }
 
     /**
+     * Completion predicate for a deferred role-change close: the registry's
+     * durable-upload watermark covers every committed seqTxn (replay window
+     * empty), or the bounded grace budget is exhausted (availability over the
+     * duplicate guard). Single source of truth shared by the deferral's two
+     * re-entry polls -- gate-refused data frames and keepalive PINGs
+     * ({@link #handlePing}) -- so the close path and its diagnostics cannot
+     * drift between them.
+     */
+    private boolean isRoleChangeCloseCompletable(QwpIngressProcessorState state) {
+        return state.isDurableWorkFullyUploaded(engine.getDurableAckRegistry())
+                || state.isRoleChangeCloseGraceExpired();
+    }
+
+    /**
      * INVARIANT B role-change close with an exactly-once guard for durable-ack
      * connections.
      * <p>
@@ -1144,9 +1161,7 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
             QwpIngressProcessorState state,
             CharSequence reason
     ) throws PeerDisconnectedException, PeerIsSlowToReadException, ServerDisconnectException {
-        if (state.isDurableAckEnabled()
-                && !state.isDurableWorkFullyUploaded(engine.getDurableAckRegistry())
-                && !state.isRoleChangeCloseGraceExpired()) {
+        if (state.isDurableAckEnabled() && !isRoleChangeCloseCompletable(state)) {
             boolean firstDeferral = !state.isRoleChangeCloseDeferred();
             state.deferRoleChangeClose(reason);
             if (firstDeferral) {
@@ -1159,7 +1174,12 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
             flushPendingAck(context, state);
             return;
         }
-        if (state.isRoleChangeCloseGraceExpired()) {
+        if (state.isRoleChangeCloseGraceExpired()
+                && !state.isDurableWorkFullyUploaded(engine.getDurableAckRegistry())) {
+            // Grace expired with genuinely un-acked durable work: the one
+            // close the operator must see. A slow-but-clean close -- uploads
+            // catching up after the deadline but before this re-entry --
+            // leaves an empty replay window and must not raise this alarm.
             LOG.error().$("role-change close upload grace expired; closing with un-acked durable work, client replay may duplicate [fd=")
                     .$(context.getFd()).I$();
         }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
@@ -875,11 +875,12 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
         // INVARIANT B: an in-place PRIMARY->REPLICA demote is TRANSIENT. Close the
         // connection with a reconnect-eligible code instead of sending a
         // SECURITY_ERROR that a store-and-forward client treats as a terminal HALT.
-        // sendFatalClose first flushes any pending ACK (so the client learns what
-        // committed); the client then reconnects, hits the 421 role reject on the
-        // now-replica endpoint, and retries from SF.
+        // For durable-ack connections the close is deferred (bounded) until the
+        // durable-upload registry covers this connection's committed work, so the
+        // final durable ack is delivered BEFORE the CLOSE frame and the client's
+        // replay window is empty -- see roleChangeCloseWithUploadGrace.
         if (roleChangeClose) {
-            sendFatalClose(context, state, WebSocketCloseCode.NORMAL_CLOSURE, errorMessage);
+            roleChangeCloseWithUploadGrace(context, state, errorMessage);
             return;
         }
 
@@ -976,7 +977,7 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
     }
 
     private void handlePing(HttpConnectionContext context, QwpIngressProcessorState state, long payload, int length)
-            throws PeerDisconnectedException, PeerIsSlowToReadException {
+            throws PeerDisconnectedException, PeerIsSlowToReadException, ServerDisconnectException {
         // PING is a documented flush point for pending ACK/durable-ACK frames.
         // A client may send PING specifically to prod the server into emitting
         // acks for commits whose uploads have completed since the last message.
@@ -986,6 +987,18 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
         // that, the parked ACK bytes would sit unsent in the response sink
         // until the next unrelated write.
         flushPendingAck(context, state);
+
+        // A deferred role-change close completes here: the client's durable-ack
+        // keepalive PING is the recv-driven poll that observes upload completion
+        // (durable acks are only ever flushed on inbound events). The flush above
+        // already delivered any newly-covered durable ack; once coverage is full
+        // (or the grace budget is exhausted) emit the reconnect-eligible close.
+        if (state.isRoleChangeCloseDeferred()
+                && (state.isDurableWorkFullyUploaded(engine.getDurableAckRegistry())
+                || state.isRoleChangeCloseGraceExpired())) {
+            sendFatalClose(context, state, WebSocketCloseCode.NORMAL_CLOSURE, state.getRoleChangeCloseReason());
+            return;
+        }
 
         // Can only send pong when the response sink is clear. If a prior ACK
         // is still draining we skip the pong rather than interleave bytes;
@@ -1026,6 +1039,67 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
             LOG.debug().$("Pong send blocked, deferring to resume [fd=").$(context.getFd()).I$();
             throw e;
         }
+    }
+
+    /**
+     * INVARIANT B role-change close with an exactly-once guard for durable-ack
+     * connections.
+     * <p>
+     * The demote cascade flips the engine read-only FIRST and completes pending
+     * WAL uploads AFTERWARDS, so at the instant the read-only gate rejects a
+     * frame the durable-ack watermark can lag this connection's committed work
+     * by the in-flight upload latency. Closing inside that lag loses the final
+     * durable ack forever -- durable acks are recv-driven, so there is no
+     * delivery opportunity after the CLOSE frame -- while the demote drain
+     * still publishes those commits to the object store. A store-and-forward
+     * client (whose replay watermark advances ONLY on durable acks) would then
+     * replay a batch the promoted replica already converged to via replication,
+     * landing it twice on tables without DEDUP UPSERT KEYS.
+     * <p>
+     * So: while committed work remains un-uploaded, DEFER the close (bounded by
+     * {@link QwpIngressProcessorState#ROLE_CHANGE_CLOSE_UPLOAD_GRACE_MICROS})
+     * and keep flushing ack progress. Re-entry points during the deferral are
+     * further gate-rejected data frames (this method) and the client's
+     * durable-ack keepalive PINGs ({@link #handlePing}). Once the registry
+     * covers the connection's pending seqTxns, sendFatalClose flushes the final
+     * durable ack and only then emits NORMAL_CLOSURE: the replay window is
+     * empty and every in-flight batch lands exactly once. If uploads stall past
+     * the grace budget the close proceeds anyway -- availability over the
+     * duplicate guard, matching the pre-deferral behaviour.
+     * <p>
+     * Non-durable-ack connections close immediately: their cumulative OK ack is
+     * flushed synchronously by sendFatalClose and carries no upload lag.
+     */
+    private void roleChangeCloseWithUploadGrace(
+            HttpConnectionContext context,
+            QwpIngressProcessorState state,
+            CharSequence reason
+    ) throws PeerDisconnectedException, PeerIsSlowToReadException, ServerDisconnectException {
+        if (state.isDurableAckEnabled()
+                && !state.isDurableWorkFullyUploaded(engine.getDurableAckRegistry())
+                && !state.isRoleChangeCloseGraceExpired()) {
+            boolean firstDeferral = !state.isRoleChangeCloseDeferred();
+            state.deferRoleChangeClose(reason);
+            if (firstDeferral) {
+                LOG.info().$("deferring role-change close until committed work is durably uploaded [fd=")
+                        .$(context.getFd()).I$();
+            }
+            // Push whatever cumulative/durable progress exists right now; the
+            // final durable ack goes out with the close itself once coverage
+            // is confirmed.
+            flushPendingAck(context, state);
+            return;
+        }
+        if (state.isRoleChangeCloseGraceExpired()) {
+            LOG.error().$("role-change close upload grace expired; closing with un-acked durable work, client replay may duplicate [fd=")
+                    .$(context.getFd()).I$();
+        }
+        sendFatalClose(
+                context,
+                state,
+                WebSocketCloseCode.NORMAL_CLOSURE,
+                state.isRoleChangeCloseDeferred() ? state.getRoleChangeCloseReason() : reason
+        );
     }
 
     private void handleWebSocketFrame(HttpConnectionContext context, QwpIngressProcessorState state, int opcode, boolean fin, long payload, int length)

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
@@ -862,6 +862,17 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
             return;
         }
 
+        // A prior error broke the ordered pipeline: committing a later pipelined
+        // frame would advance committed data past the gap the acked watermark
+        // stopped at. Consume the sequence without touching the engine; the
+        // client replays it from its acked watermark on a fresh connection.
+        if (state.hasUnresolvedSequence()) {
+            LOG.debug().$("WebSocket frame refused, connection pipeline broken by a prior error [fd=").$(context.getFd())
+                    .$(", seq=").$(seq).I$();
+            state.markSequenceUnresolved(seq);
+            return;
+        }
+
         if (!state.isOk()) {
             LOG.debug().$("WebSocket ignoring message, state is in error [fd=").$(context.getFd()).I$();
             sendErrorResponse(context, state, seq, STATUS_INTERNAL_ERROR, "Previous message failed");
@@ -994,6 +1005,9 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
                 }
             }
         } else {
+            // Before any flush that may defer, so a blocked error frame still
+            // clamps the watermark and refuses the pipelined tail.
+            state.markSequenceUnresolved(seq);
             // Error - first ACK all successful messages (if in READY state), then send error
             if (state.hasPendingAck()) {
                 try {

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressUpgradeProcessor.java
@@ -873,6 +873,7 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
         boolean roleChangeClose = false;
 
         boolean deferCommit = false;
+        boolean closesDeferredGroup = false;
         try {
             // Add the binary data to the state buffer
             state.addData(payload, payload + length);
@@ -883,10 +884,27 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
             state.processMessage();
 
             if (state.isOk() && !deferCommit) {
+                // Capture BEFORE commit(): a successful commitAll() clears the
+                // uncommitted-deferred-rows flag, and this frame's ack must then
+                // flush eagerly -- the group's deferred frames were never
+                // individually acked, so the client's store-and-forward slots
+                // (and, in durable-ack mode, seqTxn tracking) all hinge on the
+                // ack that covers this group-closing sequence.
+                closesDeferredGroup = state.hasUncommittedDeferredRows();
                 state.commit();
             }
             if (state.isOk() && deferCommit) {
                 state.commitIfMaxUncommittedRowsReached();
+                if (state.isOk()) {
+                    // Rows are buffered in WAL writers but NOT committed (the
+                    // force-commit above fires per-table at the
+                    // max-uncommitted-rows cap and gives no full-coverage
+                    // guarantee). Until the group-closing commit or a rollback,
+                    // the cumulative-ack watermark must not move past this
+                    // frame -- an OK ack would let the client trim rows the
+                    // server can still roll back (#7144's replay contract).
+                    state.markUncommittedDeferredRows();
+                }
             }
             // Read AFTER the commit calls: processMessage's read-only gate AND the
             // commit path's authorization-refusal containment (rejectCairoError)
@@ -951,10 +969,29 @@ public class QwpIngressUpgradeProcessor implements HttpRequestProcessor {
 
         // Send response using cumulative ACK strategy
         if (responseStatus == STATUS_OK) {
-            // Success - update tracking, send ACK if batch size reached
-            state.setHighestProcessedSequence(seq);
-            if (state.shouldSendAck(ACK_BATCH_SIZE)) {
-                trySendAck(context, state);
+            if (deferCommit) {
+                // Deferred frame: rows appended but uncommitted. NO watermark
+                // advance and NO ack -- a cumulative OK ack at this sequence
+                // would let the store-and-forward client trim slots whose rows
+                // the server rolls back on any error, demote, or disconnect.
+                // Coverage for this frame arrives with the ack of the
+                // group-closing commit frame (cumulative semantics), which also
+                // carries the group's real per-table seqTxns for durable-ack
+                // tracking. Until then the frame stays replayable client-side,
+                // exactly as #7144's error-handling contract requires.
+                LOG.debug().$("WebSocket deferred frame ack withheld until group commit [fd=").$(context.getFd())
+                        .$(", seq=").$(seq).I$();
+            } else {
+                // Success - update tracking, send ACK if batch size reached.
+                // A group-closing commit flushes eagerly (hasPendingAck) instead
+                // of waiting for the batch threshold: the deferred frames it
+                // covers were never individually acked, and the client's
+                // transaction confirmation should not wait for unrelated
+                // follow-up traffic.
+                state.setHighestProcessedSequence(seq);
+                if (closesDeferredGroup ? state.hasPendingAck() : state.shouldSendAck(ACK_BATCH_SIZE)) {
+                    trySendAck(context, state);
+                }
             }
         } else {
             // Error - first ACK all successful messages (if in READY state), then send error

--- a/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCompilerImpl.java
@@ -1766,7 +1766,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
             // the auth call. The eager check alone does not close the demote window though -- a
             // demote landing between here and the marker write would still strand the marker on a
             // demoting node; the role-switch read-lock hold around the write below is what closes it.
-            throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+            throw CairoException.readOnlyAccess();
         }
         executionContext.getSecurityContext().authorizeAlterTableSetType(tableToken);
         try {
@@ -1799,7 +1799,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                 lock.lock();
                 try {
                     if (engine.isReadOnlyMode()) {
-                        throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                        throw CairoException.readOnlyAccess();
                     }
                     engine.fireRoleSwitchMintObserver();
                     path.of(configuration.getDbRoot()).concat(tableToken.getDirName());
@@ -3166,7 +3166,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         // table registry, so the caller sees "replica access is read-only" rather than
         // "table does not exist" when the table has not yet been replicated to this node.
         if (engine.isReadOnlyMode()) {
-            throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+            throw CairoException.readOnlyAccess();
         }
         final ExpressionNode tableNameExpr = insertModel.getTableNameExpr();
         InsertOperationImpl insertOperation = null;
@@ -3296,7 +3296,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
         // table registry, so the caller sees "replica access is read-only" rather than
         // "table does not exist" when the table has not yet been replicated to this node.
         if (engine.isReadOnlyMode()) {
-            throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+            throw CairoException.readOnlyAccess();
         }
         final InsertModel model = (InsertModel) executionModel;
         final ExpressionNode tableNameExpr = model.getTableNameExpr();
@@ -3577,7 +3577,7 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                 // Refuse the instant the node goes read-only, mirroring the per-statement write gates
                 // on the pg-wire and HTTP /exec paths -- otherwise this enqueues an async refresh that
                 // writes to a node that is already demoting and loses the write once it settles.
-                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                throw CairoException.readOnlyAccess();
             }
             final MatViewStateStore matViewStateStore = engine.getMatViewStateStore();
             if (isStatsReset) {
@@ -3832,13 +3832,13 @@ public class SqlCompilerImpl implements SqlCompiler, Closeable, SqlParserCallbac
                             // this runs fully as PRIMARY while the flip's write acquire waits. The fence
                             // is a no-op for pure-OSS deployments (uncontended read lock, static flag).
                             if (engine.isReadOnlyMode()) {
-                                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                                throw CairoException.readOnlyAccess();
                             }
                             final Lock lock = engine.getRoleSwitchReadLock();
                             lock.lock();
                             try {
                                 if (engine.isReadOnlyMode()) {
-                                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                                    throw CairoException.readOnlyAccess();
                                 }
                                 engine.fireRoleSwitchMintObserver();
                                 writer.truncateSoft();

--- a/core/src/main/java/io/questdb/griffin/engine/ops/InsertAsSelectOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/InsertAsSelectOperationImpl.java
@@ -159,7 +159,7 @@ public class InsertAsSelectOperationImpl implements InsertOperation {
             // no writer-generation barrier is needed.
             if (engine.isReadOnlyMode()) {
                 writer.rollback();
-                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                throw CairoException.readOnlyAccess();
             }
             final Lock lock = engine.getRoleSwitchReadLock();
             lock.lock();
@@ -171,7 +171,7 @@ public class InsertAsSelectOperationImpl implements InsertOperation {
                 // tables/protocols share the read side and never serialize against each other.
                 if (engine.isReadOnlyMode()) {
                     writer.rollback();
-                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                    throw CairoException.readOnlyAccess();
                 }
                 writer.commit();
             } finally {

--- a/core/src/main/java/io/questdb/griffin/engine/ops/InsertOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/InsertOperationImpl.java
@@ -135,7 +135,7 @@ public class InsertOperationImpl implements InsertOperation {
             // sole externalization point, so the in-lock re-check here closes the whole window.
             if (engine.isReadOnlyMode()) {
                 writer.rollback();
-                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                throw CairoException.readOnlyAccess();
             }
             final Lock lock = engine.getRoleSwitchReadLock();
             lock.lock();
@@ -147,7 +147,7 @@ public class InsertOperationImpl implements InsertOperation {
                 // tables/protocols share the read side and never serialize against each other.
                 if (engine.isReadOnlyMode()) {
                     writer.rollback();
-                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                    throw CairoException.readOnlyAccess();
                 }
                 writer.commit();
             } finally {

--- a/core/src/main/java/io/questdb/griffin/engine/ops/OperationDispatcher.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/OperationDispatcher.java
@@ -151,7 +151,7 @@ public abstract class OperationDispatcher<T extends AbstractOperation> {
             // authorized force/WAL-bypass break-glass path is exempt for the same reason as in
             // applyFenced (see isWriteRefused).
             if (isWriteRefused(forceWalBypass)) {
-                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                throw CairoException.readOnlyAccess();
             }
             // Both-trees pre-externalization fire-point for the async-enqueue fallback, mirroring the
             // inline-apply path above: fire the shared role-switch mint observer before acquiring the
@@ -162,7 +162,7 @@ public abstract class OperationDispatcher<T extends AbstractOperation> {
             lock.lock();
             try {
                 if (isWriteRefused(forceWalBypass)) {
-                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                    throw CairoException.readOnlyAccess();
                 }
                 OperationFutureImpl future = futurePool.pop();
                 future.of(
@@ -241,7 +241,7 @@ public abstract class OperationDispatcher<T extends AbstractOperation> {
         // (cairo.read.only) still refuses it. Structural changes are denied earlier, so only
         // non-structural force-alters reach here.
         if (isWriteRefused(forceWalBypass)) {
-            throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+            throw CairoException.readOnlyAccess();
         }
         final Lock lock = engine.getRoleSwitchReadLock();
         lock.lock();
@@ -250,7 +250,7 @@ public abstract class OperationDispatcher<T extends AbstractOperation> {
             // lock around the REPLICA flag publish. apply() runs inside the read hold so the flip cannot
             // interleave (its write acquire waits), while other commits share the read side.
             if (isWriteRefused(forceWalBypass)) {
-                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                throw CairoException.readOnlyAccess();
             }
             firePreApplyObserver();
             return apply(operation, writer);

--- a/core/src/main/java/io/questdb/lifecycle/LifecycleOrchestrator.java
+++ b/core/src/main/java/io/questdb/lifecycle/LifecycleOrchestrator.java
@@ -424,26 +424,39 @@ public class LifecycleOrchestrator implements QuietCloseable {
                 // routed every clean switch through the error-level invalid-transition log.
                 // A republish to the current state changes nothing: skip it quietly (debug,
                 // not error) without firing the transition log or the state-change dispatch.
-                injectedLog.debug()
-                        .$("ignoring same-state republish component=").$(name)
-                        .$(" state=").$(next)
-                        .I$();
+                try {
+                    injectedLog.debug()
+                            .$("ignoring same-state republish component=").$(name)
+                            .$(" state=").$(next)
+                            .I$();
+                } catch (Throwable ignore) {
+                    // Diagnostics only; the log subsystem can already be halted when a
+                    // JVM-shutdown close publishes late (see emitTransitionLog).
+                }
                 return;
             }
             if (prev == State.FAILED && next != State.FAILED) {
                 // FAILED is a terminal state; ignore any late publish that tries to leave it.
-                injectedLog.error()
-                        .$("rejecting transition from FAILED component=").$(name)
-                        .$(" attempted to=").$(next)
-                        .I$();
+                try {
+                    injectedLog.error()
+                            .$("rejecting transition from FAILED component=").$(name)
+                            .$(" attempted to=").$(next)
+                            .I$();
+                } catch (Throwable ignore) {
+                    // Same shutdown-race guard as emitTransitionLog.
+                }
                 return;
             }
             if (!isValidTransition(prev, next)) {
-                injectedLog.error()
-                        .$("invalid transition component=").$(name)
-                        .$(" from=").$(prev)
-                        .$(" to=").$(next)
-                        .I$();
+                try {
+                    injectedLog.error()
+                            .$("invalid transition component=").$(name)
+                            .$(" from=").$(prev)
+                            .$(" to=").$(next)
+                            .I$();
+                } catch (Throwable ignore) {
+                    // Same shutdown-race guard as emitTransitionLog.
+                }
                 return;
             }
         } while (!ref.compareAndSet(prev, next));
@@ -564,7 +577,33 @@ public class LifecycleOrchestrator implements QuietCloseable {
         fireStableBelowCallbacks();
     }
 
+    /**
+     * Emits the advisory transition record, tolerating a halted log subsystem. During
+     * JVM shutdown the log factory's own shutdown hook can free the log rings while
+     * component close/stop paths are still publishing their final transitions (shutdown
+     * hook order is unspecified, and a SIGTERM'd test JVM tears the servers and the
+     * logger down concurrently). The record is diagnostics; the CAS'd state transition
+     * and the dispatch that follow in {@code publishInternal} are load-bearing and must
+     * survive a dead logger, so an emit failure is swallowed rather than allowed to
+     * abort the FAILED cascade and the state-change dispatch.
+     */
     private void emitTransitionLog(
+            String name,
+            State prev,
+            State next,
+            long ts,
+            long since,
+            @Nullable CharSequence reason
+    ) {
+        try {
+            emitTransitionLog0(name, prev, next, ts, since, reason);
+        } catch (Throwable ignore) {
+            // Log subsystem already halted (JVM shutdown race); the transition itself
+            // must still complete.
+        }
+    }
+
+    private void emitTransitionLog0(
             String name,
             State prev,
             State next,

--- a/core/src/test/java/io/questdb/test/cairo/CairoExceptionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoExceptionTest.java
@@ -57,6 +57,23 @@ public class CairoExceptionTest extends AbstractTest {
         Assert.assertFalse("clear() must reset the sticky preferences-out-of-date flag", ex.isPreferencesOutOfDateError());
     }
 
+    // readOnlyAccess() sets BOTH the authorization flag and the read-only-refusal marker in lockstep.
+    // The QWP NACK classifier keys on isReadOnlyAccessRefusal() to route a TRANSIENT demote refusal
+    // into the reconnect-eligible role-change close instead of a terminal ACL NACK. If clear() failed
+    // to reset the marker on a recycled flyweight (e.g. LineProtocolException via ThreadLocal), the
+    // NEXT exception built on that flyweight would inherit a stale marker and a genuine ACL denial
+    // would be silently misrouted into a reconnect-eligible close. This extends the sticky-flag guard
+    // pattern to the read-only-refusal marker (and the authorization flag set alongside it).
+    @Test
+    public void testClearResetsStickyReadOnlyAccessRefusalFlag() throws Exception {
+        CairoException ex = CairoException.readOnlyAccess();
+        Assert.assertTrue(ex.isReadOnlyAccessRefusal());
+        Assert.assertTrue("readOnlyAccess() implies the authorization flag", ex.isAuthorizationError());
+        invokeClear(ex);
+        Assert.assertFalse("clear() must reset the sticky read-only-access-refusal marker", ex.isReadOnlyAccessRefusal());
+        Assert.assertFalse("clear() must reset the authorization flag set alongside it", ex.isAuthorizationError());
+    }
+
     @Test
     public void testMatViewDoesNotExistIsNotCritical() {
         Assert.assertFalse(CairoException.matViewDoesNotExist("foo").isCritical());

--- a/core/src/test/java/io/questdb/test/client/QuestDBFacadeE2ETest.java
+++ b/core/src/test/java/io/questdb/test/client/QuestDBFacadeE2ETest.java
@@ -27,6 +27,7 @@ package io.questdb.test.client;
 import io.questdb.PropertyKey;
 import io.questdb.client.Completion;
 import io.questdb.client.QuestDB;
+import io.questdb.client.Query;
 import io.questdb.client.QueryException;
 import io.questdb.client.Sender;
 import io.questdb.client.cutlass.line.LineSenderException;
@@ -51,8 +52,8 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * End-to-end tests for the {@link QuestDB} facade against an embedded server.
  * Verifies that pooled Sender ingest and pooled Query egress both round-trip
- * data correctly and that the pool semantics (flush-on-return, thread-affine,
- * acquire timeout, cancel) hold under real I/O.
+ * data correctly and that the pool semantics (flush-on-return, distinct
+ * per-borrow Senders, acquire timeout, cancel) hold under real I/O.
  * <p>
  * Every run picks a small random chunk size and forces both HTTP recv and send
  * fragmentation at the server, mirroring {@code QwpEgressFragmentationFuzzTest}.
@@ -130,16 +131,17 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
 
                     AtomicLong sum = new AtomicLong();
                     AtomicInteger rows = new AtomicInteger();
-                    Completion c = db.executeSql("SELECT i FROM rt", new CollectingHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                sum.addAndGet(batch.getLongValue(0, r));
-                                rows.incrementAndGet();
+                    try (Query q = db.borrowQuery()) {
+                        q.sql("SELECT i FROM rt").handler(new CollectingHandler() {
+                            @Override
+                            public void onBatch(QwpColumnBatch batch) {
+                                for (int r = 0; r < batch.getRowCount(); r++) {
+                                    sum.addAndGet(batch.getLongValue(0, r));
+                                    rows.incrementAndGet();
+                                }
                             }
-                        }
-                    });
-                    c.await();
+                        }).submit().await();
+                    }
                     Assert.assertEquals(3, rows.get());
                     Assert.assertEquals(6L, sum.get());
                 }
@@ -160,43 +162,45 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
                     AtomicReference<Byte> errorStatus = new AtomicReference<>();
                     AtomicReference<Throwable> awaitOutcome = new AtomicReference<>();
                     CountDownLatch firstBatch = new CountDownLatch(1);
-                    Completion c = db.executeSql("SELECT x FROM big ORDER BY x", new QwpColumnBatchHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            firstBatch.countDown();
-                            // Stall longer than the typical batch turnaround so cancel
-                            // has time to land while the user thread is parked here.
-                            try {
-                                Thread.sleep(2_000);
-                            } catch (InterruptedException ie) {
-                                Thread.currentThread().interrupt();
+                    try (Query q = db.borrowQuery()) {
+                        Completion c = q.sql("SELECT x FROM big ORDER BY x").handler(new QwpColumnBatchHandler() {
+                            @Override
+                            public void onBatch(QwpColumnBatch batch) {
+                                firstBatch.countDown();
+                                // Stall longer than the typical batch turnaround so cancel
+                                // has time to land while the user thread is parked here.
+                                try {
+                                    Thread.sleep(2_000);
+                                } catch (InterruptedException ie) {
+                                    Thread.currentThread().interrupt();
+                                }
                             }
-                        }
 
-                        @Override
-                        public void onEnd(long totalRows) {
-                        }
+                            @Override
+                            public void onEnd(long totalRows) {
+                            }
 
-                        @Override
-                        public void onError(byte s, String message) {
-                            errorStatus.set(s);
+                            @Override
+                            public void onError(byte s, String message) {
+                                errorStatus.set(s);
+                            }
+                        }).submit();
+                        Assert.assertTrue(firstBatch.await(firstBatchTimeoutMs(10_000), TimeUnit.MILLISECONDS));
+                        c.cancel();
+                        try {
+                            c.await();
+                        } catch (QueryException qe) {
+                            awaitOutcome.set(qe);
                         }
-                    });
-                    Assert.assertTrue(firstBatch.await(firstBatchTimeoutMs(10_000), TimeUnit.MILLISECONDS));
-                    c.cancel();
-                    try {
-                        c.await();
-                    } catch (QueryException qe) {
-                        awaitOutcome.set(qe);
-                    }
-                    // Cancel races completion. Whichever wins, the query must reach
-                    // a terminal state without deadlocking and the API must remain
-                    // consistent. If cancel won, await threw and onError saw a
-                    // non-zero status; if completion won, await returned cleanly.
-                    Assert.assertTrue("Completion must terminate", c.isDone());
-                    if (awaitOutcome.get() != null) {
-                        Assert.assertNotNull("onError must fire when cancel wins", errorStatus.get());
-                        Assert.assertNotEquals((byte) 0, (byte) errorStatus.get());
+                        // Cancel races completion. Whichever wins, the query must reach
+                        // a terminal state without deadlocking and the API must remain
+                        // consistent. If cancel won, await threw and onError saw a
+                        // non-zero status; if completion won, await returned cleanly.
+                        Assert.assertTrue("Completion must terminate", c.isDone());
+                        if (awaitOutcome.get() != null) {
+                            Assert.assertNotNull("onError must fire when cancel wins", errorStatus.get());
+                            Assert.assertNotEquals((byte) 0, (byte) errorStatus.get());
+                        }
                     }
                 }
             }
@@ -221,13 +225,14 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
                         new Thread(() -> {
                             try {
                                 AtomicInteger seen = new AtomicInteger();
-                                Completion c = db.executeSql("SELECT x FROM conc", new CollectingHandler() {
-                                    @Override
-                                    public void onBatch(QwpColumnBatch batch) {
-                                        seen.addAndGet(batch.getRowCount());
-                                    }
-                                });
-                                c.await();
+                                try (Query q = db.borrowQuery()) {
+                                    q.sql("SELECT x FROM conc").handler(new CollectingHandler() {
+                                        @Override
+                                        public void onBatch(QwpColumnBatch batch) {
+                                            seen.addAndGet(batch.getRowCount());
+                                        }
+                                    }).submit().await();
+                                }
                                 if (seen.get() == 100) {
                                     okCount.incrementAndGet();
                                 }
@@ -254,13 +259,15 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
             try (final TestServerMain _ = startFragmented()) {
                 String config = "ws::addr=127.0.0.1:" + HTTP_PORT + ";";
                 try (QuestDB db = QuestDB.connect(config)) {
-                    Completion c = db.executeSql("SELECT * FROM no_such_table", new CollectingHandler());
-                    try {
-                        c.await();
-                        Assert.fail("expected QueryException for missing table");
-                    } catch (QueryException qe) {
-                        Assert.assertTrue("status byte must be non-zero on server error",
-                                qe.getStatus() != 0);
+                    try (Query q = db.borrowQuery()) {
+                        Completion c = q.sql("SELECT * FROM no_such_table").handler(new CollectingHandler()).submit();
+                        try {
+                            c.await();
+                            Assert.fail("expected QueryException for missing table");
+                        } catch (QueryException qe) {
+                            Assert.assertTrue("status byte must be non-zero on server error",
+                                    qe.getStatus() != 0);
+                        }
                     }
                 }
             }
@@ -297,47 +304,17 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
         });
     }
 
-    @Test
-    public void testThreadAffineSenderRoundTrip() throws Exception {
-        TestUtils.assertMemoryLeak(() -> {
-            try (final TestServerMain server = startFragmented()) {
-                server.execute("CREATE TABLE ta(i LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
-                server.awaitTable("ta");
-
-                String config = "ws::addr=127.0.0.1:" + HTTP_PORT + ";";
-                try (QuestDB db = QuestDB.connect(config)) {
-                    Sender s1 = db.sender();
-                    Sender s2 = db.sender();
-                    Assert.assertSame("same thread must see the same pinned Sender", s1, s2);
-                    s1.table("ta").longColumn("i", 7).at(7L * 1_000_000L, java.time.temporal.ChronoUnit.MICROS);
-                    s1.flush();
-                    db.releaseSender();
-                    server.awaitTxn("ta", 1);
-
-                    AtomicLong got = new AtomicLong();
-                    Completion c = db.executeSql("SELECT i FROM ta", new CollectingHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                got.set(batch.getLongValue(0, r));
-                            }
-                        }
-                    });
-                    c.await();
-                    Assert.assertEquals(7L, got.get());
-                }
-            }
-        });
-    }
-
     /**
-     * Same thread, many sequential queries. Asserts:
-     * - {@link QuestDB#query()} returns the same per-thread instance every call
-     * - state resets between submits (no SQL/handler carryover)
-     * - back-to-back submits with binds reuse the same {@link Completion}
+     * One borrowed handle, many sequential submits. Asserts:
+     * - within a single lease the {@link Completion} is the reused field on the
+     *   handle (same instance every submit)
+     * - bound values reach the server on every submit
+     * - re-borrowing from a size-1 pool hands back the same pre-allocated
+     *   handle (zero allocation) with its builder state reset, so a no-binds
+     *   query does not carry over the prior binds
      */
     @Test
-    public void testManySequentialQueriesOnSameThread() throws Exception {
+    public void testManySequentialQueriesOnSameHandle() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (final TestServerMain server = startFragmented()) {
                 server.execute("CREATE TABLE seq(x LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
@@ -346,29 +323,61 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
 
                 String config = "ws::addr=127.0.0.1:" + HTTP_PORT + ";";
                 try (QuestDB db = QuestDB.builder().fromConfig(config).queryPoolSize(1).build()) {
-                    io.questdb.client.Query firstHandle = db.query();
-                    Completion firstCompletion = firstHandle
-                            .sql("SELECT count() FROM seq")
-                            .handler(new CollectingHandler())
-                            .submit();
-                    firstCompletion.await();
+                    Query firstHandle;
+                    Completion firstCompletion;
+                    try (Query handle = db.borrowQuery()) {
+                        firstHandle = handle;
+                        firstCompletion = handle
+                                .sql("SELECT count() FROM seq")
+                                .handler(new CollectingHandler())
+                                .submit();
+                        firstCompletion.await();
 
-                    // Identity: every subsequent query() on the same thread is the
-                    // same handle, and the Completion is the same field on it.
-                    final int iterations = 50;
-                    for (int i = 0; i < iterations; i++) {
-                        io.questdb.client.Query q = db.query();
-                        Assert.assertSame("Query handle must be reused per thread", firstHandle, q);
+                        // Many sequential submits on the SAME lease: the Completion
+                        // is the reused field on the handle, and bound values reach
+                        // the server each time.
+                        final int iterations = 50;
+                        for (int i = 0; i < iterations; i++) {
+                            AtomicLong observed = new AtomicLong();
+                            Completion c = handle.sql("SELECT x FROM seq WHERE x = $1")
+                                    .binds(binds -> binds.setLong(0, 7L))
+                                    .handler(new QwpColumnBatchHandler() {
+                                        @Override
+                                        public void onBatch(QwpColumnBatch batch) {
+                                            for (int r = 0; r < batch.getRowCount(); r++) {
+                                                observed.set(batch.getLongValue(0, r));
+                                            }
+                                        }
 
-                        AtomicLong observed = new AtomicLong();
-                        Completion c = q.sql("SELECT x FROM seq WHERE x = $1")
-                                .binds(binds -> binds.setLong(0, 7L))
+                                        @Override
+                                        public void onEnd(long totalRows) {
+                                        }
+
+                                        @Override
+                                        public void onError(byte status, String message) {
+                                            Assert.fail("egress error: " + message);
+                                        }
+                                    })
+                                    .submit();
+                            Assert.assertSame("Completion must be reused per handle", firstCompletion, c);
+                            c.await();
+                            Assert.assertEquals("iter " + i + ": bound value must reach the server", 7L, observed.get());
+                        }
+                    }
+
+                    // Re-borrow from the size-1 pool: the same pre-allocated handle
+                    // comes back (zero allocation) and resetForBorrow() cleared the
+                    // prior SQL/binds/handler, so a no-binds query does not carry
+                    // over the earlier $1 binds.
+                    AtomicLong total = new AtomicLong();
+                    try (Query handle = db.borrowQuery()) {
+                        Assert.assertSame("size-1 pool must hand back the same pre-allocated handle",
+                                firstHandle, handle);
+                        handle.sql("SELECT count() FROM seq")
                                 .handler(new QwpColumnBatchHandler() {
                                     @Override
                                     public void onBatch(QwpColumnBatch batch) {
-                                        for (int r = 0; r < batch.getRowCount(); r++) {
-                                            observed.set(batch.getLongValue(0, r));
-                                        }
+                                        total.set(batch.getLongValue(0, 0));
                                     }
 
                                     @Override
@@ -377,38 +386,12 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
 
                                     @Override
                                     public void onError(byte status, String message) {
-                                        Assert.fail("egress error on iter " + " : " + message);
+                                        Assert.fail("egress error on no-binds tail: " + message);
                                     }
                                 })
-                                .submit();
-                        Assert.assertSame("Completion must be reused per Query", firstCompletion, c);
-                        c.await();
-                        Assert.assertEquals("iter " + i + ": bound value must reach the server", 7L, observed.get());
+                                .submit()
+                                .await();
                     }
-
-                    // After a binds-using query, a no-binds query on the same handle
-                    // must not carry over the previous binds (would fail server-side
-                    // with "no placeholder" or a stale value).
-                    AtomicLong total = new AtomicLong();
-                    db.query()
-                            .sql("SELECT count() FROM seq")
-                            .handler(new QwpColumnBatchHandler() {
-                                @Override
-                                public void onBatch(QwpColumnBatch batch) {
-                                    total.set(batch.getLongValue(0, 0));
-                                }
-
-                                @Override
-                                public void onEnd(long totalRows) {
-                                }
-
-                                @Override
-                                public void onError(byte status, String message) {
-                                    Assert.fail("egress error on no-binds tail: " + message);
-                                }
-                            })
-                            .submit()
-                            .await();
                     Assert.assertEquals(50L, total.get());
                 }
             }
@@ -465,27 +448,28 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
                             try {
                                 for (int i = 0; i < queriesPerThread; i++) {
                                     AtomicInteger seen = new AtomicInteger();
-                                    Completion c = db.query()
-                                            .sql("SELECT x FROM mix WHERE x > $1")
-                                            .binds(binds -> binds.setLong(0, 0L))
-                                            .handler(new QwpColumnBatchHandler() {
-                                                @Override
-                                                public void onBatch(QwpColumnBatch batch) {
-                                                    seen.addAndGet(batch.getRowCount());
-                                                }
+                                    try (Query q = db.borrowQuery()) {
+                                        q.sql("SELECT x FROM mix WHERE x > $1")
+                                                .binds(binds -> binds.setLong(0, 0L))
+                                                .handler(new QwpColumnBatchHandler() {
+                                                    @Override
+                                                    public void onBatch(QwpColumnBatch batch) {
+                                                        seen.addAndGet(batch.getRowCount());
+                                                    }
 
-                                                @Override
-                                                public void onEnd(long totalRows) {
-                                                }
+                                                    @Override
+                                                    public void onEnd(long totalRows) {
+                                                    }
 
-                                                @Override
-                                                public void onError(byte status, String message) {
-                                                    firstError.compareAndSet(null,
-                                                            new AssertionError("egress error: " + message));
-                                                }
-                                            })
-                                            .submit();
-                                    c.await();
+                                                    @Override
+                                                    public void onError(byte status, String message) {
+                                                        firstError.compareAndSet(null,
+                                                                new AssertionError("egress error: " + message));
+                                                    }
+                                                })
+                                                .submit()
+                                                .await();
+                                    }
                                     if (seen.get() >= 200) {
                                         okCount.incrementAndGet();
                                     }
@@ -510,9 +494,8 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
     }
 
     /**
-     * One thread submits two queries that execute concurrently on a 2-slot
-     * pool. Uses {@link QuestDB#newQuery()} to obtain two independent handles
-     * (the thread-local {@code query()} is single-flight).
+     * One thread runs two queries concurrently on a 2-slot pool by borrowing
+     * two {@link Query} handles (a single handle is single-flight).
      * <p>
      * Concurrency proof: each handler stalls in {@code onBatch} for 1s. If
      * the second submit had to wait for the first, total elapsed would be
@@ -563,16 +546,12 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
                     };
 
                     long start = System.nanoTime();
-                    Completion c1 = db.newQuery()
-                            .sql("SELECT x FROM cc")
-                            .handler(stallingHandler)
-                            .submit();
-                    Completion c2 = db.newQuery()
-                            .sql("SELECT x FROM cc")
-                            .handler(stallingHandler)
-                            .submit();
-                    c1.await();
-                    c2.await();
+                    try (Query q1 = db.borrowQuery(); Query q2 = db.borrowQuery()) {
+                        Completion c1 = q1.sql("SELECT x FROM cc").handler(stallingHandler).submit();
+                        Completion c2 = q2.sql("SELECT x FROM cc").handler(stallingHandler).submit();
+                        c1.await();
+                        c2.await();
+                    }
                     long elapsedMs = (System.nanoTime() - start) / 1_000_000;
 
                     if (firstError.get() != null) {
@@ -582,6 +561,157 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
                             "elapsed=" + elapsedMs + "ms; with concurrency it should be ~"
                                     + STALL_MS + "ms, not ~" + (STALL_MS * 2) + "ms",
                             elapsedMs < (STALL_MS * 2) - 200);
+                }
+            }
+        });
+    }
+
+    /**
+     * Mixed ingest + egress over one pooled handle: the main thread borrows
+     * two Senders at once -- one per table -- from a 2-slot sender pool and
+     * uses them simultaneously (interleaved row-by-row, with a shared mid-flush
+     * so they also transmit at once), while a dedicated reader thread streams
+     * two DIFFERENT SQLs, each on its own borrowed {@link io.questdb.client.Query}
+     * handle, over a 2-slot query pool.
+     * <p>
+     * Every {@link QuestDB#borrowSender()} call returns a distinct pooled
+     * Sender with its own buffer, asserted directly with {@code assertNotSame}.
+     * <p>
+     * Asserts both pools hand out two leases at once without blocking, the
+     * close-on-return flush lands every row, and each query sees the exact
+     * rows and sum for its own table (no cross-talk between the two Senders or
+     * the two Query handles).
+     */
+    @Test
+    public void testTwoSendersPerTableWhileReaderThreadStreamsTwoQueries() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (final TestServerMain server = startFragmented()) {
+                server.execute("CREATE TABLE alpha(x LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                server.execute("CREATE TABLE beta(x LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                server.awaitTable("alpha");
+                server.awaitTable("beta");
+
+                final int rowsAlpha = 100;
+                final int rowsBeta = 50;
+
+                String config = "ws::addr=127.0.0.1:" + HTTP_PORT + ";";
+                try (QuestDB db = QuestDB.builder()
+                        .fromConfig(config)
+                        .senderPoolSize(2)
+                        .queryPoolSize(2)
+                        .acquireTimeoutMillis(30_000)
+                        .build()) {
+
+                    // (1) Ingest: hold two pooled Senders at once -- one per
+                    // table -- and use them simultaneously. Every borrow hands
+                    // out a distinct pooled Sender with its own buffer, so a
+                    // 2-slot pool leases both to one thread.
+                    final int maxRows = Math.max(rowsAlpha, rowsBeta);
+                    try (Sender a = db.borrowSender();
+                         Sender b = db.borrowSender()) {
+                        // Distinct objects: borrowSender() is not thread-local,
+                        // so the two leases are independent Senders.
+                        Assert.assertNotSame("borrowSender() must hand out two distinct pooled Senders", a, b);
+
+                        // Interleave the two senders row-by-row so both buffers
+                        // fill at the same time, rather than filling alpha
+                        // completely before touching beta.
+                        for (int i = 0; i < maxRows; i++) {
+                            if (i < rowsAlpha) {
+                                a.table("alpha").longColumn("x", i)
+                                        .at((i + 1L) * 1_000_000L, java.time.temporal.ChronoUnit.MICROS);
+                            }
+                            if (i < rowsBeta) {
+                                b.table("beta").longColumn("x", 2L * i)
+                                        .at((i + 1L) * 1_000_000L, java.time.temporal.ChronoUnit.MICROS);
+                            }
+                            // Mid-way -- while both still have rows left to
+                            // write -- flush both at once so the two senders also
+                            // transmit concurrently, not merely buffer in step.
+                            if (i == rowsBeta / 2) {
+                                a.flush();
+                                b.flush();
+                            }
+                        }
+                        // close() on each flushes whatever remains.
+                    }
+                    // ws ingest is async. Each table sees two non-empty flushes
+                    // (the shared mid-flush + its close flush); wait for both.
+                    server.awaitTxn("alpha", 2);
+                    server.awaitTxn("beta", 2);
+
+                    // (2) Egress: a dedicated reader thread streams two
+                    // different SQLs at once, each on its own borrowed Query handle.
+                    final AtomicLong alphaSum = new AtomicLong();
+                    final AtomicLong betaSum = new AtomicLong();
+                    final AtomicInteger alphaRows = new AtomicInteger();
+                    final AtomicInteger betaRows = new AtomicInteger();
+                    final AtomicReference<Throwable> firstError = new AtomicReference<>();
+
+                    Thread reader = new Thread(() -> {
+                        try (Query qa = db.borrowQuery(); Query qb = db.borrowQuery()) {
+                            Completion ca = qa
+                                    .sql("SELECT x FROM alpha")
+                                    .handler(new QwpColumnBatchHandler() {
+                                        @Override
+                                        public void onBatch(QwpColumnBatch batch) {
+                                            for (int r = 0; r < batch.getRowCount(); r++) {
+                                                alphaSum.addAndGet(batch.getLongValue(0, r));
+                                                alphaRows.incrementAndGet();
+                                            }
+                                        }
+
+                                        @Override
+                                        public void onEnd(long totalRows) {
+                                        }
+
+                                        @Override
+                                        public void onError(byte status, String message) {
+                                            firstError.compareAndSet(null,
+                                                    new AssertionError("alpha egress error: " + message));
+                                        }
+                                    })
+                                    .submit();
+                            Completion cb = qb
+                                    .sql("SELECT x FROM beta")
+                                    .handler(new QwpColumnBatchHandler() {
+                                        @Override
+                                        public void onBatch(QwpColumnBatch batch) {
+                                            for (int r = 0; r < batch.getRowCount(); r++) {
+                                                betaSum.addAndGet(batch.getLongValue(0, r));
+                                                betaRows.incrementAndGet();
+                                            }
+                                        }
+
+                                        @Override
+                                        public void onEnd(long totalRows) {
+                                        }
+
+                                        @Override
+                                        public void onError(byte status, String message) {
+                                            firstError.compareAndSet(null,
+                                                    new AssertionError("beta egress error: " + message));
+                                        }
+                                    })
+                                    .submit();
+                            ca.await();
+                            cb.await();
+                        } catch (Throwable th) {
+                            firstError.compareAndSet(null, th);
+                        }
+                    }, "reader");
+                    reader.start();
+                    reader.join(TimeUnit.SECONDS.toMillis(30));
+                    Assert.assertFalse("reader thread must finish within 30s", reader.isAlive());
+
+                    if (firstError.get() != null) {
+                        throw new AssertionError("reader thread failed", firstError.get());
+                    }
+                    Assert.assertEquals(rowsAlpha, alphaRows.get());
+                    Assert.assertEquals(rowsBeta, betaRows.get());
+                    // alpha x = 0..rowsAlpha-1; beta x = 2*i for i = 0..rowsBeta-1.
+                    Assert.assertEquals((rowsAlpha - 1L) * rowsAlpha / 2, alphaSum.get());
+                    Assert.assertEquals((rowsBeta - 1L) * rowsBeta, betaSum.get());
                 }
             }
         });
@@ -644,12 +774,14 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
                     // txns. Wait for all to apply before counting.
                     server.awaitTxn("el", 4);
                     AtomicInteger seen = new AtomicInteger();
-                    db.executeSql("SELECT x FROM el", new CollectingHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            seen.addAndGet(batch.getRowCount());
-                        }
-                    }).await();
+                    try (Query q = db.borrowQuery()) {
+                        q.sql("SELECT x FROM el").handler(new CollectingHandler() {
+                            @Override
+                            public void onBatch(QwpColumnBatch batch) {
+                                seen.addAndGet(batch.getRowCount());
+                            }
+                        }).submit().await();
+                    }
                     Assert.assertEquals("burst writes must all land", burst, seen.get());
 
                     // Let the housekeeper reap idle slots back toward min.
@@ -687,14 +819,16 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
                     server.awaitTxn("two", 1);
 
                     AtomicLong sum = new AtomicLong();
-                    db.executeSql("SELECT i FROM two", new CollectingHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                sum.addAndGet(batch.getLongValue(0, r));
+                    try (Query q = db.borrowQuery()) {
+                        q.sql("SELECT i FROM two").handler(new CollectingHandler() {
+                            @Override
+                            public void onBatch(QwpColumnBatch batch) {
+                                for (int r = 0; r < batch.getRowCount(); r++) {
+                                    sum.addAndGet(batch.getLongValue(0, r));
+                                }
                             }
-                        }
-                    }).await();
+                        }).submit().await();
+                    }
                     Assert.assertEquals(33L, sum.get());
                 }
             }
@@ -721,12 +855,14 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
                     server.awaitTxn("pk", 1);
 
                     AtomicInteger rows = new AtomicInteger();
-                    db.executeSql("SELECT i FROM pk", new CollectingHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            rows.addAndGet(batch.getRowCount());
-                        }
-                    }).await();
+                    try (Query q = db.borrowQuery()) {
+                        q.sql("SELECT i FROM pk").handler(new CollectingHandler() {
+                            @Override
+                            public void onBatch(QwpColumnBatch batch) {
+                                rows.addAndGet(batch.getRowCount());
+                            }
+                        }).submit().await();
+                    }
                     Assert.assertEquals(1, rows.get());
                 }
             }
@@ -756,20 +892,22 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
                     server.awaitTxn("au", 1);
 
                     AtomicLong got = new AtomicLong();
-                    db.executeSql("SELECT i FROM au", new CollectingHandler() {
-                        @Override
-                        public void onBatch(QwpColumnBatch batch) {
-                            for (int r = 0; r < batch.getRowCount(); r++) {
-                                got.set(batch.getLongValue(0, r));
+                    try (Query q = db.borrowQuery()) {
+                        q.sql("SELECT i FROM au").handler(new CollectingHandler() {
+                            @Override
+                            public void onBatch(QwpColumnBatch batch) {
+                                for (int r = 0; r < batch.getRowCount(); r++) {
+                                    got.set(batch.getLongValue(0, r));
+                                }
                             }
-                        }
-                    }).await();
+                        }).submit().await();
+                    }
                     Assert.assertEquals(99L, got.get());
                 }
 
                 // Wrong password is rejected at the eager pool-prewarm connect.
                 String bad = "ws::addr=127.0.0.1:" + HTTP_PORT + ";user=admin;pass=wrong;";
-                try (QuestDB db = QuestDB.connect(bad)) {
+                try (QuestDB _ = QuestDB.connect(bad)) {
                     Assert.fail("expected auth failure with a wrong password");
                 } catch (RuntimeException expected) {
                     // connect rejected the bad credentials

--- a/core/src/test/java/io/questdb/test/client/QuestDBFacadeE2ETest.java
+++ b/core/src/test/java/io/questdb/test/client/QuestDBFacadeE2ETest.java
@@ -307,11 +307,12 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
     /**
      * One borrowed handle, many sequential submits. Asserts:
      * - within a single lease the {@link Completion} is the reused field on the
-     *   handle (same instance every submit)
+     * handle (same instance every submit)
      * - bound values reach the server on every submit
-     * - re-borrowing from a size-1 pool hands back the same pre-allocated
-     *   handle (zero allocation) with its builder state reset, so a no-binds
-     *   query does not carry over the prior binds
+     * - re-borrowing from a size-1 pool reuses the pooled worker and its
+     * pre-allocated QueryImpl, with builder state reset, so a no-binds query
+     * does not carry over the prior binds (the returned lease is a fresh
+     * per-borrow handle wrapping that reused state)
      */
     @Test
     public void testManySequentialQueriesOnSameHandle() throws Exception {
@@ -323,10 +324,8 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
 
                 String config = "ws::addr=127.0.0.1:" + HTTP_PORT + ";";
                 try (QuestDB db = QuestDB.builder().fromConfig(config).queryPoolSize(1).build()) {
-                    Query firstHandle;
                     Completion firstCompletion;
                     try (Query handle = db.borrowQuery()) {
-                        firstHandle = handle;
                         firstCompletion = handle
                                 .sql("SELECT count() FROM seq")
                                 .handler(new CollectingHandler())
@@ -365,14 +364,14 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
                         }
                     }
 
-                    // Re-borrow from the size-1 pool: the same pre-allocated handle
-                    // comes back (zero allocation) and resetForBorrow() cleared the
+                    // Re-borrow from the size-1 pool: the pooled worker and its
+                    // reused QueryImpl come back, and resetForBorrow() cleared the
                     // prior SQL/binds/handler, so a no-binds query does not carry
-                    // over the earlier $1 binds.
+                    // over the earlier $1 binds. The lease is a fresh per-borrow
+                    // handle wrapping that reused state; QueryImplResetTest in the
+                    // client asserts the same-pooled-object reuse directly.
                     AtomicLong total = new AtomicLong();
                     try (Query handle = db.borrowQuery()) {
-                        Assert.assertSame("size-1 pool must hand back the same pre-allocated handle",
-                                firstHandle, handle);
                         handle.sql("SELECT count() FROM seq")
                                 .handler(new QwpColumnBatchHandler() {
                                     @Override

--- a/core/src/test/java/io/questdb/test/client/QuestDBFacadeE2ETest.java
+++ b/core/src/test/java/io/questdb/test/client/QuestDBFacadeE2ETest.java
@@ -668,19 +668,18 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
     }
 
     /**
-     * Two-arg connect: separate (here identical) ingest and query ws strings.
-     * Exercises the facade's two-string path end-to-end.
+     * Single cluster config drives both the ingest and query pools. Exercises
+     * the facade's one-config path end-to-end.
      */
     @Test
-    public void testTwoArgConnectRoundTrip() throws Exception {
+    public void testSingleConfigConnectRoundTrip() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (final TestServerMain server = startFragmented()) {
                 server.execute("CREATE TABLE two(i LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
                 server.awaitTable("two");
 
-                String ingest = "ws::addr=127.0.0.1:" + HTTP_PORT + ";";
-                String query = "ws::addr=127.0.0.1:" + HTTP_PORT + ";";
-                try (QuestDB db = QuestDB.connect(ingest, query)) {
+                String config = "ws::addr=127.0.0.1:" + HTTP_PORT + ";";
+                try (QuestDB db = QuestDB.connect(config)) {
                     try (Sender s = db.borrowSender()) {
                         s.table("two").longColumn("i", 11).at(1_000_000L, java.time.temporal.ChronoUnit.MICROS);
                         s.table("two").longColumn("i", 22).at(2L * 1_000_000L, java.time.temporal.ChronoUnit.MICROS);

--- a/core/src/test/java/io/questdb/test/client/QuestDBFacadeE2ETest.java
+++ b/core/src/test/java/io/questdb/test/client/QuestDBFacadeE2ETest.java
@@ -253,6 +253,99 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
         });
     }
 
+    @Test(timeout = 60_000)
+    public void testHandlerCannotCloseOrAwaitOnWorkerThread() throws Exception {
+        // A result handler runs on the worker (dispatch) thread, so a reentrant
+        // close()/await() from inside it would block forever waiting for a
+        // terminal event only that thread can deliver. The reentrancy guard must
+        // turn that into an immediate IllegalStateException -- proving both that
+        // the handler really runs on the worker thread and that the worker is
+        // not deadlocked/leaked (the next borrow still works). The method-level
+        // timeout fails the test if the guard regresses into a deadlock.
+        TestUtils.assertMemoryLeak(() -> {
+            try (final TestServerMain server = startFragmented()) {
+                server.execute("CREATE TABLE rh(x LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                server.execute("INSERT INTO rh SELECT x, x::TIMESTAMP FROM long_sequence(3)");
+                server.awaitTable("rh");
+
+                String config = "ws::addr=127.0.0.1:" + HTTP_PORT + ";";
+                try (QuestDB db = QuestDB.builder().fromConfig(config).queryPoolSize(1).build()) {
+                    AtomicReference<Throwable> closeOutcome = new AtomicReference<>();
+                    AtomicReference<Throwable> awaitOutcome = new AtomicReference<>();
+                    AtomicInteger rows = new AtomicInteger();
+
+                    try (Query q = db.borrowQuery()) {
+                        q.sql("SELECT x FROM rh").handler(new QwpColumnBatchHandler() {
+                            @Override
+                            public void onBatch(QwpColumnBatch batch) {
+                                rows.addAndGet(batch.getRowCount());
+                                // q is also the Completion (QueryLease implements both).
+                                // Both calls run on the worker thread and must throw.
+                                if (closeOutcome.get() == null) {
+                                    try {
+                                        q.close();
+                                        closeOutcome.set(new AssertionError("close() must throw from a handler"));
+                                    } catch (Throwable t) {
+                                        closeOutcome.set(t);
+                                    }
+                                    try {
+                                        // q is the Completion at runtime (QueryLease implements both).
+                                        ((Completion) q).await();
+                                        awaitOutcome.set(new AssertionError("await() must throw from a handler"));
+                                    } catch (Throwable t) {
+                                        awaitOutcome.set(t);
+                                    }
+                                }
+                            }
+
+                            @Override
+                            public void onEnd(long totalRows) {
+                            }
+
+                            @Override
+                            public void onError(byte status, String message) {
+                                Assert.fail("egress error: " + message);
+                            }
+                        }).submit().await();
+                    }
+
+                    Assert.assertEquals("the handler must have run (onBatch saw the rows)", 3, rows.get());
+                    Assert.assertTrue("close() from a handler must throw IllegalStateException, was: "
+                                    + closeOutcome.get(),
+                            closeOutcome.get() instanceof IllegalStateException);
+                    Assert.assertTrue("await() from a handler must throw IllegalStateException, was: "
+                                    + awaitOutcome.get(),
+                            awaitOutcome.get() instanceof IllegalStateException);
+                    Assert.assertTrue("the error must point at cancel() as the safe in-handler stop",
+                            ((IllegalStateException) closeOutcome.get()).getMessage().contains("cancel()"));
+
+                    // The worker must not be deadlocked or leaked: re-borrow from
+                    // the size-1 pool and run a normal query to completion.
+                    AtomicInteger reused = new AtomicInteger();
+                    try (Query q = db.borrowQuery()) {
+                        q.sql("SELECT x FROM rh").handler(new QwpColumnBatchHandler() {
+                            @Override
+                            public void onBatch(QwpColumnBatch batch) {
+                                reused.addAndGet(batch.getRowCount());
+                            }
+
+                            @Override
+                            public void onEnd(long totalRows) {
+                            }
+
+                            @Override
+                            public void onError(byte status, String message) {
+                                Assert.fail("egress error on reuse: " + message);
+                            }
+                        }).submit().await();
+                    }
+                    Assert.assertEquals("the worker must still be usable after the in-handler misuse",
+                            3, reused.get());
+                }
+            }
+        });
+    }
+
     @Test
     public void testQueryExceptionOnBadSql() throws Exception {
         TestUtils.assertMemoryLeak(() -> {

--- a/core/src/test/java/io/questdb/test/client/QuestDBFacadeE2ETest.java
+++ b/core/src/test/java/io/questdb/test/client/QuestDBFacadeE2ETest.java
@@ -686,7 +686,20 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
                 final int rowsAlpha = 100;
                 final int rowsBeta = 50;
 
-                String config = "ws::addr=127.0.0.1:" + HTTP_PORT + ";";
+                // auto_flush_interval=3600000 (1h): the default 100ms interval
+                // auto-flush would fire on the next at() after any >=100ms stall
+                // (GC/JIT on a loaded CI agent), injecting a third txn per table.
+                // That would both break the awaitTxn(name, 2) barrier below (it
+                // returns at writerTxn >= 2, before the close-flush txn applies,
+                // so the reader would see a partial table) and degrade the
+                // choreographed shared mid-flush (a premature auto-flush drains
+                // the buffer it is meant to transmit). WS rejects
+                // auto_flush_interval=off outright, so a 1h interval -- orders of
+                // magnitude beyond the test's runtime -- stands in for it. With
+                // that, rows=1000 (> both row counts) and bytes=0, exactly two
+                // non-empty flushes per table are guaranteed: the shared
+                // mid-flush and the close flush.
+                String config = "ws::addr=127.0.0.1:" + HTTP_PORT + ";auto_flush_interval=3600000;";
                 try (QuestDB db = QuestDB.builder()
                         .fromConfig(config)
                         .senderPoolSize(2)
@@ -727,8 +740,9 @@ public class QuestDBFacadeE2ETest extends AbstractBootstrapTest {
                         }
                         // close() on each flushes whatever remains.
                     }
-                    // ws ingest is async. Each table sees two non-empty flushes
-                    // (the shared mid-flush + its close flush); wait for both.
+                    // ws ingest is async. With interval auto-flush disabled in the
+                    // config, each table sees exactly two non-empty flushes (the
+                    // shared mid-flush + its close flush); wait for both.
                     server.awaitTxn("alpha", 2);
                     server.awaitTxn("beta", 2);
 

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressDemoteRaceFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressDemoteRaceFuzzTest.java
@@ -308,16 +308,23 @@ public class QwpIngressDemoteRaceFuzzTest extends AbstractCairoTest {
     }
 
     private static CairoEngine newDemotableEngine(AtomicBoolean readOnly) {
-        // The base engine answers isReadOnlyMode() from configuration.isReadOnlyInstance()
-        // on EVERY call (documented live-read contract). Backing it with an AtomicBoolean
-        // reproduces the enterprise in-place demote: the flag flips dynamically while
-        // connections are mid-batch. The engine is constructed writable.
-        return new CairoEngine(new DefaultTestCairoConfiguration(root) {
+        // Enterprise widens isReadOnlyMode() at the ENGINE level (the dynamic replica
+        // leg: super.isReadOnlyMode() || isReadOnlyReplica()) while the static
+        // configuration.isReadOnlyInstance() flag stays false -- and the refusal-shape
+        // decision keys on exactly that difference: only ROLE-DERIVED read-only takes
+        // the reconnect-eligible role-change close, while static readonly=true keeps
+        // the terminal SECURITY_ERROR NACK (see isStaticReadOnlyInstance() in
+        // QwpIngressProcessorState). Model the demote the same way enterprise
+        // implements it: override the engine method, keep the config flag false.
+        // Backing it with an AtomicBoolean reproduces the in-place demote: the flag
+        // flips dynamically while connections are mid-batch. The engine is
+        // constructed writable.
+        return new CairoEngine(new DefaultTestCairoConfiguration(root)) {
             @Override
-            public boolean isReadOnlyInstance() {
+            public boolean isReadOnlyMode() {
                 return readOnly.get();
             }
-        });
+        };
     }
 
     private static void runScenario(

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressDemoteRaceFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressDemoteRaceFuzzTest.java
@@ -118,11 +118,11 @@ public class QwpIngressDemoteRaceFuzzTest extends AbstractCairoTest {
                         final RaceTudCache tudCache = installRaceTudCache(state, demotableEngine, lineConfig);
 
                         // Mirror the TableUpdateDetails.commit in-lock re-check contract:
-                        // once the demote flips the flag, the commit refuses with a RAW
-                        // authorization error (outside CommitFailedException wrapping).
+                        // once the demote flips the flag, the commit refuses with the MARKED
+                        // read-only refusal (outside CommitFailedException wrapping).
                         final Runnable commitRefusal = () -> {
                             if (readOnly.get()) {
-                                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                                throw CairoException.readOnlyAccess();
                             }
                         };
                         tudCache.commitHook = commitRefusal;
@@ -218,10 +218,13 @@ public class QwpIngressDemoteRaceFuzzTest extends AbstractCairoTest {
      * and nothing fences the throw-to-catch propagation (the commit path releases
      * the role-switch READ lock in its finally as the exception unwinds), so the
      * write-locked {@code setCurrentRole(PRIMARY)} can land in between.
-     * {@code rejectCairoError} then re-reads the LIVE {@code engine.isReadOnlyMode()},
-     * sees writable, and falls through to {@code cairoExceptionStatus} ->
-     * {@code SECURITY_ERROR}: the client latches a permanent terminal HALT for a
-     * milliseconds-long condition, on a node that ended up writable PRIMARY.
+     * A catch-time re-read of the LIVE {@code engine.isReadOnlyMode()} (the
+     * pre-fix classification) then sees writable and falls through to
+     * {@code cairoExceptionStatus} -> {@code SECURITY_ERROR}: the client latches
+     * a permanent terminal HALT for a milliseconds-long condition, on a node
+     * that ended up writable PRIMARY. The fix classifies by the
+     * {@code isReadOnlyAccessRefusal()} marker stamped at the throw site, which
+     * no later state flip can rewrite.
      * <p>
      * The hook compresses that interleaving deterministically: flip to read-only,
      * shape the refusal exactly as the deep gates produce it, revert to writable,
@@ -257,8 +260,9 @@ public class QwpIngressDemoteRaceFuzzTest extends AbstractCairoTest {
                         final RaceTudCache tudCache = installRaceTudCache(state, demotableEngine, lineConfig);
                         final Runnable demoteRefuseThenRevert = () -> {
                             readOnly.set(true);   // demote Step 1: dynamic flag flips mid-batch
-                            final CairoException e = CairoException.authorization()
-                                    .put(CairoException.READ_ONLY_ACCESS_MESSAGE); // refusal shaped while REPLICA
+                            // refusal shaped (and MARKED) while REPLICA, exactly as every
+                            // production read-only gate now throws it
+                            final CairoException e = CairoException.readOnlyAccess();
                             readOnly.set(false);  // drain budget expires -> demote fails -> PRIMARY restored
                             throw e;              // propagates to the catch AFTER the revert
                         };
@@ -427,12 +431,12 @@ public class QwpIngressDemoteRaceFuzzTest extends AbstractCairoTest {
             }
             case 1: {
                 // Flip lands between the gate and the WAL writer acquisition: the
-                // engine-level acquire refuses with a raw authorization error
+                // engine-level acquire refuses with the marked read-only refusal
                 // (EntCairoEngine.getWalWriter contract). Handled by the
                 // processMessage CairoException arm → rejectCairoError.
                 tudCache.getTudHook = () -> {
                     readOnly.set(true);
-                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                    throw CairoException.readOnlyAccess();
                 };
                 boolean roleChangeClose = driveBatch(state, oneTableMessage((byte) 0));
                 assertContainedRefusal(state, roleChangeClose, "writer acquisition");
@@ -440,12 +444,12 @@ public class QwpIngressDemoteRaceFuzzTest extends AbstractCairoTest {
             }
             case 2: {
                 // Flip lands between the gate and the commit: the in-lock re-check in
-                // TableUpdateDetails.commit refuses with a raw authorization error
+                // TableUpdateDetails.commit refuses with the marked read-only refusal
                 // (deliberately outside CommitFailedException wrapping; QwpTudCache
                 // propagates it raw). Handled by rejectCommitError → rejectCairoError.
                 tudCache.commitHook = () -> {
                     readOnly.set(true);
-                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                    throw CairoException.readOnlyAccess();
                 };
                 boolean roleChangeClose = driveBatch(state, zeroTableMessage((byte) 0));
                 assertContainedRefusal(state, roleChangeClose, "commit");
@@ -456,7 +460,7 @@ public class QwpIngressDemoteRaceFuzzTest extends AbstractCairoTest {
                 // commitIfMaxUncommittedRowsReached).
                 tudCache.maxRowsCommitHook = () -> {
                     readOnly.set(true);
-                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                    throw CairoException.readOnlyAccess();
                 };
                 boolean roleChangeClose = driveBatch(state, zeroTableMessage(QwpConstants.FLAG_DEFER_COMMIT));
                 assertContainedRefusal(state, roleChangeClose, "deferred commit");

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressDemoteRaceFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressDemoteRaceFuzzTest.java
@@ -209,6 +209,89 @@ public class QwpIngressDemoteRaceFuzzTest extends AbstractCairoTest {
         });
     }
 
+    /**
+     * Deterministic reproduction of the demote-REVERT race: the deep-gate refusal
+     * is thrown while the node is read-only (demote Step 1 landed mid-batch), but
+     * the demote FAILS before the exception reaches the state's catch block. Real
+     * path: {@code EntCairoEngine.drainWriterPool(restorePrimaryOnTimeout=true)}
+     * restores PRIMARY when the drain budget expires on busy non-WAL writers --
+     * and nothing fences the throw-to-catch propagation (the commit path releases
+     * the role-switch READ lock in its finally as the exception unwinds), so the
+     * write-locked {@code setCurrentRole(PRIMARY)} can land in between.
+     * {@code rejectCairoError} then re-reads the LIVE {@code engine.isReadOnlyMode()},
+     * sees writable, and falls through to {@code cairoExceptionStatus} ->
+     * {@code SECURITY_ERROR}: the client latches a permanent terminal HALT for a
+     * milliseconds-long condition, on a node that ended up writable PRIMARY.
+     * <p>
+     * The hook compresses that interleaving deterministically: flip to read-only,
+     * shape the refusal exactly as the deep gates produce it, revert to writable,
+     * THEN throw -- the exception reaches the catch after the revert, exactly as
+     * when the drain-timeout restore wins the race. Production
+     * {@code isReadOnlyMode()} is a volatile flag read (enterprise widens it with
+     * the cached volatile {@code isReadOnlyReplica}), so the AtomicBoolean is
+     * memory-semantics-equivalent; the ordering is a legal production schedule,
+     * not a test artifact.
+     * <p>
+     * NOTE: the meta-invariant in {@link #testDemoteFlipAtRandomInjectionPointsFuzz}
+     * cannot catch this case -- it re-reads the same live flag the bug re-reads
+     * (after the revert {@code readOnly.get()} IS false, so a leaked
+     * SECURITY_ERROR passes it). The oracle here is cause-based instead: the
+     * refusal was CAUSED by the transient demote, so the client must get the
+     * reconnect-eligible shape regardless of what the flag reads at catch time.
+     */
+    @Test
+    public void testDemoteRevertBetweenThrowAndCatchStaysContained() throws Exception {
+        assertMemoryLeak(() -> {
+            final AtomicBoolean readOnly = new AtomicBoolean(false);
+            final LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+
+            try (CairoEngine demotableEngine = newDemotableEngine(readOnly)) {
+                // The revert can race any of the three post-gate refusal windows.
+                for (int window = 0; window < 3; window++) {
+                    readOnly.set(false);
+                    final QwpIngressProcessorState state =
+                            new QwpIngressProcessorState(1024, 4096, demotableEngine, lineConfig);
+                    try {
+                        state.of(1, AllowAllSecurityContext.INSTANCE);
+                        final RaceTudCache tudCache = installRaceTudCache(state, demotableEngine, lineConfig);
+                        final Runnable demoteRefuseThenRevert = () -> {
+                            readOnly.set(true);   // demote Step 1: dynamic flag flips mid-batch
+                            final CairoException e = CairoException.authorization()
+                                    .put(CairoException.READ_ONLY_ACCESS_MESSAGE); // refusal shaped while REPLICA
+                            readOnly.set(false);  // drain budget expires -> demote fails -> PRIMARY restored
+                            throw e;              // propagates to the catch AFTER the revert
+                        };
+                        final byte[] message;
+                        final String where;
+                        switch (window) {
+                            case 0:
+                                tudCache.getTudHook = demoteRefuseThenRevert;
+                                message = oneTableMessage((byte) 0);
+                                where = "revert vs writer acquisition";
+                                break;
+                            case 1:
+                                tudCache.commitHook = demoteRefuseThenRevert;
+                                message = zeroTableMessage((byte) 0);
+                                where = "revert vs commit";
+                                break;
+                            default:
+                                tudCache.maxRowsCommitHook = demoteRefuseThenRevert;
+                                message = zeroTableMessage(QwpConstants.FLAG_DEFER_COMMIT);
+                                where = "revert vs deferred commit";
+                                break;
+                        }
+                        final boolean roleChangeClose = driveBatch(state, message);
+                        assertContainedRefusal(state, roleChangeClose, where);
+                    } finally {
+                        state.onDisconnected();
+                        state.close();
+                    }
+                }
+            }
+        });
+    }
+
     private static void assertContainedRefusal(QwpIngressProcessorState state, boolean roleChangeClose, String where) {
         Assert.assertFalse(where + ": batch must be refused", state.isOk());
         Assert.assertNotEquals(

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressDemoteRaceFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressDemoteRaceFuzzTest.java
@@ -1,0 +1,520 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.qwp;
+
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.PartitionBy;
+import io.questdb.cairo.SecurityContext;
+import io.questdb.cairo.security.AllowAllSecurityContext;
+import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
+import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
+import io.questdb.cutlass.line.tcp.DefaultColumnTypes;
+import io.questdb.cutlass.line.tcp.WalTableUpdateDetails;
+import io.questdb.cutlass.qwp.protocol.QwpColumnDef;
+import io.questdb.cutlass.qwp.protocol.QwpConstants;
+import io.questdb.cutlass.qwp.protocol.QwpTableBlockCursor;
+import io.questdb.cutlass.qwp.server.QwpIngressProcessorState;
+import io.questdb.cutlass.qwp.server.QwpTudCache;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Misc;
+import io.questdb.std.ObjList;
+import io.questdb.std.Rnd;
+import io.questdb.std.Unsafe;
+import io.questdb.std.str.Utf8Sequence;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.cairo.DefaultTestCairoConfiguration;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Fuzz test for INVARIANT B containment of the in-place PRIMARY-to-REPLICA
+ * demote race on the QWP ingress path (see {@code rejectCairoError} in
+ * {@link QwpIngressProcessorState}).
+ * <p>
+ * The read-only flag can flip at ANY point within a batch: before the
+ * {@code engine.isReadOnlyMode()} gate at the top of {@code processMessage()},
+ * between the gate and the WAL writer acquisition (the enterprise
+ * {@code EntCairoEngine.getWalWriter} refusal), or between the gate and the
+ * commit (the {@code TableUpdateDetails.commit} in-lock re-check refusal). The
+ * deeper engine gates refuse with {@code CairoException.authorization()}
+ * ("replica access is read-only") thrown RAW — deliberately outside
+ * {@code CommitFailedException} wrapping — which the naive
+ * {@code cairoExceptionStatus} mapping would turn into
+ * {@code Status.SECURITY_ERROR}: a status a store-and-forward client latches
+ * as a terminal HALT and surfaces to its producer. A transient demote must
+ * instead map to the reconnect-eligible {@code Status.NOT_ACCEPTING_WRITES}
+ * close ({@code isRoleChangeClosePending()}), while a genuine ACL denial on a
+ * writable node must STILL map to {@code SECURITY_ERROR}.
+ * <p>
+ * Two fuzz phases:
+ * <ol>
+ *   <li>Deterministic: the flip is injected at a randomly chosen point in the
+ *       batch lifecycle (before the gate / inside TUD acquisition / inside the
+ *       commit / inside the deferred commit), interleaved with genuine ACL
+ *       denials and clean batches, so every containment arm and the
+ *       genuine-denial arm are exercised under one random schedule.</li>
+ *   <li>Concurrent: a flipper thread demotes the engine at a random time while
+ *       the driver pumps batches, reproducing the true race timing. Within a
+ *       round the flip is one-directional (writable to read-only, matching a
+ *       real demote), so any authorization refusal raised by the read-only
+ *       gates happens-after the flip and the containment re-check must observe
+ *       it: SECURITY_ERROR is impossible unless containment is broken.</li>
+ * </ol>
+ * The batch driver mirrors {@code QwpIngressUpgradeProcessor.handleBinaryMessage}
+ * exactly, including reading {@code isRoleChangeClosePending()} AFTER the
+ * commit calls — the ordering the containment fix depends on.
+ */
+public class QwpIngressDemoteRaceFuzzTest extends AbstractCairoTest {
+
+    private static final String ACL_DENIAL_MESSAGE = "write permission denied [table=fuzz]";
+    private static final int CONCURRENT_MAX_BATCHES = 10_000;
+    private static final int CONCURRENT_ROUNDS = 30;
+    private static final int DETERMINISTIC_ITERATIONS = 300;
+
+    @Test
+    public void testConcurrentDemoteFlipNeverEmitsSecurityError() throws Exception {
+        assertMemoryLeak(() -> {
+            final Rnd rnd = TestUtils.generateRandom(LOG);
+            final AtomicBoolean readOnly = new AtomicBoolean(false);
+            final LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+
+            try (CairoEngine demotableEngine = newDemotableEngine(readOnly)) {
+                for (int round = 0; round < CONCURRENT_ROUNDS; round++) {
+                    readOnly.set(false);
+                    final QwpIngressProcessorState state =
+                            new QwpIngressProcessorState(1024, 4096, demotableEngine, lineConfig);
+                    try {
+                        state.of(1, AllowAllSecurityContext.INSTANCE);
+                        final RaceTudCache tudCache = installRaceTudCache(state, demotableEngine, lineConfig);
+
+                        // Mirror the TableUpdateDetails.commit in-lock re-check contract:
+                        // once the demote flips the flag, the commit refuses with a RAW
+                        // authorization error (outside CommitFailedException wrapping).
+                        final Runnable commitRefusal = () -> {
+                            if (readOnly.get()) {
+                                throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                            }
+                        };
+                        tudCache.commitHook = commitRefusal;
+                        tudCache.maxRowsCommitHook = commitRefusal;
+
+                        final CyclicBarrier start = new CyclicBarrier(2);
+                        final long flipDelayNanos = rnd.nextLong(1_000_000L); // 0..1ms into the round
+                        final Thread flipper = new Thread(() -> {
+                            try {
+                                start.await();
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                            LockSupport.parkNanos(flipDelayNanos);
+                            readOnly.set(true);
+                        }, "demote-flipper");
+                        flipper.start();
+                        start.await();
+
+                        boolean refused = false;
+                        for (int batch = 0; batch < CONCURRENT_MAX_BATCHES; batch++) {
+                            if (driveBatchAndAssertContained(state, rnd, readOnly)) {
+                                refused = true;
+                                break;
+                            }
+                        }
+                        flipper.join();
+
+                        if (!refused) {
+                            // The flip landed after the last batch. The flag is now
+                            // read-only for certain, so one more batch MUST refuse via
+                            // the top gate — still with the contained status.
+                            Assert.assertTrue(
+                                    "post-flip batch must be refused",
+                                    driveBatchAndAssertContained(state, rnd, readOnly)
+                            );
+                        }
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        state.onDisconnected();
+                        state.close();
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testDemoteFlipAtRandomInjectionPointsFuzz() throws Exception {
+        assertMemoryLeak(() -> {
+            final Rnd rnd = TestUtils.generateRandom(LOG);
+            final AtomicBoolean readOnly = new AtomicBoolean(false);
+            final LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+
+            try (CairoEngine demotableEngine = newDemotableEngine(readOnly)) {
+                for (int i = 0; i < DETERMINISTIC_ITERATIONS; i++) {
+                    readOnly.set(false);
+                    final int scenario = rnd.nextInt(7);
+                    final QwpIngressProcessorState state =
+                            new QwpIngressProcessorState(1024, 4096, demotableEngine, lineConfig);
+                    try {
+                        state.of(1, AllowAllSecurityContext.INSTANCE);
+                        final RaceTudCache tudCache = installRaceTudCache(state, demotableEngine, lineConfig);
+                        runScenario(scenario, state, tudCache, readOnly, rnd);
+
+                        // Meta-invariant across ALL scenarios: SECURITY_ERROR may only
+                        // ever be emitted while the node is writable. On a read-only
+                        // node it means a transient demote leaked to the client as a
+                        // terminal HALT — the exact Invariant B violation.
+                        if (state.getStatus() == QwpIngressProcessorState.Status.SECURITY_ERROR) {
+                            Assert.assertFalse(
+                                    "SECURITY_ERROR emitted while the node is read-only [scenario=" + scenario + ']',
+                                    readOnly.get()
+                            );
+                        }
+                    } finally {
+                        state.onDisconnected();
+                        state.close();
+                    }
+                }
+            }
+        });
+    }
+
+    private static void assertContainedRefusal(QwpIngressProcessorState state, boolean roleChangeClose, String where) {
+        Assert.assertFalse(where + ": batch must be refused", state.isOk());
+        Assert.assertNotEquals(
+                where + ": transient demote must never map to SECURITY_ERROR (client latches terminal HALT)",
+                QwpIngressProcessorState.Status.SECURITY_ERROR,
+                state.getStatus()
+        );
+        Assert.assertEquals(
+                where + ": demote refusal must map to the reconnect-eligible status",
+                QwpIngressProcessorState.Status.NOT_ACCEPTING_WRITES,
+                state.getStatus()
+        );
+        Assert.assertTrue(
+                where + ": connection must be flagged for the role-change close",
+                roleChangeClose
+        );
+        TestUtils.assertContains(state.getErrorText(), CairoException.READ_ONLY_ACCESS_MESSAGE);
+    }
+
+    private static void addNativeData(QwpIngressProcessorState state, byte[] data) {
+        long ptr = Unsafe.malloc(data.length, MemoryTag.NATIVE_HTTP_CONN);
+        try {
+            for (int i = 0; i < data.length; i++) {
+                Unsafe.putByte(ptr + i, data[i]);
+            }
+            state.addData(ptr, ptr + data.length);
+        } finally {
+            Unsafe.free(ptr, data.length, MemoryTag.NATIVE_HTTP_CONN);
+        }
+    }
+
+    /**
+     * Drives one message through the state, mirroring the exact call ordering of
+     * {@code QwpIngressUpgradeProcessor.handleBinaryMessage}: addData →
+     * isDeferCommit → processMessage → commit/commitIfMaxUncommittedRowsReached →
+     * read isRoleChangeClosePending AFTER the commit calls.
+     *
+     * @return the roleChangeClose flag as the upgrade processor would observe it
+     */
+    private static boolean driveBatch(QwpIngressProcessorState state, byte[] message) {
+        addNativeData(state, message);
+        boolean deferCommit = state.isDeferCommit();
+        state.processMessage();
+        if (state.isOk() && !deferCommit) {
+            state.commit();
+        }
+        if (state.isOk() && deferCommit) {
+            state.commitIfMaxUncommittedRowsReached();
+        }
+        // Read AFTER the commit calls — the ordering the containment fix
+        // (86f8556c8e) depends on: reading before commit() misses the
+        // commit-path authorization refusal.
+        return state.isRoleChangeClosePending();
+    }
+
+    /**
+     * Drives one randomly-shaped batch and asserts the containment invariant if
+     * it was refused.
+     *
+     * @return true if the batch was refused (the connection would close)
+     */
+    private static boolean driveBatchAndAssertContained(
+            QwpIngressProcessorState state, Rnd rnd, AtomicBoolean readOnly
+    ) {
+        final boolean defer = rnd.nextBoolean();
+        final byte[] message = zeroTableMessage(defer ? QwpConstants.FLAG_DEFER_COMMIT : 0);
+        final boolean roleChangeClose = driveBatch(state, message);
+        if (state.isOk()) {
+            if (defer) {
+                state.clearMessageState();
+            } else {
+                state.clear();
+            }
+            return false;
+        }
+        // Within a round the flip is one-directional, so the refusal can only be
+        // the demote: it must be contained no matter which window it landed in
+        // (top gate or commit-path re-check).
+        Assert.assertTrue("refusal implies the demote flip landed", readOnly.get());
+        assertContainedRefusal(state, roleChangeClose, "concurrent");
+        return true;
+    }
+
+    private static RaceTudCache installRaceTudCache(
+            QwpIngressProcessorState state, CairoEngine engine, LineHttpProcessorConfiguration lineConfig
+    ) {
+        try {
+            Field f = QwpIngressProcessorState.class.getDeclaredField("tudCache");
+            f.setAccessible(true);
+            Misc.free((QwpTudCache) f.get(state));
+            RaceTudCache cache = new RaceTudCache(engine, lineConfig);
+            f.set(state, cache);
+            return cache;
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static CairoEngine newDemotableEngine(AtomicBoolean readOnly) {
+        // The base engine answers isReadOnlyMode() from configuration.isReadOnlyInstance()
+        // on EVERY call (documented live-read contract). Backing it with an AtomicBoolean
+        // reproduces the enterprise in-place demote: the flag flips dynamically while
+        // connections are mid-batch. The engine is constructed writable.
+        return new CairoEngine(new DefaultTestCairoConfiguration(root) {
+            @Override
+            public boolean isReadOnlyInstance() {
+                return readOnly.get();
+            }
+        });
+    }
+
+    private static void runScenario(
+            int scenario,
+            QwpIngressProcessorState state,
+            RaceTudCache tudCache,
+            AtomicBoolean readOnly,
+            Rnd rnd
+    ) {
+        switch (scenario) {
+            case 0: {
+                // Flip lands BEFORE the batch: the top-of-processMessage gate refuses.
+                readOnly.set(true);
+                boolean roleChangeClose = driveBatch(state, randomMessage(rnd));
+                assertContainedRefusal(state, roleChangeClose, "top gate");
+                break;
+            }
+            case 1: {
+                // Flip lands between the gate and the WAL writer acquisition: the
+                // engine-level acquire refuses with a raw authorization error
+                // (EntCairoEngine.getWalWriter contract). Handled by the
+                // processMessage CairoException arm → rejectCairoError.
+                tudCache.getTudHook = () -> {
+                    readOnly.set(true);
+                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                };
+                boolean roleChangeClose = driveBatch(state, oneTableMessage((byte) 0));
+                assertContainedRefusal(state, roleChangeClose, "writer acquisition");
+                break;
+            }
+            case 2: {
+                // Flip lands between the gate and the commit: the in-lock re-check in
+                // TableUpdateDetails.commit refuses with a raw authorization error
+                // (deliberately outside CommitFailedException wrapping; QwpTudCache
+                // propagates it raw). Handled by rejectCommitError → rejectCairoError.
+                tudCache.commitHook = () -> {
+                    readOnly.set(true);
+                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                };
+                boolean roleChangeClose = driveBatch(state, zeroTableMessage((byte) 0));
+                assertContainedRefusal(state, roleChangeClose, "commit");
+                break;
+            }
+            case 3: {
+                // Same as 2, on the deferred-commit path (FLAG_DEFER_COMMIT →
+                // commitIfMaxUncommittedRowsReached).
+                tudCache.maxRowsCommitHook = () -> {
+                    readOnly.set(true);
+                    throw CairoException.authorization().put(CairoException.READ_ONLY_ACCESS_MESSAGE);
+                };
+                boolean roleChangeClose = driveBatch(state, zeroTableMessage(QwpConstants.FLAG_DEFER_COMMIT));
+                assertContainedRefusal(state, roleChangeClose, "deferred commit");
+                break;
+            }
+            case 4: {
+                // Clean batch on a writable node: no refusal, no role-change close.
+                boolean roleChangeClose = driveBatch(state, zeroTableMessage(
+                        rnd.nextBoolean() ? QwpConstants.FLAG_DEFER_COMMIT : 0));
+                Assert.assertTrue("clean batch must succeed", state.isOk());
+                Assert.assertFalse("clean batch must not flag role-change close", roleChangeClose);
+                break;
+            }
+            case 5: {
+                // GENUINE ACL denial from the commit on a WRITABLE node: containment
+                // must NOT swallow it — the client must still see SECURITY_ERROR.
+                tudCache.commitHook = () -> {
+                    throw CairoException.authorization().put(ACL_DENIAL_MESSAGE);
+                };
+                boolean roleChangeClose = driveBatch(state, zeroTableMessage((byte) 0));
+                Assert.assertFalse(state.isOk());
+                Assert.assertEquals(
+                        "genuine ACL denial on a writable node must stay SECURITY_ERROR",
+                        QwpIngressProcessorState.Status.SECURITY_ERROR,
+                        state.getStatus()
+                );
+                Assert.assertFalse(
+                        "genuine ACL denial must not trigger the role-change close",
+                        roleChangeClose
+                );
+                TestUtils.assertContains(state.getErrorText(), ACL_DENIAL_MESSAGE);
+                break;
+            }
+            default: {
+                // GENUINE ACL denial from the writer acquisition on a WRITABLE node.
+                tudCache.getTudHook = () -> {
+                    throw CairoException.authorization().put(ACL_DENIAL_MESSAGE);
+                };
+                boolean roleChangeClose = driveBatch(state, oneTableMessage((byte) 0));
+                Assert.assertFalse(state.isOk());
+                Assert.assertEquals(
+                        "genuine ACL denial on a writable node must stay SECURITY_ERROR",
+                        QwpIngressProcessorState.Status.SECURITY_ERROR,
+                        state.getStatus()
+                );
+                Assert.assertFalse(
+                        "genuine ACL denial must not trigger the role-change close",
+                        roleChangeClose
+                );
+                TestUtils.assertContains(state.getErrorText(), ACL_DENIAL_MESSAGE);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Message with one table block ("fuzz", 0 rows, 0 columns): decodes far enough
+     * to reach {@code QwpTudCache.getTableUpdateDetails}.
+     */
+    private static byte[] oneTableMessage(byte flags) {
+        byte[] payload = {
+                4, 'f', 'u', 'z', 'z',
+                0,    // rowCount=0
+                0     // columnCount=0
+        };
+        return wrapQwpPayload(payload, (short) 1, flags);
+    }
+
+    private static byte[] randomMessage(Rnd rnd) {
+        return rnd.nextBoolean()
+                ? zeroTableMessage(rnd.nextBoolean() ? QwpConstants.FLAG_DEFER_COMMIT : 0)
+                : oneTableMessage(rnd.nextBoolean() ? QwpConstants.FLAG_DEFER_COMMIT : 0);
+    }
+
+    private static byte[] wrapQwpPayload(byte[] payload, short tableCount, byte flags) {
+        byte[] message = new byte[QwpConstants.HEADER_SIZE + payload.length];
+        message[0] = 'Q';
+        message[1] = 'W';
+        message[2] = 'P';
+        message[3] = '1';
+        message[4] = QwpConstants.VERSION;
+        message[5] = flags;
+        message[6] = (byte) tableCount;
+        message[7] = (byte) (tableCount >>> 8);
+        message[8] = (byte) payload.length;
+        message[9] = (byte) (payload.length >>> 8);
+        message[10] = (byte) (payload.length >>> 16);
+        message[11] = (byte) (payload.length >>> 24);
+        System.arraycopy(payload, 0, message, QwpConstants.HEADER_SIZE, payload.length);
+        return message;
+    }
+
+    /**
+     * Well-formed message with zero table blocks: passes the read-only gate and the
+     * decoder, then goes straight to the commit calls — the exact shape needed to
+     * land the flip in the gate-to-commit window.
+     */
+    private static byte[] zeroTableMessage(byte flags) {
+        return wrapQwpPayload(new byte[0], (short) 0, flags);
+    }
+
+    /**
+     * QwpTudCache with injection hooks at the two engine-refusal sites the demote
+     * race can hit after the top gate has passed: the WAL writer acquisition
+     * ({@code getTableUpdateDetails}) and the commits. Hooks run INSIDE the cache,
+     * i.e. between the {@code processMessage} gate and the state's catch blocks —
+     * precisely the window the containment re-check must cover.
+     */
+    private static final class RaceTudCache extends QwpTudCache {
+        volatile Runnable commitHook;
+        volatile Runnable getTudHook;
+        volatile Runnable maxRowsCommitHook;
+
+        RaceTudCache(CairoEngine engine, LineHttpProcessorConfiguration lineConfig) {
+            super(engine, true, true, new DefaultColumnTypes(lineConfig), PartitionBy.DAY);
+        }
+
+        @Override
+        public void commitAll(CommittedTxnConsumer consumer) throws Throwable {
+            Runnable hook = commitHook;
+            if (hook != null) {
+                hook.run();
+            }
+        }
+
+        @Override
+        public void commitIfMaxUncommittedRowsReached(CommittedTxnConsumer consumer) throws Throwable {
+            Runnable hook = maxRowsCommitHook;
+            if (hook != null) {
+                hook.run();
+            }
+        }
+
+        @Override
+        public WalTableUpdateDetails getTableUpdateDetails(
+                SecurityContext securityContext,
+                Utf8Sequence tableName,
+                ObjList<QwpColumnDef> schema,
+                QwpTableBlockCursor cursor,
+                int maxTables
+        ) {
+            Runnable hook = getTudHook;
+            if (hook != null) {
+                hook.run();
+            }
+            // Only reached by scenarios whose hook throws; table-bearing payloads
+            // are never driven down the success path in this fuzz.
+            throw new UnsupportedOperationException("fuzz getTudHook must throw");
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressDemoteRaceFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressDemoteRaceFuzzTest.java
@@ -344,6 +344,12 @@ public class QwpIngressDemoteRaceFuzzTest extends AbstractCairoTest {
         }
         if (state.isOk() && deferCommit) {
             state.commitIfMaxUncommittedRowsReached();
+            if (state.isOk()) {
+                // Mirrors the processor's deferred-ack containment: rows are
+                // buffered but uncommitted, so the cumulative-ack watermark
+                // must not advance past this frame until the group commits.
+                state.markUncommittedDeferredRows();
+            }
         }
         // Read AFTER the commit calls — the ordering the containment fix
         // (86f8556c8e) depends on: reading before commit() misses the

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
@@ -1467,6 +1467,73 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testUnresolvedSequenceClampsAckWatermark() throws Exception {
+        // Defense-in-depth for the cumulative-ack leapfrog: a sequence that was
+        // consumed but neither committed nor error-responded (role-change close
+        // paths) must never be covered by the cumulative-ack watermark, even if
+        // the processor-level deferral gate regresses.
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+
+                state.setHighestProcessedSequence(0);
+                state.markSequenceUnresolved(1);
+
+                // watermark must not reach the unresolved sequence...
+                state.setHighestProcessedSequence(1);
+                Assert.assertEquals(0, state.getHighestProcessedSequence());
+                // ...nor leapfrog past it
+                state.setHighestProcessedSequence(2);
+                Assert.assertEquals(0, state.getHighestProcessedSequence());
+
+                // marking keeps the minimum: a later, higher unresolved sequence
+                // must not loosen the clamp
+                state.markSequenceUnresolved(5);
+                state.setHighestProcessedSequence(6);
+                Assert.assertEquals(0, state.getHighestProcessedSequence());
+
+                // advancing strictly below the unresolved sequence stays legal
+                // (clamp boundary is firstUnresolved - 1; here that is 0)
+                state.setHighestProcessedSequence(0);
+                Assert.assertEquals(0, state.getHighestProcessedSequence());
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    @Test
+    public void testUnresolvedSequenceResetOnDisconnect() throws Exception {
+        // The unresolved marker is per-connection: after the reconnect-eligible
+        // close the client replays from its acked watermark, so a recycled state
+        // must accept fresh sequences without clamping.
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+                state.markSequenceUnresolved(0);
+                state.setHighestProcessedSequence(3);
+                Assert.assertEquals(-1, state.getHighestProcessedSequence());
+
+                state.onDisconnected();
+
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+                state.setHighestProcessedSequence(3);
+                Assert.assertEquals(3, state.getHighestProcessedSequence());
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    @Test
     public void testCommitConsumerThrowRejectsState() throws Exception {
         assertMemoryLeak(() -> {
             LineHttpProcessorConfiguration lineConfig =

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
@@ -46,6 +46,7 @@ import io.questdb.cutlass.qwp.protocol.QwpTableBlockCursor;
 import io.questdb.cutlass.qwp.server.QwpIngressProcessorState;
 import io.questdb.cutlass.qwp.server.QwpTudCache;
 import io.questdb.std.CharSequenceLongHashMap;
+import io.questdb.std.datetime.MicrosecondClock;
 import io.questdb.std.LowerCaseUtf8SequenceObjHashMap;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
@@ -2354,6 +2355,110 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
         Object map = f.get(state);
         // Both CharSequenceLongHashMap and CharSequenceObjHashMap expose size().
         return (int) map.getClass().getMethod("size").invoke(map);
+    }
+
+    @Test
+    public void testIsDurableWorkFullyUploaded() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+                state.setDurableAckEnabled(true);
+                FakeConsumerTudCache fake = installFakeTudCache(state, engine, lineConfig);
+                FakeDurableAckRegistry registry = new FakeDurableAckRegistry();
+
+                // Nothing pending -> trivially covered.
+                Assert.assertTrue(state.isDurableWorkFullyUploaded(registry));
+
+                fake.queueCommit(
+                        new String[]{"t1", "t2"},
+                        new String[]{"t1~1", "t2~1"},
+                        new long[]{10L, 20L}
+                );
+                state.setHighestProcessedSequence(0);
+                state.commit();
+
+                // No uploads at all.
+                Assert.assertFalse(state.isDurableWorkFullyUploaded(registry));
+
+                // One table lagging behind its committed seqTxn.
+                registry.set("t1~1", 10L);
+                registry.set("t2~1", 19L);
+                Assert.assertFalse(state.isDurableWorkFullyUploaded(registry));
+
+                // Watermarks caught up on both tables.
+                registry.set("t2~1", 20L);
+                Assert.assertTrue(state.isDurableWorkFullyUploaded(registry));
+
+                // Coverage survives the durable-ack prune...
+                state.collectDurableProgress(registry);
+                state.onDurableAckSent();
+                Assert.assertTrue(state.isDurableWorkFullyUploaded(registry));
+
+                // ...and a fresh commit re-opens the window until its upload lands.
+                fake.queueCommit(new String[]{"t1"}, new String[]{"t1~1"}, new long[]{11L});
+                state.setHighestProcessedSequence(1);
+                state.commit();
+                Assert.assertFalse(state.isDurableWorkFullyUploaded(registry));
+                registry.set("t1~1", 11L);
+                Assert.assertTrue(state.isDurableWorkFullyUploaded(registry));
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    @Test
+    public void testRoleChangeCloseDeferralLifecycle() throws Exception {
+        assertMemoryLeak(() -> {
+            long[] nowMicros = {0L};
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration) {
+                        @Override
+                        public MicrosecondClock getMicrosecondClock() {
+                            return () -> nowMicros[0];
+                        }
+                    };
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+
+                Assert.assertFalse(state.isRoleChangeCloseDeferred());
+                Assert.assertFalse(state.isRoleChangeCloseGraceExpired());
+
+                state.deferRoleChangeClose("replica access is read-only");
+                Assert.assertTrue(state.isRoleChangeCloseDeferred());
+                Assert.assertFalse(state.isRoleChangeCloseGraceExpired());
+                Assert.assertEquals("replica access is read-only", state.getRoleChangeCloseReason().toString());
+
+                // Follow-on gate hits must not extend the deadline or clobber the reason.
+                nowMicros[0] = QwpIngressProcessorState.ROLE_CHANGE_CLOSE_UPLOAD_GRACE_MICROS - 1;
+                state.deferRoleChangeClose("a different reason");
+                Assert.assertEquals("replica access is read-only", state.getRoleChangeCloseReason().toString());
+                Assert.assertFalse(state.isRoleChangeCloseGraceExpired());
+
+                // The deferral spans messages: per-message resets must not drop it.
+                state.clear();
+                state.clearMessageState();
+                Assert.assertTrue(state.isRoleChangeCloseDeferred());
+
+                // Grace budget exhausts exactly at the deadline.
+                nowMicros[0] = QwpIngressProcessorState.ROLE_CHANGE_CLOSE_UPLOAD_GRACE_MICROS;
+                Assert.assertTrue(state.isRoleChangeCloseGraceExpired());
+
+                // Connection recycle resets the deferral.
+                state.onDisconnected();
+                Assert.assertFalse(state.isRoleChangeCloseDeferred());
+                Assert.assertFalse(state.isRoleChangeCloseGraceExpired());
+                Assert.assertEquals(0, state.getRoleChangeCloseReason().length());
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
     }
 
     private static FakeConsumerTudCache installFakeTudCache(

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
@@ -51,6 +51,7 @@ import io.questdb.std.LowerCaseUtf8SequenceObjHashMap;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Misc;
 import io.questdb.std.ObjList;
+import io.questdb.std.Rnd;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.Utf8String;
@@ -2619,6 +2620,210 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
                 state.close();
             }
         });
+    }
+
+    @Test
+    public void testOnFatalCloseBlockedFromResumeCloseClearsDeferredClose() throws Exception {
+        // The already-RESUME_CLOSE branch of onFatalCloseBlocked: a previous fatal close was partially
+        // flushed (onFatalCloseSendBlocked parked the CLOSE frame bytes and moved sendState to
+        // RESUME_CLOSE). A second fatal-close attempt behind it must NOT re-defer a code/reason -- the
+        // parked bytes ARE the CLOSE frame; the resume path finishes flushing them and disconnects. So
+        // the branch clears the just-stored deferred code/reason and leaves sendState at RESUME_CLOSE.
+        // Driven through the public API (no reflection) to pin the real production path.
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+
+                // Park a partially-flushed CLOSE frame: sendState -> RESUME_CLOSE, deferred close cleared.
+                state.onFatalCloseSendBlocked();
+                final int resumeClose = state.getSendState();
+                Assert.assertFalse("precondition: must not be READY", state.isSendReady());
+                Assert.assertEquals(-1, state.getDeferredCloseCode());
+
+                // A second fatal close arrives while the CLOSE frame is still parked.
+                state.onFatalCloseBlocked(1011, "internal error");
+
+                // The branch is idempotent: the parked CLOSE frame stands, the redundant code/reason are
+                // discarded, and the state stays RESUME_CLOSE (never re-deferred).
+                Assert.assertEquals("sendState must stay RESUME_CLOSE", resumeClose, state.getSendState());
+                Assert.assertEquals("deferred close code must be cleared", -1, state.getDeferredCloseCode());
+                Assert.assertEquals("deferred close reason must be cleared", 0, state.getDeferredCloseReason().length());
+
+                // Idempotent under repetition (a re-entered deferral must not resurrect a code/reason).
+                state.onFatalCloseBlocked(1013, "try again later");
+                Assert.assertEquals(resumeClose, state.getSendState());
+                Assert.assertEquals(-1, state.getDeferredCloseCode());
+                Assert.assertEquals(0, state.getDeferredCloseReason().length());
+
+                // Null reason path through the same branch.
+                state.onFatalCloseBlocked(1000, null);
+                Assert.assertEquals(resumeClose, state.getSendState());
+                Assert.assertEquals(-1, state.getDeferredCloseCode());
+                Assert.assertEquals(0, state.getDeferredCloseReason().length());
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    @Test
+    public void testOnFatalCloseBlockedTransitionTableCoversAllSendStates() throws Exception {
+        // Exhaustive transition table for onFatalCloseBlocked across every input sendState. Pins the
+        // full routing contract, including the RESUME_CLOSE idempotent branch and the ack/durable-ack
+        // collapse-to-*_THEN_CLOSE arms that keep the deferred code/reason for the resume path.
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+
+                final int READY = sendStateConst("SEND_STATE_READY");
+                final int RESUME_ACK = sendStateConst("SEND_STATE_RESUME_ACK");
+                final int RESUME_ERROR = sendStateConst("SEND_STATE_RESUME_ERROR");
+                final int RESUME_ACK_THEN_ERROR = sendStateConst("SEND_STATE_RESUME_ACK_THEN_ERROR");
+                final int RESUME_DURABLE_ACK = sendStateConst("SEND_STATE_RESUME_DURABLE_ACK");
+                final int RESUME_DURABLE_ACK_THEN_ERROR = sendStateConst("SEND_STATE_RESUME_DURABLE_ACK_THEN_ERROR");
+                final int RESUME_CLOSE = sendStateConst("SEND_STATE_RESUME_CLOSE");
+                final int RESUME_ACK_THEN_CLOSE = sendStateConst("SEND_STATE_RESUME_ACK_THEN_CLOSE");
+                final int RESUME_DURABLE_ACK_THEN_CLOSE = sendStateConst("SEND_STATE_RESUME_DURABLE_ACK_THEN_CLOSE");
+                final int RESUME_PONG = sendStateConst("SEND_STATE_RESUME_PONG");
+                final int RESUME_DRAIN_THEN_CLOSE = sendStateConst("SEND_STATE_RESUME_DRAIN_THEN_CLOSE");
+
+                // ACK-family inputs collapse to RESUME_ACK_THEN_CLOSE, RETAINING the deferred code/reason.
+                for (int in : new int[]{RESUME_ACK, RESUME_ACK_THEN_ERROR, RESUME_ACK_THEN_CLOSE}) {
+                    setSendState(state, in);
+                    state.onFatalCloseBlocked(1011, "boom");
+                    Assert.assertEquals("input=" + in, RESUME_ACK_THEN_CLOSE, state.getSendState());
+                    Assert.assertEquals("input=" + in, 1011, state.getDeferredCloseCode());
+                    Assert.assertEquals("input=" + in, "boom", state.getDeferredCloseReason().toString());
+                }
+
+                // DURABLE-ACK-family inputs collapse to RESUME_DURABLE_ACK_THEN_CLOSE, RETAINING code/reason.
+                for (int in : new int[]{RESUME_DURABLE_ACK, RESUME_DURABLE_ACK_THEN_ERROR, RESUME_DURABLE_ACK_THEN_CLOSE}) {
+                    setSendState(state, in);
+                    state.onFatalCloseBlocked(1012, "later");
+                    Assert.assertEquals("input=" + in, RESUME_DURABLE_ACK_THEN_CLOSE, state.getSendState());
+                    Assert.assertEquals("input=" + in, 1012, state.getDeferredCloseCode());
+                    Assert.assertEquals("input=" + in, "later", state.getDeferredCloseReason().toString());
+                }
+
+                // RESUME_CLOSE stays put and CLEARS the redundant code/reason (parked bytes ARE the CLOSE).
+                setSendState(state, RESUME_CLOSE);
+                state.onFatalCloseBlocked(1011, "boom");
+                Assert.assertEquals(RESUME_CLOSE, state.getSendState());
+                Assert.assertEquals(-1, state.getDeferredCloseCode());
+                Assert.assertEquals(0, state.getDeferredCloseReason().length());
+
+                // All other inputs park behind a non-ack response: drain-then-close, RETAINING code/reason.
+                for (int in : new int[]{READY, RESUME_ERROR, RESUME_PONG, RESUME_DRAIN_THEN_CLOSE}) {
+                    setSendState(state, in);
+                    state.onFatalCloseBlocked(1001, "going away");
+                    Assert.assertEquals("input=" + in, RESUME_DRAIN_THEN_CLOSE, state.getSendState());
+                    Assert.assertEquals("input=" + in, 1001, state.getDeferredCloseCode());
+                    Assert.assertEquals("input=" + in, "going away", state.getDeferredCloseReason().toString());
+                }
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    @Test
+    public void testOnFatalCloseBlockedFuzz() throws Exception {
+        // Property fuzz over onFatalCloseBlocked: for a random input sendState, random close code and
+        // random reason (null / empty / non-empty), the method must never throw, must always leave the
+        // connection in a terminal close-bearing state, and must obey the retain-vs-clear contract:
+        //   RESUME_CLOSE   -> stays RESUME_CLOSE, deferred code/reason CLEARED
+        //   ACK family     -> RESUME_ACK_THEN_CLOSE, code/reason RETAINED
+        //   DURABLE family -> RESUME_DURABLE_ACK_THEN_CLOSE, code/reason RETAINED
+        //   everything else-> RESUME_DRAIN_THEN_CLOSE, code/reason RETAINED
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+
+                final int READY = sendStateConst("SEND_STATE_READY");
+                final int RESUME_ACK = sendStateConst("SEND_STATE_RESUME_ACK");
+                final int RESUME_ERROR = sendStateConst("SEND_STATE_RESUME_ERROR");
+                final int RESUME_ACK_THEN_ERROR = sendStateConst("SEND_STATE_RESUME_ACK_THEN_ERROR");
+                final int RESUME_DURABLE_ACK = sendStateConst("SEND_STATE_RESUME_DURABLE_ACK");
+                final int RESUME_DURABLE_ACK_THEN_ERROR = sendStateConst("SEND_STATE_RESUME_DURABLE_ACK_THEN_ERROR");
+                final int RESUME_CLOSE = sendStateConst("SEND_STATE_RESUME_CLOSE");
+                final int RESUME_ACK_THEN_CLOSE = sendStateConst("SEND_STATE_RESUME_ACK_THEN_CLOSE");
+                final int RESUME_DURABLE_ACK_THEN_CLOSE = sendStateConst("SEND_STATE_RESUME_DURABLE_ACK_THEN_CLOSE");
+                final int RESUME_PONG = sendStateConst("SEND_STATE_RESUME_PONG");
+                final int RESUME_DRAIN_THEN_CLOSE = sendStateConst("SEND_STATE_RESUME_DRAIN_THEN_CLOSE");
+
+                final int[] inputs = {
+                        READY, RESUME_ACK, RESUME_ERROR, RESUME_ACK_THEN_ERROR, RESUME_DURABLE_ACK,
+                        RESUME_DURABLE_ACK_THEN_ERROR, RESUME_CLOSE, RESUME_ACK_THEN_CLOSE,
+                        RESUME_DURABLE_ACK_THEN_CLOSE, RESUME_PONG, RESUME_DRAIN_THEN_CLOSE
+                };
+
+                final long seed = System.nanoTime();
+                final Rnd rnd = new Rnd(seed, seed ^ 0x9E3779B97F4A7C15L);
+                final String msg = "onFatalCloseBlocked fuzz seed=" + seed;
+                for (int iter = 0; iter < 50_000; iter++) {
+                    final int in = inputs[rnd.nextInt(inputs.length)];
+                    final int code = rnd.nextInt();
+                    final int reasonKind = rnd.nextInt(3);
+                    final String reason = reasonKind == 0 ? null : (reasonKind == 1 ? "" : "r" + rnd.nextInt(1000));
+
+                    setSendState(state, in);
+                    state.onFatalCloseBlocked(code, reason);
+
+                    final int out = state.getSendState();
+                    if (in == RESUME_ACK || in == RESUME_ACK_THEN_ERROR || in == RESUME_ACK_THEN_CLOSE) {
+                        Assert.assertEquals(msg, RESUME_ACK_THEN_CLOSE, out);
+                        Assert.assertEquals(msg, code, state.getDeferredCloseCode());
+                        assertReason(msg, reason, state.getDeferredCloseReason());
+                    } else if (in == RESUME_DURABLE_ACK || in == RESUME_DURABLE_ACK_THEN_ERROR || in == RESUME_DURABLE_ACK_THEN_CLOSE) {
+                        Assert.assertEquals(msg, RESUME_DURABLE_ACK_THEN_CLOSE, out);
+                        Assert.assertEquals(msg, code, state.getDeferredCloseCode());
+                        assertReason(msg, reason, state.getDeferredCloseReason());
+                    } else if (in == RESUME_CLOSE) {
+                        Assert.assertEquals(msg, RESUME_CLOSE, out);
+                        Assert.assertEquals(msg, -1, state.getDeferredCloseCode());
+                        Assert.assertEquals(msg, 0, state.getDeferredCloseReason().length());
+                    } else {
+                        Assert.assertEquals(msg, RESUME_DRAIN_THEN_CLOSE, out);
+                        Assert.assertEquals(msg, code, state.getDeferredCloseCode());
+                        assertReason(msg, reason, state.getDeferredCloseReason());
+                    }
+                }
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    private static void assertReason(String msg, String expected, CharSequence actual) {
+        if (expected == null || expected.isEmpty()) {
+            Assert.assertEquals(msg, 0, actual.length());
+        } else {
+            Assert.assertEquals(msg, expected, actual.toString());
+        }
+    }
+
+    private static int sendStateConst(String name) throws Exception {
+        Field f = QwpIngressProcessorState.class.getDeclaredField(name);
+        f.setAccessible(true);
+        return f.getInt(null);
+    }
+
+    private static void setSendState(QwpIngressProcessorState state, int value) throws Exception {
+        Field f = QwpIngressProcessorState.class.getDeclaredField("sendState");
+        f.setAccessible(true);
+        f.setInt(state, value);
     }
 
     private static FakeConsumerTudCache installFakeTudCache(

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
@@ -128,6 +128,99 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCommitReleasesDeferredWatermarkClamp() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+                FakeConsumerTudCache fake = installFakeTudCache(state, engine, lineConfig);
+
+                // Deferred rows buffered -> clamp armed.
+                state.markUncommittedDeferredRows();
+                Assert.assertTrue(state.hasUncommittedDeferredRows());
+
+                // The group-closing commit (commitAll) releases the clamp and
+                // the watermark may then cover the whole deferred group.
+                fake.queueCommit(new String[]{"t"}, new String[]{"t~1"}, new long[]{10L});
+                state.commit();
+                Assert.assertTrue(state.isOk());
+                Assert.assertFalse(state.hasUncommittedDeferredRows());
+
+                state.setHighestProcessedSequence(7);
+                Assert.assertEquals(7, state.getHighestProcessedSequence());
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    @Test
+    public void testDeferredClampResetOnClearAndDisconnect() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+
+                // clear() rolls the deferred rows back -> clamp released (the
+                // frames were never acked; the client replays them).
+                state.markUncommittedDeferredRows();
+                state.clear();
+                Assert.assertFalse(state.hasUncommittedDeferredRows());
+                state.setHighestProcessedSequence(3);
+                Assert.assertEquals(3, state.getHighestProcessedSequence());
+
+                // clearMessageState() (between deferred frames of one group)
+                // must NOT release the clamp -- the rows are still uncommitted.
+                state.markUncommittedDeferredRows();
+                state.clearMessageState();
+                Assert.assertTrue(state.hasUncommittedDeferredRows());
+
+                // onDisconnected() resets everything.
+                state.onDisconnected();
+                Assert.assertFalse(state.hasUncommittedDeferredRows());
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    @Test
+    public void testWatermarkClampedWhileDeferredRowsUncommitted() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+
+                // Committed traffic advances the watermark normally.
+                state.setHighestProcessedSequence(2);
+                Assert.assertEquals(2, state.getHighestProcessedSequence());
+
+                // FLAG_DEFER_COMMIT rows buffered but uncommitted: the
+                // cumulative-ack watermark must refuse to advance -- an OK ack
+                // covering these frames would let a store-and-forward client
+                // trim slots whose rows the server can still roll back (the
+                // #7144 ack hole).
+                state.markUncommittedDeferredRows();
+                Assert.assertTrue(state.hasUncommittedDeferredRows());
+                state.setHighestProcessedSequence(5);
+                Assert.assertEquals("watermark must not advance over uncommitted deferred rows",
+                        2, state.getHighestProcessedSequence());
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    @Test
     public void testCollectDurableProgressMultiTable() throws Exception {
         assertMemoryLeak(() -> {
             LineHttpProcessorConfiguration lineConfig =

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressReadOnlyRefusalShapeTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressReadOnlyRefusalShapeTest.java
@@ -1,0 +1,321 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.qwp;
+
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.security.AllowAllSecurityContext;
+import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
+import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
+import io.questdb.cutlass.qwp.codec.QwpEgressMsgKind;
+import io.questdb.cutlass.qwp.protocol.QwpConstants;
+import io.questdb.cutlass.qwp.server.QwpIngressProcessorState;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Unsafe;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.cairo.DefaultTestCairoConfiguration;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Pins the read-only REFUSAL-SHAPE contract on the QWP ingress path. A
+ * read-only node refuses every write batch, but HOW it refuses must depend on
+ * WHY it is read-only ({@code isStaticReadOnlyInstance()} in
+ * {@link QwpIngressProcessorState}):
+ * <ul>
+ *   <li><b>Static</b> ({@code readonly=true} / {@code READ_ONLY_INSTANCE} in
+ *       the server config): a permanent misconfiguration from the producer's
+ *       point of view. The refusal must be the typed, terminal
+ *       {@link QwpIngressProcessorState.Status#SECURITY_ERROR} NACK the client
+ *       latches and surfaces loudly. The role-change close is wrong here
+ *       because its 421 backstop does not exist: the upgrade gate rejects only
+ *       {@code ROLE_REPLICA} / {@code ROLE_PRIMARY_CATCHUP}, and a statically
+ *       read-only node keeps reporting its upgrade-eligible role (STANDALONE
+ *       on OSS) forever — a store-and-forward client would classify each
+ *       NORMAL_CLOSURE as orderly (no NACK, no poison strike, no terminal)
+ *       and reconnect-replay in a silent infinite loop.</li>
+ *   <li><b>Role-derived</b> (an enterprise engine widens
+ *       {@code isReadOnlyMode()} with the dynamic replica leg while the static
+ *       flag stays false): a TRANSIENT in-place PRIMARY-to-REPLICA demote.
+ *       The refusal must take the reconnect-eligible role-change close
+ *       (INVARIANT B): the reconnecting client meets the 421 role reject on
+ *       the now-replica endpoint and retries from store-and-forward until a
+ *       primary is reachable. This side of the boundary is fuzzed in depth by
+ *       {@link QwpIngressDemoteRaceFuzzTest}; the deterministic case here
+ *       pins it at the unit level alongside its complement.</li>
+ *   <li><b>Both legs</b>: the static answer wins — the node refuses writes
+ *       regardless of any future promote, so the terminal NACK is the
+ *       truthful signal.</li>
+ * </ul>
+ * The batch driver mirrors {@code QwpIngressUpgradeProcessor.handleBinaryMessage}
+ * exactly (addData → isDeferCommit → processMessage → commit calls → read
+ * {@code isRoleChangeClosePending()} AFTER the commits). The static test uses
+ * a fresh state per attempt, modelling the client's reconnect: on a static
+ * node every fresh connection meets the identical refusal, which is why the
+ * wrong refusal shape loops forever rather than self-correcting.
+ */
+public class QwpIngressReadOnlyRefusalShapeTest extends AbstractCairoTest {
+
+    private static final int RECONNECT_ATTEMPTS = 3;
+
+    @Test
+    public void testRoleDerivedReadOnlyTakesRoleChangeClose() throws Exception {
+        // Deterministic complement of QwpIngressDemoteRaceFuzzTest: role-derived
+        // read-only (dynamic replica leg true, static config flag false) must
+        // take the reconnect-eligible role-change close, never SECURITY_ERROR.
+        assertMemoryLeak(() -> {
+            final LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+
+            try (CairoEngine roEngine = newRoleDerivedReadOnlyEngine()) {
+                final QwpIngressProcessorState state =
+                        new QwpIngressProcessorState(1024, 4096, roEngine, lineConfig);
+                try {
+                    state.of(1, AllowAllSecurityContext.INSTANCE);
+                    final boolean roleChangeClose = driveBatch(state, zeroTableMessage());
+
+                    Assert.assertFalse("role-derived: batch must be refused", state.isOk());
+                    Assert.assertEquals(
+                            "role-derived read-only is a transient demote — must map to the"
+                                    + " reconnect-eligible status, never the terminal SECURITY_ERROR"
+                                    + " a store-and-forward client latches as HALT (INVARIANT B)",
+                            QwpIngressProcessorState.Status.NOT_ACCEPTING_WRITES,
+                            state.getStatus()
+                    );
+                    Assert.assertTrue(
+                            "role-derived read-only must flag the role-change close: the"
+                                    + " reconnecting client is handed to the 421 role reject of the"
+                                    + " now-replica endpoint",
+                            roleChangeClose
+                    );
+                    TestUtils.assertContains(state.getErrorText(), CairoException.READ_ONLY_ACCESS_MESSAGE);
+                } finally {
+                    state.onDisconnected();
+                    state.close();
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testStaticReadOnlyRefusalStaysSecurityError() throws Exception {
+        assertMemoryLeak(() -> {
+            final LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+
+            try (CairoEngine roEngine = newStaticReadOnlyEngine()) {
+                // Premise of the whole contract: the OSS standalone role is NOT
+                // rejected by the 421 upgrade gate (it rejects only ROLE_REPLICA /
+                // ROLE_PRIMARY_CATCHUP), so a producer upgrades successfully against
+                // a statically read-only node and its refusal shape is decided
+                // per-batch in processMessage — there is no 421 backstop for the
+                // role-change close to hand the client over to.
+                Assert.assertEquals(
+                        "OSS default provider must report STANDALONE (premise: upgrade succeeds, no 421 backstop)",
+                        QwpEgressMsgKind.ROLE_STANDALONE,
+                        roEngine.getQwpServerInfoProvider().role()
+                );
+
+                // Static readonly=true is boot-time state: it holds for the FIRST
+                // batch of the FIRST connection, and identically for every
+                // reconnect. Model the client's reconnect loop with a fresh state
+                // (= fresh connection) per attempt.
+                for (int attempt = 0; attempt < RECONNECT_ATTEMPTS; attempt++) {
+                    final QwpIngressProcessorState state =
+                            new QwpIngressProcessorState(1024, 4096, roEngine, lineConfig);
+                    try {
+                        state.of(1, AllowAllSecurityContext.INSTANCE);
+                        final boolean roleChangeClose = driveBatch(state, zeroTableMessage());
+
+                        final String where = "static readonly, connection #" + (attempt + 1);
+                        Assert.assertFalse(where + ": batch must be refused", state.isOk());
+                        Assert.assertEquals(
+                                where + ": static readonly=true is a permanent misconfiguration, not a"
+                                        + " transient demote — the refusal must stay the typed, terminal"
+                                        + " SECURITY_ERROR NACK the client surfaces to its producer",
+                                QwpIngressProcessorState.Status.SECURITY_ERROR,
+                                state.getStatus()
+                        );
+                        Assert.assertFalse(
+                                where + ": must NOT take the role-change close — on a standalone node the"
+                                        + " role never changes, so the NORMAL_CLOSURE (orderly, no NACK, no"
+                                        + " poison strike) sends the client into a silent infinite"
+                                        + " reconnect-replay loop with data pinned in store-and-forward",
+                                roleChangeClose
+                        );
+                        TestUtils.assertContains(state.getErrorText(), CairoException.READ_ONLY_ACCESS_MESSAGE);
+                    } finally {
+                        state.onDisconnected();
+                        state.close();
+                    }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testStaticWinsWhenBothReadOnlyLegsHold() throws Exception {
+        // Tie-break: an enterprise node that is BOTH statically read-only and
+        // role-derived read-only refuses writes regardless of any future
+        // promote, so the terminal SECURITY_ERROR NACK is the truthful signal.
+        // (Unreachable mid-connection in practice — a statically read-only node
+        // refuses the very first batch, before any role flip can land — but the
+        // tie-break must be pinned so a refactor cannot silently invert it.)
+        assertMemoryLeak(() -> {
+            final LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+
+            try (CairoEngine roEngine = newStaticAndRoleDerivedReadOnlyEngine()) {
+                final QwpIngressProcessorState state =
+                        new QwpIngressProcessorState(1024, 4096, roEngine, lineConfig);
+                try {
+                    state.of(1, AllowAllSecurityContext.INSTANCE);
+                    final boolean roleChangeClose = driveBatch(state, zeroTableMessage());
+
+                    Assert.assertFalse("both legs: batch must be refused", state.isOk());
+                    Assert.assertEquals(
+                            "static read-only must win the tie-break: the node never accepts"
+                                    + " writes regardless of role, so the refusal is terminal",
+                            QwpIngressProcessorState.Status.SECURITY_ERROR,
+                            state.getStatus()
+                    );
+                    Assert.assertFalse(
+                            "static read-only must win the tie-break: no role-change close",
+                            roleChangeClose
+                    );
+                    TestUtils.assertContains(state.getErrorText(), CairoException.READ_ONLY_ACCESS_MESSAGE);
+                } finally {
+                    state.onDisconnected();
+                    state.close();
+                }
+            }
+        });
+    }
+
+    private static void addNativeData(QwpIngressProcessorState state, byte[] data) {
+        long ptr = Unsafe.malloc(data.length, MemoryTag.NATIVE_HTTP_CONN);
+        try {
+            for (int i = 0; i < data.length; i++) {
+                Unsafe.putByte(ptr + i, data[i]);
+            }
+            state.addData(ptr, ptr + data.length);
+        } finally {
+            Unsafe.free(ptr, data.length, MemoryTag.NATIVE_HTTP_CONN);
+        }
+    }
+
+    /**
+     * Mirrors {@code QwpIngressUpgradeProcessor.handleBinaryMessage} exactly,
+     * including reading {@code isRoleChangeClosePending()} AFTER the commit
+     * calls (same driver contract as {@link QwpIngressDemoteRaceFuzzTest}).
+     *
+     * @return the roleChangeClose flag as the upgrade processor would observe it
+     */
+    private static boolean driveBatch(QwpIngressProcessorState state, byte[] message) {
+        addNativeData(state, message);
+        boolean deferCommit = state.isDeferCommit();
+        state.processMessage();
+        if (state.isOk() && !deferCommit) {
+            state.commit();
+        }
+        if (state.isOk() && deferCommit) {
+            state.commitIfMaxUncommittedRowsReached();
+        }
+        return state.isRoleChangeClosePending();
+    }
+
+    /**
+     * Engine that is read-only through the DYNAMIC leg only: {@code isReadOnlyMode()}
+     * is widened at the engine level — the same shape as the enterprise override
+     * ({@code super.isReadOnlyMode() || isReadOnlyReplica()}) — while the static
+     * {@code configuration.isReadOnlyInstance()} flag stays false.
+     */
+    private static CairoEngine newRoleDerivedReadOnlyEngine() {
+        return new CairoEngine(new DefaultTestCairoConfiguration(root)) {
+            @Override
+            public boolean isReadOnlyMode() {
+                return true;
+            }
+        };
+    }
+
+    /**
+     * Enterprise both-legs shape: statically read-only AND role-derived read-only.
+     */
+    private static CairoEngine newStaticAndRoleDerivedReadOnlyEngine() {
+        return new CairoEngine(new DefaultTestCairoConfiguration(root) {
+            @Override
+            public boolean isReadOnlyInstance() {
+                return true;
+            }
+        }) {
+            @Override
+            public boolean isReadOnlyMode() {
+                return true;
+            }
+        };
+    }
+
+    /**
+     * Engine whose configuration reports {@code isReadOnlyInstance() == true}
+     * from construction — the plain-OSS {@code readonly=true} shape. The base
+     * {@code CairoEngine.isReadOnlyMode()} answers from exactly this flag, so
+     * the top-of-processMessage gate refuses the very first batch of every
+     * connection. Unlike the demotable engine of
+     * {@link QwpIngressDemoteRaceFuzzTest} (which widens {@code isReadOnlyMode()}
+     * dynamically to model the enterprise demote), the flag here is constant:
+     * the node was never writable and never becomes writable.
+     */
+    private static CairoEngine newStaticReadOnlyEngine() {
+        return new CairoEngine(new DefaultTestCairoConfiguration(root) {
+            @Override
+            public boolean isReadOnlyInstance() {
+                return true;
+            }
+        });
+    }
+
+    /**
+     * Well-formed QWP v1 message with zero table blocks: enough to enter
+     * {@code processMessage} and hit the read-only gate at its top.
+     */
+    private static byte[] zeroTableMessage() {
+        byte[] message = new byte[QwpConstants.HEADER_SIZE];
+        message[0] = 'Q';
+        message[1] = 'W';
+        message[2] = 'P';
+        message[3] = '1';
+        message[4] = QwpConstants.VERSION;
+        message[5] = 0; // flags
+        message[6] = 0; // tableCount lo
+        message[7] = 0; // tableCount hi
+        message[8] = 0; // payloadLength (0)
+        message[9] = 0;
+        message[10] = 0;
+        message[11] = 0;
+        return message;
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressReadOnlyRefusalShapeTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressReadOnlyRefusalShapeTest.java
@@ -243,6 +243,12 @@ public class QwpIngressReadOnlyRefusalShapeTest extends AbstractCairoTest {
         }
         if (state.isOk() && deferCommit) {
             state.commitIfMaxUncommittedRowsReached();
+            if (state.isOk()) {
+                // Mirrors the processor's deferred-ack containment: rows are
+                // buffered but uncommitted, so the cumulative-ack watermark
+                // must not advance past this frame until the group commits.
+                state.markUncommittedDeferredRows();
+            }
         }
         return state.isRoleChangeClosePending();
     }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/AbstractQwpWebSocketTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/AbstractQwpWebSocketTest.java
@@ -30,7 +30,9 @@ import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpRequestHandlerFactory;
 import io.questdb.cutlass.http.HttpServer;
 import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
+import io.questdb.client.LineSenderServerException;
 import io.questdb.client.Sender;
+import io.questdb.client.SenderError;
 import io.questdb.client.SenderErrorHandler;
 import io.questdb.client.cutlass.qwp.client.QwpWebSocketSender;
 import io.questdb.cutlass.qwp.server.QwpIngressHttpProcessor;
@@ -44,7 +46,11 @@ import io.questdb.std.str.Path;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.mp.TestWorkerPool;
 import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
 import org.junit.Before;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 public class AbstractQwpWebSocketTest extends AbstractCairoTest {
 
@@ -81,8 +87,8 @@ public class AbstractQwpWebSocketTest extends AbstractCairoTest {
      * Plain WS sender with a registered async error handler. Use when a test
      * needs to observe server-side rejections deterministically — the handler
      * fires on the dispatcher daemon thread for every {@code SenderError}
-     * (including {@link io.questdb.client.SenderError.Policy#DROP_AND_CONTINUE},
-     * which never throws from {@code flush()}).
+     * (including informational {@link SenderError.Policy#RETRIABLE} strikes,
+     * which never throw from {@code flush()}).
      */
     protected static QwpWebSocketSender connectWs(int port, SenderErrorHandler errorHandler) {
         return (QwpWebSocketSender) Sender.builder(Sender.Transport.WEBSOCKET)
@@ -90,6 +96,79 @@ public class AbstractQwpWebSocketTest extends AbstractCairoTest {
                 .errorHandler(errorHandler)
                 .closeFlushTimeoutMillis(CLOSE_FLUSH_TIMEOUT_MS)
                 .build();
+    }
+
+    /**
+     * Like {@link #connectWs(int, SenderErrorHandler)} but pins the
+     * poison-frame detector threshold ({@code max_frame_rejections}).
+     * Error-path tests pass {@code 1} so a rejection that is deterministic
+     * under byte-identical replay escalates to its
+     * {@link SenderError.Category#PROTOCOL_VIOLATION} terminal on the first
+     * strike instead of reconnect-replaying the frame
+     * {@code max_frame_rejections - 1} more times.
+     */
+    protected static QwpWebSocketSender connectWs(int port, SenderErrorHandler errorHandler, int maxFrameRejections) {
+        return (QwpWebSocketSender) Sender.builder(Sender.Transport.WEBSOCKET)
+                .address("localhost:" + port)
+                .errorHandler(errorHandler)
+                .maxFrameRejections(maxFrameRejections)
+                .closeFlushTimeoutMillis(CLOSE_FLUSH_TIMEOUT_MS)
+                .build();
+    }
+
+    /**
+     * Close a sender whose last flushed frame the server deterministically
+     * rejected. NACK policy v2 has no drop policy: the rejection ends in a
+     * latched terminal — the poisoned-frame
+     * {@link SenderError.Category#PROTOCOL_VIOLATION} escalation of a
+     * RETRIABLE rejection, or the direct TERMINAL of a
+     * {@link SenderError.Category#SCHEMA_MISMATCH} — that must surface loudly
+     * on exactly one channel: the async error handler, or a throw from
+     * {@code close()} when the handler has not received it yet
+     * ({@code close()} suppresses the double-signal once the handler owns the
+     * terminal). Asserts the surfaced terminal has {@code expectedCategory}
+     * and embeds every {@code expectedMsgParts} fragment (the poison message
+     * carries the server's last NACK verbatim in its {@code last: ...}
+     * suffix).
+     * <p>
+     * When {@code expectedCategory} is null the close is lenient: a body
+     * assertion is already propagating and must not be masked by close-path
+     * signals.
+     */
+    protected static void assertRejectionTerminalOnClose(
+            QwpWebSocketSender sender,
+            CompletableFuture<SenderError> terminalFut,
+            SenderError.Category expectedCategory,
+            String... expectedMsgParts
+    ) {
+        LineSenderServerException closeError = null;
+        try {
+            sender.close();
+        } catch (LineSenderServerException e) {
+            closeError = e;
+        }
+        if (expectedCategory == null) {
+            return;
+        }
+        String msg;
+        if (closeError != null) {
+            Assert.assertSame(expectedCategory, closeError.getServerError().getCategory());
+            msg = closeError.getMessage();
+        } else {
+            SenderError terminal;
+            try {
+                terminal = terminalFut.get(10, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                throw new AssertionError("close() did not throw and no TERMINAL SenderError reached the handler", e);
+            }
+            Assert.assertSame(expectedCategory, terminal.getCategory());
+            msg = terminal.getServerMessage();
+        }
+        for (int i = 0, n = expectedMsgParts.length; i < n; i++) {
+            String part = expectedMsgParts[i];
+            Assert.assertTrue("Expected rejection terminal containing '" + part + "' but got: " + msg,
+                    msg != null && msg.contains(part));
+        }
     }
 
     /**

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -453,6 +454,11 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
         //   3. Watermark purity: every row flushed before the poisoned
         //      chunk lands exactly per the oracle -- acks never cross a
         //      rejected frame, and the halt does not disturb settled data.
+        //   4. Retention: the NACKed frame's bytes survive in the sender's
+        //      SF slot past close -- the terminal preserves the only
+        //      replayable copy. Proven functionally by reopening the slot
+        //      and observing the byte-identical replay latch the same
+        //      deterministic terminal again.
         //
         // The poisoned chunk is each poisoned producer's LAST chunk on
         // purpose: frames published after a rejected frame are head-of-line
@@ -495,9 +501,10 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                     }
                 }
                 // producer 0 is always poisoned so every run exercises the
-                // escalation; the rest flip a coin so the clean-close path
-                // stays covered too
-                if (p == 0 || master.nextBoolean()) {
+                // escalation and the retention proof in (e) below; producer
+                // 1 is always clean so the purge check in (d) never runs
+                // vacuous; the rest flip a coin
+                if (p == 0 || (p > 1 && master.nextBoolean())) {
                     poisonedProducers++;
                     QwpRow[] chunk = new QwpRow[chunkSize];
                     int badRow = master.nextInt(chunkSize);
@@ -658,9 +665,11 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                         .$(" handler calls=").$(observed).$();
 
                 // (d) SF hygiene: clean producers' slots purge on clean
-                // close. Poisoned producers' slots intentionally RETAIN the
-                // rejected bytes (no silent loss -- the terminal preserves
-                // the frame on disk), so they are excluded here.
+                // close. Producer 1 is always clean, so this check never
+                // runs vacuous. Poisoned producers' slots intentionally
+                // RETAIN the rejected bytes (no silent loss -- the terminal
+                // preserves the frame on disk); retention is asserted in
+                // (e), so they are excluded here.
                 List<String> cleanDirs = new ArrayList<>();
                 for (int p = 0; p < producerCount; p++) {
                     if (poisonChunks[p] == null) {
@@ -668,6 +677,59 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                     }
                 }
                 assertSlotsPurged(cleanDirs.toArray(new String[0]), slotCapFor(sfMaxBytes));
+
+                // (e) Retention proof: the poisoned frame must still be on
+                // disk in producer 0's slot. Byte counting cannot
+                // distinguish a retained frame (a few KB) from clean-close
+                // residue under the generous purge cap, so retention is
+                // proven functionally: a fresh sender on the same slot must
+                // recover the frame, replay it byte-identically, and latch
+                // the same deterministic poison terminal again. A client
+                // bug that purges the NACKed frame's slot leaves nothing to
+                // replay and times out below. Producer 0 is always
+                // poisoned, so this check fires in every run. Client-side
+                // reopen only -- no server bounce, in keeping with the
+                // no-transport-blip design of this test.
+                CompletableFuture<SenderError> replayTerminalFut = new CompletableFuture<>();
+                SenderErrorHandler replayHandler = err -> {
+                    if (err.getAppliedPolicy() == SenderError.Policy.TERMINAL) {
+                        replayTerminalFut.complete(err);
+                    }
+                };
+                String replayConnect = "ws::addr=localhost:" + port + ";sf_dir=" + sfDirs[0]
+                        + ";initial_connect_retry=true"
+                        + ";reconnect_max_duration_millis=120000"
+                        + ";close_flush_timeout_millis=120000"
+                        + ";sf_max_bytes=" + sfMaxBytes
+                        + ";max_frame_rejections=1"
+                        + ";error_inbox_capacity=4096;";
+                try (Sender ignore = Sender.builder(replayConnect).errorHandler(replayHandler).build()) {
+                    SenderError replayTerminal;
+                    try {
+                        replayTerminal = replayTerminalFut.get(120, TimeUnit.SECONDS);
+                    } catch (TimeoutException e) {
+                        throw new AssertionError("retained poison frame did not replay from " + sfDirs[0]
+                                + ": the SF slot no longer holds the rejected frame -- the terminal must"
+                                + " preserve the only replayable copy on disk", e);
+                    }
+                    if (replayTerminal.getCategory() != SenderError.Category.PROTOCOL_VIOLATION) {
+                        throw new AssertionError("replayed poison frame: expected PROTOCOL_VIOLATION terminal, got " + replayTerminal);
+                    }
+                    String rMsg = replayTerminal.getServerMessage();
+                    if (rMsg == null || !rMsg.contains("overflows DECIMAL(50,6)")) {
+                        throw new AssertionError("replayed terminal should carry the decimal overflow rejection, got: " + rMsg);
+                    }
+                }
+
+                // the replayed frame must be rejected wholesale again --
+                // frame-drop atomicity holds across SF recovery too
+                drainWalQueue();
+                assertQuery("SELECT count() FROM " + TABLE_NAME
+                        + " WHERE id IN (" + poisonedIdInList + ")")
+                        .withEngine(engine)
+                        .withContext(sqlExecutionContext)
+                        .noLeakCheck()
+                        .returnsOnce("count\n0\n");
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
@@ -26,6 +26,7 @@ package io.questdb.test.cutlass.qwp.e2e;
 
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.client.LineSenderServerException;
 import io.questdb.client.Sender;
 import io.questdb.client.SenderError;
 import io.questdb.client.SenderErrorHandler;
@@ -45,6 +46,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -433,17 +437,32 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testOraclePoisonRowsTriggerErrorHandler() throws Exception {
-        // Pin down the per-batch error contract:
-        //   1. The async SenderErrorHandler fires for every poisoned chunk.
-        //   2. Rows from clean chunks land exactly per the oracle.
-        //   3. No row from a poisoned chunk leaks into the table — the
-        //      *whole* chunk is dropped, including any well-formed rows
-        //      sitting next to the bad one. This documents the per-frame
-        //      drop granularity (Sf does not drop per row).
+    public void testOraclePoisonRowsEscalateToPoisonTerminal() throws Exception {
+        // Pin down the per-frame error contract under NACK policy v2 (there
+        // is no drop policy -- a deterministically rejected frame can never
+        // be silently skipped):
+        //   1. Frame-drop atomicity: a NACKed frame is atomically not
+        //      applied -- no row from the poisoned chunk lands, including
+        //      the well-formed rows sitting next to the bad one.
+        //   2. The rejection reaches the async SenderErrorHandler (an
+        //      informational WRITE_ERROR strike, then the poison-frame
+        //      detector's TERMINAL PROTOCOL_VIOLATION escalation --
+        //      max_frame_rejections=1 makes it immediate) and the next
+        //      producer-thread call throws the latched terminal: the stream
+        //      halts loudly, it does not drain silently.
+        //   3. Watermark purity: every row flushed before the poisoned
+        //      chunk lands exactly per the oracle -- acks never cross a
+        //      rejected frame, and the halt does not disturb settled data.
         //
-        // No server bouncing here on purpose — failure mode must be
-        // unambiguously the per-batch rejection, not a transport blip.
+        // The poisoned chunk is each poisoned producer's LAST chunk on
+        // purpose: frames published after a rejected frame are head-of-line
+        // blocked and whether an already-in-flight successor was applied is
+        // timing-dependent, so a dense oracle over post-poison rows would
+        // flake. The clean prefix plus poisoned-frame absence are the
+        // deterministic observables.
+        //
+        // No server bouncing here on purpose -- failure mode must be
+        // unambiguously the per-frame rejection, not a transport blip.
         assertMemoryLeak(() -> {
             Rnd master = TestUtils.generateRandom(LOG);
             createTargetTable();
@@ -452,44 +471,57 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
             int producerCount = 2 + master.nextInt(2);              // 2..3
             int chunksPerProducer = 30 + master.nextInt(30);        // 30..59
             int chunkSize = 5 + master.nextInt(6);                  // 5..10 rows; small enough to map to one frame
-            int poisonChunkInN = 4;                                 // ~25% chunks poisoned
             long sfMaxBytes = pickSfMaxBytes(master);
             LOG.info().$("poison test sf_max_bytes=").$(sfMaxBytes).$();
 
             long baseTsMicros = 1_700_000_000_000_000L;
             QwpTable oracle = new QwpTable(TABLE_NAME);
-            QwpRow[][][] perProducerChunks = new QwpRow[producerCount][chunksPerProducer][chunkSize];
+            QwpRow[][][] cleanChunks = new QwpRow[producerCount][chunksPerProducer][chunkSize];
+            QwpRow[][] poisonChunks = new QwpRow[producerCount][];
             StringBuilder poisonedIdInList = new StringBuilder();
-            int totalPoisonedChunks = 0;
+            int poisonedProducers = 0;
 
             long globalIdx = 0;
             for (int p = 0; p < producerCount; p++) {
                 Rnd genRnd = new Rnd(master.nextLong(), master.nextLong());
-                Rnd poisonRnd = new Rnd(master.nextLong(), master.nextLong());
                 for (int c = 0; c < chunksPerProducer; c++) {
-                    boolean poisoned = poisonRnd.nextInt(poisonChunkInN) == 0;
-                    if (poisoned) {
-                        totalPoisonedChunks++;
-                    }
                     for (int r = 0; r < chunkSize; r++) {
                         long id = globalIdx;
                         long ts = baseTsMicros + globalIdx;
                         QwpRow row = generateRow(genRnd, id, ts);
-                        if (poisoned) {
-                            // hh=1 forces the unscaled value past 2^192 ~ 6.3e57,
-                            // well past DECIMAL(50,6)'s 10^50 cap. Server returns
-                            // WRITE_ERROR with DROP_AND_CONTINUE policy.
-                            row.setDecimal256("dec256", 1L, 0L, 0L, 0L, 6);
-                            if (!poisonedIdInList.isEmpty()) {
-                                poisonedIdInList.append(',');
-                            }
-                            poisonedIdInList.append(id);
-                        } else {
-                            oracle.addRow(row);
-                        }
-                        perProducerChunks[p][c][r] = row;
+                        oracle.addRow(row);
+                        cleanChunks[p][c][r] = row;
                         globalIdx++;
                     }
+                }
+                // producer 0 is always poisoned so every run exercises the
+                // escalation; the rest flip a coin so the clean-close path
+                // stays covered too
+                if (p == 0 || master.nextBoolean()) {
+                    poisonedProducers++;
+                    QwpRow[] chunk = new QwpRow[chunkSize];
+                    int badRow = master.nextInt(chunkSize);
+                    for (int r = 0; r < chunkSize; r++) {
+                        long id = globalIdx;
+                        long ts = baseTsMicros + globalIdx;
+                        QwpRow row = generateRow(genRnd, id, ts);
+                        if (r == badRow) {
+                            // hh=1 forces the unscaled value past 2^192 ~ 6.3e57,
+                            // well past DECIMAL(50,6)'s 10^50 cap: a WRITE_ERROR
+                            // NACK deterministic under byte-identical replay.
+                            row.setDecimal256("dec256", 1L, 0L, 0L, 0L, 6);
+                        }
+                        // every id of the poisoned chunk must stay absent,
+                        // the well-formed neighbours included (frame-drop
+                        // atomicity)
+                        if (!poisonedIdInList.isEmpty()) {
+                            poisonedIdInList.append(',');
+                        }
+                        poisonedIdInList.append(id);
+                        chunk[r] = row;
+                        globalIdx++;
+                    }
+                    poisonChunks[p] = chunk;
                 }
             }
 
@@ -508,29 +540,68 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                 Thread[] producers = new Thread[producerCount];
                 for (int p = 0; p < producerCount; p++) {
                     final int pp = p;
-                    final QwpRow[][] myChunks = perProducerChunks[pp];
+                    final QwpRow[][] myCleanChunks = cleanChunks[pp];
+                    final QwpRow[] myPoisonChunk = poisonChunks[pp];
                     final String mySfDir = sfDirs[pp];
                     producers[p] = new Thread(() -> {
                         try {
-                            // Generous error_inbox_capacity so a burst of
-                            // poisoned chunks can't drop notifications and
-                            // skew the count assertion.
+                            // Generous error_inbox_capacity so the strike +
+                            // terminal notifications can't be dropped;
+                            // max_frame_rejections=1 escalates the first
+                            // rejection straight to the poison terminal
+                            // instead of reconnect-replaying the frame.
                             String connect = "ws::addr=localhost:" + port + ";sf_dir=" + mySfDir
                                     + ";initial_connect_retry=true"
                                     + ";reconnect_max_duration_millis=120000"
                                     + ";close_flush_timeout_millis=120000"
                                     + ";sf_max_bytes=" + sfMaxBytes
+                                    + ";max_frame_rejections=1"
                                     + ";error_inbox_capacity=4096;";
-                            SenderErrorHandler handler = (SenderError _) -> errorHandlerCalls.incrementAndGet();
+                            CompletableFuture<SenderError> terminalFut = new CompletableFuture<>();
+                            SenderErrorHandler handler = err -> {
+                                errorHandlerCalls.incrementAndGet();
+                                if (err.getAppliedPolicy() == SenderError.Policy.TERMINAL) {
+                                    terminalFut.complete(err);
+                                }
+                            };
                             try (Sender sender = Sender.builder(connect).errorHandler(handler).build()) {
-                                for (int c = 0; c < myChunks.length; c++) {
-                                    for (int r = 0; r < myChunks[c].length; r++) {
-                                        myChunks[c][r].publishTo(sender, TABLE_NAME, ID_COLUMN);
+                                for (int c = 0; c < myCleanChunks.length; c++) {
+                                    for (int r = 0; r < myCleanChunks[c].length; r++) {
+                                        myCleanChunks[c][r].publishTo(sender, TABLE_NAME, ID_COLUMN);
                                     }
                                     // Explicit flush per chunk -> chunk == frame
                                     // (for these small chunk sizes), making the
-                                    // per-batch drop deterministic to model.
+                                    // per-frame rejection deterministic to model.
                                     sender.flush();
+                                }
+                                if (myPoisonChunk != null) {
+                                    for (QwpRow row : myPoisonChunk) {
+                                        row.publishTo(sender, TABLE_NAME, ID_COLUMN);
+                                    }
+                                    try {
+                                        sender.flush();
+                                    } catch (LineSenderServerException ignored) {
+                                        // the I/O thread can latch the terminal
+                                        // before flush()'s own error poll runs
+                                    }
+                                    SenderError terminal = terminalFut.get(120, TimeUnit.SECONDS);
+                                    if (terminal.getCategory() != SenderError.Category.PROTOCOL_VIOLATION) {
+                                        throw new AssertionError("expected PROTOCOL_VIOLATION poison terminal, got " + terminal);
+                                    }
+                                    String tMsg = terminal.getServerMessage();
+                                    if (tMsg == null || !tMsg.contains("overflows DECIMAL(50,6)")) {
+                                        throw new AssertionError("terminal should carry the decimal overflow rejection, got: " + tMsg);
+                                    }
+                                    // the latched terminal must halt the
+                                    // producer loudly on its next call
+                                    try {
+                                        sender.flush();
+                                        throw new AssertionError("flush() after the poison terminal latched must throw");
+                                    } catch (LineSenderServerException e) {
+                                        if (e.getServerError().getCategory() != SenderError.Category.PROTOCOL_VIOLATION) {
+                                            throw new AssertionError("expected the poison terminal from flush()", e);
+                                        }
+                                    }
                                 }
                             }
                         } catch (Throwable t) {
@@ -556,13 +627,14 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                 drainWalQueue();
                 engine.awaitTable(TABLE_NAME, 60, TimeUnit.SECONDS);
 
-                // (a) Clean rows: every row in every clean chunk lands
-                // exactly once; oracle drives a typed cell-by-cell check.
+                // (a) Clean prefix: every row flushed before the poisoned
+                // chunk lands exactly once; oracle drives a typed
+                // cell-by-cell check over the full table snapshot.
                 assertOracle(oracle);
 
                 // (b) Poisoned rows: no id from any poisoned chunk leaked
-                // into the table. This pins the per-batch drop semantic --
-                // even good rows in a bad chunk must be absent.
+                // into the table. This pins frame-drop atomicity -- even
+                // good rows in a bad frame must be absent.
                 if (!poisonedIdInList.isEmpty()) {
                     assertQuery("SELECT count() FROM " + TABLE_NAME
                             + " WHERE id IN (" + poisonedIdInList + ")")
@@ -572,21 +644,30 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                             .returnsOnce("count\n0\n");
                 }
 
-                // (c) Async error notifications: at least one per poisoned
-                // chunk reached the handler. Inequality (>=) tolerates the
-                // possibility that a chunk gets split across more than one
-                // frame; with chunk sizes 5..10 that should be rare but
-                // we don't want a flake on the rare event.
+                // (c) Async error notifications: each poisoned producer saw
+                // the informational WRITE_ERROR strike and the poison
+                // terminal (>= 2 dispatches). Inequality tolerates extra
+                // informational strikes if a chunk splits across frames.
                 long observed = errorHandlerCalls.get();
-                if (observed < totalPoisonedChunks) {
+                if (observed < 2L * poisonedProducers) {
                     throw new AssertionError("error handler fired " + observed
-                            + " times, expected at least " + totalPoisonedChunks
-                            + " (poisoned chunks)");
+                            + " times, expected at least " + (2L * poisonedProducers)
+                            + " (strike + terminal per poisoned producer)");
                 }
-                LOG.info().$("poison test: poisoned chunks=").$(totalPoisonedChunks)
+                LOG.info().$("poison test: poisoned producers=").$(poisonedProducers)
                         .$(" handler calls=").$(observed).$();
 
-                assertSlotsPurged(sfDirs, slotCapFor(sfMaxBytes));
+                // (d) SF hygiene: clean producers' slots purge on clean
+                // close. Poisoned producers' slots intentionally RETAIN the
+                // rejected bytes (no silent loss -- the terminal preserves
+                // the frame on disk), so they are excluded here.
+                List<String> cleanDirs = new ArrayList<>();
+                for (int p = 0; p < producerCount; p++) {
+                    if (poisonChunks[p] == null) {
+                        cleanDirs.add(sfDirs[p]);
+                    }
+                }
+                assertSlotsPurged(cleanDirs.toArray(new String[0]), slotCapFor(sfMaxBytes));
             }
         });
     }
@@ -1117,8 +1198,9 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
         //                                           full 64-bit lo
         //   DECIMAL(50,6) (max ~10^50, ~167 bits) -> hh=0, hl up to ~10^10
         //                                            plus full 64-bit lh, ll
-        // The server rejects out-of-range values per binary frame with
-        // DROP_AND_CONTINUE; the poison test pins that contract.
+        // The server rejects out-of-range values per binary frame with a
+        // WRITE_ERROR NACK; testOraclePoisonRowsEscalateToPoisonTerminal
+        // pins the client-side escalation contract.
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) {
             setSignedDecimal64(row, "dec64", id * 10_000_007L + 13L, 3, rnd.nextBoolean());
         }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
@@ -648,7 +648,9 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                             .withEngine(engine)
                             .withContext(sqlExecutionContext)
                             .noLeakCheck()
-                            .returnsOnce("count\n0\n");
+                            .noRandomAccess()
+                            .expectSize()
+                            .returns("count\n0\n");
                 }
 
                 // (c) Async error notifications: each poisoned producer saw
@@ -729,7 +731,9 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                         .withEngine(engine)
                         .withContext(sqlExecutionContext)
                         .noLeakCheck()
-                        .returnsOnce("count\n0\n");
+                        .noRandomAccess()
+                        .expectSize()
+                        .returns("count\n0\n");
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -24,8 +24,10 @@
 
 package io.questdb.test.cutlass.qwp.e2e;
 
+import io.questdb.client.LineSenderServerException;
 import io.questdb.client.Sender;
 import io.questdb.client.SenderError;
+import io.questdb.client.SenderErrorHandler;
 import io.questdb.client.cutlass.line.LineSenderException;
 import io.questdb.client.cutlass.qwp.client.QwpWebSocketSender;
 import io.questdb.client.cutlass.qwp.protocol.QwpTableBuffer;
@@ -474,18 +476,9 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             String table = "test_qwp_no_auto_col";
             execute("CREATE TABLE " + table + " (v LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
 
-            CompletableFuture<SenderError> errorFut = new CompletableFuture<>();
-            try (QwpWebSocketSender sender = connectWs(port, errorFut::complete)) {
-                sender.table(table)
-                        .longColumn("v", 1L)
-                        .longColumn("extra", 2L)
-                        .at(1_000_000, ChronoUnit.MICROS);
-                sender.flush();
-
-                SenderError err = errorFut.get(10, TimeUnit.SECONDS);
-                String msg = err.getServerMessage();
-                Assert.assertTrue("got: " + msg, msg != null && msg.contains("new columns not allowed"));
-            }
+            assertCoercionError(port, table,
+                    (s, t) -> s.table(t).longColumn("v", 1L).longColumn("extra", 2L).at(1_000_000, ChronoUnit.MICROS),
+                    "new columns not allowed", "column=extra");
         });
     }
 
@@ -616,15 +609,9 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
 
             byte[] payload = {(byte) 0x80, (byte) 0xFF, 0x00, 0x7F};
 
-            try (QwpWebSocketSender sender = connectWs(port)) {
-                sender.table(table)
-                        .binaryColumn("v", payload)
-                        .at(1_000_000, ChronoUnit.MICROS);
-                try {
-                    sender.flush();
-                } catch (LineSenderException ignored) {
-                }
-            }
+            assertCoercionError(port, table,
+                    (s, t) -> s.table(t).binaryColumn("v", payload).at(1_000_000, ChronoUnit.MICROS),
+                    "type coercion from BINARY to CHAR is not supported", "[column=v]");
 
             drainWalQueue();
             assertQuery("SELECT count() FROM " + table)
@@ -645,15 +632,9 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
 
             byte[] payload = {(byte) 0x80, (byte) 0xFF, 0x00, 0x7F};
 
-            try (QwpWebSocketSender sender = connectWs(port)) {
-                sender.table(table)
-                        .binaryColumn("v", payload)
-                        .at(1_000_000, ChronoUnit.MICROS);
-                try {
-                    sender.flush();
-                } catch (LineSenderException ignored) {
-                }
-            }
+            assertCoercionError(port, table,
+                    (s, t) -> s.table(t).binaryColumn("v", payload).at(1_000_000, ChronoUnit.MICROS),
+                    "type coercion from BINARY to STRING is not supported", "[column=v]");
 
             drainWalQueue();
             assertQuery("SELECT count() FROM " + table)
@@ -674,15 +655,9 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
 
             byte[] payload = {(byte) 0x80, (byte) 0xFF, 0x00, 0x7F};
 
-            try (QwpWebSocketSender sender = connectWs(port)) {
-                sender.table(table)
-                        .binaryColumn("v", payload)
-                        .at(1_000_000, ChronoUnit.MICROS);
-                try {
-                    sender.flush();
-                } catch (LineSenderException ignored) {
-                }
-            }
+            assertCoercionError(port, table,
+                    (s, t) -> s.table(t).binaryColumn("v", payload).at(1_000_000, ChronoUnit.MICROS),
+                    "type coercion from BINARY to SYMBOL is not supported", "[column=v]");
 
             drainWalQueue();
             assertQuery("SELECT count() FROM " + table)
@@ -715,19 +690,9 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             // they break the UTF-8 invariant the rest of QuestDB assumes.
             byte[] payload = {(byte) 0x80, (byte) 0xFF, 0x00, 0x7F};
 
-            try (QwpWebSocketSender sender = connectWs(port)) {
-                sender.table(table)
-                        .binaryColumn("v", payload)
-                        .at(1_000_000, ChronoUnit.MICROS);
-                try {
-                    sender.flush();
-                } catch (LineSenderException ignored) {
-                    // After the fix the server may surface the coercion
-                    // failure synchronously; before the fix it silently
-                    // accepts the row. Either way the count check below
-                    // is the definitive assertion.
-                }
-            }
+            assertCoercionError(port, table,
+                    (s, t) -> s.table(t).binaryColumn("v", payload).at(1_000_000, ChronoUnit.MICROS),
+                    "type coercion from BINARY to VARCHAR is not supported", "[column=v]");
 
             drainWalQueue();
             assertQuery("SELECT count() FROM " + table)
@@ -3495,17 +3460,9 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
         runInContext((port) -> {
             String table = "test_qwp_long_arr";
 
-            CompletableFuture<SenderError> errorFut = new CompletableFuture<>();
-            try (QwpWebSocketSender sender = connectWs(port, errorFut::complete)) {
-                sender.table(table)
-                        .longArray("arr", new long[]{1L, 2L, 3L})
-                        .at(1_000_000, ChronoUnit.MICROS);
-                sender.flush();
-
-                SenderError err = errorFut.get(10, TimeUnit.SECONDS);
-                String msg = err.getServerMessage();
-                Assert.assertTrue("got: " + msg, msg != null && msg.contains("long arrays are not supported"));
-            }
+            assertCoercionError(port, table,
+                    (s, t) -> s.table(t).longArray("arr", new long[]{1L, 2L, 3L}).at(1_000_000, ChronoUnit.MICROS),
+                    "long arrays are not supported", "only double arrays");
         });
     }
 
@@ -4433,18 +4390,35 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             }
             drainWalQueue();
 
-            // SCHEMA_MISMATCH defaults to DROP_AND_CONTINUE, so flush() does
-            // not throw — the rejection arrives asynchronously through the
-            // error handler.
-            CompletableFuture<SenderError> errorFut = new CompletableFuture<>();
-            try (QwpWebSocketSender sender = connectWs(port, errorFut::complete)) {
-                sender.table(table)
+            // NACK policy v2: the server-side parse failure is
+            // SCHEMA_MISMATCH -- deterministic under byte-identical replay,
+            // so the client latches a TERMINAL on the first NACK (no drop,
+            // no replay). The rejection arrives asynchronously through the
+            // error handler; the latched terminal surfaces loudly on close
+            // unless the handler already owns it.
+            CompletableFuture<SenderError> firstErrFut = new CompletableFuture<>();
+            CompletableFuture<SenderError> terminalFut = new CompletableFuture<>();
+            QwpWebSocketSender errSender = connectWs(port, err -> {
+                if (err.getAppliedPolicy() == SenderError.Policy.TERMINAL) {
+                    terminalFut.complete(err);
+                }
+                firstErrFut.complete(err);
+            });
+            SenderError.Category expectedTerminalCategory = null;
+            try {
+                errSender.table(table)
                         .stringColumn("px", "not-a-double")
                         .at(2_000_000, ChronoUnit.MICROS);
-                sender.flush();
+                try {
+                    errSender.flush();
+                } catch (LineSenderServerException ignored) {
+                    // the I/O thread latched the terminal before flush()'s
+                    // own error poll ran
+                }
 
-                SenderError err = errorFut.get(10, TimeUnit.SECONDS);
+                SenderError err = firstErrFut.get(10, TimeUnit.SECONDS);
                 Assert.assertEquals(SenderError.Category.SCHEMA_MISMATCH, err.getCategory());
+                Assert.assertSame(SenderError.Policy.TERMINAL, err.getAppliedPolicy());
                 String msg = err.getServerMessage();
                 Assert.assertNotNull("server message must not be null", msg);
                 Assert.assertTrue(
@@ -4453,6 +4427,10 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
                                 && msg.contains("not-a-double")
                                 && msg.contains("column=px]")
                 );
+                expectedTerminalCategory = SenderError.Category.SCHEMA_MISMATCH;
+            } finally {
+                assertRejectionTerminalOnClose(errSender, terminalFut, expectedTerminalCategory,
+                        "cannot parse DOUBLE from string", "not-a-double");
             }
 
             try (QwpWebSocketSender sender = QwpWebSocketSender.connect("localhost", port)) {
@@ -4570,18 +4548,9 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             // Send a micros timestamp that overflows when converted to nanos.
             // The threshold is Long.MAX_VALUE / 1000 = 9_223_372_036_854_775.
             long overflowMicros = Long.MAX_VALUE / 1000 + 1;
-            CompletableFuture<SenderError> errorFut = new CompletableFuture<>();
-            try (QwpWebSocketSender sender = connectWs(port, errorFut::complete)) {
-                sender.table(table)
-                        .longColumn("v", 1L)
-                        .at(overflowMicros, ChronoUnit.MICROS);
-                sender.flush();
-
-                SenderError err = errorFut.get(10, TimeUnit.SECONDS);
-                String msg = err.getServerMessage();
-                Assert.assertTrue("got: " + msg,
-                        msg != null && msg.contains("timestamp overflow converting micros to nanos"));
-            }
+            assertCoercionError(port, table,
+                    (s, t) -> s.table(t).longColumn("v", 1L).at(overflowMicros, ChronoUnit.MICROS),
+                    "timestamp overflow converting micros to nanos", "9223372036854776");
         });
     }
 
@@ -4769,29 +4738,74 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             java.util.function.BiConsumer<QwpWebSocketSender, String> sendAction,
             String expectedMsgPart1, String expectedMsgPart2
     ) {
-        // Server-side rejections default to DROP_AND_CONTINUE for both
-        // SCHEMA_MISMATCH and WRITE_ERROR, so flush() does not throw — the
-        // rejection arrives asynchronously through the error handler. We block
-        // on a CompletableFuture populated from the dispatcher thread to make
-        // the assertion deterministic.
-        CompletableFuture<SenderError> errorFut = new CompletableFuture<>();
-        try (QwpWebSocketSender sender = connectWs(port, errorFut::complete)) {
+        // NACK policy v2 (java-questdb-client): there is no drop policy.
+        // Server-side rejections end in a latched terminal instead of a
+        // silently discarded batch:
+        //   - WRITE_ERROR is RETRIABLE -- the client dispatches each strike
+        //     to the error handler informationally and replays the frame; a
+        //     rejection that is deterministic under byte-identical replay
+        //     escalates to a TERMINAL PROTOCOL_VIOLATION through the
+        //     poison-frame detector after max_frame_rejections consecutive
+        //     strikes on the same head frame with no ack progress. We pin
+        //     max_frame_rejections=1 so the escalation is immediate.
+        //   - SCHEMA_MISMATCH is deterministic by definition and latches
+        //     TERMINAL on the first strike, no replay.
+        // Either way we assert both observables: the first handler dispatch
+        // carries the server's rejection message, and the latched terminal
+        // surfaces loudly -- through the handler or, when the producer
+        // thread's error poll wins the race, from flush()/close() (close()
+        // suppresses the double-signal once the handler owns the terminal).
+        CompletableFuture<SenderError> firstErrFut = new CompletableFuture<>();
+        CompletableFuture<SenderError> terminalFut = new CompletableFuture<>();
+        SenderErrorHandler handler = err -> {
+            if (err.getAppliedPolicy() == SenderError.Policy.TERMINAL) {
+                terminalFut.complete(err);
+            }
+            firstErrFut.complete(err);
+        };
+        QwpWebSocketSender sender = connectWs(port, handler, 1);
+        SenderError.Category expectedTerminalCategory = null;
+        try {
             sendAction.accept(sender, table);
-            long publishedFsn = sender.flushAndGetSequence();
+            long publishedFsn;
+            try {
+                publishedFsn = sender.flushAndGetSequence();
+            } catch (LineSenderServerException e) {
+                // the I/O thread latched the terminal before
+                // flushAndGetSequence()'s own error poll ran
+                publishedFsn = -1;
+            }
 
             SenderError err;
             try {
-                err = errorFut.get(10, TimeUnit.SECONDS);
+                err = firstErrFut.get(10, TimeUnit.SECONDS);
             } catch (Exception e) {
                 throw new AssertionError("Did not receive a SenderError within 10s for table " + table, e);
             }
-            Assert.assertTrue("error fsn span [" + err.getFromFsn() + ',' + err.getToFsn()
-                            + "] should cover published " + publishedFsn,
-                    publishedFsn >= err.getFromFsn() && publishedFsn <= err.getToFsn());
+            SenderError.Category terminalCategory;
+            if (err.getCategory() == SenderError.Category.WRITE_ERROR) {
+                Assert.assertSame(SenderError.Policy.RETRIABLE, err.getAppliedPolicy());
+                terminalCategory = SenderError.Category.PROTOCOL_VIOLATION;
+            } else {
+                Assert.assertSame(SenderError.Category.SCHEMA_MISMATCH, err.getCategory());
+                Assert.assertSame(SenderError.Policy.TERMINAL, err.getAppliedPolicy());
+                terminalCategory = SenderError.Category.SCHEMA_MISMATCH;
+            }
+            if (publishedFsn >= 0) {
+                Assert.assertTrue("error fsn span [" + err.getFromFsn() + ',' + err.getToFsn()
+                                + "] should cover published " + publishedFsn,
+                        publishedFsn >= err.getFromFsn() && publishedFsn <= err.getToFsn());
+            }
             String msg = err.getServerMessage();
             Assert.assertTrue("Expected error containing '" + expectedMsgPart1 +
                             "' and '" + expectedMsgPart2 + "' but got: " + msg,
                     msg != null && msg.contains(expectedMsgPart1) && msg.contains(expectedMsgPart2));
+            // only arm the close-time terminal assertion once the body
+            // passed -- a body assertion propagating out of this try must
+            // not be masked by close-path signals
+            expectedTerminalCategory = terminalCategory;
+        } finally {
+            assertRejectionTerminalOnClose(sender, terminalFut, expectedTerminalCategory, expectedMsgPart1, expectedMsgPart2);
         }
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -2678,14 +2678,19 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
 
             drainWalQueue();
 
-            // Table may not even exist, or if auto-created it should have 0 committed rows
+            // Table may not even exist, or if auto-created it should have 0 committed rows.
+            // Both are correct rollback outcomes: since the client stopped waiting for
+            // acks of uncommitted deferred frames on close (they are withheld by the
+            // server on purpose), close() may return before the frames were ever
+            // transmitted -- in which case the table is never auto-created and the
+            // query throws SqlException instead of failing the row-count assert.
             try {
                 assertQuery("SELECT count() FROM defer_drop")
                         .noLeakCheck()
                         .returnsOnce("count\n0\n");
-            } catch (AssertionError e) {
+            } catch (AssertionError | io.questdb.griffin.SqlException e) {
                 // Table was never created — that's also correct
-                if (!e.getMessage().contains("defer_drop")) {
+                if (e.getMessage() == null || !e.getMessage().contains("defer_drop")) {
                     throw e;
                 }
             }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -2737,7 +2737,9 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             drainWalQueue();
             assertQuery("SELECT count() FROM defer_no_ack")
                     .noLeakCheck()
-                    .returnsOnce("count\n21\n");
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\n21\n");
         });
     }
 
@@ -2770,7 +2772,9 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             drainWalQueue();
             assertQuery("SELECT count() FROM defer_eager_ack")
                     .noLeakCheck()
-                    .returnsOnce("count\n4\n");
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\n4\n");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -2698,6 +2698,83 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
     }
 
     @Test
+    public void testDeferredFramesNotAckedUntilCommit() throws Exception {
+        runInContext((port) -> {
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                // 20 deferred frames -- well past the server's ACK_BATCH_SIZE
+                // of 8. Before the deferred-ack fix, cumulative OK acks flowed
+                // mid-group and the store-and-forward client trimmed slots
+                // whose rows the server could still roll back.
+                sender.setDeferCommit(true);
+                for (int i = 0; i < 20; i++) {
+                    sender.table("defer_no_ack")
+                            .longColumn("id", i)
+                            .at(1_000_000_000_000L + i * 1000L, ChronoUnit.MICROS);
+                    sender.flush();
+                }
+
+                // Grace window: pre-fix an ack reliably arrived here (batch
+                // threshold crossed twice). Post-fix NOTHING may be acked --
+                // every frame is deferred and uncommitted.
+                io.questdb.std.Os.sleep(500);
+                Assert.assertEquals("no cumulative OK ack may cover uncommitted deferred frames",
+                        -1L, sender.getAckedFsn());
+
+                // The group-closing commit frame's cumulative ack covers the
+                // whole group at once.
+                sender.setDeferCommit(false);
+                sender.table("defer_no_ack")
+                        .longColumn("id", 20L)
+                        .at(1_000_000_000_000L + 20 * 1000L, ChronoUnit.MICROS);
+                sender.flush();
+
+                // 21 frames published as FSNs 0..20; the commit frame is FSN 20
+                // and its cumulative ack covers the whole group.
+                Assert.assertTrue("group commit ack must cover the whole deferred group",
+                        sender.awaitAckedFsn(20L, 10_000));
+            }
+
+            drainWalQueue();
+            assertQuery("SELECT count() FROM defer_no_ack")
+                    .noLeakCheck()
+                    .returnsOnce("count\n21\n");
+        });
+    }
+
+    @Test
+    public void testGroupCommitAckFlushesEagerly() throws Exception {
+        runInContext((port) -> {
+            try (QwpWebSocketSender sender = connectWs(port)) {
+                // 3 deferred frames + 1 commit frame = 4 sequences, BELOW the
+                // server's ACK_BATCH_SIZE of 8. The ack for the group-closing
+                // commit must flush eagerly (hasPendingAck) instead of waiting
+                // for the batch cadence -- otherwise the client's transaction
+                // confirmation would stall behind unrelated future traffic.
+                sender.setDeferCommit(true);
+                for (int i = 0; i < 3; i++) {
+                    sender.table("defer_eager_ack")
+                            .longColumn("id", i)
+                            .at(1_000_000_000_000L + i * 1000L, ChronoUnit.MICROS);
+                    sender.flush();
+                }
+                sender.setDeferCommit(false);
+                sender.table("defer_eager_ack")
+                        .longColumn("id", 3L)
+                        .at(1_000_000_000_000L + 3 * 1000L, ChronoUnit.MICROS);
+                sender.flush();
+
+                Assert.assertTrue("group commit ack must flush eagerly below the batch threshold",
+                        sender.awaitAckedFsn(3L, 10_000));
+            }
+
+            drainWalQueue();
+            assertQuery("SELECT count() FROM defer_eager_ack")
+                    .noLeakCheck()
+                    .returnsOnce("count\n4\n");
+        });
+    }
+
+    @Test
     public void testDeferredCommitEmptyFinalMessage() throws Exception {
         runInContext((port) -> {
             try (QwpWebSocketSender sender = connectWs(port)) {

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderObservabilityTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderObservabilityTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.cutlass.qwp.e2e;
 
+import io.questdb.client.LineSenderServerException;
 import io.questdb.client.Sender;
 import io.questdb.client.SenderConnectionEvent;
 import io.questdb.client.SenderConnectionListener;
@@ -239,8 +240,8 @@ public class QwpWebSocketSenderObservabilityTest extends AbstractQwpWebSocketTes
     /**
      * Exercises {@link QwpWebSocketSender#getTotalErrorNotificationsDelivered()}.
      * Send a string into a column that was first created as DOUBLE; the server
-     * rejects with SCHEMA_MISMATCH (DROP_AND_CONTINUE policy), the error
-     * handler fires, and the delivered counter advances past zero.
+     * rejects with SCHEMA_MISMATCH (a latched TERMINAL under NACK policy v2),
+     * the error handler fires, and the delivered counter advances past zero.
      */
     @Test
     public void testGetTotalErrorNotificationsDeliveredAfterSchemaMismatch() throws Exception {
@@ -254,16 +255,32 @@ public class QwpWebSocketSenderObservabilityTest extends AbstractQwpWebSocketTes
             }
             drainWalQueue();
 
-            CompletableFuture<SenderError> errorFut = new CompletableFuture<>();
-            try (QwpWebSocketSender sender = connectWs(port, errorFut::complete)) {
+            CompletableFuture<SenderError> firstErrFut = new CompletableFuture<>();
+            CompletableFuture<SenderError> terminalFut = new CompletableFuture<>();
+            QwpWebSocketSender sender = connectWs(port, err -> {
+                if (err.getAppliedPolicy() == SenderError.Policy.TERMINAL) {
+                    terminalFut.complete(err);
+                }
+                firstErrFut.complete(err);
+            });
+            SenderError.Category expectedTerminalCategory = null;
+            try {
                 sender.table(table).stringColumn("v", "not-a-double").at(2_000_000L, ChronoUnit.MICROS);
-                sender.flush();
-                SenderError err = errorFut.get(10, TimeUnit.SECONDS);
+                try {
+                    sender.flush();
+                } catch (LineSenderServerException ignored) {
+                    // the I/O thread latched the terminal before flush()'s
+                    // own error poll ran
+                }
+                SenderError err = firstErrFut.get(10, TimeUnit.SECONDS);
                 Assert.assertEquals(SenderError.Category.SCHEMA_MISMATCH, err.getCategory());
                 long delivered = sender.getTotalErrorNotificationsDelivered();
                 Assert.assertTrue("expected at least one delivery, got " + delivered, delivered >= 1L);
                 // Sanity: error did not surface as a drop on the dispatcher inbox.
                 Assert.assertEquals(0L, sender.getDroppedErrorNotifications());
+                expectedTerminalCategory = SenderError.Category.SCHEMA_MISMATCH;
+            } finally {
+                assertRejectionTerminalOnClose(sender, terminalFut, expectedTerminalCategory);
             }
             drainWalQueue();
         });

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderReceiverTest.java
@@ -1870,12 +1870,14 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
         // Dense prefix: every row flushed before the bad one landed.
         assertQuery("SELECT v FROM ws_async_multi_ok WHERE v <= 3 ORDER BY v")
                 .noLeakCheck()
-                .returnsOnce("v\n1\n2\n3\n");
+                .returns("v\n1\n2\n3\n");
         // Frame-drop atomicity: the rejected row never landed — the err
         // table still holds only the initial setup row.
         assertQuery("SELECT count() FROM ws_async_multi_err")
                 .noLeakCheck()
-                .returnsOnce("count\n1\n");
+                .noRandomAccess()
+                .expectSize()
+                .returns("count\n1\n");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderReceiverTest.java
@@ -25,6 +25,7 @@
 package io.questdb.test.cutlass.qwp.e2e;
 
 import io.questdb.cairo.GeoHashes;
+import io.questdb.client.LineSenderServerException;
 import io.questdb.client.Sender;
 import io.questdb.client.SenderError;
 import io.questdb.client.cutlass.line.LineSenderException;
@@ -1786,7 +1787,7 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
     }
 
     @Test
-    public void testErrorPropagation_asyncMultipleBatchesInFlight_drainBufferedTailAfterBlockedError() throws Exception {
+    public void testErrorPropagation_asyncMultipleBatchesInFlight_fragmentedTransport() throws Exception {
         runInContext(this::assertErrorPropagationAsyncMultipleBatchesInFlight, 65_536, 471, 71);
     }
 
@@ -1802,16 +1803,30 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
 
         // Fresh async sender: autoFlushRows=1 so each row is enqueued
         // immediately, window=8. The sender doesn't know the server-side
-        // schema of "ws_async_multi_err", so it cannot detect the type mismatch.
-        // Server type-mismatch is SCHEMA_MISMATCH / DROP_AND_CONTINUE so flush()
-        // does not throw — the rejection arrives asynchronously through the
-        // error handler.
-        CompletableFuture<SenderError> errorFut = new CompletableFuture<>();
-        try (QwpWebSocketSender sender = connectWs(port,
+        // schema of "ws_async_multi_err", so it cannot detect the type
+        // mismatch. NACK policy v2: the server-side type mismatch is
+        // SCHEMA_MISMATCH -- deterministic under byte-identical replay, so
+        // the client latches a TERMINAL on the NACK instead of dropping the
+        // frame. Rows flushed before the bad row land; rows queued after it
+        // are head-of-line blocked behind the latched terminal (whether an
+        // already-in-flight successor was applied is timing-dependent), so
+        // only the pre-error prefix is asserted dense. The rejection arrives
+        // asynchronously through the error handler and the latched terminal
+        // surfaces loudly on close unless the handler already owns it.
+        CompletableFuture<SenderError> firstErrFut = new CompletableFuture<>();
+        CompletableFuture<SenderError> terminalFut = new CompletableFuture<>();
+        QwpWebSocketSender sender = connectWs(port,
                 1,
                 Integer.MAX_VALUE,
                 TimeUnit.HOURS.toNanos(1),
-                errorFut::complete)) {
+                err -> {
+                    if (err.getAppliedPolicy() == SenderError.Policy.TERMINAL) {
+                        terminalFut.complete(err);
+                    }
+                    firstErrFut.complete(err);
+                });
+        SenderError.Category expectedTerminalCategory = null;
+        try {
             // Good rows to a separate table — auto-flushed, no ACK wait
             for (int i = 1; i <= 3; i++) {
                 sender.table("ws_async_multi_ok")
@@ -1819,33 +1834,48 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
                         .at(1_000_000_000_000L + i, ChronoUnit.MICROS);
             }
 
-            // Bad row to the pre-existing table — STRING into LONG.
-            // Client doesn't know the server-side schema, so this passes client-side
-            // validation. The I/O thread sends it; the server rejects it.
-            sender.table("ws_async_multi_err")
-                    .stringColumn("value", "not a number")
-                    .at(1_000_000_000_001L, ChronoUnit.MICROS);
+            try {
+                // Bad row to the pre-existing table — STRING into LONG.
+                // Client doesn't know the server-side schema, so this passes
+                // client-side validation. The I/O thread sends it; the server
+                // rejects it.
+                sender.table("ws_async_multi_err")
+                        .stringColumn("value", "not a number")
+                        .at(1_000_000_000_001L, ChronoUnit.MICROS);
 
-            // More good rows — user thread doesn't know about the error yet
-            for (int i = 4; i <= 6; i++) {
-                sender.table("ws_async_multi_ok")
-                        .longColumn("v", i)
-                        .at(1_000_000_000_000L + i, ChronoUnit.MICROS);
+                // More good rows racing the NACK — they may ship before the
+                // terminal latches or stay head-of-line blocked behind it;
+                // either way they must not disturb the settled prefix or
+                // resurrect the rejected frame.
+                for (int i = 4; i <= 6; i++) {
+                    sender.table("ws_async_multi_ok")
+                            .longColumn("v", i)
+                            .at(1_000_000_000_000L + i, ChronoUnit.MICROS);
+                }
+
+                sender.flush();
+            } catch (LineSenderServerException ignored) {
+                // the I/O thread can latch the terminal while the tail is
+                // still being published -- any producer call may throw it
             }
 
-            sender.flush();
-
-            SenderError err = errorFut.get(10, TimeUnit.SECONDS);
+            SenderError err = firstErrFut.get(10, TimeUnit.SECONDS);
             Assert.assertEquals(SenderError.Category.SCHEMA_MISMATCH, err.getCategory());
+            Assert.assertSame(SenderError.Policy.TERMINAL, err.getAppliedPolicy());
+            expectedTerminalCategory = SenderError.Category.SCHEMA_MISMATCH;
+        } finally {
+            assertRejectionTerminalOnClose(sender, terminalFut, expectedTerminalCategory);
         }
         drainWalQueue();
-        assertQuery("SELECT v FROM ws_async_multi_ok ORDER BY v")
+        // Dense prefix: every row flushed before the bad one landed.
+        assertQuery("SELECT v FROM ws_async_multi_ok WHERE v <= 3 ORDER BY v")
                 .noLeakCheck()
-                .returnsOnce("v\n1\n2\n3\n4\n5\n6\n");
-        // The initial setup row (value=0) must be present
-        assertQuery("SELECT value FROM ws_async_multi_err WHERE value = 0")
+                .returnsOnce("v\n1\n2\n3\n");
+        // Frame-drop atomicity: the rejected row never landed — the err
+        // table still holds only the initial setup row.
+        assertQuery("SELECT count() FROM ws_async_multi_err")
                 .noLeakCheck()
-                .returnsOnce("value\n0\n");
+                .returnsOnce("count\n1\n");
     }
 
     @Test
@@ -2317,8 +2347,10 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
      * async modes.
      * <p>
      * Creates a table with a LONG column, then sends a STRING into it via a
-     * fresh connection. flush() must throw in both modes because it always
-     * waits for all pending ACKs before returning.
+     * fresh connection. The server NACKs SCHEMA_MISMATCH; under NACK policy
+     * v2 the client latches a TERMINAL that reaches the error handler and
+     * surfaces loudly on close (or from flush() when its error poll wins the
+     * race against the handler dispatch).
      */
     @Test
     public void testImmediateErrorPropagation_typeMismatchOnFlush() throws Exception {
@@ -2334,23 +2366,39 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
             drainWalQueue();
 
             // Second sender: fresh connection, no client-side column cache.
-            // Server-side string-to-numeric mismatch is classified as
-            // SCHEMA_MISMATCH which defaults to DROP_AND_CONTINUE, so
-            // flush() does not throw — the rejection arrives asynchronously
-            // through the error handler. Block on a CompletableFuture for
-            // deterministic delivery.
-            CompletableFuture<SenderError> errorFut = new CompletableFuture<>();
-            try (QwpWebSocketSender sender = connectWs(port,
+            // NACK policy v2: the server-side string-to-numeric mismatch is
+            // classified as SCHEMA_MISMATCH -- deterministic under
+            // byte-identical replay, so the client latches a TERMINAL on the
+            // first NACK (no drop, no replay). The rejection arrives
+            // asynchronously through the error handler; the latched terminal
+            // surfaces loudly on close unless the handler already owns it.
+            CompletableFuture<SenderError> firstErrFut = new CompletableFuture<>();
+            CompletableFuture<SenderError> terminalFut = new CompletableFuture<>();
+            QwpWebSocketSender sender = connectWs(port,
                     QwpWebSocketSender.DEFAULT_AUTO_FLUSH_ROWS,
                     QwpWebSocketSender.DEFAULT_AUTO_FLUSH_BYTES,
                     QwpWebSocketSender.DEFAULT_AUTO_FLUSH_INTERVAL_NANOS,
-                    errorFut::complete)) {
+                    err -> {
+                        if (err.getAppliedPolicy() == SenderError.Policy.TERMINAL) {
+                            terminalFut.complete(err);
+                        }
+                        firstErrFut.complete(err);
+                    });
+            SenderError.Category expectedTerminalCategory = null;
+            try {
                 sender.table("ws_error_propagation_test")
                         .stringColumn("value", "not a number")
                         .at(1_000_000_000_001L, ChronoUnit.MICROS);
-                sender.flush();
+                try {
+                    sender.flush();
+                } catch (LineSenderServerException ignored) {
+                    // the I/O thread latched the terminal before flush()'s
+                    // own error poll ran
+                }
 
-                SenderError err = errorFut.get(10, TimeUnit.SECONDS);
+                SenderError err = firstErrFut.get(10, TimeUnit.SECONDS);
+                Assert.assertEquals(SenderError.Category.SCHEMA_MISMATCH, err.getCategory());
+                Assert.assertSame(SenderError.Policy.TERMINAL, err.getAppliedPolicy());
                 String msg = err.getServerMessage();
                 Assert.assertTrue("Error message should indicate server error: " + msg,
                         msg != null && (msg.contains("WRITE_ERROR")
@@ -2359,6 +2407,9 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
                                 || msg.contains("inconvertible")
                                 || msg.contains("not a number")
                                 || msg.contains("cannot")));
+                expectedTerminalCategory = SenderError.Category.SCHEMA_MISMATCH;
+            } finally {
+                assertRejectionTerminalOnClose(sender, terminalFut, expectedTerminalCategory);
             }
         });
     }
@@ -3165,24 +3216,44 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
                     .noLeakCheck()
                     .returnsOnce("walEnabled\nfalse\n");
 
-            // Try to write to the non-WAL table via QWP - server rejects with
-            // WRITE_ERROR which defaults to DROP_AND_CONTINUE, so flush() does
-            // not throw. Block on the async error handler for deterministic
-            // delivery of the rejection.
-            CompletableFuture<SenderError> errorFut = new CompletableFuture<>();
-            try (QwpWebSocketSender sender = connectWs(port,
-                    QwpWebSocketSender.DEFAULT_AUTO_FLUSH_ROWS,
-                    QwpWebSocketSender.DEFAULT_AUTO_FLUSH_BYTES,
-                    QwpWebSocketSender.DEFAULT_AUTO_FLUSH_INTERVAL_NANOS,
-                    errorFut::complete)) {
+            // Try to write to the non-WAL table via QWP. NACK policy v2:
+            // the server rejects with WRITE_ERROR, which is RETRIABLE -- the
+            // client dispatches the strike to the error handler
+            // informationally and replays the frame; the rejection is
+            // deterministic under byte-identical replay, so the poison-frame
+            // detector escalates it to a latched TERMINAL PROTOCOL_VIOLATION
+            // (max_frame_rejections=1 makes the escalation immediate). Block
+            // on the async error handler for deterministic delivery of the
+            // rejection, then expect the latched terminal to surface loudly
+            // on close.
+            CompletableFuture<SenderError> firstErrFut = new CompletableFuture<>();
+            CompletableFuture<SenderError> terminalFut = new CompletableFuture<>();
+            QwpWebSocketSender sender = connectWs(port, err -> {
+                if (err.getAppliedPolicy() == SenderError.Policy.TERMINAL) {
+                    terminalFut.complete(err);
+                }
+                firstErrFut.complete(err);
+            }, 1);
+            SenderError.Category expectedTerminalCategory = null;
+            try {
                 sender.table("non_wal_table")
                         .symbol("tag", "test")
                         .longColumn("value", 42)
                         .at(1_000_000_000_000L, ChronoUnit.MICROS);
-                sender.flush();
+                try {
+                    sender.flush();
+                } catch (LineSenderServerException ignored) {
+                    // the I/O thread latched the terminal before flush()'s
+                    // own error poll ran
+                }
 
-                SenderError err = errorFut.get(10, TimeUnit.SECONDS);
+                SenderError err = firstErrFut.get(10, TimeUnit.SECONDS);
                 Assert.assertEquals(SenderError.Category.WRITE_ERROR, err.getCategory());
+                Assert.assertSame(SenderError.Policy.RETRIABLE, err.getAppliedPolicy());
+                expectedTerminalCategory = SenderError.Category.PROTOCOL_VIOLATION;
+            } finally {
+                assertRejectionTerminalOnClose(sender, terminalFut, expectedTerminalCategory,
+                        "cannot insert into non-WAL table", "non_wal_table");
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/QwpIngressAckLeapfrogTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/QwpIngressAckLeapfrogTest.java
@@ -1,0 +1,474 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.websocket;
+
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.TableReader;
+import io.questdb.cairo.security.AllowAllSecurityContext;
+import io.questdb.cairo.wal.DurableAckRegistry;
+import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
+import io.questdb.cutlass.http.HttpConnectionContext;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
+import io.questdb.cutlass.http.HttpRawSocket;
+import io.questdb.cutlass.http.HttpServerConfiguration;
+import io.questdb.cutlass.http.LocalValue;
+import io.questdb.cutlass.qwp.protocol.QwpConstants;
+import io.questdb.cutlass.qwp.server.QwpIngressProcessorState;
+import io.questdb.cutlass.qwp.server.QwpIngressUpgradeProcessor;
+import io.questdb.cutlass.qwp.websocket.WebSocketOpcode;
+import io.questdb.log.Log;
+import io.questdb.network.NetworkFacadeImpl;
+import io.questdb.network.PeerIsSlowToWriteException;
+import io.questdb.network.PlainSocket;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.ObjList;
+import io.questdb.std.Unsafe;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.cairo.DefaultTestCairoConfiguration;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Regression test for the cumulative-ACK leapfrog over a silently gate-rejected
+ * frame during a deferred role-change close (in-place PRIMARY-to-REPLICA demote
+ * that re-promotes within the durable-upload grace window).
+ * <p>
+ * Failure chain that was possible before the deferral gate in
+ * {@code handleBinaryMessage} ({@link QwpIngressUpgradeProcessor}):
+ * <ol>
+ *   <li>Durable-ack connection commits frame seq=0 (durable upload lags, so
+ *       the connection has un-covered durable work).</li>
+ *   <li>Demote: frame seq=1 is rejected by the {@code engine.isReadOnlyMode()}
+ *       gate. {@code roleChangeCloseWithUploadGrace} arms the bounded deferral
+ *       and returns — seq=1 gets NO error response, yet its sequence number is
+ *       consumed. The {@code finally}-block {@code state.clear()} re-arms the
+ *       connection ({@code currentStatus=OK}, {@code roleChangeClosePending=false}).</li>
+ *   <li>Re-promote within the grace window: frame seq=2 passes the live gate,
+ *       commits, and {@code setHighestProcessedSequence(2)} is recorded.</li>
+ *   <li>The client's durable-ack keepalive PING flushes a cumulative OK-ACK
+ *       carrying seq=2.</li>
+ * </ol>
+ * The OK-ACK contract is cumulative — "the server has confirmed every FSN up
+ * to and including this value" ({@code SegmentRing.acknowledge} in the Java
+ * client) — so an ACK of seq=2 makes a store-and-forward client trim the
+ * segment slot holding frame seq=1, whose rows the server refused, never
+ * wrote, and never reported. Silent data loss.
+ * <p>
+ * Invariant asserted (fix-agnostic): a cumulative OK-ACK must not cover a
+ * sequence that was neither committed nor answered with an error response.
+ * The test stays green whether the fix NACKs the rejected frame, caps the
+ * cumulative ACK below it, or refuses data frames while a role-change close
+ * deferral is armed. The shipped fix does the latter (primary gate) plus the
+ * ack-watermark clamp in {@code QwpIngressProcessorState} (last-resort
+ * containment, unit-covered in {@code QwpIngressProcessorStateTest}).
+ */
+public class QwpIngressAckLeapfrogTest extends AbstractCairoTest {
+    private static final byte[] DEFAULT_MASK_KEY = {0x12, 0x34, 0x56, 0x78};
+    private static final int RECV_BUFFER_SIZE = 1024;
+    private static final int SEND_BUFFER_SIZE = 1024;
+
+    @Test
+    public void testCumulativeAckMustNotLeapfrogGateRejectedFrame() throws Exception {
+        assertMemoryLeak(() -> {
+            final AtomicBoolean readOnly = new AtomicBoolean(false);
+            final HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+
+            // The demotable engine below shares the root with the static test
+            // engine, which holds the table-registry lock. Pre-create the WAL
+            // table through the lock holder so the QWP path only needs to
+            // acquire a WAL writer, not register a new table.
+            execute("create table tab (v long, ts timestamp) timestamp(ts) partition by day wal");
+
+            try (CairoEngine demotableEngine = new CairoEngine(new DefaultTestCairoConfiguration(root)) {
+                private final DurableAckRegistry laggingRegistry = new DurableAckRegistry() {
+                    @Override
+                    public long getDurablyUploadedSeqTxn(CharSequence tableDirName) {
+                        // uploads never catch up: the deferral stays armed for
+                        // the whole grace window
+                        return -1L;
+                    }
+
+                    @Override
+                    public boolean isEnabled() {
+                        return true;
+                    }
+                };
+
+                @Override
+                public @NotNull DurableAckRegistry getDurableAckRegistry() {
+                    return laggingRegistry;
+                }
+
+                @Override
+                public boolean isReadOnlyMode() {
+                    return readOnly.get();
+                }
+            }) {
+                QwpIngressUpgradeProcessor processor = new QwpIngressUpgradeProcessor(demotableEngine, httpConfig);
+
+                byte[] frame0 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage(100L, 1_000_000L));
+                byte[] frame1 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage(200L, 2_000_000L));
+                byte[] frame2 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage(300L, 3_000_000L));
+                byte[] ping = createMaskedFrame(WebSocketOpcode.PING, new byte[0]);
+                byte[] wire = concat(frame0, frame1, frame2, ping);
+
+                PhasedNetworkFacade nf = new PhasedNetworkFacade(wire);
+                long recvBuf = Unsafe.malloc(RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                long sendBuf = Unsafe.malloc(SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                RecordingRawSocket rawSocket = new RecordingRawSocket(sendBuf, SEND_BUFFER_SIZE);
+                try (TestableContext context = new TestableContext(httpConfig, nf, rawSocket, recvBuf, RECV_BUFFER_SIZE)) {
+                    QwpIngressProcessorState state = new QwpIngressProcessorState(
+                            RECV_BUFFER_SIZE,
+                            httpConfig.getSendBufferSize(),
+                            demotableEngine,
+                            httpConfig.getLineHttpProcessorConfiguration()
+                    );
+                    state.of(-1, AllowAllSecurityContext.INSTANCE);
+                    // durable-ack opt-in, as negotiated via X-QWP-Request-Durable-Ack
+                    state.setDurableAckEnabled(true);
+                    getLV().set(context, state);
+
+                    // Phase A: PRIMARY. seq=0 commits; durable upload lags behind.
+                    drive(processor, context, nf, frame0.length);
+
+                    // Phase B: in-place demote. seq=1 is gate-rejected; the
+                    // role-change close is deferred awaiting upload coverage;
+                    // no error response goes out for seq=1.
+                    readOnly.set(true);
+                    drive(processor, context, nf, frame1.length);
+                    Assert.assertTrue(
+                            "test setup: role-change close must be deferred awaiting durable upload coverage",
+                            state.isRoleChangeCloseDeferred()
+                    );
+
+                    // Phase C: re-promote within the grace window. seq=2 passes
+                    // the live read-only gate and commits.
+                    readOnly.set(false);
+                    drive(processor, context, nf, frame2.length);
+
+                    // Phase D: durable-ack keepalive PING — documented flush
+                    // point for pending cumulative ACKs.
+                    drive(processor, context, nf, ping.length);
+
+                    // The rejected frame's row must not have been written
+                    // (the refusal itself is legitimate; acking it is the bug).
+                    drainWalQueue(demotableEngine);
+                    long ingestedRows;
+                    try (TableReader reader = demotableEngine.getReader("tab")) {
+                        ingestedRows = reader.size();
+                    }
+                    Assert.assertTrue("gate-rejected frame must not be committed", ingestedRows <= 2);
+
+                    // INVARIANT: a cumulative OK-ACK confirms every sequence up
+                    // to and including its value, so it must never cover a
+                    // sequence that was neither committed nor refused with an
+                    // error response.
+                    long maxOkAck = maxCumulativeOkAck(rawSocket.sentFrames);
+                    boolean seq1Refused = hasErrorResponseForSeq(rawSocket.sentFrames, 1);
+                    if (!seq1Refused) {
+                        Assert.assertTrue(
+                                "SILENT DATA LOSS: cumulative OK-ACK confirms sequences 0.." + maxOkAck
+                                        + ", but seq=1 was gate-rejected during the demote, never committed ("
+                                        + ingestedRows + " rows in table for " + (maxOkAck + 1)
+                                        + " acked frames) and never refused with an error response;"
+                                        + " a durable-ack store-and-forward client trims its replay slot"
+                                        + " for seq=1 on this ACK and the rows are lost",
+                                maxOkAck < 1
+                        );
+                    }
+                } finally {
+                    Unsafe.free(recvBuf, RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                    Unsafe.free(sendBuf, SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    private static byte[] concat(byte[]... arrays) {
+        int len = 0;
+        for (byte[] a : arrays) {
+            len += a.length;
+        }
+        byte[] out = new byte[len];
+        int pos = 0;
+        for (byte[] a : arrays) {
+            System.arraycopy(a, 0, out, pos, a.length);
+            pos += a.length;
+        }
+        return out;
+    }
+
+    private static byte[] createMaskedFrame(int opcode, byte[] payload) {
+        // all test frames are tiny; single-byte payload length is sufficient
+        assert payload.length <= 125;
+        byte[] frame = new byte[2 + 4 + payload.length];
+        int offset = 0;
+        frame[offset++] = (byte) (0x80 | (opcode & 0x0F));
+        frame[offset++] = (byte) (0x80 | payload.length);
+        System.arraycopy(DEFAULT_MASK_KEY, 0, frame, offset, 4);
+        offset += 4;
+        for (int i = 0; i < payload.length; i++) {
+            frame[offset + i] = (byte) (payload[i] ^ DEFAULT_MASK_KEY[i % 4]);
+        }
+        return frame;
+    }
+
+    private static void drive(
+            QwpIngressUpgradeProcessor processor,
+            HttpConnectionContext context,
+            PhasedNetworkFacade nf,
+            int bytes
+    ) throws Exception {
+        nf.release(bytes);
+        try {
+            processor.resumeRecv(context);
+        } catch (PeerIsSlowToWriteException e) {
+            // all released bytes consumed; the dispatcher would re-arm for read
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static LocalValue<QwpIngressProcessorState> getLV() throws Exception {
+        Field lvField = QwpIngressUpgradeProcessor.class.getDeclaredField("LV");
+        lvField.setAccessible(true);
+        return (LocalValue<QwpIngressProcessorState>) lvField.get(null);
+    }
+
+    /**
+     * True if any server-to-client BINARY frame is an error response
+     * (status != OK) carrying the given sequence. Error frames share the
+     * ACK's [status][seq LE] payload prefix.
+     */
+    private static boolean hasErrorResponseForSeq(ObjList<byte[]> frames, long seq) {
+        for (int i = 0, n = frames.size(); i < n; i++) {
+            byte[] f = frames.getQuick(i);
+            if (!isBinaryFrame(f)) {
+                continue;
+            }
+            if (f[2] != QwpConstants.STATUS_OK && readLeLong(f, 3) == seq) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isBinaryFrame(byte[] frame) {
+        // server frames are unmasked; all frames in this test have single-byte
+        // payload lengths, so the payload starts at offset 2
+        return frame.length >= 11
+                && (frame[0] & 0x0F) == WebSocketOpcode.BINARY
+                && (frame[1] & 0x80) == 0
+                && (frame[1] & 0x7F) < 126;
+    }
+
+    /**
+     * Highest sequence carried by any cumulative OK-ACK frame sent to the
+     * client, or -1 when none was sent.
+     */
+    private static long maxCumulativeOkAck(ObjList<byte[]> frames) {
+        long max = -1;
+        for (int i = 0, n = frames.size(); i < n; i++) {
+            byte[] f = frames.getQuick(i);
+            if (!isBinaryFrame(f)) {
+                continue;
+            }
+            if (f[2] == QwpConstants.STATUS_OK) {
+                max = Math.max(max, readLeLong(f, 3));
+            }
+        }
+        return max;
+    }
+
+    /**
+     * QWP v1 message: table "tab", one row, schema
+     * [{@code v} LONG, {@code ""} TIMESTAMP (designated)].
+     */
+    private static byte[] oneRowMessage(long value, long tsMicros) {
+        byte[] payload = new byte[29];
+        int i = 0;
+        // table header
+        payload[i++] = 3; // table name length (varint)
+        payload[i++] = 't';
+        payload[i++] = 'a';
+        payload[i++] = 'b';
+        payload[i++] = 1; // rowCount (varint)
+        payload[i++] = 2; // columnCount (varint)
+        // schema
+        payload[i++] = 1; // column name length (varint)
+        payload[i++] = 'v';
+        payload[i++] = QwpConstants.TYPE_LONG;
+        payload[i++] = 0; // empty name = designated timestamp
+        payload[i++] = QwpConstants.TYPE_TIMESTAMP;
+        // column data: v
+        payload[i++] = 0; // no null bitmap
+        i = writeLeLong(payload, i, value);
+        // column data: designated timestamp
+        payload[i++] = 0; // no null bitmap
+        writeLeLong(payload, i, tsMicros);
+
+        byte[] message = new byte[QwpConstants.HEADER_SIZE + payload.length];
+        message[0] = 'Q';
+        message[1] = 'W';
+        message[2] = 'P';
+        message[3] = '1';
+        message[4] = QwpConstants.VERSION;
+        message[5] = 0; // flags
+        message[6] = 1; // tableCount lo
+        message[7] = 0; // tableCount hi
+        message[8] = (byte) payload.length;
+        message[9] = 0;
+        message[10] = 0;
+        message[11] = 0;
+        System.arraycopy(payload, 0, message, QwpConstants.HEADER_SIZE, payload.length);
+        return message;
+    }
+
+    private static long readLeLong(byte[] buf, int offset) {
+        long v = 0;
+        for (int i = 7; i >= 0; i--) {
+            v = (v << 8) | (buf[offset + i] & 0xFFL);
+        }
+        return v;
+    }
+
+    private static int writeLeLong(byte[] buf, int offset, long value) {
+        for (int i = 0; i < 8; i++) {
+            buf[offset++] = (byte) (value >>> (i * 8));
+        }
+        return offset;
+    }
+
+    /**
+     * Network facade that releases the client's wire bytes in explicit phases
+     * so the engine's read-only flag can be flipped between frames — the
+     * demote/re-promote race distilled to its deterministic core.
+     */
+    private static class PhasedNetworkFacade extends NetworkFacadeImpl {
+        private final byte[] data;
+        private int limit;
+        private int pos;
+
+        PhasedNetworkFacade(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public void close(long fd, Log log) {
+            // no-op for test
+        }
+
+        @Override
+        public int recvRaw(long fd, long buffer, int bufferLen) {
+            if (pos >= limit) {
+                return 0; // would block
+            }
+            int n = Math.min(bufferLen, limit - pos);
+            for (int i = 0; i < n; i++) {
+                Unsafe.putByte(buffer + i, data[pos++]);
+            }
+            return n;
+        }
+
+        void release(int bytes) {
+            limit = Math.min(data.length, limit + bytes);
+        }
+    }
+
+    /**
+     * Captures every frame the server sends, in order.
+     */
+    private static class RecordingRawSocket implements HttpRawSocket {
+        final ObjList<byte[]> sentFrames = new ObjList<>();
+        private final long bufferAddress;
+        private final int bufferSize;
+
+        RecordingRawSocket(long bufferAddress, int bufferSize) {
+            this.bufferAddress = bufferAddress;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public long getBufferAddress() {
+            return bufferAddress;
+        }
+
+        @Override
+        public int getBufferSize() {
+            return bufferSize;
+        }
+
+        @Override
+        public void send(int size) {
+            byte[] copy = new byte[size];
+            for (int i = 0; i < size; i++) {
+                copy[i] = Unsafe.getByte(bufferAddress + i);
+            }
+            sentFrames.add(copy);
+        }
+    }
+
+    /**
+     * Same shape as the contexts in
+     * {@code QwpIngressUpgradeProcessorResumeRecvTest}: overrides the I/O
+     * access points with the test doubles.
+     */
+    private static class TestableContext extends HttpConnectionContext {
+        private final RecordingRawSocket rawSocket;
+        private final long testRecvBuffer;
+        private final int testRecvBufferSize;
+
+        TestableContext(
+                HttpServerConfiguration config,
+                PhasedNetworkFacade nf,
+                RecordingRawSocket rawSocket,
+                long recvBuffer,
+                int recvBufferSize
+        ) {
+            super(config, (_, log) -> new PlainSocket(nf, log));
+            this.rawSocket = rawSocket;
+            this.testRecvBuffer = recvBuffer;
+            this.testRecvBufferSize = recvBufferSize;
+        }
+
+        @Override
+        public HttpRawSocket getRawResponseSocket() {
+            return rawSocket;
+        }
+
+        @Override
+        public long getRecvBuffer() {
+            return testRecvBuffer;
+        }
+
+        @Override
+        public int getRecvBufferSize() {
+            return testRecvBufferSize;
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/QwpIngressAckLeapfrogTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/QwpIngressAckLeapfrogTest.java
@@ -210,6 +210,82 @@ public class QwpIngressAckLeapfrogTest extends AbstractCairoTest {
         });
     }
 
+    /**
+     * A per-message error must break the ordered pipeline: a valid frame the
+     * client already pipelined behind the failing one must be refused, never
+     * committed, and the cumulative OK-ACK must not leapfrog the gap.
+     */
+    @Test
+    public void testErrorRefusesPipelinedTailOnSameConnection() throws Exception {
+        assertMemoryLeak(() -> {
+            final HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+            execute("create table tab (v long, ts timestamp) timestamp(ts) partition by day wal");
+
+            QwpIngressUpgradeProcessor processor = new QwpIngressUpgradeProcessor(engine, httpConfig);
+
+            // seq=0 valid, seq=1 schema mismatch (VARCHAR "x" into LONG v),
+            // seq=2 valid but pipelined behind the gap.
+            ObjList<byte[]> sent = ingestOnFreshConnection(
+                    processor,
+                    httpConfig,
+                    createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage(100L, 1_000_000L)),
+                    createMaskedFrame(WebSocketOpcode.BINARY, oneRowVarcharMessage("x", 2_000_000L)),
+                    createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage(300L, 3_000_000L)),
+                    createMaskedFrame(WebSocketOpcode.PING, new byte[0])
+            );
+
+            drainWalQueue();
+            try (TableReader reader = engine.getReader("tab")) {
+                Assert.assertEquals("only seq=0 must commit; the pipelined tail after the error is refused", 1, reader.size());
+            }
+            Assert.assertTrue("seq=1 must be refused with an error response", hasErrorResponseForSeq(sent, 1));
+            long maxOkAck = maxCumulativeOkAck(sent);
+            Assert.assertTrue("cumulative OK-ACK must not leapfrog the errored seq=1 (was " + maxOkAck + ")", maxOkAck < 1);
+        });
+    }
+
+    /**
+     * A frame refused because a prior error broke the pipeline is neither
+     * committed nor acked, so a reconnecting client replays it from its acked
+     * watermark and it lands exactly once -- no loss, no duplicate.
+     */
+    @Test
+    public void testReconnectReplayLandsRefusedTailExactlyOnce() throws Exception {
+        assertMemoryLeak(() -> {
+            final HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+            execute("create table tab (v long, ts timestamp) timestamp(ts) partition by day wal");
+
+            QwpIngressUpgradeProcessor processor = new QwpIngressUpgradeProcessor(engine, httpConfig);
+
+            // Connection 1: A commits, B (schema mismatch) errors, C is refused.
+            ingestOnFreshConnection(
+                    processor,
+                    httpConfig,
+                    createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage(100L, 1_000_000L)),
+                    createMaskedFrame(WebSocketOpcode.BINARY, oneRowVarcharMessage("x", 2_000_000L)),
+                    createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage(300L, 3_000_000L))
+            );
+            drainWalQueue();
+            try (TableReader reader = engine.getReader("tab")) {
+                Assert.assertEquals("first connection commits only A", 1, reader.size());
+            }
+
+            // Reconnect: the client replays its unacked tail from ackedFsn+1 --
+            // the corrected B and the still-valid C.
+            ingestOnFreshConnection(
+                    processor,
+                    httpConfig,
+                    createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage(200L, 2_000_000L)),
+                    createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage(300L, 3_000_000L))
+            );
+            drainWalQueue();
+            try (TableReader reader = engine.getReader("tab")) {
+                // A + B + C, C exactly once (never committed on connection 1).
+                Assert.assertEquals("replayed tail must land exactly once, no duplicate", 3, reader.size());
+            }
+        });
+    }
+
     private static byte[] concat(byte[]... arrays) {
         int len = 0;
         for (byte[] a : arrays) {
@@ -349,6 +425,52 @@ public class QwpIngressAckLeapfrogTest extends AbstractCairoTest {
         return message;
     }
 
+    /**
+     * Like {@link #oneRowMessage} but declares {@code v} as VARCHAR carrying a
+     * non-numeric string, which the LONG column rejects as SCHEMA_MISMATCH.
+     */
+    private static byte[] oneRowVarcharMessage(String value, long tsMicros) {
+        byte[] utf8 = value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        byte[] payload = new byte[11 + 1 + 8 + utf8.length + 1 + 8];
+        int i = 0;
+        payload[i++] = 3;
+        payload[i++] = 't';
+        payload[i++] = 'a';
+        payload[i++] = 'b';
+        payload[i++] = 1; // rowCount
+        payload[i++] = 2; // columnCount
+        payload[i++] = 1; // column name length
+        payload[i++] = 'v';
+        payload[i++] = QwpConstants.TYPE_VARCHAR;
+        payload[i++] = 0; // empty name = designated timestamp
+        payload[i++] = QwpConstants.TYPE_TIMESTAMP;
+        // column data: v -- [no-null-bitmap flag][offset array][utf8 bytes]
+        payload[i++] = 0;
+        i = writeLeInt(payload, i, 0);
+        i = writeLeInt(payload, i, utf8.length);
+        System.arraycopy(utf8, 0, payload, i, utf8.length);
+        i += utf8.length;
+        // column data: designated timestamp
+        payload[i++] = 0;
+        writeLeLong(payload, i, tsMicros);
+
+        byte[] message = new byte[QwpConstants.HEADER_SIZE + payload.length];
+        message[0] = 'Q';
+        message[1] = 'W';
+        message[2] = 'P';
+        message[3] = '1';
+        message[4] = QwpConstants.VERSION;
+        message[5] = 0;
+        message[6] = 1;
+        message[7] = 0;
+        message[8] = (byte) payload.length;
+        message[9] = 0;
+        message[10] = 0;
+        message[11] = 0;
+        System.arraycopy(payload, 0, message, QwpConstants.HEADER_SIZE, payload.length);
+        return message;
+    }
+
     private static long readLeLong(byte[] buf, int offset) {
         long v = 0;
         for (int i = 7; i >= 0; i--) {
@@ -357,11 +479,47 @@ public class QwpIngressAckLeapfrogTest extends AbstractCairoTest {
         return v;
     }
 
+    private static int writeLeInt(byte[] buf, int offset, int value) {
+        for (int i = 0; i < 4; i++) {
+            buf[offset++] = (byte) (value >>> (i * 8));
+        }
+        return offset;
+    }
+
     private static int writeLeLong(byte[] buf, int offset, long value) {
         for (int i = 0; i < 8; i++) {
             buf[offset++] = (byte) (value >>> (i * 8));
         }
         return offset;
+    }
+
+    private ObjList<byte[]> ingestOnFreshConnection(
+            QwpIngressUpgradeProcessor processor,
+            HttpFullFatServerConfiguration httpConfig,
+            byte[]... frames
+    ) throws Exception {
+        byte[] wire = concat(frames);
+        PhasedNetworkFacade nf = new PhasedNetworkFacade(wire);
+        long recvBuf = Unsafe.malloc(RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+        long sendBuf = Unsafe.malloc(SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+        RecordingRawSocket rawSocket = new RecordingRawSocket(sendBuf, SEND_BUFFER_SIZE);
+        try (TestableContext context = new TestableContext(httpConfig, nf, rawSocket, recvBuf, RECV_BUFFER_SIZE)) {
+            QwpIngressProcessorState state = new QwpIngressProcessorState(
+                    RECV_BUFFER_SIZE,
+                    httpConfig.getSendBufferSize(),
+                    engine,
+                    httpConfig.getLineHttpProcessorConfiguration()
+            );
+            state.of(-1, AllowAllSecurityContext.INSTANCE);
+            getLV().set(context, state);
+            for (byte[] frame : frames) {
+                drive(processor, context, nf, frame.length);
+            }
+        } finally {
+            Unsafe.free(recvBuf, RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+            Unsafe.free(sendBuf, SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+        }
+        return rawSocket.sentFrames;
     }
 
     /**

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/QwpIngressDeferredCloseDurableAckTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/QwpIngressDeferredCloseDurableAckTest.java
@@ -33,11 +33,13 @@ import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
 import io.questdb.cutlass.http.HttpRawSocket;
 import io.questdb.cutlass.http.HttpServerConfiguration;
 import io.questdb.cutlass.http.LocalValue;
+import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
 import io.questdb.cutlass.qwp.protocol.QwpConstants;
 import io.questdb.cutlass.qwp.server.QwpIngressProcessorState;
 import io.questdb.cutlass.qwp.server.QwpIngressUpgradeProcessor;
 import io.questdb.cutlass.qwp.websocket.WebSocketOpcode;
 import io.questdb.log.Log;
+import io.questdb.log.LogFactory;
 import io.questdb.network.NetworkFacadeImpl;
 import io.questdb.network.PeerDisconnectedException;
 import io.questdb.network.PeerIsSlowToReadException;
@@ -47,8 +49,10 @@ import io.questdb.network.ServerDisconnectException;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.ObjList;
 import io.questdb.std.Unsafe;
+import io.questdb.std.datetime.MicrosecondClock;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.cairo.DefaultTestCairoConfiguration;
+import io.questdb.test.tools.LogCapture;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
@@ -91,6 +95,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * from {@code QwpIngressUpgradeProcessorResumeRecvTest}.
  */
 public class QwpIngressDeferredCloseDurableAckTest extends AbstractCairoTest {
+    private static final Log SENTINEL_LOG = LogFactory.getLog(QwpIngressDeferredCloseDurableAckTest.class);
     private static final byte[] DEFAULT_MASK_KEY = {0x12, 0x34, 0x56, 0x78};
     private static final int RECV_BUFFER_SIZE = 1024;
     private static final int SEND_BUFFER_SIZE = 1024;
@@ -355,6 +360,207 @@ public class QwpIngressDeferredCloseDurableAckTest extends AbstractCairoTest {
     }
 
     /**
+     * Grace-expiry diagnostics, PING re-entry: {@code handlePing} completes a
+     * deferred role-change close through an inline copy of the completion
+     * predicate and skips the "role-change close upload grace expired"
+     * LOG.error that the equivalent exit in
+     * {@code roleChangeCloseWithUploadGrace} emits. PING is the designated
+     * recv-driven re-entry poll for a quiesced client (data frames are refused
+     * by the deferral gate), so the one close the operator must see -- the
+     * grace budget exhausting while committed work is still not durably
+     * uploaded, exposing the client to replay duplicates -- happens silently.
+     * <p>
+     * Invariant (fix-agnostic): a grace-expired close with un-acked durable
+     * work logs the grace-expired diagnostic no matter which re-entry point
+     * observes the expiry.
+     */
+    @Test
+    public void testGraceExpiredPingCloseMustLogAbandonedDurableWork() throws Exception {
+        final LogCapture capture = new LogCapture();
+        assertMemoryLeak(() -> {
+            final AtomicBoolean readOnly = new AtomicBoolean(false);
+            final AtomicLong durableWatermark = new AtomicLong(-1L); // uploads lag for the whole test
+            final long[] nowMicros = {0L};
+            final HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+
+            execute("create table tabd (v long, ts timestamp) timestamp(ts) partition by day wal");
+
+            try (CairoEngine demotableEngine = newEngineWithRegistry(readOnly, durableWatermark)) {
+                QwpIngressUpgradeProcessor processor = new QwpIngressUpgradeProcessor(demotableEngine, httpConfig);
+
+                byte[] frame0 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("tabd", 100L, 1_000_000L));
+                byte[] frame1 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("tabd", 200L, 2_000_000L));
+                byte[] ping = createMaskedFrame(WebSocketOpcode.PING, new byte[0]);
+                byte[] wire = concat(frame0, frame1, ping);
+
+                PhasedNetworkFacade nf = new PhasedNetworkFacade(wire);
+                long recvBuf = Unsafe.malloc(RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                long sendBuf = Unsafe.malloc(SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                BlockingRecordingRawSocket rawSocket = new BlockingRecordingRawSocket(sendBuf, SEND_BUFFER_SIZE);
+                try (TestableContext context = new TestableContext(httpConfig, nf, rawSocket, recvBuf, RECV_BUFFER_SIZE)) {
+                    QwpIngressProcessorState state = setupClockedState(httpConfig, context, demotableEngine, nowMicros);
+
+                    // Phase A: PRIMARY. seq=0 commits; the chunk-end
+                    // cumulative ACK drains cleanly (send side stays READY).
+                    drive(processor, context, nf, frame0.length);
+                    Assert.assertTrue("test setup: cumulative ACK must have drained", state.isSendReady());
+
+                    // Phase B: in-place demote. seq=1 is gate-rejected; the
+                    // role-change close is deferred awaiting upload coverage
+                    // (registry watermark lags at -1).
+                    readOnly.set(true);
+                    drive(processor, context, nf, frame1.length);
+                    Assert.assertTrue(
+                            "test setup: role-change close must be deferred awaiting durable upload coverage",
+                            state.isRoleChangeCloseDeferred()
+                    );
+
+                    // Phase C: uploads STALL past the grace budget; committed
+                    // work is still not durably uploaded.
+                    nowMicros[0] += QwpIngressProcessorState.ROLE_CHANGE_CLOSE_UPLOAD_GRACE_MICROS;
+                    Assert.assertTrue(
+                            "test setup: grace budget must be exhausted",
+                            state.isRoleChangeCloseGraceExpired()
+                    );
+                    Assert.assertFalse(
+                            "test setup: durable work must NOT be fully uploaded",
+                            state.isDurableWorkFullyUploaded(demotableEngine.getDurableAckRegistry())
+                    );
+
+                    // Phase D: the keepalive PING -- the designated deferral
+                    // re-entry poll -- observes the expiry; the close proceeds
+                    // abandoning un-acked durable work.
+                    capture.start();
+                    try {
+                        nf.release(ping.length);
+                        try {
+                            processor.resumeRecv(context);
+                            Assert.fail("Expected ServerDisconnectException (grace-expired close)");
+                        } catch (ServerDisconnectException expected) {
+                        }
+                        drainLogQueue(capture, "sentinel: grace-expired PING close done");
+                    } finally {
+                        capture.stop();
+                    }
+
+                    // Behavioural lock (green before and after the fix): the
+                    // close is still the reconnect-eligible NORMAL_CLOSURE.
+                    int closeIdx = indexOfCloseFrame(rawSocket.sentFrames);
+                    Assert.assertTrue("CLOSE frame must be sent", closeIdx >= 0);
+                    Assert.assertEquals(
+                            "CLOSE frame must carry the reconnect-eligible close code",
+                            1000 /* NORMAL_CLOSURE */, closeCode(rawSocket.sentFrames.getQuick(closeIdx))
+                    );
+
+                    // RED until fixed: handlePing's inline completion
+                    // predicate closes without emitting the diagnostic that
+                    // roleChangeCloseWithUploadGrace emits on the same exit.
+                    capture.assertLogged("role-change close upload grace expired");
+                } finally {
+                    Unsafe.free(recvBuf, RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                    Unsafe.free(sendBuf, SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    /**
+     * Grace-expiry diagnostics, false alarm: {@code roleChangeCloseWithUploadGrace}
+     * raises "closing with un-acked durable work, client replay may duplicate"
+     * purely on grace expiry, without consulting
+     * {@code isDurableWorkFullyUploaded}. A slow-but-clean close -- uploads
+     * catching up AFTER the deadline but BEFORE the next re-entry -- leaves an
+     * empty replay window (the final durable ack precedes the CLOSE, locked
+     * below), yet still fires the duplicate-risk alarm.
+     * <p>
+     * Invariant (fix-agnostic): a grace-expired close whose durable work is
+     * fully uploaded must NOT claim un-acked durable work.
+     */
+    @Test
+    public void testGraceExpiredCleanCloseMustNotRaiseFalseDuplicateAlarm() throws Exception {
+        final LogCapture capture = new LogCapture();
+        assertMemoryLeak(() -> {
+            final AtomicBoolean readOnly = new AtomicBoolean(false);
+            final AtomicLong durableWatermark = new AtomicLong(-1L);
+            final long[] nowMicros = {0L};
+            final HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+
+            execute("create table tabe (v long, ts timestamp) timestamp(ts) partition by day wal");
+
+            try (CairoEngine demotableEngine = newEngineWithRegistry(readOnly, durableWatermark)) {
+                QwpIngressUpgradeProcessor processor = new QwpIngressUpgradeProcessor(demotableEngine, httpConfig);
+
+                byte[] frame0 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("tabe", 100L, 1_000_000L));
+                byte[] frame1 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("tabe", 200L, 2_000_000L));
+                byte[] frame2 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("tabe", 300L, 3_000_000L));
+                byte[] wire = concat(frame0, frame1, frame2);
+
+                PhasedNetworkFacade nf = new PhasedNetworkFacade(wire);
+                long recvBuf = Unsafe.malloc(RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                long sendBuf = Unsafe.malloc(SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                BlockingRecordingRawSocket rawSocket = new BlockingRecordingRawSocket(sendBuf, SEND_BUFFER_SIZE);
+                try (TestableContext context = new TestableContext(httpConfig, nf, rawSocket, recvBuf, RECV_BUFFER_SIZE)) {
+                    QwpIngressProcessorState state = setupClockedState(httpConfig, context, demotableEngine, nowMicros);
+
+                    // Phase A: PRIMARY. seq=0 commits; cumulative ACK drains.
+                    drive(processor, context, nf, frame0.length);
+                    Assert.assertTrue("test setup: cumulative ACK must have drained", state.isSendReady());
+
+                    // Phase B: in-place demote. seq=1 is gate-rejected; the
+                    // role-change close is deferred awaiting upload coverage.
+                    readOnly.set(true);
+                    drive(processor, context, nf, frame1.length);
+                    Assert.assertTrue(
+                            "test setup: role-change close must be deferred awaiting durable upload coverage",
+                            state.isRoleChangeCloseDeferred()
+                    );
+
+                    // Phase C: the slow-but-clean close. Uploads catch up,
+                    // but only after the grace deadline has passed.
+                    durableWatermark.set(Long.MAX_VALUE);
+                    nowMicros[0] += QwpIngressProcessorState.ROLE_CHANGE_CLOSE_UPLOAD_GRACE_MICROS;
+                    Assert.assertTrue(
+                            "test setup: grace budget must be exhausted",
+                            state.isRoleChangeCloseGraceExpired()
+                    );
+                    Assert.assertTrue(
+                            "test setup: durable work must be fully uploaded",
+                            state.isDurableWorkFullyUploaded(demotableEngine.getDurableAckRegistry())
+                    );
+
+                    // Phase D: a data frame re-enters through the deferral
+                    // gate into roleChangeCloseWithUploadGrace; the close
+                    // proceeds with an empty replay window.
+                    capture.start();
+                    try {
+                        nf.release(frame2.length);
+                        try {
+                            processor.resumeRecv(context);
+                            Assert.fail("Expected ServerDisconnectException (grace-expired clean close)");
+                        } catch (ServerDisconnectException expected) {
+                        }
+                        drainLogQueue(capture, "sentinel: grace-expired clean close done");
+                    } finally {
+                        capture.stop();
+                    }
+
+                    // Behavioural lock (green before and after the fix): the
+                    // close is clean -- final durable ack precedes the
+                    // reconnect-eligible CLOSE, replay window empty.
+                    assertFinalDurableAckPrecedesClose(rawSocket.sentFrames, 1000 /* NORMAL_CLOSURE */);
+
+                    // RED until fixed: the grace-expired branch claims
+                    // un-acked durable work without checking upload coverage.
+                    capture.assertNotLogged("closing with un-acked durable work");
+                } finally {
+                    Unsafe.free(recvBuf, RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                    Unsafe.free(sendBuf, SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    /**
      * The invariant all tests assert: durable coverage was confirmed at
      * close time, so a {@code STATUS_DURABLE_ACK} frame must precede the
      * CLOSE frame in the outbound frame log.
@@ -412,6 +618,19 @@ public class QwpIngressDeferredCloseDurableAckTest extends AbstractCairoTest {
             frame[offset + i] = (byte) (payload[i] ^ DEFAULT_MASK_KEY[i % 4]);
         }
         return frame;
+    }
+
+    /**
+     * QuestDB logging is asynchronous: {@code LOG.error()} enqueues and a
+     * single writer job drains. Both grace-expiry diagnostics under test are
+     * ERROR level, so logging an ERROR-level sentinel AFTER the action and
+     * waiting for it guarantees the writer has drained every earlier record
+     * of the same level -- making assertLogged/assertNotLogged race-free
+     * without a blind timeout.
+     */
+    private static void drainLogQueue(LogCapture capture, String sentinel) {
+        SENTINEL_LOG.error().$(sentinel).$();
+        capture.waitFor(sentinel);
     }
 
     private static void drive(
@@ -542,6 +761,39 @@ public class QwpIngressDeferredCloseDurableAckTest extends AbstractCairoTest {
         message[11] = 0;
         System.arraycopy(payload, 0, message, QwpConstants.HEADER_SIZE, payload.length);
         return message;
+    }
+
+    /**
+     * Same as {@link #setupState}, but the state's deferral clock is the
+     * test-owned {@code nowMicros[0]}, so the grace deadline
+     * ({@link QwpIngressProcessorState#ROLE_CHANGE_CLOSE_UPLOAD_GRACE_MICROS})
+     * can be crossed deterministically. Clock-override pattern from
+     * {@code QwpIngressProcessorStateTest#testRoleChangeCloseDeferralLifecycle}.
+     */
+    private static QwpIngressProcessorState setupClockedState(
+            HttpFullFatServerConfiguration httpConfig,
+            TestableContext context,
+            CairoEngine engine,
+            long[] nowMicros
+    ) throws Exception {
+        LineHttpProcessorConfiguration lineConfig =
+                new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration) {
+                    @Override
+                    public MicrosecondClock getMicrosecondClock() {
+                        return () -> nowMicros[0];
+                    }
+                };
+        QwpIngressProcessorState state = new QwpIngressProcessorState(
+                RECV_BUFFER_SIZE,
+                httpConfig.getSendBufferSize(),
+                engine,
+                lineConfig
+        );
+        state.of(-1, AllowAllSecurityContext.INSTANCE);
+        // durable-ack opt-in, as negotiated via X-QWP-Request-Durable-Ack
+        state.setDurableAckEnabled(true);
+        getLV().set(context, state);
+        return state;
     }
 
     private static QwpIngressProcessorState setupState(

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/QwpIngressDeferredCloseDurableAckTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/QwpIngressDeferredCloseDurableAckTest.java
@@ -25,6 +25,7 @@
 package io.questdb.test.cutlass.websocket;
 
 import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.TableReader;
 import io.questdb.cairo.security.AllowAllSecurityContext;
 import io.questdb.cairo.wal.DurableAckRegistry;
 import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
@@ -552,6 +553,132 @@ public class QwpIngressDeferredCloseDurableAckTest extends AbstractCairoTest {
                     // RED until fixed: the grace-expired branch claims
                     // un-acked durable work without checking upload coverage.
                     capture.assertNotLogged("closing with un-acked durable work");
+                } finally {
+                    Unsafe.free(recvBuf, RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                    Unsafe.free(sendBuf, SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    /**
+     * Completion via the DATA-FRAME re-entry on coverage alone, strictly
+     * WITHIN the grace budget. {@code isRoleChangeCloseCompletable} is a
+     * disjunction -- durable coverage reached OR grace expired -- and every
+     * other deferral-exit test in this class either completes via the PING
+     * re-entry or crosses the grace deadline first (so the expiry disjunct
+     * is also true when the close fires). This test isolates the remaining
+     * exit: the injected clock NEVER moves off zero, so the ONLY way the
+     * close can complete is the coverage disjunct, observed by the
+     * gate-refused data frame in {@code handleBinaryMessage}'s deferral
+     * branch.
+     * <p>
+     * Pins, fix-shape-agnostic:
+     * <ul>
+     *   <li>the deferral exits promptly on coverage -- a regression that
+     *       quietly rewires completion to grace expiry alone (a full grace
+     *       stall for every well-behaved client on every demote) goes red
+     *       here and nowhere else;</li>
+     *   <li>the final durable ack precedes the reconnect-eligible CLOSE on
+     *       this exit too (the exactly-once handshake);</li>
+     *   <li>the data frame that triggers the completion is refused, not
+     *       committed -- INVARIANT B's engine-untouched deferral window;</li>
+     *   <li>a within-grace close must not raise the grace-expired operator
+     *       alarm.</li>
+     * </ul>
+     */
+    @Test
+    public void testDataFrameReEntryCompletesCloseWithinGraceOnCoverageAlone() throws Exception {
+        final LogCapture capture = new LogCapture();
+        assertMemoryLeak(() -> {
+            final AtomicBoolean readOnly = new AtomicBoolean(false);
+            final AtomicLong durableWatermark = new AtomicLong(-1L);
+            final long[] nowMicros = {0L};
+            final HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+
+            execute("create table tabf (v long, ts timestamp) timestamp(ts) partition by day wal");
+
+            try (CairoEngine demotableEngine = newEngineWithRegistry(readOnly, durableWatermark)) {
+                QwpIngressUpgradeProcessor processor = new QwpIngressUpgradeProcessor(demotableEngine, httpConfig);
+
+                byte[] frame0 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("tabf", 100L, 1_000_000L));
+                byte[] frame1 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("tabf", 200L, 2_000_000L));
+                byte[] frame2 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("tabf", 300L, 3_000_000L));
+                byte[] wire = concat(frame0, frame1, frame2);
+
+                PhasedNetworkFacade nf = new PhasedNetworkFacade(wire);
+                long recvBuf = Unsafe.malloc(RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                long sendBuf = Unsafe.malloc(SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                BlockingRecordingRawSocket rawSocket = new BlockingRecordingRawSocket(sendBuf, SEND_BUFFER_SIZE);
+                try (TestableContext context = new TestableContext(httpConfig, nf, rawSocket, recvBuf, RECV_BUFFER_SIZE)) {
+                    QwpIngressProcessorState state = setupClockedState(httpConfig, context, demotableEngine, nowMicros);
+
+                    // Phase A: PRIMARY. seq=0 commits; cumulative ACK drains.
+                    drive(processor, context, nf, frame0.length);
+                    Assert.assertTrue("test setup: cumulative ACK must have drained", state.isSendReady());
+
+                    // Phase B: in-place demote. seq=1 is gate-rejected; the
+                    // role-change close is deferred awaiting upload coverage
+                    // (registry watermark lags at -1).
+                    readOnly.set(true);
+                    drive(processor, context, nf, frame1.length);
+                    Assert.assertTrue(
+                            "test setup: role-change close must be deferred awaiting durable upload coverage",
+                            state.isRoleChangeCloseDeferred()
+                    );
+
+                    // Phase C: the demote drain completes WELL within the
+                    // grace budget -- the clock never moves off zero, so the
+                    // expiry disjunct stays false for the whole test.
+                    durableWatermark.set(Long.MAX_VALUE);
+                    Assert.assertFalse(
+                            "test setup: grace budget must NOT be exhausted -- this test isolates the coverage disjunct",
+                            state.isRoleChangeCloseGraceExpired()
+                    );
+                    Assert.assertTrue(
+                            "test setup: durable work must be fully uploaded",
+                            state.isDurableWorkFullyUploaded(demotableEngine.getDurableAckRegistry())
+                    );
+
+                    // Phase D: the writer is NOT quiesced -- the next data
+                    // frame hits the deferral gate, which must refuse it AND
+                    // observe coverage, completing the close on the spot.
+                    capture.start();
+                    try {
+                        nf.release(frame2.length);
+                        try {
+                            processor.resumeRecv(context);
+                            Assert.fail("Expected ServerDisconnectException (coverage-complete close via data-frame re-entry)");
+                        } catch (ServerDisconnectException expected) {
+                        }
+                        drainLogQueue(capture, "sentinel: within-grace data-frame close done");
+                    } finally {
+                        capture.stop();
+                    }
+
+                    // The exactly-once handshake holds on this exit: the
+                    // final durable ack precedes the reconnect-eligible CLOSE.
+                    assertFinalDurableAckPrecedesClose(rawSocket.sentFrames, 1000 /* NORMAL_CLOSURE */);
+
+                    // A within-grace close is clean by construction: the
+                    // grace-expired operator alarm must not fire.
+                    capture.assertNotLogged("role-change close upload grace expired");
+
+                    // INVARIANT B: the data frame that completed the close
+                    // was refused -- only seq=0's row may exist. A second row
+                    // here means the deferral gate let a frame commit while
+                    // its sequence was simultaneously marked unresolved for
+                    // the ack clamp -- the double-accounting the gate exists
+                    // to prevent. (The gate is engine-role-agnostic by then,
+                    // so flip the read-only flag back for the WAL apply.)
+                    readOnly.set(false);
+                    drainWalQueue(demotableEngine);
+                    try (TableReader reader = demotableEngine.getReader("tabf")) {
+                        Assert.assertEquals(
+                                "data frame refused during the deferral must not commit",
+                                1, reader.size()
+                        );
+                    }
                 } finally {
                     Unsafe.free(recvBuf, RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
                     Unsafe.free(sendBuf, SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/QwpIngressDeferredCloseDurableAckTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/QwpIngressDeferredCloseDurableAckTest.java
@@ -1,0 +1,699 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.websocket;
+
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.security.AllowAllSecurityContext;
+import io.questdb.cairo.wal.DurableAckRegistry;
+import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
+import io.questdb.cutlass.http.HttpConnectionContext;
+import io.questdb.cutlass.http.HttpFullFatServerConfiguration;
+import io.questdb.cutlass.http.HttpRawSocket;
+import io.questdb.cutlass.http.HttpServerConfiguration;
+import io.questdb.cutlass.http.LocalValue;
+import io.questdb.cutlass.qwp.protocol.QwpConstants;
+import io.questdb.cutlass.qwp.server.QwpIngressProcessorState;
+import io.questdb.cutlass.qwp.server.QwpIngressUpgradeProcessor;
+import io.questdb.cutlass.qwp.websocket.WebSocketOpcode;
+import io.questdb.log.Log;
+import io.questdb.network.NetworkFacadeImpl;
+import io.questdb.network.PeerDisconnectedException;
+import io.questdb.network.PeerIsSlowToReadException;
+import io.questdb.network.PeerIsSlowToWriteException;
+import io.questdb.network.PlainSocket;
+import io.questdb.network.ServerDisconnectException;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.ObjList;
+import io.questdb.std.Unsafe;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.cairo.DefaultTestCairoConfiguration;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Regression tests for the blocked-close resume path dropping the final
+ * durable ack ({@code QwpIngressUpgradeProcessor}).
+ * <p>
+ * The happy path honours the deferral invariant: {@code sendFatalClose} runs
+ * {@code flushPendingAck} (cumulative ACK, then durable ACK) before writing
+ * the CLOSE frame, so a durable-ack client's replay watermark is current when
+ * the connection drops. But when the send side is (or becomes) blocked, the
+ * CLOSE is parked via {@code onFatalCloseBlocked} into
+ * {@code SEND_STATE_RESUME_ACK_THEN_CLOSE}, and the resume branch calls
+ * {@code sendDeferredFatalClose}, which writes ONLY the CLOSE frame — the
+ * durable ack is never sent (unlike the plain {@code RESUME_ACK} branch,
+ * which drains the parked ACK and then flushes durable progress).
+ * <p>
+ * Cumulative OK acks cannot substitute: a store-and-forward client in
+ * durable-ack mode advances its replay/trim watermark ONLY on
+ * {@code STATUS_DURABLE_ACK} frames ({@code CursorWebSocketSendLoop}). A
+ * stale watermark at disconnect means the client replays batches the server
+ * (or, after a demote, the promoted replica via replication) already has —
+ * duplicates on tables without DEDUP UPSERT KEYS.
+ * <p>
+ * Invariant asserted (fix-agnostic): when the registry's durable-upload
+ * watermark covers the connection's committed work at fatal-close time, a
+ * {@code STATUS_DURABLE_ACK} frame covering that work must be sent before the
+ * CLOSE frame — regardless of whether the sends around the close blocked.
+ * The tests stay green whether the fix re-runs the ack/durable-ack flush in
+ * the {@code *_THEN_CLOSE} resume branches, re-checks durable progress inside
+ * {@code sendDeferredFatalClose}, or re-arms the deferral.
+ * <p>
+ * Harness lineage: engine/registry/frame doubles from
+ * {@code QwpIngressAckLeapfrogTest}; blocked-send + resumeSend drive pattern
+ * from {@code QwpIngressUpgradeProcessorResumeRecvTest}.
+ */
+public class QwpIngressDeferredCloseDurableAckTest extends AbstractCairoTest {
+    private static final byte[] DEFAULT_MASK_KEY = {0x12, 0x34, 0x56, 0x78};
+    private static final int RECV_BUFFER_SIZE = 1024;
+    private static final int SEND_BUFFER_SIZE = 1024;
+
+    /**
+     * The finding's headline scenario, including the "already parked" variant:
+     * a slow client's cumulative ACK blocks BEFORE the demote, so the
+     * connection sits in {@code RESUME_ACK} when the role-change close
+     * deferral exits with full durable coverage. {@code sendFatalClose}'s
+     * {@code flushPendingAck} no-ops (both halves require READY),
+     * {@code onFatalCloseBlocked} collapses to {@code RESUME_ACK_THEN_CLOSE},
+     * and the resume path emits the CLOSE with no durable ack — precisely the
+     * send-backpressure-at-demote-time case the deferral exists to protect.
+     */
+    @Test
+    public void testRoleChangeCloseMustFlushFinalDurableAckWhenAckParked() throws Exception {
+        assertMemoryLeak(() -> {
+            final AtomicBoolean readOnly = new AtomicBoolean(false);
+            final AtomicLong durableWatermark = new AtomicLong(-1L);
+            final HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+
+            // The demotable engine below shares the root with the static test
+            // engine, which holds the table-registry lock. Pre-create the WAL
+            // table through the lock holder so the QWP path only needs to
+            // acquire a WAL writer, not register a new table.
+            execute("create table taba (v long, ts timestamp) timestamp(ts) partition by day wal");
+
+            try (CairoEngine demotableEngine = newEngineWithRegistry(readOnly, durableWatermark)) {
+                QwpIngressUpgradeProcessor processor = new QwpIngressUpgradeProcessor(demotableEngine, httpConfig);
+
+                byte[] frame0 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("taba", 100L, 1_000_000L));
+                byte[] frame1 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("taba", 200L, 2_000_000L));
+                byte[] ping = createMaskedFrame(WebSocketOpcode.PING, new byte[0]);
+                byte[] wire = concat(frame0, frame1, ping);
+
+                PhasedNetworkFacade nf = new PhasedNetworkFacade(wire);
+                long recvBuf = Unsafe.malloc(RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                long sendBuf = Unsafe.malloc(SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                BlockingRecordingRawSocket rawSocket = new BlockingRecordingRawSocket(sendBuf, SEND_BUFFER_SIZE);
+                try (TestableContext context = new TestableContext(httpConfig, nf, rawSocket, recvBuf, RECV_BUFFER_SIZE)) {
+                    QwpIngressProcessorState state = setupState(httpConfig, context, demotableEngine);
+
+                    // Phase A: PRIMARY. seq=0 commits; the end-of-recv
+                    // cumulative ACK hits a full client receive buffer and
+                    // parks -- connection enters RESUME_ACK.
+                    rawSocket.throwSlowToReadOnCall = 1;
+                    nf.release(frame0.length);
+                    try {
+                        processor.resumeRecv(context);
+                        Assert.fail("Expected PeerIsSlowToReadException (parked cumulative ACK)");
+                    } catch (PeerIsSlowToReadException expected) {
+                        // ACK bytes queued in the framework buffer; the
+                        // dispatcher would park the connection for write.
+                    }
+                    Assert.assertFalse(
+                            "test setup: cumulative ACK must be parked (RESUME_ACK)",
+                            state.isSendReady()
+                    );
+
+                    // Phase B: in-place demote. seq=1 is gate-rejected; the
+                    // role-change close is deferred awaiting upload coverage
+                    // (registry watermark still lags at -1).
+                    readOnly.set(true);
+                    drive(processor, context, nf, frame1.length);
+                    Assert.assertTrue(
+                            "test setup: role-change close must be deferred awaiting durable upload coverage",
+                            state.isRoleChangeCloseDeferred()
+                    );
+
+                    // Phase C: the demote drain completes -- every committed
+                    // seqTxn is now durably uploaded. A durable ack flushed
+                    // now would leave the client's replay window empty.
+                    durableWatermark.set(Long.MAX_VALUE);
+
+                    // Phase D: the client's durable-ack keepalive PING is the
+                    // recv-driven poll that observes upload completion. The
+                    // deferral exits into sendFatalClose, which finds the
+                    // send side parked and defers the CLOSE.
+                    nf.release(ping.length);
+                    try {
+                        processor.resumeRecv(context);
+                        Assert.fail("Expected PeerIsSlowToReadException (deferred CLOSE behind parked ACK)");
+                    } catch (PeerIsSlowToReadException expected) {
+                    }
+                    Assert.assertEquals(
+                            "test setup: CLOSE must be deferred behind the parked ACK (SEND_STATE_RESUME_ACK_THEN_CLOSE)",
+                            7, state.getSendState()
+                    );
+
+                    // Phase E: the client drains its receive buffer; the
+                    // dispatcher fires resumeSend. The parked ACK flushes,
+                    // then the deferred CLOSE goes out and the framework
+                    // tears the connection down.
+                    try {
+                        processor.resumeSend(context);
+                        Assert.fail("Expected ServerDisconnectException after deferred CLOSE flush");
+                    } catch (ServerDisconnectException expected) {
+                    }
+
+                    assertFinalDurableAckPrecedesClose(rawSocket.sentFrames, 1000 /* NORMAL_CLOSURE */);
+                } finally {
+                    Unsafe.free(recvBuf, RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                    Unsafe.free(sendBuf, SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    /**
+     * The narrow variant from the finding: the cumulative ACK blocks INSIDE
+     * {@code sendFatalClose}'s own {@code flushPendingAck}, before
+     * {@code trySendDurableAck} is ever reached. Requires a committed frame
+     * and the close trigger in the same recv chunk (the chunk-end ACK flush
+     * has not run yet), which needs no demote machinery: a protocol-violating
+     * TEXT frame after a committed BINARY frame does it. Durable coverage is
+     * complete the whole time, yet the resume path closes without ever
+     * sending the durable ack.
+     */
+    @Test
+    public void testFatalCloseMustFlushDurableAckWhenAckBlocksDuringClose() throws Exception {
+        assertMemoryLeak(() -> {
+            final AtomicBoolean readOnly = new AtomicBoolean(false);
+            final AtomicLong durableWatermark = new AtomicLong(Long.MAX_VALUE);
+            final HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+
+            execute("create table tabb (v long, ts timestamp) timestamp(ts) partition by day wal");
+
+            try (CairoEngine demotableEngine = newEngineWithRegistry(readOnly, durableWatermark)) {
+                QwpIngressUpgradeProcessor processor = new QwpIngressUpgradeProcessor(demotableEngine, httpConfig);
+
+                byte[] frame0 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("tabb", 100L, 1_000_000L));
+                byte[] textFrame = createMaskedFrame(WebSocketOpcode.TEXT, new byte[]{'h', 'i'});
+                byte[] wire = concat(frame0, textFrame);
+
+                PhasedNetworkFacade nf = new PhasedNetworkFacade(wire);
+                long recvBuf = Unsafe.malloc(RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                long sendBuf = Unsafe.malloc(SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                BlockingRecordingRawSocket rawSocket = new BlockingRecordingRawSocket(sendBuf, SEND_BUFFER_SIZE);
+                try (TestableContext context = new TestableContext(httpConfig, nf, rawSocket, recvBuf, RECV_BUFFER_SIZE)) {
+                    QwpIngressProcessorState state = setupState(httpConfig, context, demotableEngine);
+
+                    // Both frames land in one recv chunk: frame0 commits
+                    // (pending cumulative ACK, chunk-end flush not yet run),
+                    // then the TEXT frame routes to sendFatalClose, whose
+                    // flushPendingAck attempts the cumulative ACK first --
+                    // and blocks. trySendDurableAck is never reached; state
+                    // collapses to RESUME_ACK_THEN_CLOSE.
+                    rawSocket.throwSlowToReadOnCall = 1;
+                    nf.release(wire.length);
+                    try {
+                        processor.resumeRecv(context);
+                        Assert.fail("Expected PeerIsSlowToReadException (deferred CLOSE behind blocked ACK)");
+                    } catch (PeerIsSlowToReadException expected) {
+                    }
+                    Assert.assertEquals(
+                            "test setup: CLOSE must be deferred behind the blocked ACK (SEND_STATE_RESUME_ACK_THEN_CLOSE)",
+                            7, state.getSendState()
+                    );
+
+                    try {
+                        processor.resumeSend(context);
+                        Assert.fail("Expected ServerDisconnectException after deferred CLOSE flush");
+                    } catch (ServerDisconnectException expected) {
+                    }
+
+                    assertFinalDurableAckPrecedesClose(rawSocket.sentFrames, 1003 /* UNSUPPORTED_DATA */);
+                } finally {
+                    Unsafe.free(recvBuf, RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                    Unsafe.free(sendBuf, SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    /**
+     * The deferral can also exit while a PONG (or error response) is parked:
+     * {@code onFatalCloseBlocked} collapses those states to
+     * {@code RESUME_CLOSE}, whose resume branch assumes the parked bytes ARE
+     * the CLOSE frame. They are pong bytes — so the deferred CLOSE is never
+     * written (the client sees a bare FIN with no close code) and the final
+     * durable ack is dropped with it. Same stale-watermark consequence as the
+     * other two tests, plus a missing protocol-level close signal.
+     */
+    @Test
+    public void testRoleChangeCloseMustSendCloseAndDurableAckWhenPongParked() throws Exception {
+        assertMemoryLeak(() -> {
+            final AtomicBoolean readOnly = new AtomicBoolean(false);
+            final AtomicLong durableWatermark = new AtomicLong(-1L);
+            final HttpFullFatServerConfiguration httpConfig = new DefaultHttpServerConfiguration(configuration);
+
+            execute("create table tabc (v long, ts timestamp) timestamp(ts) partition by day wal");
+
+            try (CairoEngine demotableEngine = newEngineWithRegistry(readOnly, durableWatermark)) {
+                QwpIngressUpgradeProcessor processor = new QwpIngressUpgradeProcessor(demotableEngine, httpConfig);
+
+                byte[] frame0 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("tabc", 100L, 1_000_000L));
+                byte[] ping1 = createMaskedFrame(WebSocketOpcode.PING, new byte[]{1});
+                byte[] frame1 = createMaskedFrame(WebSocketOpcode.BINARY, oneRowMessage("tabc", 200L, 2_000_000L));
+                byte[] ping2 = createMaskedFrame(WebSocketOpcode.PING, new byte[]{2});
+                byte[] wire = concat(frame0, ping1, frame1, ping2);
+
+                PhasedNetworkFacade nf = new PhasedNetworkFacade(wire);
+                long recvBuf = Unsafe.malloc(RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                long sendBuf = Unsafe.malloc(SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                BlockingRecordingRawSocket rawSocket = new BlockingRecordingRawSocket(sendBuf, SEND_BUFFER_SIZE);
+                try (TestableContext context = new TestableContext(httpConfig, nf, rawSocket, recvBuf, RECV_BUFFER_SIZE)) {
+                    QwpIngressProcessorState state = setupState(httpConfig, context, demotableEngine);
+
+                    // Phase A: PRIMARY. seq=0 commits; the cumulative ACK
+                    // (send #1) goes out cleanly. No durable progress yet:
+                    // uploads lag, so no durable ack is emitted either.
+                    drive(processor, context, nf, frame0.length);
+                    Assert.assertTrue("test setup: cumulative ACK must have drained", state.isSendReady());
+
+                    // Phase B: keepalive PING; the PONG (send #2) parks
+                    // mid-write under send backpressure.
+                    rawSocket.throwSlowToReadOnCall = 2;
+                    nf.release(ping1.length);
+                    try {
+                        processor.resumeRecv(context);
+                        Assert.fail("Expected PeerIsSlowToReadException (parked PONG)");
+                    } catch (PeerIsSlowToReadException expected) {
+                    }
+                    Assert.assertFalse("test setup: PONG must be parked", state.isSendReady());
+
+                    // Phase C: in-place demote. seq=1 is gate-rejected; the
+                    // role-change close is deferred awaiting upload coverage.
+                    readOnly.set(true);
+                    drive(processor, context, nf, frame1.length);
+                    Assert.assertTrue(
+                            "test setup: role-change close must be deferred awaiting durable upload coverage",
+                            state.isRoleChangeCloseDeferred()
+                    );
+
+                    // Phase D: the demote drain completes.
+                    durableWatermark.set(Long.MAX_VALUE);
+
+                    // Phase E: the next keepalive PING observes coverage; the
+                    // deferral exits into sendFatalClose behind the parked PONG.
+                    nf.release(ping2.length);
+                    try {
+                        processor.resumeRecv(context);
+                        Assert.fail("Expected PeerIsSlowToReadException (deferred CLOSE behind parked PONG)");
+                    } catch (PeerIsSlowToReadException expected) {
+                    }
+
+                    // Phase F: the client drains its receive buffer; the
+                    // dispatcher fires resumeSend to finish the close.
+                    try {
+                        processor.resumeSend(context);
+                        Assert.fail("Expected ServerDisconnectException after deferred CLOSE flush");
+                    } catch (ServerDisconnectException expected) {
+                    }
+
+                    assertFinalDurableAckPrecedesClose(rawSocket.sentFrames, 1000 /* NORMAL_CLOSURE */);
+                } finally {
+                    Unsafe.free(recvBuf, RECV_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                    Unsafe.free(sendBuf, SEND_BUFFER_SIZE, MemoryTag.NATIVE_DEFAULT);
+                }
+            }
+        });
+    }
+
+    /**
+     * The invariant all tests assert: durable coverage was confirmed at
+     * close time, so a {@code STATUS_DURABLE_ACK} frame must precede the
+     * CLOSE frame in the outbound frame log.
+     */
+    private static void assertFinalDurableAckPrecedesClose(ObjList<byte[]> frames, int expectedCloseCode) {
+        int closeIdx = indexOfCloseFrame(frames);
+        Assert.assertTrue("CLOSE frame must be sent on resume", closeIdx >= 0);
+        Assert.assertEquals(
+                "CLOSE frame must carry the deferred close code",
+                expectedCloseCode, closeCode(frames.getQuick(closeIdx))
+        );
+
+        int durableIdx = indexOfDurableAckFrame(frames);
+        Assert.assertTrue(
+                "STALE REPLAY WATERMARK: the registry's durable-upload watermark covered every"
+                        + " committed seqTxn at close time, but no STATUS_DURABLE_ACK frame precedes the"
+                        + " CLOSE (durableAckFrameIndex=" + durableIdx + ", closeFrameIndex=" + closeIdx
+                        + ", framesSent=" + frames.size() + "); a durable-ack store-and-forward client"
+                        + " advances its replay/trim watermark only on STATUS_DURABLE_ACK frames, so on"
+                        + " reconnect it replays batches the server already owns -- duplicates on tables"
+                        + " without DEDUP UPSERT KEYS",
+                durableIdx >= 0 && durableIdx < closeIdx
+        );
+    }
+
+    private static int closeCode(byte[] closeFrame) {
+        // small unmasked server frame: 2-byte header, close code big-endian
+        return ((closeFrame[2] & 0xFF) << 8) | (closeFrame[3] & 0xFF);
+    }
+
+    private static byte[] concat(byte[]... arrays) {
+        int len = 0;
+        for (byte[] a : arrays) {
+            len += a.length;
+        }
+        byte[] out = new byte[len];
+        int pos = 0;
+        for (byte[] a : arrays) {
+            System.arraycopy(a, 0, out, pos, a.length);
+            pos += a.length;
+        }
+        return out;
+    }
+
+    private static byte[] createMaskedFrame(int opcode, byte[] payload) {
+        // all test frames are tiny; single-byte payload length is sufficient
+        assert payload.length <= 125;
+        byte[] frame = new byte[2 + 4 + payload.length];
+        int offset = 0;
+        frame[offset++] = (byte) (0x80 | (opcode & 0x0F));
+        frame[offset++] = (byte) (0x80 | payload.length);
+        System.arraycopy(DEFAULT_MASK_KEY, 0, frame, offset, 4);
+        offset += 4;
+        for (int i = 0; i < payload.length; i++) {
+            frame[offset + i] = (byte) (payload[i] ^ DEFAULT_MASK_KEY[i % 4]);
+        }
+        return frame;
+    }
+
+    private static void drive(
+            QwpIngressUpgradeProcessor processor,
+            HttpConnectionContext context,
+            PhasedNetworkFacade nf,
+            int bytes
+    ) throws Exception {
+        nf.release(bytes);
+        try {
+            processor.resumeRecv(context);
+        } catch (PeerIsSlowToWriteException e) {
+            // all released bytes consumed; the dispatcher would re-arm for read
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static LocalValue<QwpIngressProcessorState> getLV() throws Exception {
+        Field lvField = QwpIngressUpgradeProcessor.class.getDeclaredField("LV");
+        lvField.setAccessible(true);
+        return (LocalValue<QwpIngressProcessorState>) lvField.get(null);
+    }
+
+    /**
+     * Index of the first CLOSE frame in the outbound log, or -1.
+     */
+    private static int indexOfCloseFrame(ObjList<byte[]> frames) {
+        for (int i = 0, n = frames.size(); i < n; i++) {
+            byte[] f = frames.getQuick(i);
+            if (f.length >= 4 && (f[0] & 0x0F) == WebSocketOpcode.CLOSE) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Index of the first server-to-client BINARY frame whose payload status
+     * byte is {@code STATUS_DURABLE_ACK}, or -1. Server frames are unmasked
+     * and small in these tests, so the payload starts at offset 2.
+     */
+    private static int indexOfDurableAckFrame(ObjList<byte[]> frames) {
+        for (int i = 0, n = frames.size(); i < n; i++) {
+            byte[] f = frames.getQuick(i);
+            if (f.length >= 3
+                    && (f[0] & 0x0F) == WebSocketOpcode.BINARY
+                    && (f[1] & 0x80) == 0
+                    && (f[1] & 0x7F) < 126
+                    && f[2] == QwpConstants.STATUS_DURABLE_ACK) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Engine whose read-only mode and durable-upload watermark are test-owned
+     * knobs. The registry treats the watermark as global: any dir name
+     * reports the same durably-uploaded seqTxn, mirroring "uploads lag"
+     * ({@code -1}) vs "uploads caught up" ({@code Long.MAX_VALUE}).
+     */
+    private static CairoEngine newEngineWithRegistry(AtomicBoolean readOnly, AtomicLong durableWatermark) {
+        return new CairoEngine(new DefaultTestCairoConfiguration(root)) {
+            private final DurableAckRegistry testRegistry = new DurableAckRegistry() {
+                @Override
+                public long getDurablyUploadedSeqTxn(CharSequence tableDirName) {
+                    return durableWatermark.get();
+                }
+
+                @Override
+                public boolean isEnabled() {
+                    return true;
+                }
+            };
+
+            @Override
+            public @NotNull DurableAckRegistry getDurableAckRegistry() {
+                return testRegistry;
+            }
+
+            @Override
+            public boolean isReadOnlyMode() {
+                return readOnly.get();
+            }
+        };
+    }
+
+    /**
+     * QWP v1 message: one row into {@code tableName}, schema
+     * [{@code v} LONG, {@code ""} TIMESTAMP (designated)].
+     */
+    private static byte[] oneRowMessage(String tableName, long value, long tsMicros) {
+        int nameLen = tableName.length();
+        byte[] payload = new byte[26 + nameLen];
+        int i = 0;
+        // table header
+        payload[i++] = (byte) nameLen; // table name length (varint)
+        for (int c = 0; c < nameLen; c++) {
+            payload[i++] = (byte) tableName.charAt(c);
+        }
+        payload[i++] = 1; // rowCount (varint)
+        payload[i++] = 2; // columnCount (varint)
+        // schema
+        payload[i++] = 1; // column name length (varint)
+        payload[i++] = 'v';
+        payload[i++] = QwpConstants.TYPE_LONG;
+        payload[i++] = 0; // empty name = designated timestamp
+        payload[i++] = QwpConstants.TYPE_TIMESTAMP;
+        // column data: v
+        payload[i++] = 0; // no null bitmap
+        i = writeLeLong(payload, i, value);
+        // column data: designated timestamp
+        payload[i++] = 0; // no null bitmap
+        writeLeLong(payload, i, tsMicros);
+
+        byte[] message = new byte[QwpConstants.HEADER_SIZE + payload.length];
+        message[0] = 'Q';
+        message[1] = 'W';
+        message[2] = 'P';
+        message[3] = '1';
+        message[4] = QwpConstants.VERSION;
+        message[5] = 0; // flags
+        message[6] = 1; // tableCount lo
+        message[7] = 0; // tableCount hi
+        message[8] = (byte) payload.length;
+        message[9] = 0;
+        message[10] = 0;
+        message[11] = 0;
+        System.arraycopy(payload, 0, message, QwpConstants.HEADER_SIZE, payload.length);
+        return message;
+    }
+
+    private static QwpIngressProcessorState setupState(
+            HttpFullFatServerConfiguration httpConfig,
+            TestableContext context,
+            CairoEngine engine
+    ) throws Exception {
+        QwpIngressProcessorState state = new QwpIngressProcessorState(
+                RECV_BUFFER_SIZE,
+                httpConfig.getSendBufferSize(),
+                engine,
+                httpConfig.getLineHttpProcessorConfiguration()
+        );
+        state.of(-1, AllowAllSecurityContext.INSTANCE);
+        // durable-ack opt-in, as negotiated via X-QWP-Request-Durable-Ack
+        state.setDurableAckEnabled(true);
+        getLV().set(context, state);
+        return state;
+    }
+
+    private static int writeLeLong(byte[] buf, int offset, long value) {
+        for (int i = 0; i < 8; i++) {
+            buf[offset++] = (byte) (value >>> (i * 8));
+        }
+        return offset;
+    }
+
+    /**
+     * Captures every frame the server sends, in order, and can simulate a
+     * slow client by throwing {@link PeerIsSlowToReadException} on the Nth
+     * send. The blocked frame is still recorded BEFORE the throw: in the real
+     * framework, {@code PeerIsSlowToReadException} from
+     * {@code HttpRawSocket.send} means the bytes are queued in the framework
+     * buffer and WILL be delivered by {@code resumeResponseSend} — the frame
+     * is delayed, not dropped. (The assertions only ever test for the ABSENCE
+     * of a durable-ack frame, so this fidelity choice cannot mask the bug.)
+     */
+    private static class BlockingRecordingRawSocket implements HttpRawSocket {
+        final ObjList<byte[]> sentFrames = new ObjList<>();
+        private final long bufferAddress;
+        private final int bufferSize;
+        int sendCallCount;
+        int throwSlowToReadOnCall = -1;
+
+        BlockingRecordingRawSocket(long bufferAddress, int bufferSize) {
+            this.bufferAddress = bufferAddress;
+            this.bufferSize = bufferSize;
+        }
+
+        @Override
+        public long getBufferAddress() {
+            return bufferAddress;
+        }
+
+        @Override
+        public int getBufferSize() {
+            return bufferSize;
+        }
+
+        @Override
+        public void send(int size) throws PeerDisconnectedException, PeerIsSlowToReadException {
+            byte[] copy = new byte[size];
+            for (int i = 0; i < size; i++) {
+                copy[i] = Unsafe.getByte(bufferAddress + i);
+            }
+            sentFrames.add(copy);
+            if (++sendCallCount == throwSlowToReadOnCall) {
+                throw PeerIsSlowToReadException.INSTANCE;
+            }
+        }
+    }
+
+    /**
+     * Network facade that releases the client's wire bytes in explicit phases
+     * so the engine's read-only flag and the registry watermark can be
+     * flipped between frames — the demote/backpressure race distilled to its
+     * deterministic core.
+     */
+    private static class PhasedNetworkFacade extends NetworkFacadeImpl {
+        private final byte[] data;
+        private int limit;
+        private int pos;
+
+        PhasedNetworkFacade(byte[] data) {
+            this.data = data;
+        }
+
+        @Override
+        public void close(long fd, Log log) {
+            // no-op for test
+        }
+
+        @Override
+        public int recvRaw(long fd, long buffer, int bufferLen) {
+            if (pos >= limit) {
+                return 0; // would block
+            }
+            int n = Math.min(bufferLen, limit - pos);
+            for (int i = 0; i < n; i++) {
+                Unsafe.putByte(buffer + i, data[pos++]);
+            }
+            return n;
+        }
+
+        void release(int bytes) {
+            limit = Math.min(data.length, limit + bytes);
+        }
+    }
+
+    /**
+     * Same shape as the contexts in
+     * {@code QwpIngressUpgradeProcessorResumeRecvTest}: overrides the I/O
+     * access points with the test doubles. {@code resumeResponseSend} is a
+     * no-op because the blocked frame's bytes were already captured by
+     * {@link BlockingRecordingRawSocket} at the original {@code send} call.
+     */
+    private static class TestableContext extends HttpConnectionContext {
+        private final BlockingRecordingRawSocket rawSocket;
+        private final long testRecvBuffer;
+        private final int testRecvBufferSize;
+
+        TestableContext(
+                HttpServerConfiguration config,
+                PhasedNetworkFacade nf,
+                BlockingRecordingRawSocket rawSocket,
+                long recvBuffer,
+                int recvBufferSize
+        ) {
+            super(config, (_, log) -> new PlainSocket(nf, log));
+            this.rawSocket = rawSocket;
+            this.testRecvBuffer = recvBuffer;
+            this.testRecvBufferSize = recvBufferSize;
+        }
+
+        @Override
+        public HttpRawSocket getRawResponseSocket() {
+            return rawSocket;
+        }
+
+        @Override
+        public long getRecvBuffer() {
+            return testRecvBuffer;
+        }
+
+        @Override
+        public int getRecvBufferSize() {
+            return testRecvBufferSize;
+        }
+
+        @Override
+        public void resumeResponseSend() {
+            // parked bytes already recorded by BlockingRecordingRawSocket
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
                 <module>java-questdb-client</module>
             </modules>
             <properties>
-                <questdb.client.version>1.3.5-SNAPSHOT</questdb.client.version>
+                <questdb.client.version>1.3.6-SNAPSHOT</questdb.client.version>
             </properties>
         </profile>
     </profiles>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -40,7 +40,7 @@
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
 
-        <questdb.client.version>1.3.5-SNAPSHOT</questdb.client.version>
+        <questdb.client.version>1.3.6-SNAPSHOT</questdb.client.version>
     </properties>
 
     <dependencies>
@@ -144,7 +144,7 @@
         <profile>
             <id>local-client</id>
             <properties>
-                <questdb.client.version>1.3.5-SNAPSHOT</questdb.client.version>
+                <questdb.client.version>1.3.6-SNAPSHOT</questdb.client.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
Tandem PRs:
- Client: https://github.com/questdb/java-questdb-client/pull/60
- Enterprise: https://github.com/questdb/questdb-enterprise/pull/1105

## Overview

This PR advances the `java-questdb-client` submodule to bring in an
application-level connect timeout for the client transports plus a round of
QuestDB-facade configuration work, and fixes the one parent-repo test that the
facade API change broke.

Since the original description, the branch has grown a second theme: the
server-side half of the client's failover contract. The QWP ingress now treats
an in-place demote as a TRANSIENT role change (reconnect-eligible close, never
a client-terminal `SECURITY_ERROR`), defers that close on durable-ack
connections until committed work is durably uploaded (exactly-once replay),
and the e2e error-path suites are migrated to the client's NACK policy v2.
See "Server-side QWP ingress" below.

The rest of the diff lives in the submodule (connect timeout, facade config,
Invariant B, NACK policy v2, M8–M11 hardening — see the client PR); the parent
repo carries the pointer bumps, the server-side ingress work, the e2e
migrations, and CI. The sections below describe what lands here.

## Connect timeout (the headline change)

Adds a real, cross-platform connect timeout for the HTTP and WebSocket (QWP)
transports. Until now a connect to a black-holed or firewalled host blocked on
the OS-level TCP connect timeout (often 60-120s), because the socket was created
blocking and only switched to non-blocking *after* connect, and no knob existed
to clamp it.

- A new native primitive switches the socket to non-blocking *before* connect,
  so `connect()` returns `EINPROGRESS` immediately, then polls for writability
  bounded by the caller's budget and confirms the outcome via `SO_ERROR`. A
  distinct return code (`CONNECT_TIMEOUT`, -3) lets the Java layer raise a
  timeout-flagged exception rather than decode errno.
- Implemented for POSIX (`share/net.c`) and Windows (`windows/net.c`).
- Threaded through `HttpClientConfiguration.getConnectTimeout()`,
  `HttpClient.connect()`, `WebSocketClient`, `QwpQueryClient`,
  `QwpWebSocketSender`, and the `Sender` builder, with a `connect_timeout`
  connect-string key (legacy http and ws/wss parsers) and a `ConfigSchema`
  COMMON entry.
- Default is unset (0 = OS fallback): behavior is unchanged unless
  `connect_timeout` is configured.
- The same client bump also bounds the **TLS handshake** and stops it
  busy-spinning. `JavaTlsClientSocket.startTlsSession` ran the handshake on the
  non-blocking socket with raw `recv`/`send` and no readiness wait, so a peer
  that completed TCP but stalled mid-handshake caused a 100% CPU spin with no
  deadline (`connect_timeout` covered only the TCP connect, and the upgrade's
  request/auth timeout never covered the handshake). The handshake now runs
  through the deadline-aware `ioWait`, bounded by `connect_timeout` and falling
  back to the request timeout when unset. Tradeoff: with `connect_timeout`
  unset, a `wss://` handshake that stalls now fails after the request timeout
  instead of spinning forever -- strictly better, but a behavior change for
  that edge.

## QuestDB facade configuration

- Single cluster config: collapses the dual ingest/query config surface into one
  `ws`/`wss` string for the whole cluster (one `addr` server list drives both the
  sender and query pools). This removes the `QuestDB.connect(ingest, query)`
  overload. The facade is the only caller of that overload; the single-arg
  `connect(config)` and `builder()` paths cover the same ground.
- `lazy_connect` for tolerant startup: a single connect-string flag that lets the
  handle start while the server is down (ingest connects async, the read pool
  defaults to `query_pool_min=0`), buffers writes meanwhile, and reads once the
  server is up (the read pool stays enabled and connects lazily on first query).
  Conflicting knobs that force a blocking/fail-fast startup
  (`initial_connect_retry` other than async, or an explicit `query_pool_min > 0`)
  are rejected up front with a clear remedy. This supersedes an earlier
  write-only mode explored on this branch, which permanently disabled reads.
- Ingest callbacks on the builder: `errorHandler(...)` and
  `connectionListener(...)` are now reachable from the pooled facade and threaded
  to every pooled `Sender` (internal recovery senders are deliberately excluded).
  Defaults are null, so behavior is unchanged unless a callback is set.

## Build, CI, and compatibility

- Native libraries (`.so`/`.dll`/`.dylib`) are no longer committed to the
  submodule; CI builds them on the test runners instead, including in the
  Coverage and JDK 8 legs.
- The Linux native build pins `clock_gettime` to `GLIBC_2.2.5` to keep the glibc
  floor low for broad Linux compatibility.

## Server-side QWP ingress: role changes are transient, not terminal (Invariant B)

Production incident: after `SWITCH ROLE TO REPLICA`, an existing QWP ingress
connection had its next batch rejected by the per-batch read-only re-check as
an authorization error → `SECURITY_ERROR` (wire 0x8). A store-and-forward /
durable-ack client classifies `SECURITY_ERROR` as a terminal HALT, so the
producer died on a routine failover. Fixes, in order:

- **Demote closes instead of NACKing** (`3abbb1cf76`): the read-only re-check
  now flags the connection and closes it with a reconnect-eligible
  `NORMAL_CLOSURE` (after flushing pending ACKs so the client learns what
  committed). The client reconnects, hits the 421 role gate on the
  now-replica, and retries from SF — the transient path it already handles. A
  genuine ACL denial on a writable node still maps to `SECURITY_ERROR`.
- **Mid-batch flip containment** (`86f8556c8e`): the read-only flag can flip
  BETWEEN the top-of-batch gate and the WAL-writer acquisition / commit;
  the deeper engine gates then throw `CairoException.authorization()`, which
  mapped back to `SECURITY_ERROR`. Batch-rejection errors are now routed
  through a handler that re-checks the live read-only state at catch time and
  converts the transient demote refusal into the role-change close.
- **Fuzzed across every refusal window** (`d5d2db9206`): an ingress fuzz
  drives the demote race across all refusal points and asserts
  `SECURITY_ERROR` never reaches a client during a role switch.
- **Durable-ack deferred close** (`3b6564603b`): the demote flips read-only
  FIRST and uploads AFTERWARDS, so the role-change close could sever a
  durable-ack connection before its final durable ack was deliverable — the
  client (whose replay watermark advances only on durable acks) then replayed
  a batch the promoted replica already had, landing it twice on tables
  without dedup. The close is now DEFERRED (bounded by a 10s stall guard)
  until the durable-upload registry covers the connection's pending seqTxns;
  the final durable ack is flushed and only then does the connection close —
  every in-flight batch lands exactly once. Non-durable-ack connections keep
  the immediate close.
- **`STATUS_NOT_WRITABLE` (0x0C) reserved** (`abbc04f204`): a wire status byte
  for "cannot accept writes" (read-only replica / demoting primary), so a
  future server can NACK mid-stream once deployed client fleets classify it
  as retriable-with-endpoint-rotation (client NACK policy v2
  `RETRIABLE_OTHER`).
- **E2e error-path migration to NACK policy v2** (`a8bec7b1ff`): the client
  bump removed the v1 drop policy, which the server-side e2e suites still
  encoded (32 failures). The suites now pin the v2 observables: retriable
  NACKs replay until the poison-frame detector escalates, `SCHEMA_MISMATCH`
  latches terminal on the first strike, a latched terminal surfaces on
  exactly one channel, and SF purge applies to clean producers only.

## Server-side QWP ingress: cumulative OK acks follow commit boundaries (deferred-commit ack hole)

The deferred-commit feature (#7144) let `FLAG_DEFER_COMMIT` frames fall into the pre-existing `STATUS_OK` ack branch: the cumulative-ack watermark advanced (and flushed — every `ACK_BATCH_SIZE` frames, before error responses, and on role-change closes) over rows that were appended but **not committed**. Any subsequent error, demote, or disconnect rolled those rows back after the store-and-forward client had already trimmed their replay slots: silent, unrecoverable loss of up to a full uncommitted transaction (`qwp.max.uncommitted.rows`, 1M rows/table default). This inverted #7144's own error-handling contract — "the client's store-and-forward replays all unacknowledged messages on reconnect" requires deferred frames to stay unacknowledged until their group commits.

Fix: the watermark advances only on frames whose processing ended in a successful `commitAll()`:

- OK deferred frames get no watermark advance and no ack; coverage arrives with the group-closing commit frame's cumulative ack, which also carries the group's real per-table seqTxns for durable-ack tracking (closing the "empty OK frames are trivially durable" hole for deferred groups).
- A group-closing commit flushes its ack eagerly (`hasPendingAck`) instead of waiting for the batch cadence — transaction confirmation must not stall behind unrelated future traffic.
- The per-table force-commit at the max-uncommitted-rows cap does **not** advance the watermark (it gives no full-coverage guarantee); those rows simply replay at-least-once after a reconnect.
- `QwpIngressProcessorState.setHighestProcessedSequence` grows a last-resort clamp mirroring the unresolved-sequence clamp: watermark motion over uncommitted deferred rows clamps and screams — an availability hit, never data loss.

Non-transactional traffic is byte-for-byte unchanged (every frame commits before its watermark advance; identical ack cadence). Client companion in java-questdb-client#60: `close()` drains to the last commit boundary, and a recovered orphaned deferred tail (producer killed mid-transaction) is aborted via skip-and-self-ack instead of replayed into the next session's commit.

Tests: state-level clamp tests; wire-level e2e regressions (`testDeferredFramesNotAckedUntilCommit` — 20 deferred frames, zero acks, group ack covers 0..20; `testGroupCommitAckFlushesEagerly` — sub-batch-threshold group acked on commit); demote fuzz/shape drivers re-synced to the new processor ordering.

## Design docs

Adds `design/qwp-client-startup-failover-behavior.md` and
`design/qwp-client-ergonomics-issues.md` documenting the client's
startup/failover behavior and the ergonomics rationale behind these changes.
The NACK policy v2 design lives in the client PR
(`design/qwp-nack-policy-v2.md`).

## Parent-repo change

- Bumps the `java-questdb-client` submodule pointer to the branch above — the
  bumps carry the connect-timeout/facade work, the Invariant B reconnect
  rework, NACK policy v2 + `max_frame_rejections`, and the M8–M11 hardening
  (drainer listener on the facade/builder, role-reject observability split,
  lock-free background connect walks, fast close under outage).
- Fixes `QuestDBFacadeE2ETest`, which still called the removed
  `connect(ingest, query)` overload. Both strings in that test were already
  identical, so they collapse to a single `connect(config)`; the test is renamed
  `testSingleConfigConnectRoundTrip` to reflect the one-cluster-config model.

## Parent-repo CI: build the client native library under local-client

Dropping the committed client binaries also broke the parent test pipeline.
With a `-SNAPSHOT` client, `detect-local-client.yml` activates the
`local-client` profile and the reactor builds the client from source, but
nothing compiled its native library, so every client-dependent test failed at
class load with `cannot find /io/questdb/client/bin/<platform>/libquestdb.so`
(self-hosted Linux `Other tests` and parts of `Cairo tests`, plus the
on-demand macOS/Windows legs that share the same steps).

- Adds `ci/templates/build-client-native.yml`, included by `steps.yml` right
  after JDK activation, which compiles the client's native library with CMake
  when `local-client` is active. It initializes the client's `zstd` submodule,
  builds with the agent toolchain, and copies the result into the client's
  `src/main/resources/io/questdb/client/bin/<platform>/` so it survives the
  test phase's `mvn clean` and resolves on the production resource path the
  loader checks (`io.questdb.client.std.Os`).
- The step is a no-op when the client comes from Maven Central (the release
  jar bundles the binaries), since `CLIENT_PROFILE` is then empty.
- Tradeoff: each test job that runs under `local-client` now spends the extra
  CMake build time (toolchain install is skipped when cmake/nasm are already
  present). The Linux and macOS paths are exercised directly; the Windows path
  only runs in the on-demand hosted pipeline and mirrors the client's
  mingw-based build.

## Tradeoffs and compatibility notes

- API change: the `QuestDB.connect(ingest, query)` overload is gone. Callers that
  used distinct ingest/egress endpoints must move to a single cluster config or
  the builder.
- The connect timeout adds a non-blocking-connect path in native code on both
  POSIX and Windows. The default keeps the prior OS-timeout behavior, so there is
  no change unless `connect_timeout` is set.
- Dropping committed native binaries shifts the cost of producing them onto CI;
  builds that previously relied on the checked-in artifacts now depend on the
  native build step succeeding.

## Test plan

- `mvn clean package -DskipTests -P local-client` builds cleanly (verified).
- `NetConnectTimeoutTest` covers loopback success, refused-vs-timeout
  disambiguation, and a black-hole timeout firing within budget.
- `QuestDBLazyConnectTest` covers start+write while the server is down, reads
  staying enabled, both startup conflicts (via connect string and builder), and
  flag parsing.
- `QuestDBServerRecoveryTest` dogfoods `lazy_connect=true` through the full
  down -> write -> up -> read lifecycle.
- `QuestDBFacadeCallbacksTest` asserts the facade-wired `errorHandler` and
  `connectionListener` receive ingest errors and connection events with no
  server.
- `QuestDBFacadeE2ETest.testSingleConfigConnectRoundTrip` exercises the
  single-config sender + query round trip end-to-end.

## Merge prerequisite

The corresponding `java-questdb-client` branch must merge first; the submodule
pointer here will be re-bumped to that merged commit before this PR merges.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local-client builds so required native QuestDB libraries are compiled and packaged for Linux, macOS, and Windows, reducing startup failures from missing native dependencies.
  * Improved QWP demote/read-only race handling so client-visible refusals avoid `SECURITY_ERROR`, and role-change close is deferred safely with durable-ack grace to prevent ack/ordering issues.
* **Tests**
  * Refreshed and expanded end-to-end coverage for pooled query leasing, handler behavior, and concurrency isolation.
  * Added fuzz/invariant coverage for demote races and stronger “terminal error” escalation checks under NACK policy v2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



