### PR TITLE
test(griffin): speed up recently-added slow tests

### DIFF
--- a/core/src/test/java/io/questdb/test/griffin/JoinMemoryTrackerTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/JoinMemoryTrackerTest.java
@@ -79,8 +79,8 @@ public class JoinMemoryTrackerTest extends AbstractCairoTest {
         // asof_dense + multi-key routes to AsOfJoinDenseRecordCursorFactory. Its scan maps memorize every
         // distinct join key (no eviction without TOLERANCE), so a high-cardinality join grows them past the limit.
         assertMemoryLeak(() -> {
-            execute("CREATE TABLE m AS (SELECT cast(x AS SYMBOL) k1, cast(x AS SYMBOL) k2, (x * 1_000_000L)::timestamp ts FROM long_sequence(100_000)) TIMESTAMP(ts) PARTITION BY DAY");
-            execute("CREATE TABLE s AS (SELECT cast(x AS SYMBOL) k1, cast(x AS SYMBOL) k2, (x * 1_000_000L)::timestamp ts FROM long_sequence(100_000)) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE m AS (SELECT cast(x AS SYMBOL) k1, cast(x AS SYMBOL) k2, (x * 1_000_000L)::timestamp ts FROM long_sequence(40_000)) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE s AS (SELECT cast(x AS SYMBOL) k1, cast(x AS SYMBOL) k2, (x * 1_000_000L)::timestamp ts FROM long_sequence(40_000)) TIMESTAMP(ts) PARTITION BY DAY");
             drainWalQueue();
             final String sql = "SELECT /*+ asof_dense(m s) */ m.k1 FROM m ASOF JOIN s ON (m.k1 = s.k1 AND m.k2 = s.k2)";
             assertUsesFactory(sql, AsOfJoinDenseRecordCursorFactory.class);
@@ -136,8 +136,8 @@ public class JoinMemoryTrackerTest extends AbstractCairoTest {
         // asof_dense + single SYMBOL routes to AsOfJoinDenseSingleSymbolRecordCursorFactory (no sinks; scan
         // maps bound via the base setMemoryTracker). A high-cardinality join grows the maps past the limit.
         assertMemoryLeak(() -> {
-            execute("CREATE TABLE m AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(100_000)) TIMESTAMP(ts) PARTITION BY DAY");
-            execute("CREATE TABLE s AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(100_000)) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE m AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(40_000)) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE s AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(40_000)) TIMESTAMP(ts) PARTITION BY DAY");
             drainWalQueue();
             final String sql = "SELECT /*+ asof_dense(m s) */ m.k FROM m ASOF JOIN s ON k";
             assertUsesFactory(sql, AsOfJoinDenseSingleSymbolRecordCursorFactory.class);
@@ -238,8 +238,8 @@ public class JoinMemoryTrackerTest extends AbstractCairoTest {
         // The result is iterated (not count(*), which would short-circuit via
         // calculateSize without building the map) so the map actually grows.
         assertMemoryLeak(() -> {
-            execute("CREATE TABLE m AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(100_000)) TIMESTAMP(ts) PARTITION BY DAY");
-            execute("CREATE TABLE s AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(100_000)) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE m AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(40_000)) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE s AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(40_000)) TIMESTAMP(ts) PARTITION BY DAY");
             drainWalQueue();
             final String sql = "SELECT /*+ asof_linear(m s) */ m.k FROM m ASOF JOIN s ON k";
             assertUsesFactory(sql, AsOfJoinLightRecordCursorFactory.class);
@@ -269,8 +269,8 @@ public class JoinMemoryTrackerTest extends AbstractCairoTest {
         // asof_memoized + single SYMBOL routes to AsOfJoinMemoizedRecordCursorFactory. Its rememberedSymbols
         // map caches one entry per distinct symbol (no eviction), so a high-cardinality join grows it past the limit.
         assertMemoryLeak(() -> {
-            execute("CREATE TABLE m AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(100_000)) TIMESTAMP(ts) PARTITION BY DAY");
-            execute("CREATE TABLE s AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(100_000)) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE m AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(40_000)) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE s AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(40_000)) TIMESTAMP(ts) PARTITION BY DAY");
             drainWalQueue();
             final String sql = "SELECT /*+ asof_memoized(m s) */ m.k FROM m ASOF JOIN s ON k";
             assertUsesFactory(sql, AsOfJoinMemoizedRecordCursorFactory.class);
@@ -481,8 +481,8 @@ public class JoinMemoryTrackerTest extends AbstractCairoTest {
     @Test
     public void testHashOuterJoinLightFailsOnLargeInput() throws Exception {
         assertMemoryLeak(() -> {
-            execute("CREATE TABLE m AS (SELECT cast(x AS SYMBOL) k FROM long_sequence(100_000))");
-            execute("CREATE TABLE s AS (SELECT cast(x AS SYMBOL) k, x AS v FROM long_sequence(100_000))");
+            execute("CREATE TABLE m AS (SELECT cast(x AS SYMBOL) k FROM long_sequence(40_000))");
+            execute("CREATE TABLE s AS (SELECT cast(x AS SYMBOL) k, x AS v FROM long_sequence(40_000))");
             drainWalQueue();
             final String sql = "SELECT m.k, s.v FROM m LEFT JOIN s ON k";
             assertUsesFactory(sql, HashOuterJoinLightRecordCursorFactory.class);
@@ -736,8 +736,8 @@ public class JoinMemoryTrackerTest extends AbstractCairoTest {
     @Test
     public void testSpliceJoinFailsOnLargeInput() throws Exception {
         assertMemoryLeak(() -> {
-            execute("CREATE TABLE m AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(100_000)) TIMESTAMP(ts) PARTITION BY DAY");
-            execute("CREATE TABLE s AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(100_000)) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE m AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(40_000)) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE s AS (SELECT cast(x AS SYMBOL) k, (x * 1_000_000L)::timestamp ts FROM long_sequence(40_000)) TIMESTAMP(ts) PARTITION BY DAY");
             drainWalQueue();
             final String sql = "SELECT count(*) FROM m SPLICE JOIN s ON k";
             assertUsesFactory(sql, SpliceJoinLightRecordCursorFactory.class);

--- a/core/src/test/java/io/questdb/test/griffin/ParallelHorizonJoinMemoryTrackerTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelHorizonJoinMemoryTrackerTest.java
@@ -135,8 +135,8 @@ public class ParallelHorizonJoinMemoryTrackerTest extends AbstractCairoTest {
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
-                        createTrades(engine, sqlExecutionContext, 200_000, 8);
-                        createPrices(engine, sqlExecutionContext, 2_000_000, 8);
+                        createTrades(engine, sqlExecutionContext, 40_000, 8);
+                        createPrices(engine, sqlExecutionContext, 400_000, 8);
                         final String query = "SELECT t.sym, array_agg(p.price) " +
                                 "FROM trades t HORIZON JOIN prices p ON (t.sym = p.sym) " +
                                 "RANGE FROM -15s TO 15s STEP 1s AS h";
@@ -247,7 +247,7 @@ public class ParallelHorizonJoinMemoryTrackerTest extends AbstractCairoTest {
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
-                        createMultiHorizonTables(engine, sqlExecutionContext, 200_000);
+                        createMultiHorizonTables(engine, sqlExecutionContext, 40_000);
                         final String query = "SELECT t.sym, array_agg(p0.px0), count(p1.px1) " +
                                 "FROM trades t " +
                                 "HORIZON JOIN prices0 p0 ON (t.sym = p0.sym) " +
@@ -388,8 +388,8 @@ public class ParallelHorizonJoinMemoryTrackerTest extends AbstractCairoTest {
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
-                        createTrades(engine, sqlExecutionContext, 200_000, 8);
-                        createPrices(engine, sqlExecutionContext, 2_000_000, 8);
+                        createTrades(engine, sqlExecutionContext, 40_000, 8);
+                        createPrices(engine, sqlExecutionContext, 400_000, 8);
                         final String query = "SELECT array_agg(p.price) " +
                                 "FROM trades t HORIZON JOIN prices p " +
                                 "RANGE FROM -15s TO 15s STEP 1s AS h";
@@ -499,7 +499,7 @@ public class ParallelHorizonJoinMemoryTrackerTest extends AbstractCairoTest {
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
-                        createMultiHorizonTables(engine, sqlExecutionContext, 200_000);
+                        createMultiHorizonTables(engine, sqlExecutionContext, 40_000);
                         final String query = "SELECT array_agg(p0.px0), count(p1.px1) " +
                                 "FROM trades t " +
                                 "HORIZON JOIN prices0 p0 ON (t.sym = p0.sym) " +

--- a/core/src/test/java/io/questdb/test/griffin/ParallelWindowJoinMemoryTrackerTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelWindowJoinMemoryTrackerTest.java
@@ -95,8 +95,8 @@ public class ParallelWindowJoinMemoryTrackerTest extends AbstractCairoTest {
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
-                        createTrades(engine, sqlExecutionContext, 200_000, 8);
-                        createPrices(engine, sqlExecutionContext, 2_000_000, 8);
+                        createTrades(engine, sqlExecutionContext, 40_000, 8);
+                        createPrices(engine, sqlExecutionContext, 400_000, 8);
                         final String query = "SELECT t.ts, array_agg(p.price) " +
                                 "FROM trades t WINDOW JOIN prices p ON t.sym = p.sym " +
                                 "RANGE BETWEEN 15 seconds PRECEDING AND 15 seconds FOLLOWING";
@@ -175,8 +175,8 @@ public class ParallelWindowJoinMemoryTrackerTest extends AbstractCairoTest {
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
-                        createTrades(engine, sqlExecutionContext, 200_000, 8);
-                        createPrices(engine, sqlExecutionContext, 2_000_000, 8);
+                        createTrades(engine, sqlExecutionContext, 40_000, 8);
+                        createPrices(engine, sqlExecutionContext, 400_000, 8);
                         final String query = "SELECT t.ts, array_agg(p.price) " +
                                 "FROM trades t WINDOW JOIN prices p " +
                                 "RANGE BETWEEN 15 seconds PRECEDING AND 15 seconds FOLLOWING";

--- a/core/src/test/java/io/questdb/test/griffin/SyncHorizonJoinMemoryTrackerTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SyncHorizonJoinMemoryTrackerTest.java
@@ -135,8 +135,8 @@ public class SyncHorizonJoinMemoryTrackerTest extends AbstractCairoTest {
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
-                        createTrades(engine, sqlExecutionContext, 200_000, 8);
-                        createPrices(engine, sqlExecutionContext, 2_000_000, 8);
+                        createTrades(engine, sqlExecutionContext, 40_000, 8);
+                        createPrices(engine, sqlExecutionContext, 400_000, 8);
                         final String query = "SELECT t.sym, array_agg(p.price) " +
                                 "FROM trades t HORIZON JOIN prices p ON (t.sym = p.sym) " +
                                 "RANGE FROM -15s TO 15s STEP 1s AS h";
@@ -216,7 +216,7 @@ public class SyncHorizonJoinMemoryTrackerTest extends AbstractCairoTest {
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
-                        createMultiHorizonTables(engine, sqlExecutionContext, 200_000);
+                        createMultiHorizonTables(engine, sqlExecutionContext, 40_000);
                         final String query = "SELECT t.sym, array_agg(p0.px0), count(p1.px1) " +
                                 "FROM trades t " +
                                 "HORIZON JOIN prices0 p0 ON (t.sym = p0.sym) " +
@@ -329,8 +329,8 @@ public class SyncHorizonJoinMemoryTrackerTest extends AbstractCairoTest {
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
-                        createTrades(engine, sqlExecutionContext, 200_000, 8);
-                        createPrices(engine, sqlExecutionContext, 2_000_000, 8);
+                        createTrades(engine, sqlExecutionContext, 40_000, 8);
+                        createPrices(engine, sqlExecutionContext, 400_000, 8);
                         final String query = "SELECT array_agg(p.price) " +
                                 "FROM trades t HORIZON JOIN prices p " +
                                 "RANGE FROM -15s TO 15s STEP 1s AS h";
@@ -380,7 +380,7 @@ public class SyncHorizonJoinMemoryTrackerTest extends AbstractCairoTest {
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
-                        createMultiHorizonTables(engine, sqlExecutionContext, 200_000);
+                        createMultiHorizonTables(engine, sqlExecutionContext, 40_000);
                         final String query = "SELECT array_agg(p0.px0), count(p1.px1) " +
                                 "FROM trades t " +
                                 "HORIZON JOIN prices0 p0 ON (t.sym = p0.sym) " +

--- a/core/src/test/java/io/questdb/test/griffin/SyncWindowJoinMemoryTrackerTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SyncWindowJoinMemoryTrackerTest.java
@@ -99,8 +99,8 @@ public class SyncWindowJoinMemoryTrackerTest extends AbstractCairoTest {
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
-                        createTrades(engine, sqlExecutionContext, 200_000, 8);
-                        createPrices(engine, sqlExecutionContext, 2_000_000, 8);
+                        createTrades(engine, sqlExecutionContext, 40_000, 8);
+                        createPrices(engine, sqlExecutionContext, 400_000, 8);
                         final String query = "SELECT t.ts, array_agg(p.price) " +
                                 "FROM trades t WINDOW JOIN prices p ON t.sym = p.sym " +
                                 "RANGE BETWEEN 15 seconds PRECEDING AND 15 seconds FOLLOWING";
@@ -179,8 +179,8 @@ public class SyncWindowJoinMemoryTrackerTest extends AbstractCairoTest {
             TestUtils.execute(
                     pool,
                     (engine, compiler, sqlExecutionContext) -> {
-                        createTrades(engine, sqlExecutionContext, 200_000, 8);
-                        createPrices(engine, sqlExecutionContext, 2_000_000, 8);
+                        createTrades(engine, sqlExecutionContext, 40_000, 8);
+                        createPrices(engine, sqlExecutionContext, 400_000, 8);
                         final String query = "SELECT t.ts, array_agg(p.price) " +
                                 "FROM trades t WINDOW JOIN prices p " +
                                 "RANGE BETWEEN 15 seconds PRECEDING AND 15 seconds FOLLOWING";

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstLastNotNullParallelMergeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/FirstLastNotNullParallelMergeTest.java
@@ -79,6 +79,26 @@ public class FirstLastNotNullParallelMergeTest extends AbstractCairoTest {
     private static final String FIRST_OCCURRENCE = "x <= " + KEY_COUNT;
     // first_not_null: non-null at each key's last (highest-rowId) occurrence.
     private static final String LAST_OCCURRENCE = "x > " + (ROW_COUNT - KEY_COUNT);
+    // {label, value expression} for every value type. valueExpr produces the single non-null value
+    // of that type; the label identifies the type in a failure message. All types run in one shared
+    // WorkerPool/engine per function (see assertEveryTypeKeepsNonNull) so the expensive per-test
+    // fixture (fresh engine + worker pool + memory-leak scaffolding) is paid twice, not 28 times.
+    private static final String[][] TYPES = {
+            {"Char", "'a'::char"},
+            {"Date", "100000::date"},
+            {"Decimal", "1.5::decimal(18,3)"},
+            {"Double", "1.5::double"},
+            {"Float", "1.5::float"},
+            {"GeoHash", "#u"},
+            {"IPv4", "ipv4 '10.0.0.1'"},
+            {"Int", "42::int"},
+            {"Long", "42::long"},
+            {"Str", "'abc'"},
+            {"Symbol", "'abc'::symbol"},
+            {"Timestamp", "100000::timestamp"},
+            {"Uuid", "'00000000-0000-0000-0000-000000000001'::uuid"},
+            {"Varchar", "'abc'::varchar"},
+    };
 
     @Override
     @Before
@@ -94,168 +114,49 @@ public class FirstLastNotNullParallelMergeTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testFirstNotNullChar() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "'a'::char");
+    public void testFirstNotNullAllTypes() throws Exception {
+        assertEveryTypeKeepsNonNull("first_not_null", LAST_OCCURRENCE);
     }
 
     @Test
-    public void testFirstNotNullDate() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "100000::date");
+    public void testLastNotNullAllTypes() throws Exception {
+        assertEveryTypeKeepsNonNull("last_not_null", FIRST_OCCURRENCE);
     }
 
-    @Test
-    public void testFirstNotNullDecimal() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "1.5::decimal(18,3)");
-    }
-
-    @Test
-    public void testFirstNotNullDouble() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "1.5::double");
-    }
-
-    @Test
-    public void testFirstNotNullFloat() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "1.5::float");
-    }
-
-    @Test
-    public void testFirstNotNullGeoHash() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "#u");
-    }
-
-    @Test
-    public void testFirstNotNullIPv4() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "ipv4 '10.0.0.1'");
-    }
-
-    @Test
-    public void testFirstNotNullInt() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "42::int");
-    }
-
-    @Test
-    public void testFirstNotNullLong() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "42::long");
-    }
-
-    @Test
-    public void testFirstNotNullStr() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "'abc'");
-    }
-
-    @Test
-    public void testFirstNotNullSymbol() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "'abc'::symbol");
-    }
-
-    @Test
-    public void testFirstNotNullTimestamp() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "100000::timestamp");
-    }
-
-    @Test
-    public void testFirstNotNullUuid() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "'00000000-0000-0000-0000-000000000001'::uuid");
-    }
-
-    @Test
-    public void testFirstNotNullVarchar() throws Exception {
-        assertEveryKeyKeepsNonNull("first_not_null", LAST_OCCURRENCE, "'abc'::varchar");
-    }
-
-    @Test
-    public void testLastNotNullChar() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "'a'::char");
-    }
-
-    @Test
-    public void testLastNotNullDate() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "100000::date");
-    }
-
-    @Test
-    public void testLastNotNullDecimal() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "1.5::decimal(18,3)");
-    }
-
-    @Test
-    public void testLastNotNullDouble() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "1.5::double");
-    }
-
-    @Test
-    public void testLastNotNullFloat() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "1.5::float");
-    }
-
-    @Test
-    public void testLastNotNullGeoHash() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "#u");
-    }
-
-    @Test
-    public void testLastNotNullIPv4() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "ipv4 '10.0.0.1'");
-    }
-
-    @Test
-    public void testLastNotNullInt() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "42::int");
-    }
-
-    @Test
-    public void testLastNotNullLong() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "42::long");
-    }
-
-    @Test
-    public void testLastNotNullStr() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "'abc'");
-    }
-
-    @Test
-    public void testLastNotNullSymbol() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "'abc'::symbol");
-    }
-
-    @Test
-    public void testLastNotNullTimestamp() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "100000::timestamp");
-    }
-
-    @Test
-    public void testLastNotNullUuid() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "'00000000-0000-0000-0000-000000000001'::uuid");
-    }
-
-    @Test
-    public void testLastNotNullVarchar() throws Exception {
-        assertEveryKeyKeepsNonNull("last_not_null", FIRST_OCCURRENCE, "'abc'::varchar");
-    }
-
-    // valueExpr produces the single non-null value, placed where nonNullCondition holds; the CASE
-    // has no ELSE, so every other row of the key is NULL of the same type.
-    private void assertEveryKeyKeepsNonNull(String func, String nonNullCondition, String valueExpr) throws Exception {
-        final String createSql = "CREATE TABLE tab AS (" +
-                "  SELECT (x % " + KEY_COUNT + ")::int AS g," +
-                "         CASE WHEN " + nonNullCondition + " THEN " + valueExpr + " END AS v" +
-                "  FROM long_sequence(" + ROW_COUNT + ")" +
-                ")";
-        final String query = "SELECT count(*) FROM (SELECT g, " + func + "(v) lv FROM tab) WHERE lv IS NOT NULL";
+    // Runs the merge invariant for every value type against a single shared engine and worker pool.
+    // Each type builds its own table (single non-null value per key, placed where nonNullCondition
+    // holds; the CASE has no ELSE, so every other row of the key is NULL of the same type) and runs
+    // the aggregate ITERATIONS times, since the buggy merge direction is hit only on some runs.
+    private void assertEveryTypeKeepsNonNull(String func, String nonNullCondition) throws Exception {
         assertMemoryLeak(() -> {
             try (WorkerPool pool = new WorkerPool(() -> 4)) {
                 TestUtils.execute(pool, (ignore, compiler, ctx) -> {
-                    execute(compiler, createSql, ctx);
-                    // Every key has exactly one non-null value, so a correct aggregate is non-null
-                    // for all KEY_COUNT keys. A guardless merge drops some on most runs.
-                    for (int i = 0; i < ITERATIONS; i++) {
-                        assertQuery(query)
-                                .noLeakCheck()
-                                .withCompiler(compiler)
-                                .withContext(ctx)
-                                .noRandomAccess()
-                                .expectSize()
-                                .returns("count\n" + KEY_COUNT + "\n");
+                    for (String[] type : TYPES) {
+                        final String label = type[0];
+                        final String valueExpr = type[1];
+                        final String createSql = "CREATE TABLE tab AS (" +
+                                "  SELECT (x % " + KEY_COUNT + ")::int AS g," +
+                                "         CASE WHEN " + nonNullCondition + " THEN " + valueExpr + " END AS v" +
+                                "  FROM long_sequence(" + ROW_COUNT + ")" +
+                                ")";
+                        final String query = "SELECT count(*) FROM (SELECT g, " + func + "(v) lv FROM tab) WHERE lv IS NOT NULL";
+                        try {
+                            execute(compiler, "DROP TABLE IF EXISTS tab", ctx);
+                            execute(compiler, createSql, ctx);
+                            // Every key has exactly one non-null value, so a correct aggregate is
+                            // non-null for all KEY_COUNT keys. A guardless merge drops some on most runs.
+                            for (int i = 0; i < ITERATIONS; i++) {
+                                assertQuery(query)
+                                        .noLeakCheck()
+                                        .withCompiler(compiler)
+                                        .withContext(ctx)
+                                        .noRandomAccess()
+                                        .expectSize()
+                                        .returns("count\n" + KEY_COUNT + "\n");
+                            }
+                        } catch (AssertionError e) {
+                            throw new AssertionError("type=" + label + " func=" + func + ": " + e.getMessage(), e);
+                        }
                     }
                 }, configuration, LOG);
             }

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/vect/GroupByVectorizedOomTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/vect/GroupByVectorizedOomTest.java
@@ -72,7 +72,10 @@ public class GroupByVectorizedOomTest extends AbstractCairoTest {
             // Sweep the native-memory ceiling across the cursor-open allocation points.
             // Some ceiling lets an earlier PageFrameAddressCache list reopen() succeed
             // and trips a later one; the pre-fix code then leaked the earlier buffer.
-            for (int slack = 0; slack <= 128 * 1024; slack += 16) {
+            // 80 KiB covers the whole cursor-open allocation span (the last observed OOM
+            // sits near 68 KiB of slack); past that the query just runs to completion,
+            // which the recovery drain below already exercises.
+            for (int slack = 0; slack <= 80 * 1024; slack += 16) {
                 Unsafe.setRssMemLimit(Unsafe.getRssMemUsed() + slack);
                 try {
                     drain(query);
@@ -115,8 +118,10 @@ public class GroupByVectorizedOomTest extends AbstractCairoTest {
             // memory pools buildRosti then freed. The recovery drain after each ceiling
             // work-steals that survivor and dereferences the freed pool (NPE pre-fix).
             // The ceiling is armed after compile (like the query fuzzer's MALLOC fault) so
-            // the trip lands in buildRosti, not in cursor open.
-            for (int slack = 0; slack <= 96 * 1024; slack += 64) {
+            // the trip lands in buildRosti, not in cursor open. 48 KiB covers the whole
+            // buildRosti allocation span (the last observed OOM sits near 34 KiB of slack);
+            // past that both drains just run to completion without exercising the survivor.
+            for (int slack = 0; slack <= 48 * 1024; slack += 64) {
                 try {
                     drainArmedAfterCompile(query, slack);
                 } catch (CairoException e) {

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/AsOfJoinFastOomTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/AsOfJoinFastOomTest.java
@@ -95,8 +95,12 @@ public class AsOfJoinFastOomTest extends AbstractCairoTest {
             boolean sawOom = false;
             // Sweep the native-memory ceiling across the cursor-open allocation points.
             // Some ceiling lets the first sink reopen() succeed and trips the second; the
-            // pre-fix code then leaked the first sink's 8-byte heap.
-            for (int slack = 0; slack <= 64 * 1024; slack += 8) {
+            // pre-fix code then leaked the first sink's 8-byte heap. The 8-byte step matches
+            // the sink heaps' granularity so the sweep lands inside that transition window.
+            // 24 KiB comfortably covers the whole cursor-open allocation span (the last
+            // observed OOM sits near 21 KiB of slack); past that the query simply runs to
+            // completion, which the recovery drain below already exercises.
+            for (int slack = 0; slack <= 24 * 1024; slack += 8) {
                 Unsafe.setRssMemLimit(Unsafe.getRssMemUsed() + slack);
                 try {
                     drain(query);


### PR DESCRIPTION
This branch trims runtime from several recently-added test classes without changing what they verify. Each reduction was measured against the actual behavior it depends on (breach threshold, fault-injection extent, or fixture overhead) rather than guessed. No production code is touched.

## 1. Per-query memory limit tests (#7184)

The per-query memory limit tests fed their "fails on large input" cases far more rows than needed to breach the limit, and the OOM sweeps ran well past the last failing ceiling. Both wasted CI time without adding coverage.

- **`JoinMemoryTrackerTest`** — the six `FailsOnLargeInput` joins breach the unchanged 512 KiB limit at 10-15K distinct keys (measured). Inputs cut from `100_000` to `40_000` rows, a ~2.7-4x margin. Standalone: 21.1s -> 7.1s.
- **`AsOfJoinFastOomTest`** — the RSS-ceiling sweep emitted OOMs only up to ~21 KiB of slack, then ran the query to completion for ~5.5K more iterations. Cap the sweep at 24 KiB (from 64 KiB), keeping the 8-byte step across the entire OOM/leak-transition region. 5.6s -> 2.7s.
- **`GroupByVectorizedOomTest`** — same pattern; caps lowered to 80 KiB (from 128 KiB) and 48 KiB (from 96 KiB), just past the last observed OOM (~68 KiB / ~34 KiB). The parquet method ran two parquet drains per iteration, so trimming its tail is the bigger win. 3.35s -> 2.0s.
- **Horizon/window join memory tracker tests** (`ParallelHorizon`, `SyncHorizon`, `SyncWindow`, `ParallelWindow`) — the `array_agg` `FailsOnLargeSet` cases breach the unchanged 8 MiB limit at ~5K master rows (measured). Inputs cut from `200_000`/`2_000_000` to `40_000`/`400_000`, an 8-12x margin, preserving the 10x price density needed for ASOF matches and enough page frames for parallel fan-out.

Tradeoffs: the sweeps no longer exercise the post-recovery tail of all-succeed iterations (the recovery drain after each sweep already covers that), and the breach margins shrink from roughly 10-40x to 3-12x. All thresholds are
deterministic: the tracker counts requested bytes, not OS pages, and the first sweep step always trips (limit == current usage), so the "sweep never tripped" guard cannot silently pass. The parallel `*Horizon`/`*Window` classes see only a small wall-clock gain because they are dominated by per-test `CairoEngine` + `WorkerPool` setup, not table build; the input reduction still lowers their memory and I/O footprint.

The `*MemoryTrackerTest` + `*OomTest` warm-batch total drops from ~50s to 37s.

## 2. FirstLastNotNullParallelMergeTest consolidation (#7224)

This test spent ~11s almost entirely on per-`@Test` fixture overhead: each of its 28 type methods spun up a fresh `CairoEngine` + 4-worker `WorkerPool` and
ran the memory-leak scaffolding. Table size (100K rows) and iteration count (10) were proven irrelevant to runtime — shrinking them to 2K rows / 1 iteration left the total unchanged — so only the method count mattered.

Collapsed the 28 type methods into two (one per aggregate function) that loop over every value type inside a single shared engine and worker pool, so the fixture is paid twice instead of 28 times.

Coverage is unchanged: all 14 value types still run for both `first_not_null` and `last_not_null`, each repeated 10 times over a 100K-row table with the same sharding/small-frame configuration. Verified detection is intact by reverting the 25 pre-#7224 production files: `testLastNotNullAllTypes` then fails on the first type (`last_not_null` was the actual defect; `first_not_null` is a standing regression guard), and passes again once restored.

Runtime drops from ~11.1s to ~5.5s (measured back-to-back under identical conditions). Tradeoff: a per-type failure is reported with a `type=<T> func=<f>` prefix instead of a distinct method name, so per-type reporting is
coarser.

## Test plan

- `mvn -pl core -Dtest='*MemoryTrackerTest,*OomTest' test` passes; warm-batch total drops from ~50s to 37s.
- `mvn -pl core -Dtest=FirstLastNotNullParallelMergeTest test` passes in ~5.5s (was ~11.1s); fails as expected when the pre-#7224 production files are reverted.
- Confirmed every `FailsOnLargeInput` / `FailsOnLargeSet` case still throws `isOutOfMemory()` with "query memory limit exceeded" / "workload=QUERY".
- Confirmed the reduced sweeps still cross the OOM -> success boundary, so the in-loop recovery path is still exercised.