### PR TITLE
fix(sql): report a clear error for misused DISTINCT

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -2169,6 +2169,12 @@ public class ExpressionParser {
                         // literal can be at start of input, after a bracket or part of an operator
                         // all other cases are illegal and will be considered end-of-input
                         if (scopeStack.notEmpty()) {
+                            if (last != null && SqlKeywords.isDistinctKeyword(last.token)) {
+                                // e.g. "(distinct col)": DISTINCT is being used as if it were a
+                                // function or a parenthesised modifier. It is only valid right after
+                                // SELECT, or inside count(distinct ...) / string_agg(distinct ...).
+                                throw SqlException.$(last.position, "'distinct' is not allowed here [use 'select distinct ...', or 'count(distinct ...)' / 'string_agg(distinct ...)']");
+                            }
                             throw SqlException.$(lastPos, "dangling literal");
                         }
                         lexer.unparseLast();

--- a/core/src/test/java/io/questdb/test/griffin/DistinctTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DistinctTest.java
@@ -183,6 +183,17 @@ public class DistinctTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testDistinctInsideParensReportsClearError() throws Exception {
+        // 'distinct' wrapped in grouping parentheses (a common mistake for 'select distinct')
+        // is not valid SQL; the parser now reports an actionable error instead of the opaque
+        // "dangling literal". See #6523.
+        assertMemoryLeak(() -> {
+            execute("create table t (s symbol, ts timestamp)");
+            assertExceptionNoLeakCheck("select (distinct s) from t", 8, "'distinct' is not allowed here");
+        });
+    }
+
+    @Test
     public void testDistinctOrderByPositionLimitPush() throws Exception {
         // The trivial-group-by rewrite pushes the outer LIMIT onto the nested group by, but the
         // gate runs before ORDER BY tokens are normalized, so it resolves positions/qualifiers

--- a/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ExpressionParserTest.java
@@ -786,7 +786,10 @@ public class ExpressionParserTest extends AbstractCairoTest {
 
         assertFail("count(distinct *)", 6, "count(distinct *) is not supported");
         assertFail("count(distinct ", 6, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\"");
-        assertFail("notcount(distinct foo)", 18, "dangling literal");
+        // 'distinct' misused as a grouping-parenthesis modifier or inside a non-aggregate
+        // function gets a targeted, actionable error rather than the opaque "dangling literal"
+        assertFail("(distinct foo)", 1, "'distinct' is not allowed here");
+        assertFail("notcount(distinct foo)", 9, "'distinct' is not allowed here");
         assertFail("count(distinct(foo, bar))", 23, "count distinct aggregation supports a single column only");
         assertFail("count(DISTINCT(foo, bar))", 23, "count distinct aggregation supports a single column only");
         assertFail("count(distinct (foo, bar))", 24, "count distinct aggregation supports a single column only"); // with an extra space
@@ -1570,8 +1573,8 @@ public class ExpressionParserTest extends AbstractCairoTest {
         x("string_agg bar distinct foo", "foo(bar(string_agg), distinct)");
 
         assertFail("string_agg(distinct)", 11, "table and column names that are SQL keywords have to be enclosed in double quotes, such as \"distinct\"");
-        assertFail("notcount(distinct foo, ',')", 18, "dangling literal");
-        assertFail("notcount(distinct foo)", 18, "dangling literal");
+        assertFail("notcount(distinct foo, ',')", 9, "'distinct' is not allowed here");
+        assertFail("notcount(distinct foo)", 9, "'distinct' is not allowed here");
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleArrayGroupByFunctionFactoryTest.java
@@ -784,8 +784,8 @@ public class ArrayAggDoubleArrayGroupByFunctionFactoryTest extends AbstractCairo
             execute("CREATE TABLE tab (arr DOUBLE[])");
             assertExceptionNoLeakCheck(
                     "SELECT array_agg(DISTINCT arr) FROM tab",
-                    26,
-                    "dangling literal"
+                    17,
+                    "'distinct' is not allowed here"
             );
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/groupby/ArrayAggDoubleGroupByFunctionFactoryTest.java
@@ -630,8 +630,8 @@ public class ArrayAggDoubleGroupByFunctionFactoryTest extends AbstractCairoTest 
             execute("CREATE TABLE tab (val DOUBLE)");
             assertExceptionNoLeakCheck(
                     "SELECT array_agg(DISTINCT val) FROM tab",
-                    26,
-                    "dangling literal"
+                    17,
+                    "'distinct' is not allowed here"
             );
         });
     }


### PR DESCRIPTION
Fixes #6523

## Problem

`select (distinct symbol) from t` — DISTINCT written as if it were a function or a
parenthesised modifier — failed with the opaque, non-actionable error
`dangling literal`, pointing at the column rather than at the real problem.

`ExpressionParser` only rewrites DISTINCT for `count(...)` and `string_agg(...)`.
In any other parenthesised context the keyword leaks through as a literal, and the
following operand trips the generic "dangling literal" guard.

## Fix

At that guard, when the leaked literal is the `distinct` keyword, throw a targeted
error that points at DISTINCT and names the valid forms:

```
'distinct' is not allowed here [use 'select distinct ...', or 'count(distinct ...)' / 'string_agg(distinct ...)']
```

The check sits on the existing error path only, so no previously-valid query is
affected. Because the same guard is reached for any non-distinct-capable aggregate,
this also upgrades the message — and moves the reported position onto the DISTINCT
token — for cases such as `array_agg(distinct x)`, `sum(distinct x)`, etc., which
previously all produced "dangling literal". Tests that asserted the old message and
position for `array_agg(DISTINCT ...)` are updated accordingly; that position shift
is a behavioural change to note, though it points at the actual offending keyword.

## Test plan

- ExpressionParserTest: added a `(distinct foo)` case; updated the `notcount(distinct foo)`
  cases in both the count and string_agg rewrite suites to the new message/position.
- DistinctTest: added end-to-end `testDistinctInsideParensReportsClearError`
  (`select (distinct s) from t`).
- ArrayAggDouble/ArrayAggDoubleArray GroupByFunctionFactoryTest: updated the
  `array_agg(DISTINCT ...)` rejection message and position.
- Green locally: ExpressionParserTest (300), DistinctTest (22), both ArrayAgg suites,
  SqlParserTest.
