### PR TITLE
test(core): stop fuzz tests spuriously failing when logging non-ASCII index values

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunner.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunner.java
@@ -908,7 +908,7 @@ public class FuzzRunner {
             String prefix = "a\n";
             String randomValue = sink.length() > prefix.length() + 2 ? sink.subSequence(prefix.length(), sink.length() - 1).toString() : null;
             String indexedWhereClause = " where \"" + symbolColumnName + "\" = " + (randomValue == null ? "null" : "'" + randomValue + "'");
-            LOG.info().$("checking random index with filter: ").$(indexedWhereClause).I$();
+            LOG.info().$("checking random index with filter: ").$safe(indexedWhereClause).I$();
             String limit = ""; // for debugging, e.g. " limit 100"
             TestUtils.assertSqlCursors(compiler, sqlExecutionContext, expectedTableName + indexedWhereClause + limit, actualTableName + indexedWhereClause + limit, LOG);
             // Now let's do backward order assertion


### PR DESCRIPTION
`WalWriterFuzzTest` and other `FuzzRunner`-based tests can fail intermittently with `io.questdb.log.LogError: Invalid UTF-8` while only logging a diagnostic line. This is a test-only logging defect, not a storage or query bug.

## Root cause

`FuzzRunner.checkIndexRandomValueScan()` logs a filter built from a random column value using `$()`, which takes the ASCII fast path (`putAscii()`, masking each char to its low byte). When the value is non-ASCII -- e.g. a `var_top` column filled with `Rnd.nextUtf8Str()`, converted VARCHAR -> SYMBOL, then covering-indexed -- the record becomes invalid UTF-8. Under Surefire, `LOG_PARANOIA_MODE` validates UTF-8 and throws, aborting the test. Seed-dependent; reproduced with `13212121898834012L, 1783953045292L`.

## Fix

Log the value with `$safe()` (correct UTF-16 -> UTF-8 encoding) instead of `$()`. This is the only normal-path value log in `FuzzRunner`; `assertSqlCursors()` on the following lines does not log the query on its success path, so the failure does not relocate.

## Test plan

- Run `WalWriterFuzzTest#testConvertPartitionToParquet`, including with the seeds above; it previously errored at the log line and now runs to completion.
- No production code changes; the diff is confined to test infrastructure.