### PR TITLE
fix(sql): fix premature out-of-memory errors in GROUP BY, ORDER BY and hash joins

### DIFF
--- a/core/src/main/java/io/questdb/cairo/map/OrderedMap.java
+++ b/core/src/main/java/io/questdb/cairo/map/OrderedMap.java
@@ -55,6 +55,7 @@ import io.questdb.std.bytes.Bytes;
 import io.questdb.std.str.Utf8Sequence;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 import static io.questdb.std.Numbers.MAX_SAFE_INT_POW_2;
 
@@ -81,8 +82,9 @@ import static io.questdb.std.Numbers.MAX_SAFE_INT_POW_2;
  * <li>2. Off-heap memory for key-value pairs a.k.a. "key memory"</li>
  * </ul>
  * The offset list contains [compressed_offset, hash code 32 LSBs] pairs. An offset value contains
- * an offset to the address of a key-value pair in the key memory compressed to an int. Key-value
- * pair addresses are 8 byte aligned, so a FastMap is capable of holding up to 32GB of data.
+ * an offset to the address of a key-value pair in the key memory compressed to an int. Compressed
+ * offsets are unsigned: they are shifted by +1, so that 0 marks an empty slot, and 8 byte aligned,
+ * so a FastMap is capable of holding up to 32GB of data.
  * <p>
  * The offset list is used as a hash table with linear probing. So, a table resize allocates a new
  * offset list and copies offsets there while the key memory stays as is.
@@ -98,6 +100,9 @@ import static io.questdb.std.Numbers.MAX_SAFE_INT_POW_2;
  */
 public class OrderedMap implements Map, Reopenable {
     static final long VAR_KEY_HEADER_SIZE = 4;
+    // The largest byte offset a compressed offset can encode: offsets are unsigned 32-bit,
+    // shifted by +1 and 8-byte scaled, so this is (2^32 - 2) * 8. Note that it is 16 bytes
+    // below 2^35, i.e. not a power of two, hence resize() has to clamp to it.
     private static final long MAX_HEAP_SIZE = (Integer.toUnsignedLong(-1) - 1) << 3;
     private static final int MIN_KEY_CAPACITY = 16;
 
@@ -127,6 +132,9 @@ public class OrderedMap implements Map, Reopenable {
     private long kPos;      // Current key-value memory pointer (contains searched key / pending key-value pair).
     private int keyCapacity;
     private int mask;
+    // Heap ceiling honoured by resize(). Always MAX_HEAP_SIZE in production; tests lower it
+    // to exercise the clamp without allocating 16GB.
+    private long maxHeapSize = MAX_HEAP_SIZE;
     // Per-query native memory tracker bound by the owning factory at cursor start.
     // Null when no per-query limit applies; all Unsafe.{malloc,realloc,free} calls
     // degrade to the global-only overloads in that case.
@@ -135,6 +143,8 @@ public class OrderedMap implements Map, Reopenable {
     private int nResizes;
     // Holds a list of [compressed_offset, hash_code] pairs.
     // Offsets are shifted by +1 (0 -> 1, 1 -> 2, etc.), so that we fill the memory with 0.
+    // A compressed offset is an UNSIGNED 32-bit value, so slot emptiness must be tested as
+    // "raw offset == 0", never as "raw offset <= 0": offsets past 16GB have their top bit set.
     // Lowest 32 bits of hash code can be used to obtain an entry index since
     // maximum number of entries in the map is limited with 32-bit compressed offsets.
     private long offsetsAddr;
@@ -485,6 +495,18 @@ public class OrderedMap implements Map, Reopenable {
         rehash(Numbers.ceilPow2((int) requiredCapacity));
     }
 
+    /**
+     * Lowers the heap ceiling honoured by {@code resize()}, so that both the clamp and the
+     * limit-exceeded path can be exercised without allocating 16GB. The value must be positive,
+     * 8-byte aligned, since heap offsets are 8-byte scaled, and no greater than the natural
+     * ceiling imposed by compressed offsets.
+     */
+    @TestOnly
+    public void setMaxHeapSize(long maxHeapSize) {
+        assert maxHeapSize > 0 && (maxHeapSize & 7) == 0 && maxHeapSize <= MAX_HEAP_SIZE;
+        this.maxHeapSize = maxHeapSize;
+    }
+
     @Override
     public void setMemoryTracker(@Nullable MemoryTracker tracker) {
         this.memoryTracker = tracker;
@@ -513,8 +535,9 @@ public class OrderedMap implements Map, Reopenable {
         return (int) ((offset >> 3) + 1);
     }
 
+    // Callers must have established that rawOffset != 0, i.e. that the slot is occupied.
     private static long decompressOffset(int rawOffset) {
-        return ((long) rawOffset - 1) << 3;
+        return (Integer.toUnsignedLong(rawOffset) - 1) << 3;
     }
 
     private static void validateBatchAddressable(long sizeBytes) {
@@ -555,18 +578,19 @@ public class OrderedMap implements Map, Reopenable {
         OUTER:
         for (int i = 0, n = srcMap.keyCapacity; i < n; i++) {
             long srcP = srcMap.offsetsAddr + ((long) i << 3);
-            long offset = decompressOffset(Unsafe.getInt(srcP));
-            if (offset < 0) {
+            int srcRawOffset = Unsafe.getInt(srcP);
+            if (srcRawOffset == 0) {
                 continue;
             }
 
-            long srcStartAddr = srcMap.heapAddr + offset;
+            long srcStartAddr = srcMap.heapAddr + decompressOffset(srcRawOffset);
             int hashCodeLo = Unsafe.getInt(srcP + 4);
             int index = hashCodeLo & mask;
 
-            long destOffset;
+            int destRawOffset;
             long destP = offsetsAddr + ((long) index << 3);
-            while ((destOffset = decompressOffset(Unsafe.getInt(destP))) > -1) {
+            while ((destRawOffset = Unsafe.getInt(destP)) != 0) {
+                long destOffset = decompressOffset(destRawOffset);
                 if (
                         hashCodeLo == Unsafe.getInt(destP + 4)
                                 && Vect.memeq(heapAddr + destOffset, srcStartAddr, keySize)
@@ -607,19 +631,20 @@ public class OrderedMap implements Map, Reopenable {
         OUTER:
         for (int i = 0, n = srcMap.keyCapacity; i < n; i++) {
             long srcOffsetAddr = srcMap.offsetsAddr + ((long) i << 3);
-            long offset = decompressOffset(Unsafe.getInt(srcOffsetAddr));
-            if (offset < 0) {
+            int srcRawOffset = Unsafe.getInt(srcOffsetAddr);
+            if (srcRawOffset == 0) {
                 continue;
             }
 
-            long srcStartAddr = srcMap.heapAddr + offset;
+            long srcStartAddr = srcMap.heapAddr + decompressOffset(srcRawOffset);
             int srcKeySize = Unsafe.getInt(srcStartAddr);
             int hashCodeLo = Unsafe.getInt(srcOffsetAddr + 4);
             int index = hashCodeLo & mask;
 
-            long destOffset;
+            int destRawOffset;
             long destOffsetAddr = offsetsAddr + ((long) index << 3);
-            while ((destOffset = decompressOffset(Unsafe.getInt(destOffsetAddr))) > -1) {
+            while ((destRawOffset = Unsafe.getInt(destOffsetAddr)) != 0) {
+                long destOffset = decompressOffset(destRawOffset);
                 if (
                         hashCodeLo == Unsafe.getInt(destOffsetAddr + 4)
                                 && Unsafe.getInt(heapAddr + destOffset) == srcKeySize
@@ -662,7 +687,7 @@ public class OrderedMap implements Map, Reopenable {
         // Layout: [rawOffset (4 bytes) | hashCodeLo (4 bytes)]
         long slotValue = Unsafe.getLong(offsetAddr);
         int rawOffset = Numbers.decodeLowInt(slotValue);
-        while (rawOffset > 0) {
+        while (rawOffset != 0) {
             int storedHash = Numbers.decodeHighInt(slotValue);
             if (hashCodeLo == storedHash) {
                 long offset = decompressOffset(rawOffset);
@@ -800,7 +825,7 @@ public class OrderedMap implements Map, Reopenable {
         // Read offset and hash as a single 64-bit value to reduce memory accesses.
         long slotValue = Unsafe.getLong(offsetAddr);
         int rawOffset = Numbers.decodeLowInt(slotValue);
-        while (rawOffset > 0) {
+        while (rawOffset != 0) {
             int storedHash = Numbers.decodeHighInt(slotValue);
             if (hashCodeLo == storedHash) {
                 long offset = decompressOffset(rawOffset);
@@ -843,7 +868,7 @@ public class OrderedMap implements Map, Reopenable {
             int index = hashCodeLo & newMask;
 
             long newOffsetAddr = newOffsetsAddr + ((long) index << 3);
-            while (Unsafe.getInt(newOffsetAddr) > 0) {
+            while (Unsafe.getInt(newOffsetAddr) != 0) {
                 index = (index + 1) & newMask;
                 newOffsetAddr = newOffsetsAddr + ((long) index << 3);
             }
@@ -865,13 +890,21 @@ public class OrderedMap implements Map, Reopenable {
         }
 
         nResizes++;
+        final long maxHeapSize = this.maxHeapSize;
+        final long target = appendAddr + entrySize - heapAddr;
+        if (target > maxHeapSize) {
+            throw LimitOverflowException.instance().put("limit of ").put(maxHeapSize).put(" memory exceeded in FastMap");
+        }
         long kCapacity = (heapLimit - heapAddr) << 1;
-        long target = appendAddr + entrySize - heapAddr;
         if (kCapacity < target) {
             kCapacity = Numbers.ceilPow2(target);
         }
-        if (kCapacity > MAX_HEAP_SIZE) {
-            throw LimitOverflowException.instance().put("limit of ").put(MAX_HEAP_SIZE).put(" memory exceeded in FastMap");
+        // Both the doubling and the ceilPow2 above yield a power of two, while the ceiling is
+        // 16 bytes below 2^35. Clamp rather than reject: the data we have to fit still does fit,
+        // and nothing downstream requires a power-of-two heap. Without the clamp the largest
+        // reachable heap would be 2^34, i.e. half of what compressed offsets can address.
+        if (kCapacity > maxHeapSize) {
+            kCapacity = maxHeapSize;
         }
         validateBatchAddressable(kCapacity);
         long kAddr = Unsafe.realloc(heapAddr, heapSize, kCapacity, heapMemoryTag, memoryTracker);

--- a/core/src/main/java/io/questdb/griffin/engine/AbstractRedBlackTree.java
+++ b/core/src/main/java/io/questdb/griffin/engine/AbstractRedBlackTree.java
@@ -36,7 +36,9 @@ import org.jetbrains.annotations.Nullable;
  * <p>
  * Each block ref value stores compressed offsets. A compressed offset contains
  * an offset to the address of the referenced block in the heap memory
- * compressed to an int. Block addresses are 8-byte aligned.
+ * compressed to an int. Block addresses are 8-byte aligned. Compressed offsets are
+ * unsigned, with {@link #EMPTY} reserved as the sentinel, so emptiness must be tested
+ * as {@code == EMPTY}, never as {@code < 0}.
  */
 public abstract class AbstractRedBlackTree implements Mutable, Reopenable {
     protected static final byte BLACK = 0;
@@ -122,20 +124,28 @@ public abstract class AbstractRedBlackTree implements Mutable, Reopenable {
         return (int) (rawOffset >> 3);
     }
 
+    // Compressed offsets are unsigned: blocks past the 16GB mark have the top bit set.
     private static long uncompressKeyOffset(int offset) {
-        return ((long) offset) << 3;
+        return Integer.toUnsignedLong(offset) << 3;
     }
 
     private void checkKeyCapacity() {
         if (keyHeapPos + BLOCK_SIZE > keyHeapLimit) {
-            final long newHeapSize = keyHeapSize << 1;
+            final long required = keyHeapPos - keyHeapStart + BLOCK_SIZE;
+            long newHeapSize = keyHeapSize << 1;
             if (newHeapSize > maxKeyHeapSize) {
-                LimitOverflowException ex = LimitOverflowException.instance();
-                ex.put("limit of ").put(maxKeyHeapSize).put(" memory exceeded in RedBlackTree");
-                if (keyHeapConfigKey != null) {
-                    ex.put(" (raise ").put(keyHeapConfigKey).put(')');
+                if (required > maxKeyHeapSize) {
+                    LimitOverflowException ex = LimitOverflowException.instance();
+                    ex.put("limit of ").put(maxKeyHeapSize).put(" memory exceeded in RedBlackTree");
+                    if (keyHeapConfigKey != null) {
+                        ex.put(" (raise ").put(keyHeapConfigKey).put(')');
+                    }
+                    throw ex;
                 }
-                throw ex;
+                // Doubling overshoots a cap that is rarely a power of two, so rejecting here
+                // would strand up to half of the configured budget. The block we have to fit
+                // still fits, so clamp to the cap instead.
+                newHeapSize = maxKeyHeapSize;
             }
             long newHeapPos = Unsafe.realloc(keyHeapStart, keyHeapSize, newHeapSize, MemoryTag.NATIVE_TREE_CHAIN, memoryTracker);
 
@@ -212,7 +222,7 @@ public abstract class AbstractRedBlackTree implements Mutable, Reopenable {
         do {
             parent = p;
             p = rightOf(p);
-        } while (p > -1);
+        } while (p != EMPTY);
         return parent;
     }
 
@@ -222,7 +232,7 @@ public abstract class AbstractRedBlackTree implements Mutable, Reopenable {
         do {
             parent = p;
             p = leftOf(p);
-        } while (p > -1);
+        } while (p != EMPTY);
         return parent;
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/join/LongChain.java
+++ b/core/src/main/java/io/questdb/griffin/engine/join/LongChain.java
@@ -39,7 +39,9 @@ import java.io.Closeable;
  * <p>
  * For each long value also stores compressed offset for its parent (previous in the chain) value.
  * A compressed offset contains an offset to the address of the parent value in the heap memory
- * compressed to an int. Value addresses are 4-byte aligned.
+ * compressed to an int. Value addresses are 4-byte aligned. Compressed offsets are unsigned,
+ * with -1 reserved as the end-of-chain sentinel, so the chain end must be tested as
+ * {@code == -1}, never as {@code < 0}.
  */
 public class LongChain implements Closeable, Mutable, Reopenable {
     private static final long CHAIN_VALUE_SIZE = 12;
@@ -118,15 +120,23 @@ public class LongChain implements Closeable, Mutable, Reopenable {
         return (int) (rawOffset >> 2);
     }
 
+    // Compressed offsets are unsigned: values past the 8GB mark have the top bit set.
     private static long uncompressOffset(int offset) {
-        return ((long) offset) << 2;
+        return Integer.toUnsignedLong(offset) << 2;
     }
 
     private void checkCapacity() {
         if (heapPos + CHAIN_VALUE_SIZE > heapLimit) {
-            final long newHeapSize = heapSize << 1;
+            final long required = heapPos - heapStart + CHAIN_VALUE_SIZE;
+            long newHeapSize = heapSize << 1;
             if (newHeapSize > maxHeapSize) {
-                throw LimitOverflowException.instance().put("limit of ").put(maxHeapSize).put(" memory exceeded in LongChain");
+                if (required > maxHeapSize) {
+                    throw LimitOverflowException.instance().put("limit of ").put(maxHeapSize).put(" memory exceeded in LongChain");
+                }
+                // Doubling overshoots a cap that is rarely a power of two, so rejecting here
+                // would strand up to half of the configured budget. The value we have to fit
+                // still fits, so clamp to the cap instead.
+                newHeapSize = maxHeapSize;
             }
             long newHeapPos = Unsafe.realloc(heapStart, heapSize, newHeapSize, MemoryTag.NATIVE_DEFAULT, memoryTracker);
 

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeLongTreeChain.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/LimitedSizeLongTreeChain.java
@@ -201,7 +201,7 @@ public class LimitedSizeLongTreeChain extends AbstractRedBlackTree implements Re
             } else {
                 return p;
             }
-        } while (p > -1);
+        } while (p != EMPTY);
 
         return -1;
     }
@@ -313,7 +313,7 @@ public class LimitedSizeLongTreeChain extends AbstractRedBlackTree implements Re
                 prepareComparatorLeftSideIfAtMaxCapacity(sourceCursor, ownedRecord, comparator, currentFrameIndex);
                 return;
             }
-        } while (p > -1);
+        } while (p != EMPTY);
 
         p = allocateBlock(parent, currentRecord.getRowId());
 
@@ -371,8 +371,9 @@ public class LimitedSizeLongTreeChain extends AbstractRedBlackTree implements Re
         return (int) (rawOffset >> 2);
     }
 
+    // Compressed offsets are unsigned: values past the 8GB mark have the top bit set.
     private static long uncompressValueOffset(int offset) {
-        return ((long) offset) << 2;
+        return Integer.toUnsignedLong(offset) << 2;
     }
 
     private int appendValue(long value, int prevValueOffset) {
@@ -386,14 +387,21 @@ public class LimitedSizeLongTreeChain extends AbstractRedBlackTree implements Re
 
     private void checkValueCapacity() {
         if (valueHeapPos + CHAIN_VALUE_SIZE > valueHeapLimit) {
-            final long newHeapSize = valueHeapSize << 1;
+            final long required = valueHeapPos - valueHeapStart + CHAIN_VALUE_SIZE;
+            long newHeapSize = valueHeapSize << 1;
             if (newHeapSize > maxValueHeapSize) {
-                LimitOverflowException ex = LimitOverflowException.instance();
-                ex.put("limit of ").put(maxValueHeapSize).put(" memory exceeded in LimitedSizeLongTreeChain");
-                if (valueHeapConfigKey != null) {
-                    ex.put(" (raise ").put(valueHeapConfigKey).put(')');
+                if (required > maxValueHeapSize) {
+                    LimitOverflowException ex = LimitOverflowException.instance();
+                    ex.put("limit of ").put(maxValueHeapSize).put(" memory exceeded in LimitedSizeLongTreeChain");
+                    if (valueHeapConfigKey != null) {
+                        ex.put(" (raise ").put(valueHeapConfigKey).put(')');
+                    }
+                    throw ex;
                 }
-                throw ex;
+                // Doubling overshoots a cap that is rarely a power of two, so rejecting here
+                // would strand up to half of the configured budget. The value we have to fit
+                // still fits, so clamp to the cap instead.
+                newHeapSize = maxValueHeapSize;
             }
             long newHeapPos = Unsafe.realloc(valueHeapStart, valueHeapSize, newHeapSize, MemoryTag.NATIVE_TREE_CHAIN, memoryTracker);
 

--- a/core/src/main/java/io/questdb/griffin/engine/orderby/LongTreeChain.java
+++ b/core/src/main/java/io/questdb/griffin/engine/orderby/LongTreeChain.java
@@ -159,7 +159,7 @@ public class LongTreeChain extends AbstractRedBlackTree implements Reopenable {
                 setLastRef(offset, newChainEnd);
                 return;
             }
-        } while (offset > -1);
+        } while (offset != EMPTY);
 
         offset = allocateBlock();
         setParent(offset, parent);
@@ -190,8 +190,9 @@ public class LongTreeChain extends AbstractRedBlackTree implements Reopenable {
         return (int) (rawOffset >> 2);
     }
 
+    // Compressed offsets are unsigned: values past the 8GB mark have the top bit set.
     private static long uncompressValueOffset(int offset) {
-        return ((long) offset) << 2;
+        return Integer.toUnsignedLong(offset) << 2;
     }
 
     private int appendNewValue(long rowId) {
@@ -205,14 +206,21 @@ public class LongTreeChain extends AbstractRedBlackTree implements Reopenable {
 
     private void checkValueCapacity() {
         if (valueHeapPos + CHAIN_VALUE_SIZE > valueHeapLimit) {
-            final long newHeapSize = valueHeapSize << 1;
+            final long required = valueHeapPos - valueHeapStart + CHAIN_VALUE_SIZE;
+            long newHeapSize = valueHeapSize << 1;
             if (newHeapSize > maxValueHeapSize) {
-                LimitOverflowException ex = LimitOverflowException.instance();
-                ex.put("limit of ").put(maxValueHeapSize).put(" memory exceeded in LongTreeChain");
-                if (valueHeapConfigKey != null) {
-                    ex.put(" (raise ").put(valueHeapConfigKey).put(')');
+                if (required > maxValueHeapSize) {
+                    LimitOverflowException ex = LimitOverflowException.instance();
+                    ex.put("limit of ").put(maxValueHeapSize).put(" memory exceeded in LongTreeChain");
+                    if (valueHeapConfigKey != null) {
+                        ex.put(" (raise ").put(valueHeapConfigKey).put(')');
+                    }
+                    throw ex;
                 }
-                throw ex;
+                // Doubling overshoots a cap that is rarely a power of two, so rejecting here
+                // would strand up to half of the configured budget. The value we have to fit
+                // still fits, so clamp to the cap instead.
+                newHeapSize = maxValueHeapSize;
             }
             long newHeapPos = Unsafe.realloc(valueHeapStart, valueHeapSize, newHeapSize, MemoryTag.NATIVE_TREE_CHAIN, memoryTracker);
 

--- a/core/src/test/java/io/questdb/test/cairo/map/OrderedMapTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/map/OrderedMapTest.java
@@ -49,6 +49,7 @@ import io.questdb.cairo.map.MapValueMergeFunction;
 import io.questdb.cairo.map.OrderedMap;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.griffin.engine.LimitOverflowException;
 import io.questdb.griffin.engine.functions.columns.LongColumn;
 import io.questdb.std.BinarySequence;
 import io.questdb.std.BitSet;
@@ -78,6 +79,7 @@ import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 
 public class OrderedMapTest extends AbstractCairoTest {
@@ -1825,6 +1827,40 @@ public class OrderedMapTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testOffsetCompressionRoundTripsAboveSignedIntRange() throws Exception {
+        // Compressed offsets are unsigned 32-bit. Offsets at or above (2^31 - 1) * 8 set the top
+        // bit of the raw int; reading them back as a signed int yielded a negative offset, which
+        // the probe loops then mistook for an empty slot. Pin the unsigned round-trip down.
+        final Method compressOffset = OrderedMap.class.getDeclaredMethod("compressOffset", long.class);
+        final Method decompressOffset = OrderedMap.class.getDeclaredMethod("decompressOffset", int.class);
+        compressOffset.setAccessible(true);
+        decompressOffset.setAccessible(true);
+
+        final long lastSignedOffset = (Integer.MAX_VALUE - 1L) << 3; // compresses to Integer.MAX_VALUE
+        final long firstUnsignedOffset = ((long) Integer.MAX_VALUE) << 3; // compresses to Integer.MIN_VALUE
+        final long maxHeapSize = (Integer.toUnsignedLong(-1) - 1) << 3; // (2^32 - 2) * 8
+        final long[] offsets = {
+                0,
+                8,
+                1L << 30,
+                lastSignedOffset,
+                firstUnsignedOffset,
+                1L << 34,
+                maxHeapSize - 8, // last offset an entry can start at
+        };
+        for (long offset : offsets) {
+            int rawOffset = (Integer) compressOffset.invoke(null, offset);
+            Assert.assertNotEquals("offset " + offset + " must not compress to the empty marker", 0, rawOffset);
+            Assert.assertEquals("offset " + offset, offset, ((Long) decompressOffset.invoke(null, rawOffset)).longValue());
+        }
+
+        // The upper half of the range is exactly what the signed reading got wrong.
+        Assert.assertTrue((Integer) compressOffset.invoke(null, lastSignedOffset) > 0);
+        Assert.assertTrue((Integer) compressOffset.invoke(null, firstUnsignedOffset) < 0);
+        Assert.assertTrue((Integer) compressOffset.invoke(null, maxHeapSize - 8) < 0);
+    }
+
+    @Test
     public void testRecordAsKey() throws Exception {
         assertMemoryLeak(() -> {
             final int N = 5000;
@@ -1882,6 +1918,179 @@ public class OrderedMapTest extends AbstractCairoTest {
                         mapCursor.toTop();
                         assertCursor2(rnd, binarySequence, keyColumnOffset, rnd2, mapCursor);
                     }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testResizeClampedHeapVarSizeKey() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            // Same clamp as the fixed-size case, but reached through VarSizeKey.checkCapacity(),
+            // which resizes mid-key and has to shift startAddr/appendAddr by the realloc delta.
+            // A 4-char STRING key plus a LONG value is a 24-byte entry: the heap grows
+            // 32 -> 64 -> ... -> 2048, then clamps to 3064 instead of overshooting to 4096.
+            // 3064 bytes hold 127 entries; the pre-clamp 2048 held 85.
+            final long maxHeapSize = 3_064;
+            final int clampedEntries = 127;
+            final Rnd rnd = new Rnd();
+
+            try (
+                    OrderedMap map = new OrderedMap(
+                            32,
+                            new SingleColumnType(ColumnType.STRING),
+                            new SingleColumnType(ColumnType.LONG),
+                            16,
+                            0.5,
+                            Integer.MAX_VALUE
+                    )
+            ) {
+                map.setMaxHeapSize(maxHeapSize);
+
+                // Fill to one entry short of the ceiling. The clamp happens well before that.
+                for (int i = 0; i < clampedEntries - 1; i++) {
+                    MapKey key = map.withKey();
+                    key.putStr(rnd.nextString(4));
+                    MapValue value = key.createValue();
+                    Assert.assertTrue(value.isNew());
+                    value.putLong(0, i);
+                }
+                Assert.assertEquals(maxHeapSize, map.getHeapSize());
+
+                // Every entry written into the clamped heap must still be readable.
+                rnd.reset();
+                for (int i = 0; i < clampedEntries - 1; i++) {
+                    MapKey key = map.withKey();
+                    key.putStr(rnd.nextString(4));
+                    MapValue value = key.findValue();
+                    Assert.assertNotNull(value);
+                    Assert.assertEquals(i, value.getLong(0));
+                }
+
+                // The last entry fits exactly, the one after it does not.
+                MapKey key = map.withKey();
+                key.putStr(rnd.nextString(4));
+                key.createValue().putLong(0, clampedEntries - 1);
+                Assert.assertEquals(clampedEntries, map.size());
+                Assert.assertEquals(24L * clampedEntries, map.getUsedHeapSize());
+
+                try {
+                    MapKey overflowing = map.withKey();
+                    overflowing.putStr(rnd.nextString(4));
+                    overflowing.createValue();
+                    Assert.fail("expected LimitOverflowException");
+                } catch (LimitOverflowException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "limit of 3064 memory exceeded in FastMap");
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testResizeClampsHeapToMaxHeapSize() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            // The heap ceiling is 16 bytes below 2^35, so it is never a power of two, while
+            // every doubling step is. Model that at KB scale: growing 32 -> 64 -> ... -> 2048,
+            // the next step (4096) overshoots the 3064-byte ceiling and must clamp to it
+            // rather than fail. 3064 bytes hold 191 16-byte entries; the pre-clamp 2048 held 128.
+            final long maxHeapSize = 3_064;
+            final int clampedEntries = 191;
+            final int preClampEntries = 128;
+
+            try (
+                    OrderedMap map = new OrderedMap(
+                            32,
+                            new SingleColumnType(ColumnType.LONG),
+                            new SingleColumnType(ColumnType.LONG),
+                            16,
+                            0.5,
+                            Integer.MAX_VALUE
+                    )
+            ) {
+                map.setMaxHeapSize(maxHeapSize);
+
+                // Fill to one entry short of the ceiling. The clamp happens at 2048 -> 3064,
+                // so everything past entry 128 only exists because resize() clamped.
+                for (int i = 0; i < clampedEntries - 1; i++) {
+                    MapKey key = map.withKey();
+                    key.putLong(i);
+                    MapValue value = key.createValue();
+                    Assert.assertTrue(value.isNew());
+                    value.putLong(0, i);
+                }
+                Assert.assertEquals(maxHeapSize, map.getHeapSize());
+                Assert.assertTrue("the clamp must have added capacity", map.size() > preClampEntries);
+                // A clamped heap is not a power of two - nothing downstream may assume it is.
+                Assert.assertNotEquals(maxHeapSize, Numbers.ceilPow2(maxHeapSize));
+
+                // Probing works over the clamped heap. It needs one entry of headroom at kPos,
+                // where withKey() stages the search key, so it has to run before the last insert.
+                for (int i = 0; i < clampedEntries - 1; i++) {
+                    MapKey key = map.withKey();
+                    key.putLong(i);
+                    MapValue value = key.findValue();
+                    Assert.assertNotNull(value);
+                    Assert.assertEquals(i, value.getLong(0));
+                }
+
+                // The last entry fits exactly, the one after it does not.
+                MapKey lastKey = map.withKey();
+                lastKey.putLong(clampedEntries - 1);
+                lastKey.createValue().putLong(0, clampedEntries - 1);
+                Assert.assertEquals(clampedEntries, map.size());
+                Assert.assertEquals(16L * clampedEntries, map.getUsedHeapSize());
+
+                try {
+                    MapKey overflowing = map.withKey();
+                    overflowing.putLong(clampedEntries);
+                    overflowing.createValue();
+                    Assert.fail("expected LimitOverflowException");
+                } catch (LimitOverflowException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "limit of 3064 memory exceeded in FastMap");
+                }
+
+                // Cursor iteration over the clamped heap yields every entry, in insertion order.
+                int i = 0;
+                try (RecordCursor cursor = map.getCursor()) {
+                    MapRecord record = map.getRecord();
+                    while (cursor.hasNext()) {
+                        Assert.assertEquals(i, record.getLong(1));
+                        Assert.assertEquals(i, record.getValue().getLong(0));
+                        i++;
+                    }
+                }
+                Assert.assertEquals(clampedEntries, i);
+
+                // restoreInitialCapacity() must cope with the clamped, non-power-of-two heap.
+                map.restoreInitialCapacity();
+                Assert.assertEquals(32L, map.getHeapSize());
+                Assert.assertEquals(0, map.size());
+            }
+        });
+    }
+
+    @Test
+    public void testResizeThrowsWhenEntryExceedsMaxHeapSize() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            // A single entry larger than the ceiling can never fit, clamp or no clamp.
+            try (
+                    OrderedMap map = new OrderedMap(
+                            32,
+                            new SingleColumnType(ColumnType.STRING),
+                            new SingleColumnType(ColumnType.LONG),
+                            16,
+                            0.5,
+                            Integer.MAX_VALUE
+                    )
+            ) {
+                map.setMaxHeapSize(3_064);
+
+                try {
+                    MapKey key = map.withKey();
+                    key.putStr("a".repeat(4_000));
+                    Assert.fail("expected LimitOverflowException");
+                } catch (LimitOverflowException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "limit of 3064 memory exceeded in FastMap");
                 }
             }
         });

--- a/core/src/test/java/io/questdb/test/griffin/engine/join/LongChainTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/join/LongChainTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.griffin.engine.join;
 
+import io.questdb.griffin.engine.LimitOverflowException;
 import io.questdb.griffin.engine.join.LongChain;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
@@ -31,6 +32,7 @@ import io.questdb.std.IntList;
 import io.questdb.std.LongList;
 import io.questdb.std.ObjList;
 import io.questdb.std.Rnd;
+import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -69,6 +71,39 @@ public class LongChainTest {
                     }
                     Assert.assertEquals(N, count);
                 }
+            }
+        });
+    }
+
+    @Test
+    public void testHeapClampsToMaxHeapSize() throws Exception {
+        assertMemoryLeak(() -> {
+            // 64B page x 3 pages = a 192B budget, which is not a power of two. Doubling goes
+            // 64 -> 128 -> 256, and 256 overshoots, so rejecting there stranded a third of the
+            // configured budget. Clamping to 192 fits 16 12-byte values instead of 10.
+            try (LongChain chain = new LongChain(64, 3)) {
+                final LongList expected = new LongList();
+                int tail = -1;
+                try {
+                    for (int i = 0; i < 100; i++) {
+                        tail = chain.put(i, tail);
+                        expected.add(i);
+                    }
+                    Assert.fail("expected LimitOverflowException");
+                } catch (LimitOverflowException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "limit of 192 memory exceeded in LongChain");
+                }
+                Assert.assertEquals(16, expected.size());
+
+                // Everything written into the clamped heap must still read back, in reverse order.
+                expected.reverse();
+                LongChain.Cursor cursor = chain.getCursor(tail);
+                int count = 0;
+                while (cursor.hasNext()) {
+                    Assert.assertEquals(expected.getQuick(count), cursor.next());
+                    count++;
+                }
+                Assert.assertEquals(expected.size(), count);
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/orderby/LimitedSizeLongTreeChainTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/orderby/LimitedSizeLongTreeChainTest.java
@@ -126,6 +126,24 @@ public class LimitedSizeLongTreeChainTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testKeyHeapClampsToMaxHeapSize() {
+        // A 200-byte key budget is not a power of two, while every doubling step is. The chain
+        // goes 64 -> 128 and then wants 256; rejecting there stranded a quarter of the budget
+        // at 5 blocks. Clamping to 200 fits 8 of the 24-byte blocks instead.
+        chain.close();
+        chain = new LimitedSizeLongTreeChain(
+                64,             // key page >= BLOCK_SIZE
+                200,            // key heap budget, deliberately not a power of two
+                128 * 1024,
+                Long.MAX_VALUE, // value heap uncapped
+                PropertyKey.CAIRO_SQL_SORT_KEY_MAX_BYTES.getPropertyPath(),
+                PropertyKey.CAIRO_SQL_SORT_LIGHT_VALUE_MAX_BYTES.getPropertyPath()
+        );
+        chain.updateLimits(true, 1_000);
+        Assert.assertEquals(8, fillUntilOverflow("memory exceeded in RedBlackTree"));
+    }
+
+    @Test
     public void testKeyHeapOverflowNamesConfigKey() {
         // Tiny key-heap budget (one page) with an uncapped value heap: the red-black key heap
         // overflows and the message must name the sort.key config key. Pins the LimitedSize key
@@ -423,6 +441,24 @@ public class LimitedSizeLongTreeChainTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testValueHeapClampsToMaxHeapSize() {
+        // Same clamp on the value heap: a 96-byte budget is not a power of two, the chain goes
+        // 16 -> 32 -> 64 and then wants 128. Clamping to 96 fits 8 of the 12-byte chain values
+        // instead of the 5 that fitted before.
+        chain.close();
+        chain = new LimitedSizeLongTreeChain(
+                64,
+                Long.MAX_VALUE, // key heap uncapped
+                16,             // value page >= CHAIN_VALUE_SIZE
+                96,             // value heap budget, deliberately not a power of two
+                PropertyKey.CAIRO_SQL_SORT_KEY_MAX_BYTES.getPropertyPath(),
+                PropertyKey.CAIRO_SQL_SORT_LIGHT_VALUE_MAX_BYTES.getPropertyPath()
+        );
+        chain.updateLimits(true, 1_000);
+        Assert.assertEquals(8, fillUntilOverflow("memory exceeded in LimitedSizeLongTreeChain"));
+    }
+
+    @Test
     public void testValueHeapOverflowNamesConfigKey() {
         // Tiny value-heap budget (one page) with an uncapped key heap: the rowid value chain
         // overflows and the message must name the sort.light.value config key. This branch is
@@ -468,6 +504,35 @@ public class LimitedSizeLongTreeChainTest extends AbstractCairoTest {
         while (cursor.hasNext()) {
             chain.put(left, cursor, placeholder, comparator);
         }
+    }
+
+    /**
+     * Inserts distinct ascending values until one of the heaps runs out, and returns how many
+     * of them the chain accepted. Fails when no overflow happens at all.
+     */
+    private int fillUntilOverflow(String expectedMessage) {
+        final long[] values = new long[256];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = i;
+        }
+        cursor = new TestRecordCursor(values);
+        left = (TestRecord) cursor.getRecord();
+        placeholder = (TestRecord) cursor.getRecordB();
+        comparator = new TestRecordComparator();
+        comparator.setLeft(left);
+
+        int inserted = 0;
+        while (cursor.hasNext()) {
+            try {
+                chain.put(left, cursor, placeholder, comparator);
+            } catch (LimitOverflowException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), expectedMessage);
+                return inserted;
+            }
+            inserted++;
+        }
+        Assert.fail("expected LimitOverflowException");
+        return -1;
     }
 
     private void removeRowWithValue(long value) {

--- a/core/src/test/java/io/questdb/test/griffin/engine/orderby/LongTreeChainTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/orderby/LongTreeChainTest.java
@@ -1,0 +1,199 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.orderby;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.sql.Record;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.griffin.engine.LimitOverflowException;
+import io.questdb.griffin.engine.RecordComparator;
+import io.questdb.griffin.engine.orderby.LongTreeChain;
+import io.questdb.std.LongList;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LongTreeChainTest extends AbstractCairoTest {
+
+    @Test
+    public void testKeyHeapClampsToMaxHeapSize() throws Exception {
+        // A 200-byte key budget is not a power of two, while every doubling step is. The tree
+        // goes 64 -> 128 and then wants 256; rejecting there stranded a quarter of the budget
+        // at 5 blocks. Clamping to 200 fits 8 of the 24-byte blocks instead.
+        assertMemoryLeak(() -> {
+            try (
+                    LongTreeChain chain = new LongTreeChain(
+                            64,             // key page >= BLOCK_SIZE
+                            200,            // key heap budget, deliberately not a power of two
+                            128 * 1024,
+                            Long.MAX_VALUE, // value heap uncapped
+                            PropertyKey.CAIRO_SQL_SORT_KEY_MAX_BYTES.getPropertyPath(),
+                            PropertyKey.CAIRO_SQL_SORT_LIGHT_VALUE_MAX_BYTES.getPropertyPath()
+                    )
+            ) {
+                Assert.assertEquals(8, fillUntilOverflow(chain, "memory exceeded in RedBlackTree"));
+            }
+        });
+    }
+
+    @Test
+    public void testValueHeapClampsToMaxHeapSize() throws Exception {
+        // Same clamp on the value heap: a 96-byte budget is not a power of two, the chain goes
+        // 16 -> 32 -> 64 and then wants 128. Clamping to 96 fits 8 of the 12-byte chain values
+        // instead of the 5 that fitted before.
+        assertMemoryLeak(() -> {
+            try (
+                    LongTreeChain chain = new LongTreeChain(
+                            64,
+                            Long.MAX_VALUE, // key heap uncapped
+                            16,             // value page >= CHAIN_VALUE_SIZE
+                            96,             // value heap budget, deliberately not a power of two
+                            PropertyKey.CAIRO_SQL_SORT_KEY_MAX_BYTES.getPropertyPath(),
+                            PropertyKey.CAIRO_SQL_SORT_LIGHT_VALUE_MAX_BYTES.getPropertyPath()
+                    )
+            ) {
+                Assert.assertEquals(8, fillUntilOverflow(chain, "memory exceeded in LongTreeChain"));
+            }
+        });
+    }
+
+    /**
+     * Inserts distinct ascending values until one of the heaps runs out, and returns how many
+     * of them the chain accepted. Fails when no overflow happens at all.
+     */
+    private int fillUntilOverflow(LongTreeChain chain, String expectedMessage) {
+        final long[] values = new long[256];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = i;
+        }
+        final TestRecordCursor cursor = new TestRecordCursor(values);
+        final Record left = cursor.getRecord();
+        final Record placeholder = cursor.getRecordB();
+        final RecordComparator comparator = new TestRecordComparator();
+
+        int inserted = 0;
+        while (cursor.hasNext()) {
+            comparator.setLeft(left);
+            try {
+                chain.put(left, cursor, placeholder, comparator);
+            } catch (LimitOverflowException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), expectedMessage);
+                return inserted;
+            }
+            inserted++;
+        }
+        Assert.fail("expected LimitOverflowException");
+        return -1;
+    }
+
+    private static class TestRecord implements Record {
+        long position;
+        long value;
+
+        @Override
+        public long getLong(int col) {
+            return value;
+        }
+
+        @Override
+        public long getRowId() {
+            return position;
+        }
+    }
+
+    private static class TestRecordComparator implements RecordComparator {
+        Record left;
+
+        @Override
+        public int compare(Record record) {
+            return Long.compare(left.getLong(0), record.getLong(0));
+        }
+
+        @Override
+        public void setLeft(Record record) {
+            left = record;
+        }
+    }
+
+    private static class TestRecordCursor implements RecordCursor {
+        final Record left = new TestRecord();
+        final Record right = new TestRecord();
+        final LongList values = new LongList();
+        int position = -1;
+
+        TestRecordCursor(long... newValues) {
+            for (int i = 0; i < newValues.length; i++) {
+                values.add(newValues[i]);
+            }
+        }
+
+        @Override
+        public void close() {
+            // nothing to do here
+        }
+
+        @Override
+        public Record getRecord() {
+            return left;
+        }
+
+        @Override
+        public Record getRecordB() {
+            return right;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (position < values.size() - 1) {
+                position++;
+                recordAt(left, position);
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public long preComputedStateSize() {
+            return 0;
+        }
+
+        @Override
+        public void recordAt(Record record, long atRowId) {
+            ((TestRecord) record).value = values.get((int) atRowId);
+            ((TestRecord) record).position = atRowId;
+        }
+
+        @Override
+        public long size() {
+            return values.size();
+        }
+
+        @Override
+        public void toTop() {
+            position = 0;
+        }
+    }
+}


### PR DESCRIPTION
Five off-heap data structures grow their key/value memory by doubling and reject the
allocation once a doubling step passes their ceiling. Because the ceiling is generally not
a power of two, the largest heap they can actually reach is the largest power of two below
it, and the error names a limit the query never approached. This PR makes them clamp to the
ceiling instead, and fixes the compressed-offset defect that clamping alone would have
exposed.

## 1. Clamp heap growth to the ceiling instead of rejecting

`OrderedMap.resize()`, `LongChain.checkCapacity()`, `AbstractRedBlackTree.checkKeyCapacity()`,
`LongTreeChain.checkValueCapacity()` and `LimitedSizeLongTreeChain.checkValueCapacity()` all
had the shape:

```java
final long newHeapSize = heapSize << 1;
if (newHeapSize > maxHeapSize) {
    throw LimitOverflowException.instance()...;
}
```

They now clamp, and throw only when the data that has to fit genuinely exceeds the ceiling:

```java
long newHeapSize = heapSize << 1;
if (newHeapSize > maxHeapSize) {
    if (required > maxHeapSize) {
        throw LimitOverflowException.instance()...;
    }
    newHeapSize = maxHeapSize;
}
```

How much this recovers depends on where the ceiling sits relative to the doubling chain:

| structure | ceiling | before | after |
|---|---|---|---|
| `OrderedMap` | `(2^32 - 2) * 8` = 34,359,738,352 (fixed constant, 16 bytes below 2^35) | 2^34 = 17,179,869,184 | 34,359,738,352 |
| `LongChain` | `sqlHashJoinLightValuePageSize * MaxPages`, capped at `(2^32 - 2) * 4` | largest power of two below it | the configured value |
| `AbstractRedBlackTree` | `cairo.sql.sort.key.max.bytes` (and the window equivalents), capped at `(2^32 - 2) * 8` | largest power of two below it | the configured value |
| `LongTreeChain` / `LimitedSizeLongTreeChain` | `cairo.sql.sort.light.value.max.bytes` (and the window equivalents), capped at `(2^32 - 2) * 4` | largest power of two below it | the configured value |

For `OrderedMap` the gain is a fixed factor of two, because its ceiling is a constant that
sits just under a power of two. For the other four the ceiling comes from configuration, so
the recovered fraction is whatever the doubling chain was leaving on the table: nothing when
the budget is already a power of two, and just under half in the worst case. A 3 GiB
`cairo.sql.sort.key.max.bytes`, for instance, previously stopped at 2 GiB.

This does not make anything faster. Queries that already fit are unaffected — the clamp only
fires on the final growth step, which those queries never reach. What changes is that some
queries which previously failed now run to completion instead, which means they also hold
more memory than they used to before failing. Anyone who was relying on these limits to make
a runaway query fail early will see it fail later and after allocating up to twice as much.
The limits themselves are unchanged; they are simply now enforced at the value that was
configured.

## 2. Read compressed heap offsets as unsigned

Clamping cannot be shipped on its own. All five classes compress heap offsets into 32-bit
ints and their javadoc describes those offsets as unsigned, but the code did not treat them
that way:

- `OrderedMap.decompressOffset()` was `((long) rawOffset - 1) << 3`, which sign-extends
- `probe0()`, `probeReadOnly()` and `rehash()` tested slot emptiness with `> 0`, and the two
  merge loops with `> -1`
- `uncompressKeyOffset()` / `uncompressValueOffset()` / `uncompressOffset()` in the trees and
  chains sign-extended the same way

An entry stored past the offset where the compressed value sets its top bit therefore read
back as negative. In `OrderedMap` the probe loops treat that as an empty slot, so the key is
inserted a second time — a duplicate group, not an exception. In the trees and chains a
negative offset is dereferenced against the heap base.

Nothing hit this on master, because the power-of-two ceiling stops one doubling step short of
the point where the top bit is set. That is the accident that clamping removes: without this
part of the change, part 1 would replace a loud `LimitOverflowException` with a silent wrong
result. `decompressOffset()` and the `uncompress*Offset()` helpers now widen with
`Integer.toUnsignedLong()`, and every emptiness test compares against the exact sentinel — `0`
for `OrderedMap`, `EMPTY` (`-1`) for the trees and chains.

The hot probe loops gain one `and` instruction against a register in `decompressOffset()`, and
`> 0` becomes `!= 0`, which costs nothing.

## Structures deliberately left alone

- `Unordered4Map`, `Unordered8Map`, `UnorderedVarcharMap` — they address entries by index
  rather than by compressed offset, and their key-capacity ceiling (`MAX_SAFE_INT_POW_2`,
  2^30) is itself a power of two, so doubling lands on it exactly. Neither defect applies.
- `EncodedSortRecordCursor`, `SortKeyEncoder`, `EncodedWindowSortBuffer` — these enforce their
  cap on bytes actually used (`count * entrySize + keyHeap.getAppendOffset() > maxEntryMemBytes`)
  rather than on the size of the next allocation, so they already spend the whole budget.

## Testing

`OrderedMap`'s ceiling is a constant rather than a constructor argument, so it gains a
`@TestOnly public setMaxHeapSize()` that lets the tests drive the clamp and the throw at KB
scale instead of allocating 16 GiB. The other four take their budgets as constructor
arguments already and need no such hook.

New tests:

- `OrderedMapTest.testResizeClampsHeapToMaxHeapSize` — a 3064-byte ceiling (not a power of
  two) reached by growing 32 -> 64 -> ... -> 2048, where the next step would be 4096. Asserts
  the clamped heap size, that probing, rehashing and cursor iteration all work over a
  non-power-of-two heap, that the entry after the last one still throws with the original
  message, and that `restoreInitialCapacity()` copes. 191 entries fit where 128 did.
- `OrderedMapTest.testResizeClampedHeapVarSizeKey` — the same through `VarSizeKey.checkCapacity()`,
  which resizes mid-key and has to shift `startAddr`/`appendAddr` by the realloc delta. 127
  entries where 85 fitted.
- `OrderedMapTest.testResizeThrowsWhenEntryExceedsMaxHeapSize` — a single entry larger than
  the ceiling still throws.
- `OrderedMapTest.testOffsetCompressionRoundTripsAboveSignedIntRange` — offset round-trip
  across the whole unsigned range, including the half that previously decompressed negative.
- `LongChainTest.testHeapClampsToMaxHeapSize` — a 192-byte budget from a 64-byte page:
  16 values where 10 fitted, then reads the chain back.
- `LimitedSizeLongTreeChainTest.testKeyHeapClampsToMaxHeapSize` /
  `testValueHeapClampsToMaxHeapSize` — 8 entries where 5 fitted, on each heap.
- New `LongTreeChainTest` covering the same two heaps; the class had no test class before.

Existing suites run green: `OrderedMapTest`, `MapTest`, `Unordered4MapTest`,
`Unordered8MapTest`, `UnorderedVarcharMapTest`, `ShardedMapCursorTest`,
`RecordValueSinkFactoryTest`, `LongChainTest`, `LimitedSizeLongTreeChainTest`, `GroupByTest`,
`SampleByTest`, `DistinctTest`, `WindowFunctionTest`, `ParallelGroupByFuzzTest`, `JoinTest`,
`HashJoinTest`, `LatestByTest`, the `OrderBy*` suites, and the memory-cap suites
`OrderByMemoryCapTest`, `CachedWindowMemoryCapTest` and `SecurityTest` — the last three matter
because they assert on the limit-exceeded messages this PR moves.

## Not covered by tests

The offset-unsigned fix is verified at the arithmetic level only. Reaching a real offset with
the top bit set needs a heap above 8 GiB (trees and chains) or 16 GiB (`OrderedMap`) filled
entry by entry, which is not something CI can do. The clamp itself is covered end to end at
KB scale in all five classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
