### PR TITLE
fix(sql): fix phantom SAMPLE BY bucket when FILL crosses a DST fall-back

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractNoRecordSampleByCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/AbstractNoRecordSampleByCursor.java
@@ -167,7 +167,10 @@ public abstract class AbstractNoRecordSampleByCursor extends AbstractSampleByCur
     private void kludge(long newTzOffset) {
         // time moved forward, we need to make sure we move our sample boundary
         sampleLocalEpoch += (newTzOffset - tzOffset);
-        nextSampleLocalEpoch = sampleLocalEpoch;
+        // `nextSampleLocalEpoch` drives the fill grid, so it has to stay on the sampler's
+        // calendar boundaries. Shifting it by the offset delta as well takes it off the grid,
+        // and `filling` implementations then compute `nextTimestamp(nextSampleLocalEpoch)` one
+        // offset delta short of the next real boundary and report a gap that does not exist.
         tzOffset = newTzOffset;
     }
 

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -5340,6 +5340,53 @@ public class SampleByTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSampleByDayFillNullAlignToCalendarDSTNYFallBack() throws Exception {
+        // America/New_York: UTC-4 (EDT) -> UTC-5 (EST)
+        // Fall back: Nov 3, 2013 at 2:00 EDT -> 1:00 EST (= Nov 3 06:00 UTC)
+        //
+        // The local Nov 3 day is 25 hours long, so its bucket holds 25 hourly rows and the
+        // day boundary moves from 04:00Z to 05:00Z. FILL must reuse the same calendar-aware
+        // bucket progression: the data is gapless, so no bucket may be filled in.
+        assertMemoryLeak(() -> assertQuery("SELECT ts, count() FROM (" +
+                "SELECT timestamp_sequence('2013-11-01T04:00:00.000000Z', 3_600_000_000L) ts " +
+                "FROM long_sequence(120)) timestamp(ts) " +
+                "SAMPLE BY 1d FILL(NULL) ALIGN TO CALENDAR TIME ZONE 'America/New_York';")
+                .timestamp("ts")
+                .noRandomAccess()
+                .noLeakCheck()
+                .returns("""
+                        ts\tcount
+                        2013-11-01T04:00:00.000000Z\t24
+                        2013-11-02T04:00:00.000000Z\t24
+                        2013-11-03T04:00:00.000000Z\t25
+                        2013-11-04T05:00:00.000000Z\t24
+                        2013-11-05T05:00:00.000000Z\t23
+                        """));
+    }
+
+    @Test
+    public void testSampleByDayFillPrevAlignToCalendarDSTNYFallBack() throws Exception {
+        // Same setup as testSampleByDayFillNullAlignToCalendarDSTNYFallBack.
+        // FILL(PREV) used to emit a phantom bucket at 2013-11-04T04:00:00Z, one hour before the
+        // genuine next boundary, carrying a copy of the previous bucket's value.
+        assertMemoryLeak(() -> assertQuery("SELECT ts, count() FROM (" +
+                "SELECT timestamp_sequence('2013-11-01T04:00:00.000000Z', 3_600_000_000L) ts " +
+                "FROM long_sequence(120)) timestamp(ts) " +
+                "SAMPLE BY 1d FILL(PREV) ALIGN TO CALENDAR TIME ZONE 'America/New_York';")
+                .timestamp("ts")
+                .noRandomAccess()
+                .noLeakCheck()
+                .returns("""
+                        ts\tcount
+                        2013-11-01T04:00:00.000000Z\t24
+                        2013-11-02T04:00:00.000000Z\t24
+                        2013-11-03T04:00:00.000000Z\t25
+                        2013-11-04T05:00:00.000000Z\t24
+                        2013-11-05T05:00:00.000000Z\t23
+                        """));
+    }
+
+    @Test
     public void testSampleByDayFromAlignToCalendarDSTBerlinFallBack() throws Exception {
         // Europe/Berlin: UTC+2 (CEST) -> UTC+1 (CET)
         // Fall back: Oct 31, 2021 at 3:00 CEST -> 2:00 CET (= Oct 31 01:00 UTC)

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/SampleByTest.java
@@ -5341,6 +5341,53 @@ public class SampleByTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testSampleByDayFillNullAlignToCalendarDSTNYFallBack() throws Exception {
+        // America/New_York: UTC-4 (EDT) -> UTC-5 (EST)
+        // Fall back: Nov 3, 2013 at 2:00 EDT -> 1:00 EST (= Nov 3 06:00 UTC)
+        //
+        // The local Nov 3 day is 25 hours long, so its bucket holds 25 hourly rows and the
+        // day boundary moves from 04:00Z to 05:00Z. FILL must reuse the same calendar-aware
+        // bucket progression: the data is gapless, so no bucket may be filled in.
+        assertMemoryLeak(() -> assertQuery("SELECT ts, count() FROM (" +
+                "SELECT timestamp_sequence('2013-11-01T04:00:00.000000Z', 3_600_000_000L) ts " +
+                "FROM long_sequence(120)) timestamp(ts) " +
+                "SAMPLE BY 1d FILL(NULL) ALIGN TO CALENDAR TIME ZONE 'America/New_York';")
+                .timestamp("ts")
+                .noRandomAccess()
+                .noLeakCheck()
+                .returns("""
+                        ts\tcount
+                        2013-11-01T04:00:00.000000Z\t24
+                        2013-11-02T04:00:00.000000Z\t24
+                        2013-11-03T04:00:00.000000Z\t25
+                        2013-11-04T05:00:00.000000Z\t24
+                        2013-11-05T05:00:00.000000Z\t23
+                        """));
+    }
+
+    @Test
+    public void testSampleByDayFillPrevAlignToCalendarDSTNYFallBack() throws Exception {
+        // Same setup as testSampleByDayFillNullAlignToCalendarDSTNYFallBack.
+        // FILL(PREV) used to emit a phantom bucket at 2013-11-04T04:00:00Z, one hour before the
+        // genuine next boundary, carrying a copy of the previous bucket's value.
+        assertMemoryLeak(() -> assertQuery("SELECT ts, count() FROM (" +
+                "SELECT timestamp_sequence('2013-11-01T04:00:00.000000Z', 3_600_000_000L) ts " +
+                "FROM long_sequence(120)) timestamp(ts) " +
+                "SAMPLE BY 1d FILL(PREV) ALIGN TO CALENDAR TIME ZONE 'America/New_York';")
+                .timestamp("ts")
+                .noRandomAccess()
+                .noLeakCheck()
+                .returns("""
+                        ts\tcount
+                        2013-11-01T04:00:00.000000Z\t24
+                        2013-11-02T04:00:00.000000Z\t24
+                        2013-11-03T04:00:00.000000Z\t25
+                        2013-11-04T05:00:00.000000Z\t24
+                        2013-11-05T05:00:00.000000Z\t23
+                        """));
+    }
+
+    @Test
     public void testSampleByDayFromAlignToCalendarDSTBerlinFallBack() throws Exception {
         // Europe/Berlin: UTC+2 (CEST) -> UTC+1 (CET)
         // Fall back: Oct 31, 2021 at 3:00 CEST -> 2:00 CET (= Oct 31 01:00 UTC)


### PR DESCRIPTION
Fixes #7439

## What

A `SAMPLE BY 1d` query with `ALIGN TO CALENDAR TIME ZONE` and any `FILL` strategy emitted one
extra bucket on the local day following a DST fall-back. The same query without `FILL` was
correct, so the extra bucket came from the fill logic, not from the data.

Reproduction (`America/New_York`, fall back on 2013-11-03):

```sql
SELECT ts, count() FROM (
  SELECT timestamp_sequence('2013-11-01T04:00:00.000000Z', 3600*1000000L) ts
  FROM long_sequence(120)
) timestamp(ts)
SAMPLE BY 1d FILL(PREV) ALIGN TO CALENDAR TIME ZONE 'America/New_York';
```

Before, with `FILL(PREV)`:

```
2013-11-03T04:00:00.000000Z  25
2013-11-04T04:00:00.000000Z  25   <- phantom, value copied from the previous bucket
2013-11-04T05:00:00.000000Z  24
```

`FILL(NULL)` produced a null bucket at the same timestamp and then labelled the following real
bucket `2013-11-05T04:00:00.000000Z`.

## Why

`AbstractNoRecordSampleByCursor.kludge()` shifted both `sampleLocalEpoch` and
`nextSampleLocalEpoch` by the UTC offset delta. `sampleLocalEpoch` needs that shift so the
emitted UTC timestamp of the bucket in flight stays put. `nextSampleLocalEpoch` drives the fill
grid, so it has to stay on the sampler's calendar boundaries. Once it is one hour off the grid,
each filling cursor computes `timestampSampler.nextTimestamp(nextSampleLocalEpoch)` one offset
delta short of the genuine next boundary, finds `expectedLocalEpoch < localEpoch`, and fills a
gap that does not exist.

The fix leaves `nextSampleLocalEpoch` alone in `kludge()`. That is the same invariant the
clock-moves-back branch of `adjustDst()` already maintains: it rounds `nextSampleLocalEpoch` to
the bucket boundary and lets `sampleLocalEpoch` absorb the shift.

## Scope and remaining limitation

Only the non-parallel sample-by cursors are affected. A table-backed query that plans as
`Sample By Fill` over `timestamp_floor_utc` was already correct; the reproduction above uses a
generated source, which plans onto the cursor path this commit changes.

One pre-existing wart is not addressed here: when a filled bucket sits before the transition but
the offset has already advanced, its emitted boundary carries the post-transition offset (for
data every other local day, the Nov 3 bucket is reported at `05:00Z` with `FILL(NULL)` and at
`04:00Z` without it). That behaviour is identical before and after this commit, so it is left for
a separate change.

## Test plan

- Added `SampleByTest#testSampleByDayFillPrevAlignToCalendarDSTNYFallBack` and
  `SampleByTest#testSampleByDayFillNullAlignToCalendarDSTNYFallBack`. Both fail on master with
  the output shown above and pass with this change.
- `mvn -pl core -Dtest='io.questdb.test.griffin.engine.groupby.**' test` - 1287 tests, 0 failures.
- `mvn -pl core -Dtest='SampleBySortStrategyTest,ParallelGroupByFuzzTest' test` - 203 tests, 0 failures.
- Checked the spring-forward direction (`2013-03-10`, `America/New_York`) and a sparse dataset
  with genuinely empty local days across the fall-back: output is unchanged from master in both.
- JDK 26, macOS arm64. JIT-specific suites are skipped on this platform.