### PR TITLE
ci(build): reduce Ubuntu package download failures

### DIFF
--- a/ci/ami-market-pipeline.yml
+++ b/ci/ami-market-pipeline.yml
@@ -5,6 +5,7 @@ pr: none
 pool: hetzner-incus
 
 steps:
+  - template: templates/use-hetzner-apt-mirrors.yml
   - script: |
       sudo apt-get update
       sudo apt-get install awscli

--- a/ci/configure_hetzner_apt_mirrors.py
+++ b/ci/configure_hetzner_apt_mirrors.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+
+
+CANONICAL_UBUNTU_URL = re.compile(
+    r"https?://(?:"
+    r"(?:[A-Za-z0-9-]+\.)*archive\.ubuntu\.com/ubuntu"
+    r"|security\.ubuntu\.com/ubuntu"
+    r"|ports\.ubuntu\.com/ubuntu-ports"
+    r")/?(?=\s|$)"
+)
+DEB822_FIELD = re.compile(r"^\s*([A-Za-z0-9-]+):\s*(.*)$")
+HETZNER_MIRRORS = {
+    "ubuntu": (
+        "https://mirror.hetzner.com/ubuntu/packages",
+        "https://mirror.hetzner.com/ubuntu/security",
+    ),
+    "ubuntu-ports": (
+        "https://mirror.hetzner.com/ubuntu-ports/packages",
+        "https://mirror.hetzner.com/ubuntu-ports/security",
+    ),
+}
+ONE_LINE_SOURCE = re.compile(r"^\s*deb(?:-src)?\s")
+SECURITY_SUITE = re.compile(r"(?:^|\s)\S+-security(?:\s|$)")
+SUPPORTED_ARCHITECTURES = {"amd64", "arm64"}
+
+
+def collect_deb822_fields(lines):
+    fields = {}
+    current_name = None
+    for line_index, line in enumerate(lines):
+        content = line.rstrip("\r\n")
+        if not content or content.lstrip().startswith("#"):
+            continue
+        if content[0].isspace():
+            if current_name is not None:
+                fields[current_name].append((line_index, content.strip()))
+            continue
+
+        field_match = DEB822_FIELD.match(content)
+        if field_match:
+            current_name = field_match.group(1).lower()
+            fields.setdefault(current_name, []).append(
+                (line_index, field_match.group(2))
+            )
+        else:
+            current_name = None
+    return fields
+
+
+def configure(root, architecture):
+    os_release = root / "etc/os-release"
+    if not os_release.is_file():
+        print(f"Skipping Hetzner APT mirror configuration: {os_release} is unavailable")
+        return 0
+
+    os_release_values = parse_os_release(os_release.read_text(encoding="utf-8"))
+    os_id = os_release_values.get("ID", "unknown")
+    if os_id != "ubuntu":
+        print(f"Skipping Hetzner APT mirror configuration on {os_id}")
+        return 0
+
+    if architecture not in SUPPORTED_ARCHITECTURES:
+        print(
+            "Skipping Hetzner APT mirror configuration on unsupported "
+            f"architecture: {architecture}"
+        )
+        return 0
+
+    source_files = []
+    source_list = root / "etc/apt/sources.list"
+    if source_list.is_file():
+        source_files.append(source_list)
+    source_directory = root / "etc/apt/sources.list.d"
+    if source_directory.is_dir():
+        source_files.extend(sorted(source_directory.glob("*.list")))
+        source_files.extend(sorted(source_directory.glob("*.sources")))
+
+    updated_count = 0
+    for source_file in source_files:
+        try:
+            original = source_file.read_text(encoding="utf-8")
+        except OSError as error:
+            raise RuntimeError(f"cannot read APT source file {source_file}: {error}") from error
+
+        if source_file.suffix == ".sources":
+            updated = rewrite_deb822_sources(original)
+        else:
+            updated = rewrite_one_line_sources(original)
+
+        if updated != original:
+            write_source_file(source_file, updated, root)
+            updated_count += 1
+
+    if updated_count == 0:
+        print("No canonical Ubuntu APT sources needed replacement")
+    else:
+        print(
+            f"Configured Hetzner Ubuntu mirrors for {architecture} in "
+            f"{updated_count} source file(s)"
+        )
+    return updated_count
+
+
+def mirror_for_match(match, is_security_only):
+    origin_family = (
+        "ubuntu-ports" if "ports.ubuntu.com" in match.group(0) else "ubuntu"
+    )
+    package_mirror, security_mirror = HETZNER_MIRRORS[origin_family]
+    if "security.ubuntu.com" in match.group(0) or is_security_only:
+        return f"{security_mirror}/"
+    return f"{package_mirror}/"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Replace canonical Ubuntu APT sources with Hetzner mirrors"
+    )
+    parser.add_argument(
+        "--architecture",
+        help="APT architecture; defaults to dpkg --print-architecture",
+    )
+    parser.add_argument(
+        "--root",
+        default="/",
+        type=Path,
+        help="filesystem root containing etc/apt; defaults to /",
+    )
+    return parser.parse_args()
+
+
+def parse_os_release(contents):
+    values = {}
+    for line in contents.splitlines():
+        if not line or line.lstrip().startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        parsed = shlex.split(value, comments=True)
+        values[key] = parsed[0] if parsed else ""
+    return values
+
+
+def replace_urls(line, is_security_only, count=0):
+    return CANONICAL_UBUNTU_URL.sub(
+        lambda match: mirror_for_match(match, is_security_only),
+        line,
+        count=count,
+    )
+
+
+def rewrite_deb822_sources(contents):
+    parts = re.split(r"(\r?\n[ \t]*\r?\n)", contents)
+    for part_index in range(0, len(parts), 2):
+        lines = parts[part_index].splitlines(keepends=True)
+        fields = collect_deb822_fields(lines)
+        suite_values = [
+            suite
+            for _, value in fields.get("suites", [])
+            for suite in value.split()
+        ]
+        is_security_only = bool(suite_values) and all(
+            suite.endswith("-security") for suite in suite_values
+        )
+
+        for line_index, _ in fields.get("uris", []):
+            lines[line_index] = replace_urls(lines[line_index], is_security_only)
+        parts[part_index] = "".join(lines)
+    return "".join(parts)
+
+
+def rewrite_one_line_sources(contents):
+    rewritten_lines = []
+    for line in contents.splitlines(keepends=True):
+        if not ONE_LINE_SOURCE.match(line):
+            rewritten_lines.append(line)
+            continue
+
+        active_line, comment_marker, comment = line.partition("#")
+        is_security_only = bool(SECURITY_SUITE.search(active_line))
+        active_line = replace_urls(active_line, is_security_only, count=1)
+        rewritten_lines.append(active_line + comment_marker + comment)
+    return "".join(rewritten_lines)
+
+
+def write_source_file(path, contents, root):
+    if root != Path("/") or os.geteuid() == 0:
+        path.write_text(contents, encoding="utf-8")
+        return
+    subprocess.run(
+        ["sudo", "tee", str(path)],
+        check=True,
+        input=contents,
+        stdout=subprocess.DEVNULL,
+        text=True,
+    )
+
+
+def main():
+    args = parse_args()
+    architecture = args.architecture
+    if not architecture:
+        architecture = subprocess.check_output(
+            ["dpkg", "--print-architecture"], text=True
+        ).strip()
+    configure(args.root, architecture)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/configure_hetzner_apt_mirrors.py
+++ b/ci/configure_hetzner_apt_mirrors.py
@@ -8,26 +8,48 @@ import shlex
 import subprocess
 
 
-CANONICAL_UBUNTU_URL = re.compile(
-    r"https?://(?:"
-    r"(?:[A-Za-z0-9-]+\.)*archive\.ubuntu\.com/ubuntu"
-    r"|security\.ubuntu\.com/ubuntu"
-    r"|ports\.ubuntu\.com/ubuntu-ports"
-    r")/?(?=\s|$)"
-)
 DEB822_FIELD = re.compile(r"^\s*([A-Za-z0-9-]+):\s*(.*)$")
-HETZNER_MIRRORS = {
-    "ubuntu": (
-        "https://mirror.hetzner.com/ubuntu/packages",
-        "https://mirror.hetzner.com/ubuntu/security",
+MIRROR_LIST_DIRECTORY = Path("/etc/apt/mirrors")
+MIRROR_LISTS = {
+    ("ubuntu", "packages"): (
+        "questdb-ubuntu-packages.list",
+        (
+            "https://mirror.hetzner.com/ubuntu/packages",
+            "https://archive.ubuntu.com/ubuntu",
+        ),
     ),
-    "ubuntu-ports": (
-        "https://mirror.hetzner.com/ubuntu-ports/packages",
-        "https://mirror.hetzner.com/ubuntu-ports/security",
+    ("ubuntu", "security"): (
+        "questdb-ubuntu-security.list",
+        (
+            "https://mirror.hetzner.com/ubuntu/security",
+            "https://security.ubuntu.com/ubuntu",
+        ),
+    ),
+    ("ubuntu-ports", "packages"): (
+        "questdb-ubuntu-ports-packages.list",
+        (
+            "https://mirror.hetzner.com/ubuntu-ports/packages",
+            "https://ports.ubuntu.com/ubuntu-ports",
+        ),
+    ),
+    ("ubuntu-ports", "security"): (
+        "questdb-ubuntu-ports-security.list",
+        (
+            "https://mirror.hetzner.com/ubuntu-ports/security",
+            "https://ports.ubuntu.com/ubuntu-ports",
+        ),
     ),
 }
 ONE_LINE_SOURCE = re.compile(r"^\s*deb(?:-src)?\s")
 SECURITY_SUITE = re.compile(r"(?:^|\s)\S+-security(?:\s|$)")
+SOURCE_URL = re.compile(
+    r"https?://(?:"
+    r"(?:[A-Za-z0-9-]+\.)*archive\.ubuntu\.com/ubuntu"
+    r"|security\.ubuntu\.com/ubuntu"
+    r"|ports\.ubuntu\.com/ubuntu-ports"
+    r"|mirror\.hetzner\.com/(?:ubuntu|ubuntu-ports)/(?:packages|security)"
+    r")/?(?=\s|$)"
+)
 SUPPORTED_ARCHITECTURES = {"amd64", "arm64"}
 
 
@@ -73,6 +95,8 @@ def configure(root, architecture):
         )
         return 0
 
+    write_mirror_lists(root)
+
     source_files = []
     source_list = root / "etc/apt/sources.list"
     if source_list.is_file():
@@ -95,32 +119,48 @@ def configure(root, architecture):
             updated = rewrite_one_line_sources(original)
 
         if updated != original:
-            write_source_file(source_file, updated, root)
+            write_file(source_file, updated, root)
             updated_count += 1
 
     if updated_count == 0:
-        print("No canonical Ubuntu APT sources needed replacement")
+        print("No Ubuntu APT sources needed replacement")
     else:
         print(
-            f"Configured Hetzner Ubuntu mirrors for {architecture} in "
+            f"Configured prioritized Ubuntu mirrors for {architecture} in "
             f"{updated_count} source file(s)"
         )
     return updated_count
 
 
-def mirror_for_match(match, is_security_only):
-    origin_family = (
-        "ubuntu-ports" if "ports.ubuntu.com" in match.group(0) else "ubuntu"
+def create_directory(path, root):
+    if root != Path("/") or os.geteuid() == 0:
+        path.mkdir(parents=True, exist_ok=True)
+        path.chmod(0o755)
+        return
+    subprocess.run(
+        ["sudo", "install", "-d", "-m", "0755", str(path)],
+        check=True,
     )
-    package_mirror, security_mirror = HETZNER_MIRRORS[origin_family]
-    if "security.ubuntu.com" in match.group(0) or is_security_only:
-        return f"{security_mirror}/"
-    return f"{package_mirror}/"
+    subprocess.run(["sudo", "chmod", "0755", str(path)], check=True)
+
+
+def mirror_list_uri_for_match(match, is_security_only):
+    source_url = match.group(0)
+    origin_family = "ubuntu-ports" if "ubuntu-ports" in source_url else "ubuntu"
+    mirror_kind = (
+        "security"
+        if "security.ubuntu.com" in source_url
+        or "/security" in source_url
+        or is_security_only
+        else "packages"
+    )
+    filename, _ = MIRROR_LISTS[(origin_family, mirror_kind)]
+    return f"mirror+file:{MIRROR_LIST_DIRECTORY / filename}"
 
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Replace canonical Ubuntu APT sources with Hetzner mirrors"
+        description="Configure prioritized Ubuntu mirrors for Hetzner CI runners"
     )
     parser.add_argument(
         "--architecture",
@@ -147,8 +187,8 @@ def parse_os_release(contents):
 
 
 def replace_urls(line, is_security_only, count=0):
-    return CANONICAL_UBUNTU_URL.sub(
-        lambda match: mirror_for_match(match, is_security_only),
+    return SOURCE_URL.sub(
+        lambda match: mirror_list_uri_for_match(match, is_security_only),
         line,
         count=count,
     )
@@ -188,17 +228,38 @@ def rewrite_one_line_sources(contents):
     return "".join(rewritten_lines)
 
 
-def write_source_file(path, contents, root):
+def set_file_mode(path, root, mode):
+    if root != Path("/") or os.geteuid() == 0:
+        path.chmod(mode)
+        return
+    subprocess.run(["sudo", "chmod", f"{mode:04o}", str(path)], check=True)
+
+
+def write_file(path, contents, root, mode=None):
     if root != Path("/") or os.geteuid() == 0:
         path.write_text(contents, encoding="utf-8")
-        return
-    subprocess.run(
-        ["sudo", "tee", str(path)],
-        check=True,
-        input=contents,
-        stdout=subprocess.DEVNULL,
-        text=True,
-    )
+    else:
+        subprocess.run(
+            ["sudo", "tee", str(path)],
+            check=True,
+            input=contents,
+            stdout=subprocess.DEVNULL,
+            text=True,
+        )
+    if mode is not None:
+        set_file_mode(path, root, mode)
+
+
+def write_mirror_lists(root):
+    mirror_list_directory = root / MIRROR_LIST_DIRECTORY.relative_to("/")
+    create_directory(mirror_list_directory, root)
+    for filename, mirrors in MIRROR_LISTS.values():
+        path = mirror_list_directory / filename
+        contents = "".join(
+            f"{mirror}\tpriority:{priority}\n"
+            for priority, mirror in enumerate(mirrors, start=1)
+        )
+        write_file(path, contents, root, mode=0o644)
 
 
 def main():

--- a/ci/github-release-pipeline.yml
+++ b/ci/github-release-pipeline.yml
@@ -164,6 +164,8 @@ stages:
             env:
               GITHUB_TOKEN: $(GITHUB_TOKEN)
 
+          - template: templates/use-hetzner-apt-mirrors.yml
+
           - script: |
               sudo apt-get update
               cd "$(Build.SourcesDirectory)"/pkg/ami/marketplace

--- a/ci/templates/aux-job.yml
+++ b/ci/templates/aux-job.yml
@@ -30,6 +30,9 @@ jobs:
         displayName: "Activate JDK 25 (openjdk amd64)"
       - template: detect-local-client.yml
 
+      - bash: python3 ci/test_configure_hetzner_apt_mirrors.py
+        displayName: "Test Hetzner APT mirror configuration"
+
       - template: java-lint.yml
 
       # Rust lint and test

--- a/ci/templates/checkout-source.yml
+++ b/ci/templates/checkout-source.yml
@@ -1,0 +1,20 @@
+steps:
+  - bash: |
+      # Apply only to Hetzner self-hosted agents. AGENT_MACHINENAME is the
+      # agent's self-configured name (e.g. "hetzner-incus-12"), distinct
+      # from the OS hostname and from the timeline's workerName.
+      if [[ "${AGENT_MACHINENAME:-}" != hetzner-incus-* ]]; then
+        echo "Skipping on ${AGENT_MACHINENAME:-unknown}; only applied to hetzner-incus-* agents"
+        exit 0
+      fi
+      # Abort any git HTTP transfer that averages below 100 KiB/s for 120s
+      # so Azure's checkout retry picks a fresh TCP connection instead of
+      # crawling for 30-60 min. Mitigates the per-flow upstream-network
+      # stalls observed on the FSN1 dedicated-server boxes.
+      git config --global http.lowSpeedLimit 102400
+      git config --global http.lowSpeedTime 120
+    displayName: "Set git low-speed abort thresholds"
+  - checkout: self
+    fetchDepth: 1
+    lfs: false
+    submodules: false

--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -1,23 +1,23 @@
+parameters:
+  - name: isCheckoutEnabled
+    type: boolean
+    default: true
+  - name: isHetznerAptMirrorEnabled
+    type: boolean
+    default: true
+
 steps:
-  - bash: |
-      # Apply only to Hetzner self-hosted agents. AGENT_MACHINENAME is the
-      # agent's self-configured name (e.g. "hetzner-incus-12"), distinct
-      # from the OS hostname and from the timeline's workerName.
-      if [[ "${AGENT_MACHINENAME:-}" != hetzner-incus-* ]]; then
-        echo "Skipping on ${AGENT_MACHINENAME:-unknown}; only applied to hetzner-incus-* agents"
-        exit 0
-      fi
-      # Abort any git HTTP transfer that averages below 100 KiB/s for 120s
-      # so Azure's checkout retry picks a fresh TCP connection instead of
-      # crawling for 30-60 min. Mitigates the per-flow upstream-network
-      # stalls observed on the FSN1 dedicated-server boxes.
-      git config --global http.lowSpeedLimit 102400
-      git config --global http.lowSpeedTime 120
-    displayName: "Set git low-speed abort thresholds"
-  - checkout: self
-    fetchDepth: 1
-    lfs: false
-    submodules: false
+  - ${{ if eq(parameters.isCheckoutEnabled, true) }}:
+      - template: checkout-source.yml
+  - ${{ if eq(parameters.isHetznerAptMirrorEnabled, true) }}:
+      - template: use-hetzner-apt-mirrors.yml
+        parameters:
+          shouldRun: |
+            and(
+              succeeded(),
+              eq(variables['os'], 'Linux'),
+              startsWith(variables['poolName'], 'hetzner-')
+            )
   - template: detect-local-client.yml
   - bash: |
       if curl -sf --connect-timeout 2 http://maven.internal:8081/ > /dev/null 2>&1; then

--- a/ci/templates/use-hetzner-apt-mirrors.yml
+++ b/ci/templates/use-hetzner-apt-mirrors.yml
@@ -1,0 +1,8 @@
+parameters:
+  name: shouldRun
+  default: succeeded()
+
+steps:
+  - bash: python3 "$(Build.SourcesDirectory)/ci/configure_hetzner_apt_mirrors.py"
+    displayName: "Use Hetzner Ubuntu mirrors"
+    condition: ${{ parameters.shouldRun }}

--- a/ci/test-fuzz.yml
+++ b/ci/test-fuzz.yml
@@ -54,6 +54,8 @@ stages:
           SOURCE_CODE_CHANGED: true
           ARCHIVED_CRASH_LOG: "$(Build.ArtifactStagingDirectory)/questdb-crash-$(Build.SourceBranchName)-$(Build.SourceVersion)-$(System.StageAttempt)-$(Agent.OS)-$(jdk).log"
         steps:
+          - template: templates/checkout-source.yml
+          - template: templates/use-hetzner-apt-mirrors.yml
           - bash: |
               sudo apt-get update && sudo apt-get install -y openjdk-25-jdk maven build-essential zip
               JAVA_PATH="/usr/lib/jvm/java-25-openjdk-amd64"
@@ -61,3 +63,6 @@ stages:
               echo "##vso[task.setvariable variable=JAVA_HOME_25_X64]$JAVA_PATH"
               echo "JAVA_HOME will be set to: $JAVA_PATH"
           - template: templates/steps.yml
+            parameters:
+              isCheckoutEnabled: false
+              isHetznerAptMirrorEnabled: false

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -211,6 +211,9 @@ stages:
             lfs: false
             submodules: false
             persistCredentials: true
+          - template: templates/use-hetzner-apt-mirrors.yml
+            parameters:
+              shouldRun: and(succeeded(), eq(variables['SHOULD_RUN'], 'true'))
           - bash: |
               sudo apt-get update && sudo apt-get install -y openjdk-25-jdk maven
               JAVA_PATH="/usr/lib/jvm/java-25-openjdk-amd64"

--- a/ci/test_configure_hetzner_apt_mirrors.py
+++ b/ci/test_configure_hetzner_apt_mirrors.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).with_name("configure_hetzner_apt_mirrors.py")
+SPEC = importlib.util.spec_from_file_location("configure_hetzner_apt_mirrors", SCRIPT_PATH)
+MIRRORS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MIRRORS)
+
+
+class ConfigureHetznerAptMirrorsTest(unittest.TestCase):
+    def test_rewrites_amd64_one_line_sources(self):
+        source = """\
+deb http://archive.ubuntu.com/ubuntu noble main universe
+deb https://security.ubuntu.com/ubuntu/ noble-security main universe
+deb https://de.archive.ubuntu.com/ubuntu noble-updates main
+deb https://apt.releases.hashicorp.com noble main
+# deb http://archive.ubuntu.com/ubuntu noble-backports main
+"""
+
+        actual = MIRRORS.rewrite_one_line_sources(source)
+
+        self.assertEqual(
+            """\
+deb https://mirror.hetzner.com/ubuntu/packages/ noble main universe
+deb https://mirror.hetzner.com/ubuntu/security/ noble-security main universe
+deb https://mirror.hetzner.com/ubuntu/packages/ noble-updates main
+deb https://apt.releases.hashicorp.com noble main
+# deb http://archive.ubuntu.com/ubuntu noble-backports main
+""",
+            actual,
+        )
+
+    def test_rewrites_arm64_deb822_sources(self):
+        source = """\
+Types: deb
+URIs: http://ports.ubuntu.com/ubuntu-ports/
+Suites: noble noble-updates noble-backports
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: http://ports.ubuntu.com/ubuntu-ports/
+Suites: noble-security
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+"""
+
+        actual = MIRRORS.rewrite_deb822_sources(source)
+
+        self.assertEqual(
+            """\
+Types: deb
+URIs: https://mirror.hetzner.com/ubuntu-ports/packages/
+Suites: noble noble-updates noble-backports
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: https://mirror.hetzner.com/ubuntu-ports/security/
+Suites: noble-security
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+""",
+            actual,
+        )
+
+    def test_rewrites_lowercase_deb822_continuation_fields(self):
+        source = """\
+types: deb
+uris:
+ http://ports.ubuntu.com/ubuntu-ports/
+suites:
+ noble-security
+components: main universe
+"""
+
+        actual = MIRRORS.rewrite_deb822_sources(source)
+
+        self.assertEqual(
+            """\
+types: deb
+uris:
+ https://mirror.hetzner.com/ubuntu-ports/security/
+suites:
+ noble-security
+components: main universe
+""",
+            actual,
+        )
+
+    def test_does_not_rewrite_comments_or_similar_paths(self):
+        source = """\
+deb https://ports.ubuntu.com/ubuntu-ports-custom noble main
+# http://ports.ubuntu.com/ubuntu-ports/
+Types: deb
+# URIs: http://ports.ubuntu.com/ubuntu-ports/
+URIs: https://example.com/ubuntu
+Suites: noble
+"""
+
+        one_line_actual = MIRRORS.rewrite_one_line_sources(source)
+        deb822_actual = MIRRORS.rewrite_deb822_sources(source)
+
+        self.assertEqual(source, one_line_actual)
+        self.assertEqual(source, deb822_actual)
+
+    def test_preserves_source_architecture_family(self):
+        source = """\
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main
+deb [arch=amd64] http://archive.ubuntu.com/ubuntu noble main
+"""
+
+        actual = MIRRORS.rewrite_one_line_sources(source)
+
+        self.assertEqual(
+            """\
+deb [arch=arm64] https://mirror.hetzner.com/ubuntu-ports/packages/ noble main
+deb [arch=amd64] https://mirror.hetzner.com/ubuntu/packages/ noble main
+""",
+            actual,
+        )
+
+    def test_configure_is_idempotent_and_skips_unsupported_systems(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_directory = root / "etc/apt/sources.list.d"
+            source_directory.mkdir(parents=True)
+            os_release = root / "etc/os-release"
+            os_release.write_text("ID=ubuntu\n", encoding="utf-8")
+            source_file = source_directory / "ubuntu.sources"
+            source_file.write_text(
+                "Types: deb\n"
+                "URIs: http://ports.ubuntu.com/ubuntu-ports/\n"
+                "Suites: noble\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(1, MIRRORS.configure(root, "arm64"))
+            first_result = source_file.read_text(encoding="utf-8")
+            self.assertEqual(0, MIRRORS.configure(root, "arm64"))
+            self.assertEqual(first_result, source_file.read_text(encoding="utf-8"))
+            self.assertEqual(0, MIRRORS.configure(root, "riscv64"))
+
+            os_release.write_text("ID=debian\n", encoding="utf-8")
+            self.assertEqual(0, MIRRORS.configure(root, "amd64"))
+
+    def test_configure_reports_source_read_failures(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_directory = root / "etc/apt/sources.list.d"
+            source_directory.mkdir(parents=True)
+            os_release = root / "etc/os-release"
+            os_release.write_text("ID=ubuntu\n", encoding="utf-8")
+            source_file = source_directory / "ubuntu.sources"
+            source_file.write_text("Types: deb\n", encoding="utf-8")
+            original_read_text = Path.read_text
+
+            def read_text(path, *args, **kwargs):
+                if path == source_file:
+                    raise PermissionError("permission denied")
+                return original_read_text(path, *args, **kwargs)
+
+            with mock.patch.object(Path, "read_text", read_text):
+                with self.assertRaisesRegex(
+                    RuntimeError, r"cannot read APT source file .*ubuntu\.sources"
+                ):
+                    MIRRORS.configure(root, "arm64")
+
+    def test_mixed_deb822_suite_uses_package_mirror(self):
+        source = """\
+Types: deb
+URIs: http://ports.ubuntu.com/ubuntu-ports/
+Suites: noble
+ noble-security
+"""
+
+        actual = MIRRORS.rewrite_deb822_sources(source)
+
+        self.assertIn("/ubuntu-ports/packages/", actual)
+        self.assertNotIn("/ubuntu-ports/security/", actual)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/test_configure_hetzner_apt_mirrors.py
+++ b/ci/test_configure_hetzner_apt_mirrors.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 import importlib.util
+import os
 from pathlib import Path
+import stat
 import tempfile
 import unittest
 from unittest import mock
@@ -27,9 +29,9 @@ deb https://apt.releases.hashicorp.com noble main
 
         self.assertEqual(
             """\
-deb https://mirror.hetzner.com/ubuntu/packages/ noble main universe
-deb https://mirror.hetzner.com/ubuntu/security/ noble-security main universe
-deb https://mirror.hetzner.com/ubuntu/packages/ noble-updates main
+deb mirror+file:/etc/apt/mirrors/questdb-ubuntu-packages.list noble main universe
+deb mirror+file:/etc/apt/mirrors/questdb-ubuntu-security.list noble-security main universe
+deb mirror+file:/etc/apt/mirrors/questdb-ubuntu-packages.list noble-updates main
 deb https://apt.releases.hashicorp.com noble main
 # deb http://archive.ubuntu.com/ubuntu noble-backports main
 """,
@@ -56,13 +58,13 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         self.assertEqual(
             """\
 Types: deb
-URIs: https://mirror.hetzner.com/ubuntu-ports/packages/
+URIs: mirror+file:/etc/apt/mirrors/questdb-ubuntu-ports-packages.list
 Suites: noble noble-updates noble-backports
 Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
 Types: deb
-URIs: https://mirror.hetzner.com/ubuntu-ports/security/
+URIs: mirror+file:/etc/apt/mirrors/questdb-ubuntu-ports-security.list
 Suites: noble-security
 Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
@@ -86,7 +88,7 @@ components: main universe
             """\
 types: deb
 uris:
- https://mirror.hetzner.com/ubuntu-ports/security/
+ mirror+file:/etc/apt/mirrors/questdb-ubuntu-ports-security.list
 suites:
  noble-security
 components: main universe
@@ -120,13 +122,27 @@ deb [arch=amd64] http://archive.ubuntu.com/ubuntu noble main
 
         self.assertEqual(
             """\
-deb [arch=arm64] https://mirror.hetzner.com/ubuntu-ports/packages/ noble main
-deb [arch=amd64] https://mirror.hetzner.com/ubuntu/packages/ noble main
+deb [arch=arm64] mirror+file:/etc/apt/mirrors/questdb-ubuntu-ports-packages.list noble main
+deb [arch=amd64] mirror+file:/etc/apt/mirrors/questdb-ubuntu-packages.list noble main
 """,
             actual,
         )
 
-    def test_configure_is_idempotent_and_skips_unsupported_systems(self):
+    def test_rewrites_existing_hetzner_sources_to_prioritized_lists(self):
+        source = """\
+Types: deb
+URIs: https://mirror.hetzner.com/ubuntu-ports/security
+Suites: noble-security
+"""
+
+        actual = MIRRORS.rewrite_deb822_sources(source)
+
+        self.assertIn(
+            "mirror+file:/etc/apt/mirrors/questdb-ubuntu-ports-security.list",
+            actual,
+        )
+
+    def test_configure_writes_prioritized_fallback_lists_and_is_idempotent(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             source_directory = root / "etc/apt/sources.list.d"
@@ -141,12 +157,52 @@ deb [arch=amd64] https://mirror.hetzner.com/ubuntu/packages/ noble main
                 encoding="utf-8",
             )
 
-            self.assertEqual(1, MIRRORS.configure(root, "arm64"))
+            original_umask = os.umask(0o077)
+            try:
+                self.assertEqual(1, MIRRORS.configure(root, "arm64"))
+            finally:
+                os.umask(original_umask)
+
             first_result = source_file.read_text(encoding="utf-8")
+            mirror_list_directory = root / "etc/apt/mirrors"
+            package_list = (
+                mirror_list_directory / "questdb-ubuntu-ports-packages.list"
+            )
+            mirror_list_directory.chmod(0o700)
+            package_list.chmod(0o600)
+
             self.assertEqual(0, MIRRORS.configure(root, "arm64"))
             self.assertEqual(first_result, source_file.read_text(encoding="utf-8"))
-            self.assertEqual(0, MIRRORS.configure(root, "riscv64"))
+            self.assertEqual(
+                0o755, stat.S_IMODE(mirror_list_directory.stat().st_mode)
+            )
 
+            expected_mirror_lists = {
+                "questdb-ubuntu-packages.list": (
+                    "https://mirror.hetzner.com/ubuntu/packages\tpriority:1\n"
+                    "https://archive.ubuntu.com/ubuntu\tpriority:2\n"
+                ),
+                "questdb-ubuntu-security.list": (
+                    "https://mirror.hetzner.com/ubuntu/security\tpriority:1\n"
+                    "https://security.ubuntu.com/ubuntu\tpriority:2\n"
+                ),
+                "questdb-ubuntu-ports-packages.list": (
+                    "https://mirror.hetzner.com/ubuntu-ports/packages\tpriority:1\n"
+                    "https://ports.ubuntu.com/ubuntu-ports\tpriority:2\n"
+                ),
+                "questdb-ubuntu-ports-security.list": (
+                    "https://mirror.hetzner.com/ubuntu-ports/security\tpriority:1\n"
+                    "https://ports.ubuntu.com/ubuntu-ports\tpriority:2\n"
+                ),
+            }
+            for filename, expected_contents in expected_mirror_lists.items():
+                mirror_list = mirror_list_directory / filename
+                self.assertEqual(
+                    expected_contents, mirror_list.read_text(encoding="utf-8")
+                )
+                self.assertEqual(0o644, stat.S_IMODE(mirror_list.stat().st_mode))
+
+            self.assertEqual(0, MIRRORS.configure(root, "riscv64"))
             os_release.write_text("ID=debian\n", encoding="utf-8")
             self.assertEqual(0, MIRRORS.configure(root, "amd64"))
 
@@ -172,7 +228,7 @@ deb [arch=amd64] https://mirror.hetzner.com/ubuntu/packages/ noble main
                 ):
                     MIRRORS.configure(root, "arm64")
 
-    def test_mixed_deb822_suite_uses_package_mirror(self):
+    def test_mixed_deb822_suite_uses_package_mirror_list(self):
         source = """\
 Types: deb
 URIs: http://ports.ubuntu.com/ubuntu-ports/
@@ -182,8 +238,8 @@ Suites: noble
 
         actual = MIRRORS.rewrite_deb822_sources(source)
 
-        self.assertIn("/ubuntu-ports/packages/", actual)
-        self.assertNotIn("/ubuntu-ports/security/", actual)
+        self.assertIn("questdb-ubuntu-ports-packages.list", actual)
+        self.assertNotIn("questdb-ubuntu-ports-security.list", actual)
 
 
 if __name__ == "__main__":

--- a/core/README.md
+++ b/core/README.md
@@ -126,7 +126,7 @@ docker login
 
 ### Switch Docker Desktop to Linux
 
-Right-click on the Docker Desktop tray icon (bottom right) and chose 'switch'
+Right-click on the Docker Desktop tray icon (bottom right) and choose 'switch'
 from the pop-up menu.
 
 Create new builder


### PR DESCRIPTION
## Summary

[Build 251860](https://dev.azure.com/questdb/questdb/_build/results?buildId=251860) showed concurrent self-hosted arm64 jobs timing out while connecting to `ports.ubuntu.com:80`. The failed index refresh then left `cmake` and `nasm` unavailable and stopped the native client build.

This change:

- configures APT's mirror transport with Hetzner as priority 1 and Canonical HTTPS endpoints as priority 2, allowing per-file fallback when the primary mirror fails
- preserves the source repository family so foreign-architecture entries continue to use the matching `ubuntu` or `ubuntu-ports` mirrors
- supports one-line and Deb822 source files, including continuation fields
- keeps Microsoft-hosted jobs on their existing package sources
- runs focused mirror-rewrite and fallback-list tests in the lint job
- corrects wording in `core/README.md` so Azure classifies the PR as a source change and runs the full matrix

## Effects and tradeoffs

Hetzner-hosted jobs normally keep package traffic inside Hetzner's network. If a Hetzner request fails, APT can retry the file through the matching Canonical archive, security, or ports endpoint instead of losing the package operation to one mirror outage.

APT must wait for a failed primary request to terminate before it tries the fallback. The fallback also returns traffic to the public Ubuntu infrastructure and can encounter the original external-network limitations. The helper modifies active APT source files and writes local mirror lists, so reused runners retain this configuration. Unsupported architectures keep their existing sources. The `core/README.md` change has no runtime effect; it ensures the existing change detector schedules the full CI matrix for this PR.

## Test plan

- `python3 ci/test_configure_hetzner_apt_mirrors.py`
- `python3 -m py_compile ci/configure_hetzner_apt_mirrors.py ci/test_configure_hetzner_apt_mirrors.py`
- Ran an Ubuntu Noble container integration test that made priority 1 unreachable and successfully downloaded indexes through priority 2
- Repeated the container test with `umask 077` and verified directory mode `0755` and mirror-list mode `0644`
- Tested non-root repair of pre-existing root-owned `0600` mirror lists
- Parsed all changed Azure Pipeline YAML files with PyYAML
- `git diff --check`
- Independent focused review found no blocker or moderate correctness issue
