### PR TITLE
feat(core): apply ALTER COLUMN TYPE to parquet partition files immediately

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CLAUDE.md
+++ b/core/src/main/java/io/questdb/cairo/CLAUDE.md
@@ -1,29 +1,31 @@
 # Writing Parquet Partitions with Pending Column Conversions
 
-How O3 (out-of-order) writes land on a **parquet** partition that carries a *lazy*
-`ALTER COLUMN TYPE`, and the column conversions and native-memory allocations involved —
-with and without deduplication.
+How the parquet row-group rewrite machinery applies `ALTER COLUMN TYPE` column conversions,
+and the native-memory allocations involved — with and without deduplication.
+
+`ALTER COLUMN TYPE` re-encodes parquet **eagerly** at ALTER time (see `griffin/CLAUDE.md`);
+the eager re-encode (`O3PartitionJob.rewriteParquetPartition`) drives this machinery to decode
+the old parquet and write the new type. The same helpers back O3 (out-of-order) merges, but
+because ALTER is eager, an O3 merge onto a converted partition sees already-target-typed data
+and performs no conversion.
 
 This is the **write-path** counterpart to `griffin/CLAUDE.md`, which owns the conversion
-*semantics* (per-type cast rules, null sentinels, the `replacingIndex` chain) and the
-*read* path (`PageFrameMemoryPool` / `PageFrameMemoryRecord`). Read that first for the
-"what each cast does" rules; this file covers "how the writer materialises them during O3".
+*semantics* (per-type cast rules, null sentinels, the `replacingIndex` chain) and the direct
+read path. Read that first for the "what each cast does" rules; this file covers "how the
+writer materialises them".
 
 ## When this happens
 
-A parquet partition stores each column in the type it had when the partition was converted
-to parquet. A later `ALTER COLUMN TYPE` is **lazy** — `ConvertOperatorImpl` does *not*
-re-encode parquet (it only re-encodes native partitions, and runs a pre-pass for the two
-cases lazy decode cannot handle: target SYMBOL, or a chained conversion with a type
-mismatch — see `griffin/CLAUDE.md`). So the parquet file keeps the *source* type, and the
-conversion is deferred until something reads or rewrites the partition.
+`ALTER COLUMN TYPE` re-encodes each parquet partition eagerly (`ConvertOperatorImpl` calls
+`TableWriter.rewriteParquetPartitionWithConversions`, except for the pre-pass cases that go
+parquet→native first: target SYMBOL, or a chained conversion whose parquet no longer matches
+metadata — see `griffin/CLAUDE.md`). The re-encode decodes the old parquet and writes the new
+type using the machinery below, so the on-disk bytes always match the metadata.
 
-When O3 rows fall inside such a partition's time range, `O3PartitionJob` must merge them
-into the parquet data, which forces the lazy conversion to materialise **at write time**.
-
-There is **no conversion when O3 lands on a NATIVE partition**: `ALTER COLUMN TYPE`
-materialises eagerly into native column files, so a native O3 merge always sees
-already-target-typed columns and allocates zero conversion buffers.
+Because both native and parquet `ALTER COLUMN TYPE` are now eager, an O3 merge always sees
+already-target-typed columns and allocates zero conversion buffers — whether the partition is
+native or parquet. The merge/dedup mechanics below still describe how O3 rows land on a
+parquet partition; only the conversion step is a no-op there, having run eagerly at ALTER.
 
 ## The write paths (merge actions)
 
@@ -156,9 +158,9 @@ For a var dedup key, the comparer needs a data-length bound; the writer computes
 same value Phase 1b uses), which is correct for both a converted buffer and a raw decode. The
 native comparer only reads `var_data_len` inside debug `assert`s.
 
-`ConvertOperatorImpl` has **no dedup-key pre-pass** — the merge path above handles a dedup-key
-column whose conversion crosses the fixed↔var/symbol boundary while the partition stays lazy
-parquet, so enabling dedup or altering a dedup key never eagerly rewrites partitions.
+`ConvertOperatorImpl` has **no dedup-key-specific pre-pass** — a dedup-key column whose
+conversion crosses the fixed↔var/symbol boundary is re-encoded by the eager ALTER re-encode
+like any other column, so a later O3 merge sees an already-target-typed dedup key.
 
 ## Native-memory allocation and lifetime
 
@@ -186,8 +188,8 @@ with `freeNativePairs`; the pointer-copy lists (`srcPtrs`, `convertedPtrs`) are 
   shared by the merge and rewrite paths. Fix bugs in the helper, not in one caller.
 - **`var_data_len` is a debug-assert bound**, so a tight `getDataVectorSizeAt` extent is fine;
   do not pass a stale `getChunkDataSize` for a converted buffer.
-- **No conversion buffers on the native O3 path** — only parquet partitions with a lazy ALTER
-  allocate them.
+- **No conversion buffers on the O3 path** — ALTER re-encodes eagerly, so an O3 merge (native
+  or parquet) sees target-typed columns; the eager re-encode's rewrite arm allocates them.
 
 ## Key Files
 

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -667,7 +667,9 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                         tableWriterMetadata,
                         parquetColumns,
                         rowGroupBuffers,
-                        isRewrite
+                        isRewrite,
+                        -1,
+                        ColumnType.UNDEFINED
                 );
 
                 // Publish the new _pm last: patch its header (the MVCC commit
@@ -4002,7 +4004,9 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                         tableWriterMetadata,
                         parquetColumns,
                         rowGroupBuffers,
-                        true
+                        true,
+                        overrideColumnIndex,
+                        overrideColumnType
                 );
 
                 // Publish the new _pm last (header patch + fsync), after the index build.
@@ -4231,7 +4235,9 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
             TableRecordMetadata tableWriterMetadata,
             DirectIntList parquetColumns,
             RowGroupBuffers rowGroupBuffers,
-            boolean isRewrite
+            boolean isRewrite,
+            int overrideColumnIndex,
+            int overrideColumnType
     ) {
         long parquetAddr = 0;
         long parquetMetaAddr = 0;
@@ -4272,7 +4278,13 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
             IndexWriter indexWriter;
             final int columnCount = tableWriterMetadata.getColumnCount();
             for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
-                if (tableWriterMetadata.getColumnType(columnIndex) == ColumnType.SYMBOL && tableWriterMetadata.isColumnIndexed(columnIndex)) {
+                // The eager ALTER re-encode runs before the new type reaches metadata, so a column
+                // converted away from indexed SYMBOL still reads as SYMBOL here while the new file
+                // already stores the target type. Use the override type to skip its stale index.
+                final int effectiveType = columnIndex == overrideColumnIndex
+                        ? overrideColumnType
+                        : tableWriterMetadata.getColumnType(columnIndex);
+                if (effectiveType == ColumnType.SYMBOL && tableWriterMetadata.isColumnIndexed(columnIndex)) {
                     final int indexBlockCapacity = tableWriterMetadata.getIndexValueBlockCapacity(columnIndex);
                     if (indexBlockCapacity < 0) {
                         continue;
@@ -4950,7 +4962,9 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                     metadata,
                     ctx.getParquetColumns(),
                     ctx.getRowGroupBuffers(),
-                    true
+                    true,
+                    -1,
+                    ColumnType.UNDEFINED
             );
 
             // Hand off to the consumer via the partition update sink. The

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -4303,9 +4303,9 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                         final ParquetMetaFileReader parquetMetadata = partitionDecoder.metadata();
 
                         int parquetColumnIndex = -1;
-                        final int writerIndex = tableWriterMetadata.getColumnMetadata(columnIndex).getWriterIndex();
+                        final int columnId = tableWriterMetadata.getColumnMetadata(columnIndex).getOriginalWriterIndex();
                         for (int idx = 0, cnt = parquetMetadata.getColumnCount(); idx < cnt; idx++) {
-                            if (parquetMetadata.getColumnId(idx) == writerIndex) {
+                            if (parquetMetadata.getColumnId(idx) == columnId) {
                                 parquetColumnIndex = idx;
                                 break;
                             }

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -576,7 +576,9 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                                                 metadataPosition,
                                                 ctx.getActiveToDecodeIdx(columnCount),
                                                 ctx.getActiveColIndices(columnCount),
-                                                ctx
+                                                ctx,
+                                                -1,
+                                                ColumnType.UNDEFINED
                                         );
                                     } else if (hasSchemaChange) {
                                         copyRowGroupWithNullColumns(
@@ -3755,6 +3757,292 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
     }
 
     /**
+     * Re-encodes one committed parquet partition into a fresh {@code txn}-named directory,
+     * applying the current column types so the on-disk parquet bytes match the new schema
+     * after an {@code ALTER COLUMN TYPE}.
+     * <p>
+     * The re-encode runs before the new column type reaches table metadata, so the caller
+     * passes {@code overrideColumnIndex}/{@code overrideColumnType} to substitute the new
+     * type for the column being converted; every other column keeps its metadata type.
+     * Structurally this is the {@code COPY_ROW_GROUP_SLICE} rewrite arm of
+     * {@link #processParquetPartition} run over every row group with no O3 merge. It runs
+     * synchronously on the writer thread and borrows the carrier-local
+     * {@link O3ParquetMergeContext}; that is safe because the writer holds the table lock,
+     * so no concurrent O3 job shares this thread's context.
+     * <p>
+     * Returns the new parquet data-file size, or {@code -1} when the override column is not
+     * stored in this partition's parquet file (it was added after the partition became
+     * parquet, so its rows are all NULL and there is nothing to re-encode). The caller
+     * commits the new {@code txn} directory into {@code txWriter}; on failure this method
+     * removes the half-written directory and rethrows.
+     */
+    static long rewriteParquetPartition(
+            Path pathToTable,
+            int timestampType,
+            int partitionBy,
+            long partitionTimestamp,
+            long srcNameTxn,
+            long txn,
+            TableWriter tableWriter,
+            O3Basket o3Basket,
+            int overrideColumnIndex,
+            int overrideColumnType
+    ) {
+        final TableRecordMetadata tableWriterMetadata = tableWriter.getMetadata();
+        Path path = Path.getThreadLocal(pathToTable);
+        setPathForParquetPartition(path, timestampType, partitionBy, partitionTimestamp, srcNameTxn);
+
+        final int partitionIndex = tableWriter.getPartitionIndexByTimestamp(partitionTimestamp);
+        final long parquetFileSize = tableWriter.getPartitionParquetFileSize(partitionIndex);
+        final long newPartitionSize = tableWriter.getPartitionSize(partitionIndex);
+        final CairoConfiguration cairoConfiguration = tableWriter.getConfiguration();
+        final FilesFacade ff = tableWriter.getFilesFacade();
+        final O3ParquetMergeContext ctx = PARQUET_MERGE_CONTEXT.get();
+        ctx.clear();
+        final ParquetPartitionDecoder partitionDecoder = ctx.getPartitionDecoder();
+        final RowGroupBuffers rowGroupBuffers = ctx.getRowGroupBuffers();
+        final DirectIntList parquetColumns = ctx.getParquetColumns();
+        final ParquetMetaFileReader parquetMetaReader = ctx.getParquetMetaReader();
+        final PartitionUpdater partitionUpdater = ctx.getPartitionUpdater();
+        long parquetSize = parquetFileSize;
+        long newParquetSize = -1;
+        boolean newDirCreated = false;
+        boolean updaterBound = false;
+        try {
+            int parquetNameLen = path.size();
+            int partitionDirLen = parquetNameLen - TableUtils.PARQUET_PARTITION_NAME.length() - 1;
+            path.trimTo(partitionDirLen).concat(TableUtils.PARQUET_METADATA_FILE_NAME).$();
+
+            ParquetMetaFileReader.openAndMapRO(ff, path.$(), parquetMetaReader);
+            if (parquetMetaReader.getAddr() == 0 || !parquetMetaReader.resolveFooter(parquetFileSize)) {
+                throw CairoException.critical(0)
+                        .put("_pm tail does not match current parquet file size [path=").put(path)
+                        .put(", parquetFileSize=").put(parquetFileSize).put(']');
+            }
+            parquetSize = parquetMetaReader.getParquetFileSize();
+            path.trimTo(partitionDirLen).concat(TableUtils.PARQUET_PARTITION_NAME).$();
+
+            long parquetAddr = 0;
+            try {
+                parquetAddr = TableUtils.mapRO(ff, path.$(), LOG, parquetSize, MemoryTag.MMAP_PARQUET_PARTITION_DECODER);
+                partitionDecoder.of(
+                        parquetMetaReader,
+                        parquetAddr,
+                        parquetSize,
+                        MemoryTag.NATIVE_PARQUET_PARTITION_UPDATER
+                );
+                final ParquetMetaFileReader parquetMeta = partitionDecoder.metadata();
+                final int parquetColumnCount = parquetMeta.getColumnCount();
+                final int rowGroupCount = parquetMeta.getRowGroupCount();
+                assert rowGroupCount > 0;
+
+                final int columnCount = tableWriterMetadata.getColumnCount();
+                final IntIntHashMap parquetColIdToIdx = ctx.getParquetColIdToIdx();
+                for (int i = 0; i < parquetColumnCount; i++) {
+                    parquetColIdToIdx.put(partitionDecoder.metadata().getColumnId(i), i);
+                }
+                final IntList tableToParquetIdx = ctx.getTableToParquetIdx(columnCount);
+                for (int i = 0; i < columnCount; i++) {
+                    if (tableWriterMetadata.getColumnType(i) < 0) {
+                        tableToParquetIdx.setQuick(i, -1);
+                        continue;
+                    }
+                    final int origWriterIndex = tableWriterMetadata.getColumnMetadata(i).getOriginalWriterIndex();
+                    tableToParquetIdx.setQuick(i, parquetColIdToIdx.get(origWriterIndex));
+                }
+
+                // Nothing stored for the converted column here (added after the partition
+                // became parquet): its rows are all NULL regardless of type, so skip.
+                if (tableToParquetIdx.getQuick(overrideColumnIndex) < 0) {
+                    return -1;
+                }
+
+                final int timestampIndex = tableWriterMetadata.getTimestampIndex();
+                assert ColumnType.isTimestamp(tableWriterMetadata.getColumnType(timestampIndex));
+
+                final int compressionCodec = cairoConfiguration.getPartitionEncoderParquetCompressionCodec();
+                final int compressionLevel = cairoConfiguration.getPartitionEncoderParquetCompressionLevel();
+                final int rowGroupSize = cairoConfiguration.getPartitionEncoderParquetRowGroupSize();
+                assert rowGroupSize >= 4;
+                final int dataPageSize = cairoConfiguration.getPartitionEncoderParquetDataPageSize();
+                final boolean statisticsEnabled = cairoConfiguration.isPartitionEncoderParquetStatisticsEnabled();
+                final boolean rawArrayEncoding = cairoConfiguration.isPartitionEncoderParquetRawArrayEncoding();
+                final double bloomFilterFpp = cairoConfiguration.getPartitionEncoderParquetBloomFilterFpp();
+                final double minCompressionRatio = cairoConfiguration.getPartitionEncoderParquetMinCompressionRatio();
+
+                // Two distinct OS fds are required: one RO on the committed source file, one
+                // RW on a fresh empty file in the new txn directory. writeFileSize == 0 makes
+                // Rust treat the write side as a fresh sequential append (is_rewrite).
+                final int opts = cairoConfiguration.getWriterFileOpenOpts();
+                int readerFdOs = -1, writerFdOs = -1, parquetMetaFdOs = -1;
+                long readerFd = -1, writerFd = -1, parquetMetaFd = -1;
+                try {
+                    readerFd = TableUtils.openRONoCache(ff, path.$(), LOG);
+                    readerFdOs = Files.detach(readerFd);
+                    readerFd = -1;
+
+                    Path newPath = Path.getThreadLocal2(pathToTable);
+                    setPathForNativePartition(newPath, timestampType, partitionBy, partitionTimestamp, txn);
+                    ff.mkdirs(newPath.slash(), cairoConfiguration.getMkDirMode());
+                    newDirCreated = true;
+                    newPath.concat(PARQUET_PARTITION_NAME).$();
+                    writerFd = TableUtils.openRW(ff, newPath.$(), LOG, opts);
+                    writerFdOs = Files.detach(writerFd);
+                    writerFd = -1;
+
+                    newPath.parent().concat(PARQUET_METADATA_FILE_NAME).$();
+                    parquetMetaFd = TableUtils.openRW(ff, newPath.$(), LOG, opts);
+                    parquetMetaFdOs = Files.detach(parquetMetaFd);
+                    parquetMetaFd = -1;
+                } catch (Throwable e) {
+                    O3Utils.close(ff, readerFd);
+                    if (readerFdOs != -1) {
+                        Files.closeDetached(readerFdOs);
+                    }
+                    O3Utils.close(ff, writerFd);
+                    if (writerFdOs != -1) {
+                        Files.closeDetached(writerFdOs);
+                    }
+                    O3Utils.close(ff, parquetMetaFd);
+                    if (parquetMetaFdOs != -1) {
+                        Files.closeDetached(parquetMetaFdOs);
+                    }
+                    throw e;
+                }
+
+                // partitionUpdater.of() transfers fd ownership to Rust; close() releases them.
+                partitionUpdater.of(
+                        path.$(),
+                        readerFdOs,
+                        parquetSize,
+                        writerFdOs,
+                        0, // writeFileSize == 0 -> fresh rewrite
+                        timestampIndex,
+                        ParquetCompression.packCompressionCodecLevel(compressionCodec, compressionLevel),
+                        statisticsEnabled,
+                        rawArrayEncoding,
+                        rowGroupSize,
+                        dataPageSize,
+                        bloomFilterFpp,
+                        minCompressionRatio,
+                        parquetMetaFdOs,
+                        0, // parse anchor (fresh file)
+                        parquetMetaReader.getFileSize(),
+                        parquetFileSize
+                );
+                updaterBound = true;
+
+                // Stamp the new footer with the target schema (the converted column carries
+                // overrideColumnType, which is not yet in metadata).
+                final String tableName = tableWriter.getTableToken().getTableName();
+                final PartitionDescriptor schemaDesc = ctx.getChunkDescriptor();
+                schemaDesc.of(tableName, 0, timestampIndex);
+                for (int i = 0; i < columnCount; i++) {
+                    int colType = i == overrideColumnIndex ? overrideColumnType : tableWriterMetadata.getColumnType(i);
+                    if (colType < 0) {
+                        continue;
+                    }
+                    if (ColumnType.isSymbol(colType) && !tableWriter.getSymbolMapWriter(i).getNullFlag()) {
+                        colType |= PARQUET_SYMBOL_NOT_NULL_HINT;
+                    }
+                    final int colId = tableWriterMetadata.getColumnMetadata(i).getOriginalWriterIndex();
+                    final int parquetEncodingConfig = tableWriterMetadata.getColumnMetadata(i).getParquetEncodingConfig();
+                    schemaDesc.addColumn(tableWriterMetadata.getColumnName(i), colType, colId, 0, parquetEncodingConfig);
+                }
+                partitionUpdater.setTargetSchema(schemaDesc);
+                schemaDesc.clear();
+
+                LOG.info().$("parquet partition re-encode [table=").$(tableWriter.getTableToken())
+                        .$(", partition=").$ts(partitionTimestamp)
+                        .$(", rowGroups=").$(rowGroupCount)
+                        .$(", fileSize=").$size(parquetSize)
+                        .I$();
+
+                final PartitionDescriptor chunkDescriptor = ctx.getChunkDescriptor();
+                for (int rg = 0; rg < rowGroupCount; rg++) {
+                    rewriteParquetRowGroupWithConversions(
+                            partitionDecoder,
+                            chunkDescriptor,
+                            partitionUpdater,
+                            rowGroupBuffers,
+                            parquetColumns,
+                            rg,
+                            tableWriter,
+                            tableWriterMetadata,
+                            tableToParquetIdx,
+                            timestampIndex,
+                            rg,
+                            ctx.getActiveToDecodeIdx(columnCount),
+                            ctx.getActiveColIndices(columnCount),
+                            ctx,
+                            overrideColumnIndex,
+                            overrideColumnType
+                    );
+                }
+
+                newParquetSize = partitionUpdater.updateFileMetadata();
+                final long newParquetMetaFileSize = partitionUpdater.getResultParquetMetaFileSize();
+
+                // Rebuild .k/.pk symbol indexes against the freshly written file.
+                path.of(pathToTable);
+                setPathForParquetPartition(path, timestampType, partitionBy, partitionTimestamp, txn);
+                updateParquetIndexes(
+                        partitionBy,
+                        partitionTimestamp,
+                        tableWriter,
+                        txn,
+                        o3Basket,
+                        newPartitionSize,
+                        newParquetSize,
+                        newParquetMetaFileSize,
+                        pathToTable,
+                        path,
+                        ff,
+                        partitionDecoder,
+                        tableWriterMetadata,
+                        parquetColumns,
+                        rowGroupBuffers,
+                        true
+                );
+
+                // Publish the new _pm last (header patch + fsync), after the index build.
+                partitionUpdater.commitParquetMeta(cairoConfiguration.getCommitMode() != CommitMode.NOSYNC);
+            } finally {
+                if (parquetAddr != 0) {
+                    ff.munmap(parquetAddr, parquetSize, MemoryTag.MMAP_PARQUET_PARTITION_DECODER);
+                }
+            }
+        } catch (Throwable th) {
+            LOG.error().$("parquet partition re-encode error [table=").$(tableWriter.getTableToken())
+                    .$(", partition=").$ts(partitionTimestamp)
+                    .$(", e=").$(th)
+                    .I$();
+            // Release the Rust-owned fds before removing the half-written directory so the
+            // rmdir is not blocked by open handles (Windows).
+            if (updaterBound) {
+                partitionUpdater.close();
+            }
+            if (newDirCreated) {
+                Path newPath = Path.getThreadLocal2(pathToTable);
+                setPathForNativePartition(newPath, timestampType, partitionBy, partitionTimestamp, txn);
+                if (!ff.rmdir(newPath.slash())) {
+                    LOG.error().$("could not remove new partition directory after failed re-encode [path=").$(newPath).I$();
+                }
+            }
+            throw th;
+        } finally {
+            ctx.releaseResources();
+            final long parquetMetaAddr = parquetMetaReader.getAddr();
+            final long parquetMetaSize = parquetMetaReader.getFileSize();
+            parquetMetaReader.clear();
+            if (parquetMetaAddr != 0) {
+                ff.munmap(parquetMetaAddr, parquetMetaSize, MemoryTag.MMAP_PARQUET_METADATA_READER);
+            }
+        }
+        return newParquetSize;
+    }
+
+    /**
      * Decodes a parquet row group, applies type conversions for columns that
      * have been ALTER-ed, and writes the result as a new row group via
      * addRowGroup(). This is used instead of copyRowGroupWithNullColumns()
@@ -3776,7 +4064,9 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
             int metadataPosition,
             IntList activeToDecodeIdx,
             IntList activeColIndices,
-            O3ParquetMergeContext ctx
+            O3ParquetMergeContext ctx,
+            int overrideColumnIndex,
+            int overrideColumnType
     ) {
         // Phase 1: Build the decode list with correct decode types for each column.
         parquetColumns.clear();
@@ -3786,7 +4076,12 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
         int activeColCount = 0;
 
         for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
-            int columnType = tableWriterMetadata.getColumnType(columnIndex);
+            // The ALTER COLUMN TYPE re-encode runs before the new column type reaches metadata,
+            // so it substitutes overrideColumnType for the column being converted. O3 callers
+            // pass overrideColumnIndex = -1 and read the type straight from metadata.
+            int columnType = columnIndex == overrideColumnIndex
+                    ? overrideColumnType
+                    : tableWriterMetadata.getColumnType(columnIndex);
             if (columnType < 0) {
                 continue;
             }
@@ -3824,7 +4119,9 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
         try {
             for (int ai = 0; ai < activeColCount; ai++) {
                 int columnIndex = activeColIndices.getQuick(ai);
-                int columnType = tableWriterMetadata.getColumnType(columnIndex);
+                int columnType = columnIndex == overrideColumnIndex
+                        ? overrideColumnType
+                        : tableWriterMetadata.getColumnType(columnIndex);
                 int decodeIdx = activeToDecodeIdx.getQuick(ai);
                 final String columnName = tableWriterMetadata.getColumnName(columnIndex);
                 final int columnId = tableWriterMetadata.getColumnMetadata(columnIndex).getOriginalWriterIndex();

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -3188,19 +3188,20 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * does not commit: the surrounding ALTER's structure-version commit persists it atomically
      * with the new {@code _meta}, and {@link #cleanupParquetReencodedOldDirs()} removes the
      * old directories afterwards. A no-op when the column is not stored in this
-     * partition's parquet file (its rows are all NULL there regardless of type).
+     * partition's parquet file (its rows are all NULL there regardless of type). The caller
+     * passes the physical partition entry because split partitions share the same logical floor.
      */
-    public void rewriteParquetPartitionWithConversions(long partitionTimestamp, int overrideColumnIndex, int newType) {
+    public void rewriteParquetPartitionWithConversions(int partitionIndex, long partitionTimestamp, long partitionNameTxn, int overrideColumnIndex, int newType) {
         assert metadata.getTimestampIndex() > -1;
         assert PartitionBy.isPartitioned(partitionBy);
 
-        partitionTimestamp = txWriter.getLogicalPartitionTimestamp(partitionTimestamp);
-        final int partitionIndex = txWriter.getPartitionIndex(partitionTimestamp);
-        if (partitionIndex < 0 || !txWriter.isPartitionParquet(partitionIndex)) {
+        if (partitionIndex < 0 || partitionIndex >= txWriter.getPartitionCount() || !txWriter.isPartitionParquet(partitionIndex)) {
             return;
         }
 
-        final long partitionNameTxn = txWriter.getPartitionNameTxn(partitionIndex);
+        assert txWriter.getPartitionTimestampByIndex(partitionIndex) == partitionTimestamp;
+        assert txWriter.getPartitionNameTxn(partitionIndex) == partitionNameTxn;
+
         final long partitionRowCount = getPartitionSize(partitionIndex);
 
         final O3Basket o3Basket = o3BasketPool.next();
@@ -3228,10 +3229,13 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         // row 0 now), and bump the partition table version so readers fully reconcile. The
         // commit is deferred to the ALTER's structure-version barrier so it lands atomically
         // with the new _meta; cleanupParquetReencodedOldDirs() removes the old directories.
-        txWriter.updatePartitionSizeAndTxnByRawIndex(partitionIndex * LONGS_PER_TX_ATTACHED_PARTITION, partitionRowCount);
-        txWriter.setPartitionParquetFormat(partitionTimestamp, newParquetSize);
+        final int partitionRawIndex = partitionIndex * LONGS_PER_TX_ATTACHED_PARTITION;
+        txWriter.updatePartitionSizeAndTxnByRawIndex(partitionRawIndex, partitionRowCount);
+        txWriter.setPartitionParquetFormatByRawIndex(partitionRawIndex, newParquetSize, true);
         zeroColumnTopsAfterParquetRewrite(partitionTimestamp, partitionRowCount, true);
         txWriter.bumpPartitionTableVersion();
+
+        resealParquetCoveringForPartition(partitionTimestamp, overrideColumnIndex, newType);
 
         pendingParquetReencodes.add(partitionTimestamp);
         pendingParquetReencodes.add(partitionNameTxn);
@@ -5228,7 +5232,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             SymbolColumnIndexer indexer,
             IntList coveringColumnIndices,
             long partitionTimestamp,
-            ObjList<MemoryMARW> covMmaps
+            ObjList<MemoryMARW> covMmaps,
+            int overrideColumnIndex,
+            int overrideColumnType
     ) {
         final int coverCount = coveringColumnIndices.size();
         coveringAddrs.setPos(coverCount);
@@ -5241,7 +5247,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
         for (int slot = 0; slot < coverCount; slot++) {
             int covCol = coveringColumnIndices.getQuick(slot);
-            if (covCol < 0 || metadata.getColumnType(covCol) <= 0) {
+            if (covCol < 0) {
                 coveringAddrs.setQuick(slot, 0);
                 coveringAuxAddrs.setQuick(slot, 0);
                 coveringTops.add(0);
@@ -5251,7 +5257,17 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 coveringNameTxns.add(TableUtils.COLUMN_NAME_TXN_NONE);
                 continue;
             }
-            int covType = metadata.getColumnType(covCol);
+            int covType = getEffectiveColumnType(covCol, overrideColumnIndex, overrideColumnType);
+            if (covType <= 0) {
+                coveringAddrs.setQuick(slot, 0);
+                coveringAuxAddrs.setQuick(slot, 0);
+                coveringTops.add(0);
+                coveringShifts.add(0);
+                coveringIndices.add(-1);
+                coveringTypes.add(-1);
+                coveringNameTxns.add(TableUtils.COLUMN_NAME_TXN_NONE);
+                continue;
+            }
             MemoryMARW dataMem = covMmaps.getQuick(2 * slot + 1);
             MemoryMARW auxMem = covMmaps.getQuick(2 * slot);
             coveringAddrs.setQuick(slot, dataMem != null && dataMem.isOpen() ? dataMem.addressOf(0) : 0);
@@ -6979,6 +6995,13 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         return deferredPostingSealPurgeTaskPool;
     }
 
+    private int getEffectiveColumnType(int columnIndex, int overrideColumnIndex, int overrideColumnType) {
+        if (columnIndex < 0) {
+            return -1;
+        }
+        return columnIndex == overrideColumnIndex ? overrideColumnType : metadata.getColumnType(columnIndex);
+    }
+
     private long getO3RowCount0() {
         return (masterRef - o3MasterRef + 1) / 2;
     }
@@ -7418,7 +7441,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             int plen,
             long timestamp,
             RowGroupBuffers rowGroupBuffers,
-            boolean allowDestructiveRecovery
+            boolean allowDestructiveRecovery,
+            int overrideColumnIndex,
+            int overrideColumnType
     ) {
         final ParquetMetaFileReader parquetMetadata = parquetDecoder.metadata();
 
@@ -7496,7 +7521,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 if (hasCovering) {
                     includedCoveredCount = prepareCoveredColumnMmaps(
                             coveringColumnIndices, timestamp, plen,
-                            parquetMetadata, partitionSize, covSlotMeta, covMmaps);
+                            parquetMetadata, partitionSize, covSlotMeta, covMmaps,
+                            overrideColumnIndex, overrideColumnType);
                 }
 
                 long rowCount = 0;
@@ -7550,7 +7576,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 if (hasCovering) {
                     configureCoveringFromMmaps(
                             indexer, coveringColumnIndices, timestamp,
-                            covMmaps);
+                            covMmaps, overrideColumnIndex, overrideColumnType);
                 }
 
                 indexWriter.setMaxValue(partitionSize - 1);
@@ -7594,7 +7620,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             parquetDecoder.of(parquetMetaReader, parquetAddr, parquetSize, MemoryTag.NATIVE_PARQUET_PARTITION_DECODER);
             // Fresh ADD INDEX over a parquet partition indexes a single column and
             // holds no live indexer, so destructive .pk recovery is permitted.
-            indexParquetColumn(indexer, columnName, columnIndex, columnNameTxn, indexValueBlockSize, indexType, plen, timestamp, rowGroupBuffers, true);
+            indexParquetColumn(indexer, columnName, columnIndex, columnNameTxn, indexValueBlockSize, indexType, plen, timestamp, rowGroupBuffers, true, -1, ColumnType.UNDEFINED);
         } finally {
             // Release the decoder's native state before tearing down the mmaps it
             // borrows from. ParquetPartitionDecoder documents a clear-then-munmap
@@ -9209,14 +9235,25 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             ParquetMetaFileReader parquetMetadata,
             long partitionSize,
             DirectLongList covSlotMeta,
-            ObjList<MemoryMARW> covMmaps
+            ObjList<MemoryMARW> covMmaps,
+            int overrideColumnIndex,
+            int overrideColumnType
     ) {
         final int coverCount = coveringColumnIndices.size();
         int includedCount = 0;
 
         for (int slot = 0; slot < coverCount; slot++) {
             final int tableColIdx = coveringColumnIndices.getQuick(slot);
-            if (tableColIdx < 0 || metadata.getColumnType(tableColIdx) <= 0) {
+            if (tableColIdx < 0) {
+                covSlotMeta.add(-1L);
+                covSlotMeta.add(0L);
+                covSlotMeta.add(0L);
+                covMmaps.add(null);
+                covMmaps.add(null);
+                continue;
+            }
+            final int columnType = getEffectiveColumnType(tableColIdx, overrideColumnIndex, overrideColumnType);
+            if (columnType <= 0) {
                 covSlotMeta.add(-1L);
                 covSlotMeta.add(0L);
                 covSlotMeta.add(0L);
@@ -9243,7 +9280,6 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 continue;
             }
 
-            final int columnType = metadata.getColumnType(tableColIdx);
             final boolean isVarSize = ColumnType.isVarSize(columnType);
             final CharSequence colName = metadata.getColumnName(tableColIdx);
             final long colNameTxn = columnVersionWriter.getColumnNameTxn(partitionTimestamp, tableColIdx);
@@ -12680,6 +12716,10 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * @return true if at least one covering posting column was rebuilt.
      */
     private boolean resealParquetCoveringForPartition(long partitionTimestamp) {
+        return resealParquetCoveringForPartition(partitionTimestamp, -1, ColumnType.UNDEFINED);
+    }
+
+    private boolean resealParquetCoveringForPartition(long partitionTimestamp, int overrideColumnIndex, int overrideColumnType) {
         // No covering posting index anywhere on the table: the worker-built
         // non-covering .pv already stands, so skip the path resolution + stat(2)
         // and the per-column scan entirely.
@@ -12709,7 +12749,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         long parquetSize = 0;
         try (RowGroupBuffers rowGroupBuffers = new RowGroupBuffers(MemoryTag.NATIVE_TABLE_WRITER)) {
             for (int colIdx = 0; colIdx < columnCount; colIdx++) {
-                if (metadata.getColumnType(colIdx) <= 0 || !metadata.isColumnIndexed(colIdx)
+                final int effectiveColumnType = getEffectiveColumnType(colIdx, overrideColumnIndex, overrideColumnType);
+                if (!ColumnType.isSymbol(effectiveColumnType) || !metadata.isColumnIndexed(colIdx)
                         || !IndexType.isPosting(metadata.getColumnIndexType(colIdx))) {
                     continue;
                 }
@@ -12750,7 +12791,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                                 plen,
                                 partitionTimestamp,
                                 rowGroupBuffers,
-                                false
+                                false,
+                                overrideColumnIndex,
+                                overrideColumnType
                         );
                     } finally {
                         // Drain the rebuild's seal-purge outbox (the .pv/.pc its

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -293,6 +293,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     private final int pathRootSize;
     private final int pathSize;
     private final FragileCode RECOVER_FROM_META_RENAME_FAILURE = this::recoverFromMetaRenameFailure;
+    // Old parquet dirs left behind by ALTER COLUMN TYPE re-encodes, to remove after the ALTER
+    // commits. Two longs per entry: [partitionTimestamp, oldPartitionNameTxn].
+    private final LongList pendingParquetReencodes = new LongList();
     // Pending parquet->native conversions awaiting a single batched commit.
     // Three longs per entry: [partitionTimestamp, oldPartitionNameTxn, lastPartitionConvertedFlag].
     private final LongList pendingParquetToNativeConversions = new LongList();
@@ -1278,6 +1281,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             }
 
             clearTodoAndCommitMetaStructureVersion();
+            // The parquet re-encodes are now durable (committed above with the new metadata).
+            // Remove the old parquet directories they replaced.
+            cleanupParquetReencodedOldDirs();
         } catch (Throwable th) {
             LOG.critical().$("could not change column type [table=").$(tableToken).$(", column=").$safe(columnName)
                     .$(", error=").$(th).I$();
@@ -3173,6 +3179,64 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         dedupRowsRemovedSinceLastCommit.reset();
     }
 
+    /**
+     * Re-encodes one parquet partition so its on-disk bytes carry the ALTER-ed column's new
+     * type. Called per partition from
+     * {@link io.questdb.griffin.ConvertOperatorImpl} during ALTER COLUMN TYPE, before the new
+     * type reaches metadata - hence the explicit {@code overrideColumnIndex} / {@code newType}.
+     * It writes a fresh txn-named directory and updates in-memory {@code txWriter} state, but
+     * does not commit: the surrounding ALTER's structure-version commit persists it atomically
+     * with the new {@code _meta}, and {@link #cleanupParquetReencodedOldDirs()} removes the
+     * old directories afterwards. A no-op when the column is not stored in this
+     * partition's parquet file (its rows are all NULL there regardless of type).
+     */
+    public void rewriteParquetPartitionWithConversions(long partitionTimestamp, int overrideColumnIndex, int newType) {
+        assert metadata.getTimestampIndex() > -1;
+        assert PartitionBy.isPartitioned(partitionBy);
+
+        partitionTimestamp = txWriter.getLogicalPartitionTimestamp(partitionTimestamp);
+        final int partitionIndex = txWriter.getPartitionIndex(partitionTimestamp);
+        if (partitionIndex < 0 || !txWriter.isPartitionParquet(partitionIndex)) {
+            return;
+        }
+
+        final long partitionNameTxn = txWriter.getPartitionNameTxn(partitionIndex);
+        final long partitionRowCount = getPartitionSize(partitionIndex);
+
+        final O3Basket o3Basket = o3BasketPool.next();
+        o3Basket.checkCapacity(configuration, metadata.getColumnCount(), metadata.getColumnCount());
+        final long newParquetSize = O3PartitionJob.rewriteParquetPartition(
+                path.trimTo(pathSize),
+                timestampType,
+                partitionBy,
+                partitionTimestamp,
+                partitionNameTxn,
+                getTxn(),
+                this,
+                o3Basket,
+                overrideColumnIndex,
+                newType
+        );
+        if (newParquetSize < 0) {
+            // Column not stored in this partition's parquet - nothing was re-encoded.
+            return;
+        }
+
+        // Publish in-memory exactly as the O3 parquet-rewrite sink consumer does
+        // (o3ConsumePartitionUpdateSink): bump the partition name txn to the new directory,
+        // record the new file size, zero all column tops (every column is materialised from
+        // row 0 now), and bump the partition table version so readers fully reconcile. The
+        // commit is deferred to the ALTER's structure-version barrier so it lands atomically
+        // with the new _meta; cleanupParquetReencodedOldDirs() removes the old directories.
+        txWriter.updatePartitionSizeAndTxnByRawIndex(partitionIndex * LONGS_PER_TX_ATTACHED_PARTITION, partitionRowCount);
+        txWriter.setPartitionParquetFormat(partitionTimestamp, newParquetSize);
+        zeroColumnTopsAfterParquetRewrite(partitionTimestamp, partitionRowCount, true);
+        txWriter.bumpPartitionTableVersion();
+
+        pendingParquetReencodes.add(partitionTimestamp);
+        pendingParquetReencodes.add(partitionNameTxn);
+    }
+
     @Override
     public void rollback() {
         checkDistressed();
@@ -4792,6 +4856,27 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         // transaction log is either not required or pending
         activeColumns = columns;
         activeNullSetters = nullSetters;
+    }
+
+    // Best-effort removal of the old parquet directories that ALTER COLUMN TYPE re-encodes
+    // replaced. Runs after the ALTER's structure-version commit has made the new txn
+    // directories durable, so a failure here does not roll back the (already committed) type
+    // change - it only leaves an old directory behind, which the next purge reclaims.
+    private void cleanupParquetReencodedOldDirs() {
+        if (pendingParquetReencodes.size() == 0) {
+            return;
+        }
+        try {
+            for (int i = 0, n = pendingParquetReencodes.size(); i < n; i += 2) {
+                final long pts = pendingParquetReencodes.getQuick(i);
+                final long oldNameTxn = pendingParquetReencodes.getQuick(i + 1);
+                safeDeletePartitionDir(pts, oldNameTxn);
+            }
+        } catch (Throwable e) {
+            handleHousekeepingException(e);
+        } finally {
+            pendingParquetReencodes.clear();
+        }
     }
 
     private void clearTodoAndCommitMeta() {

--- a/core/src/main/java/io/questdb/cairo/TxWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TxWriter.java
@@ -451,6 +451,13 @@ public final class TxWriter extends TxReader implements Closeable, Mutable, Symb
         if (indexRaw < 0) {
             throw CairoException.nonCritical().put("bad partition index -1");
         }
+        setPartitionParquetFormatByRawIndex(indexRaw, fileLength, isParquetFormat);
+    }
+
+    void setPartitionParquetFormatByRawIndex(int indexRaw, long fileLength, boolean isParquetFormat) {
+        if (indexRaw < 0) {
+            throw CairoException.nonCritical().put("bad partition index -1");
+        }
         int offset = indexRaw + PARTITION_MASKED_SIZE_OFFSET;
         long maskedSize = attachedPartitions.getQuick(offset);
 

--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameFilteredMemoryRecord.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameFilteredMemoryRecord.java
@@ -169,9 +169,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public boolean getBool(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getBool(columnIndex);
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getByte(address + getRowIndex(columnIndex)) == 1;
@@ -181,9 +178,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public byte getByte(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getByte(columnIndex);
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getByte(address + getRowIndex(columnIndex));
@@ -193,9 +187,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public char getChar(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getChar(columnIndex);
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getChar(address + (getRowIndex(columnIndex) << 1));
@@ -205,10 +196,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public void getDecimal128(int columnIndex, Decimal128 sink) {
-        if (needsLazyConversion(columnIndex)) {
-            super.getDecimal128(columnIndex, sink);
-            return;
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             address += (getRowIndex(columnIndex) << 4);
@@ -223,9 +210,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public short getDecimal16(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getDecimal16(columnIndex);
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getShort(address + (getRowIndex(columnIndex) << 1));
@@ -235,10 +219,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public void getDecimal256(int columnIndex, Decimal256 sink) {
-        if (needsLazyConversion(columnIndex)) {
-            super.getDecimal256(columnIndex, sink);
-            return;
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             sink.ofRawAddress(address + (getRowIndex(columnIndex) << 5));
@@ -249,9 +229,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public int getDecimal32(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getDecimal32(columnIndex);
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getInt(address + (getRowIndex(columnIndex) << 2));
@@ -261,9 +238,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public long getDecimal64(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getDecimal64(columnIndex);
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getLong(address + (getRowIndex(columnIndex) << 3));
@@ -273,9 +247,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public byte getDecimal8(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getDecimal8(columnIndex);
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getByte(address + getRowIndex(columnIndex));
@@ -285,9 +256,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public double getDouble(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getDouble(columnIndex);
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getDouble(address + (getRowIndex(columnIndex) << 3));
@@ -297,9 +265,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public float getFloat(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getFloat(columnIndex);
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getFloat(address + (getRowIndex(columnIndex) << 2));
@@ -345,9 +310,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public int getIPv4(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getIPv4(columnIndex);
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getInt(address + (getRowIndex(columnIndex) << 2));
@@ -357,9 +319,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public int getInt(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getInt(columnIndex);
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getInt(address + (getRowIndex(columnIndex) << 2));
@@ -369,9 +328,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public long getLong(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getLong(columnIndex);
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getLong(address + (getRowIndex(columnIndex) << 3));
@@ -381,9 +337,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public long getLong128Hi(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getLong128Hi(columnIndex);
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getLong(address + (getRowIndex(columnIndex) << 4) + Long.BYTES);
@@ -393,9 +346,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public long getLong128Lo(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getLong128Lo(columnIndex);
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getLong(address + (getRowIndex(columnIndex) << 4));
@@ -427,9 +377,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public short getShort(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            return super.getShort(columnIndex);
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getShort(address + (getRowIndex(columnIndex) << 1));
@@ -439,43 +386,16 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public CharSequence getStrA(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            final long saved = rowIndex;
-            try {
-                rowIndex = getRowIndex(columnIndex);
-                return super.getStrA(columnIndex);
-            } finally {
-                rowIndex = saved;
-            }
-        }
         return super.getStrA(columnIndex);
     }
 
     @Override
     public CharSequence getStrB(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            final long saved = rowIndex;
-            try {
-                rowIndex = getRowIndex(columnIndex);
-                return super.getStrB(columnIndex);
-            } finally {
-                rowIndex = saved;
-            }
-        }
         return super.getStrB(columnIndex);
     }
 
     @Override
     public int getStrLen(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            final long saved = rowIndex;
-            try {
-                rowIndex = getRowIndex(columnIndex);
-                return super.getStrLen(columnIndex);
-            } finally {
-                rowIndex = saved;
-            }
-        }
         final long dataPageAddress = pageAddresses.get(columnOffset + columnIndex);
         if (dataPageAddress != 0) {
             final long auxPageAddress = auxPageAddresses.get(columnOffset + columnIndex);
@@ -530,43 +450,16 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
 
     @Override
     public Utf8Sequence getVarcharA(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            final long saved = rowIndex;
-            try {
-                rowIndex = getRowIndex(columnIndex);
-                return super.getVarcharA(columnIndex);
-            } finally {
-                rowIndex = saved;
-            }
-        }
         return super.getVarcharA(columnIndex);
     }
 
     @Override
     public Utf8Sequence getVarcharB(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            final long saved = rowIndex;
-            try {
-                rowIndex = getRowIndex(columnIndex);
-                return super.getVarcharB(columnIndex);
-            } finally {
-                rowIndex = saved;
-            }
-        }
         return super.getVarcharB(columnIndex);
     }
 
     @Override
     public int getVarcharSize(int columnIndex) {
-        if (needsLazyConversion(columnIndex)) {
-            final long saved = rowIndex;
-            try {
-                rowIndex = getRowIndex(columnIndex);
-                return super.getVarcharSize(columnIndex);
-            } finally {
-                rowIndex = saved;
-            }
-        }
         final long auxPageAddress = auxPageAddresses.get(columnOffset + columnIndex);
         if (auxPageAddress != 0) {
             if (frameFormat == PartitionFormat.PARQUET) {
@@ -611,17 +504,6 @@ public class PageFrameFilteredMemoryRecord extends PageFrameMemoryRecord {
     @Override
     public void setRowIndex(long rowIndex) {
         throw new UnsupportedOperationException("PageFrameFilteredMemoryRecord requires setFilteredRowIndex(rowIndex, compactedRowIndex)");
-    }
-
-    /**
-     * Returns true when this column needs lazy parquet type conversion on read --
-     * Var-to-Fixed, Fixed-to-Var, or Symbol-to-non-Symbol (excluding Symbol-to-Var).
-     * The fast direct-read path bypasses the converter and would return raw bytes,
-     * so callers must instead delegate to the parent class which routes through the
-     * overridden {@link #getStr0} / {@link #getVarchar} and respects {@link #getRowIndex}.
-     */
-    private boolean needsLazyConversion(int columnIndex) {
-        return hasTypeCasts && sourceColumnTypes.getQuick(columnIndex) != -1;
     }
 
     private long getRowIndex(int columnIndex) {

--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameMemory.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameMemory.java
@@ -123,20 +123,7 @@ public interface PageFrameMemory {
     long getRowIdOffset();
 
     /**
-     * Returns the source column type tag for a type-cast column, or -1 if
-     * the column does not require a type cast. Used by
-     * {@link PageFrameMemoryRecord} to perform lazy fixed→var conversion.
-     */
-    int getSourceColumnType(int columnIndex);
-
-    /**
      * Returns true if any column has a column top (zero address).
      */
     boolean hasColumnTops();
-
-    /**
-     * Returns true if any column requires a lazy type cast (e.g. fixed→varchar
-     * conversion for parquet partitions with ALTER COLUMN TYPE).
-     */
-    boolean hasColumnTypeCasts();
 }

--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryPool.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryPool.java
@@ -120,9 +120,6 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
     private final ParquetPartitionDecoder parquetMetaDecoder;
     private final IntList queryToSlot = new IntList(16);
     private final IntLongHashMap recordAtSlices = new IntLongHashMap();
-    // Per-column source type tag for fixed-to-var type-cast columns.
-    // Indexed by query column index; -1 means no type cast.
-    private final IntList sourceColumnTypes;
     private ParquetDecoder activeDecoder;
     private PageFrameAddressCache addressCache;
     // Per-worker covered (posting-index sidecar) decode buffers, keyed by frame
@@ -169,7 +166,6 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
     // active decoder's file, letting openParquet(int) skip the rebuild on
     // every subsequent frame of the same file.
     private boolean hasFullProjectionMap;
-    private boolean hasTypeCasts;
     private ParquetBuffers lruHead;
     private ParquetBuffers lruTail;
     // Per-query tracker propagated to each ParquetBuffers' RowGroupBuffers when
@@ -196,7 +192,6 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
             parquetIdxToDecodeSlot = new IntIntHashMap(16);
             parquetMetaDecoder = new ParquetPartitionDecoder();
             legacyDecoder = new ParquetFileDecoder();
-            sourceColumnTypes = new IntList();
         } catch (Throwable th) {
             close();
             throw th;
@@ -300,8 +295,6 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
                     addressCache.getAuxPageSizes(),
                     addressCache.toColumnOffset(frameIndex),
                     addressCache.getColumnCount(),
-                    false,
-                    null,
                     null
             );
         } else if (format == PartitionFormat.PARQUET) {
@@ -319,15 +312,14 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
             if (record.getFrameIndex() == frameIndex && record.getBoundPool() == this && record.getBoundGeneration() == bindGeneration) {
                 return;
             }
-            // openParquet() rebuilds parquetColumns / parquetIdxToDecodeSlot AND the pool's
-            // per-frame lazy-conversion metadata (sourceColumnTypes / hasTypeCasts). record.init()
-            // below reads that metadata, so openParquet() must run on EVERY navigation: the pool's
-            // sourceColumnTypes is shared and a navigation to another file overwrites it, so a
-            // still-cached frame would otherwise hand the record a stale mapping and read a
-            // converted column with the wrong source type. activateDecoder() inside openParquet()
-            // clears hasFullProjectionMap on a file switch and forces the rebuild; on a same-file
-            // repeat visit the rebuild is skipped but the still-valid mapping is reused. Only the
-            // expensive decode() stays gated on the buffer cache miss / partial window.
+            // openParquet() rebuilds parquetColumns / parquetIdxToDecodeSlot (the per-frame
+            // column mapping) which record.init() below reads, so it must run on EVERY
+            // navigation: the mapping is shared and a navigation to another file overwrites it,
+            // so a still-cached frame would otherwise hand the record a stale mapping.
+            // activateDecoder() inside openParquet() clears hasFullProjectionMap on a file switch
+            // and forces the rebuild; on a same-file repeat visit the rebuild is skipped but the
+            // still-valid mapping is reused. Only the expensive decode() stays gated on the buffer
+            // cache miss / partial window.
             final byte usageBit = record.getLetter() == PageFrameMemoryRecord.RECORD_A_LETTER ? RECORD_A_MASK : RECORD_B_MASK;
             ParquetBuffers parquetBuffers = tryHit(frameIndex, usageBit);
             final int rowGroupLo = addressCache.getParquetRowGroupLo(frameIndex);
@@ -382,8 +374,6 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
                     parquetBuffers.auxPageSizes,
                     0, // parquet buffers use 0 offset since they're frame-specific
                     addressCache.getColumnCount(),
-                    hasTypeCasts,
-                    sourceColumnTypes,
                     parquetBuffers.columnTops
             );
             record.setBoundPool(this, bindGeneration);
@@ -509,14 +499,11 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
                     throw th;
                 }
             } else {
-                // Full cache hit, no decode needed, but the lazy-conversion metadata
-                // (the pool's hasTypeCasts / sourceColumnTypes, surfaced through
-                // PageFrameMemoryImpl.hasColumnTypeCasts() / getSourceColumnType()) still
-                // reflects whichever frame openParquet() last ran for. A later
-                // record.init(frameMemory) reads that metadata, so it must be rebuilt for
-                // THIS frame or the record inherits another frame's mapping and reads a
-                // converted column with the wrong source type. Mirrors the cache-hit refresh
-                // in navigateTo(int, PageFrameMemoryRecord).
+                // Full cache hit, no decode needed, but the column mapping still reflects
+                // whichever frame openParquet() last ran for. A later record.init(frameMemory)
+                // reads that mapping, so it must be rebuilt for THIS frame or the record inherits
+                // another frame's mapping. Mirrors the cache-hit refresh in
+                // navigateTo(int, PageFrameMemoryRecord).
                 try {
                     openParquet(frameIndex);
                 } catch (Throwable th) {
@@ -586,11 +573,10 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
                     throw th;
                 }
             } else {
-                // Full cache hit, no decode needed, but the lazy-conversion metadata
-                // (the pool's hasTypeCasts / sourceColumnTypes) still reflects whichever
-                // frame openParquet() last ran for. Rebuild it for THIS frame so a later
-                // record.init(frameMemory) does not inherit another frame's mapping. Mirrors
-                // the cache-hit refresh in navigateTo(int, PageFrameMemoryRecord).
+                // Full cache hit, no decode needed, but the column mapping still reflects
+                // whichever frame openParquet() last ran for. Rebuild it for THIS frame so a
+                // later record.init(frameMemory) does not inherit another frame's mapping.
+                // Mirrors the cache-hit refresh in navigateTo(int, PageFrameMemoryRecord).
                 try {
                     openParquet(frameIndex, columnIndexes, true);
                 } catch (Throwable th) {
@@ -691,8 +677,6 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
                 buffers.getAuxPageSizes(),
                 0, // covered buffers are frame-specific, so they use a 0 column offset
                 addressCache.getColumnCount(),
-                false, // covered NATIVE frames have no parquet-style lazy type conversion
-                null,
                 null
         );
         record.setBoundPool(this, bindGeneration);
@@ -1251,8 +1235,6 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
         for (int q = 0; q < readParquetColumnCount; q++) {
             queryToSlot.setQuick(q, -1);
         }
-        sourceColumnTypes.setAll(readParquetColumnCount, -1);
-        hasTypeCasts = false;
         for (int i = 0; i < readParquetColumnCount; i++) {
             resolveParquetColumn(i, columnMapping, activeDecoder);
         }
@@ -1275,15 +1257,6 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
         for (int q = 0; q < readParquetColumnCount; q++) {
             queryToSlot.setQuick(q, -1);
         }
-        if (isInclude) {
-            // First-pass navigation: start from a clean slate.
-            sourceColumnTypes.setAll(readParquetColumnCount, -1);
-            hasTypeCasts = false;
-        }
-        // isInclude=false is populateRemainingColumns: retain sourceColumnTypes / hasTypeCasts
-        // set by the prior isInclude=true call so that lazy conversion metadata for filter
-        // columns survives. Without this, PageFrameMemoryRecord re-snapshots a stale -1
-        // for filter columns and reads VARCHAR_SLICE bytes as the target fixed type.
         for (int i = 0; i < readParquetColumnCount; i++) {
             if (columnIndexes.contains(i) != isInclude) {
                 continue;
@@ -1360,101 +1333,28 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
         int parquetIdx = columnIdToParquetIdx.get(columnWriterIndex);
 
         if (parquetIdx < 0) {
-            // Direct writer index lookup failed. The column may have been type-converted
-            // (ALTER COLUMN TYPE), so the parquet file stores it under the original writer index.
+            // Direct writer index lookup failed. A type-converted column (ALTER COLUMN TYPE)
+            // is stored under its original writer index (the replacingIndex chain head), so
+            // retry under that id. ALTER re-encodes the parquet eagerly, so the stored type
+            // always matches the current type here - only the writer index differs.
             final int origWriterIndex = columnMapping.getOriginalWriterIndex(i);
             if (origWriterIndex >= 0 && origWriterIndex != columnWriterIndex) {
                 parquetIdx = columnIdToParquetIdx.get(origWriterIndex);
-            }
-            if (parquetIdx >= 0) {
-                int targetType = addressCache.getColumnTypes().getQuick(i);
-                final int sourceType = parquetMetadata.getColumnType(parquetIdx);
-                final int sourceTag = ColumnType.tagOf(sourceType);
-                final int targetTag = ColumnType.tagOf(targetType);
-                if (ColumnType.isSymbol(targetTag) && !ColumnType.isSymbol(sourceTag)) {
-                    // Non-symbol -> symbol: the pre-pass in ConvertOperatorImpl should have
-                    // converted this parquet partition to native. If we get here, it's a bug.
-                    throw CairoException.critical(0)
-                            .put("unexpected non-symbol->symbol in parquet, column=").put(i)
-                            .put(", sourceType=").put(ColumnType.nameOf(sourceTag))
-                            .put(", targetType=").put(ColumnType.nameOf(targetTag));
-                }
-                if (sourceTag == targetTag) {
-                    // Same type, just a writer index mismatch after ALTER COLUMN TYPE.
-                    // No conversion needed, decode normally.
-                    if (ColumnType.tagOf(targetType) == ColumnType.VARCHAR) {
-                        targetType = ColumnType.VARCHAR_SLICE;
+                if (parquetIdx >= 0) {
+                    final int sourceType = parquetMetadata.getColumnType(parquetIdx);
+                    final int targetType = addressCache.getColumnTypes().getQuick(i);
+                    if (ColumnType.tagOf(sourceType) != ColumnType.tagOf(targetType)) {
+                        // The eager re-encode guarantees the stored tag equals the current tag.
+                        // A mismatch means a parquet partition advanced its metadata type without
+                        // being re-encoded (only reachable if parquet partitions are ever split);
+                        // fail loud rather than read the stored bytes as the wrong type.
+                        throw CairoException.critical(0)
+                                .put("parquet column type mismatch after ALTER COLUMN TYPE [column=").put(i)
+                                .put(", stored=").put(ColumnType.nameOf(sourceType))
+                                .put(", current=").put(ColumnType.nameOf(targetType))
+                                .put(']');
                     }
-                    queryToSlot.setQuick(i, addDecodeSlotIfAbsent(parquetIdx, targetType));
-                    return;
                 }
-
-                if (ColumnType.isSymbol(sourceTag) && !ColumnType.isSymbol(targetTag)) {
-                    // Symbol -> non-symbol: decode as VARCHAR_SLICE, Java converts lazily.
-                    // For Symbol->VARCHAR, the fallthrough below handles it (VARCHAR_SLICE is native format).
-                    if (targetTag != ColumnType.VARCHAR && targetTag != ColumnType.STRING) {
-                        queryToSlot.setQuick(i, addDecodeSlotIfAbsent(parquetIdx, ColumnType.VARCHAR_SLICE));
-                        // Negative VARCHAR tag signals var->fixed/var->string conversion.
-                        // Same target-type metadata layout as the var->fixed branch
-                        // below; the Symbol-as-VARCHAR_SLICE rows are converted by
-                        // the same lazy converters in PageFrameMemoryRecord.
-                        int encoded = ColumnType.VARCHAR;
-                        if (ColumnType.isDecimal(targetType)) {
-                            encoded |= (ColumnType.getDecimalPrecision(targetType) << 8)
-                                    | (ColumnType.getDecimalScale(targetType) << 16);
-                        } else if (ColumnType.isTimestampNano(targetType)) {
-                            encoded |= (1 << 24);
-                        }
-                        sourceColumnTypes.setQuick(i, -encoded);
-                        hasTypeCasts = true;
-                        return;
-                    }
-                    // Symbol->VARCHAR falls through to the bottom of this method.
-                }
-
-                if (!ColumnType.isVarSize(sourceTag) && !ColumnType.isSymbol(sourceTag)
-                        && (targetTag == ColumnType.VARCHAR || targetTag == ColumnType.STRING)) {
-                    // Fixed -> var-size: decode as source fixed type.
-                    // Java does lazy per-row conversion in PageFrameMemoryRecord.
-                    queryToSlot.setQuick(i, addDecodeSlotIfAbsent(parquetIdx, sourceType));
-                    sourceColumnTypes.setQuick(i, sourceType);
-                    hasTypeCasts = true;
-                    return;
-                }
-
-                if (ColumnType.isVarSize(sourceTag) && !ColumnType.isVarSize(targetTag)
-                        && !ColumnType.isSymbol(targetTag)) {
-                    // Var -> fixed-size: decode as source var type.
-                    // Java does lazy per-row conversion in PageFrameMemoryRecord.
-                    int decodeType = (sourceTag == ColumnType.VARCHAR)
-                            ? ColumnType.VARCHAR_SLICE : sourceType;
-                    queryToSlot.setQuick(i, addDecodeSlotIfAbsent(parquetIdx, decodeType));
-                    // Negative value signals var->fixed direction.
-                    // -1 remains the "no conversion" sentinel.
-                    // Bit layout of the encoded value (target-specific metadata
-                    // in the upper bits - only one target family fills 8-23 at a time):
-                    //   bits 0-7:   source tag (STRING or VARCHAR)
-                    //   bits 8-15:  target decimal precision (decimal targets)
-                    //   bits 16-23: target decimal scale (decimal targets)
-                    //   bit  24:    target timestamp precision (0 = micros, 1 = nanos)
-                    int encoded = ColumnType.tagOf(sourceType);
-                    if (ColumnType.isDecimal(targetType)) {
-                        encoded |= (ColumnType.getDecimalPrecision(targetType) << 8)
-                                | (ColumnType.getDecimalScale(targetType) << 16);
-                    } else if (ColumnType.isTimestampNano(targetType)) {
-                        encoded |= (1 << 24);
-                    }
-                    sourceColumnTypes.setQuick(i, -encoded);
-                    hasTypeCasts = true;
-                    return;
-                }
-
-                // Fixed -> fixed type conversion: tell Rust to decode as target type.
-                if (targetTag == ColumnType.VARCHAR) {
-                    targetType = ColumnType.VARCHAR_SLICE;
-                }
-                queryToSlot.setQuick(i, addDecodeSlotIfAbsent(parquetIdx, targetType));
-                return;
             }
         }
 
@@ -1565,14 +1465,6 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
         }
 
         @Override
-        public int getSourceColumnType(int columnIndex) {
-            if (frameFormat == PartitionFormat.PARQUET && hasTypeCasts) {
-                return sourceColumnTypes.getQuick(columnIndex);
-            }
-            return -1;
-        }
-
-        @Override
         public boolean hasColumnTops() {
             for (int i = 0, n = addressCache.getColumnCount(); i < n; i++) {
                 // VARCHAR column that contains short strings will have zero data vector,
@@ -1582,11 +1474,6 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
                 }
             }
             return false;
-        }
-
-        @Override
-        public boolean hasColumnTypeCasts() {
-            return frameFormat == PartitionFormat.PARQUET && hasTypeCasts;
         }
 
         @Override

--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryRecord.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryRecord.java
@@ -26,48 +26,34 @@ package io.questdb.cairo.sql;
 
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
-import io.questdb.cairo.ColumnTypeConverter;
 import io.questdb.cairo.GeoHashes;
-import io.questdb.cairo.MicrosTimestampDriver;
-import io.questdb.cairo.MillisTimestampDriver;
-import io.questdb.cairo.NanosTimestampDriver;
 import io.questdb.cairo.TableUtils;
-import io.questdb.cairo.TimestampDriver;
 import io.questdb.cairo.VarcharTypeDriver;
 import io.questdb.cairo.arr.ArrayTypeDriver;
 import io.questdb.cairo.arr.ArrayView;
 import io.questdb.cairo.arr.BorrowedArray;
 import io.questdb.cairo.vm.NullMemoryCMR;
 import io.questdb.cairo.vm.Vm;
-import io.questdb.griffin.SqlKeywords;
 import io.questdb.std.BinarySequence;
 import io.questdb.std.Decimal128;
 import io.questdb.std.Decimal256;
-import io.questdb.std.Decimal64;
-import io.questdb.std.Decimals;
 import io.questdb.std.DirectByteSequenceView;
 import io.questdb.std.DirectLongList;
-import io.questdb.std.IntList;
 import io.questdb.std.Long256;
 import io.questdb.std.Long256Acceptor;
 import io.questdb.std.Long256Impl;
 import io.questdb.std.Misc;
 import io.questdb.std.Mutable;
 import io.questdb.std.Numbers;
-import io.questdb.std.NumericException;
 import io.questdb.std.ObjList;
 import io.questdb.std.QuietCloseable;
 import io.questdb.std.Rows;
 import io.questdb.std.Unsafe;
-import io.questdb.std.Uuid;
 import io.questdb.std.str.CharSink;
 import io.questdb.std.str.DirectString;
 import io.questdb.std.str.StableStringSource;
-import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.Utf8SplitString;
-import io.questdb.std.str.Utf8StringSink;
-import io.questdb.std.str.Utf8s;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -86,31 +72,9 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
     private final ObjList<BorrowedArray> arrayBuffers = new ObjList<>();
     private final ObjList<DirectByteSequenceView> bsViews = new ObjList<>();
     private final ObjList<DirectString> csViews = new ObjList<>();
-    // Reusable decimal instances for lazy var->decimal conversion.
-    private final Decimal128 decimal128Buf = new Decimal128();
-    private final Decimal256 decimal256Buf = new Decimal256();
-    private final Decimal64 decimal64Buf = new Decimal64();
     private final ObjList<Long256Impl> longs256 = new ObjList<>();
-    private final ObjList<StringSink> stringSinks = new ObjList<>();
     private final ObjList<SymbolTable> symbolTableCache = new ObjList<>();
-    // Dedicated sink for UTF-8 -> UTF-16 decoding when reading a parquet VARCHAR value
-    // for a lazy var->fixed / var->decimal conversion. Kept separate from the per-column
-    // string sinks because those are used as the return buffer of getStrA/getStrB and
-    // must not be clobbered by the decode step inside readVarValueForConversion.
-    private final StringSink utf16DecodeSink = new StringSink();
     private final ObjList<Utf8SplitString> utf8Views = new ObjList<>();
-    private final ObjList<Utf8StringSink> varcharSinks = new ObjList<>();
-    // Single-entry cache so the two UUID accessors (getLong128Hi/getLong128Lo) parse a
-    // var->UUID value once per row instead of once each. Keyed by (frame, row, column): frameIndex
-    // is part of the key so any frame switch -- via either init() overload -- self-invalidates the
-    // cache without a per-init reset, since two frames reuse the same in-frame row indexes for
-    // different data. clear() resets the key for cross-query record reuse. The fields are only read
-    // and written on the UUID-cast accessor path, so a non-cast query never touches them.
-    private int uuidCacheColumnIndex = -1;
-    private int uuidCacheFrameIndex = -1;
-    private long uuidCacheHi;
-    private long uuidCacheLo;
-    private long uuidCacheRowIndex = -1;
     protected DirectLongList auxPageAddresses;
     protected DirectLongList auxPageSizes;
     // Pool bind generation captured when boundPool was stamped. The pool bumps its
@@ -133,8 +97,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
     protected DirectLongList columnTops;
     protected byte frameFormat = -1;
     protected int frameIndex = -1;
-    // True when any column in the current frame needs lazy fixed->var conversion.
-    protected boolean hasTypeCasts;
     // Letters are used for parquet buffer reference counting in PageFrameMemoryPool.
     // RECORD_A_LETTER (0) stands for record A, RECORD_B_LETTER (1) stands for record B.
     protected byte letter;
@@ -142,17 +104,8 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
     protected DirectLongList pageSizes;
     protected long rowIdOffset;
     protected long rowIndex;
-    // Per-column source type tag for fixed->var type-cast columns.
-    // Set from PageFrameMemoryPool during init(); null when hasTypeCasts is false.
-    protected IntList sourceColumnTypes;
     protected boolean stableStrings;
     protected SymbolTableSource symbolTableSource;
-    // Per-column lazy fixed->str/varchar cache: one converter singleton (same for both
-    // destinations), packed (precision<<16)|scale args for DECIMAL, and ColumnType.sizeOf
-    // width. Null until first type-cast read; invalidated when sourceColumnTypes changes.
-    protected IntList typeCastArgs;
-    protected ObjList<ColumnTypeConverter.Fixed2VarConverter> typeCastConverters;
-    protected IntList typeCastWidth;
 
     public PageFrameMemoryRecord() {
     }
@@ -175,14 +128,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
         this.columnCount = other.columnCount;
         this.columnTops = other.columnTops;
         this.stableStrings = other.stableStrings;
-        this.hasTypeCasts = other.hasTypeCasts;
-        // Deep-copy the per-column conversion state. Sharing the reference would race
-        // with init()'s in-place mutation when this record is later navigated to a
-        // different frame. A null source list with hasTypeCasts == true would NPE in
-        // any typecast-aware getter called before the first navigateTo() on Record B.
-        if (other.sourceColumnTypes != null) {
-            this.sourceColumnTypes = new IntList(other.sourceColumnTypes);
-        }
         this.letter = letter;
     }
 
@@ -199,21 +144,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
         boundPool = null;
         boundGeneration = 0;
         columnTops = null;
-        // Reset the type-cast gate and its backing data symmetrically: in steady state
-        // the gate is what protects readers from a stale sourceColumnTypes, but clearing
-        // both keeps the cleared-state invariant honest and avoids relying on every
-        // future caller to re-init before the next read.
-        hasTypeCasts = false;
-        if (sourceColumnTypes != null) {
-            sourceColumnTypes.clear();
-        }
-        invalidateTypeCastConverterCache();
-        // Drop the var->UUID parse cache key so a recycled record cannot serve a prior query's
-        // value: a fresh query may reuse the same frameIndex with different data. The frameIndex
-        // in the cache key invalidates frame switches WITHIN a query on its own; this guards the
-        // cross-query reuse where frameIndex repeats. rowIndex is 0 after clear(), so a -1 sentinel
-        // here guarantees the next read misses.
-        uuidCacheRowIndex = -1;
     }
 
     @Override
@@ -305,12 +235,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public boolean getBool(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToBool(-srcTag, columnIndex);
-            }
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getByte(address + rowIndex) == 1;
@@ -328,12 +252,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public byte getByte(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToByte(-srcTag, columnIndex);
-            }
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getByte(address + rowIndex);
@@ -343,12 +261,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public char getChar(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToChar(-srcTag, columnIndex);
-            }
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getChar(address + (rowIndex << 1));
@@ -358,24 +270,11 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public long getDate(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToDate(-srcTag, columnIndex);
-            }
-        }
         return getLong(columnIndex);
     }
 
     @Override
     public void getDecimal128(int columnIndex, Decimal128 sink) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                convertVarToDecimal128(-srcTag, columnIndex, sink);
-                return;
-            }
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             address += (rowIndex << 4);
@@ -390,12 +289,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public short getDecimal16(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToDecimal16(-srcTag, columnIndex);
-            }
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getShort(address + (rowIndex << 1));
@@ -405,13 +298,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public void getDecimal256(int columnIndex, Decimal256 sink) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                convertVarToDecimal256(-srcTag, columnIndex, sink);
-                return;
-            }
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             sink.ofRawAddress(address + (rowIndex << 5));
@@ -422,12 +308,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public int getDecimal32(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToDecimal32(-srcTag, columnIndex);
-            }
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getInt(address + (rowIndex << 2));
@@ -437,12 +317,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public long getDecimal64(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToDecimal64(-srcTag, columnIndex);
-            }
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getLong(address + (rowIndex << 3));
@@ -452,12 +326,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public byte getDecimal8(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToDecimal8(-srcTag, columnIndex);
-            }
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getByte(address + rowIndex);
@@ -467,12 +335,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public double getDouble(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToDouble(-srcTag, columnIndex);
-            }
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getDouble(address + (rowIndex << 3));
@@ -482,12 +344,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public float getFloat(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToFloat(-srcTag, columnIndex);
-            }
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getFloat(address + (rowIndex << 2));
@@ -537,12 +393,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public int getIPv4(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToIPv4(-srcTag, columnIndex);
-            }
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getInt(address + (rowIndex << 2));
@@ -552,12 +402,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public int getInt(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToInt(-srcTag, columnIndex);
-            }
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getInt(address + (rowIndex << 2));
@@ -572,12 +416,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public long getLong(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToLong(-srcTag, columnIndex);
-            }
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getLong(address + (rowIndex << 3));
@@ -587,13 +425,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public long getLong128Hi(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                // UUID chained conversion is not supported; fall through to direct conversion.
-                return convertVarToUuidHi(-srcTag, columnIndex);
-            }
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getLong(address + (rowIndex << 4) + Long.BYTES);
@@ -603,13 +434,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public long getLong128Lo(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                // UUID chained conversion is not supported; fall through to direct conversion.
-                return convertVarToUuidLo(-srcTag, columnIndex);
-            }
-        }
         long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getLong(address + (rowIndex << 4));
@@ -647,13 +471,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
     }
 
     public long getPageAddress(int columnIndex) {
-        // A column decoded in its pre-conversion source type (e.g. VARCHAR_SLICE for a
-        // STRING->INT cast) has no directly-readable target-typed buffer. Returning 0 makes
-        // raw-address fast paths (e.g. GroupByFunction.computeKeyedBatch) fall through to the
-        // converting record accessors, as they already do for a column top.
-        if (hasTypeCasts && sourceColumnTypes.getQuick(columnIndex) != -1) {
-            return 0;
-        }
         return pageAddresses.get(columnOffset + columnIndex);
     }
 
@@ -664,12 +481,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public short getShort(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToShort(-srcTag, columnIndex);
-            }
-        }
         final long address = pageAddresses.get(columnOffset + columnIndex);
         if (address != 0) {
             return Unsafe.getShort(address + (rowIndex << 1));
@@ -679,45 +490,16 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public CharSequence getStrA(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag >= 0) {
-                return convertFixedToStr(srcTag, columnIndex, stringSinkA(columnIndex));
-            }
-            if (srcTag < -1) {
-                return convertVarToStr(-srcTag, columnIndex, stringSinkA(columnIndex));
-            }
-        }
         return getStr0(columnIndex, csViewA(columnIndex));
     }
 
     @Override
     public CharSequence getStrB(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag >= 0) {
-                return convertFixedToStr(srcTag, columnIndex, stringSinkB(columnIndex));
-            }
-            if (srcTag < -1) {
-                return convertVarToStr(-srcTag, columnIndex, stringSinkB(columnIndex));
-            }
-        }
         return getStr0(columnIndex, csViewB(columnIndex));
     }
 
     @Override
     public int getStrLen(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag >= 0) {
-                final CharSequence result = convertFixedToStr(srcTag, columnIndex, stringSinkA(columnIndex));
-                return result != null ? result.length() : TableUtils.NULL_LEN;
-            }
-            if (srcTag < -1) {
-                final CharSequence result = readVarValueForConversion(-srcTag, columnIndex);
-                return result != null ? result.length() : TableUtils.NULL_LEN;
-            }
-        }
         final long dataPageAddress = pageAddresses.get(columnOffset + columnIndex);
         if (dataPageAddress != 0) {
             final long auxPageAddress = auxPageAddresses.get(columnOffset + columnIndex);
@@ -768,12 +550,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public long getTimestamp(int columnIndex) {
-        if (hasTypeCasts) {
-            int srcTag = sourceColumnTypes.getQuick(columnIndex);
-            if (srcTag < -1) {
-                return convertVarToTimestamp(-srcTag, columnIndex);
-            }
-        }
         return getLong(columnIndex);
     }
 
@@ -784,26 +560,16 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
 
     @Override
     public Utf8Sequence getVarcharA(int columnIndex) {
-        if (hasTypeCasts && sourceColumnTypes.getQuick(columnIndex) >= 0) {
-            return convertFixedToVarchar(sourceColumnTypes.getQuick(columnIndex), columnIndex, varcharSinkA(columnIndex));
-        }
         return getVarchar(columnIndex, utf8ViewA(columnIndex));
     }
 
     @Override
     public Utf8Sequence getVarcharB(int columnIndex) {
-        if (hasTypeCasts && sourceColumnTypes.getQuick(columnIndex) >= 0) {
-            return convertFixedToVarchar(sourceColumnTypes.getQuick(columnIndex), columnIndex, varcharSinkB(columnIndex));
-        }
         return getVarchar(columnIndex, utf8ViewB(columnIndex));
     }
 
     @Override
     public int getVarcharSize(int columnIndex) {
-        if (hasTypeCasts && sourceColumnTypes.getQuick(columnIndex) >= 0) {
-            final Utf8Sequence result = convertFixedToVarchar(sourceColumnTypes.getQuick(columnIndex), columnIndex, varcharSinkA(columnIndex));
-            return result != null ? result.size() : TableUtils.NULL_LEN;
-        }
         final long auxPageAddress = auxPageAddresses.get(columnOffset + columnIndex);
         if (auxPageAddress != 0) {
             if (frameFormat == PartitionFormat.PARQUET) {
@@ -821,7 +587,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
         this.frameIndex = frameMemory.getFrameIndex();
         this.frameFormat = frameMemory.getFrameFormat();
         this.stableStrings = (frameFormat == PartitionFormat.NATIVE);
-        this.hasTypeCasts = frameMemory.hasColumnTypeCasts();
         this.rowIdOffset = frameMemory.getRowIdOffset();
         this.pageAddresses = frameMemory.getPageAddresses();
         this.auxPageAddresses = frameMemory.getAuxPageAddresses();
@@ -830,17 +595,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
         this.columnOffset = frameMemory.getColumnOffset();
         this.columnCount = frameMemory.getColumnCount();
         this.columnTops = frameMemory.getColumnTops();
-        if (this.hasTypeCasts) {
-            // Copy source column types from PageFrameMemory.
-            if (this.sourceColumnTypes == null) {
-                this.sourceColumnTypes = new IntList(columnCount);
-            }
-            this.sourceColumnTypes.setAll(columnCount, -1);
-            for (int col = 0; col < columnCount; col++) {
-                this.sourceColumnTypes.setQuick(col, frameMemory.getSourceColumnType(col));
-            }
-        }
-        invalidateTypeCastConverterCache();
         // Stamp the owning pool so navigateTo() can early-return only while this
         // record still points at that pool's live buffers. A foreign pool (e.g. a
         // reduce task's) that later frees its buffers leaves boundPool != the
@@ -882,336 +636,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
         this.rowIndex = rowIndex;
     }
 
-    private ColumnTypeConverter.Fixed2VarConverter cacheTypeCastConverter(int columnIndex, int srcType, int dstType) {
-        // The destination only affects the unsupported diagnostic in getFixedToVarConverter,
-        // so the resolved singleton is the same for STRING and VARCHAR targets and one
-        // converter cache serves both. Caller guarantees this runs at most once per column
-        // per frame (it gates on typeCastConverters being null or returning null at index).
-        if (typeCastConverters == null) {
-            typeCastConverters = new ObjList<>();
-            typeCastArgs = new IntList();
-            typeCastWidth = new IntList();
-        }
-        final ColumnTypeConverter.Fixed2VarConverter converter =
-                ColumnTypeConverter.getFixedToVarConverter(srcType, dstType);
-        typeCastConverters.extendAndSet(columnIndex, converter);
-        final int args;
-        if (ColumnType.isDecimal(srcType)) {
-            args = (ColumnType.getDecimalPrecision(srcType) << 16) | ColumnType.getDecimalScale(srcType);
-        } else {
-            args = 0;
-        }
-        typeCastArgs.extendAndSet(columnIndex, args);
-        typeCastWidth.extendAndSet(columnIndex, ColumnType.sizeOf(srcType));
-        return converter;
-    }
-
-    /**
-     * Converts a fixed-type value to a STRING CharSequence.
-     * Returns null for null values. Called only when the column needs a type cast.
-     * The first call per column per frame resolves and caches the
-     * {@link ColumnTypeConverter.Fixed2VarConverter}, the packed (precision, scale)
-     * args for decimal columns, and the row stride; subsequent rows pay only a flat
-     * array load instead of repeating the type dispatch.
-     */
-    private CharSequence convertFixedToStr(int srcType, int columnIndex, StringSink sink) {
-        final long address = pageAddresses.get(columnOffset + columnIndex);
-        if (address == 0) {
-            return null; // column top
-        }
-        // Only no-sentinel sources (BOOLEAN/BYTE/SHORT/CHAR) need the explicit column-top
-        // count: their column-top rows decode to an in-band 0/false the converter cannot tell
-        // from a real value. Sentinel sources store the column top as their null sentinel (and
-        // may also have scattered nulls), so the converter already returns null for them.
-        if (columnTops != null && ColumnType.isNoNullSentinelFixedType(srcType)
-                && rowIndex < columnTops.get(columnOffset + columnIndex)) {
-            return null;
-        }
-        sink.clear();
-        ColumnTypeConverter.Fixed2VarConverter converter =
-                typeCastConverters != null ? typeCastConverters.getQuiet(columnIndex) : null;
-        if (converter == null) {
-            converter = cacheTypeCastConverter(columnIndex, srcType, ColumnType.STRING);
-        }
-        final int args = typeCastArgs.getQuick(columnIndex);
-        return converter.convert(
-                address + rowIndex * typeCastWidth.getQuick(columnIndex),
-                sink,
-                args >>> 16,
-                args & 0xFFFF
-        ) ? sink : null;
-    }
-
-    /**
-     * Converts a fixed-type value to a VARCHAR Utf8Sequence.
-     * Returns null for null values. Called only when the column needs a type cast.
-     * See {@link #convertFixedToStr} for the per-column cache shape.
-     */
-    private Utf8Sequence convertFixedToVarchar(int srcType, int columnIndex, Utf8StringSink sink) {
-        final long address = pageAddresses.get(columnOffset + columnIndex);
-        if (address == 0) {
-            return null; // column top
-        }
-        // See convertFixedToStr: only no-sentinel sources need the explicit column-top count.
-        if (columnTops != null && ColumnType.isNoNullSentinelFixedType(srcType)
-                && rowIndex < columnTops.get(columnOffset + columnIndex)) {
-            return null;
-        }
-        sink.clear();
-        ColumnTypeConverter.Fixed2VarConverter converter =
-                typeCastConverters != null ? typeCastConverters.getQuiet(columnIndex) : null;
-        if (converter == null) {
-            converter = cacheTypeCastConverter(columnIndex, srcType, ColumnType.VARCHAR);
-        }
-        final int args = typeCastArgs.getQuick(columnIndex);
-        return converter.convert(
-                address + rowIndex * typeCastWidth.getQuick(columnIndex),
-                sink,
-                args >>> 16,
-                args & 0xFFFF
-        ) ? sink : null;
-    }
-
-    private boolean convertVarToBool(int encoded, int columnIndex) {
-        CharSequence cs = readVarValueForConversion(encoded & 0xFF, columnIndex);
-        return cs != null && SqlKeywords.isTrueKeyword(cs);
-    }
-
-    private byte convertVarToByte(int encoded, int columnIndex) {
-        CharSequence cs = readVarValueForConversion(encoded & 0xFF, columnIndex);
-        if (cs != null) {
-            try {
-                return (byte) Numbers.parseInt(cs);
-            } catch (NumericException ignore) {
-            }
-        }
-        return 0;
-    }
-
-    private char convertVarToChar(int encoded, int columnIndex) {
-        CharSequence cs = readVarValueForConversion(encoded & 0xFF, columnIndex);
-        return cs != null && cs.length() > 0 ? cs.charAt(0) : (char) 0;
-    }
-
-    private long convertVarToDate(int encoded, int columnIndex) {
-        CharSequence cs = readVarValueForConversion(encoded & 0xFF, columnIndex);
-        if (cs != null) {
-            try {
-                // parseFloorLiteral matches ColumnTypeConverter's STRING->DATE path and
-                // accepts higher-precision input (micros/nanos) by truncating extras.
-                return MillisTimestampDriver.INSTANCE.parseFloorLiteral(cs);
-            } catch (NumericException ignore) {
-            }
-        }
-        return Numbers.LONG_NULL;
-    }
-
-    private void convertVarToDecimal128(int encoded, int columnIndex, Decimal128 sink) {
-        int srcTag = encoded & 0xFF;
-        int precision = (encoded >> 8) & 0xFF;
-        int scale = (encoded >> 16) & 0xFF;
-        CharSequence cs = readVarValueForConversion(srcTag, columnIndex);
-        if (cs != null) {
-            try {
-                decimal128Buf.ofString(cs, precision, scale);
-                sink.ofRaw(decimal128Buf.getHigh(), decimal128Buf.getLow());
-                return;
-            } catch (NumericException ignore) {
-            }
-        }
-        sink.ofRawNull();
-    }
-
-    private short convertVarToDecimal16(int encoded, int columnIndex) {
-        int srcTag = encoded & 0xFF;
-        int precision = (encoded >> 8) & 0xFF;
-        int scale = (encoded >> 16) & 0xFF;
-        CharSequence cs = readVarValueForConversion(srcTag, columnIndex);
-        if (cs != null) {
-            try {
-                decimal64Buf.ofString(cs, precision, scale);
-                long v = decimal64Buf.getValue();
-                if (v >= Short.MIN_VALUE + 1 && v <= Short.MAX_VALUE) {
-                    return (short) v;
-                }
-            } catch (NumericException ignore) {
-            }
-        }
-        return Decimals.DECIMAL16_NULL;
-    }
-
-    private void convertVarToDecimal256(int encoded, int columnIndex, Decimal256 sink) {
-        int srcTag = encoded & 0xFF;
-        int precision = (encoded >> 8) & 0xFF;
-        int scale = (encoded >> 16) & 0xFF;
-        CharSequence cs = readVarValueForConversion(srcTag, columnIndex);
-        if (cs != null) {
-            try {
-                decimal256Buf.ofString(cs, precision, scale);
-                sink.ofRaw(decimal256Buf.getHh(), decimal256Buf.getHl(), decimal256Buf.getLh(), decimal256Buf.getLl());
-                return;
-            } catch (NumericException ignore) {
-            }
-        }
-        sink.ofRawNull();
-    }
-
-    private int convertVarToDecimal32(int encoded, int columnIndex) {
-        int srcTag = encoded & 0xFF;
-        int precision = (encoded >> 8) & 0xFF;
-        int scale = (encoded >> 16) & 0xFF;
-        CharSequence cs = readVarValueForConversion(srcTag, columnIndex);
-        if (cs != null) {
-            try {
-                decimal64Buf.ofString(cs, precision, scale);
-                long v = decimal64Buf.getValue();
-                if (v >= Integer.MIN_VALUE + 1 && v <= Integer.MAX_VALUE) {
-                    return (int) v;
-                }
-            } catch (NumericException ignore) {
-            }
-        }
-        return Decimals.DECIMAL32_NULL;
-    }
-
-    private long convertVarToDecimal64(int encoded, int columnIndex) {
-        int srcTag = encoded & 0xFF;
-        int precision = (encoded >> 8) & 0xFF;
-        int scale = (encoded >> 16) & 0xFF;
-        CharSequence cs = readVarValueForConversion(srcTag, columnIndex);
-        if (cs != null) {
-            try {
-                decimal64Buf.ofString(cs, precision, scale);
-                return decimal64Buf.getValue();
-            } catch (NumericException ignore) {
-            }
-        }
-        return Decimals.DECIMAL64_NULL;
-    }
-
-    private byte convertVarToDecimal8(int encoded, int columnIndex) {
-        int srcTag = encoded & 0xFF;
-        int precision = (encoded >> 8) & 0xFF;
-        int scale = (encoded >> 16) & 0xFF;
-        CharSequence cs = readVarValueForConversion(srcTag, columnIndex);
-        if (cs != null) {
-            try {
-                decimal64Buf.ofString(cs, precision, scale);
-                long v = decimal64Buf.getValue();
-                if (v >= Byte.MIN_VALUE + 1 && v <= Byte.MAX_VALUE) {
-                    return (byte) v;
-                }
-            } catch (NumericException ignore) {
-            }
-        }
-        return Decimals.DECIMAL8_NULL;
-    }
-
-    private double convertVarToDouble(int encoded, int columnIndex) {
-        CharSequence cs = readVarValueForConversion(encoded & 0xFF, columnIndex);
-        return Numbers.parseDoubleQuiet(cs);
-    }
-
-    private float convertVarToFloat(int encoded, int columnIndex) {
-        CharSequence cs = readVarValueForConversion(encoded & 0xFF, columnIndex);
-        if (cs != null) {
-            try {
-                return Numbers.parseFloat(cs);
-            } catch (NumericException ignore) {
-            }
-        }
-        return Float.NaN;
-    }
-
-    private int convertVarToIPv4(int encoded, int columnIndex) {
-        CharSequence cs = readVarValueForConversion(encoded & 0xFF, columnIndex);
-        if (cs != null) {
-            return Numbers.parseIPv4Quiet(cs);
-        }
-        return Numbers.IPv4_NULL;
-    }
-
-    private int convertVarToInt(int encoded, int columnIndex) {
-        CharSequence cs = readVarValueForConversion(encoded & 0xFF, columnIndex);
-        if (cs != null) {
-            return Numbers.parseIntQuiet(cs);
-        }
-        return Numbers.INT_NULL;
-    }
-
-    private long convertVarToLong(int encoded, int columnIndex) {
-        CharSequence cs = readVarValueForConversion(encoded & 0xFF, columnIndex);
-        if (cs != null) {
-            return Numbers.parseLongQuiet(cs);
-        }
-        return Numbers.LONG_NULL;
-    }
-
-    private short convertVarToShort(int encoded, int columnIndex) {
-        CharSequence cs = readVarValueForConversion(encoded & 0xFF, columnIndex);
-        if (cs != null) {
-            try {
-                return (short) Numbers.parseInt(cs);
-            } catch (NumericException ignore) {
-            }
-        }
-        return 0;
-    }
-
-    private CharSequence convertVarToStr(int encoded, int columnIndex, StringSink sink) {
-        int srcTag = encoded & 0xFF;
-        if (srcTag == ColumnType.VARCHAR) {
-            // Decode UTF-8 straight into the destination sink. Going through
-            // readVarValueForConversion would route the decode via utf16DecodeSink
-            // and then copy from it into sink, which both wastes a copy and creates
-            // a latent aliasing risk if the two sinks ever become the same instance.
-            Utf8Sequence utf8 = getVarchar(columnIndex, utf8ViewA(columnIndex));
-            if (utf8 == null) {
-                return null;
-            }
-            sink.clear();
-            Utf8s.utf8ToUtf16(utf8, sink);
-            return sink;
-        }
-        CharSequence cs = getStr0(columnIndex, csViewA(columnIndex));
-        if (cs == null) {
-            return null;
-        }
-        sink.clear();
-        sink.put(cs);
-        return sink;
-    }
-
-    private long convertVarToTimestamp(int encoded, int columnIndex) {
-        // bits 0-7:  source tag (STRING or VARCHAR)
-        // bit  24:   target timestamp precision (0 = micros, 1 = nanos)
-        // Without the precision bit the driver would default to micros and
-        // ALTER COLUMN c TYPE TIMESTAMP_NS would silently return values 1000x
-        // smaller than expected. Mirrors the native ColumnTypeConverter, which
-        // dispatches via ColumnType.getTimestampDriver(dstColumnType).
-        int srcTag = encoded & 0xFF;
-        boolean isNano = (encoded & (1 << 24)) != 0;
-        CharSequence cs = readVarValueForConversion(srcTag, columnIndex);
-        if (cs != null) {
-            try {
-                TimestampDriver driver = isNano ? NanosTimestampDriver.INSTANCE : MicrosTimestampDriver.INSTANCE;
-                return driver.parseFloorLiteral(cs);
-            } catch (NumericException ignore) {
-            }
-        }
-        return Numbers.LONG_NULL;
-    }
-
-    private long convertVarToUuidHi(int encoded, int columnIndex) {
-        parseVarToUuid(encoded, columnIndex);
-        return uuidCacheHi;
-    }
-
-    private long convertVarToUuidLo(int encoded, int columnIndex) {
-        parseVarToUuid(encoded, columnIndex);
-        return uuidCacheLo;
-    }
-
     private @NotNull DirectString csViewA(int columnIndex) {
         DirectString view = csViews.getQuiet(columnIndex);
         if (view != null) {
@@ -1229,18 +653,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
         }
         csViews.extendAndSet(slot, view = new DirectString(this));
         return view;
-    }
-
-    private void invalidateTypeCastConverterCache() {
-        // Source types can differ between frames (older partitions may predate an
-        // ALTER and still carry the original fixed type), so the cache must drop
-        // whenever the frame is repointed. The lists are null on records that have
-        // never seen a type-cast column, which is the common case.
-        if (typeCastConverters != null) {
-            typeCastConverters.clear();
-            typeCastArgs.clear();
-            typeCastWidth.clear();
-        }
     }
 
     private @NotNull Long256Impl long256A(int columnIndex) {
@@ -1262,89 +674,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
         return long256;
     }
 
-    /**
-     * Parses the var->UUID value at the current row into {@link #uuidCacheHi}/{@link #uuidCacheLo},
-     * so the paired getLong128Hi/getLong128Lo accessors share a single parse per row rather than
-     * parsing the string twice. A second call for the same (row, column) is a no-op cache hit.
-     * <p>
-     * Both halves are parsed together and committed only if both succeed; if either half is
-     * malformed both cache values become {@code LONG_NULL}. This mirrors the native
-     * {@link ColumnTypeConverter} {@code str2Uuid}, which nulls both halves on any parse failure,
-     * so a structurally-valid UUID with one corrupt half reads as NULL on both paths.
-     */
-    private void parseVarToUuid(int encoded, int columnIndex) {
-        if (uuidCacheFrameIndex == frameIndex && uuidCacheRowIndex == rowIndex && uuidCacheColumnIndex == columnIndex) {
-            return;
-        }
-        long hi = Numbers.LONG_NULL;
-        long lo = Numbers.LONG_NULL;
-        CharSequence cs = readVarValueForConversion(encoded & 0xFF, columnIndex);
-        if (cs != null) {
-            try {
-                // checkDashesAndLength must run first: Uuid.parseHi indexes charAt up to
-                // UUID_LENGTH unconditionally and would throw IndexOutOfBoundsException on a
-                // short input (the NumericException-only catch would not handle it).
-                Uuid.checkDashesAndLength(cs);
-                long parsedHi = Uuid.parseHi(cs);
-                lo = Uuid.parseLo(cs);
-                // Commit hi only after parseLo succeeds, so a corrupt lo leaves both at LONG_NULL.
-                hi = parsedHi;
-            } catch (NumericException ignore) {
-            }
-        }
-        uuidCacheHi = hi;
-        uuidCacheLo = lo;
-        uuidCacheFrameIndex = frameIndex;
-        uuidCacheRowIndex = rowIndex;
-        uuidCacheColumnIndex = columnIndex;
-    }
-
-    /**
-     * Decodes the var value at {@code columnIndex} of source type {@code srcTag} as a
-     * CharSequence that the convertVarToXxx callers feed into Numbers/Uuid/timestamp
-     * parsers.
-     * <p>
-     * The returned CharSequence may be backed by the single shared {@link #utf16DecodeSink}
-     * (on the non-ASCII VARCHAR path) or by a per-column DirectString view (STRING path).
-     * In both cases the caller must finish consuming the result before invoking
-     * readVarValueForConversion again on the same record -- a subsequent call writes into
-     * the same sink, which would invalidate any reference still held by the caller.
-     * All current convertVarToXxx callers consume the result in a single parse call before
-     * returning, so the invariant holds today.
-     */
-    private CharSequence readVarValueForConversion(int srcTag, int columnIndex) {
-        if (srcTag == ColumnType.VARCHAR) {
-            Utf8Sequence utf8 = getVarchar(columnIndex, utf8ViewA(columnIndex));
-            // utf8ToUtf16OrView gives a zero-alloc view on the ASCII fast path and
-            // falls back to decoding into utf16DecodeSink for non-ASCII values.
-            // Downstream callers (convertVarToChar, convertVarToStr, Numbers.parseXxx,
-            // Uuid.parseHi/Lo, timestamp parsers) rely on real UTF-16 code points to
-            // behave the same as the native conversion path.
-            return utf8 != null ? Utf8s.utf8ToUtf16OrView(utf8, utf16DecodeSink) : null;
-        } else {
-            return getStr0(columnIndex, csViewA(columnIndex));
-        }
-    }
-
-    private @NotNull StringSink stringSinkA(int columnIndex) {
-        StringSink sink = stringSinks.getQuiet(columnIndex);
-        if (sink != null) {
-            return sink;
-        }
-        stringSinks.extendAndSet(columnIndex, sink = new StringSink());
-        return sink;
-    }
-
-    private @NotNull StringSink stringSinkB(int columnIndex) {
-        final int slot = columnCount + columnIndex;
-        StringSink sink = stringSinks.getQuiet(slot);
-        if (sink != null) {
-            return sink;
-        }
-        stringSinks.extendAndSet(slot, sink = new StringSink());
-        return sink;
-    }
-
     private @NotNull Utf8SplitString utf8ViewA(int columnIndex) {
         Utf8SplitString view = utf8Views.getQuiet(columnIndex);
         if (view != null) {
@@ -1362,25 +691,6 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
         }
         utf8Views.extendAndSet(slot, view = new Utf8SplitString(this));
         return view;
-    }
-
-    private @NotNull Utf8StringSink varcharSinkA(int columnIndex) {
-        Utf8StringSink sink = varcharSinks.getQuiet(columnIndex);
-        if (sink != null) {
-            return sink;
-        }
-        varcharSinks.extendAndSet(columnIndex, sink = new Utf8StringSink());
-        return sink;
-    }
-
-    private @NotNull Utf8StringSink varcharSinkB(int columnIndex) {
-        final int slot = columnCount + columnIndex;
-        Utf8StringSink sink = varcharSinks.getQuiet(slot);
-        if (sink != null) {
-            return sink;
-        }
-        varcharSinks.extendAndSet(slot, sink = new Utf8StringSink());
-        return sink;
     }
 
     protected @NotNull BorrowedArray borrowedArray(int columnIndex) {
@@ -1547,28 +857,12 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
             DirectLongList auxPageLimits,
             int columnOffset,
             int columnCount,
-            boolean hasTypeCasts,
-            IntList sourceColumnTypes,
             DirectLongList columnTops
     ) {
         this.frameIndex = frameIndex;
         this.frameFormat = frameFormat;
         this.stableStrings = (frameFormat == PartitionFormat.NATIVE);
-        this.hasTypeCasts = hasTypeCasts;
         this.columnTops = columnTops;
-        // The pool passes its own IntList by reference and mutates it in place on every
-        // openParquet() call. Snapshot the contents so a later navigateTo() on Record B
-        // does not overwrite this record's view of the per-column conversion state.
-        if (hasTypeCasts) {
-            if (this.sourceColumnTypes == null) {
-                this.sourceColumnTypes = new IntList(sourceColumnTypes.size());
-            }
-            final int n = sourceColumnTypes.size();
-            this.sourceColumnTypes.setAll(n, -1);
-            for (int c = 0; c < n; c++) {
-                this.sourceColumnTypes.setQuick(c, sourceColumnTypes.getQuick(c));
-            }
-        }
         this.rowIdOffset = rowIdOffset;
         this.pageAddresses = pageAddresses;
         this.auxPageAddresses = auxPageAddresses;
@@ -1576,6 +870,5 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
         this.auxPageSizes = auxPageLimits;
         this.columnOffset = columnOffset;
         this.columnCount = columnCount;
-        invalidateTypeCastConverterCache();
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/parquet/ReusablePageFrameMemory.java
+++ b/core/src/main/java/io/questdb/cutlass/parquet/ReusablePageFrameMemory.java
@@ -131,18 +131,8 @@ class ReusablePageFrameMemory implements PageFrameMemory, Mutable, QuietCloseabl
     }
 
     @Override
-    public int getSourceColumnType(int columnIndex) {
-        return -1;
-    }
-
-    @Override
     public boolean hasColumnTops() {
         return hasColumnTops;
-    }
-
-    @Override
-    public boolean hasColumnTypeCasts() {
-        return false;
     }
 
     public void of(PageFrame frame) {

--- a/core/src/main/java/io/questdb/griffin/CLAUDE.md
+++ b/core/src/main/java/io/questdb/griffin/CLAUDE.md
@@ -1,7 +1,7 @@
 # Column Type Conversion Internals
 
 How `ALTER TABLE ... ALTER COLUMN ... TYPE` works across native and parquet partitions,
-including the laziness model, column tops, and the contract that both paths must produce
+including the eager re-encode model, column tops, and the contract that both paths must produce
 identical results.
 
 ## Architecture
@@ -10,8 +10,8 @@ identical results.
 ALTER COLUMN TYPE
   ↓
 ConvertOperatorImpl.convertColumn0()
-  ├── Pre-pass: convert parquet→native when lazy decode is impossible
-  │   (source or target is SYMBOL, or chained conversion with type mismatch)
+  ├── Pre-pass: convert parquet→native for the cases the re-encode can't apply
+  │   (target SYMBOL; a chained conversion whose parquet no longer matches metadata)
   ├── For each NATIVE partition:
   │   └── ColumnTypeConverter dispatches by conversion category
   │       ├── Fixed→Fixed:  JNI native (ConvertersNative.fixedToFixed)
@@ -21,8 +21,8 @@ ConvertOperatorImpl.convertColumn0()
   │       ├── →Symbol:      Java loop, resolveSymbol() builds symbol map
   │       └── Symbol→:      Java loop, map ID→string, then convert
   ├── For each PARQUET partition:
-  │   └── Skip (parquet decoder handles on-the-fly conversion later)
-  │       Column top is propagated from old column index to new column index
+  │   └── Eagerly re-encode to the new type (rewriteParquetPartition), reusing the
+  │       O3 row-group rewrite machinery; propagate the column top old→new index
   └── Update metadata: new column type, replacingIndex chain
 ```
 
@@ -33,7 +33,7 @@ ConvertOperatorImpl.convertColumn0()
 **Native path**: `ConvertersNative.fixedToFixed()` via JNI. Maps source file, allocates
 destination file, bulk-converts. Handles widening, narrowing, and null sentinels natively.
 
-**Parquet path**: Rust decoder handles during `decode_page_dispatch()`. The decoder reads
+**Parquet path**: applied during the eager re-encode. The Rust decoder reads
 the parquet physical type and decodes directly into the target fixed type. For same-width
 reinterpretation (DATE↔TIMESTAMP), `post_convert()` applies scaling:
 - Date→Timestamp: multiply i64 by 1000 (ms→μs), skip null sentinels
@@ -48,9 +48,9 @@ reinterpretation (DATE↔TIMESTAMP), `post_convert()` applies scaling:
 **Native path**: Java loop in `ColumnTypeConverter`. Reads from source `.i`+`.d` files,
 transcodes each value (UTF-16↔UTF-8), writes to destination `.i`+`.d` files.
 
-**Parquet path**: Parquet stores strings as UTF-8 BYTE_ARRAY. Decoded to VARCHAR (UTF-8)
-or STRING (UTF-16) depending on target. The Rust decoder handles the physical decode; Java
-handles UTF-16↔UTF-8 transcoding if the parquet type and target type use different encodings.
+**Parquet path**: during the eager re-encode, parquet stores strings as UTF-8 BYTE_ARRAY,
+decoded to VARCHAR (UTF-8) or STRING (UTF-16) depending on target. Rust does the physical
+decode; Java transcodes UTF-16↔UTF-8 when the parquet and target encodings differ.
 
 ### Fixed→Var (e.g., INT→STRING, DOUBLE→VARCHAR)
 
@@ -58,8 +58,8 @@ handles UTF-16↔UTF-8 transcoding if the parquet type and target type use diffe
 row, reads fixed value, formats to string via `Fixed2VarConverter` (e.g., `stringFromInt`),
 appends to destination var-size files.
 
-**Parquet path**: **Deferred to Java**. Rust decodes in the source fixed type, then Java
-performs the fixed→var conversion after parquet decode. The Rust layer cannot produce
+**Parquet path**: during the eager re-encode, Rust decodes the source fixed type, then Java
+performs the fixed→var conversion before re-encoding. The Rust layer cannot produce
 variable-length output directly.
 
 ### Var→Fixed (e.g., STRING→INT, VARCHAR→LONG)
@@ -68,8 +68,8 @@ variable-length output directly.
 reads string value, parses via `Var2FixedConverter` (e.g., `str2Int`), writes to destination
 fixed file. Parse failures produce null sentinels.
 
-**Parquet path**: **Deferred to Java**. Same as fixed→var — Rust decodes the source var type,
-Java performs parsing post-decode.
+**Parquet path**: same as fixed→var — during the eager re-encode Rust decodes the source var
+type and Java parses it to the target fixed type before re-encoding.
 
 ### →Symbol (e.g., INT→SYMBOL, STRING→SYMBOL)
 
@@ -92,11 +92,9 @@ conversion is skipped — the column top covers those rows.
 string via `symbolMapReader`, then either writes the string directly (→STRING/VARCHAR) or
 parses it to the target fixed type (→INT/LONG/etc.).
 
-**Parquet path**: The `ConvertOperatorImpl` pre-pass converts parquet partitions to native
-first (like →Symbol). The native conversion then reads symbol IDs and resolves them via the
-symbol map files. Although parquet stores SYMBOL data as UTF-8 BYTE_ARRAY, the main
-conversion loop skips parquet partitions entirely, so without the pre-pass the column would
-remain unconverted and appear as NULL after a later parquet→native conversion.
+**Parquet path**: handled by the eager re-encode, not the pre-pass. Parquet stores SYMBOL
+data as UTF-8 BYTE_ARRAY, so the re-encode decodes it as `VARCHAR_SLICE` and applies the
+symbol→var/fixed conversion before re-encoding — no symbol-map lookup is needed.
 
 ## Column Tops
 
@@ -118,18 +116,21 @@ columnVersionWriter.upsertColumnTop(pts, newColumnIndex, colTop);
 Without this, the new column would appear to have data from row 0, but the actual data
 files only contain rows from `columnTop` onward — causing misalignment.
 
-**For parquet partitions**: Column tops are propagated eagerly even though the data
-conversion is lazy. This ensures that if the parquet partition is later converted to
-native, the native reader finds data at the correct row offsets.
+**For parquet partitions**: the column top is propagated to the new column index alongside
+the eager data re-encode, so a re-encoded partition (or a later parquet→native conversion)
+finds data at the correct row offsets.
 
 **Column doesn't exist in parquet**: If `parquetColType` is undefined (column was added
 after the partition was converted to parquet), the column top equals the partition size —
 all rows are NULL. No conversion needed.
 
-## The Laziness Model
+## The Eager Re-encode Model
 
-Parquet partitions store data in the type that was current when the partition was converted
-to parquet. When the column type is later changed, **parquet is NOT re-encoded**.
+A parquet partition stores each column in its current type. When the column type changes,
+`ALTER COLUMN TYPE` **eagerly re-encodes** the partition to the new type
+(`TableWriter.rewriteParquetPartitionWithConversions` -> `O3PartitionJob.rewriteParquetPartition`),
+so its on-disk bytes always match the metadata. The commit is deferred to the ALTER's
+structure-version barrier, so the re-encode lands atomically with the new `_meta`.
 
 ### The replacingIndex Chain
 
@@ -142,11 +143,11 @@ Column "price" (current, index=5, type=STRING)
        └── replacingIndex → index=1 (type=DOUBLE, original)
 ```
 
-When reading a parquet partition, Java looks up which column index the parquet file
-actually contains. The chain head (the original writer index at the bottom of the
-`replacingIndex` chain) is precomputed at metadata load time by
-`TableUtils.getReplacingChainHead` and surfaced as `getOriginalWriterIndex()`, so the
-lookup is a direct map probe rather than a per-query walk:
+The re-encode stamps each column into the parquet footer under its original writer index
+(the chain head). When reading, Java looks up which column index the parquet file contains.
+The chain head is precomputed at metadata load time by `TableUtils.getReplacingChainHead`
+and surfaced as `getOriginalWriterIndex()`, so the lookup is a direct map probe rather than
+a per-query walk:
 
 ```java
 // PageFrameMemoryPool.resolveParquetColumn
@@ -159,24 +160,22 @@ if (parquetIdx < 0) {
 }
 ```
 
-### When Lazy Conversion Breaks
+### The parquet→native pre-pass
 
-The pre-pass in `ConvertOperatorImpl` converts parquet to native in two cases:
+Before the eager re-encode, a pre-pass in `ConvertOperatorImpl` converts a parquet partition
+to native when:
 
-**1. Target is SYMBOL**: Symbol maps cannot be built from parquet. Every parquet partition
-with data for the column must become native first.
+**Target is SYMBOL**: symbol maps cannot be built from parquet, so every parquet partition
+with data for the column must become native first, then the native →Symbol conversion runs.
 
-**2. Chained conversion with type mismatch**: If parquet stores type A, current metadata
-says type B, and we're now converting to type C — the parquet decoder would convert A→C
-directly. But the native path would convert B→C (it already did A→B in a prior ALTER).
-These paths may produce different results (e.g., INT→STRING→DATE vs INT→DATE have different
-semantics). Converting parquet to native first ensures B→C on both paths.
+The pre-pass also carries a **chained-conversion** check (a prior conversion whose parquet
+storage no longer matches metadata). Because the eager re-encode keeps a present column's
+parquet type equal to metadata, that condition is not met for a re-encoded partition, so the
+branch does not fire in practice; it stays as a guard.
 
-Symbol-as-source (SYMBOL → non-SYMBOL) is **not** a pre-pass trigger. The lazy decoder
-handles it via `VARCHAR_SLICE`: `PageFrameMemoryPool.resolveParquetColumn` decodes the
-parquet BYTE_ARRAY as VARCHAR_SLICE and flags the column for var→fixed/var→string
-conversion in `PageFrameMemoryRecord`. No symbol-map lookup is needed because the parquet
-column already stores the strings directly.
+Symbol-as-source (SYMBOL → non-SYMBOL) is **not** a pre-pass trigger — the eager re-encode
+decodes the parquet BYTE_ARRAY as `VARCHAR_SLICE` and applies the var→fixed/var→string
+conversion directly, since the parquet column already stores the strings.
 
 The check:
 ```java
@@ -193,95 +192,40 @@ if (hasPriorConversion || isTargetSymbol) {
 }
 ```
 
-## How Lazy Conversions Materialize During Queries
+## Reads After Conversion
 
-When a query reads a parquet partition whose column was type-changed after the partition
-was converted to parquet, the conversion happens on-the-fly through `PageFrameMemoryPool`.
+Because the eager re-encode keeps a parquet partition's stored column type equal to the
+current metadata type, reads are direct — there is no read-time conversion.
 
-### Setup: Opening a Parquet Frame
+`PageFrameMemoryPool.openParquet()` builds a `field_id -> parquet column index` map, then
+`resolveParquetColumn()` maps each query column:
 
-`PageFrameMemoryPool.navigateTo()` calls `openParquet(frameIndex)` which:
+1. Direct lookup by the column's current writer index.
+2. If that misses, the column went through `ALTER COLUMN TYPE`, so the parquet stores it
+   under its original writer index (the `replacingIndex` chain head, `getOriginalWriterIndex()`);
+   retry under that id. The stored type already equals the current type — only the writer
+   index differs — so the column is decoded directly at the current type.
+   `resolveParquetColumn` asserts `sourceTag == targetTag` and throws if they ever diverge
+   (they can't, unless a partition advanced its metadata type without being re-encoded).
+3. A column absent from the parquet (added after the partition became parquet) stays at
+   address 0 and reads NULL via the column-top path.
 
-1. Reads parquet file metadata via `PartitionDecoder.metadata()` (Rust call).
-2. Builds a column ID map (`field_id` → parquet column index).
-3. For each query column, calls `resolveParquetColumn()`:
-   - Tries direct lookup by the column's current writer index.
-   - If not found, falls back to the column's `getOriginalWriterIndex()` — the
-     precomputed chain head from `TableUtils.getReplacingChainHead` — to find the
-     parquet column under an older writer index.
-   - Compares the parquet column's stored type against the current metadata type.
-   - Records the conversion strategy in `sourceColumnTypes[col]`.
+`ParquetBuffers.decode()` calls the Rust `decodeRowGroup()`; the decoded data lives in
+off-heap `RowGroupBuffers` behind an LRU cache. `PageFrameMemoryRecord` reads those buffers
+directly — no per-row casts.
 
-### Conversion Strategy Signals
+## O3 Merge on a Converted Parquet Partition
 
-`sourceColumnTypes[col]` encodes what conversion is needed per column:
+`ALTER COLUMN TYPE` re-encodes parquet eagerly, so when O3 (out-of-order) rows later land in
+a converted partition the parquet already stores the current type — the merge sees an
+already-converted partition and applies no type conversion.
 
-| Value | Meaning | Example |
-|-------|---------|---------|
-| `-1` | No conversion needed | Column type matches parquet |
-| `>= 0` | Fixed→Var conversion, value is source type tag | INT stored, current type is STRING |
-| `< -1` | Var→Fixed conversion, value is negative source tag | VARCHAR stored, current type is LONG |
-
-For **Symbol→Non-Symbol**: the parquet column (stored as BYTE_ARRAY) is decoded as
-`VARCHAR_SLICE` and `sourceColumnTypes[col]` is set to `-ColumnType.VARCHAR`.
-
-For **Fixed→Fixed** (e.g., INT→LONG, DATE→TIMESTAMP): no signal needed. The Rust decoder
-handles the conversion during decode — data arrives in the target type already.
-
-If any column needs conversion, `hasTypeCasts = true` is set on the frame.
-
-### Decode
-
-`ParquetBuffers.decode()` calls `parquetDecoder.decodeRowGroup()` (Rust JNI). The Rust
-decoder receives parquet column indices paired with target decode types. For fixed→fixed
-mismatches, Rust converts during decode (widening, narrowing, date/timestamp scaling via
-`post_convert()`). For fixed→var and var→fixed, Rust decodes in the **source** type — Java
-converts later.
-
-Decoded data lives in off-heap `RowGroupBuffers` managed by an LRU buffer cache. Not
-zero-copy from parquet — the decoder writes into these buffers.
-
-### Per-Row Lazy Conversion at Record Access
-
-`PageFrameMemoryRecord` accessor methods check `hasTypeCasts` on every call:
-
-```java
-// Example: getInt(col)
-if (hasTypeCasts) {
-    int srcTag = sourceColumnTypes.getQuick(col);
-    if (srcTag < -1) {              // Var→Fixed: parse string to int
-        return convertVarToInt(-srcTag, col);
-    }
-}
-return Unsafe.getUnsafe().getInt(address + (rowIndex << 2));  // Direct read
-```
-
-```java
-// Example: getStrA(col)
-if (hasTypeCasts) {
-    int srcTag = sourceColumnTypes.getQuick(col);
-    if (srcTag >= 0) {              // Fixed→Var: format int as string
-        return convertFixedToStr(srcTag, col, stringSinkA);
-    }
-}
-// Direct varchar/string read
-```
-
-**Zero-GC**: Conversions use pre-allocated reusable `StringSink`/`Utf8StringSink` pools.
-No allocations on the data path.
-
-### O3 Merge with Type-Converted Parquet
-
-When O3 (out-of-order) rows land inside a parquet partition that has a pending lazy
-conversion, `O3PartitionJob` materialises the conversion at **write** time while merging the
-rows in (a `MERGE` action interleaves them via `mergeRowGroup`; a non-overlapping row group
-that still needs the new schema is re-encoded via `rewriteParquetRowGroupWithConversions`).
-
-That write path — the merge-action dispatch, the shared `prepareParquetSourceColumn`
-conversion and its allocations, and how **deduplication** interacts with it — is documented
-separately in `cairo/CLAUDE.md` ("Writing Parquet Partitions with Pending Column
-Conversions"). This file (griffin) owns the conversion *semantics* and the *read* path; the
-write path lives with `O3PartitionJob` / `TableWriter` in cairo.
+The re-encode itself reuses the O3 row-group rewrite machinery
+(`rewriteParquetRowGroupWithConversions`, `chooseParquetDecodeType`, `prepareParquetSourceColumn`)
+to decode the old parquet and write the new type. That write path — the merge-action
+dispatch, the shared conversion and its allocations, and how **deduplication** interacts with
+it — is documented in `cairo/CLAUDE.md` ("Writing Parquet Partitions with Pending Column
+Conversions").
 
 ## The Native/Parquet Contract
 
@@ -335,12 +279,12 @@ Now every non-designated column is written `Optional`; only the designated times
 the null branch — those rows are marked with definition level 0.
 
 **Why**: column type conversion. When `ALTER COLUMN TYPE` converts SHORT→INT (or BOOLEAN→INT)
-lazily on a parquet partition, the column-top region for the source column must materialise as
-INT_NULL on read. With `Required` repetition there is no way to distinguish column-top rows
-from real zeros/`false` at the parquet layer; the lazy decoder would produce `0` in INT space
-instead of `Integer.MIN_VALUE`, diverging from the native ALTER path which sees NULL via the
-`.top` file. Making the schema `Optional` lets def-level=0 carry the column-top NULL signal
-through to the decoder.
+on a parquet partition, the column-top region for the source column must materialise as
+INT_NULL. With `Required` repetition there is no way to distinguish column-top rows from real
+zeros/`false` at the parquet layer; the decoder would produce `0` in INT space instead of
+`Integer.MIN_VALUE`, diverging from the native ALTER path which sees NULL via the `.top` file.
+Making the schema `Optional` lets def-level=0 carry the column-top NULL signal through the
+re-encode's decode.
 
 **Test impact**: parquet schema assertions for BOOLEAN/BYTE/SHORT/CHAR columns must use
 `assertSchemaNullable` (maxDefinitionLevel=1), and Java-side reader values for column-top
@@ -365,9 +309,9 @@ must stay in sync.
 | `ColumnTypeConverter.java` | All Java conversion loops (var-size, string, symbol) |
 | `ConvertersNative.java` | JNI bridge to native fixed→fixed conversion |
 | `ColumnVersionWriter.java` | Manages `_cv` file: column tops per (partition, column) |
-| `O3PartitionJob.java` | Walks replacingIndex chain to map parquet columns to current metadata |
-| `TableWriter.java` | `convertPartitionParquetToNative()`, `getParquetColumnType()` |
-| `PageFrameMemoryPool.java` | Query path: opens parquet frames, resolves column mapping, sets up conversion strategy |
-| `PageFrameMemoryRecord.java` | Query path: per-row lazy conversion at accessor level (zero-GC) |
+| `O3PartitionJob.java` | `rewriteParquetPartition()` (eager re-encode); walks the replacingIndex chain to map parquet columns to current metadata |
+| `TableWriter.java` | `rewriteParquetPartitionWithConversions()`, `convertPartitionParquetToNative()`, `getParquetColumnType()` |
+| `PageFrameMemoryPool.java` | Query path: opens parquet frames, resolves the column mapping (writer-index remap, no conversion) |
+| `PageFrameMemoryRecord.java` | Query path: reads decoded parquet values directly |
 | `row_groups.rs` | Rust: type dispatch, `post_convert()`, boolean expansion, date/timestamp scaling |
 | `decode.rs` | Rust: physical parquet type → decoded values |

--- a/core/src/main/java/io/questdb/griffin/ConvertOperatorImpl.java
+++ b/core/src/main/java/io/questdb/griffin/ConvertOperatorImpl.java
@@ -280,6 +280,7 @@ public class ConvertOperatorImpl implements Closeable {
                 if (asyncProcessingErrorCount.get() == 0) {
                     if (tableWriter.getPartitionFormat(partitionIndex) == PartitionFormat.PARQUET) {
                         final long parquetPts = tableWriter.getPartitionTimestamp(partitionIndex);
+                        final long parquetNameTxn = tableWriter.getPartitionNameTxn(partitionIndex);
                         try {
                             // Re-encode the parquet partition so its on-disk bytes carry the new
                             // column type. This runs before the new type reaches metadata, so the
@@ -288,7 +289,7 @@ public class ConvertOperatorImpl implements Closeable {
                             // parquet, so its rows are all NULL regardless of type). The commit is
                             // deferred to the ALTER's structure-version barrier, so it lands
                             // atomically with the new metadata, like the native conversions above.
-                            tableWriter.rewriteParquetPartitionWithConversions(parquetPts, existingColIndex, newType);
+                            tableWriter.rewriteParquetPartitionWithConversions(partitionIndex, parquetPts, parquetNameTxn, existingColIndex, newType);
 
                             // Propagate the column top from existingColIndex to columnIndex. A
                             // re-encoded partition has every column materialised from row 0 (top 0);

--- a/core/src/main/java/io/questdb/griffin/ConvertOperatorImpl.java
+++ b/core/src/main/java/io/questdb/griffin/ConvertOperatorImpl.java
@@ -279,22 +279,41 @@ public class ConvertOperatorImpl implements Closeable {
             for (int partitionIndex = 0, n = tableWriter.getPartitionCount(); partitionIndex < n; partitionIndex++) {
                 if (asyncProcessingErrorCount.get() == 0) {
                     if (tableWriter.getPartitionFormat(partitionIndex) == PartitionFormat.PARQUET) {
-                        // Parquet partitions are not converted here (the parquet decoder handles
-                        // on-the-fly type conversion via the replacingIndex chain). However, we
-                        // still propagate the column top from existingColIndex to columnIndex so
-                        // that if the parquet is later converted to native (e.g. by a chained
-                        // ALTER TYPE pre-pass), the native reader finds the data at the correct
-                        // row offsets.
                         final long parquetPts = tableWriter.getPartitionTimestamp(partitionIndex);
-                        final long parquetColTop = columnVersionWriter.getColumnTop(parquetPts, existingColIndex);
-                        if (parquetColTop != tableWriter.getColumnTop(parquetPts, columnIndex, -1)) {
-                            long partTs = tableWriter.getPartitionBy() != PartitionBy.NONE
-                                    ? parquetPts
-                                    : TxReader.DEFAULT_PARTITION_TIMESTAMP;
-                            columnVersionWriter.upsertColumnTop(
-                                    partTs, columnIndex,
-                                    parquetColTop > -1 ? parquetColTop : tableWriter.getPartitionSize(partitionIndex)
-                            );
+                        try {
+                            // Re-encode the parquet partition so its on-disk bytes carry the new
+                            // column type. This runs before the new type reaches metadata, so the
+                            // new type is passed explicitly. It is a no-op when the column is not
+                            // stored in this partition's parquet (added after the partition became
+                            // parquet, so its rows are all NULL regardless of type). The commit is
+                            // deferred to the ALTER's structure-version barrier, so it lands
+                            // atomically with the new metadata, like the native conversions above.
+                            tableWriter.rewriteParquetPartitionWithConversions(parquetPts, existingColIndex, newType);
+
+                            // Propagate the column top from existingColIndex to columnIndex. A
+                            // re-encoded partition has every column materialised from row 0 (top 0);
+                            // a partition whose column was not re-encoded keeps its column top, so the
+                            // new column index still describes the correct row offsets - and if that
+                            // partition is later converted to native the reader finds the data there.
+                            final long parquetColTop = columnVersionWriter.getColumnTop(parquetPts, existingColIndex);
+                            if (parquetColTop != tableWriter.getColumnTop(parquetPts, columnIndex, -1)) {
+                                long partTs = tableWriter.getPartitionBy() != PartitionBy.NONE
+                                        ? parquetPts
+                                        : TxReader.DEFAULT_PARTITION_TIMESTAMP;
+                                columnVersionWriter.upsertColumnTop(
+                                        partTs, columnIndex,
+                                        parquetColTop > -1 ? parquetColTop : tableWriter.getPartitionSize(partitionIndex)
+                                );
+                            }
+                        } catch (Throwable th) {
+                            LOG.error().$("error re-encoding parquet partition [at=").$(tableWriter.getTableToken())
+                                    .$(", column=").$safe(columnName).$(", from=").$(ColumnType.nameOf(existingType))
+                                    .$(", to=").$(ColumnType.nameOf(newType))
+                                    .$(", error=").$(th).I$();
+                            asyncProcessingErrorCount.incrementAndGet();
+                            // Drain in-flight async native conversions so we exit at a known state.
+                            consumeConversionTasks(messageBus.getColumnTaskQueue(), queueCount, false);
+                            throw th;
                         }
                         continue;
                     }

--- a/core/src/main/java/io/questdb/griffin/engine/join/AsyncWindowJoinFastRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/AsyncWindowJoinFastRecordCursorFactory.java
@@ -1246,7 +1246,7 @@ public class AsyncWindowJoinFastRecordCursorFactory extends AbstractRecordCursor
 
         final Function filter = atom.getMasterFilter(slotId);
         final CompiledFilter compiledFilter = atom.getCompiledMasterFilter();
-        if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+        if (compiledFilter == null || frameMemory.hasColumnTops()) {
             AsyncFilterUtils.applyFilter(filter, rows, record, frameRowCount);
         } else {
             applyCompiledFilter(compiledFilter, atom.getBindVarMemory(), atom.getBindVarFunctions(), task);

--- a/core/src/main/java/io/questdb/griffin/engine/join/AsyncWindowJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/AsyncWindowJoinRecordCursorFactory.java
@@ -1558,7 +1558,7 @@ public class AsyncWindowJoinRecordCursorFactory extends AbstractRecordCursorFact
         final CompiledFilter compiledFilter = atom.getCompiledMasterFilter();
 
         try {
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(compiledFilter, atom.getBindVarMemory(), atom.getBindVarFunctions(), task);
@@ -1708,7 +1708,7 @@ public class AsyncWindowJoinRecordCursorFactory extends AbstractRecordCursorFact
         final CompiledFilter compiledFilter = atom.getCompiledMasterFilter();
 
         try {
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(compiledFilter, atom.getBindVarMemory(), atom.getBindVarFunctions(), task);
@@ -1888,7 +1888,7 @@ public class AsyncWindowJoinRecordCursorFactory extends AbstractRecordCursorFact
         final CompiledFilter compiledFilter = atom.getCompiledMasterFilter();
 
         try {
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(compiledFilter, atom.getBindVarMemory(), atom.getBindVarFunctions(), task);
@@ -2065,7 +2065,7 @@ public class AsyncWindowJoinRecordCursorFactory extends AbstractRecordCursorFact
         final CompiledFilter compiledFilter = atom.getCompiledMasterFilter();
 
         try {
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(compiledFilter, atom.getBindVarMemory(), atom.getBindVarFunctions(), task);
@@ -2329,7 +2329,7 @@ public class AsyncWindowJoinRecordCursorFactory extends AbstractRecordCursorFact
         final CompiledFilter compiledFilter = atom.getCompiledMasterFilter();
 
         try {
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(compiledFilter, atom.getBindVarMemory(), atom.getBindVarFunctions(), task);
@@ -2487,7 +2487,7 @@ public class AsyncWindowJoinRecordCursorFactory extends AbstractRecordCursorFact
         final CompiledFilter compiledFilter = atom.getCompiledMasterFilter();
 
         try {
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(compiledFilter, atom.getBindVarMemory(), atom.getBindVarFunctions(), task);
@@ -2644,7 +2644,7 @@ public class AsyncWindowJoinRecordCursorFactory extends AbstractRecordCursorFact
         final CompiledFilter compiledFilter = atom.getCompiledMasterFilter();
 
         try {
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(compiledFilter, atom.getBindVarMemory(), atom.getBindVarFunctions(), task);
@@ -2790,7 +2790,7 @@ public class AsyncWindowJoinRecordCursorFactory extends AbstractRecordCursorFact
         final CompiledFilter compiledFilter = atom.getCompiledMasterFilter();
 
         try {
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(compiledFilter, atom.getBindVarMemory(), atom.getBindVarFunctions(), task);

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/SortKeyEncoder.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/SortKeyEncoder.java
@@ -1166,13 +1166,6 @@ public class SortKeyEncoder implements QuietCloseable {
     }
 
     private boolean encodeFixed8Batch(PageFrameMemory frameMemory, int frameIndex, DirectLongList rows, long rowCount, EncodedTopKBuffer topK) {
-        if (frameMemory.getSourceColumnType(columnIndices[0]) != -1) {
-            // Lazily type-cast parquet column (ALTER COLUMN TYPE): the page holds the
-            // source type's raw bytes (e.g. a VARCHAR_SLICE for a STRING->LONG cast),
-            // not this column's current fixed type. Fall back to the per-row path,
-            // which materializes the converted value through the record accessors.
-            return false;
-        }
         final long colAddr = frameMemory.getPageAddress(columnIndices[0]);
         if (colAddr == 0) {
             return false;
@@ -1261,12 +1254,6 @@ public class SortKeyEncoder implements QuietCloseable {
      * falls back to per-row {@link #encodeTopK} - for a column-top frame.
      */
     private boolean encodeFixedWideBatch(PageFrameMemory frameMemory, int frameIndex, DirectLongList rows, long rowCount, EncodedTopKBuffer topK) {
-        if (frameMemory.getSourceColumnType(columnIndices[0]) != -1) {
-            // Lazily type-cast parquet column (ALTER COLUMN TYPE): the page holds the
-            // source type's raw bytes (e.g. a VARCHAR_SLICE for a STRING->UUID cast),
-            // not this column's current wide-fixed type. Fall back to the per-row path.
-            return false;
-        }
         final long colAddr = frameMemory.getPageAddress(columnIndices[0]);
         if (colAddr == 0) {
             // Column top: every frame row is NULL for this column.
@@ -1302,14 +1289,9 @@ public class SortKeyEncoder implements QuietCloseable {
         Unsafe.putLong(destAddr + lastWord, Long.reverseBytes(val & padMask));
     }
 
-    // A natively-stored STRING is materialized into native layout even in Parquet frames, so the
-    // value is read straight from the page. A lazily type-cast STRING (e.g. an INT->STRING cast on
-    // a Parquet partition) is not: the page holds the source type's bytes, so the per-row path must
-    // materialize the converted value through the record accessors.
+    // A STRING is materialized into native layout even in Parquet frames, so the value is read
+    // straight from the page.
     private boolean encodeStringBatch(PageFrameMemory frameMemory, int frameIndex, DirectLongList rows, long rowCount, EncodedTopKBuffer topK, PageFrameMemoryRecord record) {
-        if (frameMemory.getSourceColumnType(columnIndices[0]) != -1) {
-            return false;
-        }
         final long dataAddr = frameMemory.getPageAddress(columnIndices[0]);
         if (dataAddr == 0) {
             // Column top: every frame row is NULL for this column.

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedRecordCursorFactory.java
@@ -337,7 +337,7 @@ public class AsyncGroupByNotKeyedRecordCursorFactory extends AbstractRecordCurso
         final ObjList<GroupByFunction> functions = atom.getGroupByFunctions(slotId);
         final int functionCount = functions.size();
         try {
-            if (frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (frameMemory.hasColumnTops()) {
                 // Fall back to row-by-row for the entire frame.
                 record.init(frameMemory);
                 final GroupByFunctionsUpdater functionUpdater = atom.getFunctionUpdater(slotId);
@@ -465,7 +465,7 @@ public class AsyncGroupByNotKeyedRecordCursorFactory extends AbstractRecordCurso
         final CompiledFilter compiledFilter = filterCtx.getCompiledFilter();
         final Function filter = filterCtx.getFilter(slotId);
         try {
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 // Use Java-based filter when there is no compiled filter or in case of a page frame with column tops.
                 AsyncFilterUtils.applyFilter(filter, rows, record, frameRowCount);
             } else {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursorFactory.java
@@ -510,7 +510,7 @@ public class AsyncGroupByRecordCursorFactory extends AbstractRecordCursorFactory
         try {
             atom.resetLocalStats(slotId);
 
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 AsyncFilterUtils.applyFilter(filter, rows, record, frameRowCount);
             } else {
                 AsyncFilterUtils.applyCompiledFilter(

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinNotKeyedRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinNotKeyedRecordCursorFactory.java
@@ -297,7 +297,7 @@ public class AsyncHorizonJoinNotKeyedRecordCursorFactory extends AbstractRecordC
             // Apply filter to master rows
             final DirectLongList rows = filterCtx.getFilteredRows(slotId);
             rows.clear();
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinRecordCursorFactory.java
@@ -349,7 +349,7 @@ public class AsyncHorizonJoinRecordCursorFactory extends AbstractRecordCursorFac
             // Apply filter to master rows
             final DirectLongList rows = filterCtx.getFilteredRows(slotId);
             rows.clear();
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncJitFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncJitFilteredRecordCursorFactory.java
@@ -329,7 +329,7 @@ public class AsyncJitFilteredRecordCursorFactory extends AbstractRecordCursorFac
             }
             record.init(frameMemory);
 
-            if (frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (frameMemory.hasColumnTops()) {
                 // Use Java-based filter in case of a page frame with column tops
                 // or type-cast columns (fixed→var conversion not supported in JIT).
                 final Function filter = atom.getFilter(filterId);

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinNotKeyedRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinNotKeyedRecordCursorFactory.java
@@ -256,7 +256,7 @@ public class AsyncMultiHorizonJoinNotKeyedRecordCursorFactory extends AbstractRe
             // Apply filter to master rows
             final DirectLongList rows = filterCtx.getFilteredRows(slotId);
             rows.clear();
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinRecordCursorFactory.java
@@ -330,7 +330,7 @@ public class AsyncMultiHorizonJoinRecordCursorFactory extends AbstractRecordCurs
             // Apply filter to master rows
             final DirectLongList rows = filterCtx.getFilteredRows(slotId);
             rows.clear();
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 applyFilter(filter, rows, record, frameRowCount);
             } else {
                 applyCompiledFilter(

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncTopKRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncTopKRecordCursorFactory.java
@@ -226,7 +226,7 @@ public class AsyncTopKRecordCursorFactory extends AbstractRecordCursorFactory {
         final CompiledFilter compiledFilter = filterCtx.getCompiledFilter();
         final Function filter = filterCtx.getFilter(slotId);
         try {
-            if (compiledFilter == null || frameMemory.hasColumnTops() || frameMemory.hasColumnTypeCasts()) {
+            if (compiledFilter == null || frameMemory.hasColumnTops()) {
                 // Use Java-based filter when there is no compiled filter or in case of a page frame with column tops.
                 AsyncFilterUtils.applyFilter(filter, rows, record, frameRowCount);
             } else {

--- a/core/src/test/java/io/questdb/test/cairo/parquet/ParquetColumnTypeConversionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/parquet/ParquetColumnTypeConversionTest.java
@@ -46,12 +46,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Tests lazy column type conversion on parquet partitions.
+ * Tests column type conversion on parquet partitions.
  * <p>
  * When a column type changes via ALTER TABLE ALTER COLUMN TYPE while a partition is
- * stored in parquet, the Rust parquet decoder converts data on-the-fly during queries.
- * This test verifies that the parquet (Rust) conversion path produces the same results
- * as the native (JNI) conversion path for all supported type pairs.
+ * stored in parquet, the partition is re-encoded to the new type at ALTER time. This
+ * test verifies that the parquet conversion path produces the same results as the
+ * native (JNI) conversion path for all supported type pairs.
  * <p>
  * Rust-handled conversions tested here:
  * <ul>
@@ -69,7 +69,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     @Test
     public void testAddColumnAfterParquetConversionReadsNullThenAltersType() throws Exception {
         // ADD COLUMN fires AFTER the partition is parquet, so the parquet file
-        // never carries the new column. The lazy decoder must surface NULL for
+        // never carries the new column. The reader must surface NULL for
         // all existing rows (column-top covers the whole partition), and a
         // subsequent ALTER COLUMN TYPE on that column must keep the NULLs
         // matching the native control table.
@@ -132,7 +132,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     @Test
     public void testAllNullColumnInParquetConvertsToTargetNulls() throws Exception {
         // A partition where one column is entirely NULL must round-trip NULLs
-        // through both the lazy parquet read and the eager rewrite, regardless
+        // through both the parquet read and the eager rewrite, regardless
         // of source and target type. Covers fixed-source, var-source, and
         // var-target paths.
         assertMemoryLeak(() -> {
@@ -156,12 +156,10 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * Regression for the {@code getVarcharSize} override gap. {@code length_bytes(val)}
-     * routes through {@code LengthBytesVarcharFunctionFactory.getInt} which calls
-     * {@code arg.getVarcharSize(rec)}.
-     * {@link io.questdb.cairo.sql.PageFrameFilteredMemoryRecord#getVarcharSize(int)}
-     * reads the aux page without consulting {@code needsLazyConversion}, mirroring the
-     * {@code getStrLen} gap.
+     * Value parity for {@code length_bytes(val)} over a parquet column ALTERed from a fixed
+     * type to VARCHAR: {@code LengthBytesVarcharFunctionFactory.getInt} calls
+     * {@code getVarcharSize(rec)} on the filtered record. The eager re-encode stores
+     * {@code val} as VARCHAR, so the read is direct and must match the native control.
      */
     @Test
     public void testAsyncGroupByByLengthBytesOfFixedToVarcharParquetColumn() throws Exception {
@@ -172,15 +170,10 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * Regression for the {@code getStrLen} override gap. {@code length(val)} routes
-     * through {@code LengthStrFunctionFactory.getInt} which calls
-     * {@code arg.getStrLen(rec)}. With {@code val} on the fixed-to-STRING lazy conversion
-     * path,
-     * {@link io.questdb.cairo.sql.PageFrameFilteredMemoryRecord#getStrLen(int)} fires
-     * instead of the parent. The filtered override reads the aux page directly and
-     * does NOT check {@code needsLazyConversion}, so for a fixed-source column where
-     * no STRING aux page exists, it either returns {@code TableUtils.NULL_LEN} or
-     * reads garbage. The GROUP BY result diverges from the native control table.
+     * Value parity for {@code length(val)} over a parquet column ALTERed from a fixed type
+     * to STRING: {@code LengthStrFunctionFactory.getInt} calls {@code getStrLen(rec)} on the
+     * filtered record. The eager re-encode stores {@code val} as STRING, so the read is
+     * direct and the GROUP BY result must match the native control table.
      */
     @Test
     public void testAsyncGroupByByLengthOfFixedToStrParquetColumn() throws Exception {
@@ -191,35 +184,17 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * Regression for the fixed-to-var typecast read in {@link io.questdb.cairo.sql.PageFrameFilteredMemoryRecord}.
+     * Value parity for the async keyed group-by over a parquet column ALTERed from INT to
+     * STRING.
      * <p>
-     * {@code val} starts as INT, the partition is converted to parquet, then {@code val}
-     * is ALTERed to STRING. Reads on the parquet partition take the fixed-to-var lazy
-     * conversion path ({@code sourceColumnTypes[val] >= 0}, {@code hasTypeCasts=true}).
-     * <p>
-     * The query groups by {@code val} and filters on a separate non-typecast column
-     * {@code other}. This sequences the code path under test:
-     * <ol>
-     *   <li>{@code AsyncGroupByRecordCursorFactory.run} sees
-     *       {@code frameMemory.hasColumnTypeCasts()} and falls back to the scalar filter,
-     *       calling {@code populateRemainingColumns(filterColumnIndexes, rows, false)}
-     *       which decodes non-filter columns in compacted layout.</li>
-     *   <li>{@code aggregateFilteredNonSharded} wraps the frame in a
-     *       {@link io.questdb.cairo.sql.PageFrameFilteredMemoryRecord}, where
-     *       {@code filteredColumns[val]=false} since {@code val} is the GROUP BY key,
-     *       not the filter target.</li>
-     *   <li>The map sink calls {@code getStrA(val)}. {@code PageFrameFilteredMemoryRecord}
-     *       does NOT override {@code getStrA} (or {@code getStrB}), so the call falls
-     *       through to the parent {@link io.questdb.cairo.sql.PageFrameMemoryRecord},
-     *       which routes to {@code convertFixedToStr} and indexes by the parent's
-     *       absolute {@code rowIndex} field rather than {@code getRowIndex(columnIndex)}
-     *       (which would return the compacted index).</li>
-     *   <li>The non-filter column buffer holds only {@code rows.size()} entries in
-     *       compacted layout, so the absolute-index read goes out of bounds.</li>
-     * </ol>
-     * A miss on this path surfaces as wrong GROUP BY keys (silent data corruption)
-     * or a JVM crash on native OOB. The control table {@code nt} is native; the
-     * parquet+ALTER table {@code pt} must produce an identical cursor.
+     * The query groups by {@code val} and filters on a separate column {@code other}, so
+     * {@code val} is a non-filter GROUP BY key that
+     * {@code AsyncGroupByRecordCursorFactory} reads in compacted layout through a
+     * {@link io.questdb.cairo.sql.PageFrameFilteredMemoryRecord} (the filtered record reads
+     * non-filter columns at the compacted index). The map sink calls {@code getStrA(val)}.
+     * The eager re-encode stores {@code val} as STRING, so the read is direct; the
+     * parquet+ALTER table {@code pt} must produce a cursor identical to the native control
+     * {@code nt}.
      */
     @Test
     public void testAsyncGroupByKeyedByFixedToStrParquetColumn() throws Exception {
@@ -230,11 +205,10 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * Same regression as {@link #testAsyncGroupByKeyedByFixedToStrParquetColumn} but for
-     * fixed-to-VARCHAR. {@code PageFrameFilteredMemoryRecord} does not override
-     * {@code getVarcharA} / {@code getVarcharB}, so the call falls through to the parent
-     * which routes to {@code convertFixedToVarchar} and indexes by the absolute rowIndex
-     * into the compacted buffer.
+     * Same as {@link #testAsyncGroupByKeyedByFixedToStrParquetColumn} but for
+     * fixed-to-VARCHAR: {@code val} is a non-filter GROUP BY key read through the filtered
+     * record via {@code getVarcharA} / {@code getVarcharB}; the re-encoded parquet must
+     * match the native control.
      */
     @Test
     public void testAsyncGroupByKeyedByFixedToVarcharParquetColumn() throws Exception {
@@ -246,24 +220,14 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
 
     /**
      * Mirror of {@link #testAsyncGroupByKeyedByFixedToStrParquetColumn} in the reverse
-     * direction: var-to-fixed. {@code val} starts as STRING, the partition is converted to
-     * parquet, then {@code val} is ALTERed to INT. On {@code pt} the parquet keeps STRING
-     * storage so reads of {@code val} take the var-to-fixed lazy conversion path
-     * ({@code sourceColumnTypes[val] < -1}, {@code hasTypeCasts=true}).
+     * direction: {@code val} starts as STRING, the partition is converted to parquet, then
+     * {@code val} is ALTERed to INT. The eager re-encode stores {@code val} as INT.
      * <p>
-     * The query groups by {@code val} and filters on a separate non-typecast column
-     * {@code other}, so {@code val} is a non-filter column in compacted layout under
+     * The query groups by {@code val} and filters on a separate column {@code other}, so
+     * {@code val} is a non-filter GROUP BY key read in compacted layout through a
      * {@link io.questdb.cairo.sql.PageFrameFilteredMemoryRecord}. The map sink calls
-     * {@code getInt(val)} on the filtered record. The override delegates to
-     * {@code super.getInt}, which routes through {@code convertVarToInt} ->
-     * {@code readVarValueForConversion} -> {@code getStr0} / {@code getVarchar}. The
-     * latter pair is overridden on the filtered record to use {@code getRowIndex},
-     * so the compacted index reaches the read. This pins the routing: a future
-     * regression that adds a fall-through path inside a fixed-width lazy getter
-     * which reads {@code this.rowIndex} directly (mirroring the
-     * {@code convertFixedToStr}/{@code convertFixedToVarchar} path that
-     * {@code getStrA}/{@code getVarcharA} already wrap with save/restore of
-     * {@code rowIndex}) would break this query.
+     * {@code getInt(val)}; the re-encoded parquet must produce a cursor identical to the
+     * native control.
      */
     @Test
     public void testAsyncGroupByKeyedByStrToIntParquetColumn() throws Exception {
@@ -274,9 +238,9 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * The async keyed group-by factory. Same {@code hasColumnTypeCasts()} gate. The
-     * difference vs the not-keyed variant is that a {@code GROUP BY} key is materialized
-     * per row and the per-key aggregation update path runs.
+     * The async keyed group-by factory over an altered parquet column. The difference vs
+     * the not-keyed variant is that a {@code GROUP BY} key is materialized per row and the
+     * per-key aggregation update path runs.
      */
     @Test
     public void testAsyncGroupByKeyedOverAlteredParquetColumn() throws Exception {
@@ -287,12 +251,10 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
 
     /**
      * The async not-keyed group-by factory runs an aggregation without a {@code GROUP BY}
-     * clause. Its inner loop checks {@code frameMemory.hasColumnTypeCasts()} and falls back
-     * to a row-by-row update path when {@code true}; the batched / vectorized aggregation
-     * path reads raw page addresses and would silently produce wrong values if the parquet
-     * column needs lazy conversion. The control table {@code nt} is native; {@code pt} is a
-     * parquet partition with {@code val} ALTER'd from STRING to INT, which sets
-     * {@code hasTypeCasts=true} (var to fixed). Results across both tables must match.
+     * clause, reading raw page addresses in its batched / vectorized aggregation path. The
+     * eager re-encode stores {@code val} at its current type, so those reads are correct.
+     * The control table {@code nt} is native; {@code pt} is a parquet partition with
+     * {@code val} ALTER'd from STRING to INT. Results across both tables must match.
      */
     @Test
     public void testAsyncGroupByNotKeyedOverAlteredParquetColumn() throws Exception {
@@ -321,7 +283,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     /**
      * The async horizon-join factory with no {@code GROUP BY} keys -- a single aggregated
      * output row. The left side is the parquet+ALTER'd table; the right side is a native
-     * shared {@code prices} table. The aggregation references the lazy-converted {@code val}.
+     * shared {@code prices} table. The aggregation references the altered {@code val}.
      */
     @Test
     public void testAsyncHorizonJoinNotKeyedOverAlteredParquetColumn() throws Exception {
@@ -335,9 +297,9 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * The async JIT-filtered factory. When parquet needs a lazy conversion, the JIT'ed
-     * filter cannot be applied directly to the parquet page bytes -- the factory must
-     * fall back to scalar filter evaluation through {@code PageFrameMemoryRecord}.
+     * The async JIT-filtered factory over an altered parquet column. The eager re-encode
+     * stores {@code val} at its current type, so the JIT'ed filter applies directly to the
+     * parquet page bytes; the result must match the native control.
      */
     @Test
     public void testAsyncJitFilteredOverAlteredParquetColumn() throws Exception {
@@ -347,7 +309,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * The async multi-horizon-join factory with {@code GROUP BY} keys. Same gate as the
+     * The async multi-horizon-join factory with {@code GROUP BY} keys. Same as the
      * not-keyed variant; selects {@code AsyncMultiHorizonJoinRecordCursorFactory}.
      */
     @Test
@@ -371,10 +333,9 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
      * aggregated output row. Two HORIZON JOIN clauses share a single offset {@code LIST},
      * which routes the query through {@code AsyncMultiHorizonJoinNotKeyedRecordCursorFactory}.
      * The {@code WHERE t.val > 50} predicate is JIT-compiled against the current INT
-     * metadata, but the parquet frame still stores {@code val} as STRING. The factory
-     * must consult {@code hasColumnTypeCasts()} and fall back to the scalar filter;
-     * applying the compiled filter directly would read VARCHAR aux bytes as INT and
-     * select wrong rows. The parity check against the native control pins this gate.
+     * metadata; the eager re-encode stores {@code val} as INT, so the compiled filter
+     * applies directly to the parquet page bytes. The parity check against the native
+     * control pins this.
      */
     @Test
     public void testAsyncMultiHorizonJoinNotKeyedOverAlteredParquetColumn() throws Exception {
@@ -391,9 +352,9 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
 
     /**
      * The async top-K factory orders by {@code val} with a {@code LIMIT}. Its vectorized
-     * comparator path reads {@code val} via the column page address; with a lazy var to
-     * fixed conversion in parquet, only the scalar fallback materializes the converted
-     * integer.
+     * comparator path reads {@code val} via the column page address; the eager re-encode
+     * stores {@code val} at its current type, so the read is direct and must match the
+     * native control.
      */
     @Test
     public void testAsyncTopKOverAlteredParquetColumn() throws Exception {
@@ -404,11 +365,11 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
 
     /**
      * Sibling of {@link #testAsyncTopKSingleKeyOverAlteredParquetColumn()} for the STRING key
-     * shape: a single-column ORDER BY ... LIMIT over a lazily fixed-to-STRING converted parquet
-     * column routes through {@code SortKeyEncoder.encodeStringBatch}. For a natively-stored STRING
-     * that batch reads {@code frameMemory.getPageAddress(...)} plus the aux page straight, but with
-     * an INT-to-STRING lazy cast the parquet still stores INT, so the data page holds raw INT bytes
-     * rather than a native STRING layout. The batch must fall back to the per-row converting path.
+     * shape: a single-column ORDER BY ... LIMIT over a parquet column ALTERed from INT to
+     * STRING routes through {@code SortKeyEncoder.encodeStringBatch}, which reads
+     * {@code frameMemory.getPageAddress(...)} plus the aux page straight. The eager re-encode
+     * stores {@code val} as STRING, so the batch reads the native STRING layout directly and
+     * must match the native control.
      */
     @Test
     public void testAsyncTopKSingleKeyFixedToStrParquetColumn() throws Exception {
@@ -420,12 +381,10 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
 
     /**
      * Sibling of {@link #testAsyncTopKSingleKeyOverAlteredParquetColumn()} for the VARCHAR key
-     * shape: a single-column ORDER BY ... LIMIT over a lazily fixed-to-VARCHAR converted parquet
-     * column routes through {@code SortKeyEncoder.encodeVarcharBatch}. Unlike the fixed/string/wide
-     * siblings, that batch already special-cases parquet, and for an INT-to-VARCHAR cast the parquet
-     * keeps the INT storage so the column has no aux page ({@code auxAddr == 0}); the batch declines
-     * and the per-row converting path runs. This pins that contract for the one batch shape the fix
-     * leaves unchanged.
+     * shape: a single-column ORDER BY ... LIMIT over a parquet column ALTERed from INT to
+     * VARCHAR routes through {@code SortKeyEncoder.encodeVarcharBatch}. The eager re-encode
+     * stores {@code val} as VARCHAR, so the batch reads the native VARCHAR layout directly and
+     * must match the native control.
      */
     @Test
     public void testAsyncTopKSingleKeyFixedToVarcharParquetColumn() throws Exception {
@@ -439,8 +398,8 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
      * No-filter variant of {@link #testAsyncTopKSingleKeyOverAlteredParquetColumn()}: with no
      * WHERE predicate the async top-K routes through {@code findTopK} rather than
      * {@code filterAndFindTopK}, so {@code SortKeyEncoder.encodeFrame} runs with a null
-     * {@code rows} list (the whole-frame scan). This pins the {@code rows == null} branch of the
-     * lazy-cast fallback in the fixed-width batch path.
+     * {@code rows} list (the whole-frame scan). This pins the {@code rows == null} branch of
+     * the fixed-width batch path.
      */
     @Test
     public void testAsyncTopKSingleKeyNoFilterOverAlteredParquetColumn() throws Exception {
@@ -451,17 +410,14 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * Single-column ORDER BY ... LIMIT over a lazily var-to-fixed converted parquet column.
+     * Single-column ORDER BY ... LIMIT over a parquet column ALTERed from STRING to LONG.
      * Unlike {@link #testAsyncTopKOverAlteredParquetColumn()} (a two-column key that routes to
-     * {@code SortKeyEncoder.encodeGeneric}, i.e. the per-row converting record path), a
-     * single-column fixed-width sort key takes the batch path
+     * {@code SortKeyEncoder.encodeGeneric}, the per-row record path), a single-column
+     * fixed-width sort key takes the batch path
      * {@code SortKeyEncoder.encodeFixed8Batch}/{@code encodeFixedWideBatch}/{@code encodeStringBatch},
      * which read {@code frameMemory.getPageAddress(...)} raw and only fall back on a column top
-     * ({@code colAddr == 0}). {@code AsyncTopKRecordCursorFactory} gates only its filter on
-     * {@code frameMemory.hasColumnTypeCasts()}, not the {@code encoder.encodeFrame(...)} call, so
-     * the batch reads the VARCHAR_SLICE source buffer as raw longs and the top-K diverges from the
-     * native control. Only {@code encodeVarcharBatch} guards on {@code PartitionFormat.PARQUET}; the
-     * fixed/wide/string batch siblings do not.
+     * ({@code colAddr == 0}). The eager re-encode stores {@code val} as LONG, so the batch
+     * reads the correct fixed bytes and the top-K must match the native control.
      */
     @Test
     public void testAsyncTopKSingleKeyOverAlteredParquetColumn() throws Exception {
@@ -473,10 +429,10 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
 
     /**
      * Sibling of {@link #testAsyncTopKSingleKeyOverAlteredParquetColumn()} for the wide-fixed key
-     * shape: a single-column ORDER BY ... LIMIT over a lazily STRING-to-UUID converted parquet
-     * column routes through {@code SortKeyEncoder.encodeFixedWideBatch}. The parquet keeps the
-     * STRING storage, so the column page is a VARCHAR_SLICE buffer; reading it as raw 16-byte UUID
-     * values yields garbage. The batch must fall back to the per-row converting path.
+     * shape: a single-column ORDER BY ... LIMIT over a parquet column ALTERed from STRING to
+     * UUID routes through {@code SortKeyEncoder.encodeFixedWideBatch}. The eager re-encode
+     * stores {@code val} as UUID, so the batch reads the correct 16-byte values and must match
+     * the native control.
      */
     @Test
     public void testAsyncTopKSingleKeyStrToUuidParquetColumn() throws Exception {
@@ -488,7 +444,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     /**
      * The async window-join FAST factory ({@code WINDOW JOIN ... ON (key)}). The left
      * frame is the parquet+ALTER'd table; the join key is the symbol column. Aggregation
-     * references both the lazy-converted left column {@code t.val} and the right table's
+     * references both the altered left column {@code t.val} and the right table's
      * {@code p.price}.
      */
     @Test
@@ -506,7 +462,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
 
     /**
      * The async window-join SLOW factory ({@code WINDOW JOIN} without {@code ON}). Same
-     * fallback gate as the fast variant.
+     * as the fast variant.
      */
     @Test
     public void testAsyncWindowJoinOverAlteredParquetColumn() throws Exception {
@@ -810,7 +766,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
             // Narrowing physical width while KEEPING the scale. No rescale runs, so the
             // decode-time byte truncation is lossless as long as the value fits the target
             // precision. Every value here is representable in the narrower target, so the
-            // lazy parquet read must equal the native conversion. Covers each wider->narrower
+            // parquet read must equal the native conversion. Covers each wider->narrower
             // backing-width step.
             String v = """
                     (1.2m, '2024-01-01T00:00:01.000000Z'),
@@ -838,14 +794,14 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
             // The native converter (DecimalColumnTypeConverter.convertToDecimal) loads each value
             // into a full Decimal256, rescales at full width, range-checks against the target
             // precision, then narrows to the target (widen -> rescale -> range-check -> narrow), so
-            // it preserves any value that fits the target precision. The lazy parquet decoder mirrors
+            // it preserves any value that fits the target precision. The parquet re-encode mirrors
             // this via convert_decimal_narrowing (row_groups.rs): plan_decode_conversion keeps the
             // SOURCE width during decode, then convert_decimal_narrowing rescales, range-checks, and
             // only then narrows. So a value whose raw form (logical * 10^srcScale) exceeds the
             // target's physical byte width still survives when the logical value fits the target
             // precision -- it is the rescaled, not the raw, magnitude that is range-checked.
             //
-            // Every value below is representable in the narrower target, so the lazy parquet read
+            // Every value below is representable in the narrower target, so the parquet read
             // (pt) must equal the native conversion (nt). A naive narrow-before-rescale decoder
             // would truncate 1.2 to 0.0 here; this test pins that it does not.
 
@@ -889,9 +845,10 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     @Test
     public void testDecimalToDecimalScaleDownRounds() throws Exception {
         assertMemoryLeak(() -> {
-            // A scale reduction rounds half away from zero on BOTH the native ALTER and the lazy
-            // parquet decode; a dropped fraction never NULLs. assertConversion pins that nt (native)
-            // and pt (parquet) agree across the lazy read and the eager parquet->native rewrite.
+            // A scale reduction rounds half away from zero on BOTH the native ALTER and the
+            // parquet re-encode; a dropped fraction never NULLs. assertConversion pins that nt
+            // (native) and pt (parquet) agree across the parquet read and the eager
+            // parquet->native rewrite.
             // Values carry non-zero dropped digits, including exact-half ties and negatives, across
             // all backings.
             // Decimal16 -> Decimal16 (i64), scale 2 -> 1; 99.99 rounds up to 100.0 (carry).
@@ -925,7 +882,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     public void testDecimalToDecimalTwoStep() throws Exception {
         assertMemoryLeak(() -> {
             // Chained (two-step) decimal->decimal conversions over a parquet partition. The
-            // first ALTER reads lazily; the second ALTER sees a prior conversion, so the
+            // first ALTER re-encodes the parquet; the second ALTER sees a prior conversion, so the
             // ConvertOperatorImpl pre-pass eagerly materialises the parquet partition to native
             // (isParquetStorageCompatible is false for differing decimal types) and the second
             // step runs through the native DecimalColumnTypeConverter. Both intermediate and
@@ -1016,10 +973,11 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     @Test
     public void testDecimalToDecimalLazyUnrepresentableProducesNull() throws Exception {
         assertMemoryLeak(() -> {
-            // Decimal->decimal conversions that stay lazy (same width, or widening) must read a value
-            // that does not fit the target as NULL on the lazy parquet path, matching the native
-            // converter (DecimalColumnTypeConverter). These all keep the same or a wider physical width,
-            // so the eager pre-pass does not materialise them - the Rust decoder must do the NULL clamp.
+            // Decimal->decimal conversions where the source fits the target width (same width, or
+            // widening) must read a value that does not fit the target as NULL on the parquet path,
+            // matching the native converter (DecimalColumnTypeConverter). These all keep the same or a
+            // wider physical width, so the pre-pass does not convert them to native - the Rust decoder
+            // does the NULL clamp during the re-encode.
             // Each case mixes an unrepresentable value (-> NULL) with one that fits (-> survives).
 
             // Same width (Decimal128), precision reduced 38 -> 20, same scale. 18 integer digits exceed
@@ -1079,7 +1037,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * Pins lazy parquet behavior for DOUBLE-&gt;LONG/DATE/TIMESTAMP/INT at the
+     * Pins parquet behavior for DOUBLE-&gt;LONG/DATE/TIMESTAMP/INT at the
      * float-to-integer boundaries. Two distinct concerns share the same test:
      * <ul>
      *     <li>Upper bound precision loss (LONG/DATE/TIMESTAMP only): the Rust
@@ -1376,7 +1334,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * Pins lazy parquet behavior for FLOAT-&gt;LONG/DATE/TIMESTAMP/INT at the
+     * Pins parquet behavior for FLOAT-&gt;LONG/DATE/TIMESTAMP/INT at the
      * float-to-integer boundaries. Two distinct concerns share the same test:
      * <ul>
      *     <li>Upper bound precision loss (LONG/DATE/TIMESTAMP and INT): the Rust
@@ -1449,11 +1407,11 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     /**
      * Pins the shared overflow contract for narrow-int -&gt; narrow-decimal scaling: a value that
      * does not fit the target DECIMAL becomes the target NULL sentinel on BOTH the native ALTER and
-     * the lazy parquet decode, and neither path throws or suspends the WAL table.
+     * the parquet re-encode, and neither path throws or suspends the WAL table.
      * <p>
      * The native (JNI) {@code DecimalColumnTypeConverter.convertToDecimal} scales through Decimal256,
      * maps a rescale that loses information or a magnitude beyond the target precision to NULL, and
-     * never throws. The lazy parquet decoder ({@code convert_fixed_to_decimal} in
+     * never throws. The parquet re-encode ({@code convert_fixed_to_decimal} in
      * core/rust/qdbr/src/parquet_read/row_groups.rs) must match it: it scales each value by
      * {@code 10^scale} and NULLs the result when it exceeds the target <b>precision</b>, not merely
      * the destination byte width. Two overflow shapes are covered:
@@ -1470,7 +1428,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
      *         -&gt; {@code DECIMAL(18, 18)} computes {@code 10^18}, which fits i64 but is 19 digits.
      *         A byte-width-only guard stored these verbatim, diverging from the native NULL.</li>
      * </ul>
-     * The helper asserts NULL on the native control, the lazy parquet read, and after a
+     * The helper asserts NULL on the native control, the parquet read, and after a
      * CONVERT PARTITION TO NATIVE rewrite, so all three materialization paths agree.
      */
     @Test
@@ -1569,7 +1527,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
                     drainWalQueue();
 
                     // Materializes the fixed->var conversion through produceNativeFromParquet,
-                    // so subsequent reads hit the native files, not the lazy parquet path.
+                    // so subsequent reads hit the native files, not the parquet path.
                     execute("ALTER TABLE pt CONVERT PARTITION TO NATIVE LIST '2024-01-01'");
                     drainWalQueue();
 
@@ -1637,13 +1595,13 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * ASOF JOIN whose ON key is a lazily converted parquet column. The existing JOIN coverage
+     * ASOF JOIN whose ON key is an altered parquet column. The existing JOIN coverage
      * ({@link #testAsyncHorizonJoinKeyedOverAlteredParquetColumn} and the WINDOW/MULTI-HORIZON
      * siblings) always joins on the unconverted {@code sym} and only aggregates the converted
      * {@code val}, so the converted column is never read as a join equality key. Here {@code val}
-     * is the ASOF key, so the join driver must pull each master row's key through the lazy
-     * var-to-fixed conversion before probing the slave's key map; reading the raw parquet STRING
-     * bytes as INT would mis-key the lookup. Parity against the native control {@code nt} pins it.
+     * is the ASOF key. The eager re-encode stores {@code val} as INT, so the join driver reads
+     * each master row's key directly before probing the slave's key map. Parity against the
+     * native control {@code nt} pins it.
      * Master rows live in 2024-01-02 (the parquet partition); the slave {@code quotes} carries
      * keys 1..50 timestamped in 2024-01-01, so master {@code val} 1..50 match a preceding quote
      * and 51..100 fall through to a NULL price.
@@ -1849,8 +1807,8 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
      * O3 insert into a parquet partition that has a pending column type cast must
      * rewrite the parquet with the new type, materializing the conversion. The
      * partition stays in parquet format but the on-disk parquet column type
-     * matches the post-ALTER metadata type, so subsequent reads no longer take
-     * the lazy decode path for that column.
+     * matches the post-ALTER metadata type, so subsequent reads see the new
+     * type directly.
      */
     @Test
     public void testO3InsertRewritesConvertedParquetPartition() throws Exception {
@@ -2200,9 +2158,8 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
      * parquet-backed partition. A cursor opened against the pre-ALTER transaction must
      * continue to see the original column type and values for its entire lifetime, while
      * a fresh cursor opened after the ALTER has been applied via the WAL must see the
-     * converted type. This pins the contract between the page frame pool's
-     * {@code sourceColumnTypes} snapshot, the parquet frame cache, and cursor state
-     * across a schema change.
+     * converted type. This pins the contract between the page frame pool's parquet frame
+     * cache and cursor state across a schema change.
      */
     @Test
     public void testReaderOpenedBeforeAlterSeesOldSchema() throws Exception {
@@ -2282,9 +2239,9 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
      * read-time conversion. The test interleaves Record A iteration with a Record B
      * {@code recordAt(...)} on the other frame and asserts each record still reads its own row.
      * <p>
-     * Re-encoding 2024-01-01 at ALTER time means neither frame needs a read-time
-     * {@code sourceColumnTypes} conversion, so this no longer sets up the mixed conversion
-     * state its name suggests - it now covers only cross-frame Record A/B independence.
+     * Re-encoding 2024-01-01 at ALTER time means neither frame needs a read-time conversion,
+     * so this no longer sets up the mixed conversion state its name suggests - it now covers
+     * only cross-frame Record A/B independence.
      */
     @Test
     public void testRecordABMixedConversionStatesAcrossPartitions() throws Exception {
@@ -2342,17 +2299,16 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
                     TestUtils.assertEquals("42", recordA.getStrA(0));
 
                     // Exercise the aliasing path: navigate recordB to partition 2.
-                    // This rebuilds the pool's sourceColumnTypes in place with partition 2's
-                    // mapping (no conversion). A correct implementation must not let this
-                    // rebuild leak into Record A's view; an aliased reference would silently
-                    // overwrite the state Record A relies on.
+                    // This rebuilds the pool's per-frame column mapping for partition 2. A
+                    // correct implementation must not let this rebuild leak into Record A's
+                    // view; an aliased buffer would silently overwrite the state Record A
+                    // relies on.
                     cursor.recordAt(recordB, rowIdPartition2);
                     TestUtils.assertEquals("hello-from-p2", recordB.getStrA(0));
 
-                    // Re-read Record A: it is still anchored at partition 1 (rowIdPartition1)
-                    // which needs INT->STRING conversion. The pool must give each record a
-                    // private sourceColumnTypes snapshot; sharing a single array between
-                    // Record A and Record B would let partition 2's "no conversion" mapping
+                    // Re-read Record A: it is still anchored at partition 1 (rowIdPartition1).
+                    // The pool must give each record its own per-frame binding; sharing frame
+                    // state between Record A and Record B would let partition 2's mapping
                     // clobber Record A's view and the read would return garbage.
                     final CharSequence afterB = recordA.getStrA(0);
                     final String afterBStr = afterB == null ? "<null>" : afterB.toString();
@@ -2597,7 +2553,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
 
                 // Sweep all six decimal widths (DECIMAL8/16/32/64/128/256, precisions
                 // 2/4/9/18/38/76). Each list includes an overflow input whose magnitude
-                // exceeds the target precision; both the lazy parquet read path and the
+                // exceeds the target precision; both the parquet read and the
                 // CONVERT-PARTITION-TO-NATIVE materialized path must agree on NULL for
                 // that row (NumericException in decimal.ofString -> DECIMAL NULL).
                 assertConversion(source, "DECIMAL(2, 1)", """
@@ -2655,13 +2611,10 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
                         ('world', '2024-01-01T00:00:02.000000Z'),
                         (NULL, '2024-01-01T00:00:03.000000Z')""");
 
-                // UUID cases include malformed inputs: non-UUID strings must produce NULL on
-                // the lazy parquet path, matching the native str2Uuid converter (which calls
-                // Uuid.checkDashesAndLength first and treats failure as null). Without the
-                // length/dash pre-check, Uuid.parseHi/parseLo index past the end of short
-                // strings and raise IndexOutOfBoundsException, which the NumericException-only
-                // catch in convertVarToUuidHi/Lo does not handle, propagating out of the
-                // Record API.
+                // UUID cases include malformed inputs: non-UUID strings must produce NULL,
+                // matching the native str2Uuid converter (which calls Uuid.checkDashesAndLength
+                // first and treats failure as null). The parquet re-encode and the native ALTER
+                // must agree on NULL for every malformed input.
                 assertConversion(source, "UUID", """
                         ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', '2024-01-01T00:00:01.000000Z'),
                         ('11111111-1111-1111-1111-111111111111', '2024-01-01T00:00:02.000000Z'),
@@ -2690,12 +2643,10 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
 
     @Test
     public void testStringToUuidLazyScanAcrossParquetPartitions() throws Exception {
-        // Two parquet partitions form two frames whose in-frame row indexes both start at 0, so the
-        // lazy scan reuses the same (rowIndex, columnIndex) for different data across the frame
-        // switch. PageFrameMemoryRecord caches the per-row var->UUID parse keyed by (frameIndex,
-        // rowIndex, columnIndex) -- frameIndex is what keeps a partition-2 read from serving a
-        // partition-1 cached value. The half-corrupt value at partition 2 row 0 must read NULL
-        // (matching native), and the distinct valid UUIDs across partitions must each round-trip.
+        // Two parquet partitions ALTERed from STRING to UUID, read frame by frame. The eager
+        // re-encode stores each partition as UUID; the half-corrupt value at partition 2 row 0
+        // must read NULL (matching native), and the distinct valid UUIDs across partitions must
+        // each round-trip.
         assertMemoryLeak(() -> {
             try {
                 execute("CREATE TABLE nt (val STRING, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
@@ -2714,7 +2665,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
                 execute("ALTER TABLE nt ALTER COLUMN val TYPE UUID");
                 execute("ALTER TABLE pt ALTER COLUMN val TYPE UUID");
                 drainWalQueue();
-                // Lazy read: both partitions are still parquet, scanned frame by frame.
+                // Both partitions are parquet, scanned frame by frame.
                 assertSqlCursors("SELECT * FROM nt ORDER BY ts", "SELECT * FROM pt ORDER BY ts");
                 // Eager rewrite, then re-read against native files.
                 execute("ALTER TABLE pt CONVERT PARTITION TO NATIVE LIST '2024-01-01'");
@@ -2729,8 +2680,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * Pins parity between the lazy per-row parquet read path
-     * ({@code PageFrameMemoryRecord.convertVarToXxx}) and the eager native rewrite path
+     * Pins parity between the parquet conversion path and the native rewrite path
      * ({@code ColumnTypeConverter}) for adversarial inputs that one path might silently
      * normalize while the other rejects. Whitespace, empty strings, and non-numeric text
      * must produce the same sentinel on both paths; date strings with timezone offsets
@@ -2805,12 +2755,10 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * Pins lazy VARCHAR/STRING -> TIMESTAMP_NS conversion on a parquet partition.
-     * The partition stays in parquet (no CONVERT PARTITION TO NATIVE), so reads
-     * go through PageFrameMemoryRecord.convertVarToTimestamp. That path must
-     * dispatch to NanosTimestampDriver based on the target column type; the prior
-     * implementation hard-coded MicrosTimestampDriver, returning values 1000x
-     * too small.
+     * Pins VARCHAR/STRING -> TIMESTAMP_NS conversion on a parquet partition. The eager
+     * re-encode converts {@code val} to TIMESTAMP_NS; that conversion must dispatch to
+     * NanosTimestampDriver based on the target column type. The prior implementation
+     * hard-coded MicrosTimestampDriver, returning values 1000x too small.
      */
     @Test
     public void testStringToTimestampNanoLazyParquet() throws Exception {
@@ -2898,7 +2846,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     public void testStringToVarchar() throws Exception {
         // Covers the UTF-8/UTF-16 translation across the conversion boundary. Each width
         // class exercises a distinct encoding path and each is a canonical mojibake source
-        // if the lazy path (readVarValueForConversion -> asAsciiCharSequence) is hit:
+        // if the conversion mishandles UTF-8 decoding:
         //   - 2-byte UTF-8 (e, n, u, a with diacritics): 0xC3 0xXX pairs would render as
         //     two Latin-1 chars (e.g. UTF-8 'e-acute' 0xC3 0xA9 -> U+00C3 U+00A9 'A-tilde,
         //     copyright')
@@ -2984,14 +2932,13 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * Pins the chained-conversion guard in ConvertOperatorImpl.isParquetStorageCompatible:
-     * TIMESTAMP -> TIMESTAMP_NS -> TIMESTAMP on a parquet partition where the parquet
-     * itself stays TIMESTAMP (us) throughout. After the second hop the metadata tag is
-     * TIMESTAMP again, matching the parquet tag, but a naive tag-only equality check
-     * would let the lazy decoder return raw us values as if they were ns (off by 1000x).
-     * The guard must instead notice the prior conversion on the column metadata and
-     * force a parquet -> native rewrite before the second hop, so the round-trip is
-     * lossless. The control table nt (no parquet) must agree with pt at every step.
+     * Chained TIMESTAMP -> TIMESTAMP_NS -> TIMESTAMP on a parquet partition. Each hop
+     * eagerly re-encodes the parquet - hop 1 scales us -> ns by x1000, hop 2 scales
+     * ns -> us by /1000 - so the parquet stores the exact current type at every step and
+     * never falls back to native. TIMESTAMP and TIMESTAMP_NS share a type tag, so a naive
+     * tag-only read after hop 2 could return raw ns bytes as us (off by 1000x); re-encoding
+     * to the exact type keeps the us -> ns -> us round-trip lossless. The control table nt
+     * (no parquet) must agree with pt after each hop.
      */
     @Test
     public void testTimestampChainedThroughTimestampNanoOnParquetPartition() throws Exception {
@@ -3012,21 +2959,17 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
                 execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
                 drainWalQueue();
 
-                // Hop 1: TIMESTAMP -> TIMESTAMP_NS on both tables. On pt the parquet
-                // stays TIMESTAMP (us); the lazy decoder scales each read by 1000 via
-                // post_convert's date/timestamp branch.
+                // Hop 1: TIMESTAMP -> TIMESTAMP_NS on both tables. The re-encode scales
+                // by 1000 via post_convert's date/timestamp branch.
                 execute("ALTER TABLE nt ALTER COLUMN val TYPE TIMESTAMP_NS");
                 execute("ALTER TABLE pt ALTER COLUMN val TYPE TIMESTAMP_NS");
                 drainWalQueue();
                 assertSqlCursors("SELECT * FROM nt ORDER BY ts", "SELECT * FROM pt ORDER BY ts");
 
-                // Hop 2: TIMESTAMP_NS -> TIMESTAMP on both tables. The pt metadata now
-                // says TIMESTAMP again while the parquet still stores TIMESTAMP (us),
-                // so the metadata tag matches the parquet tag. isParquetStorageCompatible
-                // must still detect that the column has a prior conversion recorded
-                // (getReplacingIndex() >= 0) and force a parquet -> native rewrite
-                // before the second hop; otherwise the lazy path would return raw us
-                // values as ns values (off by 1000x) or the table would suspend.
+                // Hop 2: TIMESTAMP_NS -> TIMESTAMP on both tables. The parquet, re-encoded
+                // to ns in hop 1, is re-encoded again scaling ns -> us by /1000, restoring
+                // the original microsecond values exactly. A naive tag-only read that skipped
+                // the scale (TIMESTAMP and TIMESTAMP_NS share a tag) would be off by 1000x.
                 execute("ALTER TABLE nt ALTER COLUMN val TYPE TIMESTAMP");
                 execute("ALTER TABLE pt ALTER COLUMN val TYPE TIMESTAMP");
                 drainWalQueue();
@@ -3050,17 +2993,17 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
 
     /**
      * Direct fixed-to-fixed conversions from TIMESTAMP_NS source on a parquet partition.
-     * Exercises the post-decode nano-scaling branch in PageFrameMemoryPool.openParquet
-     * (the bit-24 encoded flag path) for both narrowing into Timestamp/Date (divide by
-     * 1000 and 1_000_000) and pass-through into Long. NULL preservation across the nano
-     * scale is verified by the LONG_MIN sentinel surviving the divide.
+     * Exercises the nano-scaling applied during the parquet re-encode for both narrowing
+     * into Timestamp/Date (divide by 1000 and 1_000_000) and pass-through into Long. NULL
+     * preservation across the nano scale is verified by the LONG_MIN sentinel surviving the
+     * divide.
      */
     @Test
     public void testTimestampNanoToOtherFixedTypes() throws Exception {
         assertMemoryLeak(() -> {
             // TIMESTAMP_NS stores nanoseconds since epoch.
             // Sub-microsecond precision is intentionally truncated by the ÷1000 to
-            // TIMESTAMP and the ÷1_000_000 to DATE; both lazy and native paths
+            // TIMESTAMP and the ÷1_000_000 to DATE; both the parquet and native paths
             // truncate identically.
             String values = """
                     ('2020-06-15T12:30:00.123456789Z', '2024-01-01T00:00:01.000000Z'),
@@ -3080,7 +3023,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
             // '2020-06-15T12:30:00.123456Z' = 1_592_224_200_123_456 us
             // TIMESTAMP -> DATE divides by 1000 (us -> ms), losing sub-ms precision.
             // TIMESTAMP -> TIMESTAMP_NS multiplies by 1000 (us -> ns) via the
-            // post-decode nano-scaling branch in PageFrameMemoryPool.openParquet.
+            // nano-scaling during the parquet re-encode.
             // NULL (LONG_MIN) is preserved across scaling (checked before divide).
             // Sub-millisecond precision: .000001Z = 1 microsecond, .999999Z = max micros.
             String values = """
@@ -3177,8 +3120,8 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
                             null\t2024-01-01T00:00:12.000000Z
                             """;
 
-                    // Lazy parquet read: the partition is still parquet, decoded per row group on
-                    // the fly. Pins multi-row-group correctness of the lazy var->fixed path.
+                    // Parquet read: the partition is parquet, decoded per row group. Pins
+                    // multi-row-group correctness of the var->fixed conversion.
                     assertQuery("SELECT val, ts FROM pt").noLeakCheck().inferTimestamp().inferRandomAccess().sizeMayVary().returns(expected);
 
                     // Eager rewrite: materializes the var->fixed conversion through
@@ -3269,7 +3212,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
                             \t2024-01-01T00:00:12.000000Z
                             """;
 
-                    // Lazy parquet read: per-row-group decode on the fly.
+                    // Parquet read: per-row-group decode.
                     assertQuery("SELECT val, ts FROM pt").noLeakCheck().inferTimestamp().inferRandomAccess().sizeMayVary().returns(expected);
 
                     // Eager rewrite: materializes the var->var append through produceNativeFromParquet,
@@ -3288,7 +3231,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     /**
      * Var-source mirror of {@link #testFixedWithAllEncodings}. STRING and VARCHAR columns
      * stored under each writer-supported parquet encoding must round-trip identically
-     * through both the native and lazy-parquet conversion paths. This exercises the
+     * through both the native and parquet conversion paths. This exercises the
      * encoding axis of {@code decode_byte_array_dispatch} in {@code decode.rs}:
      * <ul>
      *     <li>{@code (RleDictionary | PlainDictionary, _, String/Varchar)}</li>
@@ -3387,8 +3330,8 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
      * map the multi-byte sequence for U+00E9 (0xC3 0xA9) to two Latin-1 chars
      * (U+00C3, U+00A9) and CHAR would materialize as U+00C3 on disk.
      * The differential assertConversion helper does not catch this because both
-     * native and the lazy parquet read path use a proper UTF-8 decode, while
-     * this materialization path is only reachable through the O3 merge / convert
+     * native and the parquet read use a proper UTF-8 decode, while this
+     * materialization path is only reachable through the O3 merge / convert
      * pipeline.
      */
     @Test
@@ -3409,7 +3352,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
                 drainWalQueue();
                 // Materializes the var->fixed conversion through O3PartitionJob, so
                 // the bytes on disk are whatever writeFixedParsedValue wrote. The
-                // SELECT below reads native files, not the lazy parquet path.
+                // SELECT below reads native files, not the parquet path.
                 execute("ALTER TABLE pt CONVERT PARTITION TO NATIVE LIST '2024-01-01'");
                 drainWalQueue();
 
@@ -3423,16 +3366,11 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
 
     /**
      * Asserts VARCHAR-&gt;CHAR conversion on a parquet partition against an absolute
-     * oracle. This is a lazy conversion path: the parquet decoder hands back a
-     * {@link io.questdb.std.str.Utf8Sequence} and Java takes the first char via
-     * io.questdb.cairo.sql.PageFrameMemoryRecord#convertVarToChar, which reads
-     * through {@code readVarValueForConversion -&gt; asAsciiCharSequence()}. The latter
-     * exposes each raw UTF-8 byte as a char, so a non-ASCII value like 'é'
-     * (UTF-8: 0xC3 0xA9) yields {@code charAt(0) == U+00C3} ('Ã') instead of the
-     * correct U+00E9. The differential assertion {@code nt==pt} does NOT catch this
-     * because io.questdb.cairo.ColumnTypeConverter#convertFromVarcharToFixed
-     * uses the same {@code asAsciiCharSequence()} call, so native and parquet produce
-     * the same mojibake. Fix: use a proper UTF-8-to-UTF-16 decoder.
+     * oracle. The eager re-encode converts {@code val} to CHAR; that conversion must
+     * decode UTF-8 before taking the first code unit, so a non-ASCII value like 'é'
+     * (UTF-8: 0xC3 0xA9) yields U+00E9 rather than U+00C3 ('Ã'). A differential
+     * {@code nt==pt} assertion would miss a regression if both paths shared the same
+     * bug, so this test pins the absolute expected value.
      */
     @Test
     public void testVarcharToCharPreservesNonAsciiCodepoint() throws Exception {
@@ -3475,9 +3413,8 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     @Test
     public void testVarcharToString() throws Exception {
         // VARCHAR is stored as UTF-8 in parquet; STRING is UTF-16 in memory. Non-ASCII
-        // must survive the decode intact. If the lazy path (convertVarToStr ->
-        // readVarValueForConversion) is ever reached, asAsciiCharSequence() would expose
-        // each UTF-8 byte as a char (Latin-1), producing mojibake: e.g. UTF-8 'e-acute'
+        // must survive the decode intact. If the conversion mishandles UTF-8 decoding,
+        // each UTF-8 byte would be exposed as a char (Latin-1), producing mojibake: e.g. UTF-8 'e-acute'
         // 0xC3 0xA9 would become two UTF-16 code units U+00C3 U+00A9 ('A-tilde,
         // copyright') instead of the single 'e-acute'. Each width class exercises a
         // distinct UTF-8 decode path:
@@ -3498,8 +3435,8 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
 
     /**
      * Same absolute-oracle approach for VARCHAR-&gt;VARCHAR/STRING paths that go through
-     * the lazy per-row Java conversion. The native path performs a proper UTF-8 decode,
-     * so this test pins the expected behaviour regardless of what the peer native path does.
+     * the parquet conversion. The native path performs a proper UTF-8 decode, so this
+     * test pins the expected behaviour regardless of what the peer native path does.
      */
     @Test
     public void testVarcharToStringPreservesNonAsciiUtf8() throws Exception {
@@ -3590,8 +3527,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
      * Mirror of {@link #assertAsyncFactoryParity(String)} for the reverse cast direction:
      * {@code val} starts as INT, the partition is converted to parquet, and {@code val}
      * is ALTERed to a var type ({@code STRING} or {@code VARCHAR}). On {@code pt} the
-     * parquet keeps the INT storage so reads go through lazy fixed-to-var conversion,
-     * setting {@code hasColumnTypeCasts()=true} on every parquet frame. The extra
+     * eager re-encode stores {@code val} as the var target, so reads are direct. The extra
      * {@code other LONG} column carries the WHERE predicate so {@code val} can remain
      * a non-filter column (in compacted layout under
      * {@link io.questdb.cairo.sql.PageFrameFilteredMemoryRecord}).
@@ -3628,10 +3564,9 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     /**
      * Builds a native control table {@code nt} and a parquet-backed table {@code pt} with
      * identical data, then ALTERs {@code val} from STRING to INT on both. On {@code pt} the
-     * parquet keeps the STRING storage so reads go through lazy var to fixed conversion,
-     * setting {@code hasColumnTypeCasts()=true} on every parquet frame. The supplied
-     * query template (with {@code $T} placeholder) runs against both tables and must
-     * produce identical cursors.
+     * eager re-encode stores {@code val} as INT, so reads are direct. The supplied query
+     * template (with {@code $T} placeholder) runs against both tables and must produce
+     * identical cursors.
      */
     private void assertAsyncFactoryParity(String queryTemplate) throws Exception {
         try {
@@ -3664,9 +3599,8 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     /**
      * Mirror of {@link #assertAsyncFactoryFixedToVarParity(String, String)} for the reverse
      * cast direction: {@code val} starts as STRING, the partition is converted to parquet,
-     * and {@code val} is ALTERed to a fixed-width type (e.g. {@code INT}). On {@code pt}
-     * the parquet keeps the STRING storage so reads go through lazy var-to-fixed conversion,
-     * setting {@code hasColumnTypeCasts()=true} on every parquet frame. The extra
+     * and {@code val} is ALTERed to a fixed-width type (e.g. {@code INT}). On {@code pt} the
+     * eager re-encode stores {@code val} as the fixed target, so reads are direct. The extra
      * {@code other LONG} column carries the WHERE predicate so {@code val} can remain
      * a non-filter column (in compacted layout under
      * {@link io.questdb.cairo.sql.PageFrameFilteredMemoryRecord}).
@@ -3703,11 +3637,11 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     /**
      * Mirror of {@link #assertAsyncFactoryStrToFixedParity(String, String)} for a wide-fixed
      * target ({@code UUID}): {@code val} starts as STRING holding canonical UUID text, the
-     * partition is converted to parquet, then {@code val} is ALTERed to UUID. On {@code pt} the
-     * parquet keeps the STRING storage, so a single-column {@code ORDER BY val ... LIMIT} routes
-     * through the wide-fixed batch path {@code SortKeyEncoder.encodeFixedWideBatch}, exercising
-     * its lazy var-to-fixed fallback. {@code nt} seeds the random UUIDs and {@code pt} copies them
-     * so both tables hold identical data.
+     * partition is converted to parquet, then {@code val} is ALTERed to UUID. The eager
+     * re-encode stores {@code val} as UUID, so a single-column {@code ORDER BY val ... LIMIT}
+     * routes through the wide-fixed batch path {@code SortKeyEncoder.encodeFixedWideBatch}
+     * reading it directly. {@code nt} seeds the random UUIDs and {@code pt} copies them so
+     * both tables hold identical data.
      */
     private void assertAsyncFactoryStrToUuidParity(String queryTemplate) throws Exception {
         try {
@@ -3783,14 +3717,14 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
      * tables ({@code bids} and {@code asks}) so MULTI HORIZON JOIN queries route through
      * the {@code AsyncMultiHorizonJoin(NotKeyed)RecordCursorFactory} pair.
      * <p>
-     * Spreads data across many daily partitions on the master side. The compiled-filter
-     * fallback under {@code hasColumnTypeCasts()} only fires when SelectivityStats
-     * decides against late materialization (selectivity above 20% with at least two
-     * recorded samples). A single-partition setup keeps every frame on the late-material
-     * path, where {@code hasColumnTops()} already routes around the compiled filter and
-     * the cast bug stays hidden. Spreading rows over ~20 days produces enough frames per
-     * worker for the SelectivityStats EMA to disable late materialization on subsequent
-     * frames.
+     * Spreads data across many daily partitions on the master side so enough frames take the
+     * compiled-filter (JIT) path rather than the late-materialization path. SelectivityStats
+     * disables late materialization only above ~20% selectivity with at least two recorded
+     * samples; a single-partition setup keeps every frame on the late-material path, where
+     * {@code hasColumnTops()} already routes around the compiled filter. Spreading rows over
+     * ~20 days produces enough frames per worker for the SelectivityStats EMA to disable late
+     * materialization on subsequent frames, exercising the compiled filter over the parquet
+     * partition.
      */
     private void assertAsyncMultiJoinFactoryParity(String queryTemplate) throws Exception {
         try {
@@ -3847,7 +3781,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
             // sorts before every value row (which start at 00:00:01), so the parquet file
             // stores it as a def-level=0 (NULL) entry. This makes every conversion test also
             // assert that column-top rows materialise as the target type's NULL -- both on the
-            // lazy parquet read and after CONVERT PARTITION TO NATIVE -- exactly as the native
+            // parquet read and after CONVERT PARTITION TO NATIVE -- exactly as the native
             // ALTER path does. The remaining value rows still cover the non-column-top path.
             execute("CREATE TABLE nt (ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
             execute("CREATE TABLE pt (ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
@@ -3877,11 +3811,11 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
             execute("ALTER TABLE pt ALTER COLUMN val TYPE " + targetType);
             drainWalQueue();
 
-            // First assertion: lazy parquet read path (pt partition is still parquet).
+            // First assertion: parquet read path (pt partition is parquet).
             assertSqlCursors("SELECT * FROM nt ORDER BY ts", "SELECT * FROM pt ORDER BY ts");
 
             // Second assertion: eager rewrite path. CONVERT PARTITION TO NATIVE
-            // materializes the lazy conversion through produceNativeFromParquet ->
+            // materializes the conversion through produceNativeFromParquet ->
             // O3PartitionJob.convertVarColumnToFixed / convertFixedColumnToString /
             // convertFixedColumnToVarchar (and the in-place var->var copy), so the
             // re-read goes against native files written by the eager kernel.
@@ -3897,15 +3831,15 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     /**
      * Shared body for the equi-JOIN-on-converted-key tests. Builds a native control {@code nt}
      * and a parquet {@code pt} with a {@code val} column, converts {@code pt}'s partition to
-     * parquet, then ALTERs {@code val} from {@code sourceType} to {@code targetType} on both --
-     * on {@code pt} the parquet keeps the source storage, so reads go through the lazy
-     * conversion. A small native {@code dim} table holds the join key {@code k} (of
+     * parquet, then ALTERs {@code val} from {@code sourceType} to {@code targetType} on both.
+     * On {@code pt} the eager re-encode stores {@code val} as {@code targetType}, so reads are
+     * direct. A small native {@code dim} table holds the join key {@code k} (of
      * {@code targetType}) for the even values 2,4,...,100 only.
      * <p>
      * The query joins on the converted column itself ({@code t.val = d.k}), the case the rest of
      * the JOIN suite never exercises (it always joins on the unconverted {@code sym}). The join
-     * driver must read each {@code pt} row's key through the lazy conversion before hashing/probing;
-     * reading the raw parquet bytes of the source type would mis-key the match. Because {@code dim}
+     * driver reads each {@code pt} row's key (re-encoded to {@code targetType}) before
+     * hashing/probing. Because {@code dim}
      * carries only even keys, an INNER join keeps the even-valued rows while a LEFT join also
      * surfaces the odd-valued rows with a NULL slave side. Parity against {@code nt} pins both.
      *
@@ -3976,7 +3910,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
             execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
             drainWalQueue();
 
-            // Step 1: lazy parquet read path.
+            // Step 1: parquet read path.
             execute("ALTER TABLE nt ALTER COLUMN val TYPE " + midType);
             drainWalQueue();
             execute("ALTER TABLE pt ALTER COLUMN val TYPE " + midType);

--- a/core/src/test/java/io/questdb/test/cairo/parquet/ParquetColumnTypeConversionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/parquet/ParquetColumnTypeConversionTest.java
@@ -26,16 +26,24 @@ package io.questdb.test.cairo.parquet;
 
 import io.questdb.PropertyKey;
 import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.TableToken;
 import io.questdb.cairo.TableWriter;
 import io.questdb.cairo.sql.PartitionFormat;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.std.FilesFacade;
+import io.questdb.std.str.LPSZ;
 import io.questdb.std.str.StringSink;
+import io.questdb.std.str.Utf8s;
 import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Tests lazy column type conversion on parquet partitions.
@@ -1861,22 +1869,19 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
             execute("ALTER TABLE pt ALTER COLUMN val TYPE LONG");
             drainWalQueue();
 
-            // Before O3: parquet still stores the column as INT, the lazy decoder
-            // converts to LONG on the fly.
+            // The ALTER re-encodes the parquet partition in place, so the file already
+            // stores the column as LONG.
             try (TableWriter writer = getWriter("pt")) {
                 Assert.assertEquals(PartitionFormat.PARQUET, writer.getPartitionFormat(0));
                 int colIdx = writer.getMetadata().getColumnIndex("val");
-                Assert.assertEquals(ColumnType.INT, ColumnType.tagOf(writer.getParquetColumnType(0, colIdx)));
+                Assert.assertEquals(ColumnType.LONG, ColumnType.tagOf(writer.getParquetColumnType(0, colIdx)));
             }
 
             // O3 row lands at 00:00:02, between the existing 00:00:01 and 00:00:03.
             execute("INSERT INTO pt VALUES (99, '2024-01-01T00:00:02.000000Z')");
             drainWalQueue();
 
-            // After the merge: partition is still parquet, but the parquet file
-            // has been rewritten with the new LONG type for val. hasSchemaChange
-            // in O3PartitionJob forces this rewrite when the partition has
-            // type-converted columns and new rows land on it.
+            // The merge into an already-LONG parquet partition keeps it parquet and LONG.
             try (TableWriter writer = getWriter("pt")) {
                 Assert.assertEquals(PartitionFormat.PARQUET, writer.getPartitionFormat(0));
                 int colIdx = writer.getMetadata().getColumnIndex("val");
@@ -1892,6 +1897,302 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
                             null\t2024-01-01T00:00:05.000000Z
                             """);
         });
+    }
+
+    @Test
+    public void testAlterChainedConversionStaysParquet() throws Exception {
+        // INT -> STRING -> INT. Each ALTER re-encodes the parquet in place, keeping the stored
+        // type in sync with metadata, so the chained conversion never falls back to the
+        // parquet->native pre-pass.
+        assertMemoryLeak(() -> {
+            try {
+                execute("CREATE TABLE pt (v INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                execute("""
+                        INSERT INTO pt VALUES
+                        (10, '2024-01-01T00:00:01.000000Z'),
+                        (20, '2024-01-01T00:00:02.000000Z'),
+                        (NULL, '2024-01-01T00:00:03.000000Z')""");
+                drainWalQueue();
+                execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+                drainWalQueue();
+
+                execute("ALTER TABLE pt ALTER COLUMN v TYPE STRING");
+                drainWalQueue();
+                assertParquetColumnTag("pt", "v", ColumnType.STRING);
+
+                execute("ALTER TABLE pt ALTER COLUMN v TYPE INT");
+                drainWalQueue();
+                assertParquetColumnTag("pt", "v", ColumnType.INT);
+
+                assertQuery("SELECT v, ts FROM pt ORDER BY ts").noLeakCheck().inferTimestamp().inferRandomAccess().sizeMayVary().returns(
+                        """
+                                v\tts
+                                10\t2024-01-01T00:00:01.000000Z
+                                20\t2024-01-01T00:00:02.000000Z
+                                null\t2024-01-01T00:00:03.000000Z
+                                """);
+            } finally {
+                tryDrop("pt");
+            }
+        });
+    }
+
+    @Test
+    public void testAlterParquetFooterFixedToFixed() throws Exception {
+        assertAlterReencodesParquet("INT", "LONG", ColumnType.LONG,
+                "(10, '2024-01-01T00:00:01.000000Z'), (20, '2024-01-01T00:00:02.000000Z'), (NULL, '2024-01-01T00:00:03.000000Z')");
+    }
+
+    @Test
+    public void testAlterParquetFooterFixedToString() throws Exception {
+        assertAlterReencodesParquet("INT", "STRING", ColumnType.STRING,
+                "(10, '2024-01-01T00:00:01.000000Z'), (20, '2024-01-01T00:00:02.000000Z'), (NULL, '2024-01-01T00:00:03.000000Z')");
+    }
+
+    @Test
+    public void testAlterParquetFooterFixedToVarchar() throws Exception {
+        assertAlterReencodesParquet("INT", "VARCHAR", ColumnType.VARCHAR,
+                "(10, '2024-01-01T00:00:01.000000Z'), (20, '2024-01-01T00:00:02.000000Z'), (NULL, '2024-01-01T00:00:03.000000Z')");
+    }
+
+    @Test
+    public void testAlterParquetFooterStringToVarchar() throws Exception {
+        assertAlterReencodesParquet("STRING", "VARCHAR", ColumnType.VARCHAR,
+                "('alpha', '2024-01-01T00:00:01.000000Z'), ('beta', '2024-01-01T00:00:02.000000Z'), (NULL, '2024-01-01T00:00:03.000000Z')");
+    }
+
+    @Test
+    public void testAlterParquetFooterSymbolToFixed() throws Exception {
+        assertAlterReencodesParquet("SYMBOL", "INT", ColumnType.INT,
+                "('10', '2024-01-01T00:00:01.000000Z'), ('20', '2024-01-01T00:00:02.000000Z'), (NULL, '2024-01-01T00:00:03.000000Z')");
+    }
+
+    @Test
+    public void testAlterParquetFooterSymbolToVarchar() throws Exception {
+        assertAlterReencodesParquet("SYMBOL", "VARCHAR", ColumnType.VARCHAR,
+                "('x', '2024-01-01T00:00:01.000000Z'), ('yy', '2024-01-01T00:00:02.000000Z'), (NULL, '2024-01-01T00:00:03.000000Z')");
+    }
+
+    @Test
+    public void testAlterParquetFooterVarcharToFixed() throws Exception {
+        assertAlterReencodesParquet("VARCHAR", "LONG", ColumnType.LONG,
+                "('10', '2024-01-01T00:00:01.000000Z'), ('20', '2024-01-01T00:00:02.000000Z'), (NULL, '2024-01-01T00:00:03.000000Z')");
+    }
+
+    @Test
+    public void testAlterParquetReencodeFailureRollsBackAndRecovers() throws Exception {
+        // Fail the re-encode's writer-file open (after the source parquet + _pm are mmapped
+        // and the new txn directory is created). The ALTER must roll back cleanly -
+        // no native-memory or fd leak (assertMemoryLeak), the committed parquet left intact at
+        // the old type, the half-written directory removed - and recover once the fault clears.
+        final AtomicBoolean armed = new AtomicBoolean(false);
+        final AtomicInteger writerOpenFailures = new AtomicInteger(0);
+        final FilesFacade dodgyFacade = new TestFilesFacadeImpl() {
+            @Override
+            public long openRW(LPSZ name, int opts) {
+                if (armed.get() && Utf8s.endsWithAscii(name, "data.parquet") && writerOpenFailures.incrementAndGet() == 1) {
+                    return -1;
+                }
+                return super.openRW(name, opts);
+            }
+        };
+        assertMemoryLeak(dodgyFacade, () -> {
+            execute("CREATE TABLE pt (v INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("INSERT INTO pt VALUES (10, '2024-01-01T00:00:01.000000Z'), (20, '2024-01-01T00:00:02.000000Z')");
+            drainWalQueue();
+            execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            drainWalQueue();
+
+            final TableToken tt = engine.verifyTableName("pt");
+
+            armed.set(true);
+            execute("ALTER TABLE pt ALTER COLUMN v TYPE LONG");
+            drainWalQueue();
+            armed.set(false);
+
+            // The re-encode failed; the table suspended and the committed parquet is still INT.
+            Assert.assertEquals(1, writerOpenFailures.get());
+            Assert.assertTrue(engine.getTableSequencerAPI().isSuspended(tt));
+            assertParquetColumnTag("pt", "v", ColumnType.INT);
+
+            // With the fault gone, the retried ALTER re-encodes the partition to LONG.
+            execute("ALTER TABLE pt RESUME WAL");
+            drainWalQueue();
+            Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(tt));
+            assertParquetColumnTag("pt", "v", ColumnType.LONG);
+
+            assertQuery("SELECT v, ts FROM pt ORDER BY ts").noLeakCheck().inferTimestamp().inferRandomAccess().sizeMayVary().returns(
+                    """
+                            v\tts
+                            10\t2024-01-01T00:00:01.000000Z
+                            20\t2024-01-01T00:00:02.000000Z
+                            """);
+        });
+    }
+
+    @Test
+    public void testAlterReencodesAllParquetPartitions() throws Exception {
+        // ALTER over a table with several parquet partitions re-encodes every one of them.
+        assertMemoryLeak(() -> {
+            try {
+                execute("CREATE TABLE pt (v INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                execute("""
+                        INSERT INTO pt VALUES
+                        (1, '2024-01-01T00:00:00.000000Z'),
+                        (2, '2024-01-02T00:00:00.000000Z'),
+                        (3, '2024-01-03T00:00:00.000000Z'),
+                        (4, '2024-01-04T00:00:00.000000Z')""");
+                drainWalQueue();
+                // Convert the first three; leave the active (last) partition native.
+                execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01', '2024-01-02', '2024-01-03'");
+                drainWalQueue();
+
+                execute("ALTER TABLE pt ALTER COLUMN v TYPE LONG");
+                drainWalQueue();
+
+                try (TableWriter writer = getWriter("pt")) {
+                    Assert.assertEquals(4, writer.getPartitionCount());
+                    int colIdx = writer.getMetadata().getColumnIndex("v");
+                    for (int i = 0; i < 3; i++) {
+                        Assert.assertEquals("partition " + i, PartitionFormat.PARQUET, writer.getPartitionFormat(i));
+                        Assert.assertEquals("partition " + i, ColumnType.LONG, ColumnType.tagOf(writer.getParquetColumnType(i, colIdx)));
+                    }
+                    // The native active partition is converted through the normal native path.
+                    Assert.assertEquals(PartitionFormat.NATIVE, writer.getPartitionFormat(3));
+                }
+
+                assertQuery("SELECT v, ts FROM pt ORDER BY ts").noLeakCheck().inferTimestamp().inferRandomAccess().sizeMayVary().returns(
+                        """
+                                v\tts
+                                1\t2024-01-01T00:00:00.000000Z
+                                2\t2024-01-02T00:00:00.000000Z
+                                3\t2024-01-03T00:00:00.000000Z
+                                4\t2024-01-04T00:00:00.000000Z
+                                """);
+            } finally {
+                tryDrop("pt");
+            }
+        });
+    }
+
+    @Test
+    public void testAlterSkipsParquetPartitionWhereColumnAbsent() throws Exception {
+        // A column added after a partition became parquet is not stored in that partition's
+        // parquet file, so the re-encode skips it (its rows are all NULL regardless of type).
+        // A later partition that does store the column is re-encoded.
+        assertMemoryLeak(() -> {
+            try {
+                execute("CREATE TABLE pt (v INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                execute("INSERT INTO pt VALUES (1, '2024-01-01T00:00:00.000000Z')");
+                drainWalQueue();
+                execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+                drainWalQueue();
+
+                // Add w after 2024-01-01 is already parquet: its parquet file has no w column.
+                execute("ALTER TABLE pt ADD COLUMN w INT");
+                execute("INSERT INTO pt VALUES (2, '2024-01-02T00:00:00.000000Z', 100)");
+                drainWalQueue();
+                execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-02'");
+                drainWalQueue();
+
+                execute("ALTER TABLE pt ALTER COLUMN w TYPE LONG");
+                drainWalQueue();
+
+                try (TableWriter writer = getWriter("pt")) {
+                    int wIdx = writer.getMetadata().getColumnIndex("w");
+                    // 2024-01-01: w absent from parquet -> not re-encoded, still undefined there.
+                    Assert.assertEquals(PartitionFormat.PARQUET, writer.getPartitionFormat(0));
+                    Assert.assertTrue(ColumnType.isUndefined(writer.getParquetColumnType(0, wIdx)));
+                    // 2024-01-02: w present -> re-encoded to LONG.
+                    Assert.assertEquals(PartitionFormat.PARQUET, writer.getPartitionFormat(1));
+                    Assert.assertEquals(ColumnType.LONG, ColumnType.tagOf(writer.getParquetColumnType(1, wIdx)));
+                }
+
+                assertQuery("SELECT v, w, ts FROM pt ORDER BY ts").noLeakCheck().inferTimestamp().inferRandomAccess().sizeMayVary().returns(
+                        """
+                                v\tw\tts
+                                1\tnull\t2024-01-01T00:00:00.000000Z
+                                2\t100\t2024-01-02T00:00:00.000000Z
+                                """);
+            } finally {
+                tryDrop("pt");
+            }
+        });
+    }
+
+    @Test
+    public void testAlterTargetSymbolConvertsParquetToNative() throws Exception {
+        // A SYMBOL target cannot be built from parquet, so the pre-pass converts the partition
+        // to native first; the parquet re-encode does not apply here.
+        assertMemoryLeak(() -> {
+            try {
+                execute("CREATE TABLE pt (v INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                execute("""
+                        INSERT INTO pt VALUES
+                        (10, '2024-01-01T00:00:01.000000Z'),
+                        (20, '2024-01-01T00:00:02.000000Z'),
+                        (NULL, '2024-01-01T00:00:03.000000Z')""");
+                drainWalQueue();
+                execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+                drainWalQueue();
+
+                execute("ALTER TABLE pt ALTER COLUMN v TYPE SYMBOL");
+                drainWalQueue();
+
+                try (TableWriter writer = getWriter("pt")) {
+                    Assert.assertEquals(PartitionFormat.NATIVE, writer.getPartitionFormat(0));
+                }
+
+                assertQuery("SELECT v, ts FROM pt ORDER BY ts").noLeakCheck().inferTimestamp().inferRandomAccess().sizeMayVary().returns(
+                        """
+                                v\tts
+                                10\t2024-01-01T00:00:01.000000Z
+                                20\t2024-01-01T00:00:02.000000Z
+                                \t2024-01-01T00:00:03.000000Z
+                                """);
+            } finally {
+                tryDrop("pt");
+            }
+        });
+    }
+
+    // Creates a native reference table nt and a parquet table pt with identical data, converts
+    // pt's single partition to parquet, then ALTERs column v on both. Asserts pt's partition
+    // stays PARQUET with the footer physically carrying expectedDstTag right after the ALTER
+    // (before any O3), and that pt reads back exactly the native conversion result.
+    private void assertAlterReencodesParquet(String srcColType, String dstColType, int expectedDstTag, String insertValues) throws Exception {
+        assertMemoryLeak(() -> {
+            try {
+                execute("CREATE TABLE nt (v " + srcColType + ", ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                execute("CREATE TABLE pt (v " + srcColType + ", ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                execute("INSERT INTO nt VALUES " + insertValues);
+                execute("INSERT INTO pt VALUES " + insertValues);
+                drainWalQueue();
+                execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+                drainWalQueue();
+
+                execute("ALTER TABLE nt ALTER COLUMN v TYPE " + dstColType);
+                execute("ALTER TABLE pt ALTER COLUMN v TYPE " + dstColType);
+                drainWalQueue();
+
+                // pt's partition stays parquet and its footer physically carries the new type.
+                assertParquetColumnTag("pt", "v", expectedDstTag);
+
+                // Values read straight from the re-encoded parquet match the native conversion.
+                assertSqlCursors("SELECT v, ts FROM nt ORDER BY ts", "SELECT v, ts FROM pt ORDER BY ts");
+            } finally {
+                tryDrop("nt");
+                tryDrop("pt");
+            }
+        });
+    }
+
+    private void assertParquetColumnTag(String tableName, String columnName, int expectedTag) {
+        try (TableWriter writer = getWriter(tableName)) {
+            Assert.assertEquals(PartitionFormat.PARQUET, writer.getPartitionFormat(0));
+            int colIdx = writer.getMetadata().getColumnIndex(columnName);
+            Assert.assertEquals(expectedTag, ColumnType.tagOf(writer.getParquetColumnType(0, colIdx)));
+        }
     }
 
     /**
@@ -1975,32 +2276,15 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     /**
-     * Pins the contract that the pool's {@code sourceColumnTypes}
-     * {@link io.questdb.std.IntList} must not be aliased between Record A and Record B.
-     * The package-private {@code init(...)} overload in
-     * {@link io.questdb.cairo.sql.PageFrameMemoryRecord} (around line 1499) takes the
-     * list by reference; navigating Record B via {@code recordAt} to a partition whose
-     * parquet schema does NOT need conversion rebuilds {@code sourceColumnTypes} in
-     * place (see {@code PageFrameMemoryPool.openParquet} at the
-     * {@code setAll(readParquetColumnCount, -1)} call). If Record A keeps the same
-     * reference, its view of the conversion mapping is clobbered while it is still
-     * anchored at a partition that needs INT-&gt;STRING lazy conversion, and reads
-     * return raw INT bytes interpreted as native STRING storage -- garbage.
+     * Record A and Record B must keep independent state when navigating between parquet
+     * partitions. Both partitions below store the column as STRING - 2024-01-01 is re-encoded
+     * in place by the ALTER, 2024-01-02 is written natively as STRING - so neither needs
+     * read-time conversion. The test interleaves Record A iteration with a Record B
+     * {@code recordAt(...)} on the other frame and asserts each record still reads its own row.
      * <p>
-     * Setup:
-     * <ul>
-     *   <li>Partition 2024-01-01: inserted while column {@code val} is INT, converted to
-     *       parquet (parquet physical type = INT32). After the ALTER, the table schema
-     *       says STRING, so this partition needs lazy INT-&gt;STRING conversion.</li>
-     *   <li>Partition 2024-01-02: inserted AFTER the ALTER, so {@code val} is already
-     *       stored natively as STRING; then converted to parquet (parquet stores STRING).
-     *       This partition does NOT need any conversion -- {@code sourceColumnTypes[val]==-1}.</li>
-     * </ul>
-     * Trigger: iterate the cursor to land Record A on partition 2024-01-01, then call
-     * {@code recordAt(recordB, rowIdInPartition_2024_01_02)} to navigate Record B to the
-     * other partition. Re-reading Record A's {@code getStrA(val)} must still return the
-     * INT value as a string; a shared-reference implementation would return garbage
-     * or throw.
+     * Re-encoding 2024-01-01 at ALTER time means neither frame needs a read-time
+     * {@code sourceColumnTypes} conversion, so this no longer sets up the mixed conversion
+     * state its name suggests - it now covers only cross-frame Record A/B independence.
      */
     @Test
     public void testRecordABMixedConversionStatesAcrossPartitions() throws Exception {
@@ -2008,14 +2292,14 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
             try {
                 execute("CREATE TABLE pt (val INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
 
-                // Partition 2024-01-01: val stored as INT in parquet (conversion needed after ALTER).
+                // Partition 2024-01-01: val stored as INT in parquet.
                 execute("INSERT INTO pt VALUES (42, '2024-01-01T00:00:00.000000Z')");
                 drainWalQueue();
                 execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
                 drainWalQueue();
 
-                // Schema change: val is now STRING. Partition 2024-01-01 still stores INT
-                // in its parquet file; reads must lazy-convert INT->STRING.
+                // Schema change: val becomes STRING. The ALTER re-encodes partition
+                // 2024-01-01's parquet to STRING in place.
                 execute("ALTER TABLE pt ALTER COLUMN val TYPE STRING");
                 drainWalQueue();
 
@@ -2031,10 +2315,8 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
                         "val\tts\n42\t2024-01-01T00:00:00.000000Z\nhello-from-p2\t2024-01-02T00:00:00.000000Z\n");
 
                 // Now manually drive the cursor so we can interleave Record A iteration with
-                // a Record B recordAt() on a different frame. This exercises the case where
-                // the pool's sourceColumnTypes is rebuilt for a non-converting partition
-                // while Record A is still pointing at the converting one; each record must
-                // retain its own conversion mapping.
+                // a Record B recordAt() on a different frame. Each record must retain its own
+                // per-frame state across the two parquet partitions.
                 try (
                         RecordCursorFactory factory = select("SELECT val FROM pt ORDER BY ts");
                         RecordCursor cursor = factory.getCursor(sqlExecutionContext)
@@ -3810,10 +4092,10 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
             execute("ALTER TABLE pt ALTER COLUMN k TYPE " + dstKeyType);
             drainWalQueue();
 
-            // The crossing ALTER on a dedup key no longer eagerly materialises the parquet
-            // partition to native: ConvertOperatorImpl has no dedup-key pre-pass. The partition
-            // stays lazy parquet (still storing the source-typed key), and the O3 merge below
-            // converts it on the fly. Confirm it really stayed parquet.
+            // The crossing ALTER on a dedup key re-encodes the parquet partition to the new key
+            // type in place (still parquet format, not converted to native - there is no
+            // dedup-key pre-pass). The O3 merge below then dedups against the already-converted
+            // key. Confirm it stayed parquet.
             try (TableWriter writer = getWriter("pt")) {
                 Assert.assertEquals(PartitionFormat.PARQUET, writer.getPartitionFormat(0));
             }

--- a/core/src/test/java/io/questdb/test/cairo/parquet/ParquetColumnTypeConversionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/parquet/ParquetColumnTypeConversionTest.java
@@ -1950,6 +1950,50 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAlterParquetRebuildsCoveringPostingSidecars() throws Exception {
+        assertMemoryLeak(() -> {
+            try {
+                execute("""
+                        CREATE TABLE pt (
+                            sym SYMBOL INDEX TYPE POSTING INCLUDE (price),
+                            price DOUBLE,
+                            v INT,
+                            ts TIMESTAMP
+                        ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                        """);
+                execute("""
+                        INSERT INTO pt VALUES
+                        ('A', 10.5, 1, '2024-01-01T00:00:01.000000Z'),
+                        ('B', 20.5, 2, '2024-01-01T00:00:02.000000Z'),
+                        ('A', 30.5, 3, '2024-01-01T00:00:03.000000Z')
+                        """);
+                drainWalQueue();
+
+                execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+                drainWalQueue();
+
+                execute("ALTER TABLE pt ALTER COLUMN v TYPE LONG");
+                drainWalQueue();
+
+                assertQuery("SELECT price FROM pt WHERE sym = 'A'")
+                        .noLeakCheck()
+                        .withPlanContaining("CoveringIndex on: sym")
+                        .returns("""
+                                price
+                                10.5
+                                30.5
+                                """);
+                assertSqlCursors(
+                        "SELECT price FROM pt WHERE sym = 'A'",
+                        "SELECT /*+ no_covering */ price FROM pt WHERE sym = 'A'"
+                );
+            } finally {
+                tryDrop("pt");
+            }
+        });
+    }
+
+    @Test
     public void testAlterParquetRebuildsIndexForRekeyedSymbolColumn() throws Exception {
         assertMemoryLeak(() -> {
             try {
@@ -2202,6 +2246,51 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
         });
     }
 
+    @Test
+    public void testAlterReencodesSplitParquetPartitionsByPhysicalTimestamp() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
+        node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 3);
+        assertMemoryLeak(() -> {
+            try {
+                execute("""
+                        CREATE TABLE pt AS (
+                            SELECT
+                                cast(x AS INT) v,
+                                timestamp_sequence('2024-01-01T00:00:00.000000Z', 60 * 1000000L) ts
+                            FROM long_sequence(60 * 36)
+                        ) TIMESTAMP(ts) PARTITION BY DAY WAL""");
+                drainWalQueue();
+
+                execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+                drainWalQueue();
+
+                execute("""
+                        INSERT INTO pt
+                        SELECT
+                            cast(1000000 + x AS INT) v,
+                            timestamp_sequence('2024-01-01T20:01:00.000000Z', 1000000L) ts
+                        FROM long_sequence(200)""");
+                drainWalQueue();
+
+                final long dayTwoTimestamp = parseFloorPartialTimestamp("2024-01-02");
+                assertSplitDayOneParquetPartitions("pt", dayTwoTimestamp, ColumnType.INT);
+
+                execute("ALTER TABLE pt ALTER COLUMN v TYPE LONG");
+                drainWalQueue();
+
+                assertSplitDayOneParquetPartitions("pt", dayTwoTimestamp, ColumnType.LONG);
+                assertQuery("SELECT count(), min(v), max(v) FROM pt WHERE ts < '2024-01-02'")
+                        .noLeakCheck()
+                        .returns("""
+                                count\tmin\tmax
+                                1640\t1\t1000200
+                                """);
+            } finally {
+                tryDrop("pt");
+            }
+        });
+    }
+
     // Creates a native reference table nt and a parquet table pt with identical data, converts
     // pt's single partition to parquet, then ALTERs column v on both. Asserts pt's partition
     // stays PARQUET with the footer physically carrying expectedDstTag right after the ALTER
@@ -2238,6 +2327,25 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
             Assert.assertEquals(PartitionFormat.PARQUET, writer.getPartitionFormat(0));
             int colIdx = writer.getMetadata().getColumnIndex(columnName);
             Assert.assertEquals(expectedTag, ColumnType.tagOf(writer.getParquetColumnType(0, colIdx)));
+        }
+    }
+
+    private void assertSplitDayOneParquetPartitions(String tableName, long dayTwoTimestamp, int expectedType) {
+        try (TableWriter writer = getWriter(tableName)) {
+            int colIdx = writer.getMetadata().getColumnIndex("v");
+            int dayOneParquetPartitions = 0;
+            for (int i = 0, n = writer.getPartitionCount(); i < n; i++) {
+                if (writer.getPartitionTimestamp(i) >= dayTwoTimestamp) {
+                    continue;
+                }
+                Assert.assertEquals("partition " + i, PartitionFormat.PARQUET, writer.getPartitionFormat(i));
+                Assert.assertEquals("partition " + i, expectedType, ColumnType.tagOf(writer.getParquetColumnType(i, colIdx)));
+                dayOneParquetPartitions++;
+            }
+            Assert.assertTrue(
+                    "expected at least two parquet physical partitions before 2024-01-02, got " + dayOneParquetPartitions,
+                    dayOneParquetPartitions >= 2
+            );
         }
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/parquet/ParquetColumnTypeConversionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/parquet/ParquetColumnTypeConversionTest.java
@@ -1914,6 +1914,42 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAlterParquetFooterIndexedSymbolToFixed() throws Exception {
+        // An INDEXED symbol column converted to a fixed type on a parquet partition. The eager
+        // re-encode rewrites the column to the fixed type, so its stale symbol index must not be
+        // rebuilt against the re-encoded file - doing so decodes an INT column as SYMBOL and
+        // suspends the table on WAL apply. Regression for that suspension.
+        assertMemoryLeak(() -> {
+            try {
+                final String values = "('10', '2024-01-01T00:00:01.000000Z'), ('20', '2024-01-01T00:00:02.000000Z'), (NULL, '2024-01-01T00:00:03.000000Z')";
+                execute("CREATE TABLE nt (v SYMBOL INDEX, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                execute("CREATE TABLE pt (v SYMBOL INDEX, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                execute("INSERT INTO nt VALUES " + values);
+                execute("INSERT INTO pt VALUES " + values);
+                drainWalQueue();
+                execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+                drainWalQueue();
+
+                execute("ALTER TABLE nt ALTER COLUMN v TYPE INT");
+                execute("ALTER TABLE pt ALTER COLUMN v TYPE INT");
+                drainWalQueue();
+
+                // The re-encode succeeds; the table is not suspended on the stale index rebuild.
+                Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("pt")));
+
+                // pt's partition stays parquet and its footer physically carries the new type.
+                assertParquetColumnTag("pt", "v", ColumnType.INT);
+
+                // Values read straight from the re-encoded parquet match the native conversion.
+                assertSqlCursors("SELECT v, ts FROM nt ORDER BY ts", "SELECT v, ts FROM pt ORDER BY ts");
+            } finally {
+                tryDrop("nt");
+                tryDrop("pt");
+            }
+        });
+    }
+
+    @Test
     public void testAlterParquetFooterStringToVarchar() throws Exception {
         assertAlterReencodesParquet("STRING", "VARCHAR", ColumnType.VARCHAR,
                 "('alpha', '2024-01-01T00:00:01.000000Z'), ('beta', '2024-01-01T00:00:02.000000Z'), (NULL, '2024-01-01T00:00:03.000000Z')");

--- a/core/src/test/java/io/questdb/test/cairo/parquet/ParquetColumnTypeConversionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/parquet/ParquetColumnTypeConversionTest.java
@@ -1950,6 +1950,58 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAlterParquetRebuildsIndexForRekeyedSymbolColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            try {
+                execute("CREATE TABLE pt (k STRING, v INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                execute("""
+                        INSERT INTO pt VALUES
+                        ('A', 10, '2024-01-01T00:00:01.000000Z'),
+                        ('B', 20, '2024-01-01T00:00:02.000000Z'),
+                        ('A', 30, '2024-01-01T00:00:03.000000Z'),
+                        (NULL, 40, '2024-01-01T00:00:04.000000Z')""");
+                drainWalQueue();
+
+                // Re-key k: its current writer index no longer matches the original writer
+                // index stored as the parquet column id.
+                execute("ALTER TABLE pt ALTER COLUMN k TYPE SYMBOL INDEX");
+                drainWalQueue();
+                execute("ALTER TABLE pt CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+                drainWalQueue();
+
+                // Rewrite the parquet partition for a different column. The rewrite must rebuild
+                // k's symbol index by originalWriterIndex, otherwise it publishes a txn directory
+                // whose metadata says k is indexed but whose sidecars are missing.
+                execute("ALTER TABLE pt ALTER COLUMN v TYPE LONG");
+                drainWalQueue();
+
+                Assert.assertFalse(engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("pt")));
+                assertParquetColumnTag("pt", "v", ColumnType.LONG);
+
+                assertQuery("SELECT /*+ no_index */ count() c, sum(v) s FROM pt WHERE k = 'A'")
+                        .noLeakCheck()
+                        .noRandomAccess()
+                        .expectSize()
+                        .returns("""
+                                c\ts
+                                2\t40
+                                """);
+                assertQuery("SELECT count() c, sum(v) s FROM pt WHERE k = 'A'")
+                        .withPlanContaining("Index forward scan on: k")
+                        .noLeakCheck()
+                        .noRandomAccess()
+                        .expectSize()
+                        .returns("""
+                                c\ts
+                                2\t40
+                                """);
+            } finally {
+                tryDrop("pt");
+            }
+        });
+    }
+
+    @Test
     public void testAlterParquetFooterStringToVarchar() throws Exception {
         assertAlterReencodesParquet("STRING", "VARCHAR", ColumnType.VARCHAR,
                 "('alpha', '2024-01-01T00:00:01.000000Z'), ('beta', '2024-01-01T00:00:02.000000Z'), (NULL, '2024-01-01T00:00:03.000000Z')");

--- a/core/src/test/java/io/questdb/test/cairo/parquet/ParquetColumnTypeConversionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/parquet/ParquetColumnTypeConversionTest.java
@@ -971,7 +971,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testDecimalToDecimalLazyUnrepresentableProducesNull() throws Exception {
+    public void testDecimalToDecimalUnrepresentableProducesNull() throws Exception {
         assertMemoryLeak(() -> {
             // Decimal->decimal conversions where the source fits the target width (same width, or
             // widening) must read a value that does not fit the target as NULL on the parquet path,
@@ -2642,7 +2642,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testStringToUuidLazyScanAcrossParquetPartitions() throws Exception {
+    public void testStringToUuidScanAcrossParquetPartitions() throws Exception {
         // Two parquet partitions ALTERed from STRING to UUID, read frame by frame. The eager
         // re-encode stores each partition as UUID; the half-corrupt value at partition 2 row 0
         // must read NULL (matching native), and the distinct valid UUIDs across partitions must
@@ -2761,7 +2761,7 @@ public class ParquetColumnTypeConversionTest extends AbstractCairoTest {
      * hard-coded MicrosTimestampDriver, returning values 1000x too small.
      */
     @Test
-    public void testStringToTimestampNanoLazyParquet() throws Exception {
+    public void testStringToTimestampNanoParquet() throws Exception {
         assertMemoryLeak(() -> {
             for (String source : new String[]{"STRING", "VARCHAR"}) {
                 try {


### PR DESCRIPTION
## Summary

`ALTER TABLE ... ALTER COLUMN ... TYPE` now converts parquet partitions in place at ALTER time, writing the new column type into the parquet files, instead of deferring the conversion to read time. Once the statement returns, a parquet partition's on-disk bytes carry the current column type. This brings parquet in line with native partitions, which already convert eagerly and block until done.

Because a parquet file now always stores the current column type, the read-time lazy-conversion path that the previous behaviour relied on is unreachable, and this PR also removes it (see Read-path simplification below).

## Background

`ALTER COLUMN TYPE` on native partitions rewrites the column files eagerly. On parquet partitions the conversion was lazy: the ALTER recorded the new type in table metadata but left the parquet file storing the old type, and each read (or the next out-of-order write) applied a per-row cast on the fly. That had two consequences:

- The parquet file on disk did not match the column's current type, so any consumer that reads the file by its own schema saw the old type.
- Reads of a partition that was never rewritten paid a decode-and-cast cost on every scan.

Behaviour was therefore format-dependent — native eager, parquet lazy. This change makes the two consistent.

## What the change does

- At ALTER time, for each parquet partition that stores the column, the writer decodes the partition and re-encodes it into a new partition directory with the new type in the footer, reusing the same row-group rewrite path the out-of-order write already uses for pending conversions.
- The re-encode commits together with the metadata change, so the parquet file and the table schema advance in one step. On failure the ALTER rolls back and the original partition is left untouched; the superseded directory is removed after commit by the standard scoreboard-gated partition purge.
- Partitions that do not store the column (it was added after the partition was converted to parquet) are skipped — their rows are already all NULL.
- The parquet index rebuild now matches columns by `originalWriterIndex`, the column id stored in parquet metadata, rather than by the current writer index. This fixes a pre-existing helper bug that the eager re-encode path now depends on for indexed SYMBOL columns whose writer index changed after an earlier `ALTER COLUMN TYPE`.
- There is no configuration flag; the eager behaviour is unconditional.

## Read-path simplification

Because a parquet partition's stored column type now always matches table metadata within any read snapshot, the lazy read-time conversion path that #7024 added is unreachable, and this PR removes it:

- `PageFrameMemoryPool.resolveParquetColumn` no longer inspects source-vs-target types or sets up a conversion. A type-converted column is still stored under its original writer index (the `replacingIndex` chain head), so the writer-index remap stays; the method now checks that the stored type tag equals the current tag and throws if they ever differ, instead of silently reinterpreting the bytes.
- `PageFrameMemoryRecord` loses its per-row cast machinery (`hasTypeCasts` / `sourceColumnTypes` and every `convertVarTo*` / `convertFixedTo*` accessor), and `PageFrameFilteredMemoryRecord` loses the matching `needsLazyConversion` fast-path guard.
- The `PageFrameMemory.getSourceColumnType` / `hasColumnTypeCasts` signals are removed, along with the callers that consulted them to opt out of a fast path: the JIT filter gate, the top-K sort-key batch encoder, and the group-by raw-address paths. With lazy casts gone these opt-outs never fired, so removing them changes no result. One consequence is that compiled (JIT) filters now run on parquet frames that a lazy-cast column would previously have excluded from JIT.

This is an internal simplification with no user-visible behaviour change for correct inputs; it removes roughly 900 lines. The write-side conversion machinery is untouched — the eager re-encode itself still uses it (the same row-group rewrite and the Rust decode-with-conversion), so nothing on the conversion path is lost. It is bundled with the eager change rather than split out because it is only correct as a consequence of it: under the lazy model the read path was load-bearing.

## Tradeoffs

- `ALTER COLUMN TYPE` over parquet partitions now performs the conversion up front and blocks until it finishes, so the statement takes longer and does more I/O than before, in proportion to the size of the parquet data storing the column. The lazy model deferred that work, and for partitions that were never read or rewritten it avoided the work entirely.
- The re-encode rewrites whole partitions into new directories rather than editing in place, so it also rewrites the columns that did not change in each affected partition.
- Reads of a converted parquet partition no longer perform per-row casts, so repeated scans after an ALTER are cheaper.

The net effect depends on the workload: eager is more total work when a partition is altered but rarely read, and less when a converted partition is scanned repeatedly.

## Behaviour notes

- Chained conversions (several `ALTER COLUMN TYPE` on the same column) now stay in parquet format across steps, because each ALTER keeps the file in sync with the metadata. Previously a chained conversion with a type mismatch fell back to native.
- A target type of SYMBOL still converts the partition to native first, unchanged, as symbol maps cannot be built from parquet.
- The read-time lazy-conversion path is removed (see Read-path simplification): a converted parquet partition is read directly at its stored type, which the eager re-encode keeps equal to the current type.

## Test plan

- Added tests asserting the parquet footer physically carries the new type immediately after ALTER, before any subsequent write, for fixed->fixed, fixed->var, var->fixed, var->var and symbol->non-symbol conversions.
- Added a multi-partition test that alters a table with several parquet partitions and checks every one is re-encoded, alongside a native active partition.
- Added a test for a column absent from an older parquet partition: that partition is skipped and reads NULL, while a newer partition storing the column is re-encoded.
- Added a test that a target type of SYMBOL converts the partition to native.
- Added a test that converting an *indexed* SYMBOL column to a fixed type re-encodes the parquet partition and drops the column's now-stale symbol index, rather than rebuilding it against the re-encoded file (which already stores the fixed type). The re-encode rebuilds `.k/.pk` indexes for symbol columns that remain symbol, so the index rebuild consults the column's post-ALTER type to skip the converted column.
- Added a regression test that re-keys a column with `STRING -> SYMBOL INDEX`, converts the partition to parquet, then eagerly rewrites a different column. The test verifies the re-encode rebuilds the surviving SYMBOL index by parquet column id and that indexed and non-indexed queries return the same rows.
- Added a test that a chained conversion stays in parquet format across steps.
- Added an error-path test that injects a file-open failure during the re-encode and verifies the ALTER rolls back with no native-memory or file-descriptor leak, leaves the committed parquet at the old type, and recovers on `RESUME WAL`.
- Updated the existing lazy-behaviour tests to expect eager re-encode, and confirmed a reader opened before the ALTER still sees the old type and values for its lifetime (MVCC isolation across the in-place re-encode).
- Existing parquet type-conversion parity, out-of-order rewrite, native `ALTER COLUMN TYPE`, and convert-partition suites pass unchanged.
- All tests run under `assertMemoryLeak`, covering the re-encode's native scratch allocation and its cleanup on both the success and error paths.

For the read-path simplification, the suites that exercise every removed surface pass unchanged (the value-parity tests read the re-encoded parquet directly and match a native control):

- `ParquetColumnTypeConversionTest` (reads converted parquet through the collapsed `resolveParquetColumn` and the group-by / sample-by / join fast paths over altered columns), `ParquetTest`, and `ParquetRowGroupPruningTest`.
- `ParquetLateMaterializationFuzzTest`, covering the filtered-record path (`PageFrameFilteredMemoryRecord`) whose `needsLazyConversion` guard was removed.
- `OrderByEncodeSortTest` / `OrderByEncodeSortFuzzTest` for the top-K sort-key batch encoder, and `CompiledFilterTest` / `CompiledFilterRegressionTest` / `AsyncFilteredRecordCursorFactoryTest` for the JIT filter gate.
- Across these runs the new `resolveParquetColumn` stored-tag-vs-current-tag assertion never fired, consistent with the invariant that the eager re-encode keeps the two equal.