### PR TITLE
fix(qwp): fail fast on deterministic ingest rejections instead of retrying them

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoException.java
+++ b/core/src/main/java/io/questdb/cairo/CairoException.java
@@ -69,43 +69,23 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
     // literal first lets any later reword land without scattering the change.
     public static final String READ_ONLY_ACCESS_MESSAGE = "replica access is read-only";
     private static final StackTraceElement[] EMPTY_STACK_TRACE = {};
+    private static final int FLAG_AUTHORIZATION_ERROR = 1;
+    private static final int FLAG_CACHEABLE = 1 << 1;
+    private static final int FLAG_CANCELLATION = 1 << 2; // query was explicitly cancelled by the user
+    private static final int FLAG_HOUSEKEEPING = 1 << 3;
+    private static final int FLAG_INTERRUPTION = 1 << 4; // query timed out
+    private static final int FLAG_OUT_OF_MEMORY = 1 << 5;
+    private static final int FLAG_PREFERENCES_OUT_OF_DATE_ERROR = 1 << 6;
+    private static final int FLAG_READ_ONLY_ACCESS_REFUSAL = 1 << 7;
+    private static final int FLAG_SCHEMA_MISMATCH = 1 << 8;
     protected final StringSink message = new StringSink();
     protected final StringSink nativeBacktrace = new StringSink();
     protected int errno;
-    private boolean authorizationError = false;
-    private boolean cacheable;
-    private boolean cancellation; // when query is explicitly cancelled by user
-    private boolean housekeeping;
-    private boolean interruption; // used when a query times out
+    private int flags;
     private int messagePosition;
-    private boolean outOfMemory;
-    private boolean preferencesOutOfDateError = false;
-    private boolean readOnlyAccessRefusal = false;
 
     public static CairoException authorization() {
         return nonCritical().setAuthorizationError();
-    }
-
-    /**
-     * A write refused BECAUSE the node is read-only -- statically
-     * ({@code readonly=true} in the server configuration) or dynamically (the
-     * role-derived read-only of an enterprise replica, including a demote in
-     * flight). Carries the authorization flag, the canonical
-     * {@link #READ_ONLY_ACCESS_MESSAGE} and the read-only-refusal marker
-     * ({@link #isReadOnlyAccessRefusal()}) in lockstep, so the refusal's CAUSE
-     * travels with the exception.
-     * <p>
-     * Protocol layers that must tell a transient role-demote refusal apart from
-     * a genuine ACL denial (e.g. the QWP NACK classification) key on the marker.
-     * They must NOT re-read live engine state at catch time -- that races with a
-     * demote revert (the drain-timeout PRIMARY restore can land between the
-     * throw and the catch; nothing fences the propagation) -- and must NOT match
-     * the message text, which is brittle. Every "node is read-only" refusal site
-     * uses this factory so the marker is correct by construction; sites must not
-     * hand-roll {@code authorization().put(READ_ONLY_ACCESS_MESSAGE)}.
-     */
-    public static CairoException readOnlyAccess() {
-        return authorization().setReadOnlyAccessRefusal().put(READ_ONLY_ACCESS_MESSAGE);
     }
 
     public static CairoException critical(int errno) {
@@ -216,6 +196,44 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
         return nonCritical().put("timeout, query aborted").setInterruption(true);
     }
 
+    /**
+     * A write refused BECAUSE the node is read-only -- statically
+     * ({@code readonly=true} in the server configuration) or dynamically (the
+     * role-derived read-only of an enterprise replica, including a demote in
+     * flight). Carries the authorization flag, the canonical
+     * {@link #READ_ONLY_ACCESS_MESSAGE} and the read-only-refusal marker
+     * ({@link #isReadOnlyAccessRefusal()}) in lockstep, so the refusal's CAUSE
+     * travels with the exception.
+     * <p>
+     * Protocol layers that must tell a transient role-demote refusal apart from
+     * a genuine ACL denial (e.g. the QWP NACK classification) key on the marker.
+     * They must NOT re-read live engine state at catch time -- that races with a
+     * demote revert (the drain-timeout PRIMARY restore can land between the
+     * throw and the catch; nothing fences the propagation) -- and must NOT match
+     * the message text, which is brittle. Every "node is read-only" refusal site
+     * uses this factory so the marker is correct by construction; sites must not
+     * hand-roll {@code authorization().put(READ_ONLY_ACCESS_MESSAGE)}.
+     */
+    public static CairoException readOnlyAccess() {
+        return authorization().setReadOnlyAccessRefusal().put(READ_ONLY_ACCESS_MESSAGE);
+    }
+
+    /**
+     * A non-critical error raised BECAUSE the wire value's type, shape or
+     * precision is fundamentally incompatible with the target column (e.g.
+     * an unsupported type coercion or a geohash precision mismatch). The
+     * refusal is DETERMINISTIC under byte-identical replay -- the same bytes
+     * produce the same rejection every time -- so protocol layers that must
+     * tell a permanent data error apart from a transient write refusal (the
+     * QWP NACK classification) key on {@link #isSchemaMismatch()} to reject
+     * it terminally instead of retrying. Every such site uses this factory so
+     * the marker is correct by construction; callers must not re-derive the
+     * distinction from message text.
+     */
+    public static CairoException schemaMismatch() {
+        return nonCritical().setSchemaMismatch();
+    }
+
     public static CairoException sequencerMetadataOpenFailed(TableToken tableToken, int causeErrno, CharSequence causeMessage) {
         return critical(SEQUENCER_METADATA_OPEN_FAILED)
                 .put("could not open sequencer metadata [table=").put(tableToken)
@@ -290,7 +308,7 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
     }
 
     public boolean isAuthorizationError() {
-        return authorizationError;
+        return (flags & FLAG_AUTHORIZATION_ERROR) != 0;
     }
 
     public boolean isBlockApplyError() {
@@ -298,11 +316,11 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
     }
 
     public boolean isCacheable() {
-        return cacheable;
+        return (flags & FLAG_CACHEABLE) != 0;
     }
 
     public boolean isCancellation() {
-        return cancellation;
+        return (flags & FLAG_CANCELLATION) != 0;
     }
 
     public boolean isCritical() {
@@ -325,11 +343,11 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
     }
 
     public boolean isHousekeeping() {
-        return housekeeping;
+        return (flags & FLAG_HOUSEKEEPING) != 0;
     }
 
     public boolean isInterruption() {
-        return interruption;
+        return (flags & FLAG_INTERRUPTION) != 0;
     }
 
     public boolean isMetadataValidation() {
@@ -343,7 +361,11 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
     }
 
     public boolean isOutOfMemory() {
-        return outOfMemory;
+        return (flags & FLAG_OUT_OF_MEMORY) != 0;
+    }
+
+    public boolean isPreferencesOutOfDateError() {
+        return (flags & FLAG_PREFERENCES_OUT_OF_DATE_ERROR) != 0;
     }
 
     /**
@@ -352,11 +374,16 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
      * for genuine ACL denials.
      */
     public boolean isReadOnlyAccessRefusal() {
-        return readOnlyAccessRefusal;
+        return (flags & FLAG_READ_ONLY_ACCESS_REFUSAL) != 0;
     }
 
-    public boolean isPreferencesOutOfDateError() {
-        return preferencesOutOfDateError;
+    /**
+     * Whether this refusal is a deterministic wire-value/column-type mismatch
+     * (set only by {@link #schemaMismatch()}). Implies the error is
+     * non-critical and permanent -- replay of the same bytes cannot succeed.
+     */
+    public boolean isSchemaMismatch() {
+        return (flags & FLAG_SCHEMA_MISMATCH) != 0;
     }
 
     public boolean isSequencerMetadataOpenFailed() {
@@ -426,26 +453,26 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
     }
 
     public CairoException setCacheable(boolean cacheable) {
-        this.cacheable = cacheable;
+        setFlag(FLAG_CACHEABLE, cacheable);
         return this;
     }
 
     public CairoException setCancellation(boolean cancellation) {
-        this.cancellation = cancellation;
+        setFlag(FLAG_CANCELLATION, cancellation);
         return this;
     }
 
     public void setHousekeeping(boolean housekeeping) {
-        this.housekeeping = housekeeping;
+        setFlag(FLAG_HOUSEKEEPING, housekeeping);
     }
 
     public CairoException setInterruption(boolean interruption) {
-        this.interruption = interruption;
+        setFlag(FLAG_INTERRUPTION, interruption);
         return this;
     }
 
     public CairoException setOutOfMemory(boolean outOfMemory) {
-        this.outOfMemory = outOfMemory;
+        setFlag(FLAG_OUT_OF_MEMORY, outOfMemory);
         return this;
     }
 
@@ -494,17 +521,30 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
     }
 
     private CairoException setAuthorizationError() {
-        this.authorizationError = true;
+        this.flags |= FLAG_AUTHORIZATION_ERROR;
+        return this;
+    }
+
+    private void setFlag(int flag, boolean value) {
+        if (value) {
+            this.flags |= flag;
+        } else {
+            this.flags &= ~flag;
+        }
+    }
+
+    private CairoException setPreferencesOutOfDateError() {
+        this.flags |= FLAG_PREFERENCES_OUT_OF_DATE_ERROR;
         return this;
     }
 
     private CairoException setReadOnlyAccessRefusal() {
-        this.readOnlyAccessRefusal = true;
+        this.flags |= FLAG_READ_ONLY_ACCESS_REFUSAL;
         return this;
     }
 
-    private CairoException setPreferencesOutOfDateError() {
-        this.preferencesOutOfDateError = true;
+    private CairoException setSchemaMismatch() {
+        this.flags |= FLAG_SCHEMA_MISMATCH;
         return this;
     }
 
@@ -512,19 +552,12 @@ public class CairoException extends RuntimeException implements Sinkable, Flywei
         message.clear();
         nativeBacktrace.clear();
         this.errno = errno;
-        cacheable = false;
-        interruption = false;
         // clear() fully resets state so the instance starts from a clean slate. The base
-        // CairoException.instance() allocates a fresh object every call, so for it these flag resets
+        // CairoException.instance() allocates a fresh object every call, so for it these resets
         // are belt-and-suspenders. They are load-bearing for subclasses that still recycle a pooled
         // flyweight through this method (e.g. LineProtocolException via ThreadLocal): without a full
         // reset a stale flag would leak onto the next exception built on the same flyweight.
-        cancellation = false;
-        preferencesOutOfDateError = false;
-        authorizationError = false;
-        readOnlyAccessRefusal = false;
+        flags = 0;
         messagePosition = 0;
-        outOfMemory = false;
-        housekeeping = false;
     }
 }

--- a/core/src/main/java/io/questdb/cairo/wal/WalColumnarRowAppender.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalColumnarRowAppender.java
@@ -893,7 +893,7 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
                         putFloatToDecimal256Loop(dataMem, cursor, rowCount, columnType, columnPrecision, columnScale, columnIndex);
             }
         } catch (QwpParseException e) {
-            throw CairoException.nonCritical().put("failed to convert float column to decimal");
+            throw CairoException.schemaMismatch().put("failed to convert float column to decimal");
         }
         walWriter.setRowValueNotNullColumnar(columnIndex, startRowId + rowCount - 1);
     }
@@ -1257,22 +1257,14 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
                     } else if (b == '0') {
                         dataMem.putByte((byte) 0);
                     } else {
-                        throw CairoException.nonCritical()
-                                .put("cannot parse boolean from string [value=")
-                                .put(value)
-                                .put(", column=").put(walWriter.getMetadata().getColumnName(columnIndex))
-                                .put(']');
+                        throw stringParseError("boolean", value, columnIndex);
                     }
                 } else if (size == 4 && Utf8s.equalsIgnoreCaseAscii("true", value)) {
                     dataMem.putByte((byte) 1);
                 } else if (size == 5 && Utf8s.equalsIgnoreCaseAscii("false", value)) {
                     dataMem.putByte((byte) 0);
                 } else {
-                    throw CairoException.nonCritical()
-                            .put("cannot parse boolean from string [value=")
-                            .put(value)
-                            .put(", column=").put(walWriter.getMetadata().getColumnName(columnIndex))
-                            .put(']');
+                    throw stringParseError("boolean", value, columnIndex);
                 }
             }
         }
@@ -1395,11 +1387,7 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
                 DirectUtf8Sequence value = cursor.getUtf8Value();
                 Long256Impl result = Numbers.parseLong256(value, long256);
                 if (Long256Impl.isNull(result)) {
-                    throw CairoException.nonCritical()
-                            .put("cannot parse long256 from string [value=")
-                            .put(value)
-                            .put(", column=").put(walWriter.getMetadata().getColumnName(columnIndex))
-                            .put(']');
+                    throw stringParseError("long256", value, columnIndex);
                 }
                 dataMem.putLong256(result.getLong0(), result.getLong1(), result.getLong2(), result.getLong3());
             }
@@ -1567,7 +1555,7 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
                     long micros = MicrosFormatUtils.parseTimestamp(value.asAsciiCharSequence());
                     if (columnIsNanos) {
                         if (micros > Long.MAX_VALUE / 1000 || micros < Long.MIN_VALUE / 1000) {
-                            throw CairoException.nonCritical()
+                            throw CairoException.schemaMismatch()
                                     .put("timestamp overflow converting micros to nanos: ").put(micros);
                         }
                         dataMem.putLong(micros * 1000);
@@ -1575,11 +1563,7 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
                         dataMem.putLong(micros);
                     }
                 } catch (NumericException e) {
-                    throw CairoException.nonCritical()
-                            .put("cannot parse timestamp from string [value=")
-                            .put(value)
-                            .put(", column=").put(walWriter.getMetadata().getColumnName(columnIndex))
-                            .put(']');
+                    throw stringParseError("timestamp", value, columnIndex);
                 }
             }
         }
@@ -1604,11 +1588,7 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
                     long hi = Uuid.parseHi(value, 0);
                     dataMem.putLong128(lo, hi);
                 } catch (NumericException e) {
-                    throw CairoException.nonCritical()
-                            .put("cannot parse UUID from string [value=")
-                            .put(value)
-                            .put(", column=").put(walWriter.getMetadata().getColumnName(columnIndex))
-                            .put(']');
+                    throw stringParseError("UUID", value, columnIndex);
                 }
             }
         }
@@ -1844,7 +1824,7 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
                 } else if (!wireIsNanos && columnIsNanos) {
                     // Wire is micros, column is nanos: multiply by 1000
                     if (timestamp > Long.MAX_VALUE / 1000 || timestamp < Long.MIN_VALUE / 1000) {
-                        throw CairoException.nonCritical()
+                        throw CairoException.schemaMismatch()
                                 .put("timestamp overflow converting micros to nanos: ").put(timestamp);
                     }
                     timestamp = timestamp * 1000;
@@ -1979,7 +1959,7 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
     private long checkDoubleToInteger(double value, int columnIndex, int columnType) {
         long longValue = (long) value;
         if ((double) longValue != value) {
-            throw CairoException.nonCritical()
+            throw CairoException.schemaMismatch()
                     .put("double value ").put(value)
                     .put(" loses precision when converted to ")
                     .put(ColumnType.nameOf(columnType))
@@ -1997,7 +1977,7 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
 
     private void checkIntegerRange(long value, long min, long max, int columnIndex, int columnType) {
         if (value < min || value > max) {
-            throw CairoException.nonCritical()
+            throw CairoException.schemaMismatch()
                     .put("integer value ").put(value)
                     .put(" out of range for ").put(ColumnType.nameOf(columnType))
                     .put(" [column=").put(walWriter.getMetadata().getColumnName(columnIndex))
@@ -2008,7 +1988,7 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
     }
 
     private CairoException doubleToDecimalConversionError(double value, int columnType, int columnIndex, int columnScale) {
-        return CairoException.nonCritical()
+        return CairoException.schemaMismatch()
                 .put("double value ").put(value)
                 .put(" cannot be converted to ")
                 .put(ColumnType.nameOf(columnType))
@@ -2017,10 +1997,13 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
                 .put(']');
     }
 
-    private CairoException geoHashParseError(DirectUtf8Sequence value, int columnIndex) {
-        return CairoException.nonCritical()
-                .put("cannot parse geohash from string [value=")
-                .put(value)
+    private QwpParseException geoHashParseError(DirectUtf8Sequence value, int columnIndex) {
+        return stringParseError("geohash", value, columnIndex);
+    }
+
+    private QwpParseException stringParseError(CharSequence typeName, DirectUtf8Sequence value, int columnIndex) {
+        return QwpParseException.instance(QwpParseException.ErrorCode.SCHEMA_MISMATCH)
+                .put("cannot parse ").put(typeName).put(" from string [value=").put(value)
                 .put(", column=").put(walWriter.getMetadata().getColumnName(columnIndex))
                 .put(']');
     }
@@ -2464,16 +2447,12 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
         }
     }
 
-    private CairoException stringToDecimalConversionError(DirectUtf8Sequence value, int columnIndex) {
-        return CairoException.nonCritical()
-                .put("cannot parse decimal from string [value=")
-                .put(value)
-                .put(", column=").put(walWriter.getMetadata().getColumnName(columnIndex))
-                .put(']');
+    private QwpParseException stringToDecimalConversionError(DirectUtf8Sequence value, int columnIndex) {
+        return stringParseError("decimal", value, columnIndex);
     }
 
     private void throwDecimalOverflow(Decimal256 decimal, int columnType, int columnIndex) {
-        throw CairoException.nonCritical()
+        throw CairoException.schemaMismatch()
                 .put("decimal value overflows ")
                 .put(ColumnType.nameOf(columnType))
                 .put(" [column=").put(walWriter.getMetadata().getColumnName(columnIndex))
@@ -2482,7 +2461,7 @@ public class WalColumnarRowAppender implements ColumnarRowAppender, QuietCloseab
     }
 
     private void throwDecimalPrecisionLoss(Decimal256 decimal, int columnType, int columnIndex) {
-        throw CairoException.nonCritical()
+        throw CairoException.schemaMismatch()
                 .put("decimal value causes precision loss converting to ")
                 .put(ColumnType.nameOf(columnType))
                 .put(" [column=").put(walWriter.getMetadata().getColumnName(columnIndex))

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
@@ -122,7 +122,7 @@ public class QwpWalAppender implements QuietCloseable {
             case TYPE_GEOHASH -> ColumnType.GEOLONG; // Default to GEOLONG, precision handled separately
             case TYPE_DOUBLE_ARRAY -> ColumnType.encodeArrayTypeWithWeakDims(ColumnType.DOUBLE, false);
             case TYPE_LONG_ARRAY ->
-                    throw CairoException.nonCritical().put("long arrays are not supported, only double arrays");
+                    throw CairoException.schemaMismatch().put("long arrays are not supported, only double arrays");
             case TYPE_DECIMAL64 -> ColumnType.DECIMAL64;
             case TYPE_DECIMAL128 -> ColumnType.DECIMAL128;
             case TYPE_DECIMAL256 -> ColumnType.DECIMAL256;
@@ -224,7 +224,7 @@ public class QwpWalAppender implements QuietCloseable {
             if (batchDims == -1) {
                 batchDims = rowDims;
             } else if (batchDims != rowDims) {
-                throw CairoException.nonCritical()
+                throw CairoException.schemaMismatch()
                         .put("array dimensionality mismatch in QWP batch [column=")
                         .put(tableBlock.getColumnDef(colIndex).getName())
                         .put(", expectedDims=")
@@ -364,7 +364,7 @@ public class QwpWalAppender implements QuietCloseable {
         final int existingDims = ColumnType.decodeWeakArrayDimensionality(columnType);
         assert existingDims != -1 : "weak array dimensionality must not be persisted";
         if (existingDims != batchDims) {
-            throw CairoException.nonCritical()
+            throw CairoException.schemaMismatch()
                     .put("array dimensionality mismatch [column=")
                     .put(columnName)
                     .put(", expected=")
@@ -449,7 +449,7 @@ public class QwpWalAppender implements QuietCloseable {
                             ts = ts / 1000;
                         } else if (needsMicrosToNanos) {
                             if (ts > Long.MAX_VALUE / 1000 || ts < Long.MIN_VALUE / 1000) {
-                                throw CairoException.nonCritical()
+                                throw CairoException.schemaMismatch()
                                         .put("timestamp overflow converting micros to nanos: ").put(ts);
                             }
                             ts = ts * 1000;
@@ -967,7 +967,7 @@ public class QwpWalAppender implements QuietCloseable {
 
             if (columnName.isEmpty() && (colType == TYPE_TIMESTAMP || colType == TYPE_TIMESTAMP_NANOS)) {
                 if (timestampIndex < 0) {
-                    throw CairoException.nonCritical()
+                    throw CairoException.schemaMismatch()
                             .put("designated timestamp provided but table has no designated timestamp [table=")
                             .put(tud.getTableNameUtf16())
                             .put(']');
@@ -1002,14 +1002,14 @@ public class QwpWalAppender implements QuietCloseable {
                             }
                         }
                     } else if (!autoCreateNewColumns) {
-                        throw CairoException.nonCritical()
+                        throw CairoException.schemaMismatch()
                                 .put("new columns not allowed [table=")
                                 .put(tud.getTableNameUtf16())
                                 .put(", column=")
                                 .put(columnName)
                                 .put(']');
                     } else {
-                        throw CairoException.nonCritical()
+                        throw CairoException.schemaMismatch()
                                 .put("invalid column name [table=")
                                 .put(tud.getTableNameUtf16())
                                 .put(", column=")

--- a/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
+++ b/core/src/main/java/io/questdb/cutlass/line/tcp/QwpWalAppender.java
@@ -183,7 +183,7 @@ public class QwpWalAppender implements QuietCloseable {
     private static CairoException coercionNotSupportedException(
             byte qwpType, int columnType, QwpTableBlockCursor tableBlock, int col
     ) {
-        return CairoException.nonCritical()
+        return CairoException.schemaMismatch()
                 .put("type coercion from ")
                 .put(QwpConstants.getTypeName(qwpType))
                 .put(" to ")
@@ -196,7 +196,7 @@ public class QwpWalAppender implements QuietCloseable {
     private static CairoException geoHashPrecisionMismatchException(
             int columnType, int wireBits, QwpTableBlockCursor tableBlock, int col
     ) {
-        return CairoException.nonCritical()
+        return CairoException.schemaMismatch()
                 .put("GeoHash precision mismatch [column=")
                 .put(tableBlock.getColumnDef(col).getName())
                 .put(", columnType=")
@@ -340,7 +340,7 @@ public class QwpWalAppender implements QuietCloseable {
     private static CairoException typeMismatchException(
             byte qwpType, int columnType, QwpTableBlockCursor tableBlock, int col
     ) {
-        return CairoException.nonCritical()
+        return CairoException.schemaMismatch()
                 .put("cannot write ")
                 .put(QwpConstants.getTypeName(qwpType))
                 .put(" to column [column=")

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -1049,6 +1049,9 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
         if (e.isAuthorizationError()) {
             return Status.SECURITY_ERROR;
         }
+        if (e.isSchemaMismatch()) {
+            return Status.SCHEMA_MISMATCH;
+        }
         return e.isCritical() ? Status.INTERNAL_ERROR : Status.NOT_ACCEPTING_WRITES;
     }
 

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpTudCache.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpTudCache.java
@@ -356,7 +356,7 @@ public class QwpTudCache implements QuietCloseable {
         }
 
         if (!engine.isWalTable(tableToken)) {
-            throw CairoException.nonCritical().put("cannot insert into non-WAL table: ").put(tableNameUtf16);
+            throw CairoException.schemaMismatch().put("cannot insert into non-WAL table: ").put(tableNameUtf16);
         }
 
         TelemetryTask.store(telemetry, TelemetryOrigin.ILP_TCP, TelemetryEvent.ILP_RESERVE_WRITER);
@@ -619,7 +619,7 @@ public class QwpTudCache implements QuietCloseable {
                 if (batchDims == -1) {
                     batchDims = rowDims;
                 } else if (batchDims != rowDims) {
-                    throw CairoException.nonCritical()
+                    throw CairoException.schemaMismatch()
                             .put("array dimensionality mismatch in QWP batch [column=")
                             .put(columnName)
                             .put(", expectedDims=")

--- a/core/src/test/java/io/questdb/test/cairo/CairoExceptionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoExceptionTest.java
@@ -106,6 +106,11 @@ public class CairoExceptionTest extends AbstractTest {
         Assert.assertTrue(ex.isOutOfMemory());
         Assert.assertTrue(ex.isSchemaMismatch());
 
+        // clearing OOM alone must leave schema-mismatch set: proves distinct bits
+        ex.setOutOfMemory(false);
+        Assert.assertFalse(ex.isOutOfMemory());
+        Assert.assertTrue(ex.isSchemaMismatch());
+
         invokeClear(ex);
         Assert.assertFalse(ex.isSchemaMismatch());
         Assert.assertFalse(ex.isOutOfMemory());

--- a/core/src/test/java/io/questdb/test/cairo/CairoExceptionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CairoExceptionTest.java
@@ -75,6 +75,44 @@ public class CairoExceptionTest extends AbstractTest {
     }
 
     @Test
+    public void testClearResetsStickySchemaMismatchFlag() throws Exception {
+        CairoException ex = CairoException.schemaMismatch().put("type coercion from VARCHAR to IPV4 is not supported");
+        Assert.assertTrue(ex.isSchemaMismatch());
+        invokeClear(ex);
+        Assert.assertFalse("clear() must reset the sticky schema-mismatch marker", ex.isSchemaMismatch());
+    }
+
+    @Test
+    public void testSchemaMismatchIsNonCriticalAndNotAuthorization() {
+        CairoException ex = CairoException.schemaMismatch();
+        Assert.assertTrue(ex.isSchemaMismatch());
+        Assert.assertFalse("schema mismatch must be non-critical", ex.isCritical());
+        Assert.assertFalse("schema mismatch must not be an authorization error", ex.isAuthorizationError());
+    }
+
+    @Test
+    public void testMarkerFlagsAreIndependent() throws Exception {
+        CairoException ex = CairoException.schemaMismatch();
+        ex.setOutOfMemory(true);
+        ex.setCacheable(true);
+        Assert.assertTrue(ex.isSchemaMismatch());
+        Assert.assertTrue(ex.isOutOfMemory());
+        Assert.assertTrue(ex.isCacheable());
+        Assert.assertFalse(ex.isCancellation());
+        Assert.assertFalse(ex.isAuthorizationError());
+
+        ex.setCacheable(false);
+        Assert.assertFalse(ex.isCacheable());
+        Assert.assertTrue(ex.isOutOfMemory());
+        Assert.assertTrue(ex.isSchemaMismatch());
+
+        invokeClear(ex);
+        Assert.assertFalse(ex.isSchemaMismatch());
+        Assert.assertFalse(ex.isOutOfMemory());
+        Assert.assertFalse(ex.isCacheable());
+    }
+
+    @Test
     public void testMatViewDoesNotExistIsNotCritical() {
         Assert.assertFalse(CairoException.matViewDoesNotExist("foo").isCritical());
     }

--- a/core/src/test/java/io/questdb/test/cairo/wal/WalColumnarRowAppenderTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/wal/WalColumnarRowAppenderTest.java
@@ -6625,8 +6625,8 @@ public class WalColumnarRowAppenderTest extends AbstractCairoTest {
                 appender.beginColumnarWrite(rowCount);
                 try {
                     appender.putStringToBooleanColumn(0, wireFormat.cursor, rowCount);
-                    fail("Expected CairoException");
-                } catch (CairoException e) {
+                    fail("Expected QwpParseException");
+                } catch (QwpParseException e) {
                     assertTrue(e.getMessage().contains("cannot parse boolean from string [value=x, column=value]"));
                 }
                 appender.cancelColumnarWrite();
@@ -6654,8 +6654,8 @@ public class WalColumnarRowAppenderTest extends AbstractCairoTest {
                 appender.beginColumnarWrite(rowCount);
                 try {
                     appender.putStringToDecimalColumn(0, wireFormat.cursor, rowCount, columnType);
-                    fail("Expected CairoException");
-                } catch (CairoException e) {
+                    fail("Expected QwpParseException");
+                } catch (QwpParseException e) {
                     assertTrue(e.getMessage().contains("cannot parse decimal from string"));
                 }
                 appender.cancelColumnarWrite();

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
@@ -661,6 +661,79 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCairoExceptionStatusReturnsSchemaMismatchForSchemaMismatchException() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+
+                Field tudCacheField = QwpIngressProcessorState.class.getDeclaredField("tudCache");
+                tudCacheField.setAccessible(true);
+                Misc.free((QwpTudCache) tudCacheField.get(state));
+                DefaultColumnTypes defaultColumnTypes = new DefaultColumnTypes(lineConfig);
+                tudCacheField.set(state, new QwpTudCache(engine, true, true, defaultColumnTypes, PartitionBy.DAY) {
+                    @Override
+                    public WalTableUpdateDetails getTableUpdateDetails(
+                            SecurityContext secCtx, Utf8Sequence tableName,
+                            ObjList<QwpColumnDef> schema, QwpTableBlockCursor cursor, int maxTables) {
+                        throw CairoException.schemaMismatch().put("type coercion from VARCHAR to IPV4 is not supported");
+                    }
+                });
+
+                addNativeData(state, wrapQwpPayload(new byte[]{
+                        4, 't', 'e', 's', 't',
+                        0,    // rowCount=0
+                        0     // columnCount=0
+                }));
+                state.processMessage();
+                Assert.assertEquals(QwpIngressProcessorState.Status.SCHEMA_MISMATCH, state.getStatus());
+                Assert.assertTrue(state.getErrorText().contains("type coercion from VARCHAR to IPV4 is not supported"));
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    @Test
+    public void testCairoExceptionStatusReturnsNotAcceptingWritesForUnmarkedNonCriticalException() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+
+                Field tudCacheField = QwpIngressProcessorState.class.getDeclaredField("tudCache");
+                tudCacheField.setAccessible(true);
+                Misc.free((QwpTudCache) tudCacheField.get(state));
+                DefaultColumnTypes defaultColumnTypes = new DefaultColumnTypes(lineConfig);
+                tudCacheField.set(state, new QwpTudCache(engine, true, true, defaultColumnTypes, PartitionBy.DAY) {
+                    @Override
+                    public WalTableUpdateDetails getTableUpdateDetails(
+                            SecurityContext secCtx, Utf8Sequence tableName,
+                            ObjList<QwpColumnDef> schema, QwpTableBlockCursor cursor, int maxTables) {
+                        throw CairoException.nonCritical().put("table is busy");
+                    }
+                });
+
+                addNativeData(state, wrapQwpPayload(new byte[]{
+                        4, 't', 'e', 's', 't',
+                        0,    // rowCount=0
+                        0     // columnCount=0
+                }));
+                state.processMessage();
+                Assert.assertEquals(QwpIngressProcessorState.Status.NOT_ACCEPTING_WRITES, state.getStatus());
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    @Test
     public void testClearFreesResourcesWhenRollbackThrows() throws Exception {
         // When tud.rollback() throws during clear(), the cache enters the
         // distressed path: it frees all TUDs without rolling back and clears

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpIngressOracleFuzzTest.java
@@ -438,19 +438,18 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testOraclePoisonRowsEscalateToPoisonTerminal() throws Exception {
+    public void testOraclePoisonRowsFailFastAsTerminal() throws Exception {
         // Pin down the per-frame error contract under NACK policy v2 (there
         // is no drop policy -- a deterministically rejected frame can never
         // be silently skipped):
         //   1. Frame-drop atomicity: a NACKed frame is atomically not
         //      applied -- no row from the poisoned chunk lands, including
         //      the well-formed rows sitting next to the bad one.
-        //   2. The rejection reaches the async SenderErrorHandler (an
-        //      informational WRITE_ERROR strike, then the poison-frame
-        //      detector's TERMINAL PROTOCOL_VIOLATION escalation --
-        //      max_frame_rejections=1 makes it immediate) and the next
-        //      producer-thread call throws the latched terminal: the stream
-        //      halts loudly, it does not drain silently.
+        //   2. The rejection reaches the async SenderErrorHandler as a
+        //      deterministic terminal SCHEMA_MISMATCH (the decimal overflow
+        //      is permanent, so the client latches TERMINAL on the first NACK,
+        //      no replay) and the next producer-thread call throws the latched
+        //      terminal: the stream halts loudly, it does not drain silently.
         //   3. Watermark purity: every row flushed before the poisoned
         //      chunk lands exactly per the oracle -- acks never cross a
         //      rejected frame, and the halt does not disturb settled data.
@@ -514,8 +513,8 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                         QwpRow row = generateRow(genRnd, id, ts);
                         if (r == badRow) {
                             // hh=1 forces the unscaled value past 2^192 ~ 6.3e57,
-                            // well past DECIMAL(50,6)'s 10^50 cap: a WRITE_ERROR
-                            // NACK deterministic under byte-identical replay.
+                            // well past DECIMAL(50,6)'s 10^50 cap: a deterministic
+                            // terminal SCHEMA_MISMATCH overflow.
                             row.setDecimal256("dec256", 1L, 0L, 0L, 0L, 6);
                         }
                         // every id of the poisoned chunk must stay absent,
@@ -552,11 +551,10 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                     final String mySfDir = sfDirs[pp];
                     producers[p] = new Thread(() -> {
                         try {
-                            // Generous error_inbox_capacity so the strike +
-                            // terminal notifications can't be dropped;
-                            // max_frame_rejections=1 escalates the first
-                            // rejection straight to the poison terminal
-                            // instead of reconnect-replaying the frame.
+                            // Generous error_inbox_capacity so the terminal
+                            // notification can't be dropped. The overflow is a
+                            // terminal SCHEMA_MISMATCH latched on the first NACK,
+                            // so the frame is never reconnect-replayed.
                             String connect = "ws::addr=localhost:" + port + ";sf_dir=" + mySfDir
                                     + ";initial_connect_retry=true"
                                     + ";reconnect_max_duration_millis=120000"
@@ -592,8 +590,8 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                                         // before flush()'s own error poll runs
                                     }
                                     SenderError terminal = terminalFut.get(120, TimeUnit.SECONDS);
-                                    if (terminal.getCategory() != SenderError.Category.PROTOCOL_VIOLATION) {
-                                        throw new AssertionError("expected PROTOCOL_VIOLATION poison terminal, got " + terminal);
+                                    if (terminal.getCategory() != SenderError.Category.SCHEMA_MISMATCH) {
+                                        throw new AssertionError("expected SCHEMA_MISMATCH terminal, got " + terminal);
                                     }
                                     String tMsg = terminal.getServerMessage();
                                     if (tMsg == null || !tMsg.contains("overflows DECIMAL(50,6)")) {
@@ -603,10 +601,10 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                                     // producer loudly on its next call
                                     try {
                                         sender.flush();
-                                        throw new AssertionError("flush() after the poison terminal latched must throw");
+                                        throw new AssertionError("flush() after the terminal latched must throw");
                                     } catch (LineSenderServerException e) {
-                                        if (e.getServerError().getCategory() != SenderError.Category.PROTOCOL_VIOLATION) {
-                                            throw new AssertionError("expected the poison terminal from flush()", e);
+                                        if (e.getServerError().getCategory() != SenderError.Category.SCHEMA_MISMATCH) {
+                                            throw new AssertionError("expected the SCHEMA_MISMATCH terminal from flush()", e);
                                         }
                                     }
                                 }
@@ -654,14 +652,14 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                 }
 
                 // (c) Async error notifications: each poisoned producer saw
-                // the informational WRITE_ERROR strike and the poison
-                // terminal (>= 2 dispatches). Inequality tolerates extra
-                // informational strikes if a chunk splits across frames.
+                // the terminal SCHEMA_MISMATCH dispatch (>= 1). The overflow
+                // is terminal on the first NACK, so there is no preceding
+                // informational retriable strike.
                 long observed = errorHandlerCalls.get();
-                if (observed < 2L * poisonedProducers) {
+                if (observed < poisonedProducers) {
                     throw new AssertionError("error handler fired " + observed
-                            + " times, expected at least " + (2L * poisonedProducers)
-                            + " (strike + terminal per poisoned producer)");
+                            + " times, expected at least " + poisonedProducers
+                            + " (terminal per poisoned producer)");
                 }
                 LOG.info().$("poison test: poisoned producers=").$(poisonedProducers)
                         .$(" handler calls=").$(observed).$();
@@ -686,7 +684,7 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                 // residue under the generous purge cap, so retention is
                 // proven functionally: a fresh sender on the same slot must
                 // recover the frame, replay it byte-identically, and latch
-                // the same deterministic poison terminal again. A client
+                // the same deterministic SCHEMA_MISMATCH terminal again. A client
                 // bug that purges the NACKed frame's slot leaves nothing to
                 // replay and times out below. Producer 0 is always
                 // poisoned, so this check fires in every run. Client-side
@@ -714,8 +712,8 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
                                 + ": the SF slot no longer holds the rejected frame -- the terminal must"
                                 + " preserve the only replayable copy on disk", e);
                     }
-                    if (replayTerminal.getCategory() != SenderError.Category.PROTOCOL_VIOLATION) {
-                        throw new AssertionError("replayed poison frame: expected PROTOCOL_VIOLATION terminal, got " + replayTerminal);
+                    if (replayTerminal.getCategory() != SenderError.Category.SCHEMA_MISMATCH) {
+                        throw new AssertionError("replayed frame: expected SCHEMA_MISMATCH terminal, got " + replayTerminal);
                     }
                     String rMsg = replayTerminal.getServerMessage();
                     if (rMsg == null || !rMsg.contains("overflows DECIMAL(50,6)")) {
@@ -1265,8 +1263,8 @@ public class QwpIngressOracleFuzzTest extends AbstractCairoTest {
         //   DECIMAL(50,6) (max ~10^50, ~167 bits) -> hh=0, hl up to ~10^10
         //                                            plus full 64-bit lh, ll
         // The server rejects out-of-range values per binary frame with a
-        // WRITE_ERROR NACK; testOraclePoisonRowsEscalateToPoisonTerminal
-        // pins the client-side escalation contract.
+        // terminal SCHEMA_MISMATCH NACK; testOraclePoisonRowsFailFastAsTerminal
+        // pins the client-side fail-fast contract.
         if (!shouldFuzz(rnd, COLUMN_SKIP_FACTOR)) {
             setSignedDecimal64(row, "dec64", id * 10_000_007L + 13L, 3, rnd.nextBoolean());
         }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -1241,6 +1241,14 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
                         s.table(t).uuidColumn("v", uuid.getLeastSignificantBits(), uuid.getMostSignificantBits()).at(1_000_000, ChronoUnit.MICROS);
                     },
                     "cannot write UUID", "DECIMAL");
+            // A value whose precision exceeds the column's is a deterministic overflow.
+            assertCoercionError(port, table,
+                    (s, t) -> s.table(t).decimalColumn("v", Decimal64.fromLong(1000, 1)).at(1_000_000, ChronoUnit.MICROS),
+                    "decimal value overflows", "column=v");
+            // A value with more scale than the column cannot rescale without loss.
+            assertCoercionError(port, table,
+                    (s, t) -> s.table(t).decimalColumn("v", Decimal64.fromLong(15, 2)).at(1_000_000, ChronoUnit.MICROS),
+                    "decimal value causes precision loss", "column=v");
         });
     }
 
@@ -1458,6 +1466,18 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             assertCoercionError(port, "test_da_from_str",
                     (s, t) -> s.table(t).stringColumn("v", "not an array").at(1_000_000, ChronoUnit.MICROS),
                     "cannot write VARCHAR", "DOUBLE[]");
+        });
+    }
+
+    @Test
+    public void testArrayDimensionalityMismatchRejected() throws Exception {
+        runInContext((port) -> {
+            String table = "test_qwp_arr_dim_err";
+            execute("CREATE TABLE " + table + " (v DOUBLE[], ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            // The column is 1-D; a 2-D array is a deterministic dimensionality mismatch.
+            assertCoercionError(port, table,
+                    (s, t) -> s.table(t).doubleArray("v", new double[][]{{1.0, 2.0}, {3.0, 4.0}}).at(1_000_000, ChronoUnit.MICROS),
+                    "array dimensionality mismatch", "column=v");
         });
     }
 
@@ -4824,22 +4844,11 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             java.util.function.BiConsumer<QwpWebSocketSender, String> sendAction,
             String expectedMsgPart1, String expectedMsgPart2
     ) {
-        // NACK policy v2 (java-questdb-client): there is no drop policy.
-        // Server-side rejections end in a latched terminal instead of a
-        // silently discarded batch:
-        //   - WRITE_ERROR is RETRIABLE -- the client dispatches each strike
-        //     to the error handler informationally and replays the frame; a
-        //     rejection that is deterministic under byte-identical replay
-        //     escalates to a TERMINAL PROTOCOL_VIOLATION through the
-        //     poison-frame detector after max_frame_rejections consecutive
-        //     strikes on the same head frame with no ack progress. We pin
-        //     max_frame_rejections=1 so the escalation is immediate.
-        //   - SCHEMA_MISMATCH is deterministic by definition and latches
-        //     TERMINAL on the first strike, no replay.
-        // Either way we assert both observables: the first handler dispatch
-        // carries the server's rejection message, and the latched terminal
-        // surfaces loudly -- through the handler or, when the producer
-        // thread's error poll wins the race, from flush()/close() (close()
+        // A deterministic wire-value/column-type mismatch is a terminal SCHEMA_MISMATCH:
+        // the client latches TERMINAL on the first strike, no replay. We assert both
+        // observables: the first handler dispatch carries the server's rejection message,
+        // and the latched terminal surfaces loudly -- through the handler or, when the
+        // producer thread's error poll wins the race, from flush()/close() (close()
         // suppresses the double-signal once the handler owns the terminal).
         CompletableFuture<SenderError> firstErrFut = new CompletableFuture<>();
         CompletableFuture<SenderError> terminalFut = new CompletableFuture<>();
@@ -4868,15 +4877,12 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
             } catch (Exception e) {
                 throw new AssertionError("Did not receive a SenderError within 10s for table " + table, e);
             }
-            SenderError.Category terminalCategory;
-            if (err.getCategory() == SenderError.Category.WRITE_ERROR) {
-                Assert.assertSame(SenderError.Policy.RETRIABLE, err.getAppliedPolicy());
-                terminalCategory = SenderError.Category.PROTOCOL_VIOLATION;
-            } else {
-                Assert.assertSame(SenderError.Category.SCHEMA_MISMATCH, err.getCategory());
-                Assert.assertSame(SenderError.Policy.TERMINAL, err.getAppliedPolicy());
-                terminalCategory = SenderError.Category.SCHEMA_MISMATCH;
-            }
+            Assert.assertSame(
+                    "coercion/type/value-conversion rejects must be a deterministic terminal"
+                            + " SCHEMA_MISMATCH, not a retriable WRITE_ERROR",
+                    SenderError.Category.SCHEMA_MISMATCH, err.getCategory());
+            Assert.assertSame(SenderError.Policy.TERMINAL, err.getAppliedPolicy());
+            SenderError.Category terminalCategory = SenderError.Category.SCHEMA_MISMATCH;
             if (publishedFsn >= 0) {
                 Assert.assertTrue("error fsn span [" + err.getFromFsn() + ',' + err.getToFsn()
                                 + "] should cover published " + publishedFsn,

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpSenderE2ETest.java
@@ -1482,6 +1482,36 @@ public class QwpSenderE2ETest extends AbstractQwpWebSocketTest {
     }
 
     @Test
+    public void testArrayBatchDimensionalityMismatchRejected() throws Exception {
+        runInContext((port) -> {
+            // Rows with differing array dimensionality in one flush hit the within-batch
+            // getArrayBatchDimensionality guard, not the single-row validateArrayColumnType
+            // guard that testArrayDimensionalityMismatchRejected covers. The guard lives at
+            // two sites; which one throws depends on whether the target table exists.
+
+            // Existing table: QwpWalAppender scans the batch during WAL append.
+            String existing = "test_qwp_arr_batch_dim_existing";
+            execute("CREATE TABLE " + existing + " (v DOUBLE[], ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            assertCoercionError(port, existing,
+                    (s, t) -> {
+                        s.table(t).doubleArray("v", new double[]{1.0, 2.0}).at(1_000_000, ChronoUnit.MICROS);
+                        s.table(t).doubleArray("v", new double[][]{{3.0, 4.0}}).at(2_000_000, ChronoUnit.MICROS);
+                    },
+                    "array dimensionality mismatch in QWP batch", "column=v");
+
+            // Non-existent table: QwpTudCache scans the batch while resolving the
+            // auto-created table structure.
+            String autoCreate = "test_qwp_arr_batch_dim_autocreate";
+            assertCoercionError(port, autoCreate,
+                    (s, t) -> {
+                        s.table(t).doubleArray("v", new double[]{1.0, 2.0}).at(1_000_000, ChronoUnit.MICROS);
+                        s.table(t).doubleArray("v", new double[][]{{3.0, 4.0}}).at(2_000_000, ChronoUnit.MICROS);
+                    },
+                    "array dimensionality mismatch in QWP batch", "column=v");
+        });
+    }
+
+    @Test
     public void testCoercionToDoubleErrors() throws Exception {
         runInContext((port) -> {
             String table = "test_qwp_coerce_double_err";

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderReceiverTest.java
@@ -3218,16 +3218,12 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
                     .noLeakCheck()
                     .returnsOnce("walEnabled\nfalse\n");
 
-            // Try to write to the non-WAL table via QWP. NACK policy v2:
-            // the server rejects with WRITE_ERROR, which is RETRIABLE -- the
-            // client dispatches the strike to the error handler
-            // informationally and replays the frame; the rejection is
-            // deterministic under byte-identical replay, so the poison-frame
-            // detector escalates it to a latched TERMINAL PROTOCOL_VIOLATION
-            // (max_frame_rejections=1 makes the escalation immediate). Block
-            // on the async error handler for deterministic delivery of the
-            // rejection, then expect the latched terminal to surface loudly
-            // on close.
+            // Try to write to the non-WAL table via QWP. ILP/QWP can only write
+            // WAL tables and a non-WAL table won't become writable by replaying
+            // the same frame, so the rejection is a deterministic terminal
+            // SCHEMA_MISMATCH -- the client latches TERMINAL on the first strike,
+            // no replay. Block on the async error handler for deterministic
+            // delivery, then expect the latched terminal to surface on close.
             CompletableFuture<SenderError> firstErrFut = new CompletableFuture<>();
             CompletableFuture<SenderError> terminalFut = new CompletableFuture<>();
             QwpWebSocketSender sender = connectWs(port, err -> {
@@ -3250,9 +3246,9 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
                 }
 
                 SenderError err = firstErrFut.get(10, TimeUnit.SECONDS);
-                Assert.assertEquals(SenderError.Category.WRITE_ERROR, err.getCategory());
-                Assert.assertSame(SenderError.Policy.RETRIABLE, err.getAppliedPolicy());
-                expectedTerminalCategory = SenderError.Category.PROTOCOL_VIOLATION;
+                Assert.assertEquals(SenderError.Category.SCHEMA_MISMATCH, err.getCategory());
+                Assert.assertSame(SenderError.Policy.TERMINAL, err.getAppliedPolicy());
+                expectedTerminalCategory = SenderError.Category.SCHEMA_MISMATCH;
             } finally {
                 assertRejectionTerminalOnClose(sender, terminalFut, expectedTerminalCategory,
                         "cannot insert into non-WAL table", "non_wal_table");


### PR DESCRIPTION
## The problem

When a QWP/WebSocket client sends data that a QuestDB table can **never** accept — a value that can't be converted to the column type, an array with the wrong shape, a column the schema forbids — the server rejected the frame during WAL append, but reported the rejection as a **transient** `WRITE_ERROR`.

`WRITE_ERROR` is a *retriable* policy on the client — it exists for genuinely transient conditions like disk pressure or a suspended table, and nothing in the status byte lets the client tell a permanent error apart from a transient one. So the store-and-forward client replayed the byte-identical frame up to `max_frame_rejections` times before giving up.

Net effect for a **permanent, deterministic** data error (e.g. `type coercion from VARCHAR to IPV4 is not supported`): several wasted reconnect/replay cycles for a frame that can never succeed, and the failure surfaces only after the retries instead of on the first NACK.

### Root cause

`QwpIngressProcessorState.cairoExceptionStatus` split errors coarsely: `authorization → SECURITY_ERROR`, `critical → INTERNAL_ERROR`, and **everything else → the retriable `WRITE_ERROR`**. That last bucket lumped together two very different things the client can't tell apart from the status byte:

- deterministic data/schema rejections that will fail identically on every replay, and
- genuinely transient write refusals that a retry can clear.

## The fix

Introduce a `CairoException.schemaMismatch()` marker (following the existing `authorization()` / `readOnlyAccess()` marker convention) and stamp it on the QWP-ingest error sites that are **deterministic under byte-identical replay**. `cairoExceptionStatus` maps the marker to a terminal `SCHEMA_MISMATCH`, so the client fails fast on the first NACK — zero wasted retries — and surfaces the server's real reason. String-parse failures reuse the existing `QwpParseException(SCHEMA_MISMATCH)` path (the same mechanism `numericParseError` already used).

### Now terminal (fail fast, reason preserved)

Type / structure mismatches — `QwpWalAppender`:
- unsupported type coercion (e.g. `VARCHAR → IPV4`), `cannot write X to column`, geohash precision mismatch
- long-array unsupported, array dimensionality mismatch
- designated-timestamp mismatch, new-columns-not-allowed, invalid-column-name

Value conversions — `WalColumnarRowAppender`:
- numeric precision loss (`DOUBLE 3.14 → INT`) and range overflow (`LONG → INT`)
- timestamp `micros → nanos` overflow
- decimal overflow / precision loss / value-cannot-be-converted
- string-parse failures: boolean, long256, timestamp, uuid, geohash, decimal (numeric already terminal)

Table target — `QwpTudCache`:
- write to a non-WAL table (ILP/QWP can only write WAL tables; a non-WAL table won't become writable on replay)
- batch array-dimensionality mismatch

### Deliberately still retriable `WRITE_ERROR`

The change is **surgical** — genuinely transient and forward-compat errors keep the retriable default, so at-least-once delivery on recoverable hiccups is unchanged:
- `metadata changed too many times` (concurrent ALTER exhausted its retry budget)
- `writer is null` (table busy / locked)
- `unknown QWP wire type` (a newer client against an older server — degrade to retry, not a dead sender)

The status byte also stays honest for the retriable/terminal split; the terminal data errors carry the server's message either way.

## Incidental: `CairoException` refactor

`CairoException`'s boolean marker fields are packed into a single `int flags` bitmask. Behavior-preserving (public getters/setters unchanged); its value is that `clear()` — load-bearing for the pooled flyweight subclasses — collapses to `flags = 0`, so adding a marker can no longer forget a per-field reset.

## Testing

- **Unit**: `CairoExceptionTest` (marker set/reset + flag independence) and `QwpIngressProcessorStateTest` (a `schemaMismatch()` exception → terminal `SCHEMA_MISMATCH` with the reason preserved; an *unmarked* non-critical exception stays retriable `NOT_ACCEPTING_WRITES`).
- **E2E**: `assertCoercionError` is tightened to strictly assert terminal `SCHEMA_MISMATCH` — turning the ~50 coercion/type/value-conversion cases into real regression guards — plus new cases for decimal overflow / precision loss and array-dimensionality mismatch, and `testNonWalTableRejected` updated for the non-WAL flip.
- Every new trigger was verified against a live server to produce a terminal rejection carrying the exact asserted message (e.g. `decimal value overflows DECIMAL(2,1) [column=v, decimal=100.0]`, `array dimensionality mismatch [column=v, expected=DOUBLE[], actual=DOUBLE[][]]`).

