### PR TITLE
Fix #7389: nanos timestamp validateBounds skips positive overflow

### DIFF
--- a/core/src/main/java/io/questdb/cairo/NanosTimestampDriver.java
+++ b/core/src/main/java/io/questdb/cairo/NanosTimestampDriver.java
@@ -1627,7 +1627,7 @@ public class NanosTimestampDriver implements TimestampDriver {
 
     @Override
     public void validateBounds(long timestamp) {
-        if (timestamp < 0) {
+        if (Long.compareUnsigned(timestamp, CommonUtils.MAX_TIMESTAMP) > 0) {
             validateBounds0(timestamp);
         }
     }
@@ -1748,7 +1748,7 @@ public class NanosTimestampDriver implements TimestampDriver {
         if (timestamp == Long.MIN_VALUE) {
             throw CairoException.nonCritical().put("designated timestamp column cannot be NULL");
         }
-        if (timestamp < TableWriter.TIMESTAMP_EPOCH || timestamp > CommonUtils.TIMESTAMP_UNIT_NANOS) {
+        if (timestamp < TableWriter.TIMESTAMP_EPOCH || timestamp > CommonUtils.MAX_TIMESTAMP) {
             throw CairoException.nonCritical().put("designated timestamp_ns before 1970-01-01 and beyond ").put(MAX_NANO_TIMESTAMP_STR).put(" is not allowed");
         }
     }

--- a/core/src/test/java/io/questdb/test/cairo/NanoTimestampDriverTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/NanoTimestampDriverTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.cairo;
 
+import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.ImplicitCastException;
 import io.questdb.cairo.TimestampDriver;
@@ -171,5 +172,44 @@ public class NanoTimestampDriverTest extends AbstractCairoTest {
         Assert.assertEquals(1577836800100000000L, driver.implicitCast("2020-01-01T00:00:00.1Z", ColumnType.STRING));
         Assert.assertEquals(1577836800120000000L, driver.implicitCast("2020-01-01T00:00:00.12Z", ColumnType.STRING));
         Assert.assertEquals(1577836800123000000L, driver.implicitCast("2020-01-01T00:00:00.123Z", ColumnType.STRING));
+    }
+
+    @Test
+    public void testValidateBounds() {
+        // null sentinel
+        try {
+            driver.validateBounds(Numbers.LONG_NULL);
+            Assert.fail();
+        } catch (CairoException e) {
+            TestUtils.assertContains(e.getMessage(), "designated timestamp column cannot be NULL");
+        }
+
+        // negative (before epoch)
+        try {
+            driver.validateBounds(-1L);
+            Assert.fail();
+        } catch (CairoException e) {
+            TestUtils.assertContains(e.getMessage(), "designated timestamp_ns before 1970-01-01 and beyond 2261-12-31 23:59:59.999999999 is not allowed");
+        }
+
+        // valid boundary values must not throw
+        driver.validateBounds(0L);
+        driver.validateBounds(CommonUtils.MAX_TIMESTAMP);
+
+        // just beyond the upper bound
+        try {
+            driver.validateBounds(CommonUtils.MAX_TIMESTAMP + 1);
+            Assert.fail();
+        } catch (CairoException e) {
+            TestUtils.assertContains(e.getMessage(), "designated timestamp_ns before 1970-01-01 and beyond 2261-12-31 23:59:59.999999999 is not allowed");
+        }
+
+        // Long.MAX_VALUE - the exact repro value from issue #7389
+        try {
+            driver.validateBounds(Long.MAX_VALUE);
+            Assert.fail();
+        } catch (CairoException e) {
+            TestUtils.assertContains(e.getMessage(), "designated timestamp_ns before 1970-01-01 and beyond 2261-12-31 23:59:59.999999999 is not allowed");
+        }
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/TimestampBoundsTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/TimestampBoundsTest.java
@@ -117,4 +117,64 @@ public class TimestampBoundsTest extends AbstractCairoTest {
         });
     }
 
+    @Test
+    public void testDesignatedTimestampBoundsNonPartitionedNanos() throws Exception {
+        Assume.assumeFalse(walEnabled);
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tango (ts TIMESTAMP_NS) TIMESTAMP(ts)");
+            assertQuery("INSERT INTO tango VALUES (NULL)")
+                    .fails(26, "designated timestamp column cannot be NULL");
+            assertQuery("INSERT INTO tango VALUES (" + -1L + ")")
+                    .fails(26, "designated timestamp_ns before 1970-01-01 and beyond 2261-12-31 23:59:59.999999999 is not allowed");
+            assertQuery("INSERT INTO tango VALUES ('1969-12-31T23:59:59.900Z')")
+                    .fails(26, "designated timestamp_ns before 1970-01-01 and beyond 2261-12-31 23:59:59.999999999 is not allowed");
+            assertQuery("INSERT INTO tango VALUES (" + Long.MAX_VALUE + ")")
+                    .fails(26, "designated timestamp_ns before 1970-01-01 and beyond 2261-12-31 23:59:59.999999999 is not allowed");
+        });
+    }
+
+    @Test
+    public void testDesignatedTimestampBoundsPartitionedNanos() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tango (ts TIMESTAMP_NS) TIMESTAMP(ts) PARTITION BY HOUR "
+                    + (walEnabled ? "" : "BYPASS ") + "WAL");
+            assertQuery("INSERT INTO tango VALUES (NULL)")
+                    .fails(26, "designated timestamp column cannot be NULL");
+            assertQuery("INSERT INTO tango VALUES (" + -1L + ")")
+                    .fails(26, "designated timestamp_ns before 1970-01-01 and beyond 2261-12-31 23:59:59.999999999 is not allowed");
+            assertQuery("INSERT INTO tango VALUES ('1969-12-31T23:59:59.900Z')")
+                    .fails(26, "designated timestamp_ns before 1970-01-01 and beyond 2261-12-31 23:59:59.999999999 is not allowed");
+            assertQuery("INSERT INTO tango VALUES (" + Long.MAX_VALUE + ")")
+                    .fails(26, "designated timestamp_ns before 1970-01-01 and beyond 2261-12-31 23:59:59.999999999 is not allowed");
+        });
+    }
+
+    @Test
+    public void testDesignatedTimestampBoundsWithSwitchPartitionNanos() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tango (ts TIMESTAMP_NS) TIMESTAMP(ts) PARTITION BY HOUR "
+                    + (walEnabled ? "" : "BYPASS ") + "WAL");
+            execute("INSERT INTO tango VALUES (" + 1L + ")");
+            assertQuery("INSERT INTO tango VALUES (NULL)")
+                    .fails(26, "designated timestamp column cannot be NULL");
+            assertQuery("INSERT INTO tango VALUES (" + -1L + ")")
+                    .fails(26, "designated timestamp_ns before 1970-01-01 and beyond 2261-12-31 23:59:59.999999999 is not allowed");
+            assertQuery("INSERT INTO tango VALUES ('1969-12-31T23:59:59.900Z')")
+                    .fails(26, "designated timestamp_ns before 1970-01-01 and beyond 2261-12-31 23:59:59.999999999 is not allowed");
+            assertQuery("INSERT INTO tango VALUES (" + Long.MAX_VALUE + ")")
+                    .fails(26, "designated timestamp_ns before 1970-01-01 and beyond 2261-12-31 23:59:59.999999999 is not allowed");
+        });
+    }
+
+    @Test
+    public void testTimestampBoundsNotDesignatedNanos() throws Exception {
+        Assume.assumeFalse(walEnabled);
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE tango (ts TIMESTAMP_NS)");
+            execute("INSERT INTO tango VALUES (" + Long.MAX_VALUE + ")");
+            execute("INSERT INTO tango VALUES (" + -1L + ")");
+            execute("INSERT INTO tango VALUES ('1969-12-31T23:59:59.900Z')");
+        });
+    }
+
 }


### PR DESCRIPTION
What does this PR do?

Resolves #7389. This fixes an issue where the NanosTimestampDriver allowed positive, overflowing timestamps (beyond the year 2261 cap) to bypass validation during insert. This previously caused the table to silently suspend during WAL apply.

Root Cause:

validateBounds() only guarded against timestamp < 0, allowing any positive nanos value to pass.

validateBounds0() incorrectly compared the timestamp against CommonUtils.TIMESTAMP_UNIT_NANOS (a unit-tag constant with a value of 1) instead of the actual boundary CommonUtils.MAX_TIMESTAMP.

Changes made:

Fixed both validation methods in NanosTimestampDriver to properly compare against CommonUtils.MAX_TIMESTAMP (mirroring the safe logic already used in MicrosTimestampDriver).

Added bound validation unit tests in NanoTimestampDriverTest.

Added end-to-end WAL regression tests in TimestampBoundsTest to verify that inserting Long.MAX_VALUE into a TIMESTAMP_NS column correctly throws a CairoException on insert instead of suspending the table later.  



Note for Reviewers:

NanosTimestampDriver.getMaxDesignatedTimestamp() currently still returns Long.MAX_VALUE with a comment stating nanos are uncapped. I left this untouched to keep the scope of this fix tight, but flagging it here in case it needs a follow-up adjustment to match the enforced 2261-12-31 limit.