### PR TITLE
fix(sql): fix datediff() result type for an invalid time unit

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/date/TimestampDiffFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/date/TimestampDiffFunctionFactory.java
@@ -82,7 +82,10 @@ public class TimestampDiffFunctionFactory implements FunctionFactory {
                 }
                 return new DiffVarVarFunction(start, end, driver, diffMethod, startType, endType, period);
             }
-            return driver.getTimestampConstantNull();
+            // An invalid constant unit produces a null result, but datediff() is a
+            // long-valued function, so the null must carry the LONG type rather than
+            // the timestamp driver's TIMESTAMP-typed null. See issue #7022.
+            return LongConstant.NULL;
         }
         return new DateDiffFunc(args.getQuick(0), args.getQuick(1), args.getQuick(2), driver, startType, endType);
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/date/TimestampDiffFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/date/TimestampDiffFunctionFactoryTest.java
@@ -860,6 +860,26 @@ public class TimestampDiffFunctionFactoryTest extends AbstractFunctionFactoryTes
     }
 
     @Test
+    public void testUnknownConstantPeriodReturnsLongNull() throws Exception {
+        // datediff() is a long-valued function; an invalid constant unit must yield
+        // a LONG null rather than the timestamp driver's TIMESTAMP-typed null, else
+        // result-set metadata misreports the column type to PG/HTTP clients. See #7022.
+        assertQuery("select datediff('q', 0::timestamp, 1::timestamp) dd, typeOf(datediff('q', 0::timestamp, 1::timestamp)) tp")
+                .expectSize()
+                .returns("""
+                        dd\ttp
+                        null\tLONG
+                        """);
+
+        assertQuery("select datediff('q', 0::timestamp_ns, 1::timestamp_ns) dd, typeOf(datediff('q', 0::timestamp_ns, 1::timestamp_ns)) tp")
+                .expectSize()
+                .returns("""
+                        dd\ttp
+                        null\tLONG
+                        """);
+    }
+
+    @Test
     public void testUnknownPeriod() throws Exception {
         assertMemoryLeak(() -> call('/', 1587275359886758L, 1587275364886758L).andAssert(Double.NaN, 0.0001));
     }


### PR DESCRIPTION
Fixes #7022

## Problem

`datediff(unit, ts1, ts2)` is a long-valued function. When `unit` is a
compile-time constant that is not a recognised time unit, the factory returned
the timestamp driver's TIMESTAMP-typed null constant instead of a LONG null.
The value was correct (null), but the result column carried the wrong type:

```sql
select typeOf(datediff('q', 0::timestamp, 1::timestamp));
-- before: TIMESTAMP
-- after:  LONG
```

This misreports result-set metadata to PostgreSQL-wire and HTTP clients that
depend on the declared column type, and can perturb downstream expression
planning, since a null from `datediff()` should not change the function's
declared result type.

## Fix

`TimestampDiffFunctionFactory.newInstance()` returns `LongConstant.NULL` on the
invalid-constant-unit path. The returned value is unchanged (`Numbers.LONG_NULL`);
only the declared type changes from TIMESTAMP to LONG, matching every other
`datediff()` code path (the valid-constant path returns `LongConstant`, and the
dynamic paths extend `LongFunction`).

The change is limited to the constant-folding branch; runtime evaluation of an
unknown unit on non-constant inputs was already LONG-typed and is untouched.

## Test plan

- Added `TimestampDiffFunctionFactoryTest.testUnknownConstantPeriodReturnsLongNull`,
  asserting both the null value and `typeOf(...) = LONG` for micro- and
  nanosecond timestamp inputs.
- The pre-existing `testUnknownPeriod` (value-only, non-constant unit) still passes.
- Full class green locally: Tests run: 73, Failures: 0, Errors: 0.
