### PR TITLE
fix(sql): clarify materialized view error when timestamp lacks a sampling interval

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationImpl.java
+++ b/core/src/main/java/io/questdb/griffin/engine/ops/CreateMatViewOperationImpl.java
@@ -429,6 +429,15 @@ public class CreateMatViewOperationImpl implements CreateMatViewOperation {
 
         // We haven't found timestamp_floor() in SELECT.
         if (intervalExpr == null) {
+            if (timestamp != null) {
+                // The designated timestamp column was already confirmed present in the select
+                // list above, but the query has neither a SAMPLE BY nor a GROUP BY
+                // timestamp_floor(...), so no sampling interval could be inferred. Point the
+                // user at the two supported forms instead of claiming the column is missing.
+                throw SqlException.position(selectTextPosition)
+                        .put("materialized view query requires a sampling interval, use SAMPLE BY or GROUP BY timestamp_floor() [name=")
+                        .put(timestamp).put(']');
+            }
             throw SqlException.$(selectTextPosition, "TIMESTAMP column is not present in select list");
         }
 

--- a/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/CreateMatViewTest.java
@@ -549,6 +549,21 @@ public class CreateMatViewTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCreateMatViewGroupByPlainTimestampNoSamplingInterval() throws Exception {
+        assertMemoryLeak(() -> {
+            createTable(TABLE1);
+            // ts is the designated timestamp and is present in the select list, but there is
+            // neither a SAMPLE BY nor a GROUP BY timestamp_floor(...), so no sampling interval
+            // can be inferred. The error must not claim the timestamp column is missing.
+            assertQuery("create materialized view test as (select ts, avg(v) from " + TABLE1 +
+                    ") timestamp(ts) partition by day")
+                    .noLeakCheck()
+                    .fails(34, "materialized view query requires a sampling interval, use SAMPLE BY or GROUP BY timestamp_floor() [name=ts]");
+            assertNull(getMatViewDefinition("test"));
+        });
+    }
+
+    @Test
     public void testCreateMatViewGroupByTimestamp1() throws Exception {
         assertMemoryLeak(() -> {
             createTable(TABLE1);


### PR DESCRIPTION
Fixes #7356

## Summary

`CreateMatViewOperationImpl.validateAndUpdateMetadataFromModel()` throws "TIMESTAMP column is not present in select list" for every `CREATE MATERIALIZED VIEW` query that has neither a `SAMPLE BY` clause nor a `GROUP BY timestamp_floor(...)` column, regardless of whether the designated timestamp column is actually present in the select list or not.

As reported in #7356, a query such as:

```sql
CREATE MATERIALIZED VIEW wind_chill_1h
WITH BASE sensor_1h REFRESH IMMEDIATE AS (
    SELECT ts, last(...) AS wind_chill_f
    FROM sensor_1h
    ORDER BY ts
) TIMESTAMP(ts)
PARTITION BY DAY;
```

fails with that message even though `ts` is clearly present in the select list. The real problem, as the reporting maintainer clarified in the issue thread, is that no sampling interval could be inferred — a materialized view needs either `SAMPLE BY <interval>` or `GROUP BY timestamp_floor(<interval>, ts)` to define the fixed bucket the incremental refresh walks. A plain `GROUP BY` on the designated timestamp doesn't provide that, so it's rejected, but the existing error message names the wrong problem.

## Change

By the point the code decides no sampling interval was found, it has already confirmed (earlier in the same method) that the designated timestamp column, when present in the DDL's `TIMESTAMP(...)` clause, exists in the select list — otherwise it would have thrown a different, more specific error already. This PR uses that existing invariant to distinguish the two cases:

- Timestamp column present but no interval inferred: new message names the column and points at `SAMPLE BY` / `GROUP BY timestamp_floor(...)` as the two supported forms.
- No designated timestamp column at all: unchanged generic message, since that case really does mean the column is missing.

## Test plan

- Added `testCreateMatViewGroupByPlainTimestampNoSamplingInterval` to `CreateMatViewTest`, covering the exact query shape from the issue (`SELECT ts, avg(v) ... GROUP BY` implied by aggregation, with an explicit `TIMESTAMP(ts)` clause, no `SAMPLE BY`/`timestamp_floor`).
- Ran the new test alongside the three existing tests that exercise the same code path (`testCreateMatViewGroupByNoTimestamp`, `testCreateMatViewNoSampleBy`, `testCreateMatViewGroupByTimestamp3`) to confirm no regression: all 4 pass.
- Did not run the full test suite; the change is confined to a single error-message branch with no other callers.