### PR TITLE
fix(sql): fix split_part() dropping the string for an empty delimiter

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/SplitPartFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/SplitPartFunctionFactory.java
@@ -74,6 +74,17 @@ public class SplitPartFunctionFactory implements FunctionFactory {
             return;
         }
 
+        if (delimiter.length() == 0) {
+            // an empty delimiter cannot split the string, so the whole string is treated as a
+            // single field (matching PostgreSQL and Snowflake). Only field 1 (counting from the
+            // start) or -1 (counting from the end) exists; any other position is out of range.
+            // Previously this dropped the input and returned an empty string.
+            if (index == 1 || index == -1) {
+                sink.put(str);
+            }
+            return;
+        }
+
         int start;
         int end;
         if (index > 0) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/SplitPartVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/SplitPartVarcharFunctionFactory.java
@@ -83,6 +83,17 @@ public class SplitPartVarcharFunctionFactory implements FunctionFactory {
             return;
         }
 
+        if (delimiter.size() == 0) {
+            // an empty delimiter cannot split the string, so the whole string is treated as a
+            // single field (matching PostgreSQL and Snowflake). Only field 1 (counting from the
+            // start) or -1 (counting from the end) exists; any other position is out of range.
+            // Previously this dropped the input and returned an empty string.
+            if (index == 1 || index == -1) {
+                sink.put(utf8Str);
+            }
+            return;
+        }
+
         int size = utf8Str.size();
         int len = Utf8s.length(utf8Str);
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/SplitPartFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/SplitPartFunctionFactoryTest.java
@@ -48,6 +48,26 @@ public class SplitPartFunctionFactoryTest extends AbstractFunctionFactoryTest {
     }
 
     @Test
+    public void testEmptyDelimiterReturnsWholeString() throws Exception {
+        // An empty delimiter cannot split the string, so the whole string is a single field
+        // (matching PostgreSQL and Snowflake) rather than being dropped. Field 1 (from the
+        // start) and -1 (from the end) both return the whole string; any other position is
+        // out of range and returns an empty string.
+        assertQuery("select split_part('abc,def', '', 1)")
+                .expectSize()
+                .returns("split_part\nabc,def\n");
+        assertQuery("select split_part('abc,def', '', -1)")
+                .expectSize()
+                .returns("split_part\nabc,def\n");
+        assertQuery("select split_part('abc,def', '', 2)")
+                .expectSize()
+                .returns("split_part\n\n");
+        assertQuery("select split_part('abc,def', '', -2)")
+                .expectSize()
+                .returns("split_part\n\n");
+    }
+
+    @Test
     public void testNaNIndex() throws Exception {
         assertMemoryLeak(() -> {
             callCustomised(true, true, "abc~@~def~@~ghi", "~@~", Numbers.INT_NULL).andAssert(null);

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/SplitPartVarcharFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/SplitPartVarcharFunctionFactoryTest.java
@@ -49,6 +49,26 @@ public class SplitPartVarcharFunctionFactoryTest extends AbstractFunctionFactory
     }
 
     @Test
+    public void testEmptyDelimiterReturnsWholeString() throws Exception {
+        // An empty delimiter cannot split the string, so the whole string is a single field
+        // (matching PostgreSQL and Snowflake) rather than being dropped. Field 1 (from the
+        // start) and -1 (from the end) both return the whole string; any other position is
+        // out of range and returns an empty string.
+        assertQuery("select split_part('abc,def'::varchar, ''::varchar, 1)")
+                .expectSize()
+                .returns("split_part\nabc,def\n");
+        assertQuery("select split_part('abc,def'::varchar, ''::varchar, -1)")
+                .expectSize()
+                .returns("split_part\nabc,def\n");
+        assertQuery("select split_part('abc,def'::varchar, ''::varchar, 2)")
+                .expectSize()
+                .returns("split_part\n\n");
+        assertQuery("select split_part('abc,def'::varchar, ''::varchar, -2)")
+                .expectSize()
+                .returns("split_part\n\n");
+    }
+
+    @Test
     public void testNaNIndex() throws Exception {
         assertMemoryLeak(() -> {
             callCustomised(true, true, utf8("abc~@~def~@~ghi"), utf8("~@~"), Numbers.INT_NULL).andAssert(null);


### PR DESCRIPTION
## Problem

`split_part(string, delimiter, n)` with an empty delimiter silently dropped the
input and returned an empty string:

```sql
select split_part('abc,def', '', 1);
-- before: (empty)
-- after:  abc,def
```

An empty delimiter cannot split the string, so the whole string is a single
field. PostgreSQL and Snowflake both return the whole string for field 1 in
this case; QuestDB returned an empty string, losing the data.

## Fix

`splitToSink()` in the STRING and VARCHAR overloads now special-cases an empty
delimiter: field 1 (counting from the start) and -1 (from the end) return the
whole string; any other position is out of range and returns an empty string.
The CHAR-delimiter overload is unaffected — a char delimiter cannot be empty.

Behaviour for a non-empty delimiter, a NULL delimiter, and an out-of-range
position is unchanged (the pre-existing empty-delimiter test at index 2 still
returns an empty string).

## Test plan

- Added `testEmptyDelimiterReturnsWholeString` to both
  `SplitPartFunctionFactoryTest` and `SplitPartVarcharFunctionFactoryTest`,
  covering index 1, -1, 2, -2.
- All three split_part suites green locally: STRING (9), VARCHAR (10), CHAR (8).
