### PR TITLE
fix(core): prevent posting index corruption when .pk stat fails during column rename

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -6318,6 +6318,18 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 return -1L;
             }
             long keyFileSize = ff.length(keyFile);
+            if (keyFileSize < 0) {
+                // stat failed on a file that exists() just confirmed -- a transient
+                // IO error, not an absent chain. Treating this as "no chain" would
+                // hard-link the raw .pk (chain head intact) while skipping the live
+                // .pv link below; the purge that follows the rename then removes the
+                // old-name .pv -- the only copy of the sealed values -- and every
+                // later read of the chain head fails with "file does not exist".
+                // Fail the operation instead so the writer distresses and the
+                // caller can retry against consistent on-disk state.
+                throw CairoException.critical(ff.errno())
+                        .put("could not read posting index key file size [file=").put(keyFile).put(']');
+            }
             if (keyFileSize < PostingIndexUtils.KEY_FILE_RESERVED) {
                 return -1L;
             }


### PR DESCRIPTION
### Problem

`WalWriterFuzzTest.testWalMetadataChangeHeavy` failed on CI ([Azure build 247643](https://dev.azure.com/questdb/6c9c1a0a-74cf-4f7b-bf65-24ae4f3cd61d/_build/results?buildId=247643), `linux-fuzz1`, first seen on #7341 which does not touch storage code):

```
CairoException: [2] could not open, file does not exist:
  .../testWalMetadataChangeHeavy_nonwal~/2022-02-24.16/new_col_5.pv.45.3
```

The partition held `new_col_5.d.45` and `new_col_5.pk.45`, but no `.pv` file at all — the `.pk` chain head referenced sealTxn=3 whose value file was gone. **Permanent index corruption**: every indexed scan of the partition fails.

### Root cause

`TableWriter.dropFuturePostingIndexChainEntriesBeforeLink` treats `ff.length(keyFile) == -1` (a stat **error** on a file `ff.exists()` just confirmed) the same as "key file too short → no chain" and silently returns `-1`.

The fuzz harness (`FailureFileFacade`) injected a one-shot `length()` failure during the first of two renames (`sym2` → `new_col_2` → `new_col_5`). With the error swallowed, `hardLinkAndPurgeColumnFiles`:

1. hard-linked the raw `.pk` into the new column namespace, chain head (sealTxn=3) intact;
2. fell back to sealTxn=0 for the `.pv` link — `.pv.<txn>.0` had long been purged by the seal-purge job, so **no value file was linked**;
3. let the column purge delete the old-name `sym2.pv.3` — the **only copy** of the sealed values.

The second rename faithfully propagated the broken state (`.pk.45` → head sealTxn=3, no `.pv`).

The fuzz harness contract — and production reality, since `stat` can fail transiently (EIO, ENOMEM, ...) — requires the failure to surface as an exception so the writer distresses and the operation is retried. The WAL twin table took exactly that path in the same run and stayed healthy. `linkFile`/`openRO` already follow this discipline; this callsite was the odd one out. Both callers (RENAME COLUMN and CONVERT PARTITION) are affected.

### Fix

Throw `CairoException.critical(ff.errno())` when `length()` returns a negative value on an existing `.pk`, instead of returning "no chain". The legitimate short-file (`< KEY_FILE_RESERVED`) and absent-file paths keep their existing semantics.

### Reproducing / verification

Deterministic repro on master by freezing both fuzz seeds:

```java
// AbstractFuzzTest:58
private final Rnd setUpRnd = TestUtils.generateRandom(LOG, 12207565905404831L, 1782948489298L);
// WalWriterFuzzTest.testWalMetadataChangeHeavy:461
Rnd rnd = generateRandom(LOG, 12207565907639491L, 1782948489301L);
```

- Before the fix: fails with the exact CI error, `new_col_5.pv.45.3` missing.
- After the fix: the injected failure surfaces as `could not read posting index key file size [... sym2.pk]`, the harness logs `expected IO failure observed`, reopens the writer, retries — test passes.
- Full `WalWriterFuzzTest` class green, exercising 18 injected-failure retries.
