### PR TITLE
fix(sql): accept PARTITIONS in CONVERT PARTITION

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlKeywords.java
+++ b/core/src/main/java/io/questdb/griffin/SqlKeywords.java
@@ -1768,7 +1768,7 @@ public class SqlKeywords {
     }
 
     public static boolean isPartitionKeyword(CharSequence tok) {
-        return tok.length() == 9
+        return (tok.length() == 9 || tok.length() == 10)
                 && (tok.charAt(0) | 32) == 'p'
                 && (tok.charAt(1) | 32) == 'a'
                 && (tok.charAt(2) | 32) == 'r'
@@ -1777,7 +1777,8 @@ public class SqlKeywords {
                 && (tok.charAt(5) | 32) == 't'
                 && (tok.charAt(6) | 32) == 'i'
                 && (tok.charAt(7) | 32) == 'o'
-                && (tok.charAt(8) | 32) == 'n';
+                && (tok.charAt(8) | 32) == 'n'
+                && (tok.length() == 9 || (tok.charAt(9) | 32) == 's');
     }
 
     public static boolean isPartitionsKeyword(CharSequence tok) {

--- a/core/src/test/java/io/questdb/test/griffin/AlterTableConvertPartitionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/AlterTableConvertPartitionTest.java
@@ -1354,6 +1354,56 @@ public class AlterTableConvertPartitionTest extends AbstractCairoTest {
         });
     }
 
+    @Test
+    public void testConvertPartitionsPluralKeyword() throws Exception {
+        assertMemoryLeak(TestFilesFacadeImpl.INSTANCE, () -> {
+            execute(
+                    "create table x as (select" +
+                            " x id," +
+                            " rnd_boolean() a_boolean," +
+                            " rnd_byte() a_byte," +
+                            " timestamp_sequence('2024-06', 500)::" + timestampType.getTypeName() + " designated_ts" +
+                            " from long_sequence(10)" +
+                            ") timestamp(designated_ts) partition by month"
+            );
+
+            execute("ALTER TABLE x CONVERT PARTITIONS TO PARQUET LIST '2024-06'");
+            assertPartitionDoesNotExist("x", "2024-06.1");
+
+            execute("ALTER TABLE x CONVERT PARTITIONS TO NATIVE LIST '2024-06'");
+            assertPartitionDoesNotExist("x", "2024-06.1");
+        });
+    }
+
+    @Test
+    public void testConvertPartitionsPluralKeywordWhere() throws Exception {
+        assertMemoryLeak(TestFilesFacadeImpl.INSTANCE, () -> {
+            execute(
+                    "create table x as (select" +
+                            " x id," +
+                            " rnd_boolean() a_boolean," +
+                            " rnd_byte() a_byte," +
+                            " timestamp_sequence('2024-06', 500)::" + timestampType.getTypeName() + " designated_ts" +
+                            " from long_sequence(10)" +
+                            ") timestamp(designated_ts) partition by month"
+            );
+
+            execute("ALTER TABLE x CONVERT PARTITIONS TO PARQUET WHERE designated_ts > 0");
+            assertQuery("select count() from x")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\n10\n");
+
+            execute("ALTER TABLE x CONVERT PARTITIONS TO NATIVE WHERE designated_ts > 0");
+            assertQuery("select count() from x")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\n10\n");
+        });
+    }
+
     private void assertPartitionDoesNotExist(String tableName, String partition) {
         assertPartitionOnDisk0(tableName, false, partition);
     }


### PR DESCRIPTION
isPartitionKeyword() now accepts both PARTITION (length 9) and PARTITIONS (length 10), so ALTER TABLE CONVERT PARTITION works with the plural form too. All other keywords that use isPartitionKeyword also accept the plural form consistently.

Fixes #6494

## Testing
- Added testConvertPartitionsPluralKeyword (LIST variant)
- Added testConvertPartitionsPluralKeywordWhere (WHERE variant)
- All existing AlterTableConvertPartitionTest tests pass
- All existing SqlCompilerImplTest convert tests pass
- All AlterTableDetachPartitionTest and AlterTableAttachPartitionTest tests pass (192 tests)