### PR TITLE
fix(sql): avoid intermediate overflow/underflow in regr_r2() denominator

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/groupby/RegressionR2FunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/groupby/RegressionR2FunctionFactory.java
@@ -74,7 +74,29 @@ public class RegressionR2FunctionFactory implements FunctionFactory {
                 return 1.0;
             }
             double sumXY = rec.getDouble(valueIndex + 4);
-            return (sumXY * sumXY) / (sumX * sumY);
+
+            // Protect against intermediate overflow/underflow in the denominator
+            // sumX * sumY.  Mirror the fix applied to corr() in #7313.
+            //
+            // The Pearson denominator is sqrt(sumX * sumY).  When the product
+            // would overflow to +Infinity or underflow to 0.0 while both factors
+            // are non-zero, split into sqrt(sumX) * sqrt(sumY) to keep both
+            // factors in the finite range.  The result is then squared to obtain
+            // R² in [0, 1], and clamped to absorb the ~1 ULP rounding drift
+            // possible in the split-sqrt path.
+            double prod = sumX * sumY;
+            boolean splitDenom = !Double.isFinite(prod) || (prod == 0.0 && sumX != 0.0 && sumY != 0.0);
+            double denom = splitDenom ? Math.sqrt(sumX) * Math.sqrt(sumY) : Math.sqrt(prod);
+            if (denom == 0.0) {
+                return Double.NaN;
+            }
+            double r = sumXY / denom;
+            if (r > 1.0) {
+                r = 1.0;
+            } else if (r < -1.0) {
+                r = -1.0;
+            }
+            return r * r;
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionR2FunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/RegressionR2FunctionFactoryTest.java
@@ -151,7 +151,7 @@ public class RegressionR2FunctionFactoryTest extends AbstractCairoTest {
         // NOT exercise the parallel merge() path; that coverage lives in
         // RegressionR2ParallelGroupByTest. Group A is a perfect line y = x
         // (r^2 = 1.0); group B has constant Y with varying X (Syy = 0, Sxx > 0
-        // returns 1.0 by SQL:2003 §10.9).
+        // returns 1.0 by SQL:2003 10.9).
         assertMemoryLeak(() -> {
             execute(
                     "create table tbl1 as (" +
@@ -212,6 +212,43 @@ public class RegressionR2FunctionFactoryTest extends AbstractCairoTest {
                     .noRandomAccess()
                     .expectSize()
                     .returns("regr_r2\n1.0\n");
+        });
+    }
+
+    @Test
+    public void testRegrR2LargeMagnitudeOverflow() throws Exception {
+        // Regression test for #7328: prior to the split-sqrt refactor, the
+        // denominator sumX * sumY overflowed to +Infinity for inputs of
+        // magnitude ~1e153, causing regr_r2() to return 0.0 instead of 1.0.
+        assertMemoryLeak(() -> {
+            execute("create table tbl1(x double, y double)");
+            execute("insert into 'tbl1' VALUES (1e153, 1e153), (-1e153, -1e153)");
+            assertQuery("select regr_r2(y, x) from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("regr_r2\n1.0\n");
+        });
+    }
+
+    @Test
+    public void testRegrR2SmallMagnitudeUnderflow() throws Exception {
+        // Regression test for #7328: for inputs of very small magnitude
+        // (~1e-150) the sums of squared deviations are ~1e-300, so their
+        // product sumX * sumY underflows to exactly 0.0 while each factor
+        // stays finite and non-zero. Prior to the split-sqrt fallback,
+        // sqrt(0.0) made the denominator 0.0 and regr_r2() returned NaN
+        // instead of the true r-squared.
+        assertMemoryLeak(() -> {
+            execute("create table tbl1(x double, y double)");
+            execute("insert into 'tbl1' VALUES (1e-150, 1e-150), (-1e-150, -1e-150)");
+            // The split-sqrt fallback uses two sqrt roundings, so the result
+            // can land 1 ULP below the true 1.0. Use round() to tolerate this.
+            assertQuery("select round(regr_r2(y, x), 10) from tbl1")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("round\n1.0\n");
         });
     }
 


### PR DESCRIPTION
### What

Fixes #7328 — `regr_r2()` currently computes the denominator as `sumX * sumY` directly, which overflows to `+Infinity` for large-magnitude inputs (~1e153) and underflows to `0.0` for small-magnitude inputs (~1e-150).

Mirror the fix applied to `corr()` in #7313.

### How

- Compute the Pearson ratio `sumXY / sqrt(sumX * sumY)` with the same overflow/underflow-safe split-sqrt denominator used by `Numbers.corrFromSums()`.
- Clamp the Pearson ratio to `[-1, 1]` then square to obtain R² in `[0, 1]`.
- Preserve the existing SQL:2003 short-circuits (zero X variance → NaN, zero Y variance → 1.0).

### Tests

- `testRegrR2LargeMagnitudeOverflow` — inputs of ~1e153 return 1.0, not 0.0
- `testRegrR2SmallMagnitudeUnderflow` — inputs of ~1e-150 return close to 1.0, not NaN