### PR TITLE
test(core): add regression tests for ServerMain

### DIFF
--- a/core/src/test/java/io/questdb/test/ServerMainTest.java
+++ b/core/src/test/java/io/questdb/test/ServerMainTest.java
@@ -36,6 +36,7 @@ import io.questdb.cairo.pool.RecentWriteTracker;
 import io.questdb.cairo.security.AllowAllSecurityContext;
 import io.questdb.cairo.sql.TableMetadata;
 import io.questdb.cairo.wal.WalWriter;
+import io.questdb.cutlass.http.ActiveConnectionTracker;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.SqlExecutionContextImpl;
@@ -275,6 +276,69 @@ public class ServerMainTest extends AbstractBootstrapTest {
 
                 Assert.assertEquals(0, errorCount.get());
             }
+        });
+    }
+
+    @Test
+    public void testCreateMethods() throws Exception {
+        assertMemoryLeak(() -> {
+            try (final ServerMain serverMain = ServerMain.create(root)) {
+                Assert.assertEquals(
+                        new File(root, "db").getAbsolutePath(),
+                        serverMain.getConfiguration().getCairoConfiguration().getDbRoot()
+                );
+            }
+
+            final Map<String, String> env = new HashMap<>();
+            env.put(PropertyKey.HTTP_ENABLED.getEnvVarName(), "false");
+            try (final ServerMain serverMain = ServerMain.create(root, env)) {
+                Assert.assertFalse(serverMain.getConfiguration().getHttpServerConfiguration().isEnabled());
+            }
+
+            env.put(PropertyKey.HTTP_MIN_ENABLED.getEnvVarName(), "false");
+            env.put(PropertyKey.LINE_TCP_ENABLED.getEnvVarName(), "false");
+            env.put(PropertyKey.PG_ENABLED.getEnvVarName(), "false");
+            env.put(PropertyKey.WAL_APPLY_WORKER_COUNT.getEnvVarName(), "1");
+            try (final ServerMain serverMain = ServerMain.createWithoutWalApplyJob(root, env)) {
+                serverMain.start();
+                Assert.assertTrue(serverMain.hasStarted());
+                Assert.assertNotNull(serverMain.getWorkerPoolManager());
+            }
+        });
+    }
+
+    @Test
+    public void testHttpServerAccessorsAndLifecycle() throws Exception {
+        assertMemoryLeak(() -> {
+            Assert.assertEquals(
+                    "QDB_CAIRO_SQL_COPY_ROOT",
+                    ServerMain.propertyPathToEnvVarName("cairo.sql.copy.root")
+            );
+
+            final ServerMain serverMain = new ServerMain(getServerMainArgs());
+            try {
+                Assert.assertEquals(
+                        0,
+                        serverMain.getActiveConnectionCount(ActiveConnectionTracker.PROCESSOR_JSON)
+                );
+                try {
+                    serverMain.getHttpServerPort();
+                    Assert.fail();
+                } catch (CairoException ex) {
+                    assertContains(ex.getFlyweightMessage(), "http server is not running");
+                }
+
+                serverMain.start();
+                Assert.assertEquals(HTTP_PORT, serverMain.getHttpServerPort());
+                Assert.assertEquals(
+                        0,
+                        serverMain.getActiveConnectionCount(ActiveConnectionTracker.PROCESSOR_JSON)
+                );
+                Assert.assertTrue(serverMain.hasStarted());
+            } finally {
+                serverMain.close();
+            }
+            Assert.assertTrue(serverMain.hasBeenClosed());
         });
     }
 


### PR DESCRIPTION
Hey 👋

I added two regression tests for `ServerMain`. One covers its static create methods, while the other checks environment-variable conversion, HTTP accessors, and lifecycle behavior before startup, while running, and after shutdown.

Impact on coverage:

* Covers the [`ServerMain` static create methods](https://github.com/questdb/questdb/blob/c4cfd3ba32624628c44a9ad476f579d50e3d015a/core/src/main/java/io/questdb/ServerMain.java#L115-L146), [environment-variable conversion](https://github.com/questdb/questdb/blob/c4cfd3ba32624628c44a9ad476f579d50e3d015a/core/src/main/java/io/questdb/ServerMain.java#L169-L170), [active connection count](https://github.com/questdb/questdb/blob/c4cfd3ba32624628c44a9ad476f579d50e3d015a/core/src/main/java/io/questdb/ServerMain.java#L244-L255), [HTTP server port](https://github.com/questdb/questdb/blob/c4cfd3ba32624628c44a9ad476f579d50e3d015a/core/src/main/java/io/questdb/ServerMain.java#L269-L279), and [lifecycle state](https://github.com/questdb/questdb/blob/c4cfd3ba32624628c44a9ad476f579d50e3d015a/core/src/main/java/io/questdb/ServerMain.java#L331-L336).
* This improves line coverage for `ServerMain` by about 4%.

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,
Amir