### PR TITLE
fix(sql): fix dot_product returning wrong result for transposed arrays

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/array/DoubleArrayDotProductFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/array/DoubleArrayDotProductFunctionFactory.java
@@ -156,7 +156,7 @@ public class DoubleArrayDotProductFunctionFactory implements FunctionFactory {
             if (atDeepestDim) {
                 for (int i = 0; i < count; i++) {
                     double leftVal = left.getDouble(flatIndexLeft);
-                    double rightVal = right.getDouble(flatIndexLeft);
+                    double rightVal = right.getDouble(flatIndexRight);
                     if (Numbers.isFinite(leftVal) && Numbers.isFinite(rightVal)) {
                         sum += leftVal * rightVal;
                     }

--- a/core/src/test/java/io/questdb/test/cairo/ArrayTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/ArrayTest.java
@@ -1017,6 +1017,23 @@ public class ArrayTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testArrayDotProductTransposedOperand() throws Exception {
+        // transpose([[1,3],[2,5]]) = [[1,2],[3,5]], right = [[1,5],[7,2]]:
+        // 1*1 + 2*5 + 3*7 + 5*2 = 42.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tango (left DOUBLE[][], right DOUBLE[][])");
+            execute("INSERT INTO tango VALUES (ARRAY[[1.0, 3.0], [2.0, 5.0]], ARRAY[[1.0, 5.0], [7.0, 2.0]])");
+            assertQuery("SELECT dot_product(transpose(left), right) AS product FROM tango")
+                    .noLeakCheck()
+                    .expectSize()
+                    .returns("""
+                            product
+                            42.0
+                            """);
+        });
+    }
+
+    @Test
     public void testArrayFirstFunction() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table test (ts timestamp, x int, v double[]) timestamp(ts) partition by DAY");


### PR DESCRIPTION
## What

`dot_product()` over two `DOUBLE[]`/`DOUBLE[][]` arrays could return a silently incorrect result when one of the operands is not stored in vanilla (contiguous, row-major) layout.

In the recursive code path, the deepest-dimension loop read the right-hand array with the left array's flat index (`flatIndexLeft`) rather than its own cursor (`flatIndexRight`). `flatIndexRight` was computed and advanced but never used to read a value.

When both operands share an identical layout the two indices coincide, so the existing tests (both operands vanilla, or both transposed the same way) passed. When the operands have different strides — e.g. one is `transpose(...)` or a slice — reading the right array with the left index selects the wrong element, so the sum is wrong. Example:

```
transpose([[1,3],[2,5]]) = [[1,2],[3,5]],  right = [[1,5],[7,2]]
dot_product = 1*1 + 2*5 + 3*7 + 5*2 = 42   (previously returned 40)
```

## Fix

Read the right array with `flatIndexRight`.

## Impact

- Corrects results for `dot_product` when an operand has non-vanilla layout (transposed/sliced arrays).
- No behavior change for arrays that were already stored in identical vanilla layout — the common case — so existing correct results are unaffected.
- No performance impact: the change swaps one index variable for another that was already being maintained.

## Test plan

- Added `ArrayTest.testArrayDotProductTransposedOperand`, which mixes a transposed and a vanilla operand and asserts the corrected value (42.0). This case fails before the fix (returns 40.0).
- The existing `testArrayDotProduct` and `testArrayDotProductScalarValue` continue to pass.
