### PR TITLE
feat(sql): add ascii() string function

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/AsciiStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/AsciiStrFunctionFactory.java
@@ -1,0 +1,88 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+import io.questdb.cairo.CairoConfiguration;
+import io.questdb.cairo.sql.Function;
+import io.questdb.cairo.sql.Record;
+import io.questdb.griffin.FunctionFactory;
+import io.questdb.griffin.SqlExecutionContext;
+import io.questdb.griffin.engine.functions.IntFunction;
+import io.questdb.griffin.engine.functions.UnaryFunction;
+import io.questdb.std.IntList;
+import io.questdb.std.Numbers;
+import io.questdb.std.ObjList;
+
+/**
+ * Postgres-compatible ascii(): returns the Unicode code point of the first character
+ * of the input string. Returns 0 for an empty string and NULL for NULL input.
+ */
+public class AsciiStrFunctionFactory implements FunctionFactory {
+    @Override
+    public String getSignature() {
+        return "ascii(S)";
+    }
+
+    @Override
+    public Function newInstance(
+            int position,
+            ObjList<Function> args,
+            IntList argPositions,
+            CairoConfiguration configuration,
+            SqlExecutionContext sqlExecutionContext
+    ) {
+        return new Func(args.getQuick(0));
+    }
+
+    private static class Func extends IntFunction implements UnaryFunction {
+        private final Function arg;
+
+        public Func(Function arg) {
+            this.arg = arg;
+        }
+
+        @Override
+        public Function getArg() {
+            return arg;
+        }
+
+        @Override
+        public int getInt(Record rec) {
+            final CharSequence value = arg.getStrA(rec);
+            if (value == null) {
+                return Numbers.INT_NULL;
+            }
+            if (value.length() == 0) {
+                return 0;
+            }
+            return Character.codePointAt(value, 0);
+        }
+
+        @Override
+        public String getName() {
+            return "ascii";
+        }
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/functions/str/AsciiVarcharFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/str/AsciiVarcharFunctionFactory.java
@@ -1,0 +1,36 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.functions.str;
+
+/**
+ * VARCHAR overload of {@link AsciiStrFunctionFactory}. Mirrors the other string
+ * functions that read VARCHAR input through the STRING accessor.
+ */
+public class AsciiVarcharFunctionFactory extends AsciiStrFunctionFactory {
+    @Override
+    public String getSignature() {
+        return "ascii(Ø)";
+    }
+}

--- a/core/src/main/resources/function_list.txt
+++ b/core/src/main/resources/function_list.txt
@@ -828,6 +828,8 @@ io.questdb.griffin.engine.functions.str.LowerFunctionFactory
 io.questdb.griffin.engine.functions.str.LowerVarcharFunctionFactory
 io.questdb.griffin.engine.functions.str.UpperFunctionFactory
 io.questdb.griffin.engine.functions.str.UpperVarcharFunctionFactory
+io.questdb.griffin.engine.functions.str.AsciiStrFunctionFactory
+io.questdb.griffin.engine.functions.str.AsciiVarcharFunctionFactory
 
 # hash functions
 io.questdb.griffin.engine.functions.str.MD5BinFunctionFactory

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/AsciiStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/AsciiStrFunctionFactoryTest.java
@@ -1,0 +1,59 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.functions.str;
+
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+public class AsciiStrFunctionFactoryTest extends AbstractCairoTest {
+
+    @Test
+    public void testConstants() throws Exception {
+        // code point of the first character
+        assertQuery("select ascii('A')").expectSize().returns("ascii\n65\n");
+        assertQuery("select ascii('abc')").expectSize().returns("ascii\n97\n");
+        // Unicode code point (matches PostgreSQL)
+        assertQuery("select ascii('é')").expectSize().returns("ascii\n233\n");
+        // empty string returns 0
+        assertQuery("select ascii('')").expectSize().returns("ascii\n0\n");
+        // VARCHAR overload
+        assertQuery("select ascii('A'::varchar)").expectSize().returns("ascii\n65\n");
+    }
+
+    @Test
+    public void testNullAndColumn() throws Exception {
+        assertQuery("select s, ascii(s) from t")
+                .ddl("create table t (s string)",
+                        "insert into t values ('A'), ('abc'), (null), ('')")
+                .expectSize()
+                .returns(
+                        "s\tascii\n" +
+                                "A\t65\n" +
+                                "abc\t97\n" +
+                                "\tnull\n" +
+                                "\t0\n"
+                );
+    }
+}

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/str/AsciiStrFunctionFactoryTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/str/AsciiStrFunctionFactoryTest.java
@@ -36,10 +36,10 @@ public class AsciiStrFunctionFactoryTest extends AbstractCairoTest {
         assertQuery("select ascii('abc')").expectSize().returns("ascii\n97\n");
         // Unicode code point (matches PostgreSQL)
         assertQuery("select ascii('é')").expectSize().returns("ascii\n233\n");
+        // first character outside the BMP returns its full code point (surrogate pair)
+        assertQuery("select ascii('😀')").expectSize().returns("ascii\n128512\n");
         // empty string returns 0
         assertQuery("select ascii('')").expectSize().returns("ascii\n0\n");
-        // VARCHAR overload
-        assertQuery("select ascii('A'::varchar)").expectSize().returns("ascii\n65\n");
     }
 
     @Test
@@ -55,5 +55,33 @@ public class AsciiStrFunctionFactoryTest extends AbstractCairoTest {
                                 "\tnull\n" +
                                 "\t0\n"
                 );
+    }
+
+    @Test
+    public void testVarcharColumn() throws Exception {
+        assertQuery("select v, ascii(v) from t")
+                .ddl("create table t (v varchar)",
+                        "insert into t values ('A'), ('é'), (null), ('')")
+                .expectSize()
+                .returns(
+                        "v\tascii\n" +
+                                "A\t65\n" +
+                                "é\t233\n" +
+                                "\tnull\n" +
+                                "\t0\n"
+                );
+    }
+
+    @Test
+    public void testVarcharConstants() throws Exception {
+        // the VARCHAR overload reads the same code point through the UTF8 accessor
+        assertQuery("select ascii('A'::varchar)").expectSize().returns("ascii\n65\n");
+        // non-ASCII input takes the UTF8-to-UTF16 decode path
+        assertQuery("select ascii('é'::varchar)").expectSize().returns("ascii\n233\n");
+        // first character outside the BMP returns its full code point (surrogate pair)
+        assertQuery("select ascii('😀'::varchar)").expectSize().returns("ascii\n128512\n");
+        // empty VARCHAR returns 0, NULL VARCHAR returns NULL
+        assertQuery("select ascii(''::varchar)").expectSize().returns("ascii\n0\n");
+        assertQuery("select ascii(null::varchar)").expectSize().returns("ascii\nnull\n");
     }
 }


### PR DESCRIPTION
## What

Adds a PostgreSQL-compatible `ascii()` function that returns the Unicode code
point of the first character of the input string.

```sql
select ascii('A');    -- 65
select ascii('abc');  -- 97
select ascii('é');    -- 233
select ascii('');     -- 0
```

## Implementation

- `AsciiStrFunctionFactory` (`ascii(S)`) returns an INT via `IntFunction`, modeled
  on `LengthStrFunctionFactory`. It reads the first code point with
  `Character.codePointAt`, so a first character outside the Basic Multilingual
  Plane returns its full code point (matching PostgreSQL). Empty string returns 0;
  NULL input returns NULL.
- `AsciiVarcharFunctionFactory` (`ascii(Ø)`) is the VARCHAR overload reusing the
  same implementation.
- Registered in `function_list.txt`.

## Test plan

- `AsciiStrFunctionFactoryTest`: constants (ASCII, multi-char, Unicode code point,
  empty string, VARCHAR overload) and a column path covering NULL.
- Class green locally.
