### PR TITLE
feat(qwp): support naming the designated timestamp column when auto-creating tables

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -22,7 +22,8 @@
   ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.questdb</groupId>
@@ -117,7 +118,7 @@
           -->
         <uberjar.name>benchmarks</uberjar.name>
 
-        <questdb.client.version>1.3.6-SNAPSHOT</questdb.client.version>
+        <questdb.client.version>1.3.7-SNAPSHOT</questdb.client.version>
     </properties>
 
     <build>
@@ -152,7 +153,8 @@
                         <configuration>
                             <finalName>${uberjar.name}</finalName>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>org.openjdk.jmh.Main</mainClass>
                                 </transformer>
                             </transformers>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -45,7 +45,7 @@
         -->
         <qdbr.rustflags>-D warnings</qdbr.rustflags>
 
-        <questdb.client.version>1.3.6-SNAPSHOT</questdb.client.version>
+        <questdb.client.version>1.3.7-SNAPSHOT</questdb.client.version>
     </properties>
 
     <version>9.4.4-SNAPSHOT</version>
@@ -264,7 +264,7 @@
         <profile>
             <id>local-client</id>
             <properties>
-                <questdb.client.version>1.3.6-SNAPSHOT</questdb.client.version>
+                <questdb.client.version>1.3.7-SNAPSHOT</questdb.client.version>
             </properties>
         </profile>
         <profile>

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpConstants.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpConstants.java
@@ -82,6 +82,10 @@ public final class QwpConstants {
      */
     public static final byte FLAG_GORILLA = 0x04;
     /**
+     * Flag bit: per-table options trailer enabled.
+     */
+    public static final byte FLAG_TABLE_OPTIONS = 0x20;
+    /**
      * Flag bit: the region starting at {@code delta_symbol_dict} (or the first
      * table block if no delta dict is present) is zstd-compressed. The prelude
      * remains uncompressed so the I/O thread can dispatch on msg_kind / batch_seq
@@ -159,6 +163,10 @@ public final class QwpConstants {
      * (query timeout, memory cap, circuit breaker, OOM).
      */
     public static final byte STATUS_LIMIT_EXCEEDED = 0x0B;
+    /**
+     * Per-table option tag: designated timestamp column name.
+     */
+    public static final byte TABLE_OPTION_TAG_DESIGNATED_TIMESTAMP_NAME = 0x01;
     /**
      * Status: Reserved. Node cannot accept writes (read-only replica /
      * demoting primary). Servers currently signal this state with a

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpMessageCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpMessageCursor.java
@@ -112,6 +112,9 @@ public class QwpMessageCursor implements Mutable {
             throw new IndexOutOfBoundsException("table index out of bounds: " + tableIndex);
         }
         int offsetIndex = tableIndex * 2;
+        if (offsetIndex >= designatedTsNameBounds.size()) {
+            return null;
+        }
         long lo = designatedTsNameBounds.getQuick(offsetIndex);
         if (lo < 0) {
             return null;
@@ -206,7 +209,7 @@ public class QwpMessageCursor implements Mutable {
         this.payloadAddress = messageAddress + HEADER_SIZE;
         this.payloadEnd = payloadAddress + payloadLength;
         this.currentTableAddress = payloadAddress;
-        this.designatedTsNameBounds.setAll(tableCount * 2, -1);
+        this.designatedTsNameBounds.clear();
 
         if (messageHeader.isTableOptionsEnabled()) {
             parseTableOptions();
@@ -262,6 +265,8 @@ public class QwpMessageCursor implements Mutable {
             }
 
             long blockEnd = address + blockLength;
+            long designatedTsNameHi = -1;
+            long designatedTsNameLo = -1;
             while (address < blockEnd) {
                 int tag = Unsafe.getByte(address++) & 0xff;
                 QwpVarint.decode(address, blockEnd, varintResult);
@@ -277,12 +282,12 @@ public class QwpMessageCursor implements Mutable {
 
                 long valueEnd = address + valueLength;
                 if (tag == TABLE_OPTION_TAG_DESIGNATED_TIMESTAMP_NAME) {
-                    int offsetIndex = tableIndex * 2;
-                    designatedTsNameBounds.setQuick(offsetIndex, address);
-                    designatedTsNameBounds.setQuick(offsetIndex + 1, valueEnd);
+                    designatedTsNameLo = address;
+                    designatedTsNameHi = valueEnd;
                 }
                 address = valueEnd;
             }
+            designatedTsNameBounds.add(designatedTsNameLo, designatedTsNameHi);
         }
 
         if (address != footerAddress) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpMessageCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpMessageCursor.java
@@ -24,13 +24,18 @@
 
 package io.questdb.cutlass.qwp.protocol;
 
+import io.questdb.std.LongList;
 import io.questdb.std.Mutable;
 import io.questdb.std.ObjList;
+import io.questdb.std.Unsafe;
+import io.questdb.std.str.DirectUtf8String;
+import io.questdb.std.str.Utf8Sequence;
 import io.questdb.std.str.Utf8s;
 
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.DEFAULT_MAX_ROWS_PER_TABLE;
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.HEADER_SIZE;
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.MAX_SYMBOL_DICTIONARY_SIZE;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TABLE_OPTION_TAG_DESIGNATED_TIMESTAMP_NAME;
 
 /**
  * Streaming cursor over a QWP v1 message.
@@ -52,6 +57,8 @@ import static io.questdb.cutlass.qwp.protocol.QwpConstants.MAX_SYMBOL_DICTIONARY
  */
 public class QwpMessageCursor implements Mutable {
 
+    private final DirectUtf8String designatedTsName = new DirectUtf8String();
+    private final LongList designatedTsNameBounds = new LongList();
     private final QwpMessageHeader messageHeader = new QwpMessageHeader();
     private final QwpTableBlockCursor tableBlockCursor;
     private final QwpVarint.DecodeResult varintResult = new QwpVarint.DecodeResult();
@@ -76,6 +83,8 @@ public class QwpMessageCursor implements Mutable {
 
     @Override
     public void clear() {
+        designatedTsName.clear();
+        designatedTsNameBounds.clear();
         tableBlockCursor.clear();
         messageHeader.reset();
         payloadAddress = 0;
@@ -87,6 +96,27 @@ public class QwpMessageCursor implements Mutable {
         deltaSymbolDictEnabled = false;
         connectionSymbolDict = null;
         symbolDictRedefined = false;
+    }
+
+    /**
+     * Returns the create-only designated timestamp name option for a table.
+     * <p>
+     * The returned sequence is a reused flyweight over the message buffer and
+     * is invalidated by the next call to this method or {@link #clear()}.
+     *
+     * @param tableIndex zero-based table index in message order
+     * @return designated timestamp name, or {@code null} when absent
+     */
+    public Utf8Sequence getDesignatedTsName(int tableIndex) {
+        if (tableIndex < 0 || tableIndex >= tableCount) {
+            throw new IndexOutOfBoundsException("table index out of bounds: " + tableIndex);
+        }
+        int offsetIndex = tableIndex * 2;
+        long lo = designatedTsNameBounds.getQuick(offsetIndex);
+        if (lo < 0) {
+            return null;
+        }
+        return designatedTsName.of(lo, designatedTsNameBounds.getQuick(offsetIndex + 1));
     }
 
     /**
@@ -176,6 +206,11 @@ public class QwpMessageCursor implements Mutable {
         this.payloadAddress = messageAddress + HEADER_SIZE;
         this.payloadEnd = payloadAddress + payloadLength;
         this.currentTableAddress = payloadAddress;
+        this.designatedTsNameBounds.setAll(tableCount * 2, -1);
+
+        if (messageHeader.isTableOptionsEnabled()) {
+            parseTableOptions();
+        }
 
         // Parse delta symbol dictionary if enabled
         if (deltaSymbolDictEnabled && connectionSymbolDict != null) {
@@ -183,6 +218,80 @@ public class QwpMessageCursor implements Mutable {
         }
 
         this.currentTableIndex = -1;
+    }
+
+    private void parseTableOptions() throws QwpParseException {
+        long payloadSize = payloadEnd - payloadAddress;
+        if (payloadSize < Integer.BYTES) {
+            throw QwpParseException.create(
+                    QwpParseException.ErrorCode.INSUFFICIENT_DATA,
+                    "truncated table options footer"
+            );
+        }
+
+        long footerAddress = payloadEnd - Integer.BYTES;
+        long trailerLength = Unsafe.getInt(footerAddress) & 0xffffffffL;
+        long maxTrailerLength = footerAddress - payloadAddress;
+        if (trailerLength > maxTrailerLength) {
+            throw QwpParseException.create(
+                    QwpParseException.ErrorCode.INSUFFICIENT_DATA,
+                    "table options trailer length out of bounds [trailerLength=" + trailerLength
+                            + ", available=" + maxTrailerLength + ']'
+            );
+        }
+
+        long trailerAddress = footerAddress - trailerLength;
+        long address = trailerAddress;
+        for (int tableIndex = 0; tableIndex < tableCount; tableIndex++) {
+            if (address >= footerAddress) {
+                throw QwpParseException.create(
+                        QwpParseException.ErrorCode.INSUFFICIENT_DATA,
+                        "missing table options block [tableIndex=" + tableIndex + ']'
+                );
+            }
+
+            QwpVarint.decode(address, footerAddress, varintResult);
+            long blockLength = varintResult.value;
+            address += varintResult.bytesRead;
+            if (blockLength < 0 || blockLength > footerAddress - address) {
+                throw QwpParseException.create(
+                        QwpParseException.ErrorCode.INSUFFICIENT_DATA,
+                        "table options block overruns trailer [tableIndex=" + tableIndex
+                                + ", blockLength=" + blockLength + ']'
+                );
+            }
+
+            long blockEnd = address + blockLength;
+            while (address < blockEnd) {
+                int tag = Unsafe.getByte(address++) & 0xff;
+                QwpVarint.decode(address, blockEnd, varintResult);
+                long valueLength = varintResult.value;
+                address += varintResult.bytesRead;
+                if (valueLength < 0 || valueLength > blockEnd - address) {
+                    throw QwpParseException.create(
+                            QwpParseException.ErrorCode.INSUFFICIENT_DATA,
+                            "table option value overruns block [tableIndex=" + tableIndex
+                                    + ", tag=" + tag + ", valueLength=" + valueLength + ']'
+                    );
+                }
+
+                long valueEnd = address + valueLength;
+                if (tag == TABLE_OPTION_TAG_DESIGNATED_TIMESTAMP_NAME) {
+                    int offsetIndex = tableIndex * 2;
+                    designatedTsNameBounds.setQuick(offsetIndex, address);
+                    designatedTsNameBounds.setQuick(offsetIndex + 1, valueEnd);
+                }
+                address = valueEnd;
+            }
+        }
+
+        if (address != footerAddress) {
+            throw QwpParseException.create(
+                    QwpParseException.ErrorCode.INSUFFICIENT_DATA,
+                    "unexpected bytes after table options blocks: " + (footerAddress - address)
+            );
+        }
+        payloadEnd = trailerAddress;
     }
 
     /**

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpMessageHeader.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpMessageHeader.java
@@ -167,6 +167,15 @@ public class QwpMessageHeader {
     }
 
     /**
+     * Returns true if the per-table options trailer is present.
+     *
+     * @return true if table options are enabled
+     */
+    public boolean isTableOptionsEnabled() {
+        return (flags & FLAG_TABLE_OPTIONS) != 0;
+    }
+
+    /**
      * Parses a header from direct memory.
      *
      * @param address the memory address containing the header

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressHttpProcessor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressHttpProcessor.java
@@ -123,6 +123,8 @@ public class QwpIngressHttpProcessor implements HttpRequestHandler {
             "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: ".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] RESPONSE_ROLE_PREFIX = "\r\nX-QuestDB-Role: ".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] RESPONSE_SUFFIX = "\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] RESPONSE_TABLE_OPTIONS =
+            "\r\nX-QWP-Table-Options: 1".getBytes(StandardCharsets.US_ASCII);
     private static final int SHA1_BASE64_SIZE = 28;
     private static final CarrierLocal<byte[]> BASE64_SCRATCH = CarrierLocal.withInitial(() -> new byte[SHA1_BASE64_SIZE]);
     // Thread-local SHA-1 digest for computing Sec-WebSocket-Accept
@@ -316,6 +318,7 @@ public class QwpIngressHttpProcessor implements HttpRequestHandler {
     public static int responseSize(byte[] acceptKey, int qwpVersion, byte[] contentEncodingBytes, boolean durableAckEnabled, byte[] roleBytes, byte[] maxBatchSizeBytes) {
         int size = RESPONSE_PREFIX.length + acceptKey.length
                 + RESPONSE_AFTER_ACCEPT.length + VERSION_BYTES[qwpVersion].length
+                + RESPONSE_TABLE_OPTIONS.length
                 + RESPONSE_SUFFIX.length;
         if (contentEncodingBytes != null) {
             size += RESPONSE_CONTENT_ENCODING_PREFIX.length + contentEncodingBytes.length;
@@ -447,6 +450,9 @@ public class QwpIngressHttpProcessor implements HttpRequestHandler {
             Unsafe.putByte(buf + offset++, b);
         }
         for (byte b : VERSION_BYTES[qwpVersion]) {
+            Unsafe.putByte(buf + offset++, b);
+        }
+        for (byte b : RESPONSE_TABLE_OPTIONS) {
             Unsafe.putByte(buf + offset++, b);
         }
 

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -922,6 +922,7 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
             }
 
             // Process each table block using streaming cursors
+            int tableIndex = 0;
             while (messageCursor.hasNextTable()) {
                 QwpTableBlockCursor tableBlock = messageCursor.nextTable();
 
@@ -930,6 +931,7 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
                         tableBlock.getTableNameUtf8(),
                         tableBlock.getSchema(),
                         tableBlock,
+                        messageCursor.getDesignatedTsName(tableIndex++),
                         configuration.getQwpMaxTablesPerConnection()
                 );
                 if (tud == null) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpTudCache.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpTudCache.java
@@ -49,6 +49,7 @@ import io.questdb.cutlass.qwp.protocol.QwpConstants;
 import io.questdb.cutlass.qwp.protocol.QwpTableBlockCursor;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
+import io.questdb.std.Chars;
 import io.questdb.std.IntList;
 import io.questdb.std.LowerCaseUtf8SequenceObjHashMap;
 import io.questdb.std.Misc;
@@ -72,6 +73,7 @@ public class QwpTudCache implements QuietCloseable {
     private final long commitInterval;
     private final DefaultColumnTypes defaultColumnTypes;
     private final int defaultPartitionBy;
+    private final StringSink designatedTsNameUtf16 = new StringSink();
     private final CairoEngine engine;
     private final long maxUncommittedRows;
     private final StringSink tableNameUtf16 = new StringSink();
@@ -338,6 +340,30 @@ public class QwpTudCache implements QuietCloseable {
             QwpTableBlockCursor cursor,
             int maxTables
     ) {
+        return getTableUpdateDetails(
+                securityContext,
+                tableNameUtf8,
+                schema,
+                cursor,
+                null,
+                maxTables
+        );
+    }
+
+    /**
+     * Returns cached update details or creates them for a missing table.
+     *
+     * @param designatedTsName create-only designated timestamp name hint;
+     *                         existing tables silently ignore it
+     */
+    public WalTableUpdateDetails getTableUpdateDetails(
+            SecurityContext securityContext,
+            Utf8Sequence tableNameUtf8,
+            ObjList<QwpColumnDef> schema,
+            QwpTableBlockCursor cursor,
+            Utf8Sequence designatedTsName,
+            int maxTables
+    ) {
         int key = tableUpdateDetails.keyIndex(tableNameUtf8);
         if (key < 0) {
             return tableUpdateDetails.valueAt(key);
@@ -350,7 +376,13 @@ public class QwpTudCache implements QuietCloseable {
 
         tableNameUtf16.clear();
         Utf8s.utf8ToUtf16(tableNameUtf8, tableNameUtf16);
-        TableToken tableToken = getOrCreateTable(securityContext, tableNameUtf16, schema, cursor);
+        TableToken tableToken = getOrCreateTable(
+                securityContext,
+                tableNameUtf16,
+                schema,
+                cursor,
+                designatedTsName
+        );
         if (tableToken == null) {
             return null;
         }
@@ -419,8 +451,13 @@ public class QwpTudCache implements QuietCloseable {
         return TableUtils.isValidColumnName(columnName, maxFileNameLength);
     }
 
-    private TableToken getOrCreateTable(SecurityContext securityContext, StringSink tableNameUtf16,
-                                        ObjList<QwpColumnDef> schema, QwpTableBlockCursor cursor) {
+    private TableToken getOrCreateTable(
+            SecurityContext securityContext,
+            StringSink tableNameUtf16,
+            ObjList<QwpColumnDef> schema,
+            QwpTableBlockCursor cursor,
+            Utf8Sequence designatedTsName
+    ) {
         int maxFileNameLength = engine.getConfiguration().getMaxFileNameLength();
         if (!TableUtils.isValidTableName(tableNameUtf16, maxFileNameLength)) {
             return null;
@@ -441,17 +478,41 @@ public class QwpTudCache implements QuietCloseable {
                 }
             }
 
+            String timestampName = QwpTableStructureAdapter.DEFAULT_TIMESTAMP_FIELD;
+            if (designatedTsName != null) {
+                designatedTsNameUtf16.clear();
+                if (!Utf8s.utf8ToUtf16(designatedTsName, designatedTsNameUtf16)) {
+                    throw CairoException.schemaMismatch()
+                            .put("invalid UTF-8 in designated timestamp column name");
+                }
+                if (!TableUtils.isValidColumnName(designatedTsNameUtf16, maxFileNameLength)) {
+                    throw CairoException.schemaMismatch()
+                            .put("invalid designated timestamp column name: ")
+                            .put(designatedTsNameUtf16);
+                }
+                timestampName = designatedTsNameUtf16.toString();
+            }
+
             // Create table using QWP v1 schema
             QwpTableStructureAdapter tsa = new QwpTableStructureAdapter(
                     engine.getConfiguration(),
                     tableNameUtf16.toString(),
                     schema,
                     cursor,
+                    timestampName,
                     defaultPartitionBy
             );
 
+            final int timestampIndex = tsa.getTimestampIndex();
             for (int i = 0, n = tsa.getColumnCount(); i < n; i++) {
                 CharSequence columnName = tsa.getColumnName(i);
+                if (designatedTsName != null
+                        && i != timestampIndex
+                        && Chars.equalsIgnoreCase(columnName, timestampName)) {
+                    throw CairoException.schemaMismatch()
+                            .put("designated timestamp column name collides with schema column: ")
+                            .put(timestampName);
+                }
                 if (!TableUtils.isValidColumnName(columnName, maxFileNameLength)) {
                     return null;
                 }
@@ -467,9 +528,9 @@ public class QwpTudCache implements QuietCloseable {
     /**
      * Table structure adapter for QWP v1 schema.
      * <p>
-     * When no timestamp column is provided in the schema, this adapter automatically
-     * adds a "timestamp" column as the designated timestamp. This matches the behavior
-     * of the old ILP text protocol.
+     * When no timestamp column is provided in the schema, this adapter adds a
+     * designated timestamp column. Its name comes from the create-only QWP
+     * table option, or defaults to {@code timestamp} for older clients.
      */
     private static class QwpTableStructureAdapter implements TableStructure {
         private static final String DEFAULT_TIMESTAMP_FIELD = "timestamp";
@@ -481,14 +542,22 @@ public class QwpTudCache implements QuietCloseable {
         private final int partitionBy;
         private final ObjList<QwpColumnDef> schema;
         private final String tableName;
+        private final String timestampName;
         private int timestampSchemaIndex = -1;
 
-        QwpTableStructureAdapter(CairoConfiguration configuration, String tableName, ObjList<QwpColumnDef> schema,
-                                 QwpTableBlockCursor cursor, int partitionBy) {
+        QwpTableStructureAdapter(
+                CairoConfiguration configuration,
+                String tableName,
+                ObjList<QwpColumnDef> schema,
+                QwpTableBlockCursor cursor,
+                String timestampName,
+                int partitionBy
+        ) {
             this.configuration = configuration;
             this.tableName = tableName;
             this.schema = schema;
             this.cursor = cursor;
+            this.timestampName = timestampName;
             this.partitionBy = partitionBy;
 
             // Find designated timestamp column - empty name with TIMESTAMP or TIMESTAMP_NANOS type
@@ -522,12 +591,12 @@ public class QwpTudCache implements QuietCloseable {
         public CharSequence getColumnName(int columnIndex) {
             // If this is the auto-added timestamp column (no designated timestamp in schema)
             if (columnIndex == getTimestampIndex() && timestampSchemaIndex == -1) {
-                return DEFAULT_TIMESTAMP_FIELD;
+                return timestampName;
             }
-            // If this is the designated timestamp column from schema, use default name
+            // If this is the designated timestamp column from schema, use the option name
             // (the schema column name is empty for TYPE_DESIGNATED_TIMESTAMP)
             if (columnIndex == outputTimestampIndex) {
-                return DEFAULT_TIMESTAMP_FIELD;
+                return timestampName;
             }
             return schema.getQuick(includedSchemaIndexes.get(columnIndex)).getName();
         }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpUdpReceiver.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpUdpReceiver.java
@@ -386,6 +386,7 @@ public class QwpUdpReceiver extends SynchronizedJob implements Closeable {
         int datagramState = 0;
         try {
             messageCursor.of(address, (int) totalLength, null);
+            int tableIndex = 0;
             while (messageCursor.hasNextTable()) {
                 QwpTableBlockCursor tableBlock = messageCursor.nextTable();
                 WalTableUpdateDetails tud = tudCache.getTableUpdateDetails(
@@ -393,6 +394,7 @@ public class QwpUdpReceiver extends SynchronizedJob implements Closeable {
                         tableBlock.getTableNameUtf8(),
                         tableBlock.getSchema(),
                         tableBlock,
+                        messageCursor.getDesignatedTsName(tableIndex++),
                         configuration.getMaxTablesPerConnection()
                 );
                 if (tud == null) {

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpCursorBoundsCheckFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpCursorBoundsCheckFuzzTest.java
@@ -31,6 +31,7 @@ import io.questdb.cutlass.qwp.protocol.QwpTableBlockCursor;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.std.MemoryTag;
+import io.questdb.std.ObjList;
 import io.questdb.std.Rnd;
 import io.questdb.std.Unsafe;
 import io.questdb.test.tools.TestUtils;
@@ -174,6 +175,8 @@ public class QwpCursorBoundsCheckFuzzTest {
      */
     private static byte[] generateValidMessage(Rnd rnd) {
         int tableCount = 1 + rnd.nextInt(3); // 1-3 tables
+        boolean withTableOptions = rnd.nextBoolean();
+        ObjList<String> designatedTsNames = new ObjList<>(tableCount);
 
         ByteArrayOutputStream payload = new ByteArrayOutputStream(512);
         for (int t = 0; t < tableCount; t++) {
@@ -189,6 +192,33 @@ public class QwpCursorBoundsCheckFuzzTest {
 
             String tableName = "t" + rnd.nextInt(100);
             writeTablePayload(payload, rnd, tableName, rowCount, columnCount, columnTypes, columnNames);
+            designatedTsNames.add(withTableOptions && (t == 0 || rnd.nextBoolean()) ? "ts_" + t : null);
+        }
+
+        if (withTableOptions) {
+            ByteArrayOutputStream trailer = new ByteArrayOutputStream();
+            for (int t = 0; t < tableCount; t++) {
+                ByteArrayOutputStream block = new ByteArrayOutputStream();
+                if (rnd.nextBoolean()) {
+                    block.write(0x7f);
+                    writeVarint(block, 2);
+                    block.write('x');
+                    block.write('y');
+                }
+                String designatedTsName = designatedTsNames.getQuick(t);
+                if (designatedTsName != null) {
+                    byte[] nameBytes = designatedTsName.getBytes(StandardCharsets.UTF_8);
+                    block.write(TABLE_OPTION_TAG_DESIGNATED_TIMESTAMP_NAME);
+                    writeVarint(block, nameBytes.length);
+                    block.write(nameBytes, 0, nameBytes.length);
+                }
+                byte[] blockBytes = block.toByteArray();
+                writeVarint(trailer, blockBytes.length);
+                trailer.write(blockBytes, 0, blockBytes.length);
+            }
+            byte[] trailerBytes = trailer.toByteArray();
+            payload.write(trailerBytes, 0, trailerBytes.length);
+            writeInt32LE(payload, trailerBytes.length);
         }
 
         byte[] payloadBytes = payload.toByteArray();
@@ -200,7 +230,7 @@ public class QwpCursorBoundsCheckFuzzTest {
         message[2] = 'P';
         message[3] = '1';
         message[HEADER_OFFSET_VERSION] = VERSION;
-        message[HEADER_OFFSET_FLAGS] = 0;
+        message[HEADER_OFFSET_FLAGS] = withTableOptions ? FLAG_TABLE_OPTIONS : 0;
         message[HEADER_OFFSET_TABLE_COUNT] = (byte) tableCount;
         message[HEADER_OFFSET_TABLE_COUNT + 1] = (byte) (tableCount >>> 8);
         message[HEADER_OFFSET_PAYLOAD_LENGTH] = (byte) payloadBytes.length;
@@ -220,7 +250,9 @@ public class QwpCursorBoundsCheckFuzzTest {
         QwpMessageCursor cursor = new QwpMessageCursor();
         cursor.of(address, length, null);
 
+        int tableIndex = 0;
         while (cursor.hasNextTable()) {
+            cursor.getDesignatedTsName(tableIndex++);
             QwpTableBlockCursor table = cursor.nextTable();
 
             // Iterate all rows to exercise advanceRow() on each column cursor

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpCursorBoundsCheckTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpCursorBoundsCheckTest.java
@@ -546,6 +546,9 @@ public class QwpCursorBoundsCheckTest {
     private static byte[] generateValidMessage(Rnd rnd, int iter) {
         try (QwpTableBuffer buffer = new QwpTableBuffer("fuzz_" + iter);
              QwpWebSocketEncoder encoder = new QwpWebSocketEncoder()) {
+            if ((iter & 1) == 0) {
+                buffer.setDesignatedTimestampName("event_time_" + iter);
+            }
             populateFuzzTable(buffer, rnd, iter);
 
             int size = encoder.encode(buffer);
@@ -559,7 +562,9 @@ public class QwpCursorBoundsCheckTest {
         cursor.of(address, length, new ObjList<>());
 
         long checksum = 0;
+        int tableIndex = 0;
         while (cursor.hasNextTable()) {
+            cursor.getDesignatedTsName(tableIndex++);
             QwpTableBlockCursor table = cursor.nextTable();
             while (table.hasNextRow()) {
                 table.nextRow();

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressDemoteRaceFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressDemoteRaceFuzzTest.java
@@ -606,6 +606,7 @@ public class QwpIngressDemoteRaceFuzzTest extends AbstractCairoTest {
                 Utf8Sequence tableName,
                 ObjList<QwpColumnDef> schema,
                 QwpTableBlockCursor cursor,
+                Utf8Sequence designatedTsName,
                 int maxTables
         ) {
             Runnable hook = getTudHook;

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
@@ -834,7 +834,8 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
                 drainWalQueue();
                 assertQuery("select v from compat_unknown_flags")
                         .noLeakCheck()
-                        .returnsOnce("v\n42\n");
+                        .expectSize()
+                        .returns("v\n42\n");
             } finally {
                 state.onDisconnected();
                 state.close();
@@ -1950,6 +1951,43 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testGetTableUpdateDetailsRejectsDesignatedTimestampNameCollision() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            DefaultColumnTypes defaultColumnTypes = new DefaultColumnTypes(lineConfig);
+            final String tableName = "colliding_designated_timestamp";
+            final ObjList<QwpColumnDef> schema = new ObjList<>();
+            schema.add(new QwpColumnDef("v", QwpConstants.TYPE_LONG));
+            schema.add(new QwpColumnDef("", QwpConstants.TYPE_TIMESTAMP));
+
+            try (QwpTudCache cache = new QwpTudCache(
+                    engine, true, true, defaultColumnTypes, PartitionBy.DAY)
+            ) {
+                try {
+                    cache.getTableUpdateDetails(
+                            AllowAllSecurityContext.INSTANCE,
+                            new Utf8String(tableName),
+                            schema,
+                            null,
+                            new Utf8String("v"),
+                            1
+                    );
+                    Assert.fail("should have rejected designated timestamp name collision");
+                } catch (CairoException e) {
+                    Assert.assertTrue(e.isSchemaMismatch());
+                    Assert.assertEquals(
+                            "designated timestamp column name collides with schema column: v",
+                            e.getFlyweightMessage().toString()
+                    );
+                }
+                Assert.assertEquals(0, getCacheSize(cache));
+                Assert.assertNull(engine.getTableTokenIfExists(tableName));
+            }
+        });
+    }
+
+    @Test
     public void testGetTableUpdateDetailsRejectsInvalidDeferredArrayColumnName() throws Exception {
         assertMemoryLeak(() -> {
             LineHttpProcessorConfiguration lineConfig =
@@ -1979,6 +2017,77 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
                 Assert.assertNull(engine.getTableTokenIfExists(tableName));
             } finally {
                 Unsafe.free(addr, 2, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testGetTableUpdateDetailsRejectsInvalidDesignatedTimestampName() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            DefaultColumnTypes defaultColumnTypes = new DefaultColumnTypes(lineConfig);
+            final String tableName = "invalid_designated_timestamp";
+            final ObjList<QwpColumnDef> schema = new ObjList<>();
+            schema.add(new QwpColumnDef("", QwpConstants.TYPE_TIMESTAMP));
+
+            try (QwpTudCache cache = new QwpTudCache(
+                    engine, true, true, defaultColumnTypes, PartitionBy.DAY)
+            ) {
+                try {
+                    cache.getTableUpdateDetails(
+                            AllowAllSecurityContext.INSTANCE,
+                            new Utf8String(tableName),
+                            schema,
+                            null,
+                            new Utf8String("bad/name"),
+                            1
+                    );
+                    Assert.fail("should have rejected invalid designated timestamp name");
+                } catch (CairoException e) {
+                    Assert.assertTrue(e.isSchemaMismatch());
+                    Assert.assertEquals(
+                            "invalid designated timestamp column name: bad/name",
+                            e.getFlyweightMessage().toString()
+                    );
+                }
+                Assert.assertEquals(0, getCacheSize(cache));
+                Assert.assertNull(engine.getTableTokenIfExists(tableName));
+            }
+        });
+    }
+
+    @Test
+    public void testGetTableUpdateDetailsRejectsMalformedDesignatedTimestampName() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            DefaultColumnTypes defaultColumnTypes = new DefaultColumnTypes(lineConfig);
+            final String tableName = "malformed_designated_timestamp";
+            final ObjList<QwpColumnDef> schema = new ObjList<>();
+            schema.add(new QwpColumnDef("", QwpConstants.TYPE_TIMESTAMP));
+
+            try (QwpTudCache cache = new QwpTudCache(
+                    engine, true, true, defaultColumnTypes, PartitionBy.DAY)
+            ) {
+                try {
+                    cache.getTableUpdateDetails(
+                            AllowAllSecurityContext.INSTANCE,
+                            new Utf8String(tableName),
+                            schema,
+                            null,
+                            new Utf8String(new byte[]{(byte) 0x80}, false),
+                            1
+                    );
+                    Assert.fail("should have rejected malformed UTF-8");
+                } catch (CairoException e) {
+                    Assert.assertTrue(e.isSchemaMismatch());
+                    Assert.assertEquals(
+                            "invalid UTF-8 in designated timestamp column name",
+                            e.getFlyweightMessage().toString()
+                    );
+                }
+                Assert.assertNull(engine.getTableTokenIfExists(tableName));
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressProcessorStateTest.java
@@ -639,7 +639,8 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
                     @Override
                     public WalTableUpdateDetails getTableUpdateDetails(
                             SecurityContext secCtx, Utf8Sequence tableName,
-                            ObjList<QwpColumnDef> schema, QwpTableBlockCursor cursor, int maxTables) {
+                            ObjList<QwpColumnDef> schema, QwpTableBlockCursor cursor,
+                            Utf8Sequence designatedTsName, int maxTables) {
                         throw CairoException.critical(0).put("simulated critical error");
                     }
                 });
@@ -677,7 +678,8 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
                     @Override
                     public WalTableUpdateDetails getTableUpdateDetails(
                             SecurityContext secCtx, Utf8Sequence tableName,
-                            ObjList<QwpColumnDef> schema, QwpTableBlockCursor cursor, int maxTables) {
+                            ObjList<QwpColumnDef> schema, QwpTableBlockCursor cursor,
+                            Utf8Sequence designatedTsName, int maxTables) {
                         throw CairoException.schemaMismatch().put("type coercion from VARCHAR to IPV4 is not supported");
                     }
                 });
@@ -714,7 +716,8 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
                     @Override
                     public WalTableUpdateDetails getTableUpdateDetails(
                             SecurityContext secCtx, Utf8Sequence tableName,
-                            ObjList<QwpColumnDef> schema, QwpTableBlockCursor cursor, int maxTables) {
+                            ObjList<QwpColumnDef> schema, QwpTableBlockCursor cursor,
+                            Utf8Sequence designatedTsName, int maxTables) {
                         throw CairoException.nonCritical().put("table is busy");
                     }
                 });
@@ -796,6 +799,45 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
                 cache.setDistressed();
                 cache.clear();
                 Assert.assertEquals(0, getCacheSize(cache));
+            }
+        });
+    }
+
+    @Test
+    public void testCompatibilityIgnoresUnknownFlagsAndTrailingPayload() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+
+                byte[] payload = {
+                        20, 'c', 'o', 'm', 'p', 'a', 't', '_', 'u', 'n', 'k', 'n', 'o', 'w', 'n', '_', 'f', 'l', 'a', 'g', 's',
+                        1,
+                        2,
+                        1, 'v', QwpConstants.TYPE_LONG,
+                        0, QwpConstants.TYPE_TIMESTAMP,
+                        0, 42, 0, 0, 0, 0, 0, 0, 0,
+                        0, 0x40, 0x42, 0x0f, 0, 0, 0, 0, 0,
+                        0x55, 0x66, 0x77
+                };
+
+                // Never tighten either behavior. New QWP clients depend on old
+                // servers ignoring the new flag and options trailer bytes.
+                addNativeData(state, wrapQwpPayload(payload, (byte) (0x02 | 0x40 | 0x80)));
+                state.processMessage();
+                Assert.assertTrue(state.getErrorText().toString(), state.isOk());
+                state.commit();
+                Assert.assertTrue(state.getErrorText().toString(), state.isOk());
+
+                drainWalQueue();
+                assertQuery("select v from compat_unknown_flags")
+                        .noLeakCheck()
+                        .returnsOnce("v\n42\n");
+            } finally {
+                state.onDisconnected();
+                state.close();
             }
         });
     }
@@ -1737,6 +1779,88 @@ public class QwpIngressProcessorStateTest extends AbstractCairoTest {
             // LocalValueMap.set(key, null) which calls Misc.freeIfCloseable().
             state.close();
             state.close();
+        });
+    }
+
+    @Test
+    public void testGetTableUpdateDetailsAutoCreatesTableWithExcludedLegacyTimestampColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            DefaultColumnTypes defaultColumnTypes = new DefaultColumnTypes(lineConfig);
+            final long addr = Unsafe.malloc(2, MemoryTag.NATIVE_DEFAULT);
+            try (QwpTudCache cache = new QwpTudCache(
+                    engine, true, true, defaultColumnTypes, PartitionBy.DAY)
+            ) {
+                Unsafe.putByte(addr, (byte) 1);
+                Unsafe.putByte(addr + 1, (byte) 0x01);
+
+                final String tableName = "legacy_excluded_timestamp_col";
+                final ObjList<QwpColumnDef> schema = new ObjList<>();
+                schema.add(new QwpColumnDef("timestamp", QwpConstants.TYPE_DOUBLE_ARRAY));
+                schema.add(new QwpColumnDef("", QwpConstants.TYPE_TIMESTAMP));
+
+                // Old clients send no table-options hint. The all-NULL array
+                // column does not survive schema inference, so it cannot
+                // collide with the default designated timestamp column.
+                WalTableUpdateDetails tud = cache.getTableUpdateDetails(
+                        AllowAllSecurityContext.INSTANCE,
+                        new Utf8String(tableName),
+                        schema,
+                        getQwpTableBlockCursor(addr),
+                        1
+                );
+                Assert.assertNotNull(tud);
+
+                try (TableReader reader = engine.getReader(tableName)) {
+                    Assert.assertEquals(1, reader.getMetadata().getColumnCount());
+                    Assert.assertEquals(0, reader.getMetadata().getTimestampIndex());
+                    Assert.assertEquals("timestamp", reader.getMetadata().getColumnName(0));
+                    Assert.assertEquals(ColumnType.TIMESTAMP, reader.getMetadata().getColumnType(0));
+                }
+            } finally {
+                Unsafe.free(addr, 2, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testGetTableUpdateDetailsAutoCreatesTableWithHintMatchingExcludedColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            DefaultColumnTypes defaultColumnTypes = new DefaultColumnTypes(lineConfig);
+            final long addr = Unsafe.malloc(2, MemoryTag.NATIVE_DEFAULT);
+            try (QwpTudCache cache = new QwpTudCache(
+                    engine, true, true, defaultColumnTypes, PartitionBy.DAY)
+            ) {
+                Unsafe.putByte(addr, (byte) 1);
+                Unsafe.putByte(addr + 1, (byte) 0x01);
+
+                final String tableName = "hint_matches_excluded_col";
+                final ObjList<QwpColumnDef> schema = new ObjList<>();
+                schema.add(new QwpColumnDef("event_time", QwpConstants.TYPE_DOUBLE_ARRAY));
+                schema.add(new QwpColumnDef("", QwpConstants.TYPE_TIMESTAMP));
+
+                WalTableUpdateDetails tud = cache.getTableUpdateDetails(
+                        AllowAllSecurityContext.INSTANCE,
+                        new Utf8String(tableName),
+                        schema,
+                        getQwpTableBlockCursor(addr),
+                        new Utf8String("event_time"),
+                        1
+                );
+                Assert.assertNotNull(tud);
+
+                try (TableReader reader = engine.getReader(tableName)) {
+                    Assert.assertEquals(1, reader.getMetadata().getColumnCount());
+                    Assert.assertEquals(0, reader.getMetadata().getTimestampIndex());
+                    Assert.assertEquals("event_time", reader.getMetadata().getColumnName(0));
+                    Assert.assertEquals(ColumnType.TIMESTAMP, reader.getMetadata().getColumnType(0));
+                }
+            } finally {
+                Unsafe.free(addr, 2, MemoryTag.NATIVE_DEFAULT);
+            }
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpMessageCursorTableOptionsTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpMessageCursorTableOptionsTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.test.cutlass.qwp;
 
+import com.sun.management.ThreadMXBean;
 import io.questdb.cutlass.qwp.protocol.QwpConstants;
 import io.questdb.cutlass.qwp.protocol.QwpMessageCursor;
 import io.questdb.cutlass.qwp.protocol.QwpParseException;
@@ -31,9 +32,11 @@ import io.questdb.std.MemoryTag;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.Utf8Sequence;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.FLAG_TABLE_OPTIONS;
@@ -41,6 +44,8 @@ import static io.questdb.cutlass.qwp.protocol.QwpConstants.TABLE_OPTION_TAG_DESI
 import static io.questdb.test.tools.TestUtils.assertMemoryLeak;
 
 public class QwpMessageCursorTableOptionsTest {
+
+    private static final long MAX_CURSOR_INIT_ALLOCATION_BYTES = 64 * 1024;
 
     @Test
     public void testBlockLengthOverrunIsRejected() throws Exception {
@@ -85,6 +90,45 @@ public class QwpMessageCursorTableOptionsTest {
     }
 
     @Test
+    public void testMalformedTableOptionsDoesNotPreallocateFromTableCount() throws Exception {
+        assertMemoryLeak(() -> {
+            ThreadMXBean threadMXBean = threadAllocationBean();
+            byte[] payload = new byte[Integer.BYTES];
+
+            // Warm up the parser, flyweight exception, and allocation counter.
+            withCursor(message(1, payload), cursor -> {
+                try {
+                    cursor.ofAddress();
+                    Assert.fail("expected missing table options block");
+                } catch (QwpParseException ignored) {
+                }
+            });
+            threadMXBean.getCurrentThreadAllocatedBytes();
+
+            withCursor(message(65_535, payload), cursor -> {
+                long allocatedBefore = threadMXBean.getCurrentThreadAllocatedBytes();
+                QwpParseException parseException = null;
+                try {
+                    cursor.ofAddress();
+                } catch (QwpParseException e) {
+                    parseException = e;
+                }
+                long allocatedBytes = threadMXBean.getCurrentThreadAllocatedBytes() - allocatedBefore;
+
+                Assert.assertNotNull(parseException);
+                Assert.assertEquals(
+                        "missing table options block [tableIndex=0]",
+                        parseException.getMessage()
+                );
+                Assert.assertTrue(
+                        "malformed table options allocated " + allocatedBytes + " bytes",
+                        allocatedBytes < MAX_CURSOR_INIT_ALLOCATION_BYTES
+                );
+            });
+        });
+    }
+
+    @Test
     public void testMultiTableMixedOptions() throws Exception {
         assertMemoryLeak(() -> {
             byte[] message = validMessage(
@@ -102,6 +146,52 @@ public class QwpMessageCursorTableOptionsTest {
                 Assert.assertEquals("b", cursor.getCursor().nextTable().getTableName().toString());
                 Assert.assertEquals("c", cursor.getCursor().nextTable().getTableName().toString());
                 Assert.assertFalse(cursor.getCursor().hasNextTable());
+            });
+        });
+    }
+
+    @Test
+    public void testNoTableOptionsDoesNotAllocateBoundsFromTableCount() throws Exception {
+        assertMemoryLeak(() -> {
+            ThreadMXBean threadMXBean = threadAllocationBean();
+
+            // Warm up the no-options path and allocation counter.
+            withCursor(message(0, (byte) 0, new byte[0]), NativeCursor::ofAddress);
+            threadMXBean.getCurrentThreadAllocatedBytes();
+
+            withCursor(message(65_535, (byte) 0, new byte[0]), cursor -> {
+                long allocatedBefore = threadMXBean.getCurrentThreadAllocatedBytes();
+                cursor.ofAddress();
+                long allocatedBytes = threadMXBean.getCurrentThreadAllocatedBytes() - allocatedBefore;
+
+                Assert.assertTrue(
+                        "message without table options allocated " + allocatedBytes + " bytes",
+                        allocatedBytes < MAX_CURSOR_INIT_ALLOCATION_BYTES
+                );
+                Assert.assertNull(cursor.getCursor().getDesignatedTsName(0));
+            });
+        });
+    }
+
+    @Test
+    public void testOptionsBoundsAreClearedWhenCursorIsReusedWithoutOptions() throws Exception {
+        assertMemoryLeak(() -> {
+            byte[] optionsMessage = validMessage(
+                    new String[]{"first"},
+                    timestampBlock("event_time")
+            );
+            byte[] legacyMessage = message(1, (byte) 0, tableBlocks("second"));
+            QwpMessageCursor cursor = new QwpMessageCursor();
+
+            withCursor(optionsMessage, firstMessage -> {
+                firstMessage.ofAddress(cursor);
+                assertName(cursor, 0, "event_time");
+
+                withCursor(legacyMessage, secondMessage -> {
+                    secondMessage.ofAddress(cursor);
+                    Assert.assertNull(cursor.getDesignatedTsName(0));
+                    Assert.assertEquals("second", cursor.nextTable().getTableName().toString());
+                });
             });
         });
     }
@@ -275,13 +365,17 @@ public class QwpMessageCursorTableOptionsTest {
     }
 
     private static byte[] message(int tableCount, byte[] payload) {
+        return message(tableCount, FLAG_TABLE_OPTIONS, payload);
+    }
+
+    private static byte[] message(int tableCount, byte flags, byte[] payload) {
         ByteArrayOutputStream message = new ByteArrayOutputStream();
         message.write('Q');
         message.write('W');
         message.write('P');
         message.write('1');
         message.write(QwpConstants.VERSION);
-        message.write(FLAG_TABLE_OPTIONS);
+        message.write(flags);
         message.write(tableCount & 0xff);
         message.write((tableCount >>> 8) & 0xff);
         writeIntLE(message, payload.length);
@@ -306,6 +400,17 @@ public class QwpMessageCursorTableOptionsTest {
             writeVarint(tables, 0);
         }
         return tables.toByteArray();
+    }
+
+    private static ThreadMXBean threadAllocationBean() {
+        java.lang.management.ThreadMXBean mxBean = ManagementFactory.getThreadMXBean();
+        Assume.assumeTrue("thread allocation profiling unavailable", mxBean instanceof ThreadMXBean);
+        ThreadMXBean threadMXBean = (ThreadMXBean) mxBean;
+        Assume.assumeTrue(threadMXBean.isThreadAllocatedMemorySupported());
+        if (!threadMXBean.isThreadAllocatedMemoryEnabled()) {
+            threadMXBean.setThreadAllocatedMemoryEnabled(true);
+        }
+        return threadMXBean;
     }
 
     private static byte[] timestampBlock(String name) {
@@ -386,6 +491,10 @@ public class QwpMessageCursorTableOptionsTest {
         }
 
         private void ofAddress() throws QwpParseException {
+            cursor.of(address, length, null);
+        }
+
+        private void ofAddress(QwpMessageCursor cursor) throws QwpParseException {
             cursor.of(address, length, null);
         }
     }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpMessageCursorTableOptionsTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpMessageCursorTableOptionsTest.java
@@ -1,0 +1,347 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.qwp;
+
+import io.questdb.cutlass.qwp.protocol.QwpConstants;
+import io.questdb.cutlass.qwp.protocol.QwpMessageCursor;
+import io.questdb.cutlass.qwp.protocol.QwpParseException;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Unsafe;
+import io.questdb.std.str.Utf8Sequence;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.FLAG_TABLE_OPTIONS;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TABLE_OPTION_TAG_DESIGNATED_TIMESTAMP_NAME;
+import static io.questdb.test.tools.TestUtils.assertMemoryLeak;
+
+public class QwpMessageCursorTableOptionsTest {
+
+    @Test
+    public void testBlockLengthOverrunIsRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            byte[] tableData = tableBlocks("t");
+            ByteArrayOutputStream payload = new ByteArrayOutputStream();
+            writeBytes(payload, tableData);
+            payload.write(5);
+            writeIntLE(payload, 1);
+
+            withCursor(message(1, payload.toByteArray()), cursor -> {
+                try {
+                    cursor.ofAddress();
+                    Assert.fail("expected block overrun");
+                } catch (QwpParseException e) {
+                    Assert.assertTrue(e.getMessage().contains("overruns trailer"));
+                }
+            });
+        });
+    }
+
+    @Test
+    public void testMultiTableMixedOptions() throws Exception {
+        assertMemoryLeak(() -> {
+            byte[] message = validMessage(
+                    new String[]{"a", "b", "c"},
+                    timestampBlock("first_ts"),
+                    emptyBlock(),
+                    timestampBlock("third_ts")
+            );
+            withCursor(message, cursor -> {
+                cursor.ofAddress();
+                assertName(cursor.getCursor(), 0, "first_ts");
+                Assert.assertNull(cursor.getCursor().getDesignatedTsName(1));
+                assertName(cursor.getCursor(), 2, "third_ts");
+                Assert.assertEquals("a", cursor.getCursor().nextTable().getTableName().toString());
+                Assert.assertEquals("b", cursor.getCursor().nextTable().getTableName().toString());
+                Assert.assertEquals("c", cursor.getCursor().nextTable().getTableName().toString());
+                Assert.assertFalse(cursor.getCursor().hasNextTable());
+            });
+        });
+    }
+
+    @Test
+    public void testTrailerLengthOutOfBoundsIsRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            ByteArrayOutputStream payload = new ByteArrayOutputStream();
+            writeIntLE(payload, 1);
+            withCursor(message(0, payload.toByteArray()), cursor -> {
+                try {
+                    cursor.ofAddress();
+                    Assert.fail("expected out-of-bounds trailer length");
+                } catch (QwpParseException e) {
+                    Assert.assertTrue(e.getMessage().contains("trailer length out of bounds"));
+                }
+            });
+        });
+    }
+
+    @Test
+    public void testTruncatedFooterIsRejected() throws Exception {
+        assertMemoryLeak(() -> withCursor(
+                message(0, new byte[]{1, 2, 3}),
+                cursor -> {
+                    try {
+                        cursor.ofAddress();
+                        Assert.fail("expected truncated footer");
+                    } catch (QwpParseException e) {
+                        Assert.assertTrue(e.getMessage().contains("truncated table options footer"));
+                    }
+                }
+        ));
+    }
+
+    @Test
+    public void testUnknownTagsAreSkipped() throws Exception {
+        assertMemoryLeak(() -> {
+            ByteArrayOutputStream content = new ByteArrayOutputStream();
+            content.write(0x7f);
+            writeVarint(content, 3);
+            writeBytes(content, new byte[]{'a', 'b', 'c'});
+            writeTimestampTlv(content, "event_time");
+
+            byte[] message = validMessage(
+                    new String[]{"t"},
+                    optionsBlock(content.toByteArray())
+            );
+            withCursor(message, cursor -> {
+                cursor.ofAddress();
+                assertName(cursor.getCursor(), 0, "event_time");
+                Assert.assertEquals("t", cursor.getCursor().nextTable().getTableName().toString());
+            });
+        });
+    }
+
+    @Test
+    public void testUnsignedBlockLengthOverflowIsRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            byte[] tableData = tableBlocks("t");
+            ByteArrayOutputStream payload = new ByteArrayOutputStream();
+            writeBytes(payload, tableData);
+            for (int i = 0; i < 9; i++) {
+                payload.write(0x80);
+            }
+            payload.write(0x01);
+            writeIntLE(payload, 10);
+
+            withCursor(message(1, payload.toByteArray()), cursor -> {
+                try {
+                    cursor.ofAddress();
+                    Assert.fail("expected unsigned block length overflow");
+                } catch (QwpParseException e) {
+                    Assert.assertTrue(e.getMessage().contains("block overruns trailer"));
+                }
+            });
+        });
+    }
+
+    @Test
+    public void testUnsignedValueLengthOverflowIsRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            ByteArrayOutputStream content = new ByteArrayOutputStream();
+            content.write(TABLE_OPTION_TAG_DESIGNATED_TIMESTAMP_NAME);
+            for (int i = 0; i < 9; i++) {
+                content.write(0x80);
+            }
+            content.write(0x01);
+
+            byte[] message = validMessage(
+                    new String[]{"t"},
+                    optionsBlock(content.toByteArray())
+            );
+            withCursor(message, cursor -> {
+                try {
+                    cursor.ofAddress();
+                    Assert.fail("expected unsigned value length overflow");
+                } catch (QwpParseException e) {
+                    Assert.assertTrue(e.getMessage().contains("value overruns block"));
+                }
+            });
+        });
+    }
+
+    @Test
+    public void testValidTrailer() throws Exception {
+        assertMemoryLeak(() -> {
+            byte[] message = validMessage(
+                    new String[]{"trades"},
+                    timestampBlock("event_time")
+            );
+            withCursor(message, cursor -> {
+                cursor.ofAddress();
+                assertName(cursor.getCursor(), 0, "event_time");
+                Assert.assertEquals("trades", cursor.getCursor().nextTable().getTableName().toString());
+                Assert.assertFalse(cursor.getCursor().hasNextTable());
+            });
+        });
+    }
+
+    @Test
+    public void testZeroLengthBlocks() throws Exception {
+        assertMemoryLeak(() -> {
+            byte[] message = validMessage(
+                    new String[]{"a", "b"},
+                    emptyBlock(),
+                    emptyBlock()
+            );
+            withCursor(message, cursor -> {
+                cursor.ofAddress();
+                Assert.assertNull(cursor.getCursor().getDesignatedTsName(0));
+                Assert.assertNull(cursor.getCursor().getDesignatedTsName(1));
+                cursor.getCursor().nextTable();
+                cursor.getCursor().nextTable();
+                Assert.assertFalse(cursor.getCursor().hasNextTable());
+            });
+        });
+    }
+
+    private static void assertName(QwpMessageCursor cursor, int tableIndex, String expected) {
+        Utf8Sequence name = cursor.getDesignatedTsName(tableIndex);
+        Assert.assertNotNull(name);
+        Assert.assertEquals(expected, name.toString());
+    }
+
+    private static byte[] emptyBlock() {
+        return new byte[]{0};
+    }
+
+    private static byte[] message(int tableCount, byte[] payload) {
+        ByteArrayOutputStream message = new ByteArrayOutputStream();
+        message.write('Q');
+        message.write('W');
+        message.write('P');
+        message.write('1');
+        message.write(QwpConstants.VERSION);
+        message.write(FLAG_TABLE_OPTIONS);
+        message.write(tableCount & 0xff);
+        message.write((tableCount >>> 8) & 0xff);
+        writeIntLE(message, payload.length);
+        writeBytes(message, payload);
+        return message.toByteArray();
+    }
+
+    private static byte[] optionsBlock(byte[] content) {
+        ByteArrayOutputStream block = new ByteArrayOutputStream();
+        writeVarint(block, content.length);
+        writeBytes(block, content);
+        return block.toByteArray();
+    }
+
+    private static byte[] tableBlocks(String... tableNames) {
+        ByteArrayOutputStream tables = new ByteArrayOutputStream();
+        for (String tableName : tableNames) {
+            byte[] nameBytes = tableName.getBytes(StandardCharsets.UTF_8);
+            writeVarint(tables, nameBytes.length);
+            writeBytes(tables, nameBytes);
+            writeVarint(tables, 0);
+            writeVarint(tables, 0);
+        }
+        return tables.toByteArray();
+    }
+
+    private static byte[] timestampBlock(String name) {
+        ByteArrayOutputStream content = new ByteArrayOutputStream();
+        writeTimestampTlv(content, name);
+        return optionsBlock(content.toByteArray());
+    }
+
+    private static byte[] validMessage(String[] tableNames, byte[]... optionBlocks) {
+        Assert.assertEquals(tableNames.length, optionBlocks.length);
+        ByteArrayOutputStream payload = new ByteArrayOutputStream();
+        writeBytes(payload, tableBlocks(tableNames));
+        ByteArrayOutputStream trailer = new ByteArrayOutputStream();
+        for (byte[] optionBlock : optionBlocks) {
+            writeBytes(trailer, optionBlock);
+        }
+        byte[] trailerBytes = trailer.toByteArray();
+        writeBytes(payload, trailerBytes);
+        writeIntLE(payload, trailerBytes.length);
+        return message(tableNames.length, payload.toByteArray());
+    }
+
+    private static void withCursor(byte[] message, CursorConsumer consumer) throws Exception {
+        long address = Unsafe.malloc(message.length, MemoryTag.NATIVE_DEFAULT);
+        try {
+            for (int i = 0; i < message.length; i++) {
+                Unsafe.putByte(address + i, message[i]);
+            }
+            consumer.accept(new NativeCursor(address, message.length));
+        } finally {
+            Unsafe.free(address, message.length, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    private static void writeBytes(ByteArrayOutputStream sink, byte[] bytes) {
+        sink.write(bytes, 0, bytes.length);
+    }
+
+    private static void writeIntLE(ByteArrayOutputStream sink, int value) {
+        sink.write(value & 0xff);
+        sink.write((value >>> 8) & 0xff);
+        sink.write((value >>> 16) & 0xff);
+        sink.write((value >>> 24) & 0xff);
+    }
+
+    private static void writeTimestampTlv(ByteArrayOutputStream sink, String name) {
+        byte[] nameBytes = name.getBytes(StandardCharsets.UTF_8);
+        sink.write(TABLE_OPTION_TAG_DESIGNATED_TIMESTAMP_NAME);
+        writeVarint(sink, nameBytes.length);
+        writeBytes(sink, nameBytes);
+    }
+
+    private static void writeVarint(ByteArrayOutputStream sink, long value) {
+        while ((value & ~0x7fL) != 0) {
+            sink.write((int) ((value & 0x7f) | 0x80));
+            value >>>= 7;
+        }
+        sink.write((int) value);
+    }
+
+    @FunctionalInterface
+    private interface CursorConsumer {
+        void accept(NativeCursor cursor) throws Exception;
+    }
+
+    private static final class NativeCursor {
+        private final long address;
+        private final QwpMessageCursor cursor = new QwpMessageCursor();
+        private final int length;
+
+        private NativeCursor(long address, int length) {
+            this.address = address;
+            this.length = length;
+        }
+
+        private QwpMessageCursor getCursor() {
+            return cursor;
+        }
+
+        private void ofAddress() throws QwpParseException {
+            cursor.of(address, length, null);
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpMessageCursorTableOptionsTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpMessageCursorTableOptionsTest.java
@@ -63,6 +63,28 @@ public class QwpMessageCursorTableOptionsTest {
     }
 
     @Test
+    public void testMissingTableOptionsBlockIsRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            byte[] tableData = tableBlocks("a", "b");
+            byte[] optionBlock = emptyBlock();
+            ByteArrayOutputStream payload = new ByteArrayOutputStream();
+            writeBytes(payload, tableData);
+            writeBytes(payload, optionBlock);
+            writeIntLE(payload, optionBlock.length);
+
+            withCursor(message(2, payload.toByteArray()), cursor -> {
+                try {
+                    cursor.ofAddress();
+                    Assert.fail("expected missing table options block");
+                } catch (QwpParseException e) {
+                    Assert.assertEquals(QwpParseException.ErrorCode.INSUFFICIENT_DATA, e.getErrorCode());
+                    Assert.assertEquals("missing table options block [tableIndex=1]", e.getMessage());
+                }
+            });
+        });
+    }
+
+    @Test
     public void testMultiTableMixedOptions() throws Exception {
         assertMemoryLeak(() -> {
             byte[] message = validMessage(
@@ -113,6 +135,29 @@ public class QwpMessageCursorTableOptionsTest {
                     }
                 }
         ));
+    }
+
+    @Test
+    public void testUnexpectedBytesAfterTableOptionsBlocksAreRejected() throws Exception {
+        assertMemoryLeak(() -> {
+            byte[] tableData = tableBlocks("t");
+            byte[] optionBlock = emptyBlock();
+            ByteArrayOutputStream payload = new ByteArrayOutputStream();
+            writeBytes(payload, tableData);
+            writeBytes(payload, optionBlock);
+            payload.write(0x7f);
+            writeIntLE(payload, optionBlock.length + 1);
+
+            withCursor(message(1, payload.toByteArray()), cursor -> {
+                try {
+                    cursor.ofAddress();
+                    Assert.fail("expected unexpected bytes after table options blocks");
+                } catch (QwpParseException e) {
+                    Assert.assertEquals(QwpParseException.ErrorCode.INSUFFICIENT_DATA, e.getErrorCode());
+                    Assert.assertEquals("unexpected bytes after table options blocks: 1", e.getMessage());
+                }
+            });
+        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpMessageHeaderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpMessageHeaderTest.java
@@ -64,6 +64,15 @@ public class QwpMessageHeaderTest {
     }
 
     @Test
+    public void testFlagTableOptions() throws QwpParseException {
+        byte[] header = createValidHeader(1, FLAG_TABLE_OPTIONS, 1, 100);
+        QwpMessageHeader h = new QwpMessageHeader();
+        h.parse(header, 0, header.length);
+
+        Assert.assertTrue(h.isTableOptionsEnabled());
+    }
+
+    @Test
     public void testHeaderToString() throws QwpParseException {
         byte[] header = createValidHeader(1, FLAG_GORILLA, 5, 1234);
         QwpMessageHeader h = new QwpMessageHeader();

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderReceiverTest.java
@@ -355,13 +355,13 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
     public void testAutoCreateWithDesignatedTimestampNames() throws Exception {
         runInContext((port) -> {
             try (Sender sender = createSender(port)) {
-                sender.table("ws_named_explicit_ts")
-                        .designatedTimestampName("event_time")
-                        .longColumn("v", 42)
+                sender.table("ws_named_explicit_ts").tableOptions()
+                        .designatedTimestamp("event_time");
+                sender.longColumn("v", 42)
                         .at(1_000_000L, ChronoUnit.MICROS);
-                sender.table("ws_named_server_ts")
-                        .designatedTimestampName("ingested_at")
-                        .longColumn("v", 84)
+                sender.table("ws_named_server_ts").tableOptions()
+                        .designatedTimestamp("ingested_at");
+                sender.longColumn("v", 84)
                         .atNow();
                 sender.flush();
             }
@@ -389,9 +389,9 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
                     + "TIMESTAMP(actual_ts) PARTITION BY DAY WAL");
 
             try (Sender sender = createSender(port)) {
-                sender.table("ws_existing_named_ts")
-                        .designatedTimestampName("bad/name")
-                        .longColumn("v", 7)
+                sender.table("ws_existing_named_ts").tableOptions()
+                        .designatedTimestamp("bad/name");
+                sender.longColumn("v", 7)
                         .at(2_000_000L, ChronoUnit.MICROS);
                 sender.flush();
             }
@@ -425,9 +425,9 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
             );
 
             try (Sender sender = createSender(port)) {
-                sender.table("ws_valid_after_named_ts_rejection")
-                        .designatedTimestampName("event_time")
-                        .longColumn("v", 1)
+                sender.table("ws_valid_after_named_ts_rejection").tableOptions()
+                        .designatedTimestamp("event_time");
+                sender.longColumn("v", 1)
                         .at(3_000_000L, ChronoUnit.MICROS);
                 sender.flush();
             }
@@ -4482,9 +4482,9 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
         }, 1);
         SenderError.Category expectedTerminalCategory = null;
         try {
-            sender.table(tableName)
-                    .designatedTimestampName(designatedTimestampName)
-                    .longColumn(columnName, 1)
+            sender.table(tableName).tableOptions()
+                    .designatedTimestamp(designatedTimestampName);
+            sender.longColumn(columnName, 1)
                     .at(1_000_000L, ChronoUnit.MICROS);
             try {
                 sender.flush();

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderReceiverTest.java
@@ -369,16 +369,20 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
             drainWalQueue();
             assertQuery("SELECT v, event_time FROM ws_named_explicit_ts")
                     .noLeakCheck()
-                    .returnsOnce("v\tevent_time\n42\t1970-01-01T00:00:01.000000Z\n");
+                    .timestamp("event_time")
+                    .expectSize()
+                    .returns("v\tevent_time\n42\t1970-01-01T00:00:01.000000Z\n");
             assertQuery("SELECT \"column\" FROM table_columns('ws_named_explicit_ts') ORDER BY \"column\"")
                     .noLeakCheck()
-                    .returnsOnce("column\nevent_time\nv\n");
+                    .returns("column\nevent_time\nv\n");
             assertQuery("SELECT \"column\" FROM table_columns('ws_named_server_ts') ORDER BY \"column\"")
                     .noLeakCheck()
-                    .returnsOnce("column\ningested_at\nv\n");
+                    .returns("column\ningested_at\nv\n");
             assertQuery("SELECT count() FROM ws_named_server_ts WHERE ingested_at >= '2025-01-01'")
                     .noLeakCheck()
-                    .returnsOnce("count\n1\n");
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("count\n1\n");
         });
     }
 
@@ -399,10 +403,12 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
             drainWalQueue();
             assertQuery("SELECT v, actual_ts FROM ws_existing_named_ts")
                     .noLeakCheck()
-                    .returnsOnce("v\tactual_ts\n7\t1970-01-01T00:00:02.000000Z\n");
+                    .timestamp("actual_ts")
+                    .expectSize()
+                    .returns("v\tactual_ts\n7\t1970-01-01T00:00:02.000000Z\n");
             assertQuery("SELECT \"column\" FROM table_columns('ws_existing_named_ts') ORDER BY \"column\"")
                     .noLeakCheck()
-                    .returnsOnce("column\nactual_ts\nv\n");
+                    .returns("column\nactual_ts\nv\n");
         });
     }
 
@@ -434,7 +440,8 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
             drainWalQueue();
             assertQuery("SELECT v FROM ws_valid_after_named_ts_rejection")
                     .noLeakCheck()
-                    .returnsOnce("v\n1\n");
+                    .expectSize()
+                    .returns("v\n1\n");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderReceiverTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketSenderReceiverTest.java
@@ -351,6 +351,93 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
         });
     }
 
+    @Test
+    public void testAutoCreateWithDesignatedTimestampNames() throws Exception {
+        runInContext((port) -> {
+            try (Sender sender = createSender(port)) {
+                sender.table("ws_named_explicit_ts")
+                        .designatedTimestampName("event_time")
+                        .longColumn("v", 42)
+                        .at(1_000_000L, ChronoUnit.MICROS);
+                sender.table("ws_named_server_ts")
+                        .designatedTimestampName("ingested_at")
+                        .longColumn("v", 84)
+                        .atNow();
+                sender.flush();
+            }
+
+            drainWalQueue();
+            assertQuery("SELECT v, event_time FROM ws_named_explicit_ts")
+                    .noLeakCheck()
+                    .returnsOnce("v\tevent_time\n42\t1970-01-01T00:00:01.000000Z\n");
+            assertQuery("SELECT \"column\" FROM table_columns('ws_named_explicit_ts') ORDER BY \"column\"")
+                    .noLeakCheck()
+                    .returnsOnce("column\nevent_time\nv\n");
+            assertQuery("SELECT \"column\" FROM table_columns('ws_named_server_ts') ORDER BY \"column\"")
+                    .noLeakCheck()
+                    .returnsOnce("column\ningested_at\nv\n");
+            assertQuery("SELECT count() FROM ws_named_server_ts WHERE ingested_at >= '2025-01-01'")
+                    .noLeakCheck()
+                    .returnsOnce("count\n1\n");
+        });
+    }
+
+    @Test
+    public void testDesignatedTimestampNameIsIgnoredForExistingTable() throws Exception {
+        runInContext((port) -> {
+            execute("CREATE TABLE ws_existing_named_ts (v LONG, actual_ts TIMESTAMP) "
+                    + "TIMESTAMP(actual_ts) PARTITION BY DAY WAL");
+
+            try (Sender sender = createSender(port)) {
+                sender.table("ws_existing_named_ts")
+                        .designatedTimestampName("bad/name")
+                        .longColumn("v", 7)
+                        .at(2_000_000L, ChronoUnit.MICROS);
+                sender.flush();
+            }
+
+            drainWalQueue();
+            assertQuery("SELECT v, actual_ts FROM ws_existing_named_ts")
+                    .noLeakCheck()
+                    .returnsOnce("v\tactual_ts\n7\t1970-01-01T00:00:02.000000Z\n");
+            assertQuery("SELECT \"column\" FROM table_columns('ws_existing_named_ts') ORDER BY \"column\"")
+                    .noLeakCheck()
+                    .returnsOnce("column\nactual_ts\nv\n");
+        });
+    }
+
+    @Test
+    public void testInvalidDesignatedTimestampNamesAreRejectedCleanly() throws Exception {
+        runInContext((port) -> {
+            assertDesignatedTimestampNameRejected(
+                    port,
+                    "ws_invalid_named_ts",
+                    "bad/name",
+                    "v",
+                    "invalid designated timestamp column name"
+            );
+            assertDesignatedTimestampNameRejected(
+                    port,
+                    "ws_colliding_named_ts",
+                    "v",
+                    "v",
+                    "collides with schema column"
+            );
+
+            try (Sender sender = createSender(port)) {
+                sender.table("ws_valid_after_named_ts_rejection")
+                        .designatedTimestampName("event_time")
+                        .longColumn("v", 1)
+                        .at(3_000_000L, ChronoUnit.MICROS);
+                sender.flush();
+            }
+            drainWalQueue();
+            assertQuery("SELECT v FROM ws_valid_after_named_ts_rejection")
+                    .noLeakCheck()
+                    .returnsOnce("v\n1\n");
+        });
+    }
+
     /**
      * Tests that multiple rows sent with atNow() in the same batch get per-row timestamps.
      * <p>
@@ -4376,6 +4463,51 @@ public class QwpWebSocketSenderReceiverTest extends AbstractQwpWebSocketTest {
                     .noLeakCheck()
                     .returnsOnce("count\n1\n");
         });
+    }
+
+    private static void assertDesignatedTimestampNameRejected(
+            int port,
+            String tableName,
+            String designatedTimestampName,
+            String columnName,
+            String expectedMessage
+    ) throws Exception {
+        CompletableFuture<SenderError> firstError = new CompletableFuture<>();
+        CompletableFuture<SenderError> terminalError = new CompletableFuture<>();
+        QwpWebSocketSender sender = connectWs(port, error -> {
+            if (error.getAppliedPolicy() == SenderError.Policy.TERMINAL) {
+                terminalError.complete(error);
+            }
+            firstError.complete(error);
+        }, 1);
+        SenderError.Category expectedTerminalCategory = null;
+        try {
+            sender.table(tableName)
+                    .designatedTimestampName(designatedTimestampName)
+                    .longColumn(columnName, 1)
+                    .at(1_000_000L, ChronoUnit.MICROS);
+            try {
+                sender.flush();
+            } catch (LineSenderServerException ignored) {
+                // The I/O thread may deliver the terminal before flush polls it.
+            }
+
+            SenderError error = firstError.get(10, TimeUnit.SECONDS);
+            Assert.assertSame(SenderError.Category.SCHEMA_MISMATCH, error.getCategory());
+            Assert.assertSame(SenderError.Policy.TERMINAL, error.getAppliedPolicy());
+            Assert.assertTrue(
+                    error.getServerMessage(),
+                    error.getServerMessage() != null && error.getServerMessage().contains(expectedMessage)
+            );
+            expectedTerminalCategory = SenderError.Category.SCHEMA_MISMATCH;
+        } finally {
+            assertRejectionTerminalOnClose(
+                    sender,
+                    terminalError,
+                    expectedTerminalCategory,
+                    expectedMessage
+            );
+        }
     }
 
     /**

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpInsertTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpInsertTest.java
@@ -166,10 +166,12 @@ public class QwpUdpInsertTest extends AbstractCairoTest {
             drainWalQueue();
             assertQuery("SELECT v, event_time FROM qwp_udp_named_ts")
                     .noLeakCheck()
-                    .returnsOnce("v\tevent_time\n42\t1970-01-01T00:00:01.000000Z\n");
+                    .timestamp("event_time")
+                    .expectSize()
+                    .returns("v\tevent_time\n42\t1970-01-01T00:00:01.000000Z\n");
             assertQuery("SELECT \"column\" FROM table_columns('qwp_udp_named_ts') ORDER BY \"column\"")
                     .noLeakCheck()
-                    .returnsOnce("column\nevent_time\nv\n");
+                    .returns("column\nevent_time\nv\n");
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpInsertTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpInsertTest.java
@@ -150,6 +150,30 @@ public class QwpUdpInsertTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAutoCreatedTableWithDesignatedTimestampName() throws Exception {
+        assertMemoryLeak(() -> {
+            try (QwpUdpReceiver receiver = receiverFactory.create(RCVR_CONF, engine)) {
+                try (QwpUdpSender sender = newSender()) {
+                    sender.table("qwp_udp_named_ts")
+                            .designatedTimestampName("event_time")
+                            .longColumn("v", 42)
+                            .at(1_000_000L, ChronoUnit.MICROS);
+                    sender.flush();
+                }
+                drainReceiver(receiver);
+            }
+
+            drainWalQueue();
+            assertQuery("SELECT v, event_time FROM qwp_udp_named_ts")
+                    .noLeakCheck()
+                    .returnsOnce("v\tevent_time\n42\t1970-01-01T00:00:01.000000Z\n");
+            assertQuery("SELECT \"column\" FROM table_columns('qwp_udp_named_ts') ORDER BY \"column\"")
+                    .noLeakCheck()
+                    .returnsOnce("column\nevent_time\nv\n");
+        });
+    }
+
+    @Test
     public void testAutoCreatedTableWithMultiDimArrayReadsBack() throws Exception {
         assertMemoryLeak(() -> {
             try (QwpUdpReceiver receiver = receiverFactory.create(RCVR_CONF, engine)) {

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpInsertTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/udp/QwpUdpInsertTest.java
@@ -154,9 +154,9 @@ public class QwpUdpInsertTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             try (QwpUdpReceiver receiver = receiverFactory.create(RCVR_CONF, engine)) {
                 try (QwpUdpSender sender = newSender()) {
-                    sender.table("qwp_udp_named_ts")
-                            .designatedTimestampName("event_time")
-                            .longColumn("v", 42)
+                    sender.table("qwp_udp_named_ts").tableOptions()
+                            .designatedTimestamp("event_time");
+                    sender.longColumn("v", 42)
                             .at(1_000_000L, ChronoUnit.MICROS);
                     sender.flush();
                 }

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/QwpIngressUpgradeProcessorTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/QwpIngressUpgradeProcessorTest.java
@@ -93,6 +93,8 @@ public class QwpIngressUpgradeProcessorTest extends AbstractWebSocketTest {
                 Assert.assertTrue("Response should contain Upgrade: websocket", response.contains("Upgrade: websocket"));
                 Assert.assertTrue("Response should contain Connection: Upgrade", response.contains("Connection: Upgrade"));
                 Assert.assertTrue("Response should contain Sec-WebSocket-Accept", response.contains("Sec-WebSocket-Accept: " + expectedAccept));
+                Assert.assertTrue("Response should advertise table option tag 1",
+                        response.contains("X-QWP-Table-Options: 1\r\n"));
                 Assert.assertTrue("Response should end with double CRLF", response.endsWith("\r\n\r\n"));
             } finally {
                 Unsafe.free(buffer, bufferSize, MemoryTag.NATIVE_DEFAULT);

--- a/core/src/test/java/io/questdb/test/cutlass/websocket/WebSocketHandshakeTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/websocket/WebSocketHandshakeTest.java
@@ -247,25 +247,6 @@ public class WebSocketHandshakeTest extends AbstractWebSocketTest {
     }
 
     @Test
-    public void testWriteResponseOmitsMaxBatchSizeWhenAbsent() throws Exception {
-        assertMemoryLeak(() -> {
-            byte[] acceptKey = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=".getBytes(StandardCharsets.US_ASCII);
-
-            long buf = allocateBuffer(256);
-            try {
-                int written = QwpIngressHttpProcessor.writeResponse(
-                        buf, acceptKey, 1, null, false, null, null);
-
-                String response = new String(readBytes(buf, written), StandardCharsets.US_ASCII);
-                Assert.assertFalse("did not expect X-QWP-Max-Batch-Size header, got: " + response,
-                        response.contains("X-QWP-Max-Batch-Size"));
-            } finally {
-                freeBuffer(buf, 256);
-            }
-        });
-    }
-
-    @Test
     public void testThreadSafety() throws InterruptedException {
         // Test that accept key computation is thread-safe
         String clientKey = "dGhlIHNhbXBsZSBub25jZQ==";
@@ -358,9 +339,29 @@ public class WebSocketHandshakeTest extends AbstractWebSocketTest {
                         Connection: Upgrade\r
                         Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r
                         X-QWP-Version: 1\r
+                        X-QWP-Table-Options: 1\r
                         \r
                         """;
                 Assert.assertEquals(expected, responseStr);
+            } finally {
+                freeBuffer(buf, 256);
+            }
+        });
+    }
+
+    @Test
+    public void testWriteResponseOmitsMaxBatchSizeWhenAbsent() throws Exception {
+        assertMemoryLeak(() -> {
+            byte[] acceptKey = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=".getBytes(StandardCharsets.US_ASCII);
+
+            long buf = allocateBuffer(256);
+            try {
+                int written = QwpIngressHttpProcessor.writeResponse(
+                        buf, acceptKey, 1, null, false, null, null);
+
+                String response = new String(readBytes(buf, written), StandardCharsets.US_ASCII);
+                Assert.assertFalse("did not expect X-QWP-Max-Batch-Size header, got: " + response,
+                        response.contains("X-QWP-Max-Batch-Size"));
             } finally {
                 freeBuffer(buf, 256);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
                 <module>java-questdb-client</module>
             </modules>
             <properties>
-                <questdb.client.version>1.3.6-SNAPSHOT</questdb.client.version>
+                <questdb.client.version>1.3.7-SNAPSHOT</questdb.client.version>
             </properties>
         </profile>
     </profiles>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -22,7 +22,8 @@
   ~
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.questdb</groupId>
@@ -40,7 +41,7 @@
         <test.exclude>None</test.exclude>
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
 
-        <questdb.client.version>1.3.6-SNAPSHOT</questdb.client.version>
+        <questdb.client.version>1.3.7-SNAPSHOT</questdb.client.version>
     </properties>
 
     <dependencies>
@@ -123,7 +124,12 @@
                     <version>3.5.3</version>
                     <configuration>
                         <useModulePath>false</useModulePath>
-                        <argLine>--sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.time.zone=ALL-UNNAMED --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED</argLine>
+                        <argLine>--sun-misc-unsafe-memory-access=allow --enable-native-access=ALL-UNNAMED
+                            --add-opens=java.base/java.lang=ALL-UNNAMED
+                            --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                            --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.time.zone=ALL-UNNAMED
+                            --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED
+                        </argLine>
                         <includes>
                             <include>${test.include}</include>
                         </includes>
@@ -144,7 +150,7 @@
         <profile>
             <id>local-client</id>
             <properties>
-                <questdb.client.version>1.3.6-SNAPSHOT</questdb.client.version>
+                <questdb.client.version>1.3.7-SNAPSHOT</questdb.client.version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
When QWP ingestion auto-creates a table, the designated timestamp column is
always called `timestamp`. Users with sharded feeds rely on auto-creation and
expect to control that name, as the Python dataframe client allows. This PR
lets QWP clients name the designated timestamp column at auto-create time.

## Changes

- The QWP ingest decoder parses an optional per-table options trailer
  (header flag `0x20`, TLV tag `0x01` = designated timestamp name, length
  footer). Unknown tags are skipped, so future create-time options
  (partitioning, TTL) can reuse the same mechanism without protocol changes.
- Table auto-creation applies the name on both the WebSocket and UDP routes;
  the WebSocket upgrade response advertises support via `X-QWP-Table-Options`.
- Backward compatible in both directions: frames without the flag are
  processed exactly as before, and old servers ignore the trailer bytes, so
  new-client frames degrade to the conventional `timestamp` name. A
  compatibility test pins the trailing-bytes tolerance the design relies on.

## Limitations

- The name is a create-only hint: existing tables ignore it.
- Old servers ignore the hint silently; the client logs one warning when the
  server does not advertise support. UDP and store-and-forward replay cannot
  check support and stay best-effort.


Tandem PR: https://github.com/questdb/java-questdb-client/pull/76