### PR TITLE
fix(jit): restrict immediate-zero TEST shortcut to integer types

### DIFF
--- a/core/src/main/c/share/jit/aarch64.h
+++ b/core/src/main/c/share/jit/aarch64.h
@@ -962,11 +962,16 @@ namespace questdb::aarch64 {
                dt == data_type_t::f32 || dt == data_type_t::f64;
     }
 
+    inline bool is_integer(data_type_t dt) {
+        return dt == data_type_t::i8 || dt == data_type_t::i16 ||
+               dt == data_type_t::i32 || dt == data_type_t::i64;
+    }
+
     inline bool is_imm_int_zero(const jit_value_t &v) {
         if (!v.op().is_imm()) {
             return false;
         }
-        if (!is_number(v.dtype())) {
+        if (!is_integer(v.dtype())) {
             return false;
         }
         return v.op().as<Imm>().value_as<int64_t>() == 0;

--- a/core/src/main/c/share/jit/x86.h
+++ b/core/src/main/c/share/jit/x86.h
@@ -944,11 +944,16 @@ namespace questdb::x86 {
                dt == data_type_t::f32 || dt == data_type_t::f64;
     }
 
+    inline bool is_integer(data_type_t dt) {
+        return dt == data_type_t::i8 || dt == data_type_t::i16 ||
+               dt == data_type_t::i32 || dt == data_type_t::i64;
+    }
+
     inline bool is_imm_int_zero(const jit_value_t &v) {
         if (!v.op().is_imm()) {
             return false;
         }
-        if (!is_number(v.dtype())) {
+        if (!is_integer(v.dtype())) {
             return false;
         }
         return v.op().as<Imm>().value_as<int64_t>() == 0;


### PR DESCRIPTION
Fixes #7455

## Problem

The x86 scalar emitter's `is_imm_int_zero()` accepts `f32` and `f64` values via the `is_number()` check. When the eight-entry constant cache is full, a later float zero comparison routes through `cmp_eq_zero()` or `cmp_ne_zero()`, which only support integer GP registers (`i8`/`i16`/`i32`/`i64`). This produces a register-class mismatch in the generated assembly (e.g., `test xmm2, xmm2`).

Same bug exists in `aarch64.h`.

## Fix

Added `is_integer()` helper and used it in `is_imm_int_zero()` instead of `is_number()`, so float/double zero comparisons fall through to the normal epsilon-comparison path.

## Verification

The reproduction case from the issue:
```sql
create table x (f float, d double, ts timestamp);
insert into x values (0.0, 0.0, 1), (1.0, 1.0, 2);
select ts from x where
    f + 1.0 = 1.0 and f + 2.0 = 2.0 and f + 3.0 = 3.0 and
    f + 4.0 = 4.0 and f + 5.0 = 5.0 and f + 6.0 = 6.0 and
    f + 7.0 = 7.0 and f + 8.0 = 8.0 and f = 0.0 and d = 0.0;
```

Expected: returns `ts = 1`. With JIT enabled, this now works correctly.