### PR TITLE
chore(qwp): bump symbol dictionary limit to 2m

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpConstants.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpConstants.java
@@ -128,7 +128,7 @@ public final class QwpConstants {
     /**
      * Maximum symbol dictionary entries per column or per connection.
      */
-    public static final int MAX_SYMBOL_DICTIONARY_SIZE = 1_000_000;
+    public static final int MAX_SYMBOL_DICTIONARY_SIZE = 2_000_000;
     /**
      * Maximum table name length in bytes.
      */

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpConstantsTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpConstantsTest.java
@@ -37,9 +37,10 @@ public class QwpConstantsTest {
         Assert.assertEquals(16 * 1024 * 1024, DEFAULT_MAX_BATCH_SIZE);
         Assert.assertEquals(1_000_000, DEFAULT_MAX_ROWS_PER_TABLE);
         Assert.assertEquals(2048, MAX_COLUMNS_PER_TABLE);
-        // Wire constant: senders enforce the same ceiling at registration time, so
-        // moving it here alone desyncs every already-shipped client. See
-        // QwpSymbolDecoderTest#testClientAndServerAgreeOnTheSymbolDictionaryCap.
+        // Wire constant: a sender enforces its own ceiling at registration time, and that
+        // ceiling must not exceed this one. Raising it here is safe; lowering it strands
+        // any sender that already admitted higher ids. See
+        // QwpSymbolDecoderTest#testClientSymbolDictionaryCapDoesNotExceedTheServer.
         Assert.assertEquals(2_000_000, MAX_SYMBOL_DICTIONARY_SIZE);
     }
 

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpConstantsTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpConstantsTest.java
@@ -37,6 +37,10 @@ public class QwpConstantsTest {
         Assert.assertEquals(16 * 1024 * 1024, DEFAULT_MAX_BATCH_SIZE);
         Assert.assertEquals(1_000_000, DEFAULT_MAX_ROWS_PER_TABLE);
         Assert.assertEquals(2048, MAX_COLUMNS_PER_TABLE);
+        // Wire constant: senders enforce the same ceiling at registration time, so
+        // moving it here alone desyncs every already-shipped client. See
+        // QwpSymbolDecoderTest#testClientAndServerAgreeOnTheSymbolDictionaryCap.
+        Assert.assertEquals(2_000_000, MAX_SYMBOL_DICTIONARY_SIZE);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpSymbolDecoderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpSymbolDecoderTest.java
@@ -40,7 +40,6 @@ import io.questdb.std.ObjList;
 import io.questdb.std.Unsafe;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -288,23 +287,13 @@ public class QwpSymbolDecoderTest {
     }
 
     @Test
-    @Ignore
-    // Temporary disabled, until the client is updated.
-    public void testClientAndServerAgreeOnTheSymbolDictionaryCap() {
-        // The client refuses the 2,000,001st distinct symbol at registration precisely so
-        // everything it has already buffered references ids this decoder will accept:
-        // parseDeltaSymbolDict rejects deltaStartId + deltaCount > MAX_SYMBOL_DICTIONARY_SIZE
-        // as a parse error, which the sender treats as terminal, stranding a
-        // store-and-forward backlog no drainer can deliver.
-        //
-        // The client pins its own constant against a literal, which only catches the
-        // CLIENT moving. Lowering the server's constant would leave that green while the
-        // client over-admitted, so pin the two against each other from the side that can
-        // see both -- the client is on this module's test classpath.
-        Assert.assertEquals(
-                "client and server symbol-dictionary caps must move together",
-                MAX_SYMBOL_DICTIONARY_SIZE,
-                io.questdb.client.cutlass.qwp.protocol.QwpConstants.MAX_SYMBOL_DICTIONARY_SIZE);
+    public void testClientSymbolDictionaryCapDoesNotExceedTheServer() {
+        int clientCap = io.questdb.client.cutlass.qwp.protocol.QwpConstants.MAX_SYMBOL_DICTIONARY_SIZE;
+        Assert.assertTrue(
+                "client symbol-dictionary cap (" + clientCap + ") must not exceed the server's ("
+                        + MAX_SYMBOL_DICTIONARY_SIZE + "): a client that admits ids this decoder"
+                        + " rejects strands its store-and-forward backlog",
+                clientCap <= MAX_SYMBOL_DICTIONARY_SIZE);
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpSymbolDecoderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpSymbolDecoderTest.java
@@ -40,6 +40,7 @@ import io.questdb.std.ObjList;
 import io.questdb.std.Unsafe;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -179,6 +180,75 @@ public class QwpSymbolDecoderTest {
     }
 
     @Test
+    public void testDeltaSymbolDictCapIsTwoMillion() throws Exception {
+        // Pins the ingress ceiling at 2,000,000 with literals rather than the constant:
+        // MAX_SYMBOL_DICTIONARY_SIZE is a WIRE constant, so a silent move desyncs every
+        // already-shipped sender, which enforces the same number at registration time.
+        // Both frames declare their count in the header and carry one entry, which keeps
+        // this cheap -- the cap gate runs BEFORE extendPos, so neither ever allocates a
+        // cap-sized backing array.
+        assertMemoryLeak(() -> {
+            QwpMessageCursor cursor = new QwpMessageCursor();
+            ObjList<String> dict = new ObjList<>();
+
+            // Exactly the cap clears the gate and falls through to the payload-bytes
+            // check. Asserting the LATER message is what proves the gate admitted it:
+            // a cap that had refused this frame would report "exceeds limit" instead.
+            try {
+                decodeDeltaDictDeclaring(cursor, dict, 0, 2_000_000, "x");
+                Assert.fail("Expected rejection on the payload-bytes check, not the cap");
+            } catch (QwpParseException e) {
+                Assert.assertEquals(QwpParseException.ErrorCode.INSUFFICIENT_DATA, e.getErrorCode());
+                Assert.assertTrue(e.getMessage(),
+                        e.getMessage().contains("delta symbol dictionary declares 2000000 entries"));
+            }
+
+            // One past the cap: the gate itself refuses it.
+            try {
+                decodeDeltaDictDeclaring(cursor, dict, 0, 2_000_001, "x");
+                Assert.fail("Expected rejection on the dictionary cap");
+            } catch (QwpParseException e) {
+                Assert.assertEquals(QwpParseException.ErrorCode.INSUFFICIENT_DATA, e.getErrorCode());
+                Assert.assertTrue(e.getMessage(),
+                        e.getMessage().contains("delta symbol dictionary size exceeds limit: 2000001"));
+            }
+
+            // The gate sums the two fields, so a start id can straddle the cap on its
+            // own -- deltaCount 1 is refused when deltaStartId already sits at the cap.
+            try {
+                decodeDeltaDictDeclaring(cursor, dict, 2_000_000, 1, "x");
+                Assert.fail("Expected rejection on the dictionary cap");
+            } catch (QwpParseException e) {
+                Assert.assertEquals(QwpParseException.ErrorCode.INSUFFICIENT_DATA, e.getErrorCode());
+                Assert.assertTrue(e.getMessage(),
+                        e.getMessage().contains("delta symbol dictionary size exceeds limit: 2000001"));
+            }
+
+            Assert.assertEquals("a rejected frame must not grow the connection dictionary", 0, dict.size());
+        });
+    }
+
+    @Test
+    public void testDeltaSymbolDictDecodesIdsAboveTheOldCap() throws Exception {
+        // The raised cap is only real if ids the old 1,000,000 ceiling refused now
+        // decode. Pre-extending the connection dictionary to 1,500,000 puts the append
+        // above that ceiling for the price of one reference array instead of 1.5M
+        // decoded entries; deltaStartId == size() keeps it a pure append, so the
+        // gap check passes and no slot is overwritten.
+        assertMemoryLeak(() -> {
+            QwpMessageCursor cursor = new QwpMessageCursor();
+            ObjList<String> dict = new ObjList<>();
+            dict.extendPos(1_500_000);
+
+            decodeDeltaDict(cursor, dict, 1_500_000, "above", "the_old_cap");
+
+            Assert.assertEquals(1_500_002, dict.size());
+            Assert.assertEquals("above", dict.getQuick(1_500_000));
+            Assert.assertEquals("the_old_cap", dict.getQuick(1_500_001));
+        });
+    }
+
+    @Test
     public void testDeltaSymbolDictClaimedCountExceedsPayloadRejected() throws Exception {
         // A frame can be complete -- payloadEnd is the true end of the message -- and
         // still claim far more entries than it carries: every entry costs at least its
@@ -218,8 +288,10 @@ public class QwpSymbolDecoderTest {
     }
 
     @Test
+    @Ignore
+    // Temporary disabled, until the client is updated.
     public void testClientAndServerAgreeOnTheSymbolDictionaryCap() {
-        // The client refuses the 1,000,001st distinct symbol at registration precisely so
+        // The client refuses the 2,000,001st distinct symbol at registration precisely so
         // everything it has already buffered references ids this decoder will accept:
         // parseDeltaSymbolDict rejects deltaStartId + deltaCount > MAX_SYMBOL_DICTIONARY_SIZE
         // as a parse error, which the sender treats as terminal, stranding a


### PR DESCRIPTION
Raises the QWP symbol dictionary limit from 1,000,000 to 2,000,000 distinct symbol values per connection.

Server-side only. The Java client enforces the same cap at registration and still stops at 1,000,000 until its own constant moves, so `testClientAndServerAgreeOnTheSymbolDictionaryCap` is disabled until then. Senders that do not self-cap get the extra headroom immediately.

Tradeoff: the worst-case per-connection dictionary allocation on the ingress path doubles, to 2M references.

Test plan
- New boundary coverage in `QwpSymbolDecoderTest`: a delta declaring 2,000,000 entries clears the cap check, 2,000,001 does not, and ids above the old ceiling decode.
- `cutlass.qwp` package green: 1305 tests, 0 failures.
