### PR TITLE
fix(core): make DataID publication thread-safe

### DIFF
--- a/core/src/main/java/io/questdb/cairo/DataID.java
+++ b/core/src/main/java/io/questdb/cairo/DataID.java
@@ -42,6 +42,16 @@ import org.jetbrains.annotations.NotNull;
  * <p>
  * One shouldn't modify the data id in an unblank database as it may cause data loss.
  * </p>
+ * <p>
+ * Thread-safety: the in-memory UUID can be published by one thread (e.g. the replication
+ * downloader's {@link #initialize(long, long)} JNI up-call) and read by another (e.g. a booting
+ * backup scheduler gating on {@link #isInitialized()}). The 128-bit value is two longs, so a plain
+ * read could observe a torn half-written value or miss the publish entirely. All accessors that touch
+ * the {@code lo}/{@code hi} pair are therefore {@code synchronized} on this instance, reading/writing
+ * the pair as one critical section. The underlying {@link Uuid} fields are deliberately left
+ * non-volatile: that class is a hot, general-purpose value holder, so the synchronization is kept
+ * here where the one-writer/other-reader publication actually happens.
+ * </p>
  */
 public final class DataID implements Sinkable {
 
@@ -95,11 +105,11 @@ public final class DataID implements Sinkable {
         return id;
     }
 
-    public long getHi() {
+    public synchronized long getHi() {
         return id.getHi();
     }
 
-    public long getLo() {
+    public synchronized long getLo() {
         return id.getLo();
     }
 
@@ -112,7 +122,7 @@ public final class DataID implements Sinkable {
      * @return true if the value was initialized, or false if it could not be initialized
      * because it was already set.
      */
-    public boolean initialize(long lo, long hi) {
+    public synchronized boolean initialize(long lo, long hi) {
         if (isInitialized()) {
             return false;
         }
@@ -126,12 +136,12 @@ public final class DataID implements Sinkable {
      *
      * @return true if the data id is initialized.
      */
-    public boolean isInitialized() {
+    public synchronized boolean isInitialized() {
         return !Uuid.isNull(id.getLo(), id.getHi());
     }
 
     @Override
-    public void toSink(@NotNull CharSink<?> sink) {
+    public synchronized void toSink(@NotNull CharSink<?> sink) {
         id.toSink(sink);
     }
 

--- a/core/src/main/java/io/questdb/cairo/DataID.java
+++ b/core/src/main/java/io/questdb/cairo/DataID.java
@@ -52,6 +52,13 @@ import org.jetbrains.annotations.NotNull;
  * non-volatile: that class is a hot, general-purpose value holder, so the synchronization is kept
  * here where the one-writer/other-reader publication actually happens.
  * </p>
+ * <p>
+ * Note that {@code synchronized} gives each accessor per-call atomicity, not a multi-call snapshot:
+ * {@link #getLo()} and {@link #getHi()} each read a single half, so reading both as two separate calls
+ * re-acquires the monitor twice and can still observe a torn pair across a concurrent publish. Callers
+ * that need both halves consistently (e.g. {@code current_data_id()} and the Rust {@code JavaDataId} JNI
+ * bridge) must use {@link #getSnapshot()}, which reads the pair under a single monitor acquisition.
+ * </p>
  */
 public final class DataID implements Sinkable {
 
@@ -111,6 +118,20 @@ public final class DataID implements Sinkable {
 
     public synchronized long getLo() {
         return id.getLo();
+    }
+
+    /**
+     * Returns an atomic snapshot of the 128-bit value as a fresh {@link Uuid}. Both halves are read
+     * within a single critical section, so the returned pair is never torn across a concurrent
+     * {@link #initialize(long, long)} / {@link #change(long, long)} publish -- unlike reading
+     * {@link #getLo()} and {@link #getHi()} as two separate calls, which drops and re-acquires the
+     * monitor in between. Callers that need both halves consistently must use this accessor.
+     *
+     * @return a new {@link Uuid} holding a consistent {@code (lo, hi)} snapshot; the NULL Uuid when not
+     * yet initialized.
+     */
+    public synchronized Uuid getSnapshot() {
+        return new Uuid(id.getLo(), id.getHi());
     }
 
     /**

--- a/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/CurrentDataIdFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/catalogue/CurrentDataIdFunctionFactory.java
@@ -32,6 +32,7 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.constants.UuidConstant;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjList;
+import io.questdb.std.Uuid;
 
 public class CurrentDataIdFunctionFactory implements FunctionFactory {
     @Override
@@ -47,6 +48,11 @@ public class CurrentDataIdFunctionFactory implements FunctionFactory {
     @Override
     public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
         DataID id = sqlExecutionContext.getCairoEngine().getDataID();
-        return new UuidConstant(id.getLo(), id.getHi());
+        // Read both halves atomically: getLo()/getHi() are individually synchronized, but reading them
+        // as two separate calls can tear across the one-shot replica DataID publish, producing a
+        // UuidConstant that is neither SQL NULL nor the correct id. getSnapshot() reads the pair under
+        // a single monitor acquisition.
+        final Uuid snapshot = id.getSnapshot();
+        return new UuidConstant(snapshot.getLo(), snapshot.getHi());
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/DataIDTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/DataIDTest.java
@@ -29,6 +29,7 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.DataID;
 import io.questdb.cairo.vm.MemoryCMARWImpl;
+import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.MemoryTag;
 import io.questdb.std.Numbers;
@@ -41,6 +42,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class DataIDTest extends AbstractBootstrapTest {
     @Test
@@ -80,6 +85,188 @@ public class DataIDTest extends AbstractBootstrapTest {
             Assert.assertTrue(reopened.isInitialized());
             Assert.assertEquals(newLo, reopened.getLo());
             Assert.assertEquals(newHi, reopened.getHi());
+        });
+    }
+
+    /**
+     * Green counterpart of the cross-call torn read for the SQL consumer. {@code current_data_id()}
+     * ({@code CurrentDataIdFunctionFactory}) now reads both halves through {@link DataID#getSnapshot()},
+     * which takes the pair under a single monitor acquisition. A reader hammering {@code getSnapshot()}
+     * exactly while the one-shot replica publish ({@link DataID#initialize(long, long)}) lands must never
+     * observe a torn pair -- one half still the NULL sentinel, the other published -- the value the SQL
+     * function would otherwise surface as neither NULL nor the correct id.
+     * <p>
+     * Was RED against the pre-fix two-call read {@code new UuidConstant(id.getLo(), id.getHi())} (the
+     * publish landing between the two separate accessor calls); GREEN now that the read site routes
+     * through the atomic accessor.
+     */
+    @Test
+    public void testConcurrentSnapshotStaysAtomicAcrossInitialize() throws Exception {
+        assertMemoryLeak(() -> {
+            final java.io.File tmpDbRoot = new java.io.File(temp.newFolder(".testSnapshotInit.installRoot"), "db");
+            Assert.assertTrue(tmpDbRoot.mkdirs());
+            final CairoConfiguration config = new DefaultTestCairoConfiguration(tmpDbRoot.getAbsolutePath());
+            final DataID id = DataID.open(config);
+            Assert.assertFalse(id.isInitialized());
+
+            // Deterministic boundary check: a pre-publish snapshot is fully unpublished.
+            final Uuid before = id.getSnapshot();
+            Assert.assertEquals(Numbers.LONG_NULL, before.getLo());
+            Assert.assertEquals(Numbers.LONG_NULL, before.getHi());
+
+            // Neither half equals the NULL sentinel (Long.MIN_VALUE), so a torn pair is unambiguous.
+            final long realLo = 0x1122334455667788L;
+            final long realHi = 0x0123456789abcdefL;
+
+            final SOCountDownLatch ready = new SOCountDownLatch(1);
+            final AtomicReference<Throwable> error = new AtomicReference<>();
+            final AtomicLong tornLo = new AtomicLong();
+            final AtomicLong tornHi = new AtomicLong();
+            final AtomicBoolean torn = new AtomicBoolean(false);
+            final AtomicBoolean published = new AtomicBoolean(false);
+
+            // Reader hammers the atomic accessor the SQL function now uses, racing the one-shot publish.
+            final Thread reader = new Thread(() -> {
+                try {
+                    ready.await();
+                    final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+                    while (System.nanoTime() - deadline < 0) {
+                        final Uuid snap = id.getSnapshot();
+                        final long lo = snap.getLo();
+                        final long hi = snap.getHi();
+                        if ((lo == Numbers.LONG_NULL) != (hi == Numbers.LONG_NULL)) {
+                            tornLo.set(lo);
+                            tornHi.set(hi);
+                            torn.set(true);
+                            break;
+                        }
+                        if (published.get() && lo != Numbers.LONG_NULL) {
+                            break; // observed the fully-published value; the race window is closed
+                        }
+                    }
+                } catch (Throwable t) {
+                    error.set(t);
+                }
+            }, "dataid-snapshot-reader");
+
+            // Writer models the replication downloader's one-shot initialize() JNI up-call.
+            final Thread writer = new Thread(() -> {
+                try {
+                    ready.await();
+                    Assert.assertTrue(id.initialize(realLo, realHi));
+                    published.set(true);
+                } catch (Throwable t) {
+                    error.set(t);
+                }
+            }, "dataid-snapshot-writer");
+
+            reader.start();
+            writer.start();
+            ready.countDown(); // release reader and writer together to maximise overlap
+            reader.join();
+            writer.join();
+
+            if (error.get() != null) {
+                throw new AssertionError(error.get());
+            }
+            Assert.assertFalse(
+                    "getSnapshot() returned a torn pair across initialize(): lo=" + tornLo.get()
+                            + " hi=" + tornHi.get(),
+                    torn.get());
+
+            // Sanity: the publish landed and the post-publish snapshot is exactly the value.
+            final Uuid after = id.getSnapshot();
+            Assert.assertEquals(realLo, after.getLo());
+            Assert.assertEquals(realHi, after.getHi());
+        });
+    }
+
+    /**
+     * Symmetric green counterpart for the Rust consumer and the {@code change()} (point-in-time-recovery
+     * re-stamp) publish path. The Rust {@code JavaDataId::get()} (qdb-ent/src/data_id.rs) now holds the
+     * DataID monitor across its {@code getHi()}/{@code getLo()} JNI reads, so the pair is atomic and the
+     * {@code QDB_NULL_UUID} guard never sees a torn value. This exercises the same Java-side invariant the
+     * Rust monitor relies on, against {@link DataID#change(long, long)}, which overwrites an already
+     * published value (real -&gt; real'): a two-call read could observe {@code (newHi, oldLo)} -- BOTH
+     * non-null, so a NULL-sentinel guard would not even catch it -- whereas an atomic snapshot is always
+     * either fully the old value or fully the new value.
+     */
+    @Test
+    public void testConcurrentSnapshotStaysAtomicAcrossChange() throws Exception {
+        assertMemoryLeak(() -> {
+            final java.io.File tmpDbRoot = new java.io.File(temp.newFolder(".testSnapshotChange.installRoot"), "db");
+            Assert.assertTrue(tmpDbRoot.mkdirs());
+            final CairoConfiguration config = new DefaultTestCairoConfiguration(tmpDbRoot.getAbsolutePath());
+            final DataID id = DataID.open(config);
+
+            final long oldLo = 0x1111111111111111L;
+            final long oldHi = 0x2222222222222222L;
+            final long newLo = 0x3333333333333333L;
+            final long newHi = 0x4444444444444444L;
+            Assert.assertTrue(id.initialize(oldLo, oldHi));
+
+            final SOCountDownLatch ready = new SOCountDownLatch(1);
+            final AtomicReference<Throwable> error = new AtomicReference<>();
+            final AtomicLong badLo = new AtomicLong();
+            final AtomicLong badHi = new AtomicLong();
+            final AtomicBoolean torn = new AtomicBoolean(false);
+            final AtomicBoolean changed = new AtomicBoolean(false);
+
+            // Reader hammers getSnapshot() while change() re-stamps the value. Read hi then lo from the
+            // snapshot to mirror the Rust JavaDataId::get() order; since the snapshot is an immutable
+            // copy, both halves always belong to the same publish regardless of read order.
+            final Thread reader = new Thread(() -> {
+                try {
+                    ready.await();
+                    final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+                    while (System.nanoTime() - deadline < 0) {
+                        final Uuid snap = id.getSnapshot();
+                        final long hi = snap.getHi();
+                        final long lo = snap.getLo();
+                        final boolean isOld = lo == oldLo && hi == oldHi;
+                        final boolean isNew = lo == newLo && hi == newHi;
+                        if (!isOld && !isNew) {
+                            badLo.set(lo);
+                            badHi.set(hi);
+                            torn.set(true);
+                            break;
+                        }
+                        if (changed.get() && isNew) {
+                            break; // observed the fully re-stamped value; race window closed
+                        }
+                    }
+                } catch (Throwable t) {
+                    error.set(t);
+                }
+            }, "dataid-change-reader");
+
+            final Thread writer = new Thread(() -> {
+                try {
+                    ready.await();
+                    id.change(newLo, newHi);
+                    changed.set(true);
+                } catch (Throwable t) {
+                    error.set(t);
+                }
+            }, "dataid-change-writer");
+
+            reader.start();
+            writer.start();
+            ready.countDown();
+            reader.join();
+            writer.join();
+
+            if (error.get() != null) {
+                throw new AssertionError(error.get());
+            }
+            Assert.assertFalse(
+                    "getSnapshot() returned a value belonging to neither the old nor the new id across "
+                            + "change(): lo=" + badLo.get() + " hi=" + badHi.get(),
+                    torn.get());
+
+            final Uuid after = id.getSnapshot();
+            Assert.assertEquals(newLo, after.getLo());
+            Assert.assertEquals(newHi, after.getHi());
         });
     }
 


### PR DESCRIPTION
**Related PRs**
- Enterprise: questdb/questdb-enterprise#1100
- OSS: questdb/questdb#7343

---

## What

Make `DataID`'s in-memory UUID publication thread-safe by `synchronized`-ing every accessor that touches the `lo`/`hi` pair: `initialize()`, `isInitialized()`, `getLo()`, `getHi()`, and `toSink()` — symmetric with the already-`synchronized` `change()`.

## Why

`DataID` wraps a 128-bit UUID stored as two `long`s (`Uuid.lo`/`Uuid.hi`), which are **non-volatile**. The value is published by one thread and read by another:

- **Writer:** the replication WAL downloader learns the DataID from the object store and publishes it via a `DataID.initialize()` JNI up-call, which does two plain stores through `Uuid.of(lo, hi)`.
- **Reader:** `isInitialized()` reads `lo` and `hi` as two separate, unsynchronized loads (and the native backup/replication path plus the `current_data_id()` SQL function read via `getLo()`/`getHi()`).

Because the stores and loads are unsynchronized and non-volatile, a reader can:

- observe a **torn** half-written value (`lo` set, `hi` still unset) and act on it — e.g. exit an initialization wait early, or
- in theory **never observe** the publish at all (visibility).

`change()` was already `synchronized`, but `initialize()` and the readers were not, so the publication had no happens-before edge.

This is a pre-existing latent race in `DataID`/`Uuid` (these files are otherwise unchanged). It becomes newly reachable in Enterprise, where a booting backup scheduler makes a **control-flow decision** on `isInitialized()` while the downloader concurrently publishes the DataID — see questdb/questdb-enterprise#1100.

## Fix

Read/write the `lo`/`hi` pair as a single critical section by synchronizing the accessors on the `DataID` instance. Intrinsic locks are reentrant, so `initialize()`/`change()` calling `isInitialized()` is fine.

The fix is deliberately kept in `DataID` rather than making `Uuid.lo`/`Uuid.hi` `volatile`: `Uuid` is a hot, general-purpose value holder (record comparators, UUID columns, tight loops), and the unsafe publication is specific to `DataID`'s one-writer / other-reader pattern. Adding volatile/lock overhead to every UUID operation to fix a boot-time publish would be the wrong trade.

## Testing

- `DataIDTest` — green (5/5).
- `mvn compile -pl questdb/core` — clean.
