### PR TITLE
feat(sql): add translate() string function

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/TranslateFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/TranslateFunctionFactory.java
@@ -1,0 +1,146 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.PlanSink;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.StrFunction;
+import io.questdb.griffin.engine.functions.TernaryFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.std.str.StringSink;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Postgres-compatible translate(): any character in the input string that matches a
+ * character in the {@code from} set is replaced by the corresponding character in the
+ * {@code to} set (matched by position). If {@code from} is longer than {@code to}, the
+ * extra {@code from} characters have no replacement and are removed from the result.
+ * Returns NULL if any argument is NULL.
+ */
+public class TranslateFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "translate(SSS)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new TranslateFunc(args.getQuick(0), args.getQuick(1), args.getQuick(2));
+    }
+
+    private static class TranslateFunc extends StrFunction implements TernaryFunction {
+        private final Function fromFunc;
+        private final StringSink sinkA = new StringSink();
+        private final StringSink sinkB = new StringSink();
+        private final Function toFunc;
+        private final Function valueFunc;
+
+        public TranslateFunc(Function valueFunc, Function fromFunc, Function toFunc) {
+            this.valueFunc = valueFunc;
+            this.fromFunc = fromFunc;
+            this.toFunc = toFunc;
+        }
+
+        @Override
+        public Function getCenter() {
+            return fromFunc;
+        }
+
+        @Override
+        public Function getLeft() {
+            return valueFunc;
+        }
+
+        @Override
+        public String getName() {
+            return "translate";
+        }
+
+        @Override
+        public Function getRight() {
+            return toFunc;
+        }
+
+        @Override
+        public CharSequence getStrA(Record rec) {
+            return translate(valueFunc.getStrA(rec), fromFunc.getStrA(rec), toFunc.getStrA(rec), sinkA);
+        }
+
+        @Override
+        public CharSequence getStrB(Record rec) {
+            return translate(valueFunc.getStrB(rec), fromFunc.getStrB(rec), toFunc.getStrB(rec), sinkB);
+        }
+
+        @Override
+        public boolean isThreadSafe() {
+            return false;
+        }
+
+        @Override
+        public void toPlan(PlanSink sink) {
+            sink.val("translate(").val(valueFunc).val(',').val(fromFunc).val(',').val(toFunc).val(')');
+        }
+
+        private static int indexOf(CharSequence seq, char c) {
+            for (int i = 0, n = seq.length(); i < n; i++) {
+                if (seq.charAt(i) == c) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        @Nullable
+        private static CharSequence translate(CharSequence value, CharSequence from, CharSequence to, StringSink sink) {
+            if (value == null || from == null || to == null) {
+                return null;
+            }
+            sink.clear();
+            final int toLen = to.length();
+            for (int i = 0, n = value.length(); i < n; i++) {
+                final char c = value.charAt(i);
+                final int idx = indexOf(from, c);
+                if (idx < 0) {
+                    sink.put(c);
+                } else if (idx < toLen) {
+                    sink.put(to.charAt(idx));
+                }
+                // idx >= toLen: character has no replacement, so it is removed
+            }
+            return sink;
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/TranslateVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/TranslateVarcharFunctionFactory.java
@@ -1,0 +1,37 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+/**
+ * VARCHAR overload of {@link TranslateFunctionFactory}. Mirrors the case-transform
+ * functions (upper/lower/to_uppercase) which reuse the STRING implementation for
+ * VARCHAR input.
+ */
+public class TranslateVarcharFunctionFactory extends TranslateFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "translate(ØØØ)";
+    }
+}

--- a/core/src/main/resources/function_list.txt
+++ b/core/src/main/resources/function_list.txt
@@ -750,6 +750,8 @@ io.questdb.griffin.engine.functions.conditional.CoalesceFunctionFactory
 # replace()
 io.questdb.griffin.engine.functions.str.ReplaceStrFunctionFactory
 io.questdb.griffin.engine.functions.str.ReplaceVarcharFunctionFactory
+io.questdb.griffin.engine.functions.str.TranslateFunctionFactory
+io.questdb.griffin.engine.functions.str.TranslateVarcharFunctionFactory
 
 # json_extract()
 io.questdb.griffin.engine.functions.json.JsonExtractVarcharFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/TranslateFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/TranslateFunctionFactoryTest.java
@@ -1,0 +1,65 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.str;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class TranslateFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testConstants() throws Exception {
+        // 'from' longer than 'to': the extra 'from' chars (here '3') are removed
+        assertQuery("select translate('12345', '143', 'ax')").expectSize().returns("translate\na2x5\n");
+        // positional mapping e->i, l->p
+        assertQuery("select translate('hello', 'el', 'ip')").expectSize().returns("translate\nhippo\n");
+        // empty 'to' deletes every matched character
+        assertQuery("select translate('abcdef', 'abc', '')").expectSize().returns("translate\ndef\n");
+        // empty 'from' leaves the input unchanged
+        assertQuery("select translate('hello', '', 'xyz')").expectSize().returns("translate\nhello\n");
+        // Unicode characters are handled
+        assertQuery("select translate('café', 'é', 'e')").expectSize().returns("translate\ncafe\n");
+        // duplicate char in 'from' uses the first mapping
+        assertQuery("select translate('aaa', 'aa', 'xy')").expectSize().returns("translate\nxxx\n");
+        // VARCHAR overload
+        assertQuery("select translate('12345'::varchar, '143'::varchar, 'ax'::varchar)").expectSize().returns("translate\na2x5\n");
+    }
+
+    @Test
+    public void testNullAndColumn() throws Exception {
+        // per-row path over a column, including NULL and empty input
+        assertQuery("select s, translate(s, 'lo', 'LO') from t")
+                .ddl("create table t (s string)",
+                        "insert into t values ('hello'), ('world'), (null), ('')")
+                .expectSize()
+                .returns(
+                        "s\ttranslate\n" +
+                                "hello\theLLO\n" +
+                                "world\twOrLd\n" +
+                                "\t\n" +
+                                "\t\n"
+                );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/TranslateFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/TranslateFunctionFactoryTest.java
@@ -43,8 +43,6 @@ public class TranslateFunctionFactoryTest extends AbstractCairoTest {
         assertQuery("select translate('café', 'é', 'e')").expectSize().returns("translate\ncafe\n");
         // duplicate char in 'from' uses the first mapping
         assertQuery("select translate('aaa', 'aa', 'xy')").expectSize().returns("translate\nxxx\n");
-        // VARCHAR overload
-        assertQuery("select translate('12345'::varchar, '143'::varchar, 'ax'::varchar)").expectSize().returns("translate\na2x5\n");
     }
 
     @Test
@@ -61,5 +59,31 @@ public class TranslateFunctionFactoryTest extends AbstractCairoTest {
                                 "\t\n" +
                                 "\t\n"
                 );
+    }
+
+    @Test
+    public void testVarcharColumn() throws Exception {
+        // all-VARCHAR args resolve translate(OOO); the column path decodes UTF8 to UTF16 per row
+        assertQuery("select v, translate(v, 'lé'::varchar, 'LE'::varchar) from t")
+                .ddl("create table t (v varchar)",
+                        "insert into t values ('hello'), ('café'), (null), ('')")
+                .expectSize()
+                .returns(
+                        "v\ttranslate\n" +
+                                "hello\theLLo\n" +
+                                "café\tcafE\n" +
+                                "\t\n" +
+                                "\t\n"
+                );
+    }
+
+    @Test
+    public void testVarcharConstants() throws Exception {
+        assertQuery("select translate('12345'::varchar, '143'::varchar, 'ax'::varchar)").expectSize().returns("translate\na2x5\n");
+        // non-ASCII input
+        assertQuery("select translate('café'::varchar, 'é'::varchar, 'e'::varchar)").expectSize().returns("translate\ncafe\n");
+        // empty value stays empty, any NULL argument returns NULL
+        assertQuery("select translate(''::varchar, 'a'::varchar, 'b'::varchar)").expectSize().returns("translate\n\n");
+        assertQuery("select translate(null::varchar, 'a'::varchar, 'b'::varchar)").expectSize().returns("translate\n\n");
     }
 }


### PR DESCRIPTION
## What

Adds a PostgreSQL-compatible `translate()` string function.

`translate(string, from, to)` replaces each character in `string` that appears in
the `from` set with the character at the same position in the `to` set. When
`from` is longer than `to`, the extra `from` characters have no replacement and
are removed.

```sql
select translate('12345', '143', 'ax');   -- a2x5   ('3' has no mapping, removed)
select translate('hello', 'el', 'ip');    -- hippo
select translate('a.b.c', '.', '');       -- abc    (delete matched chars)
```

Complements the existing PG-compatible string functions (`replace`,
`upper`/`lower`, etc.).

## Implementation

- `TranslateFunctionFactory` (`translate(SSS)`) implements the mapping over a
  `StrFunction` with reusable `StringSink`s, modeled on `ReplaceStrFunctionFactory`.
  Output length never exceeds the input, so no buffer-growth limit is needed.
- `TranslateVarcharFunctionFactory` (`translate(ØØØ)`) is a thin VARCHAR overload
  reusing the STRING implementation, mirroring `upper`/`lower` (VARCHAR input
  yields a STRING result). A NULL in any argument yields NULL.
- Registered in `function_list.txt`.

## Test plan

- `TranslateFunctionFactoryTest`: constants (positional mapping, `from` longer
  than `to` removals, empty `to` deletion, empty `from` identity, duplicate
  `from` char, Unicode, VARCHAR overload) and a column path covering NULL and
  empty input.
- Class green locally.
