### PR TITLE
chore(build): make the fix-pr skill run only when explicitly invoked

### DIFF
--- a/.claude/skills/fix-pr/SKILL.md
+++ b/.claude/skills/fix-pr/SKILL.md
@@ -2,6 +2,7 @@
 name: fix-pr
 description: Validate and fix pasted QuestDB pull-request review findings one at a time, with claim verification, a failing regression test where feasible, robust and performant implementation, testing, and an independent review/fix loop. Use when the user pastes Critical, Moderate, or other actionable PR review items.
 argument-hint: "[--max-review-rounds=N] <pasted review findings>"
+disable-model-invocation: true
 allowed-tools: Bash, Read, Edit, Write, Grep, Glob, Agent, AskUserQuestion
 ---
 


### PR DESCRIPTION
Adds `disable-model-invocation: true` to the fix-pr skill's frontmatter.

## Problem

The skill's description tells the model to invoke it whenever the user pastes Critical/Moderate PR review findings. The model followed that instruction even when the user pasted findings only to discuss them, and launched the full validate-and-fix workflow uninvited.

## Change

`disable-model-invocation: true` removes fix-pr from the model's auto-invoke list; a typed `/fix-pr` keeps working unchanged. As a side effect, the skill's description no longer loads into model context in sessions that never use it.

Tradeoff: the model stops offering the workflow proactively even in cases where auto-invocation would have been the right call; the user must remember to type `/fix-pr`.

## Out of scope

`fix-ci` and `review-pr` stay model-invocable: they intervene less aggressively, so this PR leaves them unchanged. If they develop the same problem, the same one-line flag can move them too.


🤖 Generated with [Claude Code](https://claude.com/claude-code)