### PR TITLE
fix(sql): fix SYMBOL FILL(PREV) for equivalent aggregate aliases

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -3866,9 +3866,16 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             // inconsistently against a different source column.
                             // Bare FILL(PREV) keeps self-prev semantics and is safe.
                             if (targetTag == ColumnType.SYMBOL || sourceTag == ColumnType.SYMBOL) {
-                                throw SqlException.$(fillExpr.rhs.position,
-                                                "FILL(PREV(").put(srcAlias).put(")) is not supported on SYMBOL columns; ")
-                                        .put("use bare FILL(PREV) instead");
+                                CharSequence targetAlias = groupByMetadata.getColumnName(col);
+
+                                QueryColumn targetCol = model.getAliasToColumnMap().get(targetAlias);
+                                QueryColumn sourceCol = model.getAliasToColumnMap().get(srcAlias);
+
+                                if (targetCol == null || sourceCol == null || !ExpressionNode.compareNodesExact(targetCol.getAst(), sourceCol.getAst())) {
+                                    throw SqlException.$(fillExpr.rhs.position,
+                                                    "FILL(PREV(").put(srcAlias).put(")) is not supported on SYMBOL columns; ")
+                                            .put("use bare FILL(PREV) instead");
+                                }
                             }
                             final boolean needsExactTypeMatch =
                                     ColumnType.isDecimal(targetType)

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/FillRecordDispatchTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/FillRecordDispatchTest.java
@@ -225,14 +225,6 @@ public class FillRecordDispatchTest extends AbstractCairoTest {
         });
     }
 
-    @Ignore("Tracked by #7159. Cross-column FILL(PREV(symbol_col)) is rejected at codegen by the "
-            + "SYMBOL guard in SqlCodeGenerator.generateFill. The query previously slipped past "
-            + "that guard because SqlOptimiser.detectDuplicateAggregates collapsed first(s) AS sv, "
-            + "first(s) AS a into a single inner aggregate, so the FILL list never reached the "
-            + "cross-column path. The fill-list propagation in SqlOptimiser.rewriteSelectClause0 "
-            + "disables duplicate-aggregate detection on the calendar-align FILL path, exposing "
-            + "the rejection. Restore once dedup is reactivated for FILL or once cross-column "
-            + "PREV is supported on SYMBOL columns.")
     @Test
     public void testCrossColumnPrevToAggregateSymbol() throws Exception {
         // SYMBOL cross-col PREV exercises FillRecord.getSym's mode>=0 arm
@@ -253,6 +245,29 @@ public class FillRecordDispatchTest extends AbstractCairoTest {
                             2024-01-01T01:00:00.000000Z\talpha\talpha
                             2024-01-01T02:00:00.000000Z\tbeta\tbeta
                             """);
+        });
+    }
+
+    @Test
+    public void testCrossColumnPrevToDifferentAggregateSymbolFails() throws Exception {
+        // Proves that lifting the SYMBOL guard only applies to identical aggregates.
+        // first(s) and last(s) have different ASTs, so cross-column PREV should still be rejected.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE x (s SYMBOL, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("INSERT INTO x VALUES " +
+                    "('alpha', '2024-01-01T00:00:00.000000Z')," +
+                    "('beta', '2024-01-01T02:00:00.000000Z')");
+
+            try {
+                execute("SELECT ts, first(s) AS sym, last(s) AS other FROM x " +
+                        "SAMPLE BY 1h FILL(PREV, PREV(sym)) ALIGN TO CALENDAR");
+                Assert.fail("Query should have failed but didn't!");
+            } catch (Exception e) {
+                Assert.assertTrue(
+                        "Unexpected error message: " + e.getMessage(),
+                        e.getMessage().contains("FILL(PREV(sym)) is not supported on SYMBOL columns; use bare FILL(PREV) instead")
+                );
+            }
         });
     }
 


### PR DESCRIPTION
Fixes #7159 

Fix cross-column FILL(PREV) for equivalent SYMBOL aggregates. Allow FILL(PREV(alias)) on SYMBOL columns when the source and target projections resolve to the same aggregate expression, while preserving the existing guard for non-equivalent SYMBOL columns. This restores the SAMPLE BY FILL(PREV) behavior for duplicated aliased aggregates (e.g., first(s) AS sv, first(s) AS a) after fill-list propagation changes, and adds regression tests covering both the restored case and the still-rejected mismatched aggregate case.