### PR TITLE
feat(sql): add regr_rmse and regression t-statistic aggregates

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/RegressionInterceptTStatFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/RegressionInterceptTStatFunctionFactory.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * {@code regr_intercept_tstat(y, x)} - the t-statistic for the intercept of the
+ * simple linear regression of {@code y} on {@code x}, testing the null
+ * hypothesis that the true intercept is zero. It is
+ * {@code intercept / SE(intercept)} where {@code intercept = meanY - slope * meanX},
+ * {@code slope = Sxy / Sxx}, and
+ * {@code SE(intercept) = sqrt( (SSE / (n - 2)) * (1 / n + meanX^2 / Sxx) )}, with
+ * {@code SSE = Syy - Sxy^2 / Sxx} the residual sum of squares. The statistic has
+ * {@code n - 2} degrees of freedom, so at least three points are required.
+ */
+public class RegressionInterceptTStatFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "regr_intercept_tstat(DD)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new RegressionInterceptTStatFunction(args.getQuick(0), args.getQuick(1));
+    }
+
+    private static class RegressionInterceptTStatFunction extends AbstractRegressionGroupByFunction {
+
+        public RegressionInterceptTStatFunction(@NotNull Function arg0, @NotNull Function arg1) {
+            super(arg0, arg1);
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            long count = rec.getLong(valueIndex + 5);
+            // The t-statistic has n - 2 degrees of freedom, so it needs n >= 3.
+            if (count < 3) {
+                return Double.NaN;
+            }
+            double sumX = rec.getDouble(valueIndex + 3);
+            if (sumX == 0) {
+                return Double.NaN;
+            }
+            double sumY = rec.getDouble(valueIndex + 1);
+            double sumXY = rec.getDouble(valueIndex + 4);
+            double sse = sumY - (sumXY * sumXY) / sumX;
+            // A perfect fit (SSE = 0) leaves the standard error at zero and the
+            // t-statistic undefined; treat it as NULL rather than +/-Infinity.
+            if (sse <= 0) {
+                return Double.NaN;
+            }
+            double meanY = rec.getDouble(valueIndex);
+            double meanX = rec.getDouble(valueIndex + 2);
+            double slope = sumXY / sumX;
+            double intercept = meanY - slope * meanX;
+            double seIntercept = Math.sqrt((sse / (count - 2)) * (1.0 / count + (meanX * meanX) / sumX));
+            return intercept / seIntercept;
+        }
+
+        @Override
+        public String getName() {
+            return "regr_intercept_tstat";
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/RegressionRmseFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/RegressionRmseFunctionFactory.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * {@code regr_rmse(y, x)} - the root mean square error of the simple linear
+ * regression of {@code y} on {@code x}, i.e. {@code sqrt(SSE / n)} where
+ * {@code SSE = Syy - Sxy^2 / Sxx} is the residual sum of squares. This is the
+ * square root of the mean of the squared residuals; it divides by {@code n}
+ * rather than {@code n - 2}, so it is a biased estimator of the error standard
+ * deviation but matches the literal "root mean square error" definition.
+ */
+public class RegressionRmseFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "regr_rmse(DD)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new RegressionRmseFunction(args.getQuick(0), args.getQuick(1));
+    }
+
+    private static class RegressionRmseFunction extends AbstractRegressionGroupByFunction {
+
+        public RegressionRmseFunction(@NotNull Function arg0, @NotNull Function arg1) {
+            super(arg0, arg1);
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            long count = rec.getLong(valueIndex + 5);
+            if (count <= 0) {
+                return Double.NaN;
+            }
+            // Sxx = 0 means X does not vary, so no regression line exists.
+            // Also covers count = 1. Matches regr_slope / regr_r2.
+            double sumX = rec.getDouble(valueIndex + 3);
+            if (sumX == 0) {
+                return Double.NaN;
+            }
+            double sumY = rec.getDouble(valueIndex + 1);
+            double sumXY = rec.getDouble(valueIndex + 4);
+            double sse = sumY - (sumXY * sumXY) / sumX;
+            // SSE is non-negative in exact arithmetic; clamp tiny negative
+            // rounding results so sqrt() does not return NaN for a near-perfect
+            // fit.
+            if (sse < 0) {
+                sse = 0;
+            }
+            return Math.sqrt(sse / count);
+        }
+
+        @Override
+        public String getName() {
+            return "regr_rmse";
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/RegressionSlopeTStatFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/RegressionSlopeTStatFunctionFactory.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.groupby;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * {@code regr_slope_tstat(y, x)} - the t-statistic for the slope of the simple
+ * linear regression of {@code y} on {@code x}, testing the null hypothesis that
+ * the true slope is zero. It is {@code slope / SE(slope)} where
+ * {@code slope = Sxy / Sxx} and the standard error of the slope is
+ * {@code SE(slope) = sqrt( (SSE / (n - 2)) / Sxx )}, with
+ * {@code SSE = Syy - Sxy^2 / Sxx} the residual sum of squares. The statistic has
+ * {@code n - 2} degrees of freedom, so at least three points are required.
+ */
+public class RegressionSlopeTStatFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "regr_slope_tstat(DD)";
+    }
+
+    @Override
+    public boolean isGroupBy() {
+        return true;
+    }
+
+    @Override
+    public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
+        return new RegressionSlopeTStatFunction(args.getQuick(0), args.getQuick(1));
+    }
+
+    private static class RegressionSlopeTStatFunction extends AbstractRegressionGroupByFunction {
+
+        public RegressionSlopeTStatFunction(@NotNull Function arg0, @NotNull Function arg1) {
+            super(arg0, arg1);
+        }
+
+        @Override
+        public double getDouble(Record rec) {
+            long count = rec.getLong(valueIndex + 5);
+            // The t-statistic has n - 2 degrees of freedom, so it needs n >= 3.
+            if (count < 3) {
+                return Double.NaN;
+            }
+            double sumX = rec.getDouble(valueIndex + 3);
+            if (sumX == 0) {
+                return Double.NaN;
+            }
+            double sumY = rec.getDouble(valueIndex + 1);
+            double sumXY = rec.getDouble(valueIndex + 4);
+            double sse = sumY - (sumXY * sumXY) / sumX;
+            // A perfect fit (SSE = 0) leaves the standard error at zero and the
+            // t-statistic undefined; treat it as NULL rather than +/-Infinity.
+            if (sse <= 0) {
+                return Double.NaN;
+            }
+            double slope = sumXY / sumX;
+            double seSlope = Math.sqrt((sse / (count - 2)) / sumX);
+            return slope / seSlope;
+        }
+
+        @Override
+        public String getName() {
+            return "regr_slope_tstat";
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionInterceptTStatFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionInterceptTStatFunctionFactoryTest.java
@@ -31,7 +31,7 @@ public class RegressionInterceptTStatFunctionFactoryTest extends AbstractCairoTe
 
     @Test
     public void testRegrInterceptTStatAllNull() throws Exception {
-        assertMemoryLeak(() -> assertQuery("select regr_intercept_tstat(y, x) from (select cast(null as double) x, cast(null as double) y from long_sequence(100))")
+        assertMemoryLeak(() -> assertQuery("select regr_intercept_tstat(y, x) from (select null::double x, null::double y from long_sequence(100))")
                 .noLeakCheck()
                 .noRandomAccess()
                 .expectSize()
@@ -41,7 +41,7 @@ public class RegressionInterceptTStatFunctionFactoryTest extends AbstractCairoTe
     @Test
     public void testRegrInterceptTStatConstantX() throws Exception {
         assertMemoryLeak(() -> {
-            execute("create table tbl1 as (select 5.0 x, cast(x as double) y from long_sequence(100))");
+            execute("create table tbl1 as (select 5.0 x, x::double y from long_sequence(100))");
             assertQuery("select regr_intercept_tstat(y, x) from tbl1")
                     .noLeakCheck()
                     .noRandomAccess()
@@ -63,7 +63,7 @@ public class RegressionInterceptTStatFunctionFactoryTest extends AbstractCairoTe
     @Test
     public void testRegrInterceptTStatPerfectFit() throws Exception {
         assertMemoryLeak(() -> {
-            execute("create table tbl1 as (select cast(x as double) x, cast(2 * x + 1 as double) y from long_sequence(100))");
+            execute("create table tbl1 as (select x::double x, (2 * x + 1)::double y from long_sequence(100))");
             assertQuery("select regr_intercept_tstat(y, x) from tbl1")
                     .noLeakCheck()
                     .noRandomAccess()

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionInterceptTStatFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionInterceptTStatFunctionFactoryTest.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class RegressionInterceptTStatFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testRegrInterceptTStatAllNull() throws Exception {
+        assertMemoryLeak(() -> assertQuery("select regr_intercept_tstat(y, x) from (select cast(null as double) x, cast(null as double) y from long_sequence(100))")
+                .noLeakCheck()
+                .noRandomAccess()
+                .expectSize()
+                .returns("regr_intercept_tstat\nnull\n"));
+    }
+
+    @Test
+    public void testRegrInterceptTStatConstantX() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tbl1 as (select 5.0 x, cast(x as double) y from long_sequence(100))");
+            assertQuery("select regr_intercept_tstat(y, x) from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_intercept_tstat\nnull\n");
+        });
+    }
+
+    @Test
+    public void testRegrInterceptTStatExplainPlan() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tbl1 (x double, y double)");
+            assertQuery("select regr_intercept_tstat(y, x) from tbl1")
+                    .noLeakCheck()
+                    .assertsPlanContaining("regr_intercept_tstat(y,x)");
+        });
+    }
+
+    @Test
+    public void testRegrInterceptTStatPerfectFit() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tbl1 as (select cast(x as double) x, cast(2 * x + 1 as double) y from long_sequence(100))");
+            assertQuery("select regr_intercept_tstat(y, x) from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_intercept_tstat\nnull\n");
+        });
+    }
+
+    @Test
+    public void testRegrInterceptTStatScatter() throws Exception {
+        // Points (1,1),(2,3),(3,2),(4,5),(5,4): intercept=0.6, SSE=3.6, n=5, meanX=3, Sxx=10.
+        // SE(intercept) = sqrt((3.6/3)*(1/5 + 9/10)) = sqrt(1.32);
+        // t = 0.6/sqrt(1.32) = 0.522233.
+        assertMemoryLeak(() -> {
+            execute("create table tbl1(x double, y double)");
+            execute("insert into tbl1 values (1,1),(2,3),(3,2),(4,5),(5,4)");
+            assertQuery("select round(regr_intercept_tstat(y, x), 6) regr_intercept_tstat from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_intercept_tstat\n0.522233\n");
+        });
+    }
+
+    @Test
+    public void testRegrInterceptTStatTooFewRows() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tbl1(x double, y double)");
+            execute("insert into tbl1 values (1,1),(2,3)");
+            assertQuery("select regr_intercept_tstat(y, x) from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_intercept_tstat\nnull\n");
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionRmseFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionRmseFunctionFactoryTest.java
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class RegressionRmseFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testRegrRmseAllNull() throws Exception {
+        assertMemoryLeak(() -> assertQuery("select regr_rmse(y, x) from (select cast(null as double) x, cast(null as double) y from long_sequence(100))")
+                .noLeakCheck()
+                .noRandomAccess()
+                .expectSize()
+                .returns("regr_rmse\nnull\n"));
+    }
+
+    @Test
+    public void testRegrRmseConstantX() throws Exception {
+        // X does not vary, so no regression line exists and the result is NULL.
+        assertMemoryLeak(() -> {
+            execute("create table tbl1 as (select 5.0 x, cast(x as double) y from long_sequence(100))");
+            assertQuery("select regr_rmse(y, x) from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_rmse\nnull\n");
+        });
+    }
+
+    @Test
+    public void testRegrRmseExplainPlan() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tbl1 (x double, y double)");
+            assertQuery("select regr_rmse(y, x) from tbl1")
+                    .noLeakCheck()
+                    .assertsPlanContaining("regr_rmse(y,x)");
+        });
+    }
+
+    @Test
+    public void testRegrRmseNoValues() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tbl1(x double, y double)");
+            assertQuery("select regr_rmse(y, x) from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_rmse\nnull\n");
+        });
+    }
+
+    @Test
+    public void testRegrRmsePerfectFit() throws Exception {
+        // y = 2x + 1 has zero residuals, so RMSE is exactly 0.
+        assertMemoryLeak(() -> {
+            execute("create table tbl1 as (select cast(x as double) x, cast(2 * x + 1 as double) y from long_sequence(100))");
+            assertQuery("select regr_rmse(y, x) from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_rmse\n0.0\n");
+        });
+    }
+
+    @Test
+    public void testRegrRmseScatter() throws Exception {
+        // Points (1,1),(2,3),(3,2),(4,5),(5,4): Sxx=10, Syy=10, Sxy=8.
+        // SSE = Syy - Sxy^2/Sxx = 10 - 6.4 = 3.6, RMSE = sqrt(3.6/5) = sqrt(0.72).
+        assertMemoryLeak(() -> {
+            execute("create table tbl1(x double, y double)");
+            execute("insert into tbl1 values (1,1),(2,3),(3,2),(4,5),(5,4)");
+            assertQuery("select round(regr_rmse(y, x), 6) regr_rmse from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_rmse\n0.848528\n");
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionRmseFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionRmseFunctionFactoryTest.java
@@ -31,7 +31,7 @@ public class RegressionRmseFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testRegrRmseAllNull() throws Exception {
-        assertMemoryLeak(() -> assertQuery("select regr_rmse(y, x) from (select cast(null as double) x, cast(null as double) y from long_sequence(100))")
+        assertMemoryLeak(() -> assertQuery("select regr_rmse(y, x) from (select null::double x, null::double y from long_sequence(100))")
                 .noLeakCheck()
                 .noRandomAccess()
                 .expectSize()
@@ -42,7 +42,7 @@ public class RegressionRmseFunctionFactoryTest extends AbstractCairoTest {
     public void testRegrRmseConstantX() throws Exception {
         // X does not vary, so no regression line exists and the result is NULL.
         assertMemoryLeak(() -> {
-            execute("create table tbl1 as (select 5.0 x, cast(x as double) y from long_sequence(100))");
+            execute("create table tbl1 as (select 5.0 x, x::double y from long_sequence(100))");
             assertQuery("select regr_rmse(y, x) from tbl1")
                     .noLeakCheck()
                     .noRandomAccess()
@@ -77,7 +77,7 @@ public class RegressionRmseFunctionFactoryTest extends AbstractCairoTest {
     public void testRegrRmsePerfectFit() throws Exception {
         // y = 2x + 1 has zero residuals, so RMSE is exactly 0.
         assertMemoryLeak(() -> {
-            execute("create table tbl1 as (select cast(x as double) x, cast(2 * x + 1 as double) y from long_sequence(100))");
+            execute("create table tbl1 as (select x::double x, (2 * x + 1)::double y from long_sequence(100))");
             assertQuery("select regr_rmse(y, x) from tbl1")
                     .noLeakCheck()
                     .noRandomAccess()

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionSlopeTStatFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionSlopeTStatFunctionFactoryTest.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.groupby;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class RegressionSlopeTStatFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testRegrSlopeTStatAllNull() throws Exception {
+        assertMemoryLeak(() -> assertQuery("select regr_slope_tstat(y, x) from (select cast(null as double) x, cast(null as double) y from long_sequence(100))")
+                .noLeakCheck()
+                .noRandomAccess()
+                .expectSize()
+                .returns("regr_slope_tstat\nnull\n"));
+    }
+
+    @Test
+    public void testRegrSlopeTStatConstantX() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tbl1 as (select 5.0 x, cast(x as double) y from long_sequence(100))");
+            assertQuery("select regr_slope_tstat(y, x) from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_slope_tstat\nnull\n");
+        });
+    }
+
+    @Test
+    public void testRegrSlopeTStatExplainPlan() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table tbl1 (x double, y double)");
+            assertQuery("select regr_slope_tstat(y, x) from tbl1")
+                    .noLeakCheck()
+                    .assertsPlanContaining("regr_slope_tstat(y,x)");
+        });
+    }
+
+    @Test
+    public void testRegrSlopeTStatPerfectFit() throws Exception {
+        // A perfect fit leaves the standard error at zero, so the t-statistic is NULL.
+        assertMemoryLeak(() -> {
+            execute("create table tbl1 as (select cast(x as double) x, cast(2 * x + 1 as double) y from long_sequence(100))");
+            assertQuery("select regr_slope_tstat(y, x) from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_slope_tstat\nnull\n");
+        });
+    }
+
+    @Test
+    public void testRegrSlopeTStatScatter() throws Exception {
+        // Points (1,1),(2,3),(3,2),(4,5),(5,4): slope=0.8, SSE=3.6, n=5.
+        // SE(slope) = sqrt((3.6/3)/10) = sqrt(0.12); t = 0.8/sqrt(0.12) = 2.309401.
+        assertMemoryLeak(() -> {
+            execute("create table tbl1(x double, y double)");
+            execute("insert into tbl1 values (1,1),(2,3),(3,2),(4,5),(5,4)");
+            assertQuery("select round(regr_slope_tstat(y, x), 6) regr_slope_tstat from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_slope_tstat\n2.309401\n");
+        });
+    }
+
+    @Test
+    public void testRegrSlopeTStatTooFewRows() throws Exception {
+        // Fewer than three points gives no residual degrees of freedom.
+        assertMemoryLeak(() -> {
+            execute("create table tbl1(x double, y double)");
+            execute("insert into tbl1 values (1,1),(2,3)");
+            assertQuery("select regr_slope_tstat(y, x) from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_slope_tstat\nnull\n");
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionSlopeTStatFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionSlopeTStatFunctionFactoryTest.java
@@ -31,7 +31,7 @@ public class RegressionSlopeTStatFunctionFactoryTest extends AbstractCairoTest {
 
     @Test
     public void testRegrSlopeTStatAllNull() throws Exception {
-        assertMemoryLeak(() -> assertQuery("select regr_slope_tstat(y, x) from (select cast(null as double) x, cast(null as double) y from long_sequence(100))")
+        assertMemoryLeak(() -> assertQuery("select regr_slope_tstat(y, x) from (select null::double x, null::double y from long_sequence(100))")
                 .noLeakCheck()
                 .noRandomAccess()
                 .expectSize()
@@ -41,7 +41,7 @@ public class RegressionSlopeTStatFunctionFactoryTest extends AbstractCairoTest {
     @Test
     public void testRegrSlopeTStatConstantX() throws Exception {
         assertMemoryLeak(() -> {
-            execute("create table tbl1 as (select 5.0 x, cast(x as double) y from long_sequence(100))");
+            execute("create table tbl1 as (select 5.0 x, x::double y from long_sequence(100))");
             assertQuery("select regr_slope_tstat(y, x) from tbl1")
                     .noLeakCheck()
                     .noRandomAccess()
@@ -64,7 +64,7 @@ public class RegressionSlopeTStatFunctionFactoryTest extends AbstractCairoTest {
     public void testRegrSlopeTStatPerfectFit() throws Exception {
         // A perfect fit leaves the standard error at zero, so the t-statistic is NULL.
         assertMemoryLeak(() -> {
-            execute("create table tbl1 as (select cast(x as double) x, cast(2 * x + 1 as double) y from long_sequence(100))");
+            execute("create table tbl1 as (select x::double x, (2 * x + 1)::double y from long_sequence(100))");
             assertQuery("select regr_slope_tstat(y, x) from tbl1")
                     .noLeakCheck()
                     .noRandomAccess()


### PR DESCRIPTION
Fixes #6320

We already have `regr_slope`, `regr_intercept`, `regr_r2`. The issue also asked
for RMSE and t-statistics; this adds three more regression diagnostics over the
same `(y, x)` pairs:

- `regr_rmse(y, x)` - root mean square error of the fit, `sqrt(SSE / n)`
- `regr_slope_tstat(y, x)` - t-statistic for the slope, `slope / SE(slope)`
- `regr_intercept_tstat(y, x)` - t-statistic for the intercept, `intercept / SE(intercept)`

where `SSE = Syy - Sxy^2 / Sxx` is the residual sum of squares. The standard
errors use the usual `n - 2` residual degrees of freedom:

```
SE(slope)     = sqrt( (SSE / (n - 2)) / Sxx )
SE(intercept) = sqrt( (SSE / (n - 2)) * (1/n + meanX^2 / Sxx) )
```

All three ride on the existing `AbstractRegressionGroupByFunction`, so they
reuse the Welford state and the parallel merge that the other `regr_*`
aggregates already use - each new class is just the final projection plus its
edge cases. No new state, no changes to the shared base.

Design choices worth a look:

- `regr_rmse` divides by `n`, not `n - 2`, matching the literal "root mean
  square error" (so it's a biased estimate of the error sd). Say the word if
  you'd rather it be the `n - 2` residual standard error instead.
- The t-stats need `n - 2 >= 1`, so they return null for fewer than 3 points.
- When X doesn't vary (`Sxx = 0`) all three return null, same as `regr_slope`.
- On a perfect fit (`SSE = 0`) `regr_rmse` is 0, but the t-stats return null
  rather than +/-Infinity, since the standard error collapses to zero.

Test plan:

- One test class per function
- a hand-checked scatter set - (1,1),(2,3),(3,2),(4,5),(5,4) - where
  Sxx=10, Syy=10, Sxy=8, so slope=0.8, SSE=3.6
- perfect fit (rmse 0, t-stats null)
- constant X, empty input, all-null input
- fewer than 3 rows for the t-stats
- explain-plan check to pin each function name
