### PR TITLE
perf(sql): speed up covering index post-filter queries

### DIFF
--- a/benchmarks/src/main/java/org/questdb/CoveringIndexPostFilterBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/CoveringIndexPostFilterBenchmark.java
@@ -1,0 +1,259 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.questdb;
+
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.DefaultCairoConfiguration;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.SqlExecutionContextImpl;
+import io.questdb.log.LogFactory;
+import io.questdb.mp.WorkerPool;
+import io.questdb.mp.WorkerPoolConfiguration;
+import io.questdb.mp.WorkerPoolUtils;
+import io.questdb.std.Misc;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.CommandLineOptions;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures a raw timestamp/value projection with a covered residual predicate.
+ * Key and residual selectivity use coprime deterministic cycles, preventing the
+ * residual distribution from correlating with either indexed key.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2)
+@Measurement(iterations = 3)
+@Fork(0)
+public class CoveringIndexPostFilterBenchmark {
+    private static final int WORKERS = Integer.getInteger("covering.postfilter.workers", 8);
+    private static final long ROWS = Long.getLong("covering.postfilter.rows", 5_000_000L);
+    private static final String ROOT = System.getProperty("java.io.tmpdir") + java.io.File.separator + "covering-postfilter-bench";
+    private static final DefaultCairoConfiguration CONFIGURATION = new DefaultCairoConfiguration(ROOT) {
+        @Override
+        public int getSqlPageFrameMaxRows() {
+            return 100_000;
+        }
+    };
+
+    private static CairoEngine engine;
+    private static SqlCompiler compiler;
+    private static SqlExecutionContext context;
+    private static WorkerPool pool;
+
+    @Param({
+            "covering-k1-r10", "no_covering-k1-r10", "no_index-k1-r10",
+            "covering-k1-r100", "no_covering-k1-r100", "no_index-k1-r100",
+            "covering-k10-r10", "no_covering-k10-r10", "no_index-k10-r10",
+            "covering-k10-r100", "no_covering-k10-r100", "no_index-k10-r100"
+    })
+    public String scenario;
+
+    private long expectedChecksum;
+    private long expectedRows;
+    private RecordCursorFactory factory;
+    private long lastRowCount;
+
+    public static void main(String[] args) throws Exception {
+        final Options options = args.length > 0
+                ? new CommandLineOptions(args)
+                : new OptionsBuilder().include(CoveringIndexPostFilterBenchmark.class.getSimpleName()).build();
+        try {
+            new Runner(options).run();
+        } finally {
+            closeEnvironment();
+        }
+    }
+
+    @Benchmark
+    public long run() throws Exception {
+        try (RecordCursor cursor = factory.getCursor(context)) {
+            final long checksum = drain(cursor);
+            if (lastRowCount != expectedRows || checksum != expectedChecksum) {
+                throw new IllegalStateException("route returned a different result [scenario=" + scenario + ']');
+            }
+            return checksum;
+        }
+    }
+
+    @Setup(Level.Trial)
+    public void setUp() throws Exception {
+        ensureEnvironment();
+        final String route = scenario.substring(0, scenario.indexOf('-'));
+        final String query = query(scenario, route);
+        verifyRoute(query, route);
+        factory = compiler.compile(query, context).getRecordCursorFactory();
+        try (RecordCursorFactory oracleFactory = compiler.compile(query(scenario, "no_index"), context).getRecordCursorFactory();
+             RecordCursor oracleCursor = oracleFactory.getCursor(context)) {
+            expectedChecksum = drain(oracleCursor);
+            expectedRows = lastRowCount;
+        }
+        try (RecordCursor cursor = factory.getCursor(context)) {
+            final long checksum = drain(cursor);
+            if (lastRowCount != expectedRows || checksum != expectedChecksum) {
+                throw new IllegalStateException("route checksum mismatch [scenario=" + scenario + ']');
+            }
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        factory = Misc.free(factory);
+    }
+
+    private static synchronized void closeEnvironment() {
+        compiler = Misc.free(compiler);
+        if (pool != null) {
+            pool.halt();
+            pool = null;
+        }
+        engine = Misc.free(engine);
+        context = null;
+        LogFactory.haltInstance();
+    }
+
+    private long drain(RecordCursor cursor) {
+        final Record record = cursor.getRecord();
+        long checksum = 0;
+        long rows = 0;
+        while (cursor.hasNext()) {
+            checksum = checksum * 31 + record.getTimestamp(0);
+            checksum = checksum * 31 + Double.doubleToLongBits(record.getDouble(1));
+            rows++;
+        }
+        lastRowCount = rows;
+        return checksum;
+    }
+
+    private static synchronized void ensureEnvironment() throws Exception {
+        if (engine != null) {
+            return;
+        }
+        Files.createDirectories(Paths.get(ROOT));
+        engine = new CairoEngine(CONFIGURATION);
+        context = new SqlExecutionContextImpl(engine, WORKERS) {
+            @Override
+            public boolean shouldLogSql() {
+                return false;
+            }
+        }.with(
+                CONFIGURATION.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                null,
+                null,
+                -1,
+                null
+        );
+        engine.execute("DROP TABLE IF EXISTS post_filter", context);
+        engine.execute("""
+                CREATE TABLE post_filter (
+                    ts TIMESTAMP,
+                    sym SYMBOL INDEX TYPE POSTING INCLUDE (value, residual),
+                    value DOUBLE,
+                    residual INT
+                ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                """, context);
+        final long spacing = Math.max(1, 16L * 86_400_000_000L / ROWS);
+        engine.execute(
+                "INSERT INTO post_filter SELECT " +
+                        "('2024-01-01'::timestamp + (x - 1) * " + spacing + "L)::timestamp, " +
+                        "(CASE WHEN x % 1000 < 10 THEN 'k1' WHEN x % 1000 < 110 THEN 'k10' ELSE 'noise' || (x % 64) END)::symbol, " +
+                        "(x % 10_007)::double, (x % 997)::int " +
+                        "FROM long_sequence(" + ROWS + ')',
+                context
+        );
+        engine.releaseAllWriters();
+        pool = new WorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public String getPoolName() {
+                return "covering-postfilter-bench";
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return WORKERS;
+            }
+        });
+        WorkerPoolUtils.setupQueryJobs(pool, engine);
+        pool.start();
+        compiler = engine.getSqlCompiler();
+    }
+
+    private static String query(String scenario, String route) {
+        final String[] parts = scenario.split("-");
+        final String hint = switch (route) {
+            case "covering" -> "";
+            case "no_covering" -> "/*+ no_covering */ ";
+            case "no_index" -> "/*+ no_index */ ";
+            default -> throw new IllegalArgumentException("unknown route: " + route);
+        };
+        final int residualLimit = "r10".equals(parts[2]) ? 100 : 997;
+        return "SELECT " + hint + "ts, value FROM post_filter WHERE sym = '" + parts[1] +
+                "' AND residual < " + residualLimit;
+    }
+
+    private static void verifyRoute(String query, String route) throws Exception {
+        final StringBuilder plan = new StringBuilder();
+        try (RecordCursorFactory explainFactory = compiler.compile("EXPLAIN " + query, context).getRecordCursorFactory();
+             RecordCursor cursor = explainFactory.getCursor(context)) {
+            final Record record = cursor.getRecord();
+            while (cursor.hasNext()) {
+                plan.append(record.getStrA(0)).append('\n');
+            }
+        }
+        final String text = plan.toString();
+        final boolean isValid = switch (route) {
+            case "covering" -> text.contains("Async JIT Filter") && text.contains("CoveringIndex");
+            case "no_covering" -> !text.contains("CoveringIndex") && text.contains("Index");
+            case "no_index" -> !text.contains("CoveringIndex") && !text.contains("Index forward scan");
+            default -> false;
+        };
+        if (!isValid) {
+            throw new IllegalStateException("unexpected route [route=" + route + ", plan=" + text + ']');
+        }
+    }
+}

--- a/benchmarks/src/main/java/org/questdb/CoveringIndexPostFilterBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/CoveringIndexPostFilterBenchmark.java
@@ -26,6 +26,7 @@ package org.questdb;
 
 import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.DefaultCairoConfiguration;
+import io.questdb.cairo.SqlJitMode;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
@@ -64,7 +65,8 @@ import java.util.concurrent.TimeUnit;
  * Key and residual selectivity use coprime deterministic cycles, preventing the
  * residual distribution from correlating with any indexed key. The default
  * 100-million-row trial sweeps 0.1% to 20% key selectivity and 1% to 100%
- * residual selectivity; use the JMH {@code rowCount} parameter to rescale it.
+ * residual selectivity. Its residual sweep also separates Java-eager, JIT-eager,
+ * and adaptive JIT covering paths; use the JMH {@code rowCount} parameter to rescale it.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)
@@ -96,13 +98,20 @@ public class CoveringIndexPostFilterBenchmark {
     public long rowCount;
 
     @Param({
-            "covering-k10-r1", "no_covering-k10-r1", "no_index-k10-r1",
-            "covering-k10-r2", "no_covering-k10-r2", "no_index-k10-r2",
-            "covering-k10-r5", "no_covering-k10-r5", "no_index-k10-r5",
-            "covering-k10-r10", "no_covering-k10-r10", "no_index-k10-r10",
-            "covering-k10-r20", "no_covering-k10-r20", "no_index-k10-r20",
-            "covering-k10-r50", "no_covering-k10-r50", "no_index-k10-r50",
-            "covering-k10-r100", "no_covering-k10-r100", "no_index-k10-r100",
+            "covering-k10-r1", "covering_eager-k10-r1", "covering_java_eager-k10-r1",
+            "no_covering-k10-r1", "no_index-k10-r1",
+            "covering-k10-r2", "covering_eager-k10-r2", "covering_java_eager-k10-r2",
+            "no_covering-k10-r2", "no_index-k10-r2",
+            "covering-k10-r5", "covering_eager-k10-r5", "covering_java_eager-k10-r5",
+            "no_covering-k10-r5", "no_index-k10-r5",
+            "covering-k10-r10", "covering_eager-k10-r10", "covering_java_eager-k10-r10",
+            "no_covering-k10-r10", "no_index-k10-r10",
+            "covering-k10-r20", "covering_eager-k10-r20", "covering_java_eager-k10-r20",
+            "no_covering-k10-r20", "no_index-k10-r20",
+            "covering-k10-r50", "covering_eager-k10-r50", "covering_java_eager-k10-r50",
+            "no_covering-k10-r50", "no_index-k10-r50",
+            "covering-k10-r100", "covering_eager-k10-r100", "covering_java_eager-k10-r100",
+            "no_covering-k10-r100", "no_index-k10-r100",
             "covering-k01-r10", "no_covering-k01-r10", "no_index-k01-r10",
             "covering-k02-r10", "no_covering-k02-r10", "no_index-k02-r10",
             "covering-k05-r10", "no_covering-k05-r10", "no_index-k05-r10",
@@ -144,6 +153,9 @@ public class CoveringIndexPostFilterBenchmark {
     public void setUp() throws Exception {
         ensureEnvironment(rowCount);
         final String route = scenario.substring(0, scenario.indexOf('-'));
+        context.setJitMode(
+                "covering_java_eager".equals(route) ? SqlJitMode.JIT_MODE_DISABLED : SqlJitMode.JIT_MODE_ENABLED
+        );
         final String query = query(scenario, route);
         verifyRoute(query, route);
         factory = compiler.compile(query, context).getRecordCursorFactory();
@@ -259,7 +271,7 @@ public class CoveringIndexPostFilterBenchmark {
     private static String query(String scenario, String route) {
         final String[] parts = scenario.split("-");
         final String hint = switch (route) {
-            case "covering" -> "";
+            case "covering", "covering_eager", "covering_java_eager" -> "";
             case "no_covering" -> "/*+ no_covering */ ";
             case "no_index" -> "/*+ no_index */ ";
             default -> throw new IllegalArgumentException("unknown route: " + route);
@@ -274,8 +286,11 @@ public class CoveringIndexPostFilterBenchmark {
             case "r100" -> 1009;
             default -> throw new IllegalArgumentException("unknown residual selectivity: " + parts[2]);
         };
+        final String eagerDependency = route.endsWith("_eager")
+                ? " AND value >= 0 AND ts >= '1970-01-01'"
+                : "";
         return "SELECT " + hint + "ts, value FROM post_filter WHERE sym = '" + parts[1] +
-                "' AND residual < " + residualLimit;
+                "' AND residual < " + residualLimit + eagerDependency;
     }
 
     private static void verifyRoute(String query, String route) throws Exception {
@@ -293,6 +308,10 @@ public class CoveringIndexPostFilterBenchmark {
                     && (EXPECT_JIT
                         ? text.contains("Async JIT Filter")
                         : text.contains("Async Filter") && !text.contains("Async JIT Filter"));
+            case "covering_eager" -> text.contains("Async JIT Filter") && text.contains("CoveringIndex");
+            case "covering_java_eager" -> text.contains("Async Filter")
+                    && !text.contains("Async JIT Filter")
+                    && text.contains("CoveringIndex");
             case "no_covering" -> !text.contains("CoveringIndex") && text.contains("Index");
             case "no_index" -> !text.contains("CoveringIndex") && !text.contains("Index forward scan");
             default -> false;

--- a/benchmarks/src/main/java/org/questdb/CoveringIndexPostFilterBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/CoveringIndexPostFilterBenchmark.java
@@ -62,9 +62,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * Measures a raw timestamp/value projection with a covered residual predicate.
  * Key and residual selectivity use coprime deterministic cycles, preventing the
- * residual distribution from correlating with either indexed key. The default
- * 100-million-row trial yields 1 million and 10 million indexed candidates for
- * the two key selectivities; use the JMH {@code rowCount} parameter to rescale it.
+ * residual distribution from correlating with any indexed key. The default
+ * 100-million-row trial sweeps 0.1% to 20% key selectivity and 1% to 100%
+ * residual selectivity; use the JMH {@code rowCount} parameter to rescale it.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)
@@ -73,6 +73,10 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 3)
 @Fork(0)
 public class CoveringIndexPostFilterBenchmark {
+    // Baseline runs set this to false when they compile the benchmark against a pre-JIT covering build.
+    private static final boolean EXPECT_JIT = Boolean.parseBoolean(
+            System.getProperty("covering.postfilter.expect.jit", "true")
+    );
     private static final int WORKERS = Integer.getInteger("covering.postfilter.workers", 8);
     private static final String ROOT = System.getProperty("java.io.tmpdir") + java.io.File.separator + "covering-postfilter-bench";
     private static final DefaultCairoConfiguration CONFIGURATION = new DefaultCairoConfiguration(ROOT) {
@@ -92,10 +96,20 @@ public class CoveringIndexPostFilterBenchmark {
     public long rowCount;
 
     @Param({
-            "covering-k1-r10", "no_covering-k1-r10", "no_index-k1-r10",
-            "covering-k1-r100", "no_covering-k1-r100", "no_index-k1-r100",
+            "covering-k10-r1", "no_covering-k10-r1", "no_index-k10-r1",
+            "covering-k10-r2", "no_covering-k10-r2", "no_index-k10-r2",
+            "covering-k10-r5", "no_covering-k10-r5", "no_index-k10-r5",
             "covering-k10-r10", "no_covering-k10-r10", "no_index-k10-r10",
-            "covering-k10-r100", "no_covering-k10-r100", "no_index-k10-r100"
+            "covering-k10-r20", "no_covering-k10-r20", "no_index-k10-r20",
+            "covering-k10-r50", "no_covering-k10-r50", "no_index-k10-r50",
+            "covering-k10-r100", "no_covering-k10-r100", "no_index-k10-r100",
+            "covering-k01-r10", "no_covering-k01-r10", "no_index-k01-r10",
+            "covering-k02-r10", "no_covering-k02-r10", "no_index-k02-r10",
+            "covering-k05-r10", "no_covering-k05-r10", "no_index-k05-r10",
+            "covering-k1-r10", "no_covering-k1-r10", "no_index-k1-r10",
+            "covering-k2-r10", "no_covering-k2-r10", "no_index-k2-r10",
+            "covering-k5-r10", "no_covering-k5-r10", "no_index-k5-r10",
+            "covering-k20-r10", "no_covering-k20-r10", "no_index-k20-r10"
     })
     public String scenario;
 
@@ -210,8 +224,17 @@ public class CoveringIndexPostFilterBenchmark {
         engine.execute(
                 "INSERT INTO post_filter SELECT " +
                         "('2024-01-01'::timestamp + (x - 1) * " + spacing + "L)::timestamp, " +
-                        "(CASE WHEN x % 1000 < 10 THEN 'k1' WHEN x % 1000 < 110 THEN 'k10' ELSE 'noise' || (x % 64) END)::symbol, " +
-                        "(x % 10_007)::double, (x % 997)::int " +
+                        "(CASE " +
+                        "WHEN x % 10_000 < 10 THEN 'k01' " +
+                        "WHEN x % 10_000 < 30 THEN 'k02' " +
+                        "WHEN x % 10_000 < 80 THEN 'k05' " +
+                        "WHEN x % 10_000 < 180 THEN 'k1' " +
+                        "WHEN x % 10_000 < 380 THEN 'k2' " +
+                        "WHEN x % 10_000 < 880 THEN 'k5' " +
+                        "WHEN x % 10_000 < 1880 THEN 'k10' " +
+                        "WHEN x % 10_000 < 3880 THEN 'k20' " +
+                        "ELSE 'noise' || (x % 64) END)::symbol, " +
+                        "(x % 10_007)::double, (x % 1009)::int " +
                         "FROM long_sequence(" + rowCount + ')',
                 context
         );
@@ -241,7 +264,16 @@ public class CoveringIndexPostFilterBenchmark {
             case "no_index" -> "/*+ no_index */ ";
             default -> throw new IllegalArgumentException("unknown route: " + route);
         };
-        final int residualLimit = "r10".equals(parts[2]) ? 100 : 997;
+        final int residualLimit = switch (parts[2]) {
+            case "r1" -> 10;
+            case "r2" -> 20;
+            case "r5" -> 50;
+            case "r10" -> 101;
+            case "r20" -> 202;
+            case "r50" -> 505;
+            case "r100" -> 1009;
+            default -> throw new IllegalArgumentException("unknown residual selectivity: " + parts[2]);
+        };
         return "SELECT " + hint + "ts, value FROM post_filter WHERE sym = '" + parts[1] +
                 "' AND residual < " + residualLimit;
     }
@@ -257,7 +289,10 @@ public class CoveringIndexPostFilterBenchmark {
         }
         final String text = plan.toString();
         final boolean isValid = switch (route) {
-            case "covering" -> text.contains("Async JIT Filter") && text.contains("CoveringIndex");
+            case "covering" -> text.contains("CoveringIndex")
+                    && (EXPECT_JIT
+                        ? text.contains("Async JIT Filter")
+                        : text.contains("Async Filter") && !text.contains("Async JIT Filter"));
             case "no_covering" -> !text.contains("CoveringIndex") && text.contains("Index");
             case "no_index" -> !text.contains("CoveringIndex") && !text.contains("Index forward scan");
             default -> false;

--- a/benchmarks/src/main/java/org/questdb/CoveringIndexPostFilterBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/CoveringIndexPostFilterBenchmark.java
@@ -110,8 +110,16 @@ public class CoveringIndexPostFilterBenchmark {
             "no_covering-k10-r20", "no_index-k10-r20",
             "covering-k10-r50", "covering_eager-k10-r50", "covering_java_eager-k10-r50",
             "no_covering-k10-r50", "no_index-k10-r50",
+            "covering-k10-r90", "covering_eager-k10-r90", "covering_java_eager-k10-r90",
+            "covering_count-k10-r90", "no_covering-k10-r90", "no_index-k10-r90",
+            "covering-k10-r95", "covering_eager-k10-r95", "covering_java_eager-k10-r95",
+            "covering_count-k10-r95", "no_covering-k10-r95", "no_index-k10-r95",
+            "covering-k10-r99", "covering_eager-k10-r99", "covering_java_eager-k10-r99",
+            "covering_count-k10-r99", "no_covering-k10-r99", "no_index-k10-r99",
+            "covering-k10-r999", "covering_eager-k10-r999", "covering_java_eager-k10-r999",
+            "covering_count-k10-r999", "no_covering-k10-r999", "no_index-k10-r999",
             "covering-k10-r100", "covering_eager-k10-r100", "covering_java_eager-k10-r100",
-            "no_covering-k10-r100", "no_index-k10-r100",
+            "covering_count-k10-r100", "no_covering-k10-r100", "no_index-k10-r100",
             "covering-k01-r10", "no_covering-k01-r10", "no_index-k01-r10",
             "covering-k02-r10", "no_covering-k02-r10", "no_index-k02-r10",
             "covering-k05-r10", "no_covering-k05-r10", "no_index-k05-r10",
@@ -194,8 +202,12 @@ public class CoveringIndexPostFilterBenchmark {
         long checksum = 0;
         long rows = 0;
         while (cursor.hasNext()) {
-            checksum = checksum * 31 + record.getTimestamp(0);
-            checksum = checksum * 31 + Double.doubleToLongBits(record.getDouble(1));
+            if (scenario.startsWith("covering_count")) {
+                checksum = checksum * 31 + record.getLong(0);
+            } else {
+                checksum = checksum * 31 + record.getTimestamp(0);
+                checksum = checksum * 31 + Double.doubleToLongBits(record.getDouble(1));
+            }
             rows++;
         }
         lastRowCount = rows;
@@ -271,7 +283,7 @@ public class CoveringIndexPostFilterBenchmark {
     private static String query(String scenario, String route) {
         final String[] parts = scenario.split("-");
         final String hint = switch (route) {
-            case "covering", "covering_eager", "covering_java_eager" -> "";
+            case "covering", "covering_count", "covering_eager", "covering_java_eager" -> "";
             case "no_covering" -> "/*+ no_covering */ ";
             case "no_index" -> "/*+ no_index */ ";
             default -> throw new IllegalArgumentException("unknown route: " + route);
@@ -283,13 +295,18 @@ public class CoveringIndexPostFilterBenchmark {
             case "r10" -> 101;
             case "r20" -> 202;
             case "r50" -> 505;
+            case "r90" -> 908;
+            case "r95" -> 959;
+            case "r99" -> 999;
+            case "r999" -> 1008;
             case "r100" -> 1009;
             default -> throw new IllegalArgumentException("unknown residual selectivity: " + parts[2]);
         };
         final String eagerDependency = route.endsWith("_eager")
                 ? " AND value >= 0 AND ts >= '1970-01-01'"
                 : "";
-        return "SELECT " + hint + "ts, value FROM post_filter WHERE sym = '" + parts[1] +
+        final String projection = scenario.startsWith("covering_count") ? "count()" : "ts, value";
+        return "SELECT " + hint + projection + " FROM post_filter WHERE sym = '" + parts[1] +
                 "' AND residual < " + residualLimit + eagerDependency;
     }
 
@@ -308,7 +325,7 @@ public class CoveringIndexPostFilterBenchmark {
                     && (EXPECT_JIT
                         ? text.contains("Async JIT Filter")
                         : text.contains("Async Filter") && !text.contains("Async JIT Filter"));
-            case "covering_eager" -> text.contains("Async JIT Filter") && text.contains("CoveringIndex");
+            case "covering_count", "covering_eager" -> text.contains("Async JIT Filter") && text.contains("CoveringIndex");
             case "covering_java_eager" -> text.contains("Async Filter")
                     && !text.contains("Async JIT Filter")
                     && text.contains("CoveringIndex");

--- a/benchmarks/src/main/java/org/questdb/CoveringIndexPostFilterBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/CoveringIndexPostFilterBenchmark.java
@@ -62,7 +62,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * Measures a raw timestamp/value projection with a covered residual predicate.
  * Key and residual selectivity use coprime deterministic cycles, preventing the
- * residual distribution from correlating with either indexed key.
+ * residual distribution from correlating with either indexed key. The default
+ * 100-million-row trial yields 1 million and 10 million indexed candidates for
+ * the two key selectivities; use the JMH {@code rowCount} parameter to rescale it.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)
@@ -72,7 +74,6 @@ import java.util.concurrent.TimeUnit;
 @Fork(0)
 public class CoveringIndexPostFilterBenchmark {
     private static final int WORKERS = Integer.getInteger("covering.postfilter.workers", 8);
-    private static final long ROWS = Long.getLong("covering.postfilter.rows", 5_000_000L);
     private static final String ROOT = System.getProperty("java.io.tmpdir") + java.io.File.separator + "covering-postfilter-bench";
     private static final DefaultCairoConfiguration CONFIGURATION = new DefaultCairoConfiguration(ROOT) {
         @Override
@@ -81,10 +82,14 @@ public class CoveringIndexPostFilterBenchmark {
         }
     };
 
-    private static CairoEngine engine;
     private static SqlCompiler compiler;
     private static SqlExecutionContext context;
+    private static CairoEngine engine;
+    private static long environmentRowCount = -1;
     private static WorkerPool pool;
+
+    @Param({"100000000"})
+    public long rowCount;
 
     @Param({
             "covering-k1-r10", "no_covering-k1-r10", "no_index-k1-r10",
@@ -123,7 +128,7 @@ public class CoveringIndexPostFilterBenchmark {
 
     @Setup(Level.Trial)
     public void setUp() throws Exception {
-        ensureEnvironment();
+        ensureEnvironment(rowCount);
         final String route = scenario.substring(0, scenario.indexOf('-'));
         final String query = query(scenario, route);
         verifyRoute(query, route);
@@ -154,6 +159,7 @@ public class CoveringIndexPostFilterBenchmark {
         }
         engine = Misc.free(engine);
         context = null;
+        environmentRowCount = -1;
         LogFactory.haltInstance();
     }
 
@@ -170,9 +176,12 @@ public class CoveringIndexPostFilterBenchmark {
         return checksum;
     }
 
-    private static synchronized void ensureEnvironment() throws Exception {
+    private static synchronized void ensureEnvironment(long rowCount) throws Exception {
         if (engine != null) {
-            return;
+            if (environmentRowCount == rowCount) {
+                return;
+            }
+            closeEnvironment();
         }
         Files.createDirectories(Paths.get(ROOT));
         engine = new CairoEngine(CONFIGURATION);
@@ -197,16 +206,17 @@ public class CoveringIndexPostFilterBenchmark {
                     residual INT
                 ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
                 """, context);
-        final long spacing = Math.max(1, 16L * 86_400_000_000L / ROWS);
+        final long spacing = Math.max(1, 16L * 86_400_000_000L / rowCount);
         engine.execute(
                 "INSERT INTO post_filter SELECT " +
                         "('2024-01-01'::timestamp + (x - 1) * " + spacing + "L)::timestamp, " +
                         "(CASE WHEN x % 1000 < 10 THEN 'k1' WHEN x % 1000 < 110 THEN 'k10' ELSE 'noise' || (x % 64) END)::symbol, " +
                         "(x % 10_007)::double, (x % 997)::int " +
-                        "FROM long_sequence(" + ROWS + ')',
+                        "FROM long_sequence(" + rowCount + ')',
                 context
         );
         engine.releaseAllWriters();
+        environmentRowCount = rowCount;
         pool = new WorkerPool(new WorkerPoolConfiguration() {
             @Override
             public String getPoolName() {

--- a/benchmarks/src/main/java/org/questdb/CoveringIndexPostFilterBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/CoveringIndexPostFilterBenchmark.java
@@ -323,9 +323,10 @@ public class CoveringIndexPostFilterBenchmark {
         final boolean isValid = switch (route) {
             case "covering" -> text.contains("CoveringIndex")
                     && (EXPECT_JIT
-                        ? text.contains("Async JIT Filter")
-                        : text.contains("Async Filter") && !text.contains("Async JIT Filter"));
-            case "covering_count", "covering_eager" -> text.contains("Async JIT Filter") && text.contains("CoveringIndex");
+                    ? text.contains("Async JIT Filter")
+                    : text.contains("Async Filter") && !text.contains("Async JIT Filter"));
+            case "covering_count", "covering_eager" ->
+                    text.contains("Async JIT Filter") && text.contains("CoveringIndex");
             case "covering_java_eager" -> text.contains("Async Filter")
                     && !text.contains("Async JIT Filter")
                     && text.contains("CoveringIndex");

--- a/benchmarks/src/main/java/org/questdb/HighPassFilterSelectionBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/HighPassFilterSelectionBenchmark.java
@@ -1,0 +1,189 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.questdb;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Measures only the selection-vector production and consumption cost for a
+ * high-pass page-frame filter. It establishes the ceiling for replacing the
+ * current accepted-row list with rejected rows, a rejection bitmap, or runs;
+ * it does not include predicate evaluation or covered-column decoding.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@Fork(1)
+public class HighPassFilterSelectionBenchmark {
+
+    @Param({"uniform", "clustered"})
+    public String distribution;
+
+    @Param({"90", "95", "99", "99.9", "100"})
+    public double passPercent;
+
+    @Param({"100000"})
+    public int rowCount;
+
+    private boolean[] accepted;
+    private long[] bitmap;
+    private long[] excludeRows;
+    private long[] includeRows;
+    private long[] runs;
+
+    @Benchmark
+    public long acceptedRuns() {
+        int runCount = 0;
+        int row = 0;
+        while (row < rowCount) {
+            while (row < rowCount && !accepted[row]) {
+                row++;
+            }
+            final int lo = row;
+            while (row < rowCount && accepted[row]) {
+                row++;
+            }
+            if (lo < row) {
+                runs[2 * runCount] = lo;
+                runs[2 * runCount + 1] = row;
+                runCount++;
+            }
+        }
+
+        long checksum = 0;
+        for (int i = 0; i < runCount; i++) {
+            for (long r = runs[2 * i], hi = runs[2 * i + 1]; r < hi; r++) {
+                checksum = checksum * 31 + r;
+            }
+        }
+        return checksum;
+    }
+
+    @Benchmark
+    public long excludeList() {
+        int rejectedCount = 0;
+        for (int row = 0; row < rowCount; row++) {
+            if (!accepted[row]) {
+                excludeRows[rejectedCount++] = row;
+            }
+        }
+
+        long checksum = 0;
+        int rejectedIndex = 0;
+        long nextRejected = rejectedCount > 0 ? excludeRows[0] : Long.MAX_VALUE;
+        for (int row = 0; row < rowCount; row++) {
+            if (row == nextRejected) {
+                rejectedIndex++;
+                nextRejected = rejectedIndex < rejectedCount ? excludeRows[rejectedIndex] : Long.MAX_VALUE;
+            } else {
+                checksum = checksum * 31 + row;
+            }
+        }
+        return checksum;
+    }
+
+    @Benchmark
+    public long includeList() {
+        int acceptedCount = 0;
+        for (int row = 0; row < rowCount; row++) {
+            if (accepted[row]) {
+                includeRows[acceptedCount++] = row;
+            }
+        }
+
+        long checksum = 0;
+        for (int i = 0; i < acceptedCount; i++) {
+            checksum = checksum * 31 + includeRows[i];
+        }
+        return checksum;
+    }
+
+    @Benchmark
+    public long rejectionBitmap() {
+        Arrays.fill(bitmap, 0);
+        for (int row = 0; row < rowCount; row++) {
+            if (!accepted[row]) {
+                bitmap[row >>> 6] |= 1L << (row & 63);
+            }
+        }
+
+        long checksum = 0;
+        for (int wordIndex = 0, n = bitmap.length; wordIndex < n; wordIndex++) {
+            long acceptedBits = ~bitmap[wordIndex];
+            if (wordIndex == n - 1 && (rowCount & 63) != 0) {
+                acceptedBits &= (1L << (rowCount & 63)) - 1;
+            }
+            while (acceptedBits != 0) {
+                final int bit = Long.numberOfTrailingZeros(acceptedBits);
+                checksum = checksum * 31 + ((long) wordIndex << 6) + bit;
+                acceptedBits &= acceptedBits - 1;
+            }
+        }
+        return checksum;
+    }
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        accepted = new boolean[rowCount];
+        Arrays.fill(accepted, true);
+        bitmap = new long[(rowCount + 63) >>> 6];
+        excludeRows = new long[rowCount];
+        includeRows = new long[rowCount];
+        runs = new long[2 * rowCount];
+
+        final int rejectedCount = (int) Math.round(rowCount * (100.0 - passPercent) / 100.0);
+        if ("clustered".equals(distribution)) {
+            final int lo = (rowCount - rejectedCount) / 2;
+            Arrays.fill(accepted, lo, lo + rejectedCount, false);
+        } else {
+            for (int i = 0; i < rejectedCount; i++) {
+                accepted[(int) ((long) i * rowCount / rejectedCount)] = false;
+            }
+        }
+
+        final long expectedChecksum = includeList();
+        if (excludeList() != expectedChecksum
+                || rejectionBitmap() != expectedChecksum
+                || acceptedRuns() != expectedChecksum) {
+            throw new IllegalStateException("selection representations returned different rows");
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/cairo/sql/CoveredColumnDecoder.java
+++ b/core/src/main/java/io/questdb/cairo/sql/CoveredColumnDecoder.java
@@ -92,9 +92,23 @@ public final class CoveredColumnDecoder {
             int[] columnTypeTags,
             int[] columnTypes
     ) {
+        writeCoveredRow(addrs, varData, count, crc, queryColCount, coveredIncludeIdx, columnTypeTags, columnTypes, null);
+    }
+
+    public static void writeCoveredRow(
+            long[] addrs,
+            VarDataSink varData,
+            int count,
+            CoveringRowCursor crc,
+            int queryColCount,
+            int[] coveredIncludeIdx,
+            int[] columnTypeTags,
+            int[] columnTypes,
+            @Nullable boolean[] selectedColumns
+    ) {
         for (int q = 0; q < queryColCount; q++) {
             final int includeIdx = coveredIncludeIdx[q];
-            if (includeIdx < 0) {
+            if (includeIdx < 0 || selectedColumns != null && !selectedColumns[q]) {
                 continue;
             }
             final long addr = addrs[q];

--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameAddressCache.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameAddressCache.java
@@ -403,6 +403,10 @@ public class PageFrameAddressCache implements QuietCloseable, Mutable {
         return coveredColumns.getQuick(frameIndex) != null;
     }
 
+    public boolean isFrameSingleKeyCovered(int frameIndex) {
+        return isFrameCovered(frameIndex) && coveredKeys.getQuick(frameIndex) != SymbolTable.VALUE_NOT_FOUND;
+    }
+
     /**
      * Freeze every per-partition posting reader backing a covered frame, so that
      * {@link IndexReader#reloadConditionally()} becomes a no-op and the value /

--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryPool.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryPool.java
@@ -137,6 +137,9 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
     // eager production path, which allocates fresh per-frame buffers and frees
     // them at cursor close. The pool is per reduce slot, owned by one worker.
     private final IntObjHashMap<CoveringBuffers> coveringByFrame = new IntObjHashMap<>();
+    // Each selected include count gets one scratch array. The pool is thread-unsafe,
+    // so detached covered-cursor decodes can reuse these arrays without per-frame GC.
+    private final ObjList<int[]> coveringIncludeIndexScratch = new ObjList<>();
     // Bumped whenever the pool closes buffers that bound records may still alias
     // (failed decode, bulk release). Records capture it on bind; a mismatch fails
     // the navigateTo() fast path and forces a safe rebind.
@@ -550,7 +553,7 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
         // and they never issue windowed decodes, so a matching frame index implies
         // a full-frame decode. A pool mixing this overload with the windowed one
         // must go through the coverage check instead.
-        if (frameMemory.frameIndex == frameIndex) {
+        if (frameMemory.frameIndex == frameIndex && isFrameMemoryCoveringColumns(frameIndex, columnIndexes)) {
             return frameMemory;
         }
 
@@ -563,11 +566,9 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
             frameMemory.auxPageSizes = addressCache.getAuxPageSizes();
             frameMemory.columnOffset = addressCache.toColumnOffset(frameIndex);
             frameMemory.currentRowGroupBuffer = null;
-            // Covered frame: decode covered columns on this worker and rebind. See
-            // the matching arm in navigateTo(int, int, int). The columnIndexes hint
-            // is irrelevant to a covered frame -- its whole row is sidecar-decoded.
+            // Covered frame: decode only the requested columns on the first filter pass.
             try {
-                patchCoveredFrameMemory(frameIndex);
+                patchCoveredFrameMemory(frameIndex, columnIndexes);
             } catch (Throwable th) {
                 // Mirror the PARQUET arm: drop frameMemory's stale binding on failure.
                 frameMemory.clear();
@@ -636,7 +637,11 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
      * production -- see {@code fillMergedFrame}).
      */
     private void patchCoveredFrameMemory(int frameIndex) {
-        final CoveringBuffers buffers = decodeCoveredFrame(frameIndex);
+        patchCoveredFrameMemory(frameIndex, null);
+    }
+
+    private void patchCoveredFrameMemory(int frameIndex, @Nullable IntHashSet columnIndexes) {
+        final CoveringBuffers buffers = decodeCoveredFrame(frameIndex, columnIndexes);
         if (buffers == null) {
             // Non-covered or multi-key frame: keep the eager flat addresses the
             // NATIVE arm bound.
@@ -679,12 +684,12 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
         // record arm; a bulk release (releaseParquetBuffers) bumps bindGeneration so
         // a stale covered binding rebinds instead of reading recycled buffers.
         if (record.getFrameIndex() == frameIndex && record.getBoundPool() == this && record.getBoundGeneration() == bindGeneration) {
-            // Only covered frames stamp boundPool == this; a non-covered native
-            // record leaves boundPool null, so reaching here proves this frame is
-            // the covered one the record is bound to.
-            return true;
+            final CoveringBuffers buffers = coveringByFrame.valueAt(coveringByFrame.keyIndex(frameIndex));
+            if (buffers != null && buffers.isFullyDecoded()) {
+                return true;
+            }
         }
-        final CoveringBuffers buffers = decodeCoveredFrame(frameIndex);
+        final CoveringBuffers buffers = decodeCoveredFrame(frameIndex, null);
         if (buffers == null) {
             return false;
         }
@@ -717,6 +722,11 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
      */
     @Nullable
     private CoveringBuffers decodeCoveredFrame(int frameIndex) {
+        return decodeCoveredFrame(frameIndex, null);
+    }
+
+    @Nullable
+    private CoveringBuffers decodeCoveredFrame(int frameIndex, @Nullable IntHashSet columnIndexes) {
         if (!addressCache.isFrameCovered(frameIndex)) {
             return null;
         }
@@ -750,7 +760,7 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
         // Idempotent: decode() is a no-op once this frame has been decoded, so a
         // repeat navigate to the same frame reuses the live buffers (and keeps any
         // pointers stable aggregates stored into them).
-        buffers.decode(frameIndex, reader, key, rowLo, rowHi, includeIndices, rowCount);
+        buffers.decode(frameIndex, reader, key, rowLo, rowHi, includeIndices, rowCount, columnIndexes);
         return buffers;
     }
 
@@ -1216,6 +1226,10 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
     // (currentRowGroupBuffer == null) never covers a non-empty request.
     private boolean isFrameMemoryCovering(int frameIndex, int inFrameRowLo, int inFrameRowHi) {
         if (frameMemory.frameFormat == PartitionFormat.NATIVE) {
+            if (addressCache.isFrameSingleKeyCovered(frameIndex)) {
+                final CoveringBuffers buffers = coveringByFrame.valueAt(coveringByFrame.keyIndex(frameIndex));
+                return buffers != null && buffers.isFullyDecoded();
+            }
             return true;
         }
         final ParquetBuffers buffers = frameMemory.currentRowGroupBuffer;
@@ -1227,6 +1241,14 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
         final int decodeLo = (int) Math.min(rowGroupHi, rowGroupLo + (long) inFrameRowLo);
         final int decodeHi = (int) Math.min(rowGroupHi, rowGroupLo + (long) inFrameRowHi);
         return buffers.decodedRowLo <= decodeLo && buffers.decodedRowHi >= decodeHi;
+    }
+
+    private boolean isFrameMemoryCoveringColumns(int frameIndex, IntHashSet columnIndexes) {
+        if (!addressCache.isFrameSingleKeyCovered(frameIndex)) {
+            return true;
+        }
+        final CoveringBuffers buffers = coveringByFrame.valueAt(coveringByFrame.keyIndex(frameIndex));
+        return buffers != null && buffers.hasFullColumns(columnIndexes);
     }
 
     private boolean isRowFilterEligible(int frameIndex, long declaredRowCount) {
@@ -1614,6 +1636,11 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
 
         @Override
         public boolean hasColumnTops() {
+            if (addressCache.isFrameSingleKeyCovered(frameIndex)) {
+                // Zero addresses can mean intentionally deferred columns on a covered
+                // filter-first frame, not table column tops.
+                return false;
+            }
             for (int i = 0, n = addressCache.getColumnCount(); i < n; i++) {
                 // VARCHAR column that contains short strings will have zero data vector,
                 // so for such columns we also need to check that the aux (index) vector is zero.
@@ -1631,6 +1658,15 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
 
         @Override
         public boolean populateRemainingColumns(IntHashSet filterColumnIndexes, DirectLongList filteredRows, boolean fillWithNulls) {
+            if (addressCache.isFrameSingleKeyCovered(frameIndex)) {
+                // Raw async filters use full frame coordinates. Compact-layout async
+                // aggregate/join consumers remain outside the covering MVP.
+                if (!fillWithNulls || filteredRows.size() == 0) {
+                    return false;
+                }
+                final CoveringBuffers buffers = coveringByFrame.valueAt(coveringByFrame.keyIndex(frameIndex));
+                return buffers != null && buffers.populateRemainingColumns(filterColumnIndexes, filteredRows);
+            }
             assert frameFormat == PartitionFormat.PARQUET;
             if (filterColumnIndexes.size() == addressCache.getColumnCount()) {
                 return false;
@@ -1709,7 +1745,11 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
         // or the synthesized symbol key). False for a non-covered column introduced by a
         // null-pad / projection wrapper over the covered frame — published as a NULL column.
         private boolean[] coveredColumn;
+        private boolean[] isColumnDecoded;
+        private boolean[] isColumnFull;
+        private boolean[] isColumnSelected;
         private int frameIndex = -1;
+        private int rowCount;
         // Synthesized symbol-key column (broadcast int), shared by every DIRECT
         // (indexed key) column of the covered frame. 0 when unallocated.
         private long symAddr;
@@ -1758,58 +1798,171 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
         }
 
         /**
-         * Decode the covered columns of {@code frameIndex} (resolved single key
-         * {@code key} over base range {@code [rowLo, rowHi)}) into native buffers
-         * and publish their addresses. Idempotent per frame: a repeat call for the
-         * already-decoded frame is a no-op. Returns after the detached cursor has
-         * been fully drained and closed.
+         * Decodes either all covered columns or the requested filter columns. The
+         * first pass keeps original frame ordinals so JIT and Java filters share
+         * the same row-coordinate contract.
          */
-        void decode(int frameIndex, IndexReader reader, int key, long rowLo, long rowHi, int[] includeIndices, int rowCount) {
-            if (this.frameIndex == frameIndex) {
+        void decode(
+                int frameIndex,
+                IndexReader reader,
+                int key,
+                long rowLo,
+                long rowHi,
+                int[] includeIndices,
+                int rowCount,
+                @Nullable IntHashSet columnIndexes
+        ) {
+            prepareSelectedColumns(frameIndex, rowCount, columnIndexes, false);
+            if (!hasSelectedColumns()) {
+                publishAddresses(rowCount);
                 return;
             }
-            ensureColumnBuffers(frameIndex, rowCount);
-            // Open a detached cursor this worker owns; drain it fully, then close
-            // it so it never outlives the decode. rowHi is exclusive at the frame
-            // API; the index cursor's maxValue is inclusive, hence rowHi - 1.
-            final RowCursor rowCursor = reader.getDetachedCursor(TableUtils.toIndexKey(key), rowLo, rowHi - 1, includeIndices);
+            decodeSelectedColumns(reader, key, rowLo, rowHi, includeIndices, null);
+            for (int q = 0, n = queryColCount(); q < n; q++) {
+                if (isColumnSelected[q]) {
+                    isColumnDecoded[q] = true;
+                    isColumnFull[q] = true;
+                }
+            }
+            publishAddresses(rowCount);
+            this.frameIndex = frameIndex;
+        }
+
+        private void decodeSelectedColumns(
+                IndexReader reader,
+                int key,
+                long rowLo,
+                long rowHi,
+                int[] includeIndices,
+                @Nullable DirectLongList filteredRows
+        ) {
+            final int[] selectedIncludeIndices = selectIncludeIndices(includeIndices);
+            final RowCursor rowCursor = reader.getDetachedCursor(
+                    TableUtils.toIndexKey(key),
+                    rowLo,
+                    rowHi - 1,
+                    selectedIncludeIndices
+            );
             try {
                 int count = 0;
+                long filteredPosition = 0;
+                final long filteredCount = filteredRows != null ? filteredRows.size() : 0;
                 if (rowCursor instanceof CoveringRowCursor crc) {
                     while (crc.hasNext()) {
                         crc.next();
-                        // The frame's declared size caps the cursor; the buffers are
-                        // sized for exactly rowCount rows. Defensive guard only.
-                        assert count < rowCount : "covered cursor yielded more rows than the frame's declared size";
                         if (count >= rowCount) {
                             break;
                         }
-                        CoveredColumnDecoder.writeCoveredRow(
-                                colAddr, this, count, crc, queryColCount(), coveredIncludeIdx, columnTypeTags, columnTypes);
+                        final boolean isSelectedRow = filteredRows == null
+                                || filteredPosition < filteredCount && filteredRows.get(filteredPosition) == count;
+                        if (isSelectedRow) {
+                            CoveredColumnDecoder.writeCoveredRow(
+                                    colAddr,
+                                    this,
+                                    count,
+                                    crc,
+                                    queryColCount(),
+                                    coveredIncludeIdx,
+                                    columnTypeTags,
+                                    columnTypes,
+                                    isColumnSelected
+                            );
+                            filteredPosition++;
+                        } else if (filteredRows != null) {
+                            writeSkippedVarOffsets(count);
+                        }
                         count++;
                     }
                 }
-                // The detached re-scan must reproduce production's chunk row-for-row:
-                // downstream aggregation reads exactly getFrameSize() (== rowCount) values
-                // from these buffers regardless of how many the cursor yielded, so an
-                // under-fill would read the uninitialized buffer tail. The loop above caps
-                // over-fill, so count <= rowCount here; a short count is an invariant break
-                // (frozen-reader or reseal corruption). Fail loud as a hard error — NOT just
-                // an -ea assert — so a release build rejects the query instead of silently
-                // aggregating uninitialized memory.
                 if (count != rowCount) {
                     throw CairoException.critical(0)
                             .put("covered re-decode row count mismatch: decoded ").put(count)
                             .put(" of ").put(rowCount).put(" [frameIndex=").put(frameIndex).put(']');
                 }
-                // Single resolved key per covered frame: broadcast it across the
-                // synthesized symbol column.
-                CoveredColumnDecoder.fillSymbolKey(symAddr, key, count);
-                publishAddresses(count);
-                this.frameIndex = frameIndex;
+                for (int q = 0, n = queryColCount(); q < n; q++) {
+                    if (isColumnSelected[q] && coveredIncludeIdx[q] < 0) {
+                        CoveredColumnDecoder.fillSymbolKey(symAddr, key, rowCount);
+                        break;
+                    }
+                }
             } finally {
                 Misc.free(rowCursor);
             }
+        }
+
+        private boolean hasFullColumns(IntHashSet columnIndexes) {
+            if (isColumnFull == null) {
+                return false;
+            }
+            for (int q = 0, n = queryColCount(); q < n; q++) {
+                if (columnIndexes.contains(q) && coveredColumn[q] && !isColumnFull[q]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private boolean hasSelectedColumns() {
+            for (int q = 0, n = queryColCount(); q < n; q++) {
+                if (isColumnSelected[q]) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean isFullyDecoded() {
+            if (isColumnFull == null) {
+                return false;
+            }
+            for (int q = 0, n = queryColCount(); q < n; q++) {
+                if (coveredColumn[q] && !isColumnFull[q]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private void prepareSelectedColumns(
+                int frameIndex,
+                int rowCount,
+                @Nullable IntHashSet columnIndexes,
+                boolean isExcludedSet
+        ) {
+            ensureColumnMetadata(frameIndex, rowCount);
+            for (int q = 0, n = queryColCount(); q < n; q++) {
+                final boolean isRequested = columnIndexes == null
+                        || isExcludedSet != columnIndexes.contains(q);
+                isColumnSelected[q] = coveredColumn[q] && isRequested && !isColumnFull[q];
+                if (isColumnSelected[q]) {
+                    isColumnDecoded[q] = false;
+                    varDataPos[q] = 0;
+                    ensureColumnCapacity(q, rowCount);
+                }
+            }
+        }
+
+        private boolean populateRemainingColumns(IntHashSet skipColumnIndexes, DirectLongList filteredRows) {
+            prepareSelectedColumns(frameIndex, rowCount, skipColumnIndexes, true);
+            if (!hasSelectedColumns()) {
+                return false;
+            }
+            decodeSelectedColumns(
+                    addressCache.getCoveredIndexReader(frameIndex),
+                    addressCache.getCoveredKey(frameIndex),
+                    addressCache.getCoveredRowLo(frameIndex),
+                    addressCache.getCoveredRowHi(frameIndex),
+                    addressCache.getCoveredIncludeIndices(frameIndex),
+                    filteredRows
+            );
+            for (int q = 0, n = queryColCount(); q < n; q++) {
+                if (isColumnSelected[q]) {
+                    isColumnDecoded[q] = true;
+                    isColumnFull[q] = coveredIncludeIdx[q] < 0;
+                }
+            }
+            publishAddresses(rowCount);
+            return true;
         }
 
         @Override
@@ -1862,13 +2015,50 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
             return varDataPos[q];
         }
 
-        // Allocate / grow the per-column native buffers to hold rowCount rows, and
-        // (re)resolve the per-column type / include metadata from the address cache.
-        // colAddr[q] is the fixed-width data vector (rowCount * sizeOf) or the
-        // var-size aux vector; var-size columns additionally get an initial data
-        // vector grown on demand via ensureCapacity. STRING/BINARY aux carries a
-        // trailing sentinel offset, so it is sized rowCount + 1.
-        private void ensureColumnBuffers(int frameIndex, int rowCount) {
+        private void ensureColumnCapacity(int q, int rowCount) {
+            if (coveredIncludeIdx[q] < 0) {
+                final long symBytes = (long) rowCount * Integer.BYTES;
+                if (symBytes > Integer.MAX_VALUE) {
+                    throw CairoException.critical(0).put("covered frame too large for int symCap [rows=").put(rowCount).put(']');
+                }
+                if (symCap < symBytes) {
+                    symAddr = growNative(symAddr, symCap, symBytes);
+                    symCap = (int) symBytes;
+                }
+                return;
+            }
+
+            final long auxBytes;
+            final int initDataCap;
+            switch (columnTypeTags[q]) {
+                case ColumnType.VARCHAR -> {
+                    auxBytes = (long) rowCount * VarcharTypeDriver.VARCHAR_AUX_WIDTH_BYTES;
+                    initDataCap = rowCount * 32;
+                }
+                case ColumnType.STRING, ColumnType.BINARY -> {
+                    auxBytes = (long) (rowCount + 1) * Long.BYTES;
+                    initDataCap = rowCount * 32;
+                }
+                case ColumnType.ARRAY -> {
+                    auxBytes = (long) rowCount * ArrayTypeDriver.ARRAY_AUX_WIDTH_BYTES;
+                    initDataCap = rowCount * 32;
+                }
+                default -> {
+                    auxBytes = (long) rowCount * columnSizeBytes[q];
+                    initDataCap = 0;
+                }
+            }
+            if (colCap[q] < auxBytes) {
+                colAddr[q] = growNative(colAddr[q], colCap[q], auxBytes);
+                colCap[q] = auxBytes;
+            }
+            if (initDataCap > 0 && varDataCap[q] < initDataCap) {
+                varDataAddr[q] = growNative(varDataAddr[q], varDataCap[q], initDataCap);
+                varDataCap[q] = initDataCap;
+            }
+        }
+
+        private void ensureColumnMetadata(int frameIndex, int rowCount) {
             final int queryColCount = queryColCount();
             if (colAddr == null) {
                 colAddr = new long[queryColCount];
@@ -1881,81 +2071,24 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
                 columnSizeBytes = new int[queryColCount];
                 coveredIncludeIdx = new int[queryColCount];
                 coveredColumn = new boolean[queryColCount];
+                isColumnDecoded = new boolean[queryColCount];
+                isColumnFull = new boolean[queryColCount];
+                isColumnSelected = new boolean[queryColCount];
                 final IntList types = addressCache.getColumnTypes();
                 for (int q = 0; q < queryColCount; q++) {
                     final int type = types.getQuick(q);
                     columnTypes[q] = type;
                     columnTypeTags[q] = ColumnType.tagOf(type);
                     columnSizeBytes[q] = ColumnType.sizeOf(type);
+                    coveredIncludeIdx[q] = addressCache.getCoveredIncludeIndex(frameIndex, q);
+                    coveredColumn[q] = addressCache.isColumnCovered(frameIndex, q);
                 }
             }
-            // The covered include mapping is query-constant across a query's covered
-            // frames, but resolve it per decode so the slot stays correct even if a
-            // pool is reused across address caches.
-            for (int q = 0; q < queryColCount; q++) {
-                coveredIncludeIdx[q] = addressCache.getCoveredIncludeIndex(frameIndex, q);
-                coveredColumn[q] = addressCache.isColumnCovered(frameIndex, q);
-            }
-            // Guard against a theoretical int overflow in initDataCap = rowCount * 32
-            // (var-size initial data cap). In practice a covered frame is bounded by
-            // the table's page-frame row cap (order of thousands). Throw (not assert) so
-            // a pathological rowCount fails loud even with -ea off, matching the >2GB
-            // var-data guards below rather than silently truncating the int cap.
             if ((long) rowCount * 32 > Integer.MAX_VALUE) {
                 throw CairoException.critical(0).put("covered frame too large for int varDataCap init [rows=").put(rowCount).put(']');
             }
-            for (int q = 0; q < queryColCount; q++) {
-                varDataPos[q] = 0;
-                if (!coveredColumn[q] || coveredIncludeIdx[q] < 0) {
-                    // Non-covered column (published as NULL) or the symbol key column
-                    // (broadcast via symAddr) — neither needs a per-column decode buffer.
-                    continue;
-                }
-                final long auxBytes;
-                final int initDataCap;
-                switch (columnTypeTags[q]) {
-                    case ColumnType.VARCHAR -> {
-                        auxBytes = (long) rowCount * VarcharTypeDriver.VARCHAR_AUX_WIDTH_BYTES;
-                        initDataCap = rowCount * 32;
-                    }
-                    case ColumnType.STRING, ColumnType.BINARY -> {
-                        auxBytes = (long) (rowCount + 1) * Long.BYTES;
-                        initDataCap = rowCount * 32;
-                    }
-                    case ColumnType.ARRAY -> {
-                        auxBytes = (long) rowCount * ArrayTypeDriver.ARRAY_AUX_WIDTH_BYTES;
-                        initDataCap = rowCount * 32;
-                    }
-                    default -> {
-                        auxBytes = (long) rowCount * columnSizeBytes[q];
-                        initDataCap = 0;
-                    }
-                }
-                if (colCap[q] < auxBytes) {
-                    colAddr[q] = growNative(colAddr[q], colCap[q], auxBytes);
-                    colCap[q] = auxBytes;
-                }
-                if (initDataCap > 0 && varDataCap[q] < initDataCap) {
-                    varDataAddr[q] = growNative(varDataAddr[q], varDataCap[q], initDataCap);
-                    varDataCap[q] = initDataCap;
-                }
-            }
-            final long symBytes = (long) rowCount * Integer.BYTES;
-            if (symCap < symBytes) {
-                // Only ever grow: symCap must stay the true allocation size so the
-                // matching Unsafe.free() in freeColumnBuffers() accounts the right
-                // number of bytes (a smaller frame must not shrink it).
-                // Guard the int symCap cast below: symBytes = rowCount * 4 cannot
-                // exceed int range for any page-frame-bounded rowCount, but never
-                // say never — throw (not assert) so a pathological rowCount fails loud
-                // even with -ea off rather than letting the cast truncate symCap and
-                // under-account the matching Unsafe.free().
-                if (symBytes > Integer.MAX_VALUE) {
-                    throw CairoException.critical(0).put("covered frame too large for int symCap [rows=").put(rowCount).put(']');
-                }
-                symAddr = growNative(symAddr, symCap, symBytes);
-                symCap = (int) symBytes;
-            }
+            this.frameIndex = frameIndex;
+            this.rowCount = rowCount;
         }
 
         private void freeColumnBuffers() {
@@ -2011,6 +2144,45 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
             return result;
         }
 
+        private int[] selectIncludeIndices(int[] includeIndices) {
+            int selectedCount = 0;
+            for (int includeIndex : includeIndices) {
+                for (int q = 0, n = queryColCount(); q < n; q++) {
+                    if (isColumnSelected[q] && coveredIncludeIdx[q] == includeIndex) {
+                        selectedCount++;
+                        break;
+                    }
+                }
+            }
+            if (selectedCount == includeIndices.length) {
+                return includeIndices;
+            }
+            int[] selectedIncludeIndices = coveringIncludeIndexScratch.getQuiet(selectedCount);
+            if (selectedIncludeIndices == null) {
+                selectedIncludeIndices = new int[selectedCount];
+                coveringIncludeIndexScratch.extendAndSet(selectedCount, selectedIncludeIndices);
+            }
+            int selectedIndex = 0;
+            for (int includeIndex : includeIndices) {
+                for (int q = 0, n = queryColCount(); q < n; q++) {
+                    if (isColumnSelected[q] && coveredIncludeIdx[q] == includeIndex) {
+                        selectedIncludeIndices[selectedIndex++] = includeIndex;
+                        break;
+                    }
+                }
+            }
+            return selectedIncludeIndices;
+        }
+
+        private void writeSkippedVarOffsets(int row) {
+            for (int q = 0, n = queryColCount(); q < n; q++) {
+                if (isColumnSelected[q]
+                        && (columnTypeTags[q] == ColumnType.STRING || columnTypeTags[q] == ColumnType.BINARY)) {
+                    Unsafe.putLong(colAddr[q] + (long) row * Long.BYTES, varDataPos[q]);
+                }
+            }
+        }
+
         // Fan the decoded native buffers out to the four published per-column
         // address/size lists, exactly mirroring CoveringPageFrameCursor#finalizeFrame
         // so a downstream native reader sees the same layout the eager production
@@ -2025,14 +2197,9 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
             ensureListCapacity(auxPageSizes, queryColCount);
             for (int q = 0; q < queryColCount; q++) {
                 final int includeIdx = coveredIncludeIdx[q];
-                if (!coveredColumn[q]) {
-                    // Non-covered column in a covered frame (e.g. a null-pad synthetic added by
-                    // a wrapper above the covering frame). The covered-decode arm owns only the
-                    // covered includes and the symbol key; a non-covered column has no decoded
-                    // data, so publish it as a NULL column (address 0) — matching how the address
-                    // cache already stores such a column — rather than mis-binding it to the
-                    // 4-byte symbol-key buffer (which would read the key int and, for a wider
-                    // type, run past it). Today the only such columns are null-pad synthetics.
+                if (!coveredColumn[q] || !isColumnDecoded[q]) {
+                    // Non-covered or not-yet-decoded columns publish NULL addresses. The
+                    // filter-first pass never exposes omitted columns to the filter.
                     pageAddresses.set(q, 0);
                     pageSizes.set(q, 0);
                     auxPageAddresses.set(q, 0);

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceTask.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceTask.java
@@ -232,6 +232,10 @@ public class PageFrameReduceTask implements QuietCloseable, Mutable {
         return frameSequence.getPageFrameAddressCache().getFrameFormat(frameIndex) == PartitionFormat.PARQUET;
     }
 
+    public boolean isSingleKeyCoveredFrame() {
+        return frameSequence.getPageFrameAddressCache().isFrameSingleKeyCovered(frameIndex);
+    }
+
     public void of(PageFrameSequence<?> frameSequence, int frameIndex, boolean countOnly) {
         this.frameSequence = frameSequence;
         final boolean sameQueryExecution = frameSequenceId == frameSequence.getId();
@@ -291,7 +295,7 @@ public class PageFrameReduceTask implements QuietCloseable, Mutable {
 
     public boolean populateRemainingColumns(IntHashSet filterColumnIndexes, DirectLongList filteredRows, boolean fillWithNulls) {
         assert frameMemory != null;
-        if (frameMemory.getFrameFormat() == PartitionFormat.PARQUET) {
+        if (frameMemory.getFrameFormat() == PartitionFormat.PARQUET || isSingleKeyCoveredFrame()) {
             return frameMemory.populateRemainingColumns(filterColumnIndexes, filteredRows, fillWithNulls);
         }
         return false;

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -4325,6 +4325,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             }
         }
 
+        Function limitLoFunction = null;
         try {
             // This path applies only to the read_parquet() table function.
             // For native tables, generateTableQuery0() handles pushdown separately.
@@ -4339,81 +4340,24 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                 IntHashSet filterUsedColumnIndexes = new IntHashSet();
                 collectColumnIndexes(sqlNodeStack, factory.getMetadata(), filterExpr, filterUsedColumnIndexes);
 
-                final boolean useJit = executionContext.getJitMode() != SqlJitMode.JIT_MODE_DISABLED
-                        && (!model.isUpdate() || executionContext.isWalApplication());
-                final boolean canCompile = factory.supportsPageFrameCursor() && JitUtil.isJitSupported();
-                if (useJit && canCompile) {
-                    CompiledFilter compiledFilter = null;
-                    CompiledCountOnlyFilter compiledCountOnlyFilter = null;
-                    try {
-                        int jitOptions;
-                        final ObjList<Function> bindVarFunctions = new ObjList<>();
-                        try (PageFrameCursor cursor = factory.getPageFrameCursor(executionContext, ORDER_ANY)) {
-                            final boolean forceScalar = executionContext.getJitMode() == SqlJitMode.JIT_MODE_FORCE_SCALAR;
-                            jitIRSerializer.of(jitIRMem, executionContext, factory.getMetadata(), cursor, bindVarFunctions);
-                            jitOptions = jitIRSerializer.serialize(filterExpr, forceScalar, enableJitDebug, enableJitNullChecks);
-                        }
-
-                        compiledFilter = new CompiledFilter();
-                        compiledFilter.compile(jitIRMem, jitOptions);
-
-                        compiledCountOnlyFilter = new CompiledCountOnlyFilter();
-                        compiledCountOnlyFilter.compile(jitIRMem, jitOptions);
-
-                        final Function limitLoFunction = getLimitLoFunctionOnly(model, executionContext);
-                        final int limitLoPos = model.getLimitAdviceLo() != null ? model.getLimitAdviceLo().position : 0;
-
-                        LOG.debug()
-                                .$("JIT enabled for (sub)query [tableName=").$safe(model.getName())
-                                .$(", fd=").$(executionContext.getRequestFd())
-                                .I$();
-                        return new AsyncJitFilteredRecordCursorFactory(
-                                executionContext.getCairoEngine(),
-                                configuration,
-                                executionContext.getMessageBus(),
-                                factory,
-                                bindVarFunctions,
-                                compiledFilter,
-                                compiledCountOnlyFilter,
-                                filter,
-                                filterUsedColumnIndexes,
-                                reduceTaskFactory,
-                                compileWorkerFiltersConditionally(
-                                        executionContext,
-                                        filter,
-                                        executionContext.getSharedQueryWorkerCount(),
-                                        filterExpr,
-                                        factory.getMetadata()
-                                ),
-                                deepClone(expressionNodePool, filterExpr),
-                                limitLoFunction,
-                                limitLoPos,
-                                executionContext.getSharedQueryWorkerCount(),
-                                enablePreTouch
-                        );
-                    } catch (SqlException | LimitOverflowException ex) {
-                        // for these errors we are intentionally **not** rethrowing the exception
-                        // if a JIT filter cannot be used, we will simply use a Java filter
-                        Misc.free(compiledFilter);
-                        Misc.free(compiledCountOnlyFilter);
-                        LOG.debug()
-                                .$("JIT cannot be applied to (sub)query [tableName=").$safe(model.getName())
-                                .$(", ex=").$safe(ex.getFlyweightMessage())
-                                .$(", fd=").$(executionContext.getRequestFd()).I$();
-                    } catch (Throwable t) {
-                        // other errors are fatal -> rethrow them
-                        Misc.free(compiledFilter);
-                        Misc.free(compiledCountOnlyFilter);
-                        throw t;
-                    } finally {
-                        jitIRSerializer.clear();
-                        jitIRMem.truncate();
-                    }
+                limitLoFunction = getLimitLoFunctionOnly(model, executionContext);
+                final int limitLoPos = model.getLimitAdviceLo() != null ? model.getLimitAdviceLo().position : 0;
+                final RecordCursorFactory jitFactory = generateJitFilter(
+                        factory,
+                        filter,
+                        filterExpr,
+                        filterUsedColumnIndexes,
+                        limitLoFunction,
+                        limitLoPos,
+                        model,
+                        executionContext,
+                        enablePreTouch
+                );
+                if (jitFactory != null) {
+                    return jitFactory;
                 }
 
                 // Use Java filter.
-                final Function limitLoFunction = getLimitLoFunctionOnly(model, executionContext);
-                final int limitLoPos = model.getLimitAdviceLo() != null ? model.getLimitAdviceLo().position : 0;
                 return new AsyncFilteredRecordCursorFactory(
                         executionContext.getCairoEngine(),
                         configuration,
@@ -4438,6 +4382,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             }
             return new FilteredRecordCursorFactory(factory, filter);
         } catch (Throwable e) {
+            Misc.free(limitLoFunction);
             Misc.free(filter);
             Misc.free(factory);
             throw e;
@@ -5057,6 +5002,92 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             return generateSetFactory(model.getUnionModel(), unionAllFactory, executionContext);
         }
         return unionAllFactory;
+    }
+
+    @Nullable
+    private RecordCursorFactory generateJitFilter(
+            RecordCursorFactory factory,
+            Function filter,
+            ExpressionNode filterExpr,
+            IntHashSet filterUsedColumnIndexes,
+            @Nullable Function limitLoFunction,
+            int limitLoPos,
+            IQueryModel model,
+            SqlExecutionContext executionContext,
+            boolean isPreTouchEnabled
+    ) throws SqlException {
+        final boolean isJitEnabled = executionContext.getJitMode() != SqlJitMode.JIT_MODE_DISABLED
+                && (!model.isUpdate() || executionContext.isWalApplication());
+        if (!isJitEnabled || !factory.supportsPageFrameCursor() || !JitUtil.isJitSupported()) {
+            return null;
+        }
+
+        ObjList<Function> bindVarFunctions = new ObjList<>();
+        CompiledCountOnlyFilter compiledCountOnlyFilter = null;
+        CompiledFilter compiledFilter = null;
+        ObjList<Function> perWorkerFilters = null;
+        try {
+            final int jitOptions;
+            try (PageFrameCursor cursor = factory.getPageFrameCursor(executionContext, ORDER_ANY)) {
+                final boolean forceScalar = executionContext.getJitMode() == SqlJitMode.JIT_MODE_FORCE_SCALAR;
+                jitIRSerializer.of(jitIRMem, executionContext, factory.getMetadata(), cursor, bindVarFunctions);
+                jitOptions = jitIRSerializer.serialize(filterExpr, forceScalar, enableJitDebug, enableJitNullChecks);
+            }
+
+            compiledFilter = new CompiledFilter();
+            compiledFilter.compile(jitIRMem, jitOptions);
+            compiledCountOnlyFilter = new CompiledCountOnlyFilter();
+            compiledCountOnlyFilter.compile(jitIRMem, jitOptions);
+            perWorkerFilters = compileWorkerFiltersConditionally(
+                    executionContext,
+                    filter,
+                    executionContext.getSharedQueryWorkerCount(),
+                    filterExpr,
+                    factory.getMetadata()
+            );
+
+            final AsyncJitFilteredRecordCursorFactory jitFactory = new AsyncJitFilteredRecordCursorFactory(
+                    executionContext.getCairoEngine(),
+                    configuration,
+                    executionContext.getMessageBus(),
+                    factory,
+                    bindVarFunctions,
+                    compiledFilter,
+                    compiledCountOnlyFilter,
+                    filter,
+                    filterUsedColumnIndexes,
+                    reduceTaskFactory,
+                    perWorkerFilters,
+                    deepClone(expressionNodePool, filterExpr),
+                    limitLoFunction,
+                    limitLoPos,
+                    executionContext.getSharedQueryWorkerCount(),
+                    isPreTouchEnabled
+            );
+            bindVarFunctions = null;
+            compiledCountOnlyFilter = null;
+            compiledFilter = null;
+            perWorkerFilters = null;
+            LOG.debug()
+                    .$("JIT enabled for (sub)query [tableName=").$safe(model.getName())
+                    .$(", fd=").$(executionContext.getRequestFd())
+                    .I$();
+            return jitFactory;
+        } catch (SqlException | LimitOverflowException ex) {
+            // These errors deliberately fall back to the Java async filter.
+            LOG.debug()
+                    .$("JIT cannot be applied to (sub)query [tableName=").$safe(model.getName())
+                    .$(", ex=").$safe(ex.getFlyweightMessage())
+                    .$(", fd=").$(executionContext.getRequestFd()).I$();
+            return null;
+        } finally {
+            Misc.free(compiledCountOnlyFilter);
+            Misc.free(compiledFilter);
+            Misc.freeObjList(bindVarFunctions);
+            Misc.freeObjList(perWorkerFilters);
+            jitIRSerializer.clear();
+            jitIRMem.truncate();
+        }
     }
 
     private RecordCursorFactory generateJoinAsof(
@@ -11997,6 +12028,21 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     }
                     IntHashSet filterUsedColumnIndexes = new IntHashSet();
                     collectColumnIndexes(sqlNodeStack, queryMeta, filterExpr, filterUsedColumnIndexes);
+                    final boolean isPreTouchEnabled = SqlHints.hasEnablePreTouchHint(model, model.getName());
+                    final RecordCursorFactory jitFactory = generateJitFilter(
+                            coveringFactory,
+                            filter,
+                            filterExpr,
+                            filterUsedColumnIndexes,
+                            asyncLimitLoFunction,
+                            limitLoPos,
+                            model,
+                            executionContext,
+                            isPreTouchEnabled
+                    );
+                    if (jitFactory != null) {
+                        return jitFactory;
+                    }
                     return new AsyncFilteredRecordCursorFactory(
                             executionContext.getCairoEngine(),
                             configuration,
@@ -12016,7 +12062,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                             asyncLimitLoFunction,
                             limitLoPos,
                             executionContext.getSharedQueryWorkerCount(),
-                            SqlHints.hasEnablePreTouchHint(model, model.getName())
+                            isPreTouchEnabled
                     );
                 }
                 // Serial fallback owns no limit function; drop the one we created so

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilterAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilterAtom.java
@@ -53,6 +53,9 @@ import java.util.concurrent.atomic.LongAdder;
 
 public class AsyncFilterAtom implements StatefulAtom, PerWorkerLockOwner, Plannable {
     public static final LongAdder PRE_TOUCH_BLACK_HOLE = new LongAdder();
+    // Covered sidecars make fixed-width projection decoding cheap relative to replaying
+    // their posting cursor, so late materialization needs a more conservative cutoff.
+    private static final double COVERING_SELECTIVITY_THRESHOLD = 0.01;
     private final IntList columnTypes;
     private final Function filter;
     private final IntHashSet filterUsedColumnIndexes;
@@ -297,8 +300,14 @@ public class AsyncFilterAtom implements StatefulAtom, PerWorkerLockOwner, Planna
         lateMatSkipColumnIndexes = skipSet;
     }
 
-    public boolean shouldUseLateMaterialization(int slotId, boolean isDecodeBackedFrame, boolean isCountOnly) {
-        if (!isDecodeBackedFrame) {
+    public boolean shouldUseLateMaterialization(
+            int slotId,
+            boolean isParquetFrame,
+            boolean isSingleKeyCoveredFrame,
+            boolean isCountOnly
+    ) {
+        assert !isParquetFrame || !isSingleKeyCoveredFrame;
+        if (!isParquetFrame && !isSingleKeyCoveredFrame) {
             return false;
         }
         if (filterUsedColumnIndexes == null || filterUsedColumnIndexes.size() == 0) {
@@ -307,7 +316,13 @@ public class AsyncFilterAtom implements StatefulAtom, PerWorkerLockOwner, Planna
         if (isCountOnly) {
             return true;
         }
-        return getSelectivityStats(slotId).shouldUseLateMaterialization();
+        final SelectivityStats stats = getSelectivityStats(slotId);
+        if (isSingleKeyCoveredFrame) {
+            // Start covered frames eagerly while gathering samples. Unlike Parquet,
+            // replaying a posting cursor can cost more than decoding a narrow INCLUDE.
+            return stats.shouldUseLateMaterialization(COVERING_SELECTIVITY_THRESHOLD, false);
+        }
+        return stats.shouldUseLateMaterialization();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilterAtom.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilterAtom.java
@@ -297,8 +297,8 @@ public class AsyncFilterAtom implements StatefulAtom, PerWorkerLockOwner, Planna
         lateMatSkipColumnIndexes = skipSet;
     }
 
-    public boolean shouldUseLateMaterialization(int slotId, boolean isParquetFrame, boolean isCountOnly) {
-        if (!isParquetFrame) {
+    public boolean shouldUseLateMaterialization(int slotId, boolean isDecodeBackedFrame, boolean isCountOnly) {
+        if (!isDecodeBackedFrame) {
             return false;
         }
         if (filterUsedColumnIndexes == null || filterUsedColumnIndexes.size() == 0) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactory.java
@@ -293,14 +293,14 @@ public class AsyncFilteredRecordCursorFactory extends AbstractRecordCursorFactor
         final long frameRowCount = task.getFrameRowCount();
         final AsyncFilterAtom atom = task.getFrameSequence(AsyncFilterAtom.class).getAtom();
 
-        final boolean isParquetFrame = task.isParquetFrame();
+        final boolean isLateMaterializationCandidate = task.isParquetFrame() || task.isSingleKeyCoveredFrame();
         final boolean owner = stealingFrameSequence != null && stealingFrameSequence == task.getFrameSequence();
         final int filterId = atom.maybeAcquireFilter(workerId, owner, circuitBreaker);
         // The slot is held from here on, so everything below belongs inside the try that releases
         // it: populateFrameMemory() navigates to the frame, which decodes parquet and can breach the
         // per-query memory limit. See PerWorkerLocks.acquireSlot().
         try {
-            final boolean useLateMaterialization = atom.shouldUseLateMaterialization(filterId, isParquetFrame, task.isCountOnly());
+            final boolean useLateMaterialization = atom.shouldUseLateMaterialization(filterId, isLateMaterializationCandidate, task.isCountOnly());
 
             final PageFrameMemory frameMemory;
             if (useLateMaterialization) {
@@ -331,7 +331,7 @@ public class AsyncFilteredRecordCursorFactory extends AbstractRecordCursorFactor
                     }
                 }
 
-                if (isParquetFrame) {
+                if (isLateMaterializationCandidate) {
                     atom.getSelectivityStats(filterId).update(rows.size(), frameRowCount);
                 }
                 if (useLateMaterialization && task.populateRemainingColumns(atom.getLateMaterializationSkipColumnIndexes(), rows, true)) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilteredRecordCursorFactory.java
@@ -293,14 +293,21 @@ public class AsyncFilteredRecordCursorFactory extends AbstractRecordCursorFactor
         final long frameRowCount = task.getFrameRowCount();
         final AsyncFilterAtom atom = task.getFrameSequence(AsyncFilterAtom.class).getAtom();
 
-        final boolean isLateMaterializationCandidate = task.isParquetFrame() || task.isSingleKeyCoveredFrame();
+        final boolean isParquetFrame = task.isParquetFrame();
+        final boolean isSingleKeyCoveredFrame = task.isSingleKeyCoveredFrame();
+        final boolean isLateMaterializationCandidate = isParquetFrame || isSingleKeyCoveredFrame;
         final boolean owner = stealingFrameSequence != null && stealingFrameSequence == task.getFrameSequence();
         final int filterId = atom.maybeAcquireFilter(workerId, owner, circuitBreaker);
         // The slot is held from here on, so everything below belongs inside the try that releases
         // it: populateFrameMemory() navigates to the frame, which decodes parquet and can breach the
         // per-query memory limit. See PerWorkerLocks.acquireSlot().
         try {
-            final boolean useLateMaterialization = atom.shouldUseLateMaterialization(filterId, isLateMaterializationCandidate, task.isCountOnly());
+            final boolean useLateMaterialization = atom.shouldUseLateMaterialization(
+                    filterId,
+                    isParquetFrame,
+                    isSingleKeyCoveredFrame,
+                    task.isCountOnly()
+            );
 
             final PageFrameMemory frameMemory;
             if (useLateMaterialization) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncJitFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncJitFilteredRecordCursorFactory.java
@@ -326,8 +326,15 @@ public class AsyncJitFilteredRecordCursorFactory extends AbstractRecordCursorFac
         final int filterId = atom.maybeAcquireFilter(workerId, owner, circuitBreaker);
 
         try {
-            final boolean isLateMaterializationCandidate = task.isParquetFrame() || task.isSingleKeyCoveredFrame();
-            final boolean useLateMaterialization = atom.shouldUseLateMaterialization(filterId, isLateMaterializationCandidate, task.isCountOnly());
+            final boolean isParquetFrame = task.isParquetFrame();
+            final boolean isSingleKeyCoveredFrame = task.isSingleKeyCoveredFrame();
+            final boolean isLateMaterializationCandidate = isParquetFrame || isSingleKeyCoveredFrame;
+            final boolean useLateMaterialization = atom.shouldUseLateMaterialization(
+                    filterId,
+                    isParquetFrame,
+                    isSingleKeyCoveredFrame,
+                    task.isCountOnly()
+            );
 
             final PageFrameMemory frameMemory;
             if (useLateMaterialization) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncJitFilteredRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncJitFilteredRecordCursorFactory.java
@@ -326,8 +326,8 @@ public class AsyncJitFilteredRecordCursorFactory extends AbstractRecordCursorFac
         final int filterId = atom.maybeAcquireFilter(workerId, owner, circuitBreaker);
 
         try {
-            final boolean isParquetFrame = task.isParquetFrame();
-            final boolean useLateMaterialization = atom.shouldUseLateMaterialization(filterId, isParquetFrame, task.isCountOnly());
+            final boolean isLateMaterializationCandidate = task.isParquetFrame() || task.isSingleKeyCoveredFrame();
+            final boolean useLateMaterialization = atom.shouldUseLateMaterialization(filterId, isLateMaterializationCandidate, task.isCountOnly());
 
             final PageFrameMemory frameMemory;
             if (useLateMaterialization) {
@@ -359,7 +359,7 @@ public class AsyncJitFilteredRecordCursorFactory extends AbstractRecordCursorFac
                         }
                     }
 
-                    if (isParquetFrame) {
+                    if (isLateMaterializationCandidate) {
                         atom.getSelectivityStats(filterId).update(rows.size(), frameRowCount);
                     }
                     if (useLateMaterialization && task.populateRemainingColumns(atom.getLateMaterializationSkipColumnIndexes(), rows, true)) {
@@ -397,7 +397,7 @@ public class AsyncJitFilteredRecordCursorFactory extends AbstractRecordCursorFac
                 );
 
                 rows.setPos(filteredRowCount);
-                if (isParquetFrame) {
+                if (isLateMaterializationCandidate) {
                     atom.getSelectivityStats(filterId).update(filteredRowCount, frameRowCount);
                 }
                 if (useLateMaterialization && task.populateRemainingColumns(atom.getLateMaterializationSkipColumnIndexes(), rows, true)) {

--- a/core/src/main/java/io/questdb/griffin/engine/table/SelectivityStats.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/SelectivityStats.java
@@ -36,7 +36,7 @@ import io.questdb.std.Unsafe;
  * <p>
  * Late materialization benefits:
  * - Low selectivity -> most rows filtered -> avoid decoding unused column data
- * - Only applicable to Parquet format (columnar storage requiring decoding)
+ * - Only applicable to decode-backed frames such as Parquet and single-key covering frames
  * <p>
  * A thread-safe filter hands out no per-worker slots, so every reducing worker, the query owner
  * and any work-stealing thread share one instance. {@link #update(long, long)} therefore has to

--- a/core/src/main/java/io/questdb/griffin/engine/table/SelectivityStats.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/SelectivityStats.java
@@ -31,8 +31,8 @@ import io.questdb.std.Unsafe;
  * Selectivity statistics for late materialization heuristics.
  * <p>
  * This class tracks the historical selectivity (ratio of filtered rows to total rows)
- * using exponential moving average (EMA). Late materialization is enabled only when
- * the selectivity is below a threshold (20%), meaning most rows are filtered out.
+ * using exponential moving average (EMA). Callers enable late materialization only
+ * when selectivity falls below their threshold; the default threshold is 20%.
  * <p>
  * Late materialization benefits:
  * - Low selectivity -> most rows filtered -> avoid decoding unused column data
@@ -53,7 +53,7 @@ public class SelectivityStats implements Mutable {
     // EMA smoothing factor (0.3 favors recent results)
     private static final double ALPHA = 0.3;
     private static final int MIN_SAMPLES = 2;
-    // Selectivity threshold (20%) - enable late materialization when selectivity is below this
+    // Default selectivity threshold (20%) for Parquet late materialization.
     private static final double SELECTIVITY_THRESHOLD = 0.2;
     private static final long STATE_OFFSET = Unsafe.getFieldOffset(SelectivityStats.class, "state");
     // Packed [sampleCount:32][avgSelectivity float bits:32].
@@ -65,11 +65,18 @@ public class SelectivityStats implements Mutable {
     }
 
     public boolean shouldUseLateMaterialization() {
+        return shouldUseLateMaterialization(SELECTIVITY_THRESHOLD, true);
+    }
+
+    public boolean shouldUseLateMaterialization(
+            double threshold,
+            boolean isLateMaterializationEnabledDuringWarmup
+    ) {
         final long state = this.state;
         if (sampleCountOf(state) < MIN_SAMPLES) {
-            return true;
+            return isLateMaterializationEnabledDuringWarmup;
         }
-        return avgSelectivityOf(state) < SELECTIVITY_THRESHOLD;
+        return avgSelectivityOf(state) < threshold;
     }
 
     public void update(long filteredRowCount, long totalRowCount) {

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexJitFilterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexJitFilterTest.java
@@ -98,15 +98,11 @@ public class CoveringIndexJitFilterTest extends AbstractCairoTest {
             engine.releaseAllWriters();
             sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_ENABLED);
 
-            assertQuery("SELECT score, note, payload IS NOT NULL AS has_payload FROM sparse WHERE sym = 'A' AND score != 10")
+            assertQuery("SELECT score, note, payload IS NOT NULL AS has_payload FROM sparse WHERE sym = 'A' AND score = 60")
                     .noLeakCheck()
                     .withPlanContaining("Async JIT Filter", "CoveringIndex on: sym")
                     .returns("""
                             score\tnote\thas_payload
-                            20\tnote-2\ttrue
-                            30\tnote-3\ttrue
-                            40\tnote-4\ttrue
-                            50\tnote-5\ttrue
                             60\tnote-6\ttrue
                             """);
         });

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexJitFilterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexJitFilterTest.java
@@ -1,0 +1,159 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.covering;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.SqlJitMode;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CoveringIndexJitFilterTest extends AbstractCairoTest {
+
+    @Before
+    public void configureFrames() {
+        setProperty(PropertyKey.CAIRO_SQL_PAGE_FRAME_MAX_ROWS, 2);
+    }
+
+    @Test
+    public void testJavaFallbackRetainsCoveringRoute() throws Exception {
+        assertMemoryLeak(() -> {
+            createTable();
+            sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_ENABLED);
+            final String sql = "SELECT score, qty, tag FROM tab WHERE sym = 'A' AND length(tag) > 3 ORDER BY score";
+            assertQuery(sql)
+                    .noLeakCheck()
+                    .withPlanContaining("Async Filter", "CoveringIndex on: sym")
+                    .returns("""
+                            score\tqty\ttag
+                            10\t100\tkeep-one
+                            20\t400\tdrop
+                            95\t300\tkeep-three
+                            """);
+            try (RecordCursorFactory factory = select(sql)) {
+                Assert.assertFalse(factory.usesCompiledFilter());
+            }
+        });
+    }
+
+    @Test
+    public void testJitFilterFirstFixedAndVariableNativeAndParquet() throws Exception {
+        assertMemoryLeak(() -> {
+            createTable();
+            sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_ENABLED);
+            assertJitResults();
+
+            engine.releaseAllWriters();
+            execute("ALTER TABLE tab CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            assertJitResults();
+        });
+    }
+
+    @Test
+    public void testSparseStringAndBinaryProjectionKeepsAuxOffsetsValid() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE sparse (
+                        ts TIMESTAMP,
+                        sym SYMBOL INDEX TYPE POSTING INCLUDE (score, note, payload),
+                        score INT,
+                        note STRING,
+                        payload BINARY
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            execute("""
+                    INSERT INTO sparse
+                    SELECT
+                        '2024-01-01'::TIMESTAMP + x * 1_000_000L,
+                        'A'::SYMBOL,
+                        x * 10,
+                        'note-' || x,
+                        rnd_bin(4, 4, 0)
+                    FROM long_sequence(6)
+                    """);
+            engine.releaseAllWriters();
+            sqlExecutionContext.setJitMode(SqlJitMode.JIT_MODE_ENABLED);
+
+            assertQuery("SELECT score, note, payload IS NOT NULL AS has_payload FROM sparse WHERE sym = 'A' AND score != 10")
+                    .noLeakCheck()
+                    .withPlanContaining("Async JIT Filter", "CoveringIndex on: sym")
+                    .returns("""
+                            score\tnote\thas_payload
+                            20\tnote-2\ttrue
+                            30\tnote-3\ttrue
+                            40\tnote-4\ttrue
+                            50\tnote-5\ttrue
+                            60\tnote-6\ttrue
+                            """);
+        });
+    }
+
+    private void assertJitResults() throws Exception {
+        final String sql = "SELECT score, qty, tag FROM tab WHERE sym = 'A' AND score >= 90 ORDER BY score";
+        assertQuery(sql)
+                .noLeakCheck()
+                .withPlanContaining("Async JIT Filter", "CoveringIndex on: sym")
+                .returns("""
+                        score\tqty\ttag
+                        90\t200\t
+                        95\t300\tkeep-three
+                        """);
+        try (RecordCursorFactory factory = select(sql)) {
+            Assert.assertTrue(factory.usesCompiledFilter());
+        }
+
+        assertQuery("SELECT count() FROM tab WHERE sym = 'A' AND score >= 90")
+                .noLeakCheck()
+                .expectSize()
+                .noRandomAccess()
+                .withPlanContaining("Async JIT Filter", "CoveringIndex on: sym")
+                .returns("count\n2\n");
+    }
+
+    private void createTable() throws Exception {
+        execute("""
+                CREATE TABLE tab (
+                    ts TIMESTAMP,
+                    sym SYMBOL INDEX TYPE POSTING INCLUDE (score, qty, tag),
+                    score INT,
+                    qty LONG,
+                    tag VARCHAR
+                ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                """);
+        execute("""
+                INSERT INTO tab VALUES
+                    ('2024-01-01T00:00:00.000000Z', 'A', 10, 100, 'keep-one'),
+                    ('2024-01-01T01:00:00.000000Z', 'A', 90, 200, null),
+                    ('2024-01-01T02:00:00.000000Z', 'A', 95, 300, 'keep-three'),
+                    ('2024-01-01T03:00:00.000000Z', 'A', 20, 400, 'drop'),
+                    ('2024-01-01T04:00:00.000000Z', 'A', 30, 500, 'x'),
+                    ('2024-01-01T05:00:00.000000Z', 'A', 40, 600, 'y'),
+                    ('2024-01-01T06:00:00.000000Z', 'B', 99, 700, 'other')
+                """);
+        engine.releaseAllWriters();
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexParallelDecodeTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexParallelDecodeTest.java
@@ -1628,7 +1628,7 @@ public class CoveringIndexParallelDecodeTest extends AbstractCairoTest {
                         engine.execute("INSERT INTO ref " + gen, sqlExecutionContext);
                         engine.releaseAllWriters();
 
-                        // Confirm the projection-with-residual runs Async Filter over
+                        // Confirm the projection-with-residual runs Async JIT Filter over
                         // the covering scan (the record fast-path), then equal the
                         // non-indexed twin -- both the projection (record path) and
                         // the aggregate (sum over the same residual).
@@ -1639,8 +1639,8 @@ public class CoveringIndexParallelDecodeTest extends AbstractCairoTest {
                                 sink
                         );
                         final String plan = sink.toString();
-                        assertTrue("residual projection must run Async Filter over CoveringIndex; plan=\n" + plan,
-                                plan.contains("Async Filter") && plan.contains("CoveringIndex on: sym"));
+                        assertTrue("residual projection must run Async JIT Filter over CoveringIndex; plan=\n" + plan,
+                                plan.contains("Async JIT Filter") && plan.contains("CoveringIndex on: sym"));
 
                         for (String sym : new String[]{"S0", "S3", "S7"}) {
                             final String proj = "SELECT price FROM %s WHERE sym = '" + sym + "' AND price > 500 ORDER BY price";

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexTest.java
@@ -5276,7 +5276,7 @@ public class CoveringIndexTest extends AbstractCairoTest {
         // Regression for the async-filter-over-covering random-access contract.
         //
         // SELECT name, price ... WHERE sym = 'A' AND price > N compiles to
-        // Async Filter -> CoveringIndex. AsyncFilteredRecordCursor services
+        // Async JIT Filter -> CoveringIndex. AsyncJitFilteredRecordCursor services
         // recordAt()/getRecordB() through its own page-frame memory pool, so the
         // factory reports recordCursorSupportsRandomAccess() == true even though
         // the covering base's row cursor does not support random access.
@@ -5318,7 +5318,7 @@ public class CoveringIndexTest extends AbstractCairoTest {
                 // every matching row via recordAt() across the 6 covering frames.
                 assertQuery("SELECT name, price FROM t_cov_ra WHERE sym = 'A' AND price > 25")
                         .noLeakCheck()
-                        .withPlanContaining("Async Filter", "CoveringIndex on: sym")
+                        .withPlanContaining("Async JIT Filter", "CoveringIndex on: sym")
                         .returns("""
                                 name\tprice
                                 a3\t30.0
@@ -5597,13 +5597,13 @@ public class CoveringIndexTest extends AbstractCairoTest {
                     """);
             engine.releaseAllWriters();
 
-            // Plan: Async Filter wrapping CoveringIndex (parallel filter enabled in tests)
+            // Plan: Async JIT Filter wrapping CoveringIndex (parallel filter enabled in tests)
             // Data correctness: only A rows with price > 15
             assertQuery("SELECT price FROM t_resid WHERE sym = 'A' AND price > 15")
                     .noLeakCheck()
                     .withPlan("""
                             SelectedRecord
-                                Async Filter workers: 1
+                                Async JIT Filter workers: 1
                                   filter: 15<price
                                     CoveringIndex on: sym with: price
                                       filter: sym='A'
@@ -17491,7 +17491,7 @@ public class CoveringIndexTest extends AbstractCairoTest {
             assertQuery("SELECT price FROM t_neg WHERE sym = 'A' AND price > 0 LIMIT -3")
                     .noLeakCheck()
                     .expectSize()
-                    .withPlanContaining("Async Filter")
+                    .withPlanContaining("Async JIT Filter")
                     .returns("""
                             price
                             8.0
@@ -17672,10 +17672,10 @@ public class CoveringIndexTest extends AbstractCairoTest {
                             9.0
                             10.0
                             """);
-            // Positive limit over multi-key still uses the parallel path.
+            // Positive limit over multi-key still uses the parallel JIT path.
             assertQuery("SELECT price FROM t_neg_mk WHERE sym IN ('A', 'B') AND price > 0 LIMIT 3")
                     .noLeakCheck()
-                    .assertsPlanContaining("Async Filter");
+                    .assertsPlanContaining("Async JIT Filter");
         });
     }
 }

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/AsyncFilterAtomTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/AsyncFilterAtomTest.java
@@ -39,6 +39,24 @@ public class AsyncFilterAtomTest extends AbstractCairoTest {
     private static final int SLOT_COUNT = 2;
 
     @Test
+    public void testCoveredFramesStartEagerAndUseConservativeThreshold() {
+        final AsyncFilterAtom atom = newAtom();
+
+        Assert.assertFalse(atom.shouldUseLateMaterialization(-1, false, true, false));
+        Assert.assertTrue(atom.shouldUseLateMaterialization(-1, true, false, false));
+
+        atom.getSelectivityStats(-1).update(0, 1_000);
+        Assert.assertFalse(atom.shouldUseLateMaterialization(-1, false, true, false));
+        atom.getSelectivityStats(-1).update(0, 1_000);
+        Assert.assertTrue(atom.shouldUseLateMaterialization(-1, false, true, false));
+
+        atom.getSelectivityStats(-1).clear();
+        atom.getSelectivityStats(-1).update(20, 1_000);
+        atom.getSelectivityStats(-1).update(20, 1_000);
+        Assert.assertFalse(atom.shouldUseLateMaterialization(-1, false, true, false));
+    }
+
+    @Test
     public void testPerWorkerFiltersUseSlotStatistics() {
         final AsyncFilterAtom atom = newAtomWithPerWorkerFilters();
 
@@ -46,10 +64,10 @@ public class AsyncFilterAtomTest extends AbstractCairoTest {
         // reads the shared stats. Every other thread holds a slot and reads its own.
         atom.getSelectivityStats(-1).update(100, 100);
         atom.getSelectivityStats(-1).update(100, 100);
-        Assert.assertFalse(atom.shouldUseLateMaterialization(-1, true, false));
+        Assert.assertFalse(atom.shouldUseLateMaterialization(-1, true, false, false));
 
         // A slot holder is unaffected by what the owner sampled.
-        Assert.assertTrue(atom.shouldUseLateMaterialization(0, true, false));
+        Assert.assertTrue(atom.shouldUseLateMaterialization(0, true, false, false));
     }
 
     @Test
@@ -72,7 +90,7 @@ public class AsyncFilterAtomTest extends AbstractCairoTest {
         // So MIN_SAMPLES frames settle the heuristic for the whole scan, whichever thread saw them.
         atom.getSelectivityStats(-1).update(100, 100);
         atom.getSelectivityStats(-1).update(100, 100);
-        Assert.assertFalse(atom.shouldUseLateMaterialization(-1, true, false));
+        Assert.assertFalse(atom.shouldUseLateMaterialization(-1, true, false, false));
     }
 
     private AsyncFilterAtom newAtom() {


### PR DESCRIPTION
## Summary

This change speeds up raw covering-index queries with residual predicates by enabling compiled async filters and selectively decoding projection-only INCLUDE columns after filtering on replayable single-key frames.

## Root cause

`SqlCodeGenerator` routed covering-index residual filters directly to the Java async filter instead of the shared JIT path. `PageFrameMemoryPool` also decoded every covered projection column before the residual filter ran, so queries such as `SELECT ts, value ... WHERE sym = ? AND errorflags = 0` paid to decode `value` for rows they later discarded.

The first implementation reused Parquet's late-materialization policy. A follow-up ablation showed that covered posting-cursor replay has a different cost: for this narrow projection, JIT with eager covered decoding usually beat a 20%-threshold filter-first path.

## Approach

- Share JIT filter construction, fallback, and resource ownership between generic and covering async-filter routes.
- Let single-key covered frames decode filter columns first, preserve full frame coordinates, and replay the detached posting cursor for survivors.
- Start covered frames eagerly while collecting selectivity samples, then enable replay only below 1%. Parquet retains its existing warm-late 20% policy.
- Keep multi-key merged frames eager and retain the existing negative-LIMIT serial fallback.
- Add a 100-million-row JMH sweep over 0.1%-20% key selectivity and 1%-100% residual selectivity.
- Add Java-eager, JIT-eager, and adaptive-JIT covering modes to separate filter compilation from replay behavior.

Broad indexed keys can still trail a sequential table scan because the planner has no reliable posting-list estimate at compile time. This change does not add speculative cost-based routing.

## Before/after benchmark

The comparison uses the same benchmark source and 100-million-row data distribution on both revisions:

- Before: `dfdd699011` (the parent revision)
- After: this branch with the conservative covering policy
- 8 query workers, non-forked JMH
- Key sweep fixes residual pass rate at 10%
- Residual sweep fixes key match rate at 10%

Bars show before latency and lines show after latency. Lower is better.

```mermaid
xychart-beta
    title "Residual-selectivity sweep at 10% key match"
    x-axis "Residual pass rate (%)" [1, 2, 5, 10, 20, 50, 100]
    y-axis "Query latency (ms)" 0 --> 120
    bar [48.309, 48.971, 54.735, 60.034, 62.456, 86.519, 111.567]
    line [37.406, 50.006, 51.946, 57.520, 62.739, 88.482, 98.460]
```

| Residual pass | Before | After | Change |
| ---: | ---: | ---: | ---: |
| 1% | 48.309 ms | 37.406 ms | 22.6% faster |
| 2% | 48.971 ms | 50.006 ms | 2.1% slower |
| 5% | 54.735 ms | 51.946 ms | 5.1% faster |
| 10% | 60.034 ms | 57.520 ms | 4.2% faster |
| 20% | 62.456 ms | 62.739 ms | 0.5% slower |
| 50% | 86.519 ms | 88.482 ms | 2.3% slower |
| 100% | 111.567 ms | 98.460 ms | 11.7% faster |

```mermaid
xychart-beta
    title "Key-selectivity sweep at 10% residual pass"
    x-axis "Key match rate (%)" [0.1, 0.2, 0.5, 1, 2, 5, 10, 20]
    y-axis "Query latency (ms)" 0 --> 120
    bar [0.464, 0.825, 1.657, 3.564, 7.634, 26.722, 61.949, 93.834]
    line [0.408, 0.655, 1.635, 3.537, 8.179, 23.945, 53.053, 116.300]
```

| Key match | Before | After | Change |
| ---: | ---: | ---: | ---: |
| 0.1% | 0.464 ms | 0.408 ms | 12.1% faster |
| 0.2% | 0.825 ms | 0.655 ms | 20.6% faster |
| 0.5% | 1.657 ms | 1.635 ms | 1.3% faster |
| 1% | 3.564 ms | 3.537 ms | 0.8% faster |
| 2% | 7.634 ms | 8.179 ms | 7.1% slower |
| 5% | 26.722 ms | 23.945 ms | 10.4% faster |
| 10% | 61.949 ms | 53.053 ms | 14.4% faster |
| 20% | 93.834 ms | 116.300 ms | 23.9% slower |

The 20% key point has wide, overlapping confidence intervals. It also remains a poor index-routing case; a sequential `no_index` scan is faster there.

## Ablation

The residual sweep now includes three covering modes in one process:

- Adaptive JIT: production policy from this PR.
- JIT eager: always-true dependencies on projected columns force one eager covered decode.
- Java eager: the same eager dependency with SQL JIT disabled.

The eager modes execute two additional always-true comparisons, so use them to distinguish direction and crossover rather than as exact substitutes for the parent revision.

```mermaid
xychart-beta
    title "Covering-filter ablation at 10% key match"
    x-axis "Residual pass rate (%)" [1, 2, 5, 10, 20, 50, 100]
    y-axis "Query latency (ms)" 0 --> 125
    bar [51.537, 54.666, 57.932, 69.251, 67.171, 94.905, 118.544]
    line [50.715, 43.725, 57.140, 61.293, 67.286, 78.038, 113.834]
    line [37.406, 50.006, 51.946, 57.520, 62.739, 88.482, 98.460]
```

Bars are Java eager; the first line is JIT eager; the second line is adaptive JIT.

| Residual pass | Java eager | JIT eager | Adaptive JIT |
| ---: | ---: | ---: | ---: |
| 1% | 51.537 ms | 50.715 ms | 37.406 ms |
| 2% | 54.666 ms | 43.725 ms | 50.006 ms |
| 5% | 57.932 ms | 57.140 ms | 51.946 ms |
| 10% | 69.251 ms | 61.293 ms | 57.520 ms |
| 20% | 67.171 ms | 67.286 ms | 62.739 ms |
| 50% | 94.905 ms | 78.038 ms | 88.482 ms |
| 100% | 118.544 ms | 113.834 ms | 98.460 ms |

The ablation supports two conclusions: compiled filtering accounts for most of the broad-selectivity gain, while posting replay pays only at the very selective end for this narrow covered projection. That evidence motivated the eager warm-up and 1% covered threshold.

## High-pass residual exploration

The customer case keeps more than 90% of the symbol posting rows. The benchmark now includes 90%, 95%, 99%, 99.9%, and 100% pass rates, plus a count-only mode that isolates posting traversal and predicate evaluation.

```mermaid
xychart-beta
    title "High-pass routes at 10% key match"
    x-axis "Residual pass rate (%)" [90, 95, 99, 99.9, 100]
    y-axis "Query latency (ms)" 0 --> 170
    bar [121.296, 136.401, 136.615, 151.958, 147.276]
    line [123.992, 154.301, 147.227, 151.659, 144.264]
```

Bars are `no_index`; the line is adaptive covering. At a 10% key match the routes are close and their confidence intervals overlap. Residual pass rate alone therefore does not justify a new route hint.

Key selectivity remains decisive:

| Key match | Residual pass | Covering | `no_index` |
| ---: | ---: | ---: | ---: |
| 1% | 95% | 7.358 ms | 13.218 ms |
| 1% | 99% | 7.502 ms | 12.818 ms |
| 10% | 95% | 154.301 ms | 136.401 ms |
| 10% | 99% | 147.227 ms | 136.615 ms |

The count-only covering path takes approximately 12.5-14.3 ms across 90%-100% pass rates, while the raw timestamp/value projection takes roughly 96-169 ms in the same run. Predicate evaluation and posting traversal therefore account for a minority of end-to-end time; decoding and consuming the retained rows dominate.

A zero-allocation 100,000-row frame benchmark compared accepted-row lists with rejected-row lists, rejection bitmaps, and accepted runs under uniform and clustered exceptions. No alternative won consistently:

| Uniform pass rate | Accepted list | Rejected list | Bitmap | Runs |
| ---: | ---: | ---: | ---: | ---: |
| 90% | 105.1 us | 105.8 us | 115.2 us | 87.5 us |
| 99% | 103.8 us | 109.4 us | 159.1 us | 121.6 us |
| 100% | 90.5 us | 88.7 us | 121.6 us | 109.1 us |

This bounds a selection-representation improvement to only a few milliseconds over the approximately 100 frames in the 10%-key benchmark, while implementing EXCLUDE/ALL representations would affect the native JIT ABI, streaming and negative-LIMIT cursors, skip/toTop behavior, and row-ID invariants.

The other explored options are also poor fits for this PR:

- Per-sidecar min/max or all-equal metadata changes the durable index format and only skips useful work when exceptions are clustered into mixed-free blocks.
- Subtracting an exception index requires a materialized exception key and a posting-list difference API that `IndexReader` does not currently expose.
- A high-pass hint cannot skip predicate evaluation without weakening correctness, and eager covered decoding is already the default for this pass rate.
- Positive LIMIT already has an early-stop path; the customer query has no LIMIT.

Based on these results, this PR keeps the conservative eager/JIT policy rather than adding a dense-selection representation or a public hint.

## Verification

- `mvn -pl core -Dtest=AsyncFilterAtomTest,CoveringIndexJitFilterTest test`
- `mvn -pl core -Dtest=SelectivityStatsTest test`
- `mvn -pl core -Dtest=CoveringIndexParallelDecodeTest test` (29 tests)
- `mvn -pl core -Dtest=CoveringIndexTest test` (404 tests)
- `mvn -pl benchmarks -am package -DskipTests`
- 100-million-row key and residual before/after sweeps
- 21-scenario same-process Java/JIT/replay ablation
- 25-scenario 90%-100% high-pass route sweep and count-only isolation
- `HighPassFilterSelectionBenchmark` across accepted lists, rejected lists, bitmaps, and runs
