### PR TITLE
fix(core): fix server startup when a password file is used with strict config validation

### DIFF
--- a/core/src/main/java/io/questdb/PropServerConfiguration.java
+++ b/core/src/main/java/io/questdb/PropServerConfiguration.java
@@ -3570,7 +3570,7 @@ public class PropServerConfiguration implements ServerConfiguration {
                     String obsoleteMsg = obsoleteSettings.get(propName);
                     if (obsoleteMsg != null) {
                         obsolete.put(propName, obsoleteMsg);
-                    } else {
+                    } else if (!isSecretFileProperty(propName)) {
                         incorrect.add(propName);
                     }
                 }
@@ -3640,6 +3640,19 @@ public class PropServerConfiguration implements ServerConfiguration {
             } else {
                 map.put(old, "No longer used");
             }
+        }
+
+        /**
+         * Tests whether the property is the {@code .file} variant of a sensitive setting, such as
+         * {@code http.password.file}. These are read by {@link #getSecretFilePath} to support secret file
+         * mounts, but have no {@link PropertyKey} of their own, so they must not be reported as typos.
+         */
+        protected boolean isSecretFileProperty(String propName) {
+            if (!propName.endsWith(SECRET_FILE_PROPERTY_SUFFIX)) {
+                return false;
+            }
+            String keyName = propName.substring(0, propName.length() - SECRET_FILE_PROPERTY_SUFFIX.length());
+            return lookupConfigProperty(keyName).map(ConfigPropertyKey::isSensitive).orElse(false);
         }
 
         protected Optional<ConfigPropertyKey> lookupConfigProperty(String propName) {

--- a/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
+++ b/core/src/test/java/io/questdb/test/PropServerConfigurationTest.java
@@ -782,6 +782,49 @@ public class PropServerConfigurationTest {
     }
 
     @Test
+    public void testSecretFilePropertiesPassStrictValidation() throws Exception {
+        // The <secret>.file properties are read by getSecretFilePath() to support secret file mounts,
+        // but they have no PropertyKey of their own, so strict validation used to reject them as typos
+        // and the server refused to start.
+        File httpPassword = temp.newFile("http-password");
+        File pgPassword = temp.newFile("pg-password");
+        File pgRoPassword = temp.newFile("pg-readonly-password");
+        java.nio.file.Files.write(httpPassword.toPath(), "http-secret".getBytes());
+        java.nio.file.Files.write(pgPassword.toPath(), "pg-secret".getBytes());
+        java.nio.file.Files.write(pgRoPassword.toPath(), "pg-readonly-secret".getBytes());
+
+        Properties properties = new Properties();
+        properties.setProperty("config.validation.strict", "true");
+        properties.setProperty("http.user", "admin");
+        properties.setProperty("http.password.file", httpPassword.getAbsolutePath());
+        properties.setProperty("pg.password.file", pgPassword.getAbsolutePath());
+        properties.setProperty("pg.readonly.password.file", pgRoPassword.getAbsolutePath());
+
+        Assert.assertNull(validate(properties));
+
+        // Strict validation must not stop the server from starting, and the secrets must still be
+        // read from the files.
+        PropServerConfiguration configuration = newPropServerConfiguration(properties);
+        Assert.assertEquals("http-secret", configuration.getHttpServerConfiguration().getPassword());
+    }
+
+    @Test
+    public void testSecretFileValidationRejectsUnknownAndNonSensitiveKeys() {
+        // The .file suffix is only accepted for sensitive settings, so a typo in the base key, or a
+        // .file variant of a setting that holds no secret, is still reported as invalid.
+        Properties properties = new Properties();
+        properties.setProperty("config.validation.strict", "true");
+        properties.setProperty("http.pasword.file", "/tmp/typo");
+        properties.setProperty("http.bind.to.file", "/tmp/not-a-secret");
+
+        PropServerConfiguration.ValidationResult result = validate(properties);
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isError());
+        Assert.assertNotEquals(-1, result.message().indexOf("http.pasword.file"));
+        Assert.assertNotEquals(-1, result.message().indexOf("http.bind.to.file"));
+    }
+
+    @Test
     public void testDeprecatedValidationResult() {
         Properties properties = new Properties();
         properties.setProperty("http.net.rcv.buf.size", "10000");


### PR DESCRIPTION
Fixes #7174

QuestDB can read a secret from a file instead of from `server.conf`, via a `<key>.file` property — `http.password.file`, `pg.password.file`, `pg.readonly.password.file`. This supports Kubernetes secret mounts, and `getSecretFilePath()` reads those properties at startup.

`PropertyValidator` resolves every property in `server.conf` against the `PropertyKey` enum. The `.file` variants have no `PropertyKey` of their own, so the validator classified them as typos. With `config.validation.strict=true` — the default on the AMI — the server then refused to start:

```
Invalid settings (not recognized, probable typos):
    * http.password.file
    * pg.password.file
```

So a documented, working feature stopped the server from booting, and the only workaround was to turn strict validation off.

## Change

`PropertyValidator` now strips the `.file` suffix and accepts the property when the base key resolves to a setting that `isSensitive()`.

Deriving the check from `isSensitive()` rather than adding three constants to `PropertyKey` keeps the validator in step with `getSecretFilePath()`, which builds the key the same way (`key.getPropertyPath() + SECRET_FILE_PROPERTY_SUFFIX`), and it covers any sensitive setting added later without a second edit. The three sensitive keys today are `http.password`, `pg.password` and `pg.readonly.password`.

The tradeoff is that the validator now accepts a property that no `PropertyKey` declares, so `server.conf` gains a small family of keys that are valid but not enumerated. The check is narrow: a `.file` suffix on a non-sensitive key (`http.bind.to.file`) or on a misspelled key (`http.pasword.file`) is still reported as a typo, so the typo protection that strict validation exists to provide is preserved for everything else.

## Test plan

- `PropServerConfigurationTest#testSecretFilePropertiesPassStrictValidation` — sets the three `.file` properties under `config.validation.strict=true`, asserts `validate()` reports no issues, and asserts the server configuration is constructed and reads the password back out of the file. It fails on `master` with `expected null, but was:<ValidationResult[isError=true, ...]>`, and passes with this change.
- `PropServerConfigurationTest#testSecretFileValidationRejectsUnknownAndNonSensitiveKeys` — asserts `http.pasword.file` (typo) and `http.bind.to.file` (not a secret) are still reported as invalid, so the fix is not a blanket `.file` allow-list.
- `mvn -P local-client -pl core -am test -Dtest=PropServerConfigurationTest` — 105 tests, 0 failures, 0 errors, 1 skipped.
- `BootstrapTest` — 7 tests, 0 failures.
- `ServerMainTest` — 16 tests, 1 error: `testServerUpgradeDoesNotOverrideWebConsoleConfig` fails with `Cannot read from .../public/assets/console-configuration.json`. This is not caused by this change: it reproduces identically on an unmodified checkout of `master` in the same working copy, because the web console assets are not built in a source-only clone. Everything else in the class passes.
