### PR TITLE
feat(sql): add to_timezone() support for interval values

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/ToTimezoneIntervalFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/ToTimezoneIntervalFunctionFactory.java
@@ -1,0 +1,318 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.date;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.TimestampDriver;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.FunctionExtension;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.SymbolTableSource;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BinaryFunction;
+import io.questdb.griffin.engine.functions.IntervalFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.griffin.model.IntervalUtils;
+import io.questdb.std.IntList;
+import io.questdb.std.Interval;
+import io.questdb.std.Misc;
+import io.questdb.std.Numbers;
+import io.questdb.std.NumericException;
+import io.questdb.std.ObjList;
+import io.questdb.std.datetime.DateLocaleFactory;
+import io.questdb.std.datetime.TimeZoneRules;
+import io.questdb.std.datetime.millitime.Dates;
+import org.jetbrains.annotations.NotNull;
+
+public class ToTimezoneIntervalFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "to_timezone(ΔS)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) throws SqlException {
+        final Function intervalFunc = args.getQuick(0);
+        final Function timezoneFunc = args.getQuick(1);
+        final int timezonePos = argPositions.getQuick(1);
+        final int intervalType = intervalFunc.getType();
+        final TimestampDriver timestampDriver = IntervalUtils.getTimestampDriverByIntervalType(intervalType);
+
+        if (timezoneFunc.isConstant()) {
+            return toTimezoneConstFunction(intervalFunc, timezoneFunc, timezonePos, timestampDriver, intervalType);
+        } else if (timezoneFunc.isRuntimeConstant()) {
+            return new RuntimeConstFunc(intervalFunc, timezoneFunc, timezonePos, timestampDriver, intervalType);
+        } else {
+            return new Func(intervalFunc, timezoneFunc, timestampDriver, intervalType);
+        }
+    }
+
+    @NotNull
+    private static IntervalFunction toTimezoneConstFunction(
+            Function intervalFunc,
+            Function timezoneFunc,
+            int timezonePos,
+            TimestampDriver timestampDriver,
+            int intervalType
+    ) throws SqlException {
+        final CharSequence tz = timezoneFunc.getStrA(null);
+        if (tz != null) {
+            final int hi = tz.length();
+            final long l = Dates.parseOffset(tz, 0, hi);
+            if (l == Long.MIN_VALUE) {
+                try {
+                    return new ConstRulesFunc(
+                            intervalFunc,
+                            DateLocaleFactory.EN_LOCALE.getZoneRules(
+                                    Numbers.decodeLowInt(DateLocaleFactory.EN_LOCALE.matchZone(tz, 0, hi)), timestampDriver.getTZRuleResolution()
+                            ),
+                            intervalType
+                    );
+                } catch (NumericException e) {
+                    Misc.free(intervalFunc);
+                    throw SqlException.$(timezonePos, "invalid timezone: ").put(tz);
+                }
+            } else {
+                return new OffsetFunc(
+                        intervalFunc,
+                        timestampDriver.fromMinutes(Numbers.decodeLowInt(l)),
+                        intervalType
+                );
+            }
+        }
+        throw SqlException.$(timezonePos, "timezone must not be null");
+    }
+
+    private abstract static class AbstractFunc extends IntervalFunction implements FunctionExtension {
+        protected final Interval interval = new Interval();
+        protected final Function intervalFunc;
+
+        protected AbstractFunc(Function intervalFunc, int intervalType) {
+            super(intervalType);
+            this.intervalFunc = intervalFunc;
+        }
+
+        @Override
+        public FunctionExtension extendedOps() {
+            return this;
+        }
+
+        @Override
+        public int getArrayLength() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getName() {
+            return "to_timezone";
+        }
+
+        @Override
+        public Record getRecord(Record rec) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CharSequence getStrA(Record rec, int arrayIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CharSequence getStrB(Record rec, int arrayIndex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getStrLen(Record rec, int arrayIndex) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class ConstRulesFunc extends AbstractFunc implements UnaryFunction {
+        private final TimeZoneRules tzRules;
+
+        public ConstRulesFunc(Function intervalFunc, TimeZoneRules tzRules, int intervalType) {
+            super(intervalFunc, intervalType);
+            this.tzRules = tzRules;
+        }
+
+        @Override
+        public Function getArg() {
+            return intervalFunc;
+        }
+
+        @Override
+        public @NotNull Interval getInterval(Record rec) {
+            final Interval src = intervalFunc.getInterval(rec);
+            final long lo = src.getLo();
+            final long hi = src.getHi();
+            if (lo == Numbers.LONG_NULL || hi == Numbers.LONG_NULL) {
+                return Interval.NULL;
+            }
+            return interval.of(lo + tzRules.getOffset(lo), hi + tzRules.getOffset(hi));
+        }
+    }
+
+    private static class Func extends AbstractFunc implements BinaryFunction {
+        private final TimestampDriver timestampDriver;
+        private final Function timezoneFunc;
+
+        public Func(Function intervalFunc, Function timezoneFunc, TimestampDriver timestampDriver, int intervalType) {
+            super(intervalFunc, intervalType);
+            this.timezoneFunc = timezoneFunc;
+            this.timestampDriver = timestampDriver;
+        }
+
+        @Override
+        public @NotNull Interval getInterval(Record rec) {
+            final Interval src = intervalFunc.getInterval(rec);
+            final long lo = src.getLo();
+            final long hi = src.getHi();
+            if (lo == Numbers.LONG_NULL || hi == Numbers.LONG_NULL) {
+                return Interval.NULL;
+            }
+            final CharSequence tz = timezoneFunc.getStrA(rec);
+            if (tz == null) {
+                return interval.of(lo, hi);
+            }
+            try {
+                return interval.of(
+                        timestampDriver.toTimezone(lo, DateLocaleFactory.EN_LOCALE, tz),
+                        timestampDriver.toTimezone(hi, DateLocaleFactory.EN_LOCALE, tz)
+                );
+            } catch (NumericException e) {
+                return interval.of(lo, hi);
+            }
+        }
+
+        @Override
+        public Function getLeft() {
+            return intervalFunc;
+        }
+
+        @Override
+        public Function getRight() {
+            return timezoneFunc;
+        }
+    }
+
+    private static class OffsetFunc extends AbstractFunc implements UnaryFunction {
+        private final long offset;
+
+        public OffsetFunc(Function intervalFunc, long offset, int intervalType) {
+            super(intervalFunc, intervalType);
+            this.offset = offset;
+        }
+
+        @Override
+        public Function getArg() {
+            return intervalFunc;
+        }
+
+        @Override
+        public @NotNull Interval getInterval(Record rec) {
+            final Interval src = intervalFunc.getInterval(rec);
+            final long lo = src.getLo();
+            final long hi = src.getHi();
+            if (lo == Numbers.LONG_NULL || hi == Numbers.LONG_NULL) {
+                return Interval.NULL;
+            }
+            return interval.of(lo + offset, hi + offset);
+        }
+    }
+
+    private static class RuntimeConstFunc extends AbstractFunc implements BinaryFunction {
+        private final TimestampDriver timestampDriver;
+        private final Function timezoneFunc;
+        private final int timezonePos;
+        private long tzOffset;
+        private TimeZoneRules tzRules;
+
+        public RuntimeConstFunc(Function intervalFunc, Function timezoneFunc, int timezonePos, TimestampDriver timestampDriver, int intervalType) {
+            super(intervalFunc, intervalType);
+            this.timezoneFunc = timezoneFunc;
+            this.timezonePos = timezonePos;
+            this.timestampDriver = timestampDriver;
+        }
+
+        @Override
+        public @NotNull Interval getInterval(Record rec) {
+            final Interval src = intervalFunc.getInterval(rec);
+            final long lo = src.getLo();
+            final long hi = src.getHi();
+            if (lo == Numbers.LONG_NULL || hi == Numbers.LONG_NULL) {
+                return Interval.NULL;
+            }
+            if (tzRules != null) {
+                return interval.of(lo + tzRules.getOffset(lo), hi + tzRules.getOffset(hi));
+            }
+            return interval.of(lo + tzOffset, hi + tzOffset);
+        }
+
+        @Override
+        public Function getLeft() {
+            return intervalFunc;
+        }
+
+        @Override
+        public Function getRight() {
+            return timezoneFunc;
+        }
+
+        @Override
+        public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+            BinaryFunction.super.init(symbolTableSource, executionContext);
+
+            final CharSequence tz = timezoneFunc.getStrA(null);
+            if (tz == null) {
+                throw SqlException.$(timezonePos, "timezone must not be null");
+            }
+
+            final int hi = tz.length();
+            final long l = Dates.parseOffset(tz, 0, hi);
+            if (l == Long.MIN_VALUE) {
+                try {
+                    tzRules = DateLocaleFactory.EN_LOCALE.getZoneRules(
+                            Numbers.decodeLowInt(DateLocaleFactory.EN_LOCALE.matchZone(tz, 0, hi)), timestampDriver.getTZRuleResolution()
+                    );
+                    tzOffset = 0;
+                } catch (NumericException e) {
+                    throw SqlException.$(timezonePos, "invalid timezone: ").put(tz);
+                }
+            } else {
+                tzOffset = timestampDriver.fromMinutes(Numbers.decodeLowInt(l));
+                tzRules = null;
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/date/ToTimezoneIntervalFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/date/ToTimezoneIntervalFunctionFactoryTest.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.date;
+
+import io.questdb.griffin.SqlException;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.TestTimestampType;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class ToTimezoneIntervalFunctionFactoryTest extends AbstractCairoTest {
+    private final TestTimestampType timestampType;
+
+    public ToTimezoneIntervalFunctionFactoryTest(TestTimestampType timestampType) {
+        this.timestampType = timestampType;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> testParams() {
+        return Arrays.asList(new Object[][]{
+                {TestTimestampType.MICRO}, {TestTimestampType.NANO}
+        });
+    }
+
+    @Test
+    public void testAreaName() throws Exception {
+        assertMemoryLeak(() -> assertToTimezone(
+                "('1970-01-01T01:00:00.000Z', '1970-01-01T01:30:00.000Z')",
+                "1970-01-01T00:00:00.000Z",
+                "1970-01-01T00:30:00.000Z",
+                "Europe/Prague"
+        ));
+    }
+
+    @Test
+    public void testDstStraddle() throws Exception {
+        // Europe/Berlin springs forward (CET +01:00 -> CEST +02:00) at 01:00 UTC on 2021-03-28.
+        // The interval start falls before the transition and the end falls after it, so each
+        // boundary is shifted by its own offset.
+        assertMemoryLeak(() -> assertToTimezone(
+                "('2021-03-28T01:30:00.000Z', '2021-03-28T03:30:00.000Z')",
+                "2021-03-28T00:30:00.000Z",
+                "2021-03-28T01:30:00.000Z",
+                "Europe/Berlin"
+        ));
+    }
+
+    @Test
+    public void testNullInterval() throws Exception {
+        assertMemoryLeak(() -> {
+            final String tsName = timestampType.getTypeName();
+            assertQuery("select to_timezone(interval(cast(null as " + tsName + "), cast(null as " + tsName + ")), 'UTC')")
+                    .noLeakCheck()
+                    .expectSize()
+                    .returns("""
+                            to_timezone
+
+                            """);
+        });
+    }
+
+    @Test
+    public void testNullConstantTimeZone() throws Exception {
+        assertMemoryLeak(() -> {
+            try {
+                assertExceptionNoLeakCheck("select to_timezone(interval('2020-03-12T15:30:00.000Z', '2020-03-12T16:30:00.000Z'), null)");
+            } catch (SqlException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "timezone must not be null");
+            }
+        });
+    }
+
+    @Test
+    public void testTimeOffset() throws Exception {
+        assertMemoryLeak(() -> assertToTimezone(
+                "('2020-03-12T07:50:00.000Z', '2020-03-12T08:50:00.000Z')",
+                "2020-03-12T15:30:00.000Z",
+                "2020-03-12T16:30:00.000Z",
+                "-07:40"
+        ));
+    }
+
+    @Test
+    public void testVarInvalidTimezone() throws Exception {
+        assertMemoryLeak(() -> assertQuery(
+                "select to_timezone(interval(cast('2020-03-12T15:30:00.000Z' as " + timestampType.getTypeName() +
+                        "), cast('2020-03-12T16:30:00.000Z' as " + timestampType.getTypeName() + ")), zone) from (select 'XU' zone)")
+                .noLeakCheck()
+                .expectSize()
+                .returns("""
+                        to_timezone
+                        ('2020-03-12T15:30:00.000Z', '2020-03-12T16:30:00.000Z')
+                        """));
+    }
+
+    @Test
+    public void testVarNullTimezone() throws Exception {
+        // A null projection folds to a constant null zone, so it is rejected at compile time.
+        assertMemoryLeak(() -> {
+            try {
+                assertExceptionNoLeakCheck(
+                        "select to_timezone(interval(cast('2020-03-12T15:30:00.000Z' as " + timestampType.getTypeName() +
+                                "), cast('2020-03-12T16:30:00.000Z' as " + timestampType.getTypeName() + ")), zone) from (select null zone)");
+            } catch (SqlException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "timezone must not be null");
+            }
+        });
+    }
+
+    @Test
+    public void testZoneName() throws Exception {
+        // PST resolves with DST rules; 2020-03-12 is in Pacific Daylight Time (-07:00).
+        assertMemoryLeak(() -> assertToTimezone(
+                "('2020-03-12T08:30:00.000Z', '2020-03-12T09:30:00.000Z')",
+                "2020-03-12T15:30:00.000Z",
+                "2020-03-12T16:30:00.000Z",
+                "PST"
+        ));
+    }
+
+    private void assertToTimezone(
+            String expectedInterval,
+            String lo,
+            String hi,
+            String timeZone
+    ) throws Exception {
+        final String tsName = timestampType.getTypeName();
+        final String intervalArg = "interval(cast('" + lo + "' as " + tsName + "), cast('" + hi + "' as " + tsName + "))";
+        final String expected = "to_timezone\n" + expectedInterval + "\n";
+
+        assertQuery("select to_timezone(" + intervalArg + ", '" + timeZone + "')")
+                .noLeakCheck()
+                .expectSize()
+                .returns(expected);
+
+        bindVariableService.clear();
+        bindVariableService.setStr("tz", timeZone);
+        assertQuery("select to_timezone(" + intervalArg + ", :tz)")
+                .noLeakCheck()
+                .expectSize()
+                .returns(expected);
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/date/ToTimezoneIntervalFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/date/ToTimezoneIntervalFunctionFactoryTest.java
@@ -83,7 +83,7 @@ public class ToTimezoneIntervalFunctionFactoryTest extends AbstractCairoTest {
                     .expectSize()
                     .returns("""
                             to_timezone
-
+                            
                             """);
         });
     }


### PR DESCRIPTION
Fixes #5041

`to_timezone()` only worked on a single timestamp. This adds an overload that
takes an `interval` and returns a new interval with both ends converted from UTC
to the given time zone, so you no longer have to pull the interval apart and
rebuild it by hand:

```sql
SELECT to_timezone(
    interval('2024-08-10T00:00:00Z', '2024-08-10T03:00:00Z'),
    'Europe/Berlin'
);
-- ('2024-08-10T02:00:00.000Z', '2024-08-10T05:00:00.000Z')
```

The old way, from the issue:

```sql
SELECT interval(
    to_timezone(interval_start(interval('2024-08-10T00:00:00Z', '2024-08-10T03:00:00Z')), 'Europe/Berlin'),
    to_timezone(interval_end(interval('2024-08-10T00:00:00Z', '2024-08-10T03:00:00Z')), 'Europe/Berlin')
);
```

The new factory follows the existing timestamp one and specialises the same way:
a constant numeric offset, a constant named zone, a runtime-constant zone from a
bind variable, or a per-row lookup when the zone isn't constant. Each end is
shifted by the offset in effect at that instant, so an interval that spans a DST
change gets the right offset on each side. Micro and nano interval types both
work.

A couple of things worth calling out:

- A null interval gives back a null interval.
- A null constant zone is rejected at compile time ("timezone must not be
  null"), same as the timestamp variant. A null runtime zone is rejected in
  init().
- Since each end uses its own offset, an interval that straddles a fall-back DST
  transition can end up with a start slightly after its end. That's the same
  result you'd get from the interval(to_timezone(start), to_timezone(end))
  workaround this replaces, so I didn't add a guard for it. Happy to add one if
  you'd rather it clamp.

Test plan:

- New ToTimezoneIntervalFunctionFactoryTest, run against both MICRO and NANO
  interval types
- constant numeric offset
- constant named zone and abbreviations
- an interval straddling a spring-forward transition, so the two ends get
  different offsets
- runtime-constant zone via a bind variable
- null interval
- null and invalid time zones
