### PR TITLE
feat(sql): support scalar boolean sub-queries as WHERE predicates

### DIFF
--- a/core/src/main/java/io/questdb/griffin/FunctionParser.java
+++ b/core/src/main/java/io/questdb/griffin/FunctionParser.java
@@ -39,6 +39,7 @@ import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.RuntimeConstFunction;
 import io.questdb.griffin.engine.functions.bind.IndexedParameterLinkFunction;
 import io.questdb.griffin.engine.functions.bind.NamedParameterLinkFunction;
+import io.questdb.griffin.engine.functions.bool.BooleanSubQueryFunction;
 import io.questdb.griffin.engine.functions.cast.CastByteToDecimalFunctionFactory;
 import io.questdb.griffin.engine.functions.cast.CastCharToSymbolFunctionFactory;
 import io.questdb.griffin.engine.functions.cast.CastGeoHashToGeoHashFunctionFactory;
@@ -1154,7 +1155,23 @@ public class FunctionParser implements PostOrderTreeTraversalAlgo.Visitor, Mutab
         }
 
         if (candidate == null) {
-            // no signature match — find the best descriptor for a helpful error message
+            // no signature match. A CURSOR argument may be a scalar boolean sub-query used in
+            // boolean context (e.g. "a and (select b from x)"); coerce such arguments to
+            // BOOLEAN and retry once. Coerced arguments are no longer CURSOR-typed, so the
+            // retry cannot recurse further.
+            boolean coerced = false;
+            for (int i = 0; i < argCount; i++) {
+                final Function wrapped = BooleanSubQueryFunction.maybeWrap(args.getQuick(i), argPositions.getQuick(i));
+                if (wrapped != null) {
+                    args.setQuick(i, wrapped);
+                    coerced = true;
+                }
+            }
+            if (coerced) {
+                return createFunction(node, args, argPositions);
+            }
+
+            // find the best descriptor for a helpful error message
             if (overload.size() == 1) {
                 candidateDescriptor = overload.getQuick(0);
             } else {

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -77,6 +77,7 @@ import io.questdb.griffin.engine.RecordComparator;
 import io.questdb.griffin.engine.functions.GroupByFunction;
 import io.questdb.griffin.engine.functions.PerWorkerFunctionList;
 import io.questdb.griffin.engine.functions.SymbolFunction;
+import io.questdb.griffin.engine.functions.bool.BooleanSubQueryFunction;
 import io.questdb.griffin.engine.functions.cast.CastByteToCharFunctionFactory;
 import io.questdb.griffin.engine.functions.cast.CastByteToDecimalFunctionFactory;
 import io.questdb.griffin.engine.functions.cast.CastByteToStrFunctionFactory;
@@ -734,6 +735,11 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         final Function filter = functionParser.parseFunction(expr, metadata, executionContext);
         if (isBoolean(filter.getType())) {
             return filter;
+        }
+        // a scalar boolean sub-query used directly as a predicate evaluates once per execution
+        final Function coerced = BooleanSubQueryFunction.maybeWrap(filter, expr.position);
+        if (coerced != null) {
+            return coerced;
         }
         Misc.free(filter);
         throw SqlException.$(expr.position, "boolean expression expected");
@@ -6494,8 +6500,13 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             if (constFilterExpr != null) {
                 Function filter = functionParser.parseFunction(constFilterExpr, null, executionContext);
                 if (!isBoolean(filter.getType())) {
-                    Misc.free(filter);
-                    throw SqlException.position(constFilterExpr.position).put("boolean expression expected");
+                    // a scalar boolean sub-query used directly as a predicate evaluates once per execution
+                    final Function coerced = BooleanSubQueryFunction.maybeWrap(filter, constFilterExpr.position);
+                    if (coerced == null) {
+                        Misc.free(filter);
+                        throw SqlException.position(constFilterExpr.position).put("boolean expression expected");
+                    }
+                    filter = coerced;
                 }
                 filter.init(null, executionContext);
                 if (filter.isConstant()) {

--- a/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlOptimiser.java
@@ -6014,17 +6014,26 @@ public class SqlOptimiser implements Mutable {
                     break;
                 default:
                     if (reverse) {
-                        ExpressionNode n = expressionNodePool.next();
-                        n.token = "not";
-                        n.paramCount = 1;
-                        n.rhs = node;
-                        n.type = OPERATION;
-                        return n;
+                        return negate(node);
                     }
                     break;
             }
+        } else if (reverse) {
+            // tokenless node, e.g. a sub-query used directly as a boolean predicate:
+            // like any other non-negatable expression it must be wrapped in NOT,
+            // otherwise the negation would be silently discarded
+            return negate(node);
         }
         return node;
+    }
+
+    private ExpressionNode negate(ExpressionNode node) {
+        final ExpressionNode n = expressionNodePool.next();
+        n.token = "not";
+        n.paramCount = 1;
+        n.rhs = node;
+        n.type = OPERATION;
+        return n;
     }
 
     private void optimiseBooleanNot(IQueryModel model) {
@@ -6578,7 +6587,10 @@ public class SqlOptimiser implements Mutable {
         sqlNodeStack.clear();
         while (!sqlNodeStack.isEmpty() || n != null) {
             if (n != null) {
-                switch (joinOps.get(n.token)) {
+                // a tokenless node (e.g. a sub-query used directly as a boolean predicate)
+                // is not a join op; route it to the default arm so it is kept as a plain
+                // predicate and rejected later by filter compilation
+                switch (n.token != null ? joinOps.get(n.token) : -1) {
                     case JOIN_OP_EQUAL:
                         analyseEquals(parent, n, innerPredicate, joinModel, joinIndex);
                         n = null;

--- a/core/src/main/java/io/questdb/griffin/WhereClauseParser.java
+++ b/core/src/main/java/io/questdb/griffin/WhereClauseParser.java
@@ -276,7 +276,10 @@ public final class WhereClauseParser implements Mutable {
         stack.clear();
         while (!stack.isEmpty() || node != null) {
             if (node != null) {
-                if (isAndKeyword(node.token)) {
+                // tokenless nodes (e.g. sub-queries used as boolean predicates) are not
+                // intrinsic candidates; fall through to the poll branch so they stay in
+                // the residual filter
+                if (node.token != null && isAndKeyword(node.token)) {
                     if (!removeAndIntrinsics(
                             timestampDriver,
                             translator,
@@ -311,7 +314,7 @@ public final class WhereClauseParser implements Mutable {
                     } else {
                         node = node.lhs;
                     }
-                } else if (isOrKeyword(node.token) && tryExtractOrTimestampIntrinsics(timestampDriver, model, node, functionParser, metadata, executionContext)) {
+                } else if (node.token != null && isOrKeyword(node.token) && tryExtractOrTimestampIntrinsics(timestampDriver, model, node, functionParser, metadata, executionContext)) {
                     // Entire OR tree was extracted as timestamp intrinsics
                     node = stack.poll();
                 } else {
@@ -2534,14 +2537,14 @@ public final class WhereClauseParser implements Mutable {
     }
 
     private ExpressionNode collapseWithin0(ExpressionNode node) {
-        if (node == null || isWithinKeyword(node.token)) {
+        if (node == null || (node.token != null && isWithinKeyword(node.token))) {
             return null;
         }
-        if (node.queryModel == null && (isAndKeyword(node.token) || isOrKeyword(node.token))) {
-            if (node.lhs == null || isWithinKeyword(node.lhs.token)) {
+        if (node.queryModel == null && node.token != null && (isAndKeyword(node.token) || isOrKeyword(node.token))) {
+            if (node.lhs == null || (node.lhs.token != null && isWithinKeyword(node.lhs.token))) {
                 return node.rhs;
             }
-            if (node.rhs == null || isWithinKeyword(node.rhs.token)) {
+            if (node.rhs == null || (node.rhs.token != null && isWithinKeyword(node.rhs.token))) {
                 return node.lhs;
             }
         }
@@ -2549,7 +2552,7 @@ public final class WhereClauseParser implements Mutable {
     }
 
     private ExpressionNode collapseWithinNodes(ExpressionNode node) {
-        if (node == null || isWithinKeyword(node.token)) {
+        if (node == null || (node.token != null && isWithinKeyword(node.token))) {
             return null;
         }
         node.lhs = collapseWithinNodes(collapseWithin0(node.lhs));
@@ -3239,7 +3242,7 @@ public final class WhereClauseParser implements Mutable {
             SqlExecutionContext executionContext,
             LongList prefixes) throws SqlException {
 
-        if (isWithinKeyword(node.token)) {
+        if (node.token != null && isWithinKeyword(node.token)) {
 
             if (prefixes.size() > 0) {
                 throw SqlException.$(node.position, "Multiple 'within' expressions not supported");
@@ -3584,7 +3587,7 @@ public final class WhereClauseParser implements Mutable {
         stack.clear();
         while (!stack.isEmpty() || node != null) {
             if (node != null) {
-                if (isAndKeyword(node.token) || isOrKeyword(node.token)) {
+                if (node.token != null && (isAndKeyword(node.token) || isOrKeyword(node.token))) {
                     if (!removeWithin(translator, node.rhs, metadata, functionParser, executionContext, prefixes)) {
                         stack.push(node.rhs);
                     }

--- a/core/src/main/java/io/questdb/griffin/WhereClauseParser.java
+++ b/core/src/main/java/io/questdb/griffin/WhereClauseParser.java
@@ -2919,7 +2919,7 @@ public final class WhereClauseParser implements Mutable {
      * - Nested OR of the above
      */
     private boolean isOrOfTimestampIn(ExpressionNode node) {
-        if (node == null) {
+        if (node == null || node.token == null) {
             return false;
         }
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/bool/BooleanSubQueryFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/bool/BooleanSubQueryFunction.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.bool;
+
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cairo.sql.RecordMetadata;
+import io.questdb.cairo.sql.SymbolTableSource;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlException;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.BooleanFunction;
+import io.questdb.griffin.engine.functions.ScalarSubQueryUtils;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Adapts a scalar boolean sub-query used directly as a predicate, for example
+ * {@code where (select b from x limit 1)} or {@code where a and not (select b from x limit 1)}.
+ * Follows the scalar-cursor lifecycle established by
+ * {@link io.questdb.griffin.engine.functions.lt.AbstractScalarCursorFunction}:
+ * <ul>
+ *     <li>the sub-query executes once per query execution - not per row - in {@link #init},
+ *     and its single value is cached;</li>
+ *     <li>single-row cardinality is enforced
+ *     ({@link ScalarSubQueryUtils#assertNoMoreRows});</li>
+ *     <li>an empty sub-query yields NULL, which QuestDB's two-valued BOOLEAN represents as
+ *     {@code false}, so the predicate matches no rows;</li>
+ *     <li>the cached value is donated to per-worker clones ({@link #offerStateTo}) so the
+ *     sub-query never re-executes per worker.</li>
+ * </ul>
+ */
+public class BooleanSubQueryFunction extends BooleanFunction implements UnaryFunction {
+    private final Function cursorFunc;
+    private final RecordCursorFactory factory;
+    private final int position;
+    private boolean stateInherited = false;
+    private boolean stateShared = false;
+    private boolean value = false;
+
+    public BooleanSubQueryFunction(RecordCursorFactory factory, Function cursorFunc, int position) {
+        this.factory = factory;
+        this.cursorFunc = cursorFunc;
+        this.position = position;
+    }
+
+    /**
+     * Wraps a CURSOR-typed function in a {@link BooleanSubQueryFunction} when the underlying
+     * sub-query yields exactly one BOOLEAN column, making it usable in boolean expression
+     * context. Returns {@code null} when the function is not coercible; the caller then reports
+     * its usual type error.
+     *
+     * @param function a candidate function, typically CURSOR-typed
+     * @param position the parse position of the sub-query, used for error markers
+     * @return the boolean adapter, or {@code null} if the function is not a scalar boolean cursor
+     */
+    public static @Nullable Function maybeWrap(Function function, int position) {
+        if (!ColumnType.isCursor(function.getType())) {
+            return null;
+        }
+        final RecordCursorFactory factory = function.getRecordCursorFactory();
+        if (factory == null) {
+            return null;
+        }
+        final RecordMetadata metadata = factory.getMetadata();
+        if (metadata.getColumnCount() == 1 && ColumnType.tagOf(metadata.getColumnType(0)) == ColumnType.BOOLEAN) {
+            return new BooleanSubQueryFunction(factory, function, position);
+        }
+        return null;
+    }
+
+    @Override
+    public Function getArg() {
+        return cursorFunc;
+    }
+
+    @Override
+    public boolean getBool(Record rec) {
+        return value;
+    }
+
+    @Override
+    public void init(SymbolTableSource symbolTableSource, SqlExecutionContext executionContext) throws SqlException {
+        UnaryFunction.super.init(symbolTableSource, executionContext);
+        if (stateInherited) {
+            return;
+        }
+        this.stateShared = false;
+        try (RecordCursor cursor = factory.getCursor(executionContext)) {
+            if (cursor.hasNext()) {
+                value = cursor.getRecord().getBool(0);
+                ScalarSubQueryUtils.assertNoMoreRows(cursor, position);
+            } else {
+                // empty scalar sub-query yields NULL; two-valued BOOLEAN renders it as false
+                value = false;
+            }
+        }
+    }
+
+    @Override
+    public void offerStateTo(Function that) {
+        // state moves only between clones compiled from the same expression
+        if (that instanceof BooleanSubQueryFunction thatF) {
+            thatF.value = value;
+            thatF.stateInherited = this.stateShared = true;
+        }
+        UnaryFunction.super.offerStateTo(that);
+    }
+
+    @Override
+    public void toPlan(PlanSink sink) {
+        sink.val(cursorFunc);
+        if (stateShared) {
+            sink.val(" [state-shared]");
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/PushdownFilterExtractor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/PushdownFilterExtractor.java
@@ -262,7 +262,11 @@ public class PushdownFilterExtractor implements Mutable {
 
         while (!stack.isEmpty() || node != null) {
             if (node != null) {
-                if (SqlKeywords.isAndKeyword(node.token)) {
+                if (node.token == null) {
+                    // tokenless node (e.g. subquery); not extractable, skip it -
+                    // extraction is best-effort and fewer conditions is always safe
+                    node = null;
+                } else if (SqlKeywords.isAndKeyword(node.token)) {
                     if (node.rhs != null) {
                         stack.push(node.rhs);
                     }
@@ -463,6 +467,10 @@ public class PushdownFilterExtractor implements Mutable {
         while (cur != null || !orStack.isEmpty()) {
             if (cur == null) {
                 cur = orStack.poll();
+            }
+            if (cur.token == null) {
+                // tokenless OR operand (e.g. subquery); the whole OR chain is not extractable
+                return;
             }
             if (SqlKeywords.isOrKeyword(cur.token)) {
                 if (cur.lhs == null || cur.rhs == null) {

--- a/core/src/main/java/io/questdb/griffin/model/QueryModel.java
+++ b/core/src/main/java/io/questdb/griffin/model/QueryModel.java
@@ -1532,8 +1532,12 @@ public class QueryModel implements IQueryModel {
         // pre-order traversal
         sqlNodeStack.clear();
         while (!sqlNodeStack.isEmpty() || n != null) {
-            if (n != null && n.token != null) {
-                if (isAndKeyword(n.token)) {
+            if (n != null) {
+                // a tokenless conjunct (e.g. a sub-query used directly as a boolean predicate)
+                // is not an AND node and must be kept: dropping it here would silently remove
+                // the predicate from the rebuilt WHERE clause instead of letting filter
+                // compilation reject (or evaluate) it
+                if (n.token != null && isAndKeyword(n.token)) {
                     if (n.rhs != null) {
                         sqlNodeStack.push(n.rhs);
                     }

--- a/core/src/test/java/io/questdb/test/griffin/BooleanSubQueryPredicateTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/BooleanSubQueryPredicateTest.java
@@ -1,0 +1,188 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2024 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin;
+
+import io.questdb.PropertyKey;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Test;
+
+/**
+ * A scalar sub-query used directly as a boolean predicate in WHERE must be
+ * rejected with a clean SQL error in every shape: bare, AND conjunct, NOT,
+ * joins, LATEST ON, UPDATE.
+ * <p>
+ * Historically these conjuncts carried a null token and were either silently
+ * dropped from the rebuilt WHERE clause (wrong results: the filter vanished
+ * from the plan entirely, and UPDATE modified rows it should not have) or
+ * crashed intrinsic extraction and join analysis with an NPE. The OR shape
+ * always produced a clean type error; these tests pin the same behaviour for
+ * all other shapes.
+ */
+public class BooleanSubQueryPredicateTest extends AbstractCairoTest {
+
+    private static final String BOOL_EXPECTED = "boolean expression expected";
+    private static final String TYPE_MISMATCH = "expression type mismatch, expected: BOOLEAN, actual: CURSOR";
+
+    @Test
+    public void testAndConjunctSubQueryPredicateRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            // used to be silently dropped: returned the row despite the false predicate
+            assertExceptionNoLeakCheck("select * from t where ts = '2018-01-01' and (select b from x_false limit 1)", 45, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("select * from t where (select b from x_false limit 1) and ts = '2018-01-01'", 23, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("select * from t where ts = '2018-01-01' and (select b from x_empty limit 1)", 45, BOOL_EXPECTED);
+            // nested AND group
+            assertExceptionNoLeakCheck("select * from t where v = 1 and (ts in '2018' and (select b from x_false limit 1))", 51, TYPE_MISMATCH);
+            // both conjuncts tokenless
+            assertExceptionNoLeakCheck("select * from t where (select b from x_false limit 1) and (select b from x_true limit 1)", 23, TYPE_MISMATCH);
+        });
+    }
+
+    @Test
+    public void testBareSubQueryPredicateRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            // used to be silently dropped: no filter node in the plan at all
+            assertExceptionNoLeakCheck("select * from t where (select b from x_false limit 1)", 23, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("select * from t where (select b from x_true limit 1)", 23, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("select * from t where (select b from x_empty limit 1)", 23, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("select * from t where (select null::boolean from x_true limit 1)", 23, BOOL_EXPECTED);
+            // non-boolean scalar sub-query
+            assertExceptionNoLeakCheck("select * from t where (select 42 from x_true limit 1)", 23, BOOL_EXPECTED);
+            // extra parentheses
+            assertExceptionNoLeakCheck("select * from t where ((select b from x_false limit 1))", 24, BOOL_EXPECTED);
+            // explain compiles the same plan and must fail the same way
+            assertExceptionNoLeakCheck("explain select * from t where (select b from x_false limit 1)", 31, BOOL_EXPECTED);
+        });
+    }
+
+    @Test
+    public void testJoinWhereSubQueryPredicateRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            // used to throw NPE in join condition analysis
+            assertExceptionNoLeakCheck("select * from t t1 join t t2 on t1.v = t2.v where (select b from x_false limit 1)", 51, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("select * from t t1 left join t t2 on t1.v = t2.v where (select b from x_false limit 1)", 56, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("select * from t t1 cross join t t2 where (select b from x_false limit 1)", 42, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("select * from t t1 asof join t t2 where (select b from x_false limit 1)", 41, BOOL_EXPECTED);
+        });
+    }
+
+    @Test
+    public void testLatestOnWhereSubQueryPredicateRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            assertExceptionNoLeakCheck("select * from t where (select b from x_false limit 1) latest on ts partition by sym", 23, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("select * from t where sym in ('a') and (select b from x_false limit 1) latest on ts partition by sym", 40, BOOL_EXPECTED);
+        });
+    }
+
+    @Test
+    public void testLatestOnWithinWhereSubQueryPredicateRejected() throws Exception {
+        // exercises the extractWithin path, which runs ahead of intrinsic extraction
+        setProperty(PropertyKey.QUERY_WITHIN_LATEST_BY_OPTIMISATION_ENABLED, "true");
+        assertMemoryLeak(() -> {
+            execute("create table gt (ts timestamp, g geohash(8c), sym symbol index) timestamp(ts) partition by day");
+            execute("insert into gt values ('2018-01-01', #sp052w92, 'a')");
+            execute("create table x_false (b boolean)");
+            execute("insert into x_false values (false)");
+            assertExceptionNoLeakCheck("select * from gt where (select b from x_false limit 1) latest on ts partition by sym", 24, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("select * from gt where sym in ('a') and (select b from x_false limit 1) latest on ts partition by sym", 41, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("select * from gt where g within(#sp05) and (select b from x_false limit 1) latest on ts partition by sym", 44, BOOL_EXPECTED);
+        });
+    }
+
+    @Test
+    public void testNestedModelSubQueryPredicateRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            assertExceptionNoLeakCheck("select * from (select * from t where (select b from x_false limit 1))", 38, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("with q as (select * from t where (select b from x_false limit 1)) select * from q", 34, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("select sum(v) from t where (select b from x_false limit 1)", 28, BOOL_EXPECTED);
+        });
+    }
+
+    @Test
+    public void testNotSubQueryPredicateRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            // the negation must not be silently discarded; NOT over a cursor is rejected
+            assertExceptionNoLeakCheck("select * from t where not (select b from x_true limit 1)", 27,
+                    "argument type mismatch for function `not` at #1 expected: BOOLEAN, actual: CURSOR");
+            // double negation collapses to the bare sub-query
+            assertExceptionNoLeakCheck("select * from t where not not (select b from x_true limit 1)", 31, BOOL_EXPECTED);
+        });
+    }
+
+    @Test
+    public void testOrSubQueryPredicateRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            // consistency control: the OR shape always produced this error; the other
+            // shapes above must fail validation the same way instead of being dropped
+            assertExceptionNoLeakCheck("select * from t where v = 5 or (select b from x_false limit 1)", 32, TYPE_MISMATCH);
+        });
+    }
+
+    @Test
+    public void testScalarSubQueryComparisonsStillWork() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            final String expected = "ts\tv\tsym\n2018-01-01T00:00:00.000000Z\t1\ta\n";
+            printSql("select * from t where ts = (select max(ts) from t)");
+            TestUtils.assertEquals(expected, sink);
+            printSql("select * from t where v = (select 1)");
+            TestUtils.assertEquals(expected, sink);
+            printSql("select * from t where v > (select 0)");
+            TestUtils.assertEquals(expected, sink);
+            printSql("select * from t where not (v = 5)");
+            TestUtils.assertEquals(expected, sink);
+        });
+    }
+
+    @Test
+    public void testUpdateWhereSubQueryPredicateRejectedAndRowsUntouched() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            // used to be silently dropped: the UPDATE modified every row
+            assertExceptionNoLeakCheck("update t set v = 42 where (select false)", 27, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("update t set v = 42 where (select b from x_false limit 1)", 27, BOOL_EXPECTED);
+            assertExceptionNoLeakCheck("update t set v = 42 where ts = '2018-01-01' and (select b from x_false limit 1)", 49, BOOL_EXPECTED);
+            printSql("select count() from t where v = 42");
+            TestUtils.assertEquals("count\n0\n", sink);
+        });
+    }
+
+    private void createTables() throws Exception {
+        execute("create table t (ts timestamp, v int, sym symbol index) timestamp(ts) partition by day");
+        execute("insert into t values ('2018-01-01T00:00:00.000000Z', 1, 'a')");
+        execute("create table x_false (b boolean)");
+        execute("insert into x_false values (false)");
+        execute("create table x_true (b boolean)");
+        execute("insert into x_true values (true)");
+        execute("create table x_empty (b boolean)");
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/BooleanSubQueryPredicateTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/BooleanSubQueryPredicateTest.java
@@ -30,78 +30,101 @@ import io.questdb.test.tools.TestUtils;
 import org.junit.Test;
 
 /**
- * A scalar sub-query used directly as a boolean predicate in WHERE must be
- * rejected with a clean SQL error in every shape: bare, AND conjunct, NOT,
- * joins, LATEST ON, UPDATE.
+ * A scalar boolean sub-query used directly as a predicate in WHERE evaluates once per query
+ * execution, in every shape: bare, AND conjunct, NOT, OR, joins, LATEST ON, UPDATE. An empty
+ * sub-query yields NULL, which QuestDB's two-valued BOOLEAN renders as false, so the predicate
+ * matches no rows. Non-boolean and multi-column sub-queries are rejected at compile time;
+ * multi-row sub-queries are rejected at execution time.
  * <p>
- * Historically these conjuncts carried a null token and were either silently
- * dropped from the rebuilt WHERE clause (wrong results: the filter vanished
- * from the plan entirely, and UPDATE modified rows it should not have) or
- * crashed intrinsic extraction and join analysis with an NPE. The OR shape
- * always produced a clean type error; these tests pin the same behaviour for
- * all other shapes.
+ * Historically these conjuncts carried a null token and were either silently dropped from the
+ * rebuilt WHERE clause (wrong results: the filter vanished from the plan entirely, and UPDATE
+ * modified rows it should not have) or crashed intrinsic extraction and join analysis with an
+ * NPE, while the OR shape failed with a type error. These tests pin the evaluated semantics for
+ * all shapes.
  */
 public class BooleanSubQueryPredicateTest extends AbstractCairoTest {
 
-    private static final String BOOL_EXPECTED = "boolean expression expected";
-    private static final String TYPE_MISMATCH = "expression type mismatch, expected: BOOLEAN, actual: CURSOR";
+    private static final String NO_ROWS = "ts\tv\tsym\n";
+    private static final String THE_ROW = "ts\tv\tsym\n2018-01-01T00:00:00.000000Z\t1\ta\n";
 
     @Test
-    public void testAndConjunctSubQueryPredicateRejected() throws Exception {
+    public void testAndConjunctSubQueryPredicate() throws Exception {
         assertMemoryLeak(() -> {
             createTables();
             // used to be silently dropped: returned the row despite the false predicate
-            assertExceptionNoLeakCheck("select * from t where ts = '2018-01-01' and (select b from x_false limit 1)", 45, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("select * from t where (select b from x_false limit 1) and ts = '2018-01-01'", 23, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("select * from t where ts = '2018-01-01' and (select b from x_empty limit 1)", 45, BOOL_EXPECTED);
-            // nested AND group
-            assertExceptionNoLeakCheck("select * from t where v = 1 and (ts in '2018' and (select b from x_false limit 1))", 51, TYPE_MISMATCH);
-            // both conjuncts tokenless
-            assertExceptionNoLeakCheck("select * from t where (select b from x_false limit 1) and (select b from x_true limit 1)", 23, TYPE_MISMATCH);
+            assertPredicate(NO_ROWS, "select * from t where ts = '2018-01-01' and (select b from x_false limit 1)");
+            assertPredicate(THE_ROW, "select * from t where ts = '2018-01-01' and (select b from x_true limit 1)");
+            assertPredicate(NO_ROWS, "select * from t where (select b from x_false limit 1) and ts = '2018-01-01'");
+            assertPredicate(NO_ROWS, "select * from t where ts = '2018-01-01' and (select b from x_empty limit 1)");
+            // nested AND group; the timestamp intrinsic is extracted, the sub-query filters
+            assertPredicate(NO_ROWS, "select * from t where v = 1 and (ts in '2018' and (select b from x_false limit 1))");
+            assertPredicate(THE_ROW, "select * from t where v = 1 and (ts in '2018' and (select b from x_true limit 1))");
+            // both conjuncts are sub-queries
+            assertPredicate(NO_ROWS, "select * from t where (select b from x_false limit 1) and (select b from x_true limit 1)");
+            assertPredicate(THE_ROW, "select * from t where (select b from x_true limit 1) and (select b from x_true limit 1)");
         });
     }
 
     @Test
-    public void testBareSubQueryPredicateRejected() throws Exception {
+    public void testBareSubQueryPredicate() throws Exception {
         assertMemoryLeak(() -> {
             createTables();
             // used to be silently dropped: no filter node in the plan at all
-            assertExceptionNoLeakCheck("select * from t where (select b from x_false limit 1)", 23, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("select * from t where (select b from x_true limit 1)", 23, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("select * from t where (select b from x_empty limit 1)", 23, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("select * from t where (select null::boolean from x_true limit 1)", 23, BOOL_EXPECTED);
-            // non-boolean scalar sub-query
-            assertExceptionNoLeakCheck("select * from t where (select 42 from x_true limit 1)", 23, BOOL_EXPECTED);
+            assertPredicate(NO_ROWS, "select * from t where (select b from x_false limit 1)");
+            assertPredicate(THE_ROW, "select * from t where (select b from x_true limit 1)");
+            // empty sub-query yields NULL, which two-valued BOOLEAN renders as false
+            assertPredicate(NO_ROWS, "select * from t where (select b from x_empty limit 1)");
+            assertPredicate(NO_ROWS, "select * from t where (select null::boolean from x_true limit 1)");
             // extra parentheses
-            assertExceptionNoLeakCheck("select * from t where ((select b from x_false limit 1))", 24, BOOL_EXPECTED);
-            // explain compiles the same plan and must fail the same way
-            assertExceptionNoLeakCheck("explain select * from t where (select b from x_false limit 1)", 31, BOOL_EXPECTED);
+            assertPredicate(THE_ROW, "select * from t where ((select b from x_true limit 1))");
         });
     }
 
     @Test
-    public void testJoinWhereSubQueryPredicateRejected() throws Exception {
+    public void testBooleanComparisonWithSubQuery() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            // boolean expression compared with a scalar boolean sub-query
+            assertPredicate(THE_ROW, "select * from t where (v = 1) = (select b from x_true limit 1)");
+            assertPredicate(NO_ROWS, "select * from t where (v = 1) = (select b from x_false limit 1)");
+        });
+    }
+
+    @Test
+    public void testExplainShowsSubQueryFilter() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            printSql("explain select * from t where (select b from x_false limit 1)");
+            TestUtils.assertContains(sink, "filter: cursor");
+            TestUtils.assertContains(sink, "Frame forward scan on: x_false");
+        });
+    }
+
+    @Test
+    public void testJoinWhereSubQueryPredicate() throws Exception {
         assertMemoryLeak(() -> {
             createTables();
             // used to throw NPE in join condition analysis
-            assertExceptionNoLeakCheck("select * from t t1 join t t2 on t1.v = t2.v where (select b from x_false limit 1)", 51, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("select * from t t1 left join t t2 on t1.v = t2.v where (select b from x_false limit 1)", 56, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("select * from t t1 cross join t t2 where (select b from x_false limit 1)", 42, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("select * from t t1 asof join t t2 where (select b from x_false limit 1)", 41, BOOL_EXPECTED);
+            assertCount("0", "select count() from t t1 join t t2 on t1.v = t2.v where (select b from x_false limit 1)");
+            assertCount("1", "select count() from t t1 join t t2 on t1.v = t2.v where (select b from x_true limit 1)");
+            assertCount("0", "select count() from t t1 left join t t2 on t1.v = t2.v where (select b from x_false limit 1)");
+            assertCount("0", "select count() from t t1 cross join t t2 where (select b from x_false limit 1)");
+            assertCount("1", "select count() from t t1 cross join t t2 where (select b from x_true limit 1)");
+            assertCount("0", "select count() from t t1 asof join t t2 where (select b from x_false limit 1)");
         });
     }
 
     @Test
-    public void testLatestOnWhereSubQueryPredicateRejected() throws Exception {
+    public void testLatestOnWhereSubQueryPredicate() throws Exception {
         assertMemoryLeak(() -> {
             createTables();
-            assertExceptionNoLeakCheck("select * from t where (select b from x_false limit 1) latest on ts partition by sym", 23, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("select * from t where sym in ('a') and (select b from x_false limit 1) latest on ts partition by sym", 40, BOOL_EXPECTED);
+            assertPredicate(NO_ROWS, "select * from t where (select b from x_false limit 1) latest on ts partition by sym");
+            assertPredicate(THE_ROW, "select * from t where sym in ('a') and (select b from x_true limit 1) latest on ts partition by sym");
         });
     }
 
     @Test
-    public void testLatestOnWithinWhereSubQueryPredicateRejected() throws Exception {
+    public void testLatestOnWithinWhereSubQueryPredicate() throws Exception {
         // exercises the extractWithin path, which runs ahead of intrinsic extraction
         setProperty(PropertyKey.QUERY_WITHIN_LATEST_BY_OPTIMISATION_ENABLED, "true");
         assertMemoryLeak(() -> {
@@ -109,41 +132,67 @@ public class BooleanSubQueryPredicateTest extends AbstractCairoTest {
             execute("insert into gt values ('2018-01-01', #sp052w92, 'a')");
             execute("create table x_false (b boolean)");
             execute("insert into x_false values (false)");
-            assertExceptionNoLeakCheck("select * from gt where (select b from x_false limit 1) latest on ts partition by sym", 24, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("select * from gt where sym in ('a') and (select b from x_false limit 1) latest on ts partition by sym", 41, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("select * from gt where g within(#sp05) and (select b from x_false limit 1) latest on ts partition by sym", 44, BOOL_EXPECTED);
+            execute("create table x_true (b boolean)");
+            execute("insert into x_true values (true)");
+            final String expected = "ts\tg\tsym\n2018-01-01T00:00:00.000000Z\tsp052w92\ta\n";
+            printSql("select * from gt where g within(#sp05) and (select b from x_true limit 1) latest on ts partition by sym");
+            TestUtils.assertEquals(expected, sink);
+            printSql("select * from gt where g within(#sp05) and (select b from x_false limit 1) latest on ts partition by sym");
+            TestUtils.assertEquals("ts\tg\tsym\n", sink);
         });
     }
 
     @Test
-    public void testNestedModelSubQueryPredicateRejected() throws Exception {
+    public void testNestedModelSubQueryPredicate() throws Exception {
         assertMemoryLeak(() -> {
             createTables();
-            assertExceptionNoLeakCheck("select * from (select * from t where (select b from x_false limit 1))", 38, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("with q as (select * from t where (select b from x_false limit 1)) select * from q", 34, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("select sum(v) from t where (select b from x_false limit 1)", 28, BOOL_EXPECTED);
+            assertPredicate(NO_ROWS, "select * from (select * from t where (select b from x_false limit 1))");
+            assertPredicate(THE_ROW, "with q as (select * from t where (select b from x_true limit 1)) select * from q");
+            assertCount("0", "select count() from t where (select b from x_false limit 1)");
+            printSql("select sum(v) from t where (select b from x_false limit 1)");
+            TestUtils.assertEquals("sum\nnull\n", sink);
         });
     }
 
     @Test
-    public void testNotSubQueryPredicateRejected() throws Exception {
+    public void testNotSubQueryPredicate() throws Exception {
         assertMemoryLeak(() -> {
             createTables();
-            // the negation must not be silently discarded; NOT over a cursor is rejected
-            assertExceptionNoLeakCheck("select * from t where not (select b from x_true limit 1)", 27,
-                    "argument type mismatch for function `not` at #1 expected: BOOLEAN, actual: CURSOR");
-            // double negation collapses to the bare sub-query
-            assertExceptionNoLeakCheck("select * from t where not not (select b from x_true limit 1)", 31, BOOL_EXPECTED);
+            // the negation must not be silently discarded
+            assertPredicate(NO_ROWS, "select * from t where not (select b from x_true limit 1)");
+            assertPredicate(THE_ROW, "select * from t where not (select b from x_false limit 1)");
+            // an empty sub-query yields NULL, which two-valued BOOLEAN renders as false,
+            // so its negation is true - consistent with "not null::boolean"
+            assertPredicate(THE_ROW, "select * from t where not null::boolean");
+            assertPredicate(THE_ROW, "select * from t where not (select b from x_empty limit 1)");
+            assertPredicate(THE_ROW, "select * from t where not not (select b from x_true limit 1)");
         });
     }
 
     @Test
-    public void testOrSubQueryPredicateRejected() throws Exception {
+    public void testOrSubQueryPredicate() throws Exception {
         assertMemoryLeak(() -> {
             createTables();
-            // consistency control: the OR shape always produced this error; the other
-            // shapes above must fail validation the same way instead of being dropped
-            assertExceptionNoLeakCheck("select * from t where v = 5 or (select b from x_false limit 1)", 32, TYPE_MISMATCH);
+            // the OR shape used to fail with "expression type mismatch"; it now evaluates
+            // like every other shape
+            assertPredicate(THE_ROW, "select * from t where v = 5 or (select b from x_true limit 1)");
+            assertPredicate(NO_ROWS, "select * from t where v = 5 or (select b from x_false limit 1)");
+            assertPredicate(THE_ROW, "select * from t where v = 1 or (select b from x_false limit 1)");
+        });
+    }
+
+    @Test
+    public void testRejectedSubQueryShapes() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            execute("create table x_multi (b boolean)");
+            execute("insert into x_multi values (true), (false)");
+            // non-boolean scalar sub-query
+            assertExceptionNoLeakCheck("select * from t where (select 42 from x_true limit 1)", 23, "boolean expression expected");
+            // multi-column sub-query
+            assertExceptionNoLeakCheck("select * from t where (select b, b from x_true limit 1)", 23, "boolean expression expected");
+            // multi-row sub-query is rejected at execution time
+            assertExceptionNoLeakCheck("select * from t where (select b from x_multi)", 23, "scalar sub-query returned more than one row");
         });
     }
 
@@ -151,29 +200,38 @@ public class BooleanSubQueryPredicateTest extends AbstractCairoTest {
     public void testScalarSubQueryComparisonsStillWork() throws Exception {
         assertMemoryLeak(() -> {
             createTables();
-            final String expected = "ts\tv\tsym\n2018-01-01T00:00:00.000000Z\t1\ta\n";
-            printSql("select * from t where ts = (select max(ts) from t)");
-            TestUtils.assertEquals(expected, sink);
-            printSql("select * from t where v = (select 1)");
-            TestUtils.assertEquals(expected, sink);
-            printSql("select * from t where v > (select 0)");
-            TestUtils.assertEquals(expected, sink);
-            printSql("select * from t where not (v = 5)");
-            TestUtils.assertEquals(expected, sink);
+            assertPredicate(THE_ROW, "select * from t where ts = (select max(ts) from t)");
+            assertPredicate(THE_ROW, "select * from t where v = (select 1)");
+            assertPredicate(THE_ROW, "select * from t where v > (select 0)");
+            assertPredicate(THE_ROW, "select * from t where not (v = 5)");
         });
     }
 
     @Test
-    public void testUpdateWhereSubQueryPredicateRejectedAndRowsUntouched() throws Exception {
+    public void testUpdateWhereSubQueryPredicate() throws Exception {
         assertMemoryLeak(() -> {
             createTables();
             // used to be silently dropped: the UPDATE modified every row
-            assertExceptionNoLeakCheck("update t set v = 42 where (select false)", 27, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("update t set v = 42 where (select b from x_false limit 1)", 27, BOOL_EXPECTED);
-            assertExceptionNoLeakCheck("update t set v = 42 where ts = '2018-01-01' and (select b from x_false limit 1)", 49, BOOL_EXPECTED);
-            printSql("select count() from t where v = 42");
-            TestUtils.assertEquals("count\n0\n", sink);
+            update("update t set v = 42 where (select b from x_false limit 1)");
+            assertCount("0", "select count() from t where v = 42");
+            update("update t set v = 42 where ts = '2018-01-01' and (select b from x_false limit 1)");
+            assertCount("0", "select count() from t where v = 42");
+            update("update t set v = 42 where (select b from x_empty limit 1)");
+            assertCount("0", "select count() from t where v = 42");
+            // a true predicate updates the matching rows
+            update("update t set v = 42 where (select b from x_true limit 1)");
+            assertCount("1", "select count() from t where v = 42");
         });
+    }
+
+    private void assertCount(String expectedCount, String sql) throws Exception {
+        printSql(sql);
+        TestUtils.assertEquals("count\n" + expectedCount + "\n", sink);
+    }
+
+    private void assertPredicate(String expected, String sql) throws Exception {
+        printSql(sql);
+        TestUtils.assertEquals(expected, sink);
     }
 
     private void createTables() throws Exception {

--- a/core/src/test/java/io/questdb/test/griffin/PushdownFilterTokenlessNodeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/PushdownFilterTokenlessNodeTest.java
@@ -1,0 +1,45 @@
+package io.questdb.test.griffin;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+// Red regression test for claim C1: a retained filter containing a tokenless
+// (subquery) node must not NPE in PushdownFilterExtractor when the table has
+// parquet-format partitions; instead the query must fail with the same clean
+// type-mismatch error the native path produces.
+public class PushdownFilterTokenlessNodeTest extends AbstractCairoTest {
+
+    @Test
+    public void testTokenlessOrOperandOnParquetPartitionNonTimestamp() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            // pre-existing on master too (never reaches interval extraction)
+            assertExceptionNoLeakCheck(
+                    "select * from p where v = 1 or (select b from x limit 1)",
+                    32,
+                    "expression type mismatch, expected: BOOLEAN, actual: CURSOR"
+            );
+        });
+    }
+
+    @Test
+    public void testTokenlessOrOperandOnParquetPartitionTimestamp() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            // the exact retained-filter shape produced by the PR's WhereClauseParser fix
+            assertExceptionNoLeakCheck(
+                    "select * from p where ts = '2018-01-01' or (select b from x limit 1)",
+                    44,
+                    "expression type mismatch, expected: BOOLEAN, actual: CURSOR"
+            );
+        });
+    }
+
+    private void createTables() throws Exception {
+        execute("CREATE TABLE p (v INT, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY");
+        execute("INSERT INTO p VALUES (1, '2018-01-01T00:00:00.000000Z'), (2, '2018-01-02T00:00:00.000000Z')");
+        execute("CREATE TABLE x (b BOOLEAN)");
+        execute("INSERT INTO x VALUES (true)");
+        execute("ALTER TABLE p CONVERT PARTITION TO PARQUET LIST '2018-01-01'");
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/PushdownFilterTokenlessNodeTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/PushdownFilterTokenlessNodeTest.java
@@ -1,24 +1,25 @@
 package io.questdb.test.griffin;
 
 import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
 import org.junit.Test;
 
-// Red regression test for claim C1: a retained filter containing a tokenless
-// (subquery) node must not NPE in PushdownFilterExtractor when the table has
-// parquet-format partitions; instead the query must fail with the same clean
-// type-mismatch error the native path produces.
+// Regression test for claim C1: a retained filter containing a tokenless
+// (sub-query) node must not NPE in PushdownFilterExtractor when the table has
+// parquet-format partitions. Extraction skips the tokenless node (best-effort;
+// fewer extracted conditions is always safe) and the filter evaluates normally.
 public class PushdownFilterTokenlessNodeTest extends AbstractCairoTest {
+
+    private static final String BOTH_ROWS = "v\tts\n1\t2018-01-01T00:00:00.000000Z\n2\t2018-01-02T00:00:00.000000Z\n";
 
     @Test
     public void testTokenlessOrOperandOnParquetPartitionNonTimestamp() throws Exception {
         assertMemoryLeak(() -> {
             createTables();
-            // pre-existing on master too (never reaches interval extraction)
-            assertExceptionNoLeakCheck(
-                    "select * from p where v = 1 or (select b from x limit 1)",
-                    32,
-                    "expression type mismatch, expected: BOOLEAN, actual: CURSOR"
-            );
+            printSql("select * from p where v = 1 or (select b from x limit 1)");
+            TestUtils.assertEquals(BOTH_ROWS, sink);
+            printSql("select * from p where v = 1 or (select b from x_false limit 1)");
+            TestUtils.assertEquals("v\tts\n1\t2018-01-01T00:00:00.000000Z\n", sink);
         });
     }
 
@@ -26,12 +27,11 @@ public class PushdownFilterTokenlessNodeTest extends AbstractCairoTest {
     public void testTokenlessOrOperandOnParquetPartitionTimestamp() throws Exception {
         assertMemoryLeak(() -> {
             createTables();
-            // the exact retained-filter shape produced by the PR's WhereClauseParser fix
-            assertExceptionNoLeakCheck(
-                    "select * from p where ts = '2018-01-01' or (select b from x limit 1)",
-                    44,
-                    "expression type mismatch, expected: BOOLEAN, actual: CURSOR"
-            );
+            // the retained-filter shape produced by the WhereClauseParser tokenless-node fix
+            printSql("select * from p where ts = '2018-01-01' or (select b from x limit 1)");
+            TestUtils.assertEquals(BOTH_ROWS, sink);
+            printSql("select * from p where ts = '2018-01-01' or (select b from x_false limit 1)");
+            TestUtils.assertEquals("v\tts\n1\t2018-01-01T00:00:00.000000Z\n", sink);
         });
     }
 
@@ -40,6 +40,8 @@ public class PushdownFilterTokenlessNodeTest extends AbstractCairoTest {
         execute("INSERT INTO p VALUES (1, '2018-01-01T00:00:00.000000Z'), (2, '2018-01-02T00:00:00.000000Z')");
         execute("CREATE TABLE x (b BOOLEAN)");
         execute("INSERT INTO x VALUES (true)");
+        execute("CREATE TABLE x_false (b BOOLEAN)");
+        execute("INSERT INTO x_false VALUES (false)");
         execute("ALTER TABLE p CONVERT PARTITION TO PARQUET LIST '2018-01-01'");
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/SqlParserTest.java
@@ -8956,8 +8956,11 @@ public class SqlParserTest extends AbstractSqlParserTest {
 
     @Test
     public void testNullChecks() throws SqlException {
+        // the dangling select parses into a tokenless sub-query conjunct; it is
+        // retained in the model (and rejected later by filter compilation) instead
+        // of being silently dropped from the WHERE clause
         assertQuery(
-                "select-choose a from (select [a, time] from x timestamp (time) where time in ('2020-08-01T17:00:00.305314Z', '2020-09-20T17:00:00.312334Z'))",
+                "select-choose a from (select [a, time] from x timestamp (time) where time in ('2020-08-01T17:00:00.305314Z', '2020-09-20T17:00:00.312334Z') and (select-choose x from (select [x] from long_sequence(1))))",
                 """
                         SELECT\s
                         a

--- a/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
@@ -3233,6 +3233,25 @@ public class WhereClauseParserTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testBareTokenlessSubQueryPredicateKeptAsFilter() throws Exception {
+        // a sub-query used directly as a boolean predicate has a null token;
+        // it is not an intrinsic and must survive extraction as a regular filter
+        // (used to throw NPE)
+        IntrinsicModel m = modelOf("(select * from x)");
+        Assert.assertNotNull(m.filter);
+        Assert.assertEquals(IntrinsicModel.UNDEFINED, m.intrinsicValue);
+    }
+
+    @Test
+    public void testIntervalExtractedAroundTokenlessSubQueryConjunct() throws Exception {
+        // the timestamp intrinsic must still be extracted while the tokenless
+        // sub-query conjunct stays in the residual filter (used to throw NPE)
+        IntrinsicModel m = modelOf("timestamp in '2015-02-23' and (select * from x)");
+        TestUtils.assertEquals(replaceTimestampSuffix("[{lo=2015-02-23T00:00:00.000000Z, hi=2015-02-23T23:59:59.999999Z}]"), intervalToString(m));
+        Assert.assertNotNull(m.filter);
+    }
+
+    @Test
     public void testNotInIntervalIntersect() throws Exception {
         IntrinsicModel m = modelOf("timestamp not between '2015-05-11T15:00:00.000Z' and '2015-05-11T20:00:00.000Z' and timestamp in '2015-05-11'");
         Assert.assertEquals(IntrinsicModel.UNDEFINED, m.intrinsicValue);

--- a/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/WhereClauseParserTest.java
@@ -3745,6 +3745,20 @@ public class WhereClauseParserTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testTimestampEqualsOrSubqueryOnLeft() throws Exception {
+        IntrinsicModel m = modelOf("(select * from x) or timestamp = '2018-01-01'");
+        Assert.assertFalse(m.hasIntervalFilters());
+        assertFilter(m, "'2018-01-01' timestamp = (select-choose * from (x)) or");
+    }
+
+    @Test
+    public void testTimestampEqualsOrSubqueryOnRight() throws Exception {
+        IntrinsicModel m = modelOf("timestamp = '2018-01-01' or (select * from x)");
+        Assert.assertFalse(m.hasIntervalFilters());
+        assertFilter(m, "(select-choose * from (x)) '2018-01-01' timestamp = or");
+    }
+
+    @Test
     public void testTimestampEqualsRejectedSubqueryCloseFailureClosesOnce() throws Exception {
         ThrowingCloseFunction function = new ThrowingCloseFunction(false, false, null, new RuntimeException("injected close failure"));
         try {


### PR DESCRIPTION
Targets `fix/subquery-timestamp-bounds-intrinsics` (#7388) rather than master, so all scalar sub-query work lands through a single PR chain. The base branch already carries the shared guard commit (`2298061e46`) this work builds on.

## What this PR does

A scalar sub-query used **directly as a boolean predicate** (not compared to anything) produces a tokenless expression node. Historically this crashed or, worse, silently corrupted results. This PR fixes the crashes, stops the silent filter drop, and then makes the shape work:

```sql
SELECT * FROM t WHERE (SELECT b FROM x LIMIT 1);
SELECT * FROM t WHERE ts IN '2024' AND NOT (SELECT enabled FROM config LIMIT 1);
UPDATE t SET v = 0 WHERE (SELECT flag FROM ctl LIMIT 1);
```

## Before → after

| Shape | Before | After |
|---|---|---|
| `WHERE (SELECT b …)` bare | **filter silently dropped — wrong results** (no filter node in the plan) | evaluates |
| `WHERE a AND (SELECT b …)` | **conjunct silently dropped — wrong results** | evaluates |
| `WHERE NOT (SELECT b …)` | **NOT + predicate silently dropped — wrong results** | evaluates |
| `UPDATE … WHERE (SELECT b …)` | **updated rows it should not have** | evaluates |
| `WHERE a OR (SELECT b …)` | `expression type mismatch` error (released behaviour) | evaluates |
| `JOIN … WHERE (SELECT b …)` | **NPE** in join condition analysis | evaluates |
| `and_offset((SELECT b …), …)` | **NPE** in intrinsic extraction | clean error (internal function) |
| `WHERE (SELECT 42 …)` / multi-column | silently dropped | `boolean expression expected` |
| sub-query yields >1 row | silently dropped | `scalar sub-query returned more than one row` |

The silent drops date back to at least the 9.1.0 history boundary and reproduce before #7377; they were caused by `QueryModel.parseWhereClause` routing tokenless conjuncts to the poll branch so `moveWhereInsideSubQueries` rebuilt the WHERE clause without them.

## Evaluation semantics

`BooleanSubQueryFunction` follows the scalar-cursor lifecycle established by #7377's `AbstractScalarCursorFunction`:

- the sub-query executes **once per query execution** (in `init`), not per row;
- single-row cardinality is enforced at execution time;
- an **empty sub-query yields NULL**, which QuestDB's two-valued BOOLEAN renders as `false` — so `NOT (empty)` is `true`, consistent with `NOT NULL::boolean`;
- the cached value is donated to per-worker clones (`offerStateTo`, `[state-shared]` in EXPLAIN), so the sub-query never re-executes per worker;
- non-boolean and multi-column sub-queries keep failing with `boolean expression expected`.

Coercion points: `SqlCodeGenerator.compileBooleanFilter` and the join constant-WHERE path wrap a bare scalar boolean cursor; `FunctionParser` retries overload resolution once with coerced CURSOR arguments when no signature matched, which makes the sub-query compose under `not`/`and`/`or` and boolean comparisons (`(v = 1) = (SELECT b …)`).

## Commits

1. **Handle tokenless OR filter nodes** — null-token guard in `isOrOfTimestampIn` (the original NPE this PR set out to fix).
2. **Guard parquet pushdown filter extraction against tokenless nodes** — `PushdownFilterExtractor` skips tokenless nodes (extraction is best-effort; fewer conditions is always safe).
3. **Reject boolean sub-query predicates instead of dropping them** — `parseWhereClause` keeps tokenless conjuncts; null-safe guards in intrinsic extraction loop heads, the `extractWithin`/latest-by path, `optimiseBooleanNot` (no longer silently discards the negation), and `processJoinConditions` (NPE fix).
4. **Evaluate scalar boolean sub-query predicates** — the adapter + coercion points described above.

## Testing

- `BooleanSubQueryPredicateTest` (new): full shape matrix — bare/AND/NOT/OR, empty/NULL/multi-row/multi-column/non-boolean sub-queries, 4 join types, LATEST ON, LATEST ON + `within`, CTE/nested/GROUP BY, UPDATE (both truth values, row counts verified), EXPLAIN filter node, and controls proving `ts = (SELECT max(ts) …)` comparisons are untouched.
- `WhereClauseParserTest`: unit coverage for tokenless nodes in intrinsic extraction (bare, AND-conjunct with interval still extracted, NOT arm, `and_offset`).
- `PushdownFilterTokenlessNodeTest`: tokenless OR operands over parquet partitions.
- `SqlParserTest.testNullChecks` updated: its expected model had codified the silent conjunct drop.
- Regression sweep (~4,700 tests green): WhereClauseParser, SqlParser, ExplainPlan, SqlOptimiser, SqlCodeGenerator, FunctionParser×4, Join/AsOfJoin/HashJoin/WindowJoin/HorizonJoin/LateralJoin, LatestBy/ParallelLatestBy, Update ×3, all #7377 cursor-function suites, and the base branch's runtime-interval/sub-query-bounds suites.

## Release note

`WHERE a OR (SELECT b …)`, which failed with `expression type mismatch` in released versions, now evaluates. All previously-silent wrong-result shapes either evaluate correctly or fail loudly.
