### PR TITLE
fix(SQL): fix SAMPLE BY w to accept the week unit without a leading digit

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -477,8 +477,10 @@ public class SqlParser {
             // minutes
             // hours
             // days
+            // weeks
             // months
-            case 'n', 'U', 'T', 's', 'm', 'h', 'd', 'M', 'y' -> true;
+            // years
+            case 'n', 'U', 'T', 's', 'm', 'h', 'd', 'w', 'M', 'y' -> true;
             default -> false;
         };
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -16920,6 +16920,37 @@ public class SampleByTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSampleFillWithWeekStrideNoDigit() throws Exception {
+        assertMemoryLeak(() -> {
+            execute(FROM_TO_DDL);
+
+            String expected = """
+                    ts\tavg
+                    2017-12-20T00:00:00.000000Z\tnull
+                    2017-12-27T00:00:00.000000Z\t48.5
+                    2018-01-03T00:00:00.000000Z\t264.5
+                    2018-01-10T00:00:00.000000Z\t456.5
+                    2018-01-17T00:00:00.000000Z\tnull
+                    2018-01-24T00:00:00.000000Z\tnull
+                    """;
+
+            String queryNoDigit = "select ts, avg(x) from fromto\n" +
+                    "sample by w from '2017-12-20' to '2018-01-31' fill(null) align to calendar";
+            assertQuery(queryNoDigit)
+                    .timestamp("ts")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns(expected);
+
+            assertQuery(queryNoDigit.replace("sample by w", "sample by 1w"))
+                    .timestamp("ts")
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns(expected);
+        });
+    }
+
+    @Test
     public void testSamplePeriodInvalidWithNoUnits() throws Exception {
         testSampleByPeriodFails(
                 "select sum(a), k from x sample by 300/10 align to calendar",


### PR DESCRIPTION
Fixes #7293

`SAMPLE BY w` (week) failed to parse with the error `one letter sample by period unit expected`, even though every other single-letter sampling unit works without a leading digit: `SAMPLE BY h`, `SAMPLE BY d`, `SAMPLE BY M`, and so on. Users had to write `SAMPLE BY 1w` as a workaround.

## Root cause

The parser validates the bare single-letter form against an allow-list in `SqlParser.isValidSampleByPeriodLetter()`. That list was missing `'w'`. The method backs both parser paths that accept a unit with no interval (`isFullSampleByPeriod()` and `expectSample()`), so `w` alone was rejected before it ever reached the sampler.

The week unit itself was already fully supported everywhere downstream: both the micros and nanos timestamp drivers map `'w'` to a `WeekTimestamp*Sampler`, and the no-digit form resolves to "1 week" via `TimestampSamplerFactory.parsePositiveInterval()` (which returns 1 when no number precedes the unit, exactly as `SAMPLE BY m` == `SAMPLE BY 1m`). This was purely a validation-list oversight, not a missing feature.

## Fix

- Add `'w'` to the allow-list in `isValidSampleByPeriodLetter()`.
- Complete the accompanying comment, which was also missing `weeks` and `years`.

## Impact and tradeoffs

The change only widens what the parser accepts; it does not alter the behavior of any query that already parsed. `SAMPLE BY w` now behaves identically to `SAMPLE BY 1w`. There is no performance impact and no change to existing valid or invalid inputs other than `w` moving from rejected to accepted.

## Test plan

- Added `SampleByTest#testSampleFillWithWeekStrideNoDigit`, which runs the issue's query shape (`SAMPLE BY w ... FILL(NULL) ALIGN TO CALENDAR`) and asserts it returns the same result as the explicit `1w` form.
- Ran the new test together with the existing `testSampleFillWithWeekStride`.