### PR TITLE
fix(sql): properly unquote dotted column aliases

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -5519,13 +5519,15 @@ public class SqlParser {
                         assertNameIsQuotedOrNotAKeyword(tok, lexer.lastTokenPosition());
                         CharSequence aliasTok = GenericLexer.immutableOf(tok);
                         validateIdentifier(lexer, aliasTok);
-                        boolean unquoting = Chars.indexOf(aliasTok, '.') == -1;
-                        alias = unquoting ? unquote(aliasTok) : aliasTok;
+                        // Always unquote a quoted alias. A dot inside the alias is content
+                        // (e.g. AS '10.0.0 QuestDB'), not a table.column separator, so it must
+                        // not suppress the unquoting the way unquoteIfNoDots() would.
+                        alias = unquote(aliasTok);
                     } else {
                         validateIdentifier(lexer, tok);
                         assertNameIsQuotedOrNotAKeyword(tok, lexer.lastTokenPosition());
-                        boolean unquoting = Chars.indexOf(tok, '.') == -1;
-                        alias = GenericLexer.immutableOf(unquoting ? unquote(tok) : tok);
+                        // Same as above: strip quotes from a quoted alias even when it holds dots.
+                        alias = GenericLexer.immutableOf(unquote(tok));
                     }
                     aliasPosition = lexer.lastTokenPosition();
 


### PR DESCRIPTION
## Description

A single-quoted column alias that contains a `.` gets truncated: everything up to and including the last dot is stripped, and the closing quote is left behind in the column name.

### Reproduce

```sql
SELECT sum(downloads) AS '10.0.0 QuestDB' FROM t;
```

**Expected column name:** `10.0.0 QuestDB`
**Actual column name:** `0 QuestDB'`

### Root cause

`SqlParser.java` uses `unquoteIfNoDots()` semantics for column aliases — it checks `Chars.indexOf(aliasTok, '.') == -1` and only strips quotes when the alias contains no dots. When a quoted alias contains a dot (e.g. `'10.0.0 QuestDB'`), the code treats the dot as a `table.column` separator and keeps the surrounding quotes, producing the truncated output.

### Fix

Replace the manual `unquoteIfNoDots` logic with `GenericLexer.unquote()` which always strips quotes from a quoted alias regardless of dot content. A dot inside a quoted alias is content, not a separator.

Closes #7478
