### PR TITLE
test(core): retry transient table reads in fuzz tests

### DIFF
--- a/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunner.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunner.java
@@ -82,6 +82,7 @@ import org.junit.Before;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 import static io.questdb.cairo.wal.WalUtils.WAL_DEDUP_MODE_REPLACE_RANGE;
 
@@ -536,8 +537,11 @@ public class FuzzRunner {
 
     public ObjList<FuzzTransaction> generateTransactions(String tableName, Rnd rnd, long start, long end) {
         TableToken tableToken = engine.verifyTableName(tableName);
+        // getTableMetadata reloads the table _meta and can hit the same transient read timeout as a
+        // reader open while a structural change applies; for a WAL table getLegacyMetadata reads the
+        // sequencer from memory and cannot, so only the table-metadata open needs the retry.
         try (TableRecordMetadata sequencerMetadata = engine.getLegacyMetadata(tableToken);
-             TableMetadata tableMetadata = engine.getTableMetadata(tableToken)
+             TableMetadata tableMetadata = openWithRetries(() -> engine.getTableMetadata(tableToken), false)
         ) {
             return generateSet(rnd, sequencerMetadata, tableMetadata, start, end, tableName);
         }
@@ -1192,8 +1196,8 @@ public class FuzzRunner {
     private void drainWalQueue(Rnd applyRnd, String tableName) {
         try (ApplyWal2TableJob walApplyJob = new ApplyWal2TableJob(engine, 0);
              O3PartitionPurgeJob purgeJob = new O3PartitionPurgeJob(engine, 1);
-             TableReader rdr1 = getReaderHandleTableDropped(tableName);
-             TableReader rdr2 = getReaderHandleTableDropped(tableName)
+             TableReader rdr1 = getReaderWithRetries(tableName);
+             TableReader rdr2 = getReaderWithRetries(tableName)
         ) {
             CheckWalTransactionsJob checkWalTransactionsJob = new CheckWalTransactionsJob(engine);
             while (walApplyJob.run() || checkWalTransactionsJob.run()) {
@@ -1226,23 +1230,36 @@ public class FuzzRunner {
         return engine.getReader(engine.verifyTableName(tableName));
     }
 
-    private TableReader getReaderHandleTableDropped(String tableNameWal) {
-        int metadataTimeoutRetries = 10;
+    // Concurrent-read reader open: on top of the read-timeout retry, also waits out the table being
+    // concurrently dropped and recreated (dropped / name reserved / entry locked).
+    private TableReader getReaderWithRetries(String tableName) {
+        return openWithRetries(() -> getReader(tableName), true);
+    }
+
+    // Retries a table-resource open past the read timeouts (metadata / transaction / column version) that
+    // a reader or metadata open hits while a structural change is mid-apply (10x, 100ms backoff). With
+    // tolerateTableRecreate it also waits out a dropped / name-reserved / entry-locked table; otherwise
+    // those surface immediately, so setup and verify callers - whose table is never concurrently dropped -
+    // fail fast on a genuine error instead of spinning forever.
+    <T> T openWithRetries(Supplier<T> open, boolean tolerateTableRecreate) {
+        int readTimeoutRetries = 10;
         while (true) {
             try {
-                return getReader(tableNameWal);
+                return open.get();
             } catch (CairoException e) {
-                if (Chars.contains(e.getFlyweightMessage(), "table does not exist")
-                        || Chars.contains(e.getFlyweightMessage(), "table name is reserved")
-                        || e instanceof EntryLockedException) {
-                    LOG.error().$((Throwable) e).$();
-                    Os.sleep(10);
-                } else if (Chars.contains(e.getFlyweightMessage(), "Metadata read timeout")) {
-                    if (--metadataTimeoutRetries < 0) {
+                CharSequence message = e.getFlyweightMessage();
+                if (Chars.contains(message, "read timeout")) {
+                    if (--readTimeoutRetries < 0) {
                         throw e;
                     }
-                    LOG.error().$("metadata read timeout, retrying [remainingRetries=").$(metadataTimeoutRetries).$("]").$((Throwable) e).$();
+                    LOG.error().$("read timeout opening table resource, retrying [remainingRetries=").$(readTimeoutRetries).$("]").$((Throwable) e).$();
                     Os.sleep(100);
+                } else if (tolerateTableRecreate
+                        && (Chars.contains(message, "table does not exist")
+                        || Chars.contains(message, "table name is reserved")
+                        || e instanceof EntryLockedException)) {
+                    LOG.error().$((Throwable) e).$();
+                    Os.sleep(10);
                 } else {
                     throw e;
                 }
@@ -1312,8 +1329,8 @@ public class FuzzRunner {
                 int forceReloadNum = forceReaderReload.get();
                 for (int i = 0; i < tableCount; i++) {
                     String tableNameWal = multiTable ? getWalParallelApplyTableName(tableNameBase, i) : tableNameBase;
-                    readers.add(getReaderHandleTableDropped(tableNameWal));
-                    readers.add(getReaderHandleTableDropped(tableNameWal));
+                    readers.add(getReaderWithRetries(tableNameWal));
+                    readers.add(getReaderWithRetries(tableNameWal));
                 }
 
                 while (done.get() == 0 && errors.isEmpty()) {
@@ -1322,7 +1339,7 @@ public class FuzzRunner {
                         for (int i = 0; i < readers.size(); i++) {
                             String tableNameWal = multiTable ? getWalParallelApplyTableName(tableNameBase, i / 2) : tableNameBase;
                             readers.get(i).close();
-                            readers.setQuick(i, getReaderHandleTableDropped(tableNameWal));
+                            readers.setQuick(i, getReaderWithRetries(tableNameWal));
                         }
                     }
                     int reader = runRnd.nextInt(tableCount);
@@ -1380,7 +1397,7 @@ public class FuzzRunner {
     }
 
     protected void assertStringColDensity(String tableNameWal) {
-        try (TableReader reader = getReader(tableNameWal)) {
+        try (TableReader reader = openWithRetries(() -> getReader(tableNameWal), false)) {
             TableReaderMetadata metadata = reader.getMetadata();
             for (int i = 0; i < metadata.getColumnCount(); i++) {
                 int columnType = metadata.getColumnType(i);
@@ -1410,7 +1427,7 @@ public class FuzzRunner {
         String[] symbols = new String[totalSymbols];
         int symbolIndex = 0;
 
-        try (TableReader reader = getReader(baseSymbolTableName)) {
+        try (TableReader reader = openWithRetries(() -> getReader(baseSymbolTableName), false)) {
             TableReaderMetadata metadata = reader.getMetadata();
             for (int i = 0; i < metadata.getColumnCount(); i++) {
                 int columnType = metadata.getColumnType(i);

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunnerTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunnerTest.java
@@ -1,0 +1,249 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.fuzz;
+
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.pool.ex.EntryLockedException;
+import io.questdb.cairo.sql.TableMetadata;
+import io.questdb.cairo.sql.TableRecordMetadata;
+import io.questdb.std.Chars;
+import io.questdb.std.Misc;
+import io.questdb.std.ObjList;
+import io.questdb.std.Rnd;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.fuzz.FuzzTransaction;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+public class FuzzRunnerTest extends AbstractCairoTest {
+
+    private final FuzzRunner fuzzer = new FuzzRunner();
+
+    @Test
+    public void testAssertStringColDensityUsesRetries() throws Exception {
+        assertMemoryLeak(() -> {
+            createWalTable("density");
+            RetryInjectingFuzzRunner retryingFuzzer = newFuzzer(1, "Transaction read timeout [src=density]");
+
+            retryingFuzzer.assertStringColDensity("density");
+
+            assertRetryRouting(retryingFuzzer, 1, 0);
+        });
+    }
+
+    @Test
+    public void testDrainWalQueueUsesRetries() throws Exception {
+        assertMemoryLeak(() -> {
+            createWalTable("drain");
+            RetryInjectingFuzzRunner retryingFuzzer = newFuzzer(1, "Transaction read timeout [src=drain]");
+            ObjList<FuzzTransaction> transactions = new ObjList<>();
+
+            retryingFuzzer.applyWal(transactions, "drain", 1, new Rnd());
+
+            assertRetryRouting(retryingFuzzer, 4, 4);
+        });
+    }
+
+    @Test
+    public void testGenerateSymbolsUsesRetries() throws Exception {
+        assertMemoryLeak(() -> {
+            createWalTable("symbols");
+            RetryInjectingFuzzRunner retryingFuzzer = newFuzzer(1, "Column Version read timeout [src=symbols]");
+
+            String[] symbols = retryingFuzzer.generateSymbols(new Rnd(), 3, 4, "symbols");
+
+            Assert.assertEquals(3, symbols.length);
+            assertRetryRouting(retryingFuzzer, 1, 0);
+        });
+    }
+
+    @Test
+    public void testGenerateTransactionsUsesRetries() throws Exception {
+        assertMemoryLeak(() -> {
+            createWalTable("generate");
+            RetryInjectingFuzzRunner retryingFuzzer = newFuzzer(1, "Metadata read timeout [src=generate]");
+            ObjList<FuzzTransaction> transactions = retryingFuzzer.generateTransactions("generate", new Rnd(), 0, 1);
+
+            try {
+                assertRetryRouting(retryingFuzzer, 1, 0);
+            } finally {
+                Misc.freeObjListAndClear(transactions);
+            }
+        });
+    }
+
+    @Test
+    public void testPurgePartitionReadersUseRetries() throws Exception {
+        assertMemoryLeak(() -> {
+            createWalTable("purge");
+            RetryInjectingFuzzRunner retryingFuzzer = newFuzzer(1, "Metadata read timeout [src=purge]");
+            ObjList<ObjList<FuzzTransaction>> transactions = new ObjList<>();
+            transactions.add(new ObjList<>());
+
+            retryingFuzzer.applyManyWalParallel(transactions, new Rnd(), "purge", false, true);
+
+            assertRetryRouting(retryingFuzzer, 2, 2);
+        });
+    }
+
+    @Test
+    public void testReadTimeoutRethrownAfterRetriesExhausted() {
+        AtomicInteger attempts = new AtomicInteger();
+        try {
+            // Transaction, not Metadata: the retry must cover the whole read-timeout family, not just
+            // the Metadata variant the pre-broadening code matched.
+            fuzzer.openWithRetries(() -> {
+                attempts.incrementAndGet();
+                throw CairoException.critical(0).put("Transaction read timeout [src=reader]");
+            }, false);
+            Assert.fail("read timeout should surface once retries are exhausted");
+        } catch (CairoException e) {
+            Assert.assertTrue(Chars.contains(e.getFlyweightMessage(), "read timeout"));
+        }
+        Assert.assertEquals(11, attempts.get()); // 1 initial attempt + 10 retries
+    }
+
+    @Test
+    public void testReadTimeoutRetriedThenSucceeds() {
+        AtomicInteger attempts = new AtomicInteger();
+        String reader = fuzzer.openWithRetries(() -> {
+            if (attempts.incrementAndGet() < 3) {
+                throw CairoException.critical(0).put("Metadata read timeout [src=metadata]");
+            }
+            return "reader";
+        }, false);
+        Assert.assertEquals("reader", reader);
+        Assert.assertEquals(3, attempts.get());
+    }
+
+    @Test
+    public void testTableRecreateNotToleratedFailsFast() {
+        AtomicInteger attempts = new AtomicInteger();
+        try {
+            fuzzer.openWithRetries(() -> {
+                attempts.incrementAndGet();
+                throw CairoException.critical(0).put("table does not exist [table=x]");
+            }, false);
+            Assert.fail("a dropped table should surface immediately when recreate is not tolerated");
+        } catch (CairoException e) {
+            Assert.assertTrue(Chars.contains(e.getFlyweightMessage(), "table does not exist"));
+        }
+        Assert.assertEquals(1, attempts.get()); // no retry: the first attempt rethrows
+    }
+
+    @Test
+    public void testTableRecreateToleratedIsWaitedOut() {
+        AtomicInteger attempts = new AtomicInteger();
+        String reader = fuzzer.openWithRetries(() -> {
+            int n = attempts.incrementAndGet();
+            if (n == 1) {
+                throw CairoException.critical(0).put("table name is reserved [table=x]");
+            }
+            if (n == 2) {
+                throw EntryLockedException.instance("locked");
+            }
+            return "reader";
+        }, true);
+        Assert.assertEquals("reader", reader);
+        Assert.assertEquals(3, attempts.get());
+    }
+
+    @Test
+    public void testUnrelatedCairoExceptionAlwaysRethrown() {
+        AtomicInteger attempts = new AtomicInteger();
+        try {
+            // Even with recreate tolerated, anything outside the read-timeout / recreate families surfaces at once.
+            fuzzer.openWithRetries(() -> {
+                attempts.incrementAndGet();
+                throw CairoException.critical(0).put("some other failure");
+            }, true);
+            Assert.fail("an unrelated error should surface immediately");
+        } catch (CairoException e) {
+            Assert.assertTrue(Chars.contains(e.getFlyweightMessage(), "some other failure"));
+        }
+        Assert.assertEquals(1, attempts.get());
+    }
+
+    private static void assertRetryRouting(RetryInjectingFuzzRunner fuzzer, int expectedOpenCalls, int expectedToleratedRecreateCalls) {
+        Assert.assertEquals(expectedOpenCalls, fuzzer.openCalls.get());
+        Assert.assertEquals(2, fuzzer.readTimeoutAttempts.get());
+        Assert.assertEquals(expectedToleratedRecreateCalls, fuzzer.toleratedRecreateCalls.get());
+    }
+
+    private void createWalTable(String tableName) throws Exception {
+        execute("create table " + tableName + " (sym symbol, str string, ts timestamp) timestamp(ts) partition by DAY WAL");
+    }
+
+    private RetryInjectingFuzzRunner newFuzzer(int injectedCall, String timeoutMessage) {
+        RetryInjectingFuzzRunner retryingFuzzer = new RetryInjectingFuzzRunner(injectedCall, timeoutMessage);
+        retryingFuzzer.withDb(engine, sqlExecutionContext);
+        return retryingFuzzer;
+    }
+
+    private static class RetryInjectingFuzzRunner extends FuzzRunner {
+        private final int injectedCall;
+        private final AtomicInteger openCalls = new AtomicInteger();
+        private final AtomicInteger readTimeoutAttempts = new AtomicInteger();
+        private final String timeoutMessage;
+        private final AtomicInteger toleratedRecreateCalls = new AtomicInteger();
+
+        private RetryInjectingFuzzRunner(int injectedCall, String timeoutMessage) {
+            this.injectedCall = injectedCall;
+            this.timeoutMessage = timeoutMessage;
+        }
+
+        @Override
+        public ObjList<FuzzTransaction> generateSet(
+                Rnd rnd,
+                TableRecordMetadata sequencerMetadata,
+                TableMetadata tableMetadata,
+                long start,
+                long end,
+                String tableName
+        ) {
+            return new ObjList<>();
+        }
+
+        @Override
+        <T> T openWithRetries(Supplier<T> open, boolean tolerateTableRecreate) {
+            int call = openCalls.incrementAndGet();
+            if (tolerateTableRecreate) {
+                toleratedRecreateCalls.incrementAndGet();
+            }
+            if (call == injectedCall) {
+                return super.openWithRetries(() -> {
+                    if (readTimeoutAttempts.incrementAndGet() == 1) {
+                        throw CairoException.critical(0).put(timeoutMessage);
+                    }
+                    return open.get();
+                }, tolerateTableRecreate);
+            }
+            return super.openWithRetries(open, tolerateTableRecreate);
+        }
+    }
+}


### PR DESCRIPTION
Tandem https://github.com/questdb/questdb-enterprise/pull/1138

## Summary

Fuzz setup and verification can open table metadata or readers while WAL structural changes update the corresponding files. Those opens may observe a transient Metadata, Transaction, or Column Version read timeout even though retrying the operation succeeds.

The existing fuzz retry logic covered only selected concurrent reader opens and matched only the Metadata timeout message. This change applies one retry policy consistently to every affected metadata and reader-open path. It changes test infrastructure only.

## Implementation

- Generalize the reader-specific retry loop into `openWithRetries` so it can open either metadata or readers.
- Retry the complete read-timeout family up to ten times with a 100 ms backoff.
- Preserve table drop/recreate tolerance for concurrent drain and purge readers.
- Fail immediately on missing, reserved, or locked tables during setup and verification, where a concurrent recreate is not expected.
- Route transaction generation, symbol loading, density verification, WAL draining, and purge readers through the appropriate retry mode.

## Tests

Helper-level tests cover successful retries, retry exhaustion, optional table-recreate tolerance, and immediate propagation of unrelated errors.

Caller-level regression tests create real WAL tables, inject a transient timeout through each changed route, and assert both the retry count and the selected recreate policy. They cover:

- transaction-generation metadata opens;
- symbol-reader opens, including the Column Version timeout variant;
- string-density reader opens;
- synchronous WAL queue drain readers; and
- concurrent purge-partition readers.

The caller tests fail when their corresponding retry wiring is bypassed, so they protect the actual fix rather than only exercising the helper in isolation.

## Verification

- `FuzzRunnerTest`: 10 passed, 0 failed, 0 skipped.
- Caller-wiring mutation check: all 5 caller tests failed with the retry routes bypassed.
- Restored caller tests: 5 passed, 0 failed, 0 skipped.
- `git diff --check`: passed.