### PR TITLE
chore(parquet): let a parquet decoder observe the query circuit breaker

### DIFF
--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryPool.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryPool.java
@@ -147,6 +147,10 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
     private ParquetBuffers boundForRecordA;
     private ParquetBuffers boundForRecordB;
     private long cachedBytes;
+    // Pushed down to the parquet decoder so a decode that blocks waiting for data
+    // probes for query cancellation. Null on the owner-thread cursor paths
+    // (cancellation parity); set from the parallel reduce path.
+    private SqlExecutionCircuitBreaker cancelHandle;
     // Live native bytes held by retained CoveringBuffers (covered decode buffers).
     // Unlike parquet's cachedBytes this is NOT an eviction budget: covered buffers are
     // query-lifetime and cannot be LRU-evicted mid-query (zero-copy first()/last()
@@ -893,6 +897,18 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
         this.memoryTracker = memoryTracker;
     }
 
+    /**
+     * Forwards a cancel handle to the active (and lazily-created) parquet decoder so
+     * a decode that blocks waiting for data can probe for query cancellation. Set
+     * from the parallel reduce path; left null (cancellation parity) elsewhere.
+     */
+    public void setCancelHandle(SqlExecutionCircuitBreaker cancelHandle) {
+        this.cancelHandle = cancelHandle;
+        if (parquetMetaDecoder != null) {
+            parquetMetaDecoder.setCancelHandle(cancelHandle);
+        }
+    }
+
     public void setParquetDecodeHint(ParquetDecodeHint hint) {
         this.decodeHint = hint;
         this.effectiveBudgetBytes = hint.applyTo(maxCacheBytes);
@@ -1034,6 +1050,7 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
             if (parquetMetaDecoder == null) {
                 // Created lazily so the configuration's decoder factory is fully wired before first use.
                 parquetMetaDecoder = configuration.newParquetPartitionDecoder();
+                parquetMetaDecoder.setCancelHandle(cancelHandle);
             }
             if (parquetMetaDecoder.getParquetMetaAddr() != parquetMetaFrame.getParquetMetaAddr() || parquetMetaDecoder.getParquetMetaSize() != parquetMetaFrame.getParquetMetaSize()) {
                 parquetMetaDecoder.of(parquetMetaFrame);

--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryPool.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryPool.java
@@ -26,6 +26,7 @@ package io.questdb.cairo.sql;
 
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.TableUtils;
 import io.questdb.cairo.VarcharTypeDriver;
@@ -147,10 +148,13 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
     private ParquetBuffers boundForRecordA;
     private ParquetBuffers boundForRecordB;
     private long cachedBytes;
-    // Pushed down to the parquet decoder so a decode that blocks waiting for data
-    // probes for query cancellation. Null on the owner-thread cursor paths
-    // (cancellation parity); set from the parallel reduce path.
-    private SqlExecutionCircuitBreaker cancelHandle;
+    // Per-pool, thread-safe view of the query's circuit breaker, forwarded to the parquet decoder so
+    // a decode that blocks waiting for data can probe for query cancellation. It keeps its OWN
+    // throttle/timer state over the query's shared cancelled flag, fd and timeout, so concurrent
+    // parallel-reduce decoders never probe one shared, thread-unsafe breaker. Lazily created on the
+    // first setCancelHandle and re-init'd per reduce; stays null on the owner-thread cursor paths
+    // (cancellation parity); freed at close().
+    private SqlExecutionCircuitBreakerWrapper cancelCircuitBreaker;
     // Live native bytes held by retained CoveringBuffers (covered decode buffers).
     // Unlike parquet's cachedBytes this is NOT an eviction budget: covered buffers are
     // query-lifetime and cannot be LRU-evicted mid-query (zero-copy first()/last()
@@ -242,6 +246,7 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
         Misc.freeObjListAndClear(freeParquetBufferShells);
         addressCache = null;
         memoryTracker = null;
+        cancelCircuitBreaker = Misc.free(cancelCircuitBreaker);
     }
 
     public long getBindGeneration() {
@@ -888,6 +893,26 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
     }
 
     /**
+     * Binds the query's circuit breaker so a parquet decode that blocks waiting for data can probe
+     * for cancellation/timeout. The pool wraps it in its OWN {@link SqlExecutionCircuitBreakerWrapper}
+     * -- a per-pool view with private throttle/timer state over the query's shared cancelled flag, fd
+     * and timeout -- and forwards that wrapper to the decoder, never the raw {@code queryCircuitBreaker}
+     * (which is thread-unsafe and shared across the parallel-reduce workers). Set per reduce on the
+     * parallel path; left null (cancellation parity) on the owner-thread cursor paths.
+     */
+    public void setCancelHandle(CairoEngine engine, SqlExecutionCircuitBreaker queryCircuitBreaker) {
+        if (queryCircuitBreaker != null) {
+            if (cancelCircuitBreaker == null) {
+                cancelCircuitBreaker = new SqlExecutionCircuitBreakerWrapper(engine, configuration.getCircuitBreakerConfiguration());
+            }
+            cancelCircuitBreaker.init(queryCircuitBreaker);
+        }
+        if (parquetMetaDecoder != null) {
+            parquetMetaDecoder.setCancelHandle(cancelCircuitBreaker);
+        }
+    }
+
+    /**
      * Binds the per-query tracker propagated to each decode buffer on reopen.
      * Owners set it at per-query init (before the first {@link #navigateTo});
      * context-less owners leave it null for global-only accounting. A null
@@ -895,18 +920,6 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
      */
     public void setMemoryTracker(MemoryTracker memoryTracker) {
         this.memoryTracker = memoryTracker;
-    }
-
-    /**
-     * Forwards a cancel handle to the active (and lazily-created) parquet decoder so
-     * a decode that blocks waiting for data can probe for query cancellation. Set
-     * from the parallel reduce path; left null (cancellation parity) elsewhere.
-     */
-    public void setCancelHandle(SqlExecutionCircuitBreaker cancelHandle) {
-        this.cancelHandle = cancelHandle;
-        if (parquetMetaDecoder != null) {
-            parquetMetaDecoder.setCancelHandle(cancelHandle);
-        }
     }
 
     public void setParquetDecodeHint(ParquetDecodeHint hint) {
@@ -1050,7 +1063,7 @@ public class PageFrameMemoryPool implements RecordRandomAccess, QuietCloseable, 
             if (parquetMetaDecoder == null) {
                 // Created lazily so the configuration's decoder factory is fully wired before first use.
                 parquetMetaDecoder = configuration.newParquetPartitionDecoder();
-                parquetMetaDecoder.setCancelHandle(cancelHandle);
+                parquetMetaDecoder.setCancelHandle(cancelCircuitBreaker);
             }
             if (parquetMetaDecoder.getParquetMetaAddr() != parquetMetaFrame.getParquetMetaAddr() || parquetMetaDecoder.getParquetMetaSize() != parquetMetaFrame.getParquetMetaSize()) {
                 parquetMetaDecoder.of(parquetMetaFrame);

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
@@ -327,8 +327,10 @@ public class PageFrameReduceJob implements Job, QuietCloseable {
             frameSequence.getReduceStartedCounter().incrementAndGet();
             // Push the query's breaker down to the frame pool's decoder so a decode
             // that blocks waiting for data probes it; a cancel/timeout then ends the
-            // wait instead of stalling teardown on the slowest in-flight read.
-            task.setCancelHandle(frameSequence.getCircuitBreaker());
+            // wait instead of stalling teardown on the slowest in-flight read. The pool
+            // wraps it in a per-pool thread-safe view, so concurrent parallel-reduce
+            // decoders never share one thread-unsafe breaker.
+            task.setCancelHandle(frameSequence.getEngine(), frameSequence.getCircuitBreaker());
             frameSequence.getReducer().reduce(workerId, record, task, circuitBreaker, stealingFrameSequence);
         } else {
             frameSequence.cancel(cbState);

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
@@ -325,6 +325,10 @@ public class PageFrameReduceJob implements Job, QuietCloseable {
             record.of(frameSequence.getSymbolTableSource());
             assert !frameSequence.done;
             frameSequence.getReduceStartedCounter().incrementAndGet();
+            // Push the query's breaker down to the frame pool's decoder so a decode
+            // that blocks waiting for data probes it; a cancel/timeout then ends the
+            // wait instead of stalling teardown on the slowest in-flight read.
+            task.setCancelHandle(frameSequence.getCircuitBreaker());
             frameSequence.getReducer().reduce(workerId, record, task, circuitBreaker, stealingFrameSequence);
         } else {
             frameSequence.cancel(cbState);

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
@@ -267,6 +267,10 @@ public class PageFrameReduceJob implements Job, QuietCloseable {
             record.of(frameSequence.getSymbolTableSource());
             assert !frameSequence.done;
             frameSequence.getReduceStartedCounter().incrementAndGet();
+            // Push the query's breaker down to the frame pool's decoder so a decode
+            // that blocks waiting for data probes it; a cancel/timeout then ends the
+            // wait instead of stalling teardown on the slowest in-flight read.
+            task.setCancelHandle(frameSequence.getCircuitBreaker());
             frameSequence.getReducer().reduce(workerId, record, task, circuitBreaker, stealingFrameSequence);
         } else {
             frameSequence.cancel(cbState);

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceJob.java
@@ -269,8 +269,10 @@ public class PageFrameReduceJob implements Job, QuietCloseable {
             frameSequence.getReduceStartedCounter().incrementAndGet();
             // Push the query's breaker down to the frame pool's decoder so a decode
             // that blocks waiting for data probes it; a cancel/timeout then ends the
-            // wait instead of stalling teardown on the slowest in-flight read.
-            task.setCancelHandle(frameSequence.getCircuitBreaker());
+            // wait instead of stalling teardown on the slowest in-flight read. The pool
+            // wraps it in a per-pool thread-safe view, so concurrent parallel-reduce
+            // decoders never share one thread-unsafe breaker.
+            task.setCancelHandle(frameSequence.getEngine(), frameSequence.getCircuitBreaker());
             frameSequence.getReducer().reduce(workerId, record, task, circuitBreaker, stealingFrameSequence);
         } else {
             frameSequence.cancel(cbState);

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceTask.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceTask.java
@@ -300,6 +300,14 @@ public class PageFrameReduceTask implements QuietCloseable, Mutable {
         frameMemory = null;
     }
 
+    /**
+     * Pushes the query's cancel handle down to the frame memory pool's parquet
+     * decoder, so a decode that blocks waiting for data can be cancelled.
+     */
+    public void setCancelHandle(SqlExecutionCircuitBreaker cancelHandle) {
+        frameMemoryPool.setCancelHandle(cancelHandle);
+    }
+
     public void setErrorMsg(Throwable th) {
         if (th instanceof FlyweightMessageContainer fmc) {
             errorMsg.put(fmc.getFlyweightMessage());

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceTask.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameReduceTask.java
@@ -25,6 +25,7 @@
 package io.questdb.cairo.sql.async;
 
 import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ImplicitCastException;
 import io.questdb.cairo.sql.PageFrameAddressCache;
@@ -301,11 +302,12 @@ public class PageFrameReduceTask implements QuietCloseable, Mutable {
     }
 
     /**
-     * Pushes the query's cancel handle down to the frame memory pool's parquet
-     * decoder, so a decode that blocks waiting for data can be cancelled.
+     * Pushes the query's circuit breaker down to the frame memory pool, which wraps it in a
+     * per-pool thread-safe view for the parquet decoder, so a decode that blocks waiting for
+     * data can be cancelled.
      */
-    public void setCancelHandle(SqlExecutionCircuitBreaker cancelHandle) {
-        frameMemoryPool.setCancelHandle(cancelHandle);
+    public void setCancelHandle(CairoEngine engine, SqlExecutionCircuitBreaker queryCircuitBreaker) {
+        frameMemoryPool.setCancelHandle(engine, queryCircuitBreaker);
     }
 
     public void setErrorMsg(Throwable th) {

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -65,6 +65,7 @@ public class PageFrameSequence<T extends StatefulAtom> extends AbstractPageFrame
     private static final long LOCAL_TASK_CURSOR = Long.MAX_VALUE;
     private static final Log LOG = LogFactory.getLog(PageFrameSequence.class);
     private final MillisecondClock clock;
+    private final CairoEngine engine;
     private final LongList frameRowCounts = new LongList();
     private final PageFrameReduceTaskFactory localTaskFactory;
     private final MessageBus messageBus;
@@ -115,6 +116,7 @@ public class PageFrameSequence<T extends StatefulAtom> extends AbstractPageFrame
     ) {
         try {
             this.atom = atom;
+            this.engine = engine;
             this.frameAddressCache = new PageFrameAddressCache();
             this.messageBus = messageBus;
             this.reducer = reducer;
@@ -275,6 +277,10 @@ public class PageFrameSequence<T extends StatefulAtom> extends AbstractPageFrame
     @Override
     public SqlExecutionCircuitBreaker getCircuitBreaker() {
         return sqlExecutionContext.getCircuitBreaker();
+    }
+
+    public CairoEngine getEngine() {
+        return engine;
     }
 
     public int getFrameCount() {

--- a/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/PageFrameSequence.java
@@ -68,6 +68,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
     private final AtomicInteger cancelReason = new AtomicInteger(CANCEL_REASON_UNSET);
     private final FiberCancellationSignal cancellationSignal = new FiberCancellationSignal();
     private final MillisecondClock clock;
+    private final CairoEngine engine;
     private final LongList frameRowCounts = new LongList();
     private final PageFrameReduceTaskFactory localTaskFactory;
     private final MessageBus messageBus;
@@ -118,6 +119,7 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
     ) {
         try {
             this.atom = atom;
+            this.engine = engine;
             this.frameAddressCache = new PageFrameAddressCache();
             this.messageBus = messageBus;
             this.reducer = reducer;
@@ -303,6 +305,10 @@ public class PageFrameSequence<T extends StatefulAtom> implements Closeable {
     // warning: the circuit breaker may be thread unsafe, so don't use it concurrently
     public SqlExecutionCircuitBreaker getCircuitBreaker() {
         return sqlExecutionContext.getCircuitBreaker();
+    }
+
+    public CairoEngine getEngine() {
+        return engine;
     }
 
     public int getFrameCount() {

--- a/core/src/main/java/io/questdb/cairo/sql/async/UnorderedPageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/UnorderedPageFrameSequence.java
@@ -70,6 +70,7 @@ public class UnorderedPageFrameSequence<T extends StatefulAtom> extends Abstract
     private static final Log LOG = LogFactory.getLog(UnorderedPageFrameSequence.class);
     private final MillisecondClock clock;
     private final SOUnboundedCountDownLatch doneLatch = new SOUnboundedCountDownLatch();
+    private final CairoEngine engine;
     private final AsyncQueryErrorState errorState = new AsyncQueryErrorState("unexpected reduce error");
     private final LongList frameRowCounts = new LongList();
     private final MessageBus messageBus;
@@ -108,6 +109,7 @@ public class UnorderedPageFrameSequence<T extends StatefulAtom> extends Abstract
     ) {
         try {
             this.atom = atom;
+            this.engine = engine;
             this.frameAddressCache = new PageFrameAddressCache();
             this.messageBus = messageBus;
             this.reducer = reducer;
@@ -352,6 +354,10 @@ public class UnorderedPageFrameSequence<T extends StatefulAtom> extends Abstract
 
     public SOUnboundedCountDownLatch getDoneLatch() {
         return doneLatch;
+    }
+
+    public CairoEngine getEngine() {
+        return engine;
     }
 
     public int getFrameCount() {

--- a/core/src/main/java/io/questdb/cairo/sql/async/UnorderedPageFrameSequence.java
+++ b/core/src/main/java/io/questdb/cairo/sql/async/UnorderedPageFrameSequence.java
@@ -77,6 +77,7 @@ public class UnorderedPageFrameSequence<T extends StatefulAtom> implements Close
     private final FiberCancellationSignal cancellationSignal = new FiberCancellationSignal();
     private final MillisecondClock clock;
     private final SOUnboundedCountDownLatch doneLatch = new SOUnboundedCountDownLatch();
+    private final CairoEngine engine;
     private final StringSink errorMsg = new StringSink();
     private final LongList frameRowCounts = new LongList();
     private final MessageBus messageBus;
@@ -120,6 +121,7 @@ public class UnorderedPageFrameSequence<T extends StatefulAtom> implements Close
     ) {
         try {
             this.atom = atom;
+            this.engine = engine;
             this.frameAddressCache = new PageFrameAddressCache();
             this.messageBus = messageBus;
             this.reducer = reducer;
@@ -388,6 +390,10 @@ public class UnorderedPageFrameSequence<T extends StatefulAtom> implements Close
 
     public SOUnboundedCountDownLatch getDoneLatch() {
         return doneLatch;
+    }
+
+    public CairoEngine getEngine() {
+        return engine;
     }
 
     public int getFrameCount() {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilterContext.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncFilterContext.java
@@ -25,12 +25,14 @@
 package io.questdb.griffin.engine.table;
 
 import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.CairoEngine;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.PageFrameAddressCache;
 import io.questdb.cairo.sql.PageFrameFilteredMemoryRecord;
 import io.questdb.cairo.sql.PageFrameMemoryPool;
 import io.questdb.cairo.sql.ParquetDecodeHint;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.cairo.sql.SymbolTableSource;
 import io.questdb.cairo.vm.api.MemoryCARW;
 import io.questdb.griffin.PlanSink;
@@ -288,17 +290,32 @@ public class AsyncFilterContext implements Closeable {
         }
     }
 
-    public void initMemoryPools(PageFrameAddressCache pageFrameAddressCache, MemoryTracker memoryTracker) {
-        initMemoryPools(pageFrameAddressCache, memoryTracker, ParquetDecodeHint.MONOTONIC);
+    public void initMemoryPools(
+            PageFrameAddressCache pageFrameAddressCache,
+            MemoryTracker memoryTracker,
+            CairoEngine engine,
+            SqlExecutionCircuitBreaker queryCircuitBreaker
+    ) {
+        initMemoryPools(pageFrameAddressCache, memoryTracker, ParquetDecodeHint.MONOTONIC, engine, queryCircuitBreaker);
     }
 
-    public void initMemoryPools(PageFrameAddressCache pageFrameAddressCache, MemoryTracker memoryTracker, ParquetDecodeHint ownerHint) {
+    public void initMemoryPools(
+            PageFrameAddressCache pageFrameAddressCache,
+            MemoryTracker memoryTracker,
+            ParquetDecodeHint ownerHint,
+            CairoEngine engine,
+            SqlExecutionCircuitBreaker queryCircuitBreaker
+    ) {
         ownerMemoryPool.setMemoryTracker(memoryTracker);
         ownerMemoryPool.of(pageFrameAddressCache, ownerHint);
+        // Wrap the query breaker in each pool's own thread-safe view so a cold decode on any
+        // per-worker pool can probe it without racing the other workers' decoders.
+        ownerMemoryPool.setCancelHandle(engine, queryCircuitBreaker);
         for (int i = 0, n = perWorkerMemoryPools.size(); i < n; i++) {
             final PageFrameMemoryPool pool = perWorkerMemoryPools.getQuick(i);
             pool.setMemoryTracker(memoryTracker);
             pool.of(pageFrameAddressCache, ParquetDecodeHint.MONOTONIC);
+            pool.setCancelHandle(engine, queryCircuitBreaker);
         }
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByNotKeyedRecordCursor.java
@@ -137,7 +137,7 @@ class AsyncGroupByNotKeyedRecordCursor implements NoRandomAccessRecordCursor {
         // Consult the breaker before dispatching frames, so an empty base scan still observes cancellation.
         circuitBreaker.statefulThrowExceptionIfTrippedTimeThrottled();
         frameSequence.prepareForDispatch();
-        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker());
+        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker(), frameSequence.getEngine(), frameSequence.getCircuitBreaker());
         frameSequence.dispatchAndAwait();
 
         // Merge the values.

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
@@ -204,7 +204,7 @@ class AsyncGroupByRecordCursor implements RecordCursor {
         // Consult the breaker before dispatching frames, so an empty base scan still observes cancellation.
         circuitBreaker.statefulThrowExceptionIfTrippedTimeThrottled();
         frameSequence.prepareForDispatch();
-        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker());
+        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker(), frameSequence.getEngine(), frameSequence.getCircuitBreaker());
         frameSequence.dispatchAndAwait();
 
         final AsyncGroupByAtom atom = frameSequence.getAtom();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
@@ -200,7 +200,7 @@ class AsyncGroupByRecordCursor implements RecordCursor {
         // Consult the breaker before dispatching frames, so an empty base scan still observes cancellation.
         circuitBreaker.statefulThrowExceptionIfTrippedTimeThrottled();
         frameSequence.prepareForDispatch();
-        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker());
+        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker(), frameSequence.getEngine(), frameSequence.getCircuitBreaker());
         frameSequence.dispatchAndAwait();
 
         final AsyncGroupByAtom atom = frameSequence.getAtom();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinNotKeyedRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinNotKeyedRecordCursor.java
@@ -184,7 +184,7 @@ class AsyncHorizonJoinNotKeyedRecordCursor implements NoRandomAccessRecordCursor
         // Consult the breaker before dispatching frames, so an empty base scan still observes cancellation.
         executionContext.getCircuitBreaker().statefulThrowExceptionIfTrippedTimeThrottled();
         frameSequence.prepareForDispatch();
-        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker());
+        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker(), frameSequence.getEngine(), frameSequence.getCircuitBreaker());
         frameSequence.dispatchAndAwait();
 
         // Merge all per-worker values into the owner value

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinRecordCursor.java
@@ -191,7 +191,7 @@ class AsyncHorizonJoinRecordCursor implements RecordCursor {
         // Consult the breaker before dispatching frames, so an empty base scan still observes cancellation.
         executionContext.getCircuitBreaker().statefulThrowExceptionIfTrippedTimeThrottled();
         frameSequence.prepareForDispatch();
-        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker());
+        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker(), frameSequence.getEngine(), frameSequence.getCircuitBreaker());
         frameSequence.dispatchAndAwait();
 
         final AsyncHorizonJoinAtom atom = frameSequence.getAtom();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinRecordCursor.java
@@ -187,7 +187,7 @@ class AsyncHorizonJoinRecordCursor implements RecordCursor {
         // Consult the breaker before dispatching frames, so an empty base scan still observes cancellation.
         executionContext.getCircuitBreaker().statefulThrowExceptionIfTrippedTimeThrottled();
         frameSequence.prepareForDispatch();
-        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker());
+        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker(), frameSequence.getEngine(), frameSequence.getCircuitBreaker());
         frameSequence.dispatchAndAwait();
 
         final AsyncHorizonJoinAtom atom = frameSequence.getAtom();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinNotKeyedRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinNotKeyedRecordCursor.java
@@ -213,7 +213,7 @@ class AsyncMultiHorizonJoinNotKeyedRecordCursor implements NoRandomAccessRecordC
         // Consult the breaker before dispatching frames, so an empty base scan still observes cancellation.
         executionContext.getCircuitBreaker().statefulThrowExceptionIfTrippedTimeThrottled();
         frameSequence.prepareForDispatch();
-        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker());
+        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker(), frameSequence.getEngine(), frameSequence.getCircuitBreaker());
         frameSequence.dispatchAndAwait();
 
         final AsyncMultiHorizonJoinNotKeyedAtom atom = frameSequence.getAtom();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinRecordCursor.java
@@ -207,7 +207,7 @@ class AsyncMultiHorizonJoinRecordCursor implements RecordCursor {
         // Consult the breaker before dispatching frames, so an empty base scan still observes cancellation.
         executionContext.getCircuitBreaker().statefulThrowExceptionIfTrippedTimeThrottled();
         frameSequence.prepareForDispatch();
-        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker());
+        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker(), frameSequence.getEngine(), frameSequence.getCircuitBreaker());
         frameSequence.dispatchAndAwait();
 
         final AsyncMultiHorizonJoinAtom atom = frameSequence.getAtom();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinRecordCursor.java
@@ -203,7 +203,7 @@ class AsyncMultiHorizonJoinRecordCursor implements RecordCursor {
         // Consult the breaker before dispatching frames, so an empty base scan still observes cancellation.
         executionContext.getCircuitBreaker().statefulThrowExceptionIfTrippedTimeThrottled();
         frameSequence.prepareForDispatch();
-        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker());
+        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker(), frameSequence.getEngine(), frameSequence.getCircuitBreaker());
         frameSequence.dispatchAndAwait();
 
         final AsyncMultiHorizonJoinAtom atom = frameSequence.getAtom();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncTopKRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncTopKRecordCursor.java
@@ -183,7 +183,7 @@ class AsyncTopKRecordCursor implements RecordCursor, RecordCursor.RowIdSource {
 
     private void buildChain() {
         frameSequence.prepareForDispatch();
-        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker(), ParquetDecodeHint.SCATTERED);
+        frameSequence.getAtom().getFilterContext().initMemoryPools(frameSequence.getPageFrameAddressCache(), frameSequence.getMemoryTracker(), ParquetDecodeHint.SCATTERED, frameSequence.getEngine(), frameSequence.getCircuitBreaker());
         frameSequence.dispatchAndAwait();
 
         // merge the per-worker results into the owner buffer (encoded) or chain (tree)

--- a/core/src/main/java/io/questdb/griffin/engine/table/parquet/ParquetPartitionDecoder.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/parquet/ParquetPartitionDecoder.java
@@ -27,6 +27,7 @@ package io.questdb.griffin.engine.table.parquet;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ParquetMetaFileReader;
 import io.questdb.cairo.TableToken;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.std.DirectIntList;
 import io.questdb.std.DirectLongList;
 import io.questdb.std.Os;
@@ -324,6 +325,14 @@ public class ParquetPartitionDecoder implements ParquetDecoder, QuietCloseable {
 
     public long rowGroupMinTimestamp(int rowGroupIndex, int timestampColumnIndex) {
         return parquetMetaReader.getRowGroupMinTimestamp(rowGroupIndex, timestampColumnIndex);
+    }
+
+    /**
+     * Pushes a cancel handle down to the decoder so a decode that blocks waiting for
+     * data (rather than reading resident memory) can probe for query cancellation.
+     * A no-op by default; a subclass that performs blocking I/O overrides it.
+     */
+    public void setCancelHandle(SqlExecutionCircuitBreaker cancelHandle) {
     }
 
     protected static int decodeRowGroupFromBuffersShim(

--- a/core/src/test/java/io/questdb/test/griffin/engine/table/parquet/ParquetDecoderCancelHandleTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/table/parquet/ParquetDecoderCancelHandleTest.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.table.parquet;
+
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
+import io.questdb.cairo.sql.SqlExecutionCircuitBreakerWrapper;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.table.parquet.ParquetPartitionDecoder;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.cairo.CairoTestConfiguration;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Verifies the plumbing that lets a parquet decoder observe a query's cancellation while it
+ * decodes on the parallel-reduce path. A cold (blocking) decoder probes the handle it was
+ * handed, so the handle must be safe to probe from the reduce workers and must reach the
+ * decoder on every parallel-reduce query shape.
+ * <p>
+ * A recording {@link ParquetPartitionDecoder} installed via the configuration's decoder factory
+ * captures the handle the pool forwards. The assertions would fail against the pre-fix plumbing,
+ * which pushed the raw, thread-unsafe {@code SqlExecutionContext} breaker (shared across every
+ * reduce worker) on the filter path only and never wired the aggregation/join paths at all.
+ */
+public class ParquetDecoderCancelHandleTest extends AbstractCairoTest {
+
+    private static final AtomicInteger decodersCreated = new AtomicInteger();
+    // Captures the last non-null cancel handle any parquet decoder received. Written from the
+    // reduce path (owner or worker thread), read from the test thread -> AtomicReference.
+    private static final AtomicReference<SqlExecutionCircuitBreaker> lastCancelHandle = new AtomicReference<>();
+    private static final AtomicInteger nonNullCancelHandleCalls = new AtomicInteger();
+
+    @BeforeClass
+    public static void setUpStatic() throws Exception {
+        configurationFactory = (root, telemetry, overrides) ->
+                new CairoTestConfiguration(root, telemetry, overrides) {
+                    @Override
+                    public boolean isSqlParallelFilterEnabled() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isSqlParallelGroupByEnabled() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isSqlParallelReadParquetEnabled() {
+                        return true;
+                    }
+
+                    @Override
+                    public ParquetPartitionDecoder newParquetPartitionDecoder() {
+                        return new RecordingParquetPartitionDecoder();
+                    }
+                };
+        AbstractCairoTest.setUpStatic();
+    }
+
+    @Test
+    public void testAsyncFilterOverParquetDeliversPerPoolBreaker() throws Exception {
+        // Ordered reduce path (async filter). The decoder is created lazily on the first parquet
+        // frame AFTER setCancelHandle runs, so this also exercises the activateDecoder re-arm.
+        assertPerPoolBreakerDelivered("SELECT ts, v FROM x WHERE v > 100");
+    }
+
+    @Test
+    public void testAsyncGroupByOverParquetDeliversPerPoolBreaker() throws Exception {
+        // Unordered reduce path (async keyed GROUP BY) decodes cold parquet through the
+        // AsyncFilterContext per-worker pools, which before the fix never received a handle.
+        assertPerPoolBreakerDelivered("SELECT v % 100 AS k, count() FROM x WHERE v > 100");
+    }
+
+    private void assertPerPoolBreakerDelivered(String query) throws Exception {
+        assertMemoryLeak(() -> {
+            // Sanity: the engine really uses our recording decoder.
+            try (ParquetPartitionDecoder probe = configuration.newParquetPartitionDecoder()) {
+                Assert.assertTrue(
+                        "recording decoder is not installed engine-wide",
+                        probe instanceof RecordingParquetPartitionDecoder
+                );
+            }
+
+            // 2000 rows at 5-minute steps span seven daily partitions; the first three are converted
+            // to parquet (they are not the active partition), so the scan decodes real parquet frames.
+            execute("CREATE TABLE x AS (" +
+                    "  SELECT x::double v, timestamp_sequence(0, 300_000_000L) ts" +
+                    "  FROM long_sequence(2000)" +
+                    ") TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+            execute("ALTER TABLE x CONVERT PARTITION TO PARQUET LIST '1970-01-01', '1970-01-02', '1970-01-03'");
+
+            // Drop any handle/counters captured while building/converting the partition.
+            lastCancelHandle.set(null);
+            nonNullCancelHandleCalls.set(0);
+            decodersCreated.set(0);
+
+            // workerCount > 0 makes the compiler pick the parallel (async) factory; the owner
+            // thread work-steals and runs the reduce, which is what pushes the handle.
+            try (SqlExecutionContext parallelCtx = TestUtils.createSqlExecutionCtx(engine, 4);
+                 SqlCompiler compiler = engine.getSqlCompiler();
+                 RecordCursorFactory factory = compiler.compile(query, parallelCtx).getRecordCursorFactory()) {
+                try (RecordCursor cursor = factory.getCursor(parallelCtx)) {
+                    //noinspection StatementWithEmptyBody
+                    while (cursor.hasNext()) {
+                        // drain: forces the reduce path to decode the parquet frame
+                    }
+                }
+            }
+
+            final SqlExecutionCircuitBreaker handle = lastCancelHandle.get();
+            Assert.assertNotNull(
+                    "parquet decoder never received a cancel handle [decodersCreated=" + decodersCreated.get()
+                            + ", nonNullCancelHandleCalls=" + nonNullCancelHandleCalls.get() + "]",
+                    handle
+            );
+            // Before the fix the decoder got the raw, thread-unsafe query breaker shared across every
+            // reduce worker; the fix hands each pool its own SqlExecutionCircuitBreakerWrapper view.
+            Assert.assertTrue(
+                    "decoder must receive a per-pool wrapper, not the raw shared query breaker (got "
+                            + handle.getClass().getName() + ")",
+                    handle instanceof SqlExecutionCircuitBreakerWrapper
+            );
+        });
+    }
+
+    private static class RecordingParquetPartitionDecoder extends ParquetPartitionDecoder {
+        private RecordingParquetPartitionDecoder() {
+            decodersCreated.incrementAndGet();
+        }
+
+        @Override
+        public void setCancelHandle(SqlExecutionCircuitBreaker cancelHandle) {
+            if (cancelHandle != null) {
+                nonNullCancelHandleCalls.incrementAndGet();
+                lastCancelHandle.set(cancelHandle);
+            }
+            super.setCancelHandle(cancelHandle);
+        }
+    }
+}


### PR DESCRIPTION
Depend on https://github.com/questdb/questdb/pull/7379

## Summary

Adds an extension point so a `ParquetPartitionDecoder` implementation can be handed the query's `SqlExecutionCircuitBreaker` and probe it while decoding a row group. The default decoder reads resident (mmapped) memory and never blocks, so its implementation is a **no-op** — this is dormant plumbing with no observable behaviour change on its own. It exists for decoder implementations (installed via the existing `CairoConfiguration.newParquetPartitionDecoder()` factory seam) whose row-group navigation may *block waiting for data* rather than read memory that is already present: without a cancel handle such a decode cannot observe a query cancellation or timeout and would stall query teardown on the slowest in-flight read.

No cursor, factory or reducer signature widens, and no SQL-visible behaviour changes. Two internal signatures do: `AsyncFilterContext.initMemoryPools(...)` takes the engine and the query breaker, and `PageFrameMemoryPool.setCancelHandle(...)` takes the engine (for the per-pool breaker wrapper — see below). Owner-thread cursor paths leave the handle null and keep their current cancellation behaviour exactly.

## Change

New method `ParquetPartitionDecoder.setCancelHandle(SqlExecutionCircuitBreaker)`, a no-op by default, plumbed through the parallel reduce path so the active decoder receives a breaker it can safely probe:

- **`ParquetPartitionDecoder.setCancelHandle(...)`** — no-op base method; a subclass that performs blocking work during decode overrides it.
- **`PageFrameMemoryPool.setCancelHandle(CairoEngine, SqlExecutionCircuitBreaker)`** — the substance of the change, see below. Wraps the query breaker in a per-pool `SqlExecutionCircuitBreakerWrapper` and forwards *that* to the active decoder, re-applying it in `activateDecoder` after the lazy `newParquetPartitionDecoder()` so a decoder created on first use still gets it. The wrapper is created once per pool, re-`init`'d per reduce, and freed in `close()`.
- **`PageFrameReduceTask.setCancelHandle(...)`** — forwards to its `frameMemoryPool`.
- **`PageFrameReduceJob.reduce(...)`** — pushes `frameSequence.getCircuitBreaker()` down to the task immediately before the decode navigation, so the handle in effect is always the current query's.
- **`AsyncFilterContext.initMemoryPools(...)`** — now also binds the handle on the owner pool and every per-worker pool at query init, so a pool reached outside `PageFrameReduceJob` (the atom's own per-worker pools) is covered too. Takes two new parameters, `CairoEngine` and the query breaker.
- **`PageFrameSequence` / `UnorderedPageFrameSequence`** — gain an `engine` field and `getEngine()`, which is how the seven `Async*RecordCursor` call sites reach the engine to pass into `initMemoryPools`. Those seven are one-line call-site updates and nothing else.

### Why the per-pool wrapper

The obvious implementation — hand the decoder `frameSequence.getCircuitBreaker()` directly — is wrong on the parallel path. A `SqlExecutionCircuitBreaker` is per-query and **thread-unsafe**: `statefulThrowExceptionIfTripped()` mutates throttle counters and timer state on the instance. Under a parallel reduce, N workers decode concurrently against one frame sequence, so N decoders would be mutating one breaker's throttle state at once.

So each `PageFrameMemoryPool` owns a `SqlExecutionCircuitBreakerWrapper`: private throttle and timer state, over the query's *shared* cancelled flag, fd and timeout. Every decoder probes its own pool's wrapper; cancellation, disconnect and timeout still resolve to the same underlying query state.

## Behaviour

- The default `ParquetPartitionDecoder` ignores the handle — zero behaviour change for every existing query. The only added work is a few field writes per reduce, plus one `SqlExecutionCircuitBreakerWrapper` allocated lazily per pool on first use (not per reduce, and never on a pool that is never handed a breaker).
- A decoder that overrides `setCancelHandle` can, from inside a blocking decode, poll the breaker and abort a cancelled or timed-out query instead of running to completion.
- The handle is set per reduce and each `PageFrameMemoryPool` owns its own decoder instance and its own wrapper, so no stale breaker is ever probed and pool instances never cross-contaminate each other's handle.

## Testing

- `ParquetDecoderCancelHandleTest` (new) — the seam end to end, through real queries over real parquet partitions. A recording `ParquetPartitionDecoder` installed via the configuration factory captures what the pool forwards, and both parallel-reduce shapes are covered: `testAsyncFilterOverParquetDeliversPerPoolBreaker` (ordered path, which also exercises the `activateDecoder` re-arm because the decoder is created lazily on the first parquet frame *after* `setCancelHandle` runs) and `testAsyncGroupByOverParquetDeliversPerPoolBreaker` (unordered path, decoding through the `AsyncFilterContext` per-worker pools). Both assert the decoder receives a per-pool wrapper rather than the raw query breaker. Both fail against the pre-change plumbing, which pushed the shared thread-unsafe breaker on the filter path only and never wired the aggregation/join paths at all.
- `AsyncFilteredRecordCursorFactoryTest` — the parallel-reduce path exercised by the new `reduce` push stays green; the handle plumbing does not disturb async filtering.
- `ParallelFilterTest` — broader parallel coverage over the same reduce path.
- Existing parquet decode and page-frame reduce suites remain green (no behaviour change on the default path).