### PR TITLE
fix(sql): fix crash joining or grouping on empty VARCHAR values

### DIFF
--- a/core/src/main/java/io/questdb/cairo/VarcharTypeDriver.java
+++ b/core/src/main/java/io/questdb/cairo/VarcharTypeDriver.java
@@ -89,7 +89,10 @@ public class VarcharTypeDriver implements ColumnTypeDriver {
         if (eraseAsciiFlag) {
             Unsafe.putInt(dataMemAddr, hi);
         } else {
-            final boolean ascii = value.isAscii();
+            // An empty varchar is ASCII by definition; force the flag so that an empty value
+            // does not write a 0 header, which collides with the "size == 0" NULL/empty-slot
+            // sentinels the readers rely on.
+            final boolean ascii = value.isAscii() || hi == 0;
             // ASCII flag is signaled with the highest bit
             Unsafe.putInt(dataMemAddr, ascii ? hi | Integer.MIN_VALUE : hi);
         }
@@ -108,7 +111,10 @@ public class VarcharTypeDriver implements ColumnTypeDriver {
             return;
         }
         final int size = value.size();
-        dataMem.putInt(value.isAscii() ? size | Integer.MIN_VALUE : size);
+        // An empty varchar is ASCII by definition; force the flag so that an empty value does
+        // not write a 0 header, which collides with the "size == 0" NULL/empty-slot sentinels.
+        final boolean ascii = value.isAscii() || size == 0;
+        dataMem.putInt(ascii ? size | Integer.MIN_VALUE : size);
         dataMem.putVarchar(value, 0, size);
     }
 

--- a/core/src/main/java/io/questdb/cairo/VarcharTypeDriver.java
+++ b/core/src/main/java/io/questdb/cairo/VarcharTypeDriver.java
@@ -90,8 +90,9 @@ public class VarcharTypeDriver implements ColumnTypeDriver {
             Unsafe.putInt(dataMemAddr, hi);
         } else {
             // An empty varchar is ASCII by definition; force the flag so that an empty value
-            // does not write a 0 header, which collides with the "size == 0" NULL/empty-slot
-            // sentinels the readers rely on.
+            // writes a non-zero header (size 0 | high bit) instead of 0. getPlainValue treats a
+            // 0 header as absent/uninitialized memory (assert header != 0), so a 0 header for an
+            // empty non-ASCII value would trip that assertion on read.
             final boolean ascii = value.isAscii() || hi == 0;
             // ASCII flag is signaled with the highest bit
             Unsafe.putInt(dataMemAddr, ascii ? hi | Integer.MIN_VALUE : hi);
@@ -111,8 +112,10 @@ public class VarcharTypeDriver implements ColumnTypeDriver {
             return;
         }
         final int size = value.size();
-        // An empty varchar is ASCII by definition; force the flag so that an empty value does
-        // not write a 0 header, which collides with the "size == 0" NULL/empty-slot sentinels.
+        // An empty varchar is ASCII by definition; force the flag so that an empty value writes
+        // a non-zero header (size 0 | high bit) instead of 0. getPlainValue treats a 0 header as
+        // absent/uninitialized memory (assert header != 0), so a 0 header for an empty non-ASCII
+        // value would trip that assertion on read.
         final boolean ascii = value.isAscii() || size == 0;
         dataMem.putInt(ascii ? size | Integer.MIN_VALUE : size);
         dataMem.putVarchar(value, 0, size);

--- a/core/src/main/java/io/questdb/cairo/map/UnorderedVarcharMap.java
+++ b/core/src/main/java/io/questdb/cairo/map/UnorderedVarcharMap.java
@@ -1050,7 +1050,14 @@ public class UnorderedVarcharMap implements Map, Reopenable {
                     long ptr = keySink.ptr();
                     ptrWithUnstableFlag = ptr | PTR_UNSTABLE_MASK;
                 }
-                flags = value.isAscii() ? FLAG_IS_ASCII : 0;
+                // An empty varchar is ASCII by definition (it has no non-ASCII bytes), but the
+                // Utf8Sequence contract only guarantees that isAscii() == true means ASCII, not
+                // the converse: a producer is free to report isAscii() == false for an empty
+                // value. The map packs hash, size and flags into a single long and relies on
+                // empty keys carrying the ASCII flag, otherwise an empty non-ASCII key packs to
+                // 0 (zero hash, zero size, no flags) -- indistinguishable from an empty slot,
+                // which silently corrupts the map. Force the flag for empty keys.
+                flags = (value.isAscii() || size == 0) ? FLAG_IS_ASCII : 0;
             }
 
             // Empty string must have the ascii flag set to true, otherwise we won't be able to differentiate

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressRequestDecoder.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressRequestDecoder.java
@@ -384,7 +384,12 @@ public class QwpEgressRequestDecoder {
                         throw QwpParseException.instance(QwpParseException.ErrorCode.INSUFFICIENT_DATA).put("bind: truncated VARCHAR bytes");
                     // Reuse varcharBindView -- StrBindVariable.setValue(Utf8Sequence) copies into
                     // its own utf8Sink, so the view can be re-pointed for the next bind.
-                    bindVars.setVarchar(index, varcharBindView.of(p, p + strLen));
+                    // Compute the ASCII flag (like PGWire does) instead of leaving it cleared:
+                    // the 2-arg of() hardcodes ascii=false, which would flag an empty bind value
+                    // as non-ASCII and break the empty => ASCII invariant relied on by the varchar
+                    // hash map (UnorderedVarcharMap) when the bind variable is used as a join key.
+                    final boolean ascii = Utf8s.isAscii(p, strLen);
+                    bindVars.setVarchar(index, varcharBindView.of(p, p + strLen, ascii));
                     p += strLen;
                 }
             }

--- a/core/src/test/java/io/questdb/test/cairo/VarcharTypeDriverTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/VarcharTypeDriverTest.java
@@ -71,6 +71,30 @@ public class VarcharTypeDriverTest extends AbstractTest {
     }
 
     @Test
+    public void testAppendPlainValueAddressEmptyNonAsciiVarchar() throws Exception {
+        // Same empty => ASCII invariant for the address-based appendPlainValue(long, value, false)
+        // overload used by RecordChain: an empty non-ASCII value must write a non-zero header, not 0.
+        TestUtils.assertMemoryLeak(() -> {
+            try (MemoryCARW dataMem = Vm.getCARWInstance(1024, Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)) {
+                long addr = dataMem.appendAddressFor(16);
+                Utf8Sequence emptyNonAscii = new Utf8String(new byte[0], false);
+                Assert.assertEquals(0, emptyNonAscii.size());
+                Assert.assertFalse(emptyNonAscii.isAscii());
+
+                VarcharTypeDriver.appendPlainValue(addr, emptyNonAscii, false);
+
+                // The header must be non-zero, otherwise the asserting getPlainValue overload rejects it.
+                Assert.assertNotEquals(0, Unsafe.getInt(addr));
+
+                Utf8Sequence read = VarcharTypeDriver.getPlainValue(addr, new DirectUtf8String());
+                Assert.assertNotNull(read);
+                Assert.assertEquals(0, read.size());
+                Assert.assertTrue(read.isAscii());
+            }
+        });
+    }
+
+    @Test
     public void testGetDataVectorSize() throws Exception {
         final FilesFacade ff = TestFilesFacadeImpl.INSTANCE;
         final VarcharTypeDriver driver = new VarcharTypeDriver();

--- a/core/src/test/java/io/questdb/test/cairo/VarcharTypeDriverTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/VarcharTypeDriverTest.java
@@ -45,6 +45,32 @@ import static io.questdb.cairo.VarcharTypeDriver.VARCHAR_MAX_BYTES_FULLY_INLINED
 public class VarcharTypeDriverTest extends AbstractTest {
 
     @Test
+    public void testAppendPlainEmptyNonAsciiVarchar() throws Exception {
+        // An empty varchar is ASCII by definition, but the Utf8Sequence contract lets a producer
+        // report isAscii() == false for it. In the single-vector "plain" format the length prefix
+        // encodes the ASCII flag in its top bit, so an empty non-ASCII value used to write a 0
+        // header -- which getPlainValue rejects via "assert header != 0" (it is the NULL / empty
+        // sentinel). The value must round-trip as an empty ASCII varchar instead.
+        TestUtils.assertMemoryLeak(() -> {
+            try (MemoryCARW dataMem = Vm.getCARWInstance(1024, Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)) {
+                Utf8Sequence emptyNonAscii = new Utf8String(new byte[0], false);
+                Assert.assertEquals(0, emptyNonAscii.size());
+                Assert.assertFalse(emptyNonAscii.isAscii());
+
+                VarcharTypeDriver.appendPlainValue(dataMem, emptyNonAscii);
+
+                // The header must be non-zero, otherwise getPlainValue mistakes it for a missing entry.
+                Assert.assertNotEquals(0, dataMem.getInt(0));
+
+                Utf8Sequence read = VarcharTypeDriver.getPlainValue(dataMem, 0);
+                Assert.assertNotNull(read);
+                Assert.assertEquals(0, read.size());
+                Assert.assertTrue(read.isAscii());
+            }
+        });
+    }
+
+    @Test
     public void testGetDataVectorSize() throws Exception {
         final FilesFacade ff = TestFilesFacadeImpl.INSTANCE;
         final VarcharTypeDriver driver = new VarcharTypeDriver();

--- a/core/src/test/java/io/questdb/test/cairo/map/UnorderedVarcharMapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/map/UnorderedVarcharMapTest.java
@@ -262,6 +262,52 @@ public class UnorderedVarcharMapTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testBlankNonAsciiKey() throws Exception {
+        // An empty VARCHAR whose isAscii() reports false is legal: the Utf8Sequence contract
+        // only guarantees that isAscii() == true means ASCII, not the converse. Such a value
+        // used to trip an assertion in putVarchar (and, with assertions off, packed to 0 and
+        // collided with the empty-slot sentinel, corrupting the map). This is the map-level
+        // reproduction of the hash join crash on empty non-ASCII join keys.
+        TestUtils.assertMemoryLeak(() -> {
+            SingleColumnType valueType = new SingleColumnType(ColumnType.INT);
+            try (UnorderedVarcharMap map = newDefaultMap(valueType)) {
+                Utf8Sequence emptyNonAscii = new Utf8String(new byte[0], false);
+                Assert.assertEquals(0, emptyNonAscii.size());
+                Assert.assertFalse(emptyNonAscii.isAscii());
+
+                MapKey key = map.withKey();
+                key.putVarchar(emptyNonAscii);
+                MapValue value = key.createValue();
+                Assert.assertTrue(value.isNew());
+                value.putInt(0, 42);
+
+                // The entry must be retrievable and NOT be mistaken for a missing entry.
+                MapKey lookup = map.withKey();
+                lookup.putVarchar(emptyNonAscii);
+                MapValue found = lookup.findValue();
+                Assert.assertNotNull(found);
+                Assert.assertEquals(42, found.getInt(0));
+
+                // Re-inserting the same empty key must resolve to the existing entry.
+                MapKey again = map.withKey();
+                again.putVarchar(emptyNonAscii);
+                MapValue existing = again.createValue();
+                Assert.assertFalse(existing.isNew());
+                Assert.assertEquals(1, map.size());
+
+                // An empty ASCII varchar has the same (empty) content, so it must resolve to
+                // the same slot: the ASCII flag must not affect key identity.
+                MapKey asciiKey = map.withKey();
+                asciiKey.putVarchar(new Utf8String(new byte[0], true));
+                MapValue asciiFound = asciiKey.findValue();
+                Assert.assertNotNull(asciiFound);
+                Assert.assertEquals(42, asciiFound.getInt(0));
+                Assert.assertEquals(1, map.size());
+            }
+        });
+    }
+
+    @Test
     public void testDeferredKeyCopyCopyFrom() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             SingleColumnType valueTypes = new SingleColumnType(ColumnType.INT);

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressBindRoundTripTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressBindRoundTripTest.java
@@ -632,6 +632,31 @@ public class QwpEgressBindRoundTripTest extends AbstractReusedServerQwpEgressTes
     }
 
     @Test
+    public void testBindVarcharEmptyHashJoinKey() throws Exception {
+        // An empty varchar bind used as a hash-join key must not crash. The egress decoder used to
+        // build the bind view with the 2-arg DirectUtf8String.of(), which hardcodes ascii=false, so
+        // an empty bind became an empty non-ASCII varchar. Feeding that into UnorderedVarcharMap
+        // (the varchar hash-join key map) tripped an assertion, because the map's packed key
+        // representation for a zero-hash, zero-size, non-ASCII key is 0 -- indistinguishable from an
+        // empty slot. Equivalent to the crash a customer hit joining on a VARCHAR key.
+        TestUtils.assertMemoryLeak(() -> {
+            try (TestServerMain serverMain = startEgressServer()) {
+                runFilterMatch(
+                        serverMain,
+                        "CREATE TABLE t(c VARCHAR, part_ts TIMESTAMP) TIMESTAMP(part_ts) PARTITION BY DAY WAL",
+                        "INSERT INTO t VALUES ('x', 1::TIMESTAMP), ('', 2::TIMESTAMP)",
+                        "SELECT count() cnt FROM t JOIN (SELECT $1::varchar AS k FROM long_sequence(1)) b ON t.c = b.k",
+                        binds -> binds.setVarchar(0, ""),
+                        batch -> {
+                            Assert.assertEquals(1, batch.getRowCount());
+                            Assert.assertEquals(1L, batch.getLongValue(0, 0));
+                        }
+                );
+            }
+        });
+    }
+
+    @Test
     public void testBindVarcharUnicodeFilter() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (TestServerMain serverMain = startEgressServer()) {

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/HashJoinTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/HashJoinTest.java
@@ -25,10 +25,12 @@
 package io.questdb.test.griffin.engine.join;
 
 import io.questdb.cairo.TableReader;
+import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.std.Misc;
 import io.questdb.std.Unsafe;
+import io.questdb.std.str.Utf8String;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
@@ -119,6 +121,61 @@ public class HashJoinTest extends AbstractCairoTest {
                 Assert.assertTrue(freeCount < Unsafe.getFreeCount());
                 Assert.assertTrue(getMemUsedByFactories() < tagBeforeFactory + 1024 * 1024);
             }
+        });
+    }
+
+    @Test
+    public void testHashJoinEmptyNonAsciiVarcharKey() throws Exception {
+        // Reproduces a crash reported against QuestDB 3.3.x: an inner (hash) join on a VARCHAR
+        // key failed with an AssertionError in UnorderedVarcharMap.putVarchar when a join key
+        // held an empty, non-ASCII VARCHAR. An empty varchar is ASCII by definition, but the
+        // Utf8Sequence contract lets a value report isAscii() == false for it, and such values
+        // exist at rest. Its packed (hash, size, flags) representation was 0, colliding with the
+        // map's empty-slot sentinel. The same data worked through an ASOF join, which does not
+        // use the varchar hash map.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE m (k VARCHAR, v INT)");
+            execute("CREATE TABLE s (k VARCHAR, w INT)");
+
+            // "" written with the ASCII flag deliberately cleared, matching at-rest data that no
+            // longer round-trips through a value producer that would re-flag it as ASCII.
+            Utf8String emptyNonAscii = new Utf8String(new byte[0], false);
+            Assert.assertEquals(0, emptyNonAscii.size());
+            Assert.assertFalse(emptyNonAscii.isAscii());
+
+            try (TableWriter writer = getWriter("m")) {
+                TableWriter.Row row = writer.newRow();
+                row.putVarchar(0, new Utf8String("a"));
+                row.putInt(1, 1);
+                row.append();
+
+                row = writer.newRow();
+                row.putVarchar(0, emptyNonAscii);
+                row.putInt(1, 2);
+                row.append();
+                writer.commit();
+            }
+
+            try (TableWriter writer = getWriter("s")) {
+                TableWriter.Row row = writer.newRow();
+                row.putVarchar(0, new Utf8String("a"));
+                row.putInt(1, 10);
+                row.append();
+
+                row = writer.newRow();
+                row.putVarchar(0, emptyNonAscii);
+                row.putInt(1, 20);
+                row.append();
+                writer.commit();
+            }
+
+            assertQuery("SELECT m.v, s.w FROM m JOIN s ON m.k = s.k ORDER BY m.v")
+                    .noLeakCheck()
+                    .returns("""
+                            v\tw
+                            1\t10
+                            2\t20
+                            """);
         });
     }
 


### PR DESCRIPTION
## Summary

A customer on 3.3.x reported that an inner (hash) join on a `VARCHAR` key
crashed with an `AssertionError`, while an ASOF join over the same data
worked. The failing query was a plain equi-join:

```
SELECT rfq.* FROM QDBK_CREDIT_RFQ rfq
INNER JOIN SALES_MAPPING ON rfq.SalesPersonId = InputSalesIdentifer
WHERE LoginId = 'zu1450' AND timestamp > '2026-06-28'
```

Stack trace:

```
java.lang.AssertionError
  at io.questdb.cairo.map.UnorderedVarcharMap$Key.putVarchar(UnorderedVarcharMap.java)
  at io.questdb.cairo.map.UnorderedVarcharMap$Key.put(...)
  at io.questdb.griffin.engine.join.HashJoinLightRecordCursorFactory$HashJoinRecordCursor.hasNext(...)
```

## Root cause

The crash triggers when a join/`GROUP BY`/`DISTINCT` `VARCHAR` key is an
**empty, non-ASCII** varchar. An empty varchar is ASCII by definition, but
the `Utf8Sequence` contract only guarantees that `isAscii() == true` means
ASCII, not the converse: a producer is free to report `isAscii() == false`
for an empty value ("Returning false does not guarantee anything").

`UnorderedVarcharMap` packs the key hash, size and flags into a single
`long`. An empty non-ASCII key packs to `0` (zero hash, since
`Hash.hashMem64(p, 0) == 0`; zero size; no flags), which is exactly the
map's empty-slot sentinel. The entry then silently corrupts the table.
An assertion existed to catch this, but the invariant was *asserted*
rather than *enforced*. ASOF joins do not use this map, which is why the
workaround worked.

## Fix

The same "empty ⇒ ASCII" invariant is violated at three layers, all
addressed here:

- **`UnorderedVarcharMap.putVarchar`** forces the ASCII flag for empty
  keys. This is the crash fix and it also covers values already at rest,
  which no read-side change alone could. `makePackComparable()` already
  ignores the ASCII bit when probing, so key identity is unchanged (an
  empty ASCII and empty non-ASCII key still resolve to the same slot).
- **`QwpEgressRequestDecoder`** built varchar bind views with the 2-arg
  `DirectUtf8String.of()`, which hardcodes `ascii=false`; an empty
  varchar bind therefore became an empty non-ASCII varchar. It now
  computes the flag with `Utf8s.isAscii()`, mirroring the pgwire decoder.
- **`VarcharTypeDriver.appendPlainValue`** (single-vector "plain" format,
  used by `RecordChain` and `BlockFileWriter`) wrote a `0` header for an
  empty non-ASCII value, colliding with the NULL/empty sentinel that
  `getPlainValue` rejects via `assert header != 0`. It now forces the
  flag for empty values, matching the Rust parquet writers, which already
  special-case `len == 0`.

## Scope and tradeoffs

- The column storage format (`VarcharTypeDriver.appendValue`, aux/data
  vectors) is intentionally **not** changed. There, an empty value still
  sets the INLINED flag, so the header is non-zero and harmless; the map
  fix handles such values on read. This keeps existing on-disk data valid
  without a rewrite and preserves the natural reproduction path in tests.
- `QwpEgressRequestDecoder` now scans the bind bytes to compute the ASCII
  flag (`Utf8s.isAscii`). This is a per-varchar-bind cost, equivalent to
  what pgwire already does, and negligible for typical bind sizes. A side
  effect is that ASCII varchar binds are now flagged ASCII rather than
  always non-ASCII, which is more correct and can enable faster
  downstream ASCII paths.
- `appendPlainValue` now reads empty non-ASCII values back as empty ASCII.
  This only affects the in-memory plain format (chains/block files), not
  persisted column data, so there is no migration concern.

## Test plan

- `UnorderedVarcharMapTest#testBlankNonAsciiKey` - the map accepts an
  empty non-ASCII key, keeps it distinct from a missing entry, dedups it,
  and collapses it with an empty ASCII key.
- `HashJoinTest#testHashJoinEmptyNonAsciiVarcharKey` - an inner join over
  a column holding an empty non-ASCII varchar returns the expected rows
  (reproduces the customer scenario via at-rest data).
- `QwpEgressBindRoundTripTest#testBindVarcharEmptyHashJoinKey` - an empty
  varchar bind used as a hash-join key succeeds end-to-end over QWP.
- `VarcharTypeDriverTest#testAppendPlainEmptyNonAsciiVarchar` - the plain
  format round-trips an empty non-ASCII value without a 0 header.
- Each test fails with an `AssertionError` before the fix and passes
  after it. The full `UnorderedVarcharMapTest`, `VarcharTypeDriverTest`,
  `HashJoinTest`, `QwpEgressBindRoundTripTest` and `OrderedMapTest`
  suites (108 tests) pass with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
