### PR TITLE
fix(core): survive an orphan _query_trace directory

### DIFF
--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -2363,21 +2363,27 @@ public class CairoEngine implements Closeable, WriterSource {
         }
         final FilesFacade ff = configuration.getFilesFacade();
         if (status == TableUtils.TABLE_RESERVED && tableToken.isSystem() && !ff.isSoftLink(tableDir.$())) {
-            final StringSink quarantineName = Misc.getThreadLocalSink();
-            for (int i = 0; i < TableUtils.MAX_ORPHAN_DIRS; i++) {
-                quarantineName.clear();
-                quarantineName.put(tableToken.getDirName()).put(TableUtils.ORPHAN_DIR_SUFFIX).put(i);
-                final Path quarantine = Path.getThreadLocal2(configuration.getDbRoot()).concat(quarantineName);
-                if (ff.exists(quarantine.$())) {
-                    continue;
+            // a dedicated Path rather than a thread-local one: tableDir belongs to the caller, and
+            // a caller that passed the same thread-local would alias it, silently turning the
+            // rename below into a one-buffer no-op. this runs at most once per orphan directory,
+            // so the allocation does not matter
+            try (Path quarantine = new Path()) {
+                final StringSink quarantineName = Misc.getThreadLocalSink();
+                for (int i = 0; i < TableUtils.MAX_ORPHAN_DIRS; i++) {
+                    quarantineName.clear();
+                    quarantineName.put(tableToken.getDirName()).put(TableUtils.ORPHAN_DIR_SUFFIX).put(i);
+                    quarantine.of(configuration.getDbRoot()).concat(quarantineName);
+                    if (ff.exists(quarantine.$())) {
+                        continue;
+                    }
+                    if (ff.rename(tableDir.$(), quarantine.$()) == Files.FILES_RENAME_OK) {
+                        LOG.advisory().$("quarantined orphan system table directory [table=").$(tableToken)
+                                .$(", from=").$(tableDir)
+                                .$(", to=").$(quarantine).I$();
+                        return;
+                    }
+                    break;
                 }
-                if (ff.rename(tableDir.$(), quarantine.$()) == Files.FILES_RENAME_OK) {
-                    LOG.advisory().$("quarantined orphan system table directory [table=").$(tableToken)
-                            .$(", from=").$(tableDir)
-                            .$(", to=").$(quarantine).I$();
-                    return;
-                }
-                break;
             }
         }
         throw CairoException.nonCritical().put("name is reserved [table=")

--- a/core/src/main/java/io/questdb/cairo/CairoEngine.java
+++ b/core/src/main/java/io/questdb/cairo/CairoEngine.java
@@ -2342,6 +2342,51 @@ public class CairoEngine implements Closeable, WriterSource {
         }
     }
 
+    /**
+     * Verifies that the directory a table is about to be created in is free. An orphan directory -
+     * one that exists on disk while the table name registry has no entry for it - otherwise blocks
+     * the create forever, because {@link TableNameRegistryStore} only adopts a directory that has
+     * a _txn file, and every retry hits the same directory on disk.
+     * <p>
+     * A system table directory with no _txn holds nothing a reader could open, so it is moved
+     * aside. It is never deleted, and a soft link is never touched. Anything else, including any
+     * user table, is reported with the path and the reason.
+     * <p>
+     * The caller holds the name lock, the create lock and lockAll(), so nothing else can be
+     * reading this directory. {@code tableDir} must point at the table directory itself:
+     * {@link TableUtils#exists(FilesFacade, Path, CharSequence, CharSequence)} leaves the path it
+     * is given pointing at the _txn file below it.
+     */
+    private void checkTableDirAvailable(int status, Path tableDir, TableToken tableToken) {
+        if (status == TableUtils.TABLE_DOES_NOT_EXIST) {
+            return;
+        }
+        final FilesFacade ff = configuration.getFilesFacade();
+        if (status == TableUtils.TABLE_RESERVED && tableToken.isSystem() && !ff.isSoftLink(tableDir.$())) {
+            final StringSink quarantineName = Misc.getThreadLocalSink();
+            for (int i = 0; i < TableUtils.MAX_ORPHAN_DIRS; i++) {
+                quarantineName.clear();
+                quarantineName.put(tableToken.getDirName()).put(TableUtils.ORPHAN_DIR_SUFFIX).put(i);
+                final Path quarantine = Path.getThreadLocal2(configuration.getDbRoot()).concat(quarantineName);
+                if (ff.exists(quarantine.$())) {
+                    continue;
+                }
+                if (ff.rename(tableDir.$(), quarantine.$()) == Files.FILES_RENAME_OK) {
+                    LOG.advisory().$("quarantined orphan system table directory [table=").$(tableToken)
+                            .$(", from=").$(tableDir)
+                            .$(", to=").$(quarantine).I$();
+                    return;
+                }
+                break;
+            }
+        }
+        throw CairoException.nonCritical().put("name is reserved [table=")
+                .put(tableToken.getTableName())
+                .put(", path=").put(tableDir)
+                .put(", txn=").put(status == TableUtils.TABLE_EXISTS ? "present" : "missing")
+                .put("]; directory exists on disk but has no table name registry entry");
+    }
+
     // caller has to acquire the lock before this method is called and release the lock after the call
     private void createTableOrMatViewInVolumeUnsafe(MemoryMARW mem, @Nullable BlockFileWriter blockFileWriter, Path path, TableStructure struct, TableToken tableToken) {
         if (TableUtils.TABLE_DOES_NOT_EXIST != TableUtils.existsInVolume(configuration.getFilesFacade(), path, tableToken.getDirName())) {
@@ -2366,9 +2411,9 @@ public class CairoEngine implements Closeable, WriterSource {
 
     // caller has to acquire the lock before this method is called and release the lock after the call
     private void createTableOrViewOrMatViewUnsafe(MemoryMARW mem, @Nullable BlockFileWriter blockFileWriter, Path path, TableStructure struct, TableToken tableToken) {
-        if (TableUtils.exists(configuration.getFilesFacade(), path, configuration.getDbRoot(), tableToken.getDirName()) != TableUtils.TABLE_DOES_NOT_EXIST) {
-            throw CairoException.nonCritical().put("name is reserved [table=").put(tableToken.getTableName()).put(']');
-        }
+        final int status = TableUtils.exists(configuration.getFilesFacade(), path, configuration.getDbRoot(), tableToken.getDirName());
+        // exists() appends _txn to the path it is given, rebuild the directory path
+        checkTableDirAvailable(status, path.of(configuration.getDbRoot()).concat(tableToken.getDirName()), tableToken);
 
         // only create the table after it has been registered
         TableUtils.createTableOrViewOrMatView(

--- a/core/src/main/java/io/questdb/cairo/TableNameRegistryStore.java
+++ b/core/src/main/java/io/questdb/cairo/TableNameRegistryStore.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.vm.api.MemoryCMR;
 import io.questdb.cairo.vm.api.MemoryMR;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
+import io.questdb.std.CharSequenceHashSet;
 import io.questdb.std.Chars;
 import io.questdb.std.ConcurrentHashMap;
 import io.questdb.std.Files;
@@ -57,6 +58,8 @@ import static io.questdb.std.Files.DT_FILE;
 public class TableNameRegistryStore extends GrowOnlyTableNameRegistryStore {
     private static final Log LOG = LogFactory.getLog(TableNameRegistryStore.class);
     private final CairoConfiguration configuration;
+    // directory names already reported by reloadFromRootDirectory(), which runs repeatedly
+    private final CharSequenceHashSet loggedOrphanDirs = new CharSequenceHashSet();
     private final StringSink nameSink = new StringSink();
     private final TableFlagResolver tableFlagResolver;
     private final MemoryCMR tableNameRoMemory = Vm.getCMRInstance();
@@ -351,10 +354,25 @@ public class TableNameRegistryStore extends GrowOnlyTableNameRegistryStore {
             do {
                 if (ff.isDirOrSoftLinkDirNoDots(path, plimit, ff.findName(findPtr), ff.findType(findPtr), dirNameSink)) {
                     String dirName = Utf8s.toString(dirNameSink);
-                    if (
-                            !dirNameToTableTokenMap.containsKey(dirName)
-                                    && TableUtils.exists(ff, path, configuration.getDbRoot(), dirNameSink) == TableUtils.TABLE_EXISTS
-                    ) {
+                    boolean isRegistered = dirNameToTableTokenMap.containsKey(dirName);
+                    int status = isRegistered
+                            ? TableUtils.TABLE_DOES_NOT_EXIST
+                            : TableUtils.exists(ff, path, configuration.getDbRoot(), dirNameSink);
+                    if (status == TableUtils.TABLE_RESERVED
+                            && tableFlagResolver.isSystem(TableUtils.getTableNameFromDirName(dirName))
+                            && loggedOrphanDirs.add(dirName)) {
+                        // a directory with no _txn is never adopted here, so it stays invisible to
+                        // the registry while still blocking every create under the same name. that
+                        // is only worth reporting for a system table, which the server creates by
+                        // itself and cannot be told to skip - for anything else the create path
+                        // reports it, with the path and the reason, at the moment someone asks.
+                        // an ordinary table is briefly TABLE_RESERVED while being created or
+                        // dropped, so reporting those would be pure noise. reload() runs
+                        // repeatedly, hence report each directory once
+                        LOG.advisory().$("orphan system table directory ignored, not in table name registry [dir=")
+                                .$(dirNameSink).$(", reason=no _txn file]").$();
+                    }
+                    if (status == TableUtils.TABLE_EXISTS) {
                         int tableId;
                         boolean isWal;
                         String tableName;

--- a/core/src/main/java/io/questdb/cairo/TableNameRegistryStore.java
+++ b/core/src/main/java/io/questdb/cairo/TableNameRegistryStore.java
@@ -312,6 +312,23 @@ public class TableNameRegistryStore extends GrowOnlyTableNameRegistryStore {
         return findLastTablesFileVersion(ff, path, nameSink);
     }
 
+    /**
+     * Whether a directory name belongs to a system table. Deliberately avoids
+     * {@link TableUtils#getTableNameFromDirName(CharSequence)}, which allocates two Strings for a
+     * mangled name: this is called for every directory the root scan skips, and on a read-only
+     * instance the scan repeats for the life of the process.
+     */
+    private boolean isSystemTableDir(CharSequence dirName) {
+        final int suffixIndex = Chars.indexOf(dirName, TableUtils.SYSTEM_TABLE_NAME_SUFFIX);
+        if (suffixIndex == -1) {
+            return tableFlagResolver.isSystem(dirName);
+        }
+        final StringSink tableName = Misc.getThreadLocalSink();
+        tableName.clear();
+        tableName.put(dirName, 0, suffixIndex);
+        return tableFlagResolver.isSystem(tableName);
+    }
+
     private int readTableId(Path path, CharSequence dirName, FilesFacade ff) {
         path.of(configuration.getDbRoot()).concat(dirName);
         int pathLen = path.size();
@@ -359,7 +376,7 @@ public class TableNameRegistryStore extends GrowOnlyTableNameRegistryStore {
                             ? TableUtils.TABLE_DOES_NOT_EXIST
                             : TableUtils.exists(ff, path, configuration.getDbRoot(), dirNameSink);
                     if (status == TableUtils.TABLE_RESERVED
-                            && tableFlagResolver.isSystem(TableUtils.getTableNameFromDirName(dirName))
+                            && isSystemTableDir(dirName)
                             && loggedOrphanDirs.add(dirName)) {
                         // a directory with no _txn is never adopted here, so it stays invisible to
                         // the registry while still blocking every create under the same name. that

--- a/core/src/main/java/io/questdb/cairo/TableUtils.java
+++ b/core/src/main/java/io/questdb/cairo/TableUtils.java
@@ -117,6 +117,9 @@ public final class TableUtils {
     public static final String LEGACY_CHECKPOINT_DIRECTORY = "snapshot";
     public static final int LONGS_PER_TX_ATTACHED_PARTITION = 4;
     public static final int LONGS_PER_TX_ATTACHED_PARTITION_MSB = Numbers.msb(LONGS_PER_TX_ATTACHED_PARTITION);
+    // upper bound on the orphan directories kept aside under one table name,
+    // see CairoEngine.checkTableDirAvailable()
+    public static final int MAX_ORPHAN_DIRS = 32;
     public static final long META_COLUMN_DATA_SIZE = 32;
     public static final String META_FILE_NAME = "_meta";
     public static final short META_FORMAT_MINOR_VERSION_LATEST = 2;
@@ -144,6 +147,9 @@ public final class TableUtils {
     // 24-byte header left empty for possible future use
     // in case we decide to support ALTER MAT VIEW, and modify mat view metadata
     public static final int NULL_LEN = -1;
+    // suffix of a table directory that was moved aside because it had no table name
+    // registry entry, see CairoEngine.checkTableDirAvailable()
+    public static final String ORPHAN_DIR_SUFFIX = ".orphan.";
     public static final String PARQUET_METADATA_FILE_NAME = "_pm";
     public static final String PARQUET_METADATA_STAGING_FILE_NAME = "_pm.staging";
     public static final String PARQUET_PARTITION_NAME = "data.parquet";

--- a/core/src/main/java/io/questdb/metrics/QueryTracingJob.java
+++ b/core/src/main/java/io/questdb/metrics/QueryTracingJob.java
@@ -35,12 +35,13 @@ import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.ConcurrentQueue;
 import io.questdb.mp.SynchronizedJob;
+import io.questdb.std.Misc;
 import io.questdb.std.ValueHolderList;
+import io.questdb.std.datetime.MicrosecondClock;
 import io.questdb.std.datetime.microtime.Micros;
 import io.questdb.std.str.Utf8StringSink;
 
 import java.io.Closeable;
-import java.io.IOException;
 
 public class QueryTracingJob extends SynchronizedJob implements Closeable {
     public static final String COLUMN_EXECUTION_MICROS = "execution_micros";
@@ -50,33 +51,37 @@ public class QueryTracingJob extends SynchronizedJob implements Closeable {
     public static final String TABLE_NAME = "_query_trace";
     // Writer lock reason used when the query-tracing job acquires its own table writer.
     public static final String WRITER_LOCK_REASON = "query_tracing";
+    private static final long BACKOFF_MAX_MICROS = 5 * Micros.MINUTE_MICROS;
+    private static final long BACKOFF_MIN_MICROS = Micros.SECOND_MICROS;
     private static final int BATCH_LIMIT = 1024;
     private static final int INITIAL_CAPACITY = 128;
     private static final Log LOG = LogFactory.getLog(QueryTracingJob.class.getName());
     private final ValueHolderList<QueryTrace> buffer;
+    private final MicrosecondClock clock;
     private final CairoEngine engine;
     private final ConcurrentQueue<QueryTrace> queue;
     private final SqlExecutionContextImpl sqlExecutionContext;
-    private final TableWriter tableWriter;
     private final QueryTrace trace = new QueryTrace();
     private final Utf8StringSink utf8sink = new Utf8StringSink();
+    private long backoffMicros = BACKOFF_MIN_MICROS;
+    private long nextAttemptMicros = Long.MIN_VALUE;
+    private TableWriter tableWriter;
 
-
-    public QueryTracingJob(CairoEngine engine) throws SqlException {
+    public QueryTracingJob(CairoEngine engine) {
         this.queue = engine.getMessageBus().getQueryTraceQueue();
         this.buffer = new ValueHolderList<>(QueryTrace.ITEM_FACTORY, INITIAL_CAPACITY);
         this.engine = engine;
+        this.clock = engine.getConfiguration().getMicrosecondClock();
         this.sqlExecutionContext = new SqlExecutionContextImpl(engine, 1).with(
                 engine.getConfiguration().getFactoryProvider().getSecurityContextFactory().getRootContext(),
                 null,
                 null
         );
-        this.tableWriter = acquireTableWriter();
     }
 
     @Override
-    public void close() throws IOException {
-        tableWriter.close();
+    public void close() {
+        tableWriter = Misc.free(tableWriter);
     }
 
     private TableWriter acquireTableWriter() throws SqlException {
@@ -100,6 +105,11 @@ public class QueryTracingJob extends SynchronizedJob implements Closeable {
         return engine.getWriter(tableToken, WRITER_LOCK_REASON);
     }
 
+    private void armBackoff() {
+        nextAttemptMicros = clock.getTicks() + backoffMicros;
+        backoffMicros = Math.min(backoffMicros * 2, BACKOFF_MAX_MICROS);
+    }
+
     private void putVarchar(TableWriter.Row row, int column, String value) {
         utf8sink.clear();
         utf8sink.put(value);
@@ -115,6 +125,23 @@ public class QueryTracingJob extends SynchronizedJob implements Closeable {
         if (buffer.size() <= 0) {
             return false;
         }
+        if (tableWriter == null) {
+            // the batch drained above is dropped on every path that has no writer: the trace
+            // queue is unbounded, so the job has to consume whether or not it can write
+            if (clock.getTicks() < nextAttemptMicros) {
+                return false;
+            }
+            try {
+                tableWriter = acquireTableWriter();
+                backoffMicros = BACKOFF_MIN_MICROS;
+            } catch (Throwable th) {
+                armBackoff();
+                LOG.error().$("could not open query trace table, dropping traces [table=").$(TABLE_NAME)
+                        .$(", nextAttemptMicros=").$(nextAttemptMicros)
+                        .$(", error=").$(th).I$();
+                return false;
+            }
+        }
         try {
             for (int n = buffer.size(), i = 0; i < n; i++) {
                 buffer.moveQuick(i, trace);
@@ -126,8 +153,12 @@ public class QueryTracingJob extends SynchronizedJob implements Closeable {
             }
             tableWriter.commit();
             trace.clear();
-        } catch (Exception e) {
-            LOG.error().$("Failed to save query trace").$(e).$();
+        } catch (Throwable th) {
+            LOG.error().$("Failed to save query trace").$(th).$();
+            // drop the writer so one that has gone bad is reopened rather than failing
+            // every batch from here on
+            tableWriter = Misc.free(tableWriter);
+            armBackoff();
         }
         return false;
     }

--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -27,6 +27,7 @@ package io.questdb.test;
 import io.questdb.Bootstrap;
 import io.questdb.DefaultBootstrapConfiguration;
 import io.questdb.PropBootstrapConfiguration;
+import io.questdb.PropServerConfiguration;
 import io.questdb.PropertyKey;
 import io.questdb.ServerMain;
 import io.questdb.cairo.CairoConfiguration;
@@ -39,6 +40,7 @@ import io.questdb.cairo.wal.WalWriter;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionContextImpl;
+import io.questdb.metrics.QueryTracingJob;
 import io.questdb.mp.SOCountDownLatch;
 import io.questdb.std.ConcurrentIntHashMap;
 import io.questdb.std.Files;
@@ -293,6 +295,20 @@ public class ServerMainTest extends AbstractBootstrapTest {
                 serverMain.start();
                 int port = serverMain.getPgWireServerPort();
                 Assert.assertTrue(port > 0);
+            }
+        });
+    }
+
+    @Test
+    public void testQueryTraceTableNotCreatedWhenTracingDisabled() throws Exception {
+        assertMemoryLeak(() -> {
+            try (final ServerMain serverMain = ServerMain.create(root, new HashMap<>() {{
+                put(PropertyKey.QUERY_TRACING_ENABLED.getEnvVarName(), "false");
+            }})) {
+                serverMain.start();
+                // the tracing job acquires its writer on the first trace, and no trace is ever
+                // enqueued while tracing is off, so the table is never created
+                Assert.assertNull(serverMain.getEngine().getTableTokenIfExists(QueryTracingJob.TABLE_NAME));
             }
         });
     }
@@ -1229,6 +1245,24 @@ public class ServerMainTest extends AbstractBootstrapTest {
                             actualSink
                     );
                 }
+            }
+        });
+    }
+
+    @Test
+    public void testStartsWithOrphanQueryTraceDir() throws Exception {
+        assertMemoryLeak(() -> {
+            // a table directory with no _txn file reports TABLE_RESERVED, so the registry scan
+            // never adopts it while CREATE still trips over it on disk. the tracing job used to
+            // acquire its writer in its constructor, which made that fatal to startup - forever
+            try (Path path = new Path()) {
+                path.of(root).concat(PropServerConfiguration.DB_DIRECTORY).concat(QueryTracingJob.TABLE_NAME).slash();
+                Assert.assertEquals(0, Files.mkdirs(path, 509));
+            }
+            try (final ServerMain serverMain = ServerMain.create(root, new HashMap<>() {{
+                put(PropertyKey.QUERY_TRACING_ENABLED.getEnvVarName(), "true");
+            }})) {
+                serverMain.start();
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
@@ -41,6 +41,8 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.ops.CreateTableOperationFuture;
 import io.questdb.griffin.engine.ops.Operation;
 import io.questdb.log.Log;
+import io.questdb.metrics.QueryTracingJob;
+import io.questdb.std.Files;
 import io.questdb.std.IntList;
 import io.questdb.std.ObjHashSet;
 import io.questdb.std.ObjList;
@@ -390,6 +392,71 @@ public class CreateTableTest extends AbstractCairoTest {
                 0,
                 "cannot create NULL-type column, please use type cast, e.g. x::type"
         );
+    }
+
+    @Test
+    public void testCreateSystemTableFailsWhenRenameRefused() throws Exception {
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public int rename(LPSZ from, LPSZ to) {
+                if (Utf8s.containsAscii(to, TableUtils.ORPHAN_DIR_SUFFIX)) {
+                    return Files.FILES_RENAME_ERR_OTHER;
+                }
+                return super.rename(from, to);
+            }
+        };
+        assertMemoryLeak(ff, () -> {
+            plantOrphanDir(QueryTracingJob.TABLE_NAME);
+            try {
+                execute(createQueryTraceSql());
+                fail("expected CREATE to fail when the orphan directory cannot be moved aside");
+            } catch (CairoException | SqlException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "name is reserved");
+            }
+            assertTrue(isDirPresent(orphanDirName(QueryTracingJob.TABLE_NAME)));
+        });
+    }
+
+    @Test
+    public void testCreateSystemTableIgnoresSoftLinkedDir() throws Exception {
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public boolean isSoftLink(LPSZ softLink) {
+                return Utf8s.containsAscii(softLink, QueryTracingJob.TABLE_NAME) || super.isSoftLink(softLink);
+            }
+
+            @Override
+            public int rename(LPSZ from, LPSZ to) {
+                if (Utf8s.containsAscii(to, TableUtils.ORPHAN_DIR_SUFFIX)) {
+                    fail("a soft-linked directory must never be renamed");
+                }
+                return super.rename(from, to);
+            }
+        };
+        assertMemoryLeak(ff, () -> {
+            plantOrphanDir(QueryTracingJob.TABLE_NAME);
+            try {
+                execute(createQueryTraceSql());
+                fail("expected CREATE to fail on a soft-linked orphan directory");
+            } catch (CairoException | SqlException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "name is reserved");
+            }
+        });
+    }
+
+    @Test
+    public void testCreateSystemTableQuarantinesOrphanDir() throws Exception {
+        assertMemoryLeak(() -> {
+            final String dirName = orphanDirName(QueryTracingJob.TABLE_NAME);
+            plantOrphanDir(QueryTracingJob.TABLE_NAME);
+            plantMarkerFile(dirName);
+
+            execute(createQueryTraceSql());
+
+            assertNotNull(engine.getTableTokenIfExists(QueryTracingJob.TABLE_NAME));
+            // the husk was moved aside rather than deleted, and its contents survived
+            assertTrue(isMarkerFilePresent(dirName + TableUtils.ORPHAN_DIR_SUFFIX + "0"));
+        });
     }
 
     @Test
@@ -1354,6 +1421,23 @@ public class CreateTableTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCreateUserTableFailsOnOrphanDir() throws Exception {
+        assertMemoryLeak(() -> {
+            plantOrphanDir("x_user_orphan");
+            try {
+                execute("CREATE TABLE x_user_orphan (ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY HOUR BYPASS WAL");
+                fail("expected CREATE to fail on an orphan user table directory");
+            } catch (CairoException | SqlException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "name is reserved");
+                TestUtils.assertContains(e.getFlyweightMessage(), "path=");
+                TestUtils.assertContains(e.getFlyweightMessage(), "txn=missing");
+            }
+            // a user table directory is never moved aside
+            assertTrue(isDirPresent(orphanDirName("x_user_orphan")));
+        });
+    }
+
+    @Test
     public void testCreateWalAndNonWalTablesParallel() throws Throwable {
         assertMemoryLeak(() -> {
             int threadCount = 3;
@@ -1711,6 +1795,47 @@ public class CreateTableTest extends AbstractCairoTest {
                 assertEquals(maxUncommittedRows, reader.getMetadata().getMaxUncommittedRows());
             }
         });
+    }
+
+    private static String createQueryTraceSql() {
+        return "CREATE TABLE '" + QueryTracingJob.TABLE_NAME +
+                "' (ts TIMESTAMP, query_text VARCHAR, execution_micros LONG, principal VARCHAR)" +
+                " TIMESTAMP(ts) PARTITION BY HOUR TTL 1 DAY BYPASS WAL";
+    }
+
+    private static boolean isDirPresent(String dirName) {
+        try (Path path = new Path()) {
+            path.of(engine.getConfiguration().getDbRoot()).concat(dirName);
+            return TestFilesFacadeImpl.INSTANCE.exists(path.$());
+        }
+    }
+
+    private static boolean isMarkerFilePresent(String dirName) {
+        try (Path path = new Path()) {
+            path.of(engine.getConfiguration().getDbRoot()).concat(dirName).concat("marker.txt");
+            return TestFilesFacadeImpl.INSTANCE.exists(path.$());
+        }
+    }
+
+    // the test configuration mangles table directory names, so a non-WAL table does not
+    // simply live in a directory named after it
+    private static String orphanDirName(String tableName) {
+        return TableUtils.getTableDir(engine.getConfiguration().mangleTableDirNames(), tableName, 0, false);
+    }
+
+    private static void plantMarkerFile(String dirName) {
+        try (Path path = new Path()) {
+            path.of(engine.getConfiguration().getDbRoot()).concat(dirName).concat("marker.txt");
+            assertTrue(TestFilesFacadeImpl.INSTANCE.touch(path.$()));
+        }
+    }
+
+    // a table directory with no _txn file: TableUtils.exists() reports TABLE_RESERVED
+    private static void plantOrphanDir(String tableName) {
+        try (Path path = new Path()) {
+            path.of(engine.getConfiguration().getDbRoot()).concat(orphanDirName(tableName)).slash();
+            assertEquals(0, TestFilesFacadeImpl.INSTANCE.mkdirs(path, engine.getConfiguration().getMkDirMode()));
+        }
     }
 
     private void createTableLike(boolean isWalEnabled) throws Exception {

--- a/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/CreateTableTest.java
@@ -460,6 +460,25 @@ public class CreateTableTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testCreateSystemTableQuarantinesSecondOrphanDir() throws Exception {
+        assertMemoryLeak(() -> {
+            final String dirName = orphanDirName(QueryTracingJob.TABLE_NAME);
+            plantOrphanDir(QueryTracingJob.TABLE_NAME);
+            execute(createQueryTraceSql());
+            assertTrue(isDirPresent(dirName + TableUtils.ORPHAN_DIR_SUFFIX + "0"));
+
+            execute("DROP TABLE '" + QueryTracingJob.TABLE_NAME + "'");
+            plantOrphanDir(QueryTracingJob.TABLE_NAME);
+            plantMarkerFile(dirName);
+            execute(createQueryTraceSql());
+
+            // .orphan.0 is taken, so the next free suffix is used and the first husk is left alone
+            assertTrue(isDirPresent(dirName + TableUtils.ORPHAN_DIR_SUFFIX + "0"));
+            assertTrue(isMarkerFilePresent(dirName + TableUtils.ORPHAN_DIR_SUFFIX + "1"));
+        });
+    }
+
+    @Test
     public void testCreateTableArrayWithMismatchedBrackets() throws Exception {
         assertMemoryLeak(() -> {
             assertException("create table x (arr double[);", 26, "syntax error at column type definition, expected array type: 'DOUBLE[]...', but found: 'double[)'");

--- a/core/src/test/java/io/questdb/test/metrics/QueryTracingTest.java
+++ b/core/src/test/java/io/questdb/test/metrics/QueryTracingTest.java
@@ -26,12 +26,21 @@ package io.questdb.test.metrics;
 
 
 import io.questdb.PropertyKey;
+import io.questdb.cairo.TableToken;
 import io.questdb.griffin.SqlException;
+import io.questdb.metrics.QueryTrace;
 import io.questdb.metrics.QueryTracingJob;
 import io.questdb.mp.WorkerPool;
+import io.questdb.std.datetime.microtime.Micros;
+import io.questdb.std.str.Path;
+import io.questdb.std.str.Utf8s;
 import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.std.TestFilesFacadeImpl;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.questdb.metrics.QueryTracingJob.*;
 
@@ -41,6 +50,67 @@ public class QueryTracingTest extends AbstractCairoTest {
     public void setup() throws SqlException {
         node1.getConfigurationOverrides().setProperty(PropertyKey.QUERY_TRACING_ENABLED, true);
         engine.execute("DROP TABLE IF EXISTS '" + TABLE_NAME + "'");
+    }
+
+    @Test
+    public void testJobRecoversAfterAcquireFailure() throws Exception {
+        final AtomicBoolean isMkdirsFailing = new AtomicBoolean(true);
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public int mkdirs(Path path, int mode) {
+                if (isMkdirsFailing.get() && Utf8s.containsAscii(path, TABLE_NAME)) {
+                    return -1;
+                }
+                return super.mkdirs(path, mode);
+            }
+        };
+        assertMemoryLeak(ff, () -> {
+            setCurrentMicros(1_000_000L);
+            try (QueryTracingJob job = new QueryTracingJob(engine)) {
+                enqueueTrace("SELECT 1");
+                job.run();
+                Assert.assertNull(engine.getTableTokenIfExists(TABLE_NAME));
+
+                // clear the injected failure and step past the backoff
+                isMkdirsFailing.set(false);
+                setCurrentMicros(currentMicros + 2 * Micros.SECOND_MICROS);
+                enqueueTrace("SELECT 2");
+                job.run();
+
+                final TableToken token = engine.getTableTokenIfExists(TABLE_NAME);
+                Assert.assertNotNull(token);
+            }
+            assertQuery("SELECT " + COLUMN_QUERY_TEXT + " FROM '" + TABLE_NAME + "'")
+                    .expectSize()
+                    .returns(COLUMN_QUERY_TEXT + "\nSELECT 2\n");
+        });
+    }
+
+    @Test
+    public void testJobSurvivesWriterAcquireFailure() throws Exception {
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public int mkdirs(Path path, int mode) {
+                if (Utf8s.containsAscii(path, TABLE_NAME)) {
+                    return -1;
+                }
+                return super.mkdirs(path, mode);
+            }
+        };
+        assertMemoryLeak(ff, () -> {
+            setCurrentMicros(1_000_000L);
+            // the constructor must not throw even though the table cannot be created
+            try (QueryTracingJob job = new QueryTracingJob(engine)) {
+                for (int i = 0; i < 4; i++) {
+                    enqueueTrace("SELECT " + i);
+                    Assert.assertFalse(job.run());
+                }
+                // the queue must be drained even though nothing could be written,
+                // otherwise it grows without bound
+                Assert.assertFalse(engine.getMessageBus().getQueryTraceQueue().tryDequeue(new QueryTrace()));
+                Assert.assertNull(engine.getTableTokenIfExists(TABLE_NAME));
+            }
+        });
     }
 
     @Test
@@ -76,5 +146,27 @@ public class QueryTracingTest extends AbstractCairoTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testTableNotCreatedWithoutTraces() throws Exception {
+        // the table is created on the first trace, never at construction time. this is what makes
+        // the hot-reloadable query.tracing.enabled flag gate the table: no traces are enqueued
+        // while it is off, so nothing is ever created
+        assertMemoryLeak(() -> {
+            try (QueryTracingJob job = new QueryTracingJob(engine)) {
+                Assert.assertFalse(job.run());
+                Assert.assertNull(engine.getTableTokenIfExists(TABLE_NAME));
+            }
+        });
+    }
+
+    private static void enqueueTrace(String queryText) {
+        final QueryTrace queryTrace = new QueryTrace();
+        queryTrace.timestamp = currentMicros;
+        queryTrace.queryText = queryText;
+        queryTrace.principal = "admin";
+        queryTrace.executionNanos = 1_000L;
+        engine.getMessageBus().getQueryTraceQueue().enqueue(queryTrace);
     }
 }


### PR DESCRIPTION
## What

A read replica seeded by hand-copying files from a primary refused to start, and kept refusing on every restart:

```
could not start: io.questdb.griffin.SqlException: [27] Could not create table, name is reserved [table=_query_trace]
```

`_query_trace` is `BYPASS WAL`, so for it the table directory name is the table name verbatim. The copied `db/_query_trace` directory had no `_txn` file, and that state is a dead end in both directions: `TableNameRegistryStore.reloadFromRootDirectory` adopts a directory only when it is `TABLE_EXISTS`, so the registry never learns about it, while `CREATE TABLE IF NOT EXISTS` consults the registry and then still finds the directory on disk. `QueryTracingJob` acquired its `TableWriter` in its constructor, so that throw was fatal to `ServerMain.start()` - forever, with no config escape, since `query.tracing.enabled` only gates enqueuing.

## Changes

- **`QueryTracingJob` acquires its writer lazily**, with capped exponential backoff, draining and discarding traces while it has none. The trace queue is an unbounded `ConcurrentQueue`, so the job has to consume whether or not it can write. A writer that goes bad at runtime is now dropped and reopened instead of failing every batch from there on.
- **`CairoEngine` moves an orphan system table directory aside** on create, renamed to `<name>.orphan.<n>`. Nothing is deleted, soft links are never touched, and a refused rename or an exhausted suffix range falls through to the error rather than being swallowed. User tables are untouched and still fail, now with the path and the txn state in the message. Note that `TableUtils.exists()` appends `_txn` to the `Path` it is handed, so the create site rebuilds the directory path before using it.
- **`TableNameRegistryStore` reports an orphan system table directory** its scan skipped, once per name, at advisory level. Deliberately limited to system tables: `TABLE_RESERVED` is a routine transient state for an ordinary table being created or dropped, so reporting every skipped directory is log spam rather than a diagnostic.

Behaviour change worth a reviewer's attention: `_query_trace` is no longer created at boot. It is created on the first trace, which only happens while `query.tracing.enabled` is true - so the hot-reloadable flag now genuinely gates the table, and a server with tracing off never creates it.

The in-volume create path is intentionally left alone: its `Path` argument is the volume root, which it cannot reconstruct after `existsInVolume()` has mutated it, and system tables are never created in volumes.

## Test plan

- `ServerMainTest#testStartsWithOrphanQueryTraceDir` - the incident end to end: plant `db/_query_trace` with no `_txn`, start the server. Verified as a real regression test by reverting only the production change, which reproduces `boot-essential component(s) failed [component=worker-pool-manager] ... name is reserved [table=_query_trace]`
- `ServerMainTest#testQueryTraceTableNotCreatedWhenTracingDisabled` - the table is never created with tracing off
- `QueryTracingTest#testJobSurvivesWriterAcquireFailure` - constructor does not throw, the queue is still drained, nothing is created
- `QueryTracingTest#testJobRecoversAfterAcquireFailure` - tracing resumes once the blockage clears, without a restart
- `QueryTracingTest#testTableNotCreatedWithoutTraces` - no trace, no table
- `CreateTableTest#testCreateSystemTableQuarantinesOrphanDir` - directory moved aside, its contents intact
- `CreateTableTest#testCreateUserTableFailsOnOrphanDir` - user tables still fail, with path and reason
- `CreateTableTest#testCreateSystemTableFailsWhenRenameRefused` - a refused rename surfaces as the error
- `CreateTableTest#testCreateSystemTableIgnoresSoftLinkedDir` - a soft link is never renamed

Suites run locally: `CreateTableTest` 87/87, `TableNameRegistryTest` 20/20, `QueryTracingTest` 4/4, `DdlListenerTest` 14/14, plus `TextLoaderTest` and `ParallelCsvFileImporterTest` for the `name is reserved` message consumers, which keep matching on the unchanged `name is reserved [table=` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)