### PR TITLE
feat(sql): add reverse() string function

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/ReverseStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/ReverseStrFunctionFactory.java
@@ -1,0 +1,111 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.StrFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.ObjList;
+import io.questdb.std.str.StringSink;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Postgres-compatible reverse(): returns the input string with its characters in
+ * reverse order. Returns NULL for NULL input.
+ */
+public class ReverseStrFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "reverse(S)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new ReverseFunc(args.get(0));
+    }
+
+    private static class ReverseFunc extends StrFunction implements UnaryFunction {
+        private final Function arg;
+        private final StringSink sinkA = new StringSink();
+        private final StringSink sinkB = new StringSink();
+
+        public ReverseFunc(final Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public String getName() {
+            return "reverse";
+        }
+
+        @Override
+        public CharSequence getStrA(final Record rec) {
+            return reverse(arg.getStrA(rec), sinkA);
+        }
+
+        @Override
+        public CharSequence getStrB(final Record rec) {
+            return reverse(arg.getStrB(rec), sinkB);
+        }
+
+        @Override
+        public int getStrLen(final Record rec) {
+            return arg.getStrLen(rec);
+        }
+
+        @Override
+        public boolean isThreadSafe() {
+            return false;
+        }
+
+        @Nullable
+        private static CharSequence reverse(final CharSequence str, final StringSink sink) {
+            if (str == null) {
+                return null;
+            }
+            sink.clear();
+            for (int i = str.length() - 1; i >= 0; i--) {
+                sink.put(str.charAt(i));
+            }
+            return sink;
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/ReverseVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/ReverseVarcharFunctionFactory.java
@@ -1,0 +1,37 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+/**
+ * VARCHAR overload of {@link ReverseStrFunctionFactory}. Mirrors the case-transform
+ * functions (upper/lower/to_uppercase) which reuse the STRING implementation for
+ * VARCHAR input.
+ */
+public class ReverseVarcharFunctionFactory extends ReverseStrFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "reverse(Ø)";
+    }
+}

--- a/core/src/main/resources/function_list.txt
+++ b/core/src/main/resources/function_list.txt
@@ -828,6 +828,8 @@ io.questdb.griffin.engine.functions.str.LowerFunctionFactory
 io.questdb.griffin.engine.functions.str.LowerVarcharFunctionFactory
 io.questdb.griffin.engine.functions.str.UpperFunctionFactory
 io.questdb.griffin.engine.functions.str.UpperVarcharFunctionFactory
+io.questdb.griffin.engine.functions.str.ReverseStrFunctionFactory
+io.questdb.griffin.engine.functions.str.ReverseVarcharFunctionFactory
 
 # hash functions
 io.questdb.griffin.engine.functions.str.MD5BinFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/ReverseStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/ReverseStrFunctionFactoryTest.java
@@ -1,0 +1,59 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.str;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class ReverseStrFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testConstants() throws Exception {
+        assertQuery("select reverse('abc')").expectSize().returns("reverse\ncba\n");
+        assertQuery("select reverse('Hello, World!')").expectSize().returns("reverse\n!dlroW ,olleH\n");
+        assertQuery("select reverse('a')").expectSize().returns("reverse\na\n");
+        // empty string stays empty
+        assertQuery("select reverse('')").expectSize().returns("reverse\n\n");
+        // Unicode (BMP) characters
+        assertQuery("select reverse('café')").expectSize().returns("reverse\néfac\n");
+        // VARCHAR overload
+        assertQuery("select reverse('abc'::varchar)").expectSize().returns("reverse\ncba\n");
+    }
+
+    @Test
+    public void testNullAndColumn() throws Exception {
+        assertQuery("select s, reverse(s) from t")
+                .ddl("create table t (s string)",
+                        "insert into t values ('abc'), ('Hello'), (null), ('')")
+                .expectSize()
+                .returns(
+                        "s\treverse\n" +
+                                "abc\tcba\n" +
+                                "Hello\tolleH\n" +
+                                "\t\n" +
+                                "\t\n"
+                );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/ReverseStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/ReverseStrFunctionFactoryTest.java
@@ -38,8 +38,6 @@ public class ReverseStrFunctionFactoryTest extends AbstractCairoTest {
         assertQuery("select reverse('')").expectSize().returns("reverse\n\n");
         // Unicode (BMP) characters
         assertQuery("select reverse('café')").expectSize().returns("reverse\néfac\n");
-        // VARCHAR overload
-        assertQuery("select reverse('abc'::varchar)").expectSize().returns("reverse\ncba\n");
     }
 
     @Test
@@ -55,5 +53,31 @@ public class ReverseStrFunctionFactoryTest extends AbstractCairoTest {
                                 "\t\n" +
                                 "\t\n"
                 );
+    }
+
+    @Test
+    public void testVarcharColumn() throws Exception {
+        // per-row VARCHAR path decodes UTF8 to UTF16 before reversing
+        assertQuery("select v, reverse(v) from t")
+                .ddl("create table t (v varchar)",
+                        "insert into t values ('abc'), ('café'), (null), ('')")
+                .expectSize()
+                .returns(
+                        "v\treverse\n" +
+                                "abc\tcba\n" +
+                                "café\téfac\n" +
+                                "\t\n" +
+                                "\t\n"
+                );
+    }
+
+    @Test
+    public void testVarcharConstants() throws Exception {
+        assertQuery("select reverse('abc'::varchar)").expectSize().returns("reverse\ncba\n");
+        // non-ASCII (BMP) input
+        assertQuery("select reverse('café'::varchar)").expectSize().returns("reverse\néfac\n");
+        // empty VARCHAR stays empty, NULL VARCHAR returns NULL
+        assertQuery("select reverse(''::varchar)").expectSize().returns("reverse\n\n");
+        assertQuery("select reverse(null::varchar)").expectSize().returns("reverse\n\n");
     }
 }


### PR DESCRIPTION
## What

Adds a PostgreSQL-compatible `reverse()` string function that returns the input
string with its characters in reverse order.

```sql
select reverse('abc');            -- cba
select reverse('Hello, World!');  -- !dlroW ,olleH
```

QuestDB already ships a `reverse()` for `DOUBLE[]`; this adds the scalar string
form present in PostgreSQL.

## Implementation

- `ReverseStrFunctionFactory` (`reverse(S)`) reverses characters into a reusable
  `StringSink`, matching the other single-argument string transforms.
- `ReverseVarcharFunctionFactory` (`reverse(Ø)`) is a thin VARCHAR overload that
  reuses the STRING implementation, mirroring `upper`/`lower` (VARCHAR input
  yields a STRING result). NULL input returns NULL.
- Registered in `function_list.txt`.

Reversal is over UTF-16 code units, consistent with the existing case-transform
string functions.

## Test plan

- `ReverseStrFunctionFactoryTest`: constants (basic, punctuation, single char,
  empty string, Unicode BMP, VARCHAR overload) and a column path covering NULL.
- Class green locally.
