### PR TITLE
test(core): fix seed-dependent crash in checkpoint fuzz test

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/fuzz/CheckpointFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/CheckpointFuzzTest.java
@@ -358,7 +358,10 @@ public class CheckpointFuzzTest extends AbstractFuzzTest {
             }
 
             try {
-                int snapshotIndex = 1 + rnd.nextInt(transactions.size() - 1);
+                // The fuzzer can generate a single transaction; Rnd.nextInt(0) divides by
+                // zero, so a one-transaction run takes the checkpoint after its only
+                // transaction and leaves the (already optional) after-set empty.
+                int snapshotIndex = transactions.size() > 1 ? 1 + rnd.nextInt(transactions.size() - 1) : 1;
 
                 ObjList<FuzzTransaction> beforeSnapshot = new ObjList<>();
                 beforeSnapshot.addAll(transactions, 0, snapshotIndex);


### PR DESCRIPTION
## Problem

`runFuzzWithCheckpoint` splits generated transactions into before/after-checkpoint sets with `1 + rnd.nextInt(transactions.size() - 1)`. When a seed makes the fuzzer generate exactly one transaction, `Rnd.nextInt(0)` throws `ArithmeticException: / by zero` and the harness crashes before the test does anything. `FuzzTransactionGenerator.generateSet` clamps its loop to at least 3 iterations, but the emitted list can still end up with a single transaction, so the crash is seed-dependent.

## Fix

A one-transaction run now takes the checkpoint after its only transaction and leaves the after-set empty — a path the test already supports: it falls back to `drainWalQueue()` when `afterSnapshot` is empty, and the `rnd.nextLong(snapshotIndex * 50L)` sleep draw is fine with `snapshotIndex = 1`.

QuestDB Enterprise's `BackupTest` carries copies of this line and its CI hit the identical divide-by-zero; questdb/questdb-enterprise#1126 fixes those copies with the same guard.

## Test plan

- Pinned seeds on the identical enterprise copy of this line reproduced the exact crash (`ArithmeticException: / by zero` at `Rnd.nextInt` from the split draw) against the unguarded code and run green with the guard.
- `CheckpointFuzzTest#testCheckpointFullFuzz` passes with random seeds against the guarded line; this confirms non-breakage of the common path rather than exercising the one-transaction case.
- `mvn test-compile -pl core` passes on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)