### PR TITLE
feat(sql): add initcap() string function

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/InitCapFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/InitCapFunctionFactory.java
@@ -1,0 +1,120 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.StrFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.std.str.StringSink;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Postgres-compatible initcap(): converts the first letter of each word to upper
+ * case and the rest to lower case. Words are sequences of alphanumeric characters
+ * separated by non-alphanumeric characters.
+ */
+public class InitCapFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "initcap(S)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new InitCapFunc(args.get(0));
+    }
+
+    private static class InitCapFunc extends StrFunction implements UnaryFunction {
+        private final Function arg;
+        private final StringSink sinkA = new StringSink();
+        private final StringSink sinkB = new StringSink();
+
+        public InitCapFunc(final Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public String getName() {
+            return "initcap";
+        }
+
+        @Override
+        public CharSequence getStrA(final Record rec) {
+            return toInitCap(arg.getStrA(rec), sinkA);
+        }
+
+        @Override
+        public CharSequence getStrB(final Record rec) {
+            return toInitCap(arg.getStrA(rec), sinkB);
+        }
+
+        @Override
+        public int getStrLen(final Record rec) {
+            return arg.getStrLen(rec);
+        }
+
+        @Override
+        public boolean isThreadSafe() {
+            return false;
+        }
+
+        @Nullable
+        private static CharSequence toInitCap(final CharSequence str, final StringSink sink) {
+            if (str == null) {
+                return null;
+            }
+            sink.clear();
+            boolean prevAlphanumeric = false;
+            for (int i = 0, n = str.length(); i < n; i++) {
+                final char c = str.charAt(i);
+                final boolean alphanumeric = Character.isLetterOrDigit(c);
+                if (alphanumeric) {
+                    sink.put(prevAlphanumeric ? Character.toLowerCase(c) : Character.toUpperCase(c));
+                } else {
+                    sink.put(c);
+                }
+                prevAlphanumeric = alphanumeric;
+            }
+            return sink;
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/InitCapVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/InitCapVarcharFunctionFactory.java
@@ -1,0 +1,37 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+/**
+ * VARCHAR overload of {@link InitCapFunctionFactory}. Mirrors the case-transform
+ * functions (upper/lower/to_uppercase) which reuse the STRING implementation for
+ * VARCHAR input.
+ */
+public class InitCapVarcharFunctionFactory extends InitCapFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "initcap(Ø)";
+    }
+}

--- a/core/src/main/resources/function_list.txt
+++ b/core/src/main/resources/function_list.txt
@@ -828,6 +828,8 @@ io.questdb.griffin.engine.functions.str.LowerFunctionFactory
 io.questdb.griffin.engine.functions.str.LowerVarcharFunctionFactory
 io.questdb.griffin.engine.functions.str.UpperFunctionFactory
 io.questdb.griffin.engine.functions.str.UpperVarcharFunctionFactory
+io.questdb.griffin.engine.functions.str.InitCapFunctionFactory
+io.questdb.griffin.engine.functions.str.InitCapVarcharFunctionFactory
 
 # hash functions
 io.questdb.griffin.engine.functions.str.MD5BinFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/InitCapFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/InitCapFunctionFactoryTest.java
@@ -1,0 +1,64 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.str;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class InitCapFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testConstants() throws Exception {
+        // first letter of each word to upper, the rest to lower; words are alphanumeric runs
+        assertQuery("select initcap('hello world')").expectSize().returns("initcap\nHello World\n");
+        assertQuery("select initcap('hELLO wORLD')").expectSize().returns("initcap\nHello World\n");
+        // non-alphanumeric characters (apostrophe, hyphen, underscore) act as word separators
+        assertQuery("select initcap('o''reilly-style_name')").expectSize().returns("initcap\nO'Reilly-Style_Name\n");
+        // a leading digit is the first character of the word, so the following letters are lowercased
+        assertQuery("select initcap('123ABC def')").expectSize().returns("initcap\n123abc Def\n");
+        // Unicode letters are handled
+        assertQuery("select initcap('CAFÉ crème')").expectSize().returns("initcap\nCafé Crème\n");
+        // empty string stays empty
+        assertQuery("select initcap('')").expectSize().returns("initcap\n\n");
+        // VARCHAR overload
+        assertQuery("select initcap('hELLO wORLD'::varchar)").expectSize().returns("initcap\nHello World\n");
+    }
+
+    @Test
+    public void testNullAndColumn() throws Exception {
+        // exercises the per-row path over a column, including NULL and repeated separators
+        assertQuery("select s, initcap(s) from t")
+                .ddl("create table t (s string)",
+                        "insert into t values ('hELLO wORLD'), ('multi   space'), (null), ('')")
+                .expectSize()
+                .returns(
+                        "s\tinitcap\n" +
+                                "hELLO wORLD\tHello World\n" +
+                                "multi   space\tMulti   Space\n" +
+                                "\t\n" +
+                                "\t\n"
+                );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/InitCapFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/InitCapFunctionFactoryTest.java
@@ -42,8 +42,6 @@ public class InitCapFunctionFactoryTest extends AbstractCairoTest {
         assertQuery("select initcap('CAFÉ crème')").expectSize().returns("initcap\nCafé Crème\n");
         // empty string stays empty
         assertQuery("select initcap('')").expectSize().returns("initcap\n\n");
-        // VARCHAR overload
-        assertQuery("select initcap('hELLO wORLD'::varchar)").expectSize().returns("initcap\nHello World\n");
     }
 
     @Test
@@ -60,5 +58,31 @@ public class InitCapFunctionFactoryTest extends AbstractCairoTest {
                                 "\t\n" +
                                 "\t\n"
                 );
+    }
+
+    @Test
+    public void testVarcharColumn() throws Exception {
+        // per-row VARCHAR path decodes UTF8 to UTF16 before title-casing
+        assertQuery("select v, initcap(v) from t")
+                .ddl("create table t (v varchar)",
+                        "insert into t values ('hELLO wORLD'), ('CAFÉ crème'), (null), ('')")
+                .expectSize()
+                .returns(
+                        "v\tinitcap\n" +
+                                "hELLO wORLD\tHello World\n" +
+                                "CAFÉ crème\tCafé Crème\n" +
+                                "\t\n" +
+                                "\t\n"
+                );
+    }
+
+    @Test
+    public void testVarcharConstants() throws Exception {
+        assertQuery("select initcap('hELLO wORLD'::varchar)").expectSize().returns("initcap\nHello World\n");
+        // non-ASCII (BMP) input
+        assertQuery("select initcap('CAFÉ crème'::varchar)").expectSize().returns("initcap\nCafé Crème\n");
+        // empty VARCHAR stays empty, NULL VARCHAR returns NULL
+        assertQuery("select initcap(''::varchar)").expectSize().returns("initcap\n\n");
+        assertQuery("select initcap(null::varchar)").expectSize().returns("initcap\n\n");
     }
 }


### PR DESCRIPTION
## What

Adds a PostgreSQL-compatible `initcap()` string function.

`initcap(string)` converts the first letter of each word to upper case and the
rest to lower case. Words are sequences of alphanumeric characters separated by
non-alphanumeric characters.

```sql
select initcap('hELLO wORLD');   -- Hello World
select initcap('o''reilly');     -- O'Reilly
select initcap('cafe creme');    -- Cafe Creme
```

QuestDB already ships PG-compatible `upper`/`lower`/`to_uppercase`/`to_lowercase`;
this fills a common remaining gap.

## Implementation

- `InitCapFunctionFactory` (`initcap(S)`) implements the transform over a
  `StrFunction` with a reusable `StringSink`, matching `to_uppercase`.
- `InitCapVarcharFunctionFactory` (`initcap(Ø)`) is a thin VARCHAR overload that
  reuses the STRING implementation, mirroring `upper`/`lower` (VARCHAR input
  yields a STRING result). NULL input returns NULL.
- Registered in `function_list.txt`.

## Test plan

- `InitCapFunctionFactoryTest`: constants (case folding, apostrophe/hyphen/
  underscore separators, leading-digit words, Unicode letters, empty string,
  VARCHAR overload) and a column path covering NULL and repeated separators.
- Class green locally.
