### PR TITLE
fix(core): keep wal_pending_row_count from going negative

### DIFF
--- a/core/src/main/java/io/questdb/cairo/pool/RecentWriteTracker.java
+++ b/core/src/main/java/io/questdb/cairo/pool/RecentWriteTracker.java
@@ -72,6 +72,9 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class RecentWriteTracker {
     private static final Log LOG = LogFactory.getLog(RecentWriteTracker.class);
+    // Sentinel for "the pending-row floor has not been seeded yet". Cannot be 0: 0 is a
+    // legitimate floor (a table whose WAL is empty when this process first sees it).
+    private static final long UNSET_FLOOR = Long.MIN_VALUE;
 
     private final AtomicBoolean evictionInProgress = new AtomicBoolean(false);
     private final int maxCapacity;
@@ -287,19 +290,23 @@ public class RecentWriteTracker {
     /**
      * Records that WAL rows have been processed (applied to the table).
      * <p>
-     * This decrements the pending WAL row count (if seqTxn > floor) and accumulates dedup row count.
+     * This decrements the pending WAL row count and accumulates dedup row count.
      * Called after successful WAL transaction application.
+     * <p>
+     * <b>walRowCount must already exclude transactions at or below the table's pending-row
+     * floor</b> - see {@link #seedAndGetWalPendingFloor(TableToken, long)}. The floor cannot be
+     * applied here: an apply batch spans a range of seqTxns and only the caller knows how the
+     * rows are distributed across them, so an all-or-nothing test on the batch's last seqTxn
+     * would subtract pre-floor rows that were never added and drive the count negative.
      *
      * @param tableToken       the table whose WAL was processed
-     * @param seqTxn           the sequencer transaction number being processed
-     * @param walRowCount      the number of WAL rows that were processed (before dedup)
+     * @param walRowCount      the number of above-floor WAL rows processed (before dedup)
      * @param dedupRowsRemoved the number of duplicate rows removed during dedup
      */
-    public void recordWalProcessed(@NotNull TableToken tableToken, long seqTxn, long walRowCount, long dedupRowsRemoved) {
+    public void recordWalProcessed(@NotNull TableToken tableToken, long walRowCount, long dedupRowsRemoved) {
         try {
             WriteStats stats = getOrCreateStats(tableToken);
-            // Only subtract if seqTxn is above the floor (rows added after tracking started)
-            if (seqTxn > stats.getFloorSeqTxn()) {
+            if (walRowCount > 0) {
                 stats.walRowCount.add(-walRowCount);
             }
             if (dedupRowsRemoved > 0) {
@@ -307,6 +314,41 @@ public class RecentWriteTracker {
             }
         } catch (Throwable th) {
             LOG.error().$("could not record WAL processed [table=").$(tableToken).$(", error=").$(th).I$();
+        }
+    }
+
+    /**
+     * Returns the pending-row floor for a table, seeding it on first sight.
+     * <p>
+     * WAL transactions at or below the floor were committed before this process began counting
+     * rows for the table, so their rows are absent from the pending count and must not be
+     * subtracted when they are applied.
+     * <p>
+     * The floor is seeded by whichever component sees the table first and is never moved
+     * afterwards. A WAL commit seeds it to {@code seqTxn - 1} (everything older predates this
+     * process); a WAL apply seeds it to the last seqTxn of the batch it is about to apply
+     * (nothing in that batch was counted, or a commit would have seeded the floor first).
+     * Seeding from both paths is what makes the floor independent of the startup race between
+     * ingestion and the apply job - relying on a single seeder leaves a table unprotected
+     * whenever the other one gets there first.
+     * <p>
+     * A commit publishes its seqTxn to the sequencer before it records the write here, so an
+     * apply of that same txn can seed the floor first and leave the commit's rows counted but
+     * never subtracted. That biases the pending count high, never low, and only for txns
+     * in flight at the instant a table is first seen. Erring high is deliberate: an
+     * over-reported backlog is a cosmetic stat, an under-reported one goes negative.
+     *
+     * @param tableToken the table to look up
+     * @param seedFloor  the floor to install if the table has not been seen before
+     * @return the effective floor; WAL rows with seqTxn &lt;= this value must not be subtracted
+     */
+    public long seedAndGetWalPendingFloor(@NotNull TableToken tableToken, long seedFloor) {
+        try {
+            return getOrCreateStats(tableToken).seedAndGetFloorSeqTxn(seedFloor);
+        } catch (Throwable th) {
+            LOG.error().$("could not read WAL pending floor [table=").$(tableToken).$(", error=").$(th).I$();
+            // Subtract nothing rather than risk a negative pending count.
+            return Long.MAX_VALUE;
         }
     }
 
@@ -588,8 +630,12 @@ public class RecentWriteTracker {
         private final SimpleReadWriteLock batchSizeHistogramLock = new SimpleReadWriteLock();
         // Dedup row count - accumulated count of rows removed by deduplication
         private final LongAdder dedupRowCount = new LongAdder();
-        // Floor seqTxn - set on startup, WAL rows with seqTxn <= floor are not subtracted
-        private final AtomicLong floorSeqTxn = new AtomicLong(0);
+        // Floor seqTxn - WAL rows with seqTxn <= floor were committed before this process
+        // started tracking the table, so they were never added to walRowCount and must not be
+        // subtracted from it. UNSET_FLOOR until the first component to see the table seeds it;
+        // seeded once and never moved after that (lowering it would expose uncounted rows to
+        // subtraction and drive the pending count negative).
+        private final AtomicLong floorSeqTxn = new AtomicLong(UNSET_FLOOR);
         // Lock for merge stats (write amplification and merge throughput) access
         private final SimpleReadWriteLock mergeStatsLock = new SimpleReadWriteLock();
         // Merge throughput histogram - tracks rows/second during WAL apply
@@ -718,7 +764,7 @@ public class RecentWriteTracker {
          * Returns the floor seqTxn. WAL rows with seqTxn &lt;= floor are not subtracted
          * from pending count (they were never added because they existed before tracking started).
          *
-         * @return floor seqTxn, or 0 if not set
+         * @return floor seqTxn, or {@link Long#MIN_VALUE} if it has not been seeded yet
          */
         public long getFloorSeqTxn() {
             return floorSeqTxn.get();
@@ -1126,6 +1172,10 @@ public class RecentWriteTracker {
          * @param txnRowCount     the number of rows in this WAL transaction
          */
         private void updateWal(long newTxn, long newWalTimestamp, long txnRowCount) {
+            // First commit this process has seen for the table: everything strictly older was
+            // committed before we started counting, so its rows must never be subtracted.
+            seedAndGetFloorSeqTxn(newTxn - 1);
+
             // Always increment WAL row count - contention-free via LongAdder
             walRowCount.add(txnRowCount);
 
@@ -1192,13 +1242,27 @@ public class RecentWriteTracker {
         }
 
         /**
-         * Sets the floor seqTxn. Only succeeds if not already set (floor is 0).
+         * Seeds the floor seqTxn if it has not been seeded yet, and returns the effective floor.
+         * The first seed wins; later calls only read.
+         *
+         * @param floor the floor seqTxn to install if unseeded
+         * @return the effective floor seqTxn
+         */
+        long seedAndGetFloorSeqTxn(long floor) {
+            if (floorSeqTxn.compareAndSet(UNSET_FLOOR, floor)) {
+                return floor;
+            }
+            return floorSeqTxn.get();
+        }
+
+        /**
+         * Sets the floor seqTxn. Only succeeds if not already seeded.
          * Called on startup to mark WAL transactions that existed before tracking started.
          *
          * @param floor the floor seqTxn to set
          */
         void setFloorSeqTxn(long floor) {
-            floorSeqTxn.compareAndSet(0, floor);
+            floorSeqTxn.compareAndSet(UNSET_FLOOR, floor);
         }
     }
 }

--- a/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
+++ b/core/src/main/java/io/questdb/cairo/wal/ApplyWal2TableJob.java
@@ -774,17 +774,28 @@ public class ApplyWal2TableJob extends AbstractQueueConsumerJob<WalTxnNotificati
                 long totalPhysicalRowCount = writer.getPhysicallyWrittenRowsSinceLastCommit();
                 long lastCommittedSeqTxn = writer.getAppliedSeqTxn();
                 lastCommittedRows = 0;
+                // Rows of this batch that the pending counter actually holds. A batch can span
+                // the table's pending-row floor - typically the first batch after startup, which
+                // block-applies a pre-existing backlog together with freshly committed txns - and
+                // only the pre-floor part is missing from the counter. Subtracting the whole batch
+                // would take the pending count negative by the size of that backlog.
+                long pendingRowsApplied = 0;
+                final long pendingFloor = engine.getRecentWriteTracker()
+                        .seedAndGetWalPendingFloor(writer.getTableToken(), lastCommittedSeqTxn);
                 for (long s = seqTxn; s <= lastCommittedSeqTxn; s++) {
                     long walRowCount = txnDetails.getSegmentRowHi(s) - txnDetails.getSegmentRowLo(s);
                     long commitPhRowCount = s == lastCommittedSeqTxn ? totalPhysicalRowCount : 0;
                     metrics.addApplyRowsWritten(walRowCount, commitPhRowCount, latency);
                     walTelemetryFacade.store(WAL_TXN_DATA_APPLIED, writer.getTableToken(), walId, s, walRowCount, commitPhRowCount, latency, txnDetails.getMinTimestamp(s), txnDetails.getMaxTimestamp(s));
                     lastCommittedRows += walRowCount;
+                    if (s > pendingFloor) {
+                        pendingRowsApplied += walRowCount;
+                    }
                 }
 
                 // Decrement pending WAL row count and track dedup after successful processing
                 final long dedupRowsRemoved = writer.getDedupRowsRemovedSinceLastCommit();
-                engine.getRecentWriteTracker().recordWalProcessed(writer.getTableToken(), lastCommittedSeqTxn, lastCommittedRows, dedupRowsRemoved);
+                engine.getRecentWriteTracker().recordWalProcessed(writer.getTableToken(), pendingRowsApplied, dedupRowsRemoved);
                 // Dedup-base signal: a DATA batch matches its raw WAL stream only if it skipped
                 // nothing (a skipped DATA commit's rows never materialise), deduped nothing
                 // (a dedup replaced/removed a row the raw append would keep) and expired nothing

--- a/core/src/test/java/io/questdb/test/cairo/pool/WalPendingRowCountTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/pool/WalPendingRowCountTest.java
@@ -1,0 +1,209 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.pool;
+
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.wal.CheckWalTransactionsJob;
+import io.questdb.cairo.wal.WalUtils;
+import io.questdb.cairo.wal.WalWriter;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Test;
+
+/**
+ * wal_pending_row_count in tables() counts WAL rows committed but not yet applied, so it can
+ * never be negative.
+ * <p>
+ * It goes negative when an apply batch subtracts rows the counter never held. The counter is
+ * per-process and in-memory: rows committed before this process started counting a table are
+ * absent from it, and the table's pending-row floor marks where counting began. A single
+ * block-apply batch can span that floor - the common case is the first batch after a restart,
+ * which applies a pre-existing backlog together with freshly committed transactions - so the
+ * floor has to be applied per transaction, not to the batch as a whole.
+ */
+public class WalPendingRowCountTest extends AbstractCairoTest {
+
+    private static final long DAY = 86_400_000_000L;
+
+    @Test
+    public void testDedupUpsertRewriteDoesNotGoNegative() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, v INT) TIMESTAMP(ts) PARTITION BY DAY WAL DEDUP UPSERT KEYS(ts)");
+            engine.getRecentWriteTracker().clear();
+            TableToken tt = engine.verifyTableName("t");
+            for (int b = 0; b < 10; b++) {
+                writeRows(tt, DAY * (b + 1), 500);
+            }
+            drainWalQueue();
+            // rewrite the same partitions - every row is a duplicate
+            for (int b = 0; b < 10; b++) {
+                writeRows(tt, DAY * (b + 1), 500);
+            }
+            drainWalQueue();
+            assertPendingRows("t", 0);
+        });
+    }
+
+    @Test
+    public void testO3BackfillDoesNotGoNegative() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, v INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            engine.getRecentWriteTracker().clear();
+            TableToken tt = engine.verifyTableName("t");
+            writeRows(tt, DAY * 100, 100);
+            drainWalQueue();
+            // backfill many older partitions, all committed before a single drain so that the
+            // apply job block-applies them as one batch
+            for (int b = 0; b < 20; b++) {
+                writeRows(tt, DAY * (b + 1), 500);
+            }
+            drainWalQueue();
+            assertPendingRows("t", 0);
+        });
+    }
+
+    @Test
+    public void testPendingRowsCountedWhileWalIsOutstanding() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, v INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            engine.getRecentWriteTracker().clear();
+            TableToken tt = engine.verifyTableName("t");
+            for (int b = 0; b < 4; b++) {
+                writeRows(tt, DAY * (b + 1), 250);
+            }
+            // nothing applied yet - all 1000 rows are pending
+            assertPendingRows("t", 1000);
+            drainWalQueue();
+            assertPendingRows("t", 0);
+        });
+    }
+
+    @Test
+    public void testReplaceRangeRewriteDoesNotGoNegative() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, v INT) TIMESTAMP(ts) PARTITION BY DAY WAL DEDUP UPSERT KEYS(ts)");
+            engine.getRecentWriteTracker().clear();
+            TableToken tt = engine.verifyTableName("t");
+            for (int b = 0; b < 10; b++) {
+                writeRows(tt, DAY * (b + 1), 200);
+            }
+            drainWalQueue();
+            for (int b = 0; b < 10; b++) {
+                long lo = DAY * (b + 1);
+                try (WalWriter ww = engine.getWalWriter(tt)) {
+                    for (int i = 0; i < 50; i++) {
+                        TableWriter.Row row = ww.newRow(lo + i * 1_000_000L);
+                        row.putInt(1, i);
+                        row.append();
+                    }
+                    ww.commitWithParams(lo, lo + DAY, WalUtils.WAL_DEDUP_MODE_REPLACE_RANGE);
+                }
+            }
+            drainWalQueue();
+            assertPendingRows("t", 0);
+        });
+    }
+
+    /**
+     * The floor is seeded by whichever component sees the table first. Here the apply job and
+     * ingestion get there before CheckWalTransactionsJob's first sweep, which is what happens on
+     * a busy server: the sweep then finds the txn tracker already initialised and never sets the
+     * floor at all. The seed has to come from the write/apply path for the backlog to be
+     * protected.
+     */
+    @Test
+    public void testRestartWithBacklogApplyRacesCheckJob() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, v INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            TableToken tt = engine.verifyTableName("t");
+            for (int b = 0; b < 6; b++) {
+                writeRows(tt, DAY * (b + 1), 1000);
+            }
+
+            restart();
+
+            // ingestion resumes before the check job's first sweep
+            for (int b = 6; b < 10; b++) {
+                writeRows(tt, DAY * (b + 1), 1000);
+            }
+            drainWalQueue();
+            assertPendingRows("t", 0);
+        });
+    }
+
+    /**
+     * Same restart, but CheckWalTransactionsJob wins the race and does set the floor. The batch
+     * still spans it, so the floor has to be honoured per transaction.
+     */
+    @Test
+    public void testRestartWithBacklogCheckJobSetsFloor() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, v INT) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            TableToken tt = engine.verifyTableName("t");
+            for (int b = 0; b < 6; b++) {
+                writeRows(tt, DAY * (b + 1), 1000);
+            }
+
+            restart();
+            new CheckWalTransactionsJob(engine).run();
+
+            for (int b = 6; b < 10; b++) {
+                writeRows(tt, DAY * (b + 1), 1000);
+            }
+            // the 4000 post-restart rows are pending; the 6000-row backlog is below the floor
+            // and was never counted
+            assertPendingRows("t", 4000);
+            drainWalQueue();
+            assertPendingRows("t", 0);
+        });
+    }
+
+    private void assertPendingRows(String table, long expected) throws Exception {
+        assertQuery("SELECT wal_pending_row_count FROM tables() WHERE table_name = '" + table + "'")
+                .noLeakCheck()
+                .noRandomAccess()
+                .returns("wal_pending_row_count\n" + expected + "\n");
+    }
+
+    /**
+     * Drops all in-memory WAL tracking state, leaving the WAL backlog on disk, the way a server
+     * restart does.
+     */
+    private void restart() {
+        engine.getTableSequencerAPI().releaseAll();
+        engine.getRecentWriteTracker().clear();
+    }
+
+    private void writeRows(TableToken tt, long baseTs, int count) {
+        try (WalWriter ww = engine.getWalWriter(tt)) {
+            for (int i = 0; i < count; i++) {
+                TableWriter.Row row = ww.newRow(baseTs + i * 1_000_000L);
+                row.putInt(1, i);
+                row.append();
+            }
+            ww.commit();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`wal_pending_row_count` in `tables()` counts WAL rows committed but not yet applied, so it cannot be negative. It was observed at **-55163** during a large backfill that rewrote many partitions.

The counter (`RecentWriteTracker.walRowCount`) is per-process and in-memory: WAL commits add rows, WAL applies subtract them. Rows committed before this process started counting a table are absent from it, and the table's **pending-row floor** marks where counting began.

### 1. The floor was tested against the wrong seqTxn

```java
// RecentWriteTracker.recordWalProcessed
if (seqTxn > stats.getFloorSeqTxn()) {   // seqTxn = the batch's LAST txn
    stats.walRowCount.add(-walRowCount); // walRowCount = rows of the WHOLE batch
}
```

`ApplyWal2TableJob` block-applies a *range* `[seqTxn … appliedSeqTxn]` and sums rows across it. A batch that starts below the floor and ends above it passes this all-or-nothing guard, so the pre-floor rows — which were never added — are subtracted too. The first batch after a restart is exactly that shape: it applies the pre-existing backlog together with freshly committed transactions.

### 2. The floor was frequently never set

`setFloorSeqTxn` had a single caller, `CheckWalTransactionsJob`, on the branch that *initialises* the `SeqTxnTracker`. Once ingestion or the apply job initialised the tracker first (`isInitialised()` is `writerTxn != UNINITIALIZED`), the sweep took the `isTxnTrackerInitialised()` branch and the floor stayed `0`, making the guard a no-op and exposing the whole backlog to subtraction.

Both defects land the counter at minus the size of the table's un-applied WAL backlog.

## Evidence

Probes across backfill shapes — plain O3 backfill, dedup `UPSERT KEYS` rewrite, `REPLACE RANGE` rewrite — all settle at 0. Only restart-with-backlog breaks, and it breaks whichever way the startup race goes:

| scenario | floor | pending count |
|---|---|---|
| restart, apply job wins the race | 0 (never set) | **-6000** (= whole backlog) |
| restart, check job wins the race | 6 (set correctly) | **-6000** (batch spans the floor) |

The second row is the point: a correctly-set floor did not help, which is why the observed magnitude is the *entire* backlog rather than a partial.

## Fix

- Apply the floor **per transaction** in the `ApplyWal2TableJob` loop. That loop is the only place that knows how rows are distributed across a batch's seqTxns, so it is the only place the floor can be applied exactly.
- Seed the floor from **both** the commit and the apply path, so it no longer depends on who wins the startup race. A commit seeds `seqTxn - 1`; an apply seeds the batch's last seqTxn.
- Use `Long.MIN_VALUE` rather than `0` as the "unseeded" sentinel, since `0` is a legitimate floor.

Seeding errs high (over-reported backlog), never low. A commit publishes its seqTxn to the sequencer before it records the write, so an apply of that same txn can seed the floor first and leave the commit's rows counted but never subtracted. That is bounded to txns in flight when a table is first seen, and an over-reported backlog is a cosmetic stat where an under-reported one goes negative.

## Testing

New `WalPendingRowCountTest` covers the two restart orderings plus O3 backfill, dedup rewrite, `REPLACE RANGE` rewrite, and pending rows counted while WAL is outstanding.

- New test: 6/6 pass.
- **Negative control** — same tests with only the two production files reverted to `master`: **2 fail**, both restart cases. Confirms the tests bind to the defect.
- `RecentWriteTrackerTest`, `RecentWriteTrackerIntegrationTest`, `TablesFunctionFactoryTest`, `WalWriterTest`, `WalTableSqlTest`, `WalTableFailureTest`: 269 pass.
- Full `io.questdb.test.cairo.wal.**`: 652 run, 0 failures. (4 errors in `SeqTxnMetricsTest` are a local port `:9003` bind collision, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
