### PR TITLE
fix(pgwire): fix "unsupported type" error when selecting DECIMAL columns

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGPipelineEntry.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGPipelineEntry.java
@@ -174,6 +174,12 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
     private final IntList pgResultSetColumnTypes;
     private final Utf8StringSink utf8StringSink = new Utf8StringSink();
     private final ObjectPool<PGNonNullVarcharArrayView> varcharArrayViewPool = new ObjectPool<>(PGNonNullVarcharArrayView::new, 1);
+    // scratch decimals PGUtils.calculateColumnBinSize() reads a DECIMAL128 / DECIMAL256 column into.
+    // They cannot share sqlExecutionContext.getDecimal128() / getDecimal256() with outColBinDecimal():
+    // that encoder consumes the value it is given, and the size calculation runs while a partially
+    // written record still holds the encoder's scratch.
+    final Decimal128 binSizeDecimal128 = new Decimal128();
+    final Decimal256 binSizeDecimal256 = new Decimal256();
     boolean isCopy;
     private boolean cacheHit = false;    // extended protocol cursor resume callback
     private CompiledQueryImpl compiledQuery;

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGPipelineEntry.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGPipelineEntry.java
@@ -174,10 +174,6 @@ public class PGPipelineEntry implements QuietCloseable, Mutable {
     private final IntList pgResultSetColumnTypes;
     private final Utf8StringSink utf8StringSink = new Utf8StringSink();
     private final ObjectPool<PGNonNullVarcharArrayView> varcharArrayViewPool = new ObjectPool<>(PGNonNullVarcharArrayView::new, 1);
-    // scratch decimals PGUtils.calculateColumnBinSize() reads a DECIMAL128 / DECIMAL256 column into.
-    // They cannot share sqlExecutionContext.getDecimal128() / getDecimal256() with outColBinDecimal():
-    // that encoder consumes the value it is given, and the size calculation runs while a partially
-    // written record still holds the encoder's scratch.
     final Decimal128 binSizeDecimal128 = new Decimal128();
     final Decimal256 binSizeDecimal256 = new Decimal256();
     boolean isCopy;

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGUtils.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGUtils.java
@@ -30,6 +30,9 @@ import io.questdb.cairo.arr.ArrayView;
 import io.questdb.cairo.sql.Record;
 import io.questdb.std.BinarySequence;
 import io.questdb.std.Chars;
+import io.questdb.std.Decimal128;
+import io.questdb.std.Decimal256;
+import io.questdb.std.Decimals;
 import io.questdb.std.Long256;
 import io.questdb.std.Long256Impl;
 import io.questdb.std.Numbers;
@@ -47,6 +50,9 @@ class PGUtils {
     private static final int MAX_GEOINT_TEXT_LEN = 32;
     private static final int MAX_GEOLONG_TEXT_LEN = 64;
     private static final int MAX_GEOSHORT_TEXT_LEN = 16;
+    // "('<timestamp>', '<timestamp>')": two quoted timestamps (31 chars each, see MAX_TIMESTAMP_TEXT_LEN)
+    // plus the brackets and the separator. A "null" bound and a raw long bound are both shorter than that.
+    private static final int MAX_INTERVAL_TEXT_LEN = 2 * (31 + 2) + 4;
     private static final int MAX_INT_TEXT_LEN = String.valueOf(Integer.MIN_VALUE).length();
     private static final int MAX_IPv4_TEXT_LEN = 15; // "255.255.255.255"
     private static final int MAX_LONG256_TEXT_LEN = 66; // "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
@@ -144,9 +150,56 @@ class PGUtils {
                 int vcResumePoint = Math.max(0, resumePoint);
                 int vcRemaining = vcValue.size() - vcResumePoint;
                 return resumePoint == -1 ? Integer.BYTES + vcRemaining : vcRemaining;
+            case ColumnType.ARRAY_STRING:
+                // ARRAY_STRING travels the wire as a STRING, see outRecord()
             case ColumnType.STRING:
                 final CharSequence strValue = record.getStrA(columnIndex);
                 return strValue == null ? Integer.BYTES : Integer.BYTES + Utf8s.utf8Bytes(strValue);
+            case ColumnType.DECIMAL8:
+                final byte dec8Value = record.getDecimal8(columnIndex);
+                return dec8Value == Decimals.DECIMAL8_NULL
+                        ? Integer.BYTES
+                        : decimalBinSize(topDigitPow(Math.abs((long) dec8Value), columnType), columnType);
+            case ColumnType.DECIMAL16:
+                final short dec16Value = record.getDecimal16(columnIndex);
+                return dec16Value == Decimals.DECIMAL16_NULL
+                        ? Integer.BYTES
+                        : decimalBinSize(topDigitPow(Math.abs((long) dec16Value), columnType), columnType);
+            case ColumnType.DECIMAL32:
+                final int dec32Value = record.getDecimal32(columnIndex);
+                return dec32Value == Decimals.DECIMAL32_NULL
+                        ? Integer.BYTES
+                        : decimalBinSize(topDigitPow(Math.abs((long) dec32Value), columnType), columnType);
+            case ColumnType.DECIMAL64:
+                final long dec64Value = record.getDecimal64(columnIndex);
+                return dec64Value == Decimals.DECIMAL64_NULL
+                        ? Integer.BYTES
+                        : decimalBinSize(topDigitPow(Math.abs(dec64Value), columnType), columnType);
+            case ColumnType.DECIMAL128:
+                final Decimal128 dec128Value = pipelineEntry.binSizeDecimal128;
+                record.getDecimal128(columnIndex, dec128Value);
+                if (dec128Value.isNull()) {
+                    return Integer.BYTES;
+                }
+                if (dec128Value.isNegative()) {
+                    // getDigitAtPowerOfTen() requires a positive value, and outColBinDecimal() negates too
+                    dec128Value.negate();
+                }
+                return decimalBinSize(topDigitPow(dec128Value, columnType), columnType);
+            case ColumnType.DECIMAL256:
+                final Decimal256 dec256Value = pipelineEntry.binSizeDecimal256;
+                record.getDecimal256(columnIndex, dec256Value);
+                if (dec256Value.isNull()) {
+                    return Integer.BYTES;
+                }
+                if (dec256Value.isNegative()) {
+                    dec256Value.negate();
+                }
+                return decimalBinSize(topDigitPow(dec256Value, columnType), columnType);
+            case ColumnType.INTERVAL:
+                // outColInterval() renders the interval as text, so its length is only known once it
+                // has been rendered. Bail out and let the caller re-send the whole record after a flush.
+                return -1;
             case ColumnType.SYMBOL:
                 final CharSequence symValue = record.getSymA(columnIndex);
                 return symValue == null ? Integer.BYTES : Integer.BYTES + Utf8s.utf8Bytes(symValue);
@@ -240,11 +293,17 @@ class PGUtils {
                 final Utf8Sequence vcValue = record.getVarcharA(columnIndex);
                 yield vcValue == null ? Integer.BYTES : Integer.BYTES + vcValue.size();
             }
-            case ColumnType.STRING -> {
+            case ColumnType.ARRAY_STRING, ColumnType.STRING -> {
                 final CharSequence strValue = record.getStrA(columnIndex);
                 // take a rough upper estimate based on the string length
                 yield strValue == null ? Integer.BYTES : Integer.BYTES + 3L * strValue.length();
             }
+            case ColumnType.INTERVAL -> Integer.BYTES + MAX_INTERVAL_TEXT_LEN;
+            // the sign, a possible leading zero, the decimal point and at most precision + 1 digits,
+            // see Decimal64.toSink() and its Decimal128 / Decimal256 counterparts
+            case ColumnType.DECIMAL8, ColumnType.DECIMAL16, ColumnType.DECIMAL32,
+                 ColumnType.DECIMAL64, ColumnType.DECIMAL128, ColumnType.DECIMAL256 ->
+                    Integer.BYTES + Decimals.getDecimalTagPrecision(typeTag) + 4;
             case ColumnType.SYMBOL -> {
                 final CharSequence symValue = record.getSymA(columnIndex);
                 // take a rough upper estimate based on the string length
@@ -300,6 +359,27 @@ class PGUtils {
         return count;
     }
 
+    /**
+     * Mirrors {@link PGPipelineEntry}'s {@code outColBinDecimal()}: a 4-byte length prefix, the 8-byte
+     * NUMERIC header (ndigits, weight, sign, dscale) and 2 bytes per base-10000 digit group. The groups
+     * align on the decimal point; the encoder skips the leading all-zero ones but writes the trailing
+     * ones, so the group count follows from the position of the most significant non-zero digit.
+     *
+     * @param topDigitPow power of ten of the most significant non-zero digit, -1 for a zero value
+     */
+    private static int decimalBinSize(int topDigitPow, int columnType) {
+        final int headerSize = Integer.BYTES + 4 * Short.BYTES;
+        if (topDigitPow < 0) {
+            // the encoder returns right after the header, leaving ndigits at zero
+            return headerSize;
+        }
+        final int scale = ColumnType.getDecimalScale(columnType);
+        final int groupCount = topDigitPow >= scale
+                ? (topDigitPow - scale) / 4 + 1 + (scale + 3) / 4 // whole part groups plus every fraction group
+                : (scale + 3) / 4 - (scale - topDigitPow - 1) / 4; // purely fractional, leading groups dropped
+        return headerSize + groupCount * Short.BYTES;
+    }
+
     private static int geoHashBytes(long value, int size) {
         if (value == GeoHashes.NULL) {
             return Integer.BYTES;
@@ -308,5 +388,48 @@ class PGUtils {
             // chars or bits
             return Integer.BYTES + size;
         }
+    }
+
+    /**
+     * Returns the power of ten of the most significant non-zero digit of the given non-null decimal,
+     * or -1 when the decimal is zero. The result is clamped to {@code precision - 1}, which is what the
+     * encoder sees: it never inspects a higher digit, and {@code getDigitAtPowerOfTen()} saturates at 9
+     * for a value that overflows the declared precision.
+     */
+    private static int topDigitPow(Decimal128 value, int columnType) {
+        if (value.isZero()) {
+            return -1;
+        }
+        for (int pow = ColumnType.getDecimalPrecision(columnType) - 1; pow > 0; pow--) {
+            if (value.getDigitAtPowerOfTen(pow) != 0) {
+                return pow;
+            }
+        }
+        return 0;
+    }
+
+    private static int topDigitPow(Decimal256 value, int columnType) {
+        if (value.isZero()) {
+            return -1;
+        }
+        for (int pow = ColumnType.getDecimalPrecision(columnType) - 1; pow > 0; pow--) {
+            if (value.getDigitAtPowerOfTen(pow) != 0) {
+                return pow;
+            }
+        }
+        return 0;
+    }
+
+    private static int topDigitPow(long absUnscaledValue, int columnType) {
+        if (absUnscaledValue == 0) {
+            return -1;
+        }
+        final int maxPow = ColumnType.getDecimalPrecision(columnType) - 1;
+        int pow = 0;
+        while (pow < maxPow && absUnscaledValue >= 10) {
+            absUnscaledValue /= 10;
+            pow++;
+        }
+        return pow;
     }
 }

--- a/core/src/main/java/io/questdb/cutlass/pgwire/PGUtils.java
+++ b/core/src/main/java/io/questdb/cutlass/pgwire/PGUtils.java
@@ -50,8 +50,6 @@ class PGUtils {
     private static final int MAX_GEOINT_TEXT_LEN = 32;
     private static final int MAX_GEOLONG_TEXT_LEN = 64;
     private static final int MAX_GEOSHORT_TEXT_LEN = 16;
-    // "('<timestamp>', '<timestamp>')": two quoted timestamps (31 chars each, see MAX_TIMESTAMP_TEXT_LEN)
-    // plus the brackets and the separator. A "null" bound and a raw long bound are both shorter than that.
     private static final int MAX_INTERVAL_TEXT_LEN = 2 * (31 + 2) + 4;
     private static final int MAX_INT_TEXT_LEN = String.valueOf(Integer.MIN_VALUE).length();
     private static final int MAX_IPv4_TEXT_LEN = 15; // "255.255.255.255"
@@ -151,7 +149,6 @@ class PGUtils {
                 int vcRemaining = vcValue.size() - vcResumePoint;
                 return resumePoint == -1 ? Integer.BYTES + vcRemaining : vcRemaining;
             case ColumnType.ARRAY_STRING:
-                // ARRAY_STRING travels the wire as a STRING, see outRecord()
             case ColumnType.STRING:
                 final CharSequence strValue = record.getStrA(columnIndex);
                 return strValue == null ? Integer.BYTES : Integer.BYTES + Utf8s.utf8Bytes(strValue);
@@ -182,7 +179,6 @@ class PGUtils {
                     return Integer.BYTES;
                 }
                 if (dec128Value.isNegative()) {
-                    // getDigitAtPowerOfTen() requires a positive value, and outColBinDecimal() negates too
                     dec128Value.negate();
                 }
                 return decimalBinSize(topDigitPow(dec128Value, columnType), columnType);
@@ -197,8 +193,6 @@ class PGUtils {
                 }
                 return decimalBinSize(topDigitPow(dec256Value, columnType), columnType);
             case ColumnType.INTERVAL:
-                // outColInterval() renders the interval as text, so its length is only known once it
-                // has been rendered. Bail out and let the caller re-send the whole record after a flush.
                 return -1;
             case ColumnType.SYMBOL:
                 final CharSequence symValue = record.getSymA(columnIndex);
@@ -299,8 +293,6 @@ class PGUtils {
                 yield strValue == null ? Integer.BYTES : Integer.BYTES + 3L * strValue.length();
             }
             case ColumnType.INTERVAL -> Integer.BYTES + MAX_INTERVAL_TEXT_LEN;
-            // the sign, a possible leading zero, the decimal point and at most precision + 1 digits,
-            // see Decimal64.toSink() and its Decimal128 / Decimal256 counterparts
             case ColumnType.DECIMAL8, ColumnType.DECIMAL16, ColumnType.DECIMAL32,
                  ColumnType.DECIMAL64, ColumnType.DECIMAL128, ColumnType.DECIMAL256 ->
                     Integer.BYTES + Decimals.getDecimalTagPrecision(typeTag) + 4;
@@ -359,14 +351,6 @@ class PGUtils {
         return count;
     }
 
-    /**
-     * Mirrors {@link PGPipelineEntry}'s {@code outColBinDecimal()}: a 4-byte length prefix, the 8-byte
-     * NUMERIC header (ndigits, weight, sign, dscale) and 2 bytes per base-10000 digit group. The groups
-     * align on the decimal point; the encoder skips the leading all-zero ones but writes the trailing
-     * ones, so the group count follows from the position of the most significant non-zero digit.
-     *
-     * @param topDigitPow power of ten of the most significant non-zero digit, -1 for a zero value
-     */
     private static int decimalBinSize(int topDigitPow, int columnType) {
         final int headerSize = Integer.BYTES + 4 * Short.BYTES;
         if (topDigitPow < 0) {
@@ -390,12 +374,6 @@ class PGUtils {
         }
     }
 
-    /**
-     * Returns the power of ten of the most significant non-zero digit of the given non-null decimal,
-     * or -1 when the decimal is zero. The result is clamped to {@code precision - 1}, which is what the
-     * encoder sees: it never inspects a higher digit, and {@code getDigitAtPowerOfTen()} saturates at 9
-     * for a value that overflows the declared precision.
-     */
     private static int topDigitPow(Decimal128 value, int columnType) {
         if (value.isZero()) {
             return -1;

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/IntervalPGTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/IntervalPGTest.java
@@ -24,7 +24,10 @@
 
 package io.questdb.test.cutlass.pgwire;
 
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
 import org.junit.Test;
+import org.postgresql.util.PSQLException;
 
 import java.sql.PreparedStatement;
 
@@ -42,5 +45,24 @@ public class IntervalPGTest extends BasePGTest {
                 );
             }
         });
+    }
+
+    @Test
+    public void testIntervalTooLargeForSendBuffer() throws Exception {
+        // An INTERVAL renders as text, so its length is only known once rendered and the send buffer
+        // size calculators cannot predict it. A row that outgrows the whole buffer has to come back as
+        // the actionable "not enough space" message, not as an internal "unsupported type: 39".
+        final StringBuilder columns = new StringBuilder();
+        for (int i = 0; i < 10; i++) {
+            columns.append(i > 0 ? ", " : "").append("interval(100, 200) i").append(i);
+        }
+        assertWithPgServer(Mode.EXTENDED, false, -1, (connection, binary, mode, port) -> {
+            try (PreparedStatement ps = connection.prepareStatement("SELECT " + columns + " FROM long_sequence(5)")) {
+                ps.executeQuery();
+                Assert.fail("expected the server to reject a record larger than the send buffer");
+            } catch (PSQLException e) {
+                TestUtils.assertContains(e.getMessage(), "not enough space in send buffer");
+            }
+        }, () -> sendBufferSize = 512);
     }
 }

--- a/core/src/test/java/io/questdb/test/cutlass/pgwire/PGDecimalsTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/pgwire/PGDecimalsTest.java
@@ -228,6 +228,44 @@ public class PGDecimalsTest extends BasePGTest {
     }
 
     @Test
+    public void testDecimalAcrossSendBufferBoundaryBinary() throws Exception {
+        // The send buffer holds only a handful of rows, so some row is guaranteed to run out of
+        // space mid-record. That drives PGPipelineEntry.outRecord into its
+        // NoSpaceLeftInResponseBufferException handler, which asks PGUtils.calculateColumnBinSize
+        // for the size of the record tail. PGUtils has no DECIMAL branch, so it falls through to
+        // "assert false : unsupported type: <tag>" and the client sees "unsupported type: 31"
+        // (ColumnType.DECIMAL64) instead of the result set.
+        assertWithPgServerExtendedBinaryOnly((connection, binary, mode, port) -> {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(
+                        """
+                                CREATE TABLE tango AS (
+                                  SELECT
+                                    (x * 1_000_000)::timestamp AS ts,
+                                    CAST(x || '.1234' AS decimal(18, 4)) AS dec
+                                  FROM long_sequence(1000)
+                                ) TIMESTAMP(ts) PARTITION BY DAY"""
+                );
+            }
+            // run it twice: pgjdbc only switches the result set to binary once the statement
+            // is server-prepared, so the first pass may still travel as text
+            for (int i = 0; i < 2; i++) {
+                int rowCount = 0;
+                try (
+                        PreparedStatement statement = connection.prepareStatement("SELECT ts, dec FROM tango");
+                        ResultSet rs = statement.executeQuery()
+                ) {
+                    while (rs.next()) {
+                        rowCount++;
+                        Assert.assertEquals(new BigDecimal(rowCount + ".1234"), rs.getBigDecimal(2));
+                    }
+                }
+                Assert.assertEquals(1000, rowCount);
+            }
+        }, () -> sendBufferSize = 1024);
+    }
+
+    @Test
     public void testDecimalBind() throws Exception {
         assertWithPgServer(CONN_AWARE_ALL, (connection, binary, mode, port) -> {
             try (Statement statement = connection.createStatement()) {
@@ -345,6 +383,26 @@ public class PGDecimalsTest extends BasePGTest {
         });
     }
 
+    @Test
+    public void testDecimalsAcrossSendBufferBoundaryBinary() throws Exception {
+        // PGUtils.calculateColumnBinSize() has to report the exact number of bytes outColBinDecimal()
+        // will write, because calculateRecordTailSize() patches that number into the DataRow length
+        // before the tail is serialized. These values cover the cases the base-10000 group count turns
+        // on: zero (no groups at all), NULL, a value small enough to drop the leading fraction groups,
+        // a value with trailing zero groups (which are written, unlike the leading ones), a negative
+        // one and the widest value the precision allows.
+        assertDecimalsSurviveSendBufferBoundary(2, 1, null, "0", "9.9", "-9.9", "0.1");
+        assertDecimalsSurviveSendBufferBoundary(4, 0, null, "0", "9999", "-9999", "1");
+        assertDecimalsSurviveSendBufferBoundary(9, 4, null, "0", "99999.9999", "-123.0000", "0.0001");
+        assertDecimalsSurviveSendBufferBoundary(18, 4, null, "0", "99999999999999.9999", "-123.0000", "0.0001");
+        // the largest scale the precision leaves room for, i.e. a single whole-part digit
+        assertDecimalsSurviveSendBufferBoundary(19, 18, null, "0", "0.999999999999999999", "-0.000000000000000001");
+        assertDecimalsSurviveSendBufferBoundary(38, 6, null, "0", "99999999999999999999999999999999.999999", "-1.000000", "0.000001");
+        assertDecimalsSurviveSendBufferBoundary(76, 8, null, "0",
+                "99999999999999999999999999999999999999999999999999999999999999999999.99999999",
+                "-1.00000000", "0.00000001");
+    }
+
     // Test fractional values
     @Test
     public void testFractionalValues() throws Exception {
@@ -456,6 +514,55 @@ public class PGDecimalsTest extends BasePGTest {
                 }
             }
         });
+    }
+
+    /**
+     * Fills a table with the given values, cycling through them, and reads it back over a send buffer
+     * far too small to hold the whole result set. Every buffer boundary lands mid-record and drives
+     * PGPipelineEntry.outRecord() into its NoSpaceLeftInResponseBufferException handler, which is the
+     * only caller of the PGUtils size calculators.
+     */
+    private void assertDecimalsSurviveSendBufferBoundary(int precision, int scale, String... values) throws Exception {
+        final int rowCount = 200;
+        final StringBuilder insert = new StringBuilder("INSERT INTO tango VALUES ");
+        for (int i = 0; i < rowCount; i++) {
+            final String value = values[i % values.length];
+            insert.append(i > 0 ? ",(" : "(").append(i * 1_000_000L).append("::timestamp,");
+            if (value == null) {
+                insert.append("NULL");
+            } else {
+                insert.append("CAST('").append(value).append("' AS decimal(").append(precision).append(", ").append(scale).append("))");
+            }
+            insert.append(')');
+        }
+        assertWithPgServerExtendedBinaryOnly((connection, binary, mode, port) -> {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(String.format(
+                        "CREATE TABLE tango (ts TIMESTAMP, dec decimal(%d, %d)) TIMESTAMP(ts) PARTITION BY YEAR",
+                        precision,
+                        scale
+                ));
+                statement.execute(insert.toString());
+            }
+            drainWalQueue();
+            int readCount = 0;
+            try (
+                    PreparedStatement statement = connection.prepareStatement("SELECT ts, dec FROM tango");
+                    ResultSet rs = statement.executeQuery()
+            ) {
+                while (rs.next()) {
+                    final String expected = values[readCount % values.length];
+                    final BigDecimal actual = rs.getBigDecimal(2);
+                    if (expected == null) {
+                        Assert.assertNull(actual);
+                    } else {
+                        Assert.assertEquals(expected, 0, new BigDecimal(expected).compareTo(actual));
+                    }
+                    readCount++;
+                }
+            }
+            Assert.assertEquals(rowCount, readCount);
+        }, () -> sendBufferSize = 512);
     }
 
     private void assertNull(int precision, int scale) throws Exception {


### PR DESCRIPTION
## Symptoms

Selecting a `DECIMAL` column fails part-way through a result set:

```
ERROR: unsupported type: 31
```

The number is the internal type tag, so it varies with the column's
precision: 28-33 for `DECIMAL8` through `DECIMAL256`, and 39 for an
`INTERVAL` column.

What users see:

- The query starts returning rows and then dies mid-stream. Small result
  sets are fine; the same query over a larger table fails.
- It is not tied to particular values. Whichever row happens to land on a
  send-buffer boundary is the one that fails, so the error moves around as
  the data changes.
- Reported with Npgsql. pgjdbc with `binaryTransfer=true` fails the same
  way. Clients reading in text format are mostly unaffected.
- Only servers running the JVM with `-ea` report the error. That includes
  the AMI/marketplace unit
  (`pkg/ami/marketplace/assets/systemd.service`). Elsewhere the query
  succeeds, but the server gives up an optimisation and re-sends the whole
  row on every buffer boundary.

Raising `pg.send.buffer.size` above the result-set size hides it, which is
why it tends to show up as the dataset grows.

## Fix

`PGUtils.calculateColumnBinSize()` and `estimateColumnTxtSize()` size a
record when it overflows the send buffer. Neither had a `DECIMAL` branch,
so decimals fell through to `assert false`. Both now size them.

The binary size must be exact, not an upper bound: it is patched into the
DataRow length before the rest of the row is written. It is
`4 + 8 + 2 x groups`, where the base-10000 group count follows from the
position of the most significant non-zero digit.

Two neighbours fell through the same switches. `ARRAY_STRING` now shares the
`STRING` branch, matching how it is serialized. `INTERVAL` has no
predictable length, so it returns `-1` and the caller re-sends the record
after a flush; an oversized interval row now reports `not enough space in
send buffer` rather than an assertion.

## Test plan

- `PGDecimalsTest.testDecimalAcrossSendBufferBoundaryBinary` — the reported
  scenario: `decimal(18,4)`, binary format, 1 KB send buffer, 1000 rows.
  Fails on master with `unsupported type: 31`.
- `PGDecimalsTest.testDecimalsAcrossSendBufferBoundaryBinary` — every
  decimal width over a 512-byte buffer: zero, NULL, negative, purely
  fractional, trailing zero groups, and the widest value each precision
  allows.
- `IntervalPGTest.testIntervalTooLargeForSendBuffer` — an oversized row
  returns the actionable message. Fails on master with
  `unsupported type: 39`.
- `PGDecimalsTest` 41, `IntervalPGTest` 2, `PGArraysTest` 25,
  `PGJobContextTest` 285 — all pass locally.
