### PR TITLE
fix(sql): preserve row order for order-sensitive aggregates

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -12700,6 +12700,7 @@ public class SqlOptimiser implements Mutable {
         orderedGroupByFunctions.add("last");
         orderedGroupByFunctions.add("last_not_null");
         orderedGroupByFunctions.add("string_agg");
+        orderedGroupByFunctions.add("string_distinct_agg");
         orderedGroupByFunctions.add("haversine_dist_deg");
         orderedGroupByFunctions.add("array_agg");
         orderedGroupByFunctions.add("sparkline");

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -12699,5 +12699,7 @@ public class SqlOptimiser implements Mutable {
         orderedGroupByFunctions.add("first_not_null");
         orderedGroupByFunctions.add("last");
         orderedGroupByFunctions.add("last_not_null");
+        orderedGroupByFunctions.add("string_agg");
+        orderedGroupByFunctions.add("haversine_dist_deg");
     }
 }

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -12701,5 +12701,7 @@ public class SqlOptimiser implements Mutable {
         orderedGroupByFunctions.add("last_not_null");
         orderedGroupByFunctions.add("string_agg");
         orderedGroupByFunctions.add("haversine_dist_deg");
+        orderedGroupByFunctions.add("array_agg");
+        orderedGroupByFunctions.add("sparkline");
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/OrderByAdviceTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/OrderByAdviceTest.java
@@ -32,6 +32,28 @@ import org.junit.Test;
 public class OrderByAdviceTest extends AbstractCairoTest {
 
     @Test
+    public void testArrayAggPreservesOrderByAdvice() throws Exception {
+        execute("create table nums (val double, seq int)");
+        execute("""
+                insert into nums values
+                (1.0, 1),
+                (4.0, 4),
+                (2.0, 2),
+                (3.0, 3)
+                """);
+
+        assertQuery("select array_agg(val) arr from (select * from nums order by seq)")
+                .ddl(null)
+                .noRandomAccess()
+                .expectSize()
+                .withPlanContaining("GroupBy", "Encode sort light", "keys: [seq]")
+                .returns("""
+                        arr
+                        [1.0,2.0,3.0,4.0]
+                        """);
+    }
+
+    @Test
     public void testCreateDesignatedTimestampFromMultipleOrderBy() throws Exception {
         assertQuery("select * from x order by t, a")
                 .ddl("create table x as (" +
@@ -813,6 +835,28 @@ public class OrderByAdviceTest extends AbstractCairoTest {
                         1326447242\t1970-01-01T00:00:00.006000Z
                         1548800833\t1970-01-01T00:00:00.002000Z
                         1868723706\t1970-01-01T00:00:00.008000Z
+                        """);
+    }
+
+    @Test
+    public void testSparklinePreservesOrderByAdvice() throws Exception {
+        execute("create table series (val double, seq int)");
+        execute("""
+                insert into series values
+                (0.0, 1),
+                (3.0, 4),
+                (1.0, 2),
+                (2.0, 3)
+                """);
+
+        assertQuery("select sparkline(val) spark from (select * from series order by seq)")
+                .ddl(null)
+                .noRandomAccess()
+                .expectSize()
+                .withPlanContaining("GroupBy", "Encode sort light", "keys: [seq]")
+                .returns("""
+                        spark
+                        ▁▃▅█
                         """);
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/OrderByAdviceTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/OrderByAdviceTest.java
@@ -183,6 +183,27 @@ public class OrderByAdviceTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testHaversineDistDegPreservesOrderByAdvice() throws Exception {
+        execute("create table geo (lat double, lon double, seq int, ts timestamp)");
+        execute("""
+                insert into geo values
+                (0, 0,  1, '2020-01-01T00:00:00.000000Z'),
+                (0, 30, 4, '2020-01-01T00:00:03.000000Z'),
+                (0, 10, 2, '2020-01-01T00:00:01.000000Z'),
+                (0, 20, 3, '2020-01-01T00:00:02.000000Z')
+                """);
+
+        assertQuery("select haversine_dist_deg(lat, lon, ts) d from (select * from geo order by seq)")
+                .ddl(null)
+                .noRandomAccess()
+                .expectSize()
+                .returns("""
+                        d
+                        3335.893876029014
+                        """);
+    }
+
+    @Test
     public void testNoKeyGroupBy() throws Exception {
         assertQuery("select sum(price) / count() from x where price > 0")
                 .ddl("""
@@ -791,6 +812,27 @@ public class OrderByAdviceTest extends AbstractCairoTest {
                         1326447242\t1970-01-01T00:00:00.006000Z
                         1548800833\t1970-01-01T00:00:00.002000Z
                         1868723706\t1970-01-01T00:00:00.008000Z
+                        """);
+    }
+
+    @Test
+    public void testStringAggPreservesOrderByAdvice() throws Exception {
+        execute("create table words (val string, seq int)");
+        execute("""
+                insert into words values
+                ('A', 1),
+                ('D', 4),
+                ('B', 2),
+                ('C', 3)
+                """);
+
+        assertQuery("select string_agg(val, ',') s from (select * from words order by seq)")
+                .ddl(null)
+                .noRandomAccess()
+                .expectSize()
+                .returns("""
+                        s
+                        A,B,C,D
                         """);
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/OrderByAdviceTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/OrderByAdviceTest.java
@@ -46,7 +46,7 @@ public class OrderByAdviceTest extends AbstractCairoTest {
                 .ddl(null)
                 .noRandomAccess()
                 .expectSize()
-                .withPlanContaining("GroupBy", "Encode sort light", "keys: [seq]")
+                .withPlanContaining("GroupBy", "keys: [seq]")
                 .returns("""
                         arr
                         [1.0,2.0,3.0,4.0]
@@ -219,7 +219,7 @@ public class OrderByAdviceTest extends AbstractCairoTest {
                 .ddl(null)
                 .noRandomAccess()
                 .expectSize()
-                .withPlanContaining("GroupBy", "Encode sort light", "keys: [seq]")
+                .withPlanContaining("GroupBy", "keys: [seq]")
                 .returns("""
                         d
                         3335.893876029014
@@ -853,7 +853,7 @@ public class OrderByAdviceTest extends AbstractCairoTest {
                 .ddl(null)
                 .noRandomAccess()
                 .expectSize()
-                .withPlanContaining("GroupBy", "Encode sort light", "keys: [seq]")
+                .withPlanContaining("GroupBy", "keys: [seq]")
                 .returns("""
                         spark
                         ▁▃▅█
@@ -875,10 +875,56 @@ public class OrderByAdviceTest extends AbstractCairoTest {
                 .ddl(null)
                 .noRandomAccess()
                 .expectSize()
-                .withPlanContaining("GroupBy", "Encode sort light", "keys: [seq]")
+                .withPlanContaining("GroupBy", "keys: [seq]")
                 .returns("""
                         s
                         A,B,C,D
+                        """);
+    }
+
+    @Test
+    public void testStringDistinctAggPreservesOrderByAdvice() throws Exception {
+        execute("create table words (val string, seq int)");
+        execute("""
+                insert into words values
+                ('A', 1),
+                ('D', 4),
+                ('B', 2),
+                ('C', 3),
+                ('B', 5)
+                """);
+
+        assertQuery("select string_distinct_agg(val, ',') s from (select * from words order by seq)")
+                .ddl(null)
+                .noRandomAccess()
+                .expectSize()
+                .withPlanContaining("GroupBy", "keys: [seq]")
+                .returns("""
+                        s
+                        A,B,C,D
+                        """);
+    }
+
+    @Test
+    public void testStringDistinctAggPreservesOrderByAdviceDesc() throws Exception {
+        execute("create table words (val string, seq int)");
+        execute("""
+                insert into words values
+                ('A', 1),
+                ('D', 4),
+                ('B', 2),
+                ('C', 3),
+                ('B', 5)
+                """);
+
+        assertQuery("select string_distinct_agg(val, ',') s from (select * from words order by seq desc)")
+                .ddl(null)
+                .noRandomAccess()
+                .expectSize()
+                .withPlanContaining("GroupBy", "keys: [seq desc]")
+                .returns("""
+                        s
+                        B,D,C,A
                         """);
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/OrderByAdviceTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/OrderByAdviceTest.java
@@ -197,6 +197,7 @@ public class OrderByAdviceTest extends AbstractCairoTest {
                 .ddl(null)
                 .noRandomAccess()
                 .expectSize()
+                .withPlanContaining("GroupBy", "Encode sort light", "keys: [seq]")
                 .returns("""
                         d
                         3335.893876029014
@@ -830,6 +831,7 @@ public class OrderByAdviceTest extends AbstractCairoTest {
                 .ddl(null)
                 .noRandomAccess()
                 .expectSize()
+                .withPlanContaining("GroupBy", "Encode sort light", "keys: [seq]")
                 .returns("""
                         s
                         A,B,C,D


### PR DESCRIPTION
## Summary

Make sure `string_agg`, `haversine_dist_deg`, `array_agg`, `sparkline`, and `string_distinct_agg` preserve the order

## Context

 [optimiseOrderBy](https://github.com/questdb/questdb/blob/9.4.3/core/src/main/java/io/questdb/griffin/SqlOptimiser.java#L6117) inside `SqlOptimiser` drops the ordering in sub-queries when not needed. 

Some GROUP BY functions require order though, and there's a check for that:

```java
if (model.getSelectModelType() == IQueryModel.SELECT_MODEL_GROUP_BY) {
	for (int i = 0; i < n && orderByMnemonic != OrderByMnemonic.ORDER_BY_REQUIRED; i++) {
		if (hasOrderedGroupByFunc(columns.getQuick(i).getAst())) {
			orderByMnemonic = OrderByMnemonic.ORDER_BY_REQUIRED;
			break;
		}
	}
}
```

`hasOrderedGroupByFunc` uses the following list to decide on that:
```java
static {
	orderedGroupByFunctions = new LowerCaseAsciiCharSequenceHashSet();
	orderedGroupByFunctions.add("first");
	orderedGroupByFunctions.add("first_not_null");
	orderedGroupByFunctions.add("last");
	orderedGroupByFunctions.add("last_not_null");
}
```
`string_agg`, `haversine_dist_deg`, `array_agg`, `sparkline`, and `string_distinct_agg` are missing from that list.

Example for `string_agg`:
```sql
-- Non-designated timestamp => table scans in INSERTION order
CREATE TABLE words (val STRING, seq INT, ts TIMESTAMP);                                                                         
-- Insertion order spells  A, D, B, C  (scrambled).
-- The `seq` column encodes the INTENDED order:  A, B, C, D.                                                                                           
INSERT INTO words VALUES                                                       
('A', 1, '2020-01-01T00:00:00.000000Z'),                                         
('D', 4, '2020-01-01T00:00:01.000000Z'),                                         
('B', 2, '2020-01-01T00:00:02.000000Z'),                                        
 ('C', 3, '2020-01-01T00:00:03.000000Z');

SELECT string_agg(val, ',') FROM (SELECT * FROM words ORDER BY seq);
--  returns A,D,B,C

SELECT string_agg(val, ',') FROM (SELECT * FROM words ORDER BY seq DESC);
--  also returns A,D,B,C
```

Also, `EXPLAIN` does not show any `SORT`. 
```bash
explain SELECT string_agg(val, ',') FROM (SELECT * FROM words ORDER BY seq DESC);
              QUERY PLAN              
--------------------------------------
 GroupBy vectorized: false
   values: [string_agg(val,,)]
     PageFrame
         Row forward scan
         Frame forward scan on: words
(5 rows)
```

## Changes

- Adds `string_agg` and `haversine_dist_deg` to `orderedGroupByFunctions` list