### PR TITLE
fix(qwp): reject oversized table counts

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpArrayColumnCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpArrayColumnCursor.java
@@ -25,6 +25,7 @@
 package io.questdb.cutlass.qwp.protocol;
 
 import io.questdb.std.Unsafe;
+import org.jetbrains.annotations.TestOnly;
 
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_DOUBLE_ARRAY;
 
@@ -117,6 +118,18 @@ public final class QwpArrayColumnCursor implements QwpColumnCursor {
         return currentNDims;
     }
 
+    @TestOnly
+    public long getRowCacheBytes() {
+        return (long) rowOffsets.length * Long.BYTES
+                + (long) rowDims.length * Integer.BYTES
+                + (long) rowElementCounts.length * Integer.BYTES;
+    }
+
+    @TestOnly
+    public int getRowCacheCapacity() {
+        return rowOffsets.length;
+    }
+
     /**
      * Returns the total number of elements in the current row's array.
      *
@@ -172,8 +185,8 @@ public final class QwpArrayColumnCursor implements QwpColumnCursor {
         this.typeCode = typeCode;
         this.isDoubleArray = (typeCode == TYPE_DOUBLE_ARRAY);
 
-        ensureRowCapacity(rowCount);
         int offset = 0;
+        boolean isRowCacheGrowthRequired = rowCount > rowOffsets.length;
 
         // Read null bitmap flag
         if (offset >= dataLength) {
@@ -182,6 +195,7 @@ public final class QwpArrayColumnCursor implements QwpColumnCursor {
                     "array column data truncated: expected null bitmap flag"
             );
         }
+        int nullCount = 0;
         if (Unsafe.getByte(dataAddress + offset) != 0) {
             offset++;
             int bitmapSize = QwpNullBitmap.sizeInBytes(rowCount);
@@ -192,10 +206,28 @@ public final class QwpArrayColumnCursor implements QwpColumnCursor {
                 );
             }
             this.nullBitmapAddress = dataAddress + offset;
+            if (isRowCacheGrowthRequired) {
+                nullCount = QwpNullBitmap.countNulls(nullBitmapAddress, rowCount);
+            }
             offset += bitmapSize;
         } else {
             offset++;
             this.nullBitmapAddress = 0;
+        }
+
+        if (isRowCacheGrowthRequired) {
+            int nonNullCount = rowCount - nullCount;
+            long minimumRowDataBytes = (long) nonNullCount * 5;
+            if (dataLength - (long) offset < minimumRowDataBytes) {
+                throw QwpParseException.create(
+                        QwpParseException.ErrorCode.INSUFFICIENT_DATA,
+                        "array column data truncated: " + nonNullCount
+                                + " non-null rows require at least " + minimumRowDataBytes + " bytes"
+                );
+            }
+            if (nonNullCount > 0) {
+                ensureRowCapacity(rowCount);
+            }
         }
 
         this.dataAddress = dataAddress + offset;
@@ -205,9 +237,7 @@ public final class QwpArrayColumnCursor implements QwpColumnCursor {
         long scanAddr = this.dataAddress;
         for (int row = 0; row < rowCount; row++) {
             if (nullBitmapAddress != 0 && QwpNullBitmap.isNull(nullBitmapAddress, row)) {
-                rowOffsets[row] = -1; // Mark as null
-                rowDims[row] = 0;
-                rowElementCounts[row] = 0;
+                // Null rows do not read the row caches during iteration.
             } else {
                 rowOffsets[row] = scanAddr - this.dataAddress;
 
@@ -287,6 +317,15 @@ public final class QwpArrayColumnCursor implements QwpColumnCursor {
         currentNDims = 0;
         currentElementCount = 0;
         currentValuesAddress = 0;
+    }
+
+    void releaseCachedResources() {
+        clear();
+        if (rowOffsets.length > INITIAL_ROW_CAPACITY) {
+            rowOffsets = new long[INITIAL_ROW_CAPACITY];
+            rowDims = new int[INITIAL_ROW_CAPACITY];
+            rowElementCounts = new int[INITIAL_ROW_CAPACITY];
+        }
     }
 
     private void ensureRowCapacity(int required) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpMessageCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpMessageCursor.java
@@ -27,6 +27,7 @@ package io.questdb.cutlass.qwp.protocol;
 import io.questdb.std.Mutable;
 import io.questdb.std.ObjList;
 import io.questdb.std.str.Utf8s;
+import org.jetbrains.annotations.TestOnly;
 
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.DEFAULT_MAX_ROWS_PER_TABLE;
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.HEADER_SIZE;
@@ -96,6 +97,11 @@ public class QwpMessageCursor implements Mutable {
         releaseDictRollbackScratch();
     }
 
+    @TestOnly
+    public long getRetainedCacheBytes() {
+        return tableBlockCursor.getRetainedCacheBytes();
+    }
+
     /**
      * Returns whether there are more tables to iterate.
      */
@@ -140,9 +146,15 @@ public class QwpMessageCursor implements Mutable {
             );
         }
         int remainingBytes = (int) remaining;
-        int consumed = tableBlockCursor.of(
-                currentTableAddress, remainingBytes, gorillaEnabled,
-                connectionSymbolDict, deltaSymbolDictEnabled);
+        final int consumed;
+        try {
+            consumed = tableBlockCursor.of(
+                    currentTableAddress, remainingBytes, gorillaEnabled,
+                    connectionSymbolDict, deltaSymbolDictEnabled);
+        } catch (QwpParseException e) {
+            tableBlockCursor.releaseCachedResources();
+            throw e;
+        }
         currentTableAddress += consumed;
 
         return tableBlockCursor;
@@ -190,6 +202,11 @@ public class QwpMessageCursor implements Mutable {
         }
 
         this.currentTableIndex = -1;
+    }
+
+    public void releaseCachedResources() {
+        clear();
+        tableBlockCursor.releaseCachedResources();
     }
 
     /**

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpSymbolColumnCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpSymbolColumnCursor.java
@@ -31,6 +31,7 @@ import io.questdb.std.str.DirectUtf8Sequence;
 import io.questdb.std.str.DirectUtf8String;
 import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8s;
+import org.jetbrains.annotations.TestOnly;
 
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.MAX_SYMBOL_DICTIONARY_SIZE;
 import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_SYMBOL;
@@ -53,9 +54,10 @@ import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_SYMBOL;
  */
 public final class QwpSymbolColumnCursor implements QwpColumnCursor {
 
+    private static final int INITIAL_CACHE_CAPACITY = 16;
     private final QwpVarint.DecodeResult decodeResult = new QwpVarint.DecodeResult();
     // Pre-allocated dictionary storage (flyweights pointing to wire memory)
-    private final ObjList<DirectUtf8String> dictionaryUtf8 = new ObjList<>();
+    private ObjList<DirectUtf8String> dictionaryUtf8 = new ObjList<>();
     private final StringSink utf16Sink = new StringSink();
     // External dictionary reference (for delta mode)
     private ObjList<String> connectionDict;
@@ -65,7 +67,7 @@ public final class QwpSymbolColumnCursor implements QwpColumnCursor {
     private int currentSymbolIndex;
     private int currentValueIndex;
     // Pre-decoded varint indices (reused across calls, grows to max batch size)
-    private final IntList decodedIndices = new IntList();
+    private IntList decodedIndices = new IntList();
     private boolean deltaMode;  // When true, use connectionDict instead of per-column dictionary
     private int dictionarySize;
     // Wire pointers
@@ -105,6 +107,21 @@ public final class QwpSymbolColumnCursor implements QwpColumnCursor {
             dictionaryUtf8.getQuick(i).clear();
         }
         resetRowPosition();
+    }
+
+    @TestOnly
+    public int getDecodedIndexCacheCapacity() {
+        return decodedIndices.capacity();
+    }
+
+    @TestOnly
+    public Object getDictionaryCacheIdentity() {
+        return dictionaryUtf8;
+    }
+
+    @TestOnly
+    public int getDictionaryCacheSize() {
+        return dictionaryUtf8.size();
     }
 
     /**
@@ -235,6 +252,7 @@ public final class QwpSymbolColumnCursor implements QwpColumnCursor {
             this.nullBitmapAddress = 0;
             nullCount = 0;
         }
+        this.valueCount = rowCount - nullCount;
 
         if (deltaMode) {
             // Delta mode: no per-column dictionary, indices reference connection dictionary
@@ -263,6 +281,15 @@ public final class QwpSymbolColumnCursor implements QwpColumnCursor {
                         QwpParseException.ErrorCode.INSUFFICIENT_DATA,
                         "symbol dictionary size exceeds limit: " + dictionarySize
                                 + " (max " + MAX_SYMBOL_DICTIONARY_SIZE + ')'
+                );
+            }
+
+            long minimumEncodedBytes = (long) dictionarySize + valueCount;
+            if (minimumEncodedBytes > dataLength - (long) offset) {
+                throw QwpParseException.create(
+                        QwpParseException.ErrorCode.INSUFFICIENT_DATA,
+                        "symbol column data truncated: dictionary entries and indices require at least "
+                                + minimumEncodedBytes + " bytes"
                 );
             }
 
@@ -301,9 +328,15 @@ public final class QwpSymbolColumnCursor implements QwpColumnCursor {
             );
         }
 
+        if (valueCount > dataLength - (long) offset) {
+            throw QwpParseException.create(
+                    QwpParseException.ErrorCode.INSUFFICIENT_DATA,
+                    "symbol column data truncated: " + valueCount + " indices require at least " + valueCount + " bytes"
+            );
+        }
+
         // Decode all varint indices in one pass. This avoids re-decoding
         // during advanceRow() and lets us return the total bytes consumed.
-        this.valueCount = rowCount - nullCount;
         decodedIndices.clear();
         decodedIndices.setPos(valueCount);
         int dictLimit = deltaMode ? (connectionDict != null ? connectionDict.size() : 0) : dictionarySize;
@@ -337,6 +370,17 @@ public final class QwpSymbolColumnCursor implements QwpColumnCursor {
         currentSymbolIndex = -1;
         currentIsNull = false;
         currentValueIndex = -1;
+    }
+
+    void releaseCachedResources() {
+        if (decodedIndices.capacity() > INITIAL_CACHE_CAPACITY) {
+            decodedIndices = new IntList();
+        }
+        if (dictionaryUtf8.size() > INITIAL_CACHE_CAPACITY) {
+            dictionaryUtf8 = new ObjList<>();
+        }
+        clear();
+        decodedIndices.clear();
     }
 
     private void ensureDictionaryCapacity(int capacity) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpTableBlockCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpTableBlockCursor.java
@@ -386,6 +386,36 @@ public class QwpTableBlockCursor implements Mutable {
         }
     }
 
+    long getRetainedCacheBytes() {
+        long bytes = 0;
+        for (int i = 0, n = columnCursors.size(); i < n; i++) {
+            QwpColumnCursor cursor = columnCursors.getQuick(i);
+            if (cursor instanceof QwpArrayColumnCursor arrayCursor) {
+                bytes += arrayCursor.getRowCacheBytes();
+            } else if (cursor instanceof QwpSymbolColumnCursor symbolCursor) {
+                bytes += (long) symbolCursor.getDecodedIndexCacheCapacity() * Integer.BYTES;
+                bytes += (long) symbolCursor.getDictionaryCacheSize() * Long.BYTES;
+            } else if (cursor instanceof QwpTimestampColumnCursor timestampCursor) {
+                bytes += (long) timestampCursor.getGorillaCacheCapacity() * Long.BYTES;
+            }
+        }
+        return bytes;
+    }
+
+    void releaseCachedResources() {
+        clear();
+        for (int i = 0, n = columnCursors.size(); i < n; i++) {
+            QwpColumnCursor cursor = columnCursors.getQuick(i);
+            if (cursor instanceof QwpArrayColumnCursor arrayCursor) {
+                arrayCursor.releaseCachedResources();
+            } else if (cursor instanceof QwpSymbolColumnCursor symbolCursor) {
+                symbolCursor.releaseCachedResources();
+            } else if (cursor instanceof QwpTimestampColumnCursor timestampCursor) {
+                timestampCursor.releaseCachedResources();
+            }
+        }
+    }
+
     private void ensureColumnCursorCapacity(int capacity) {
         while (columnCursors.size() < capacity) {
             // Pre-allocate with null, will be replaced with correct type

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpTableHeader.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpTableHeader.java
@@ -149,13 +149,14 @@ public class QwpTableHeader {
             throw QwpParseException.headerTooShort();
         }
         QwpVarint.decode(address + offset, limit, decodeResult);
-        this.rowCount = decodeResult.value;
-        if (rowCount > maxRowCount) {
+        long decodedRowCount = decodeResult.value;
+        if (decodedRowCount < 0 || decodedRowCount > maxRowCount) {
             throw QwpParseException.create(
                     QwpParseException.ErrorCode.ROW_COUNT_EXCEEDED,
-                    "row count exceeds maximum: " + rowCount + " (max " + maxRowCount + ')'
+                    "row count exceeds maximum: " + Long.toUnsignedString(decodedRowCount) + " (max " + maxRowCount + ')'
             );
         }
+        this.rowCount = decodedRowCount;
         offset += decodeResult.bytesRead;
 
         // Parse column count
@@ -164,10 +165,10 @@ public class QwpTableHeader {
         }
         QwpVarint.decode(address + offset, limit, decodeResult);
         long colCount = decodeResult.value;
-        if (colCount > QwpConstants.MAX_COLUMNS_PER_TABLE) {
+        if (colCount < 0 || colCount > QwpConstants.MAX_COLUMNS_PER_TABLE) {
             throw QwpParseException.create(
                     QwpParseException.ErrorCode.COLUMN_COUNT_EXCEEDED,
-                    "column count exceeds maximum: " + colCount + " (max " + QwpConstants.MAX_COLUMNS_PER_TABLE + ")"
+                    "column count exceeds maximum: " + Long.toUnsignedString(colCount) + " (max " + QwpConstants.MAX_COLUMNS_PER_TABLE + ")"
             );
         }
         this.columnCount = (int) colCount;

--- a/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpTimestampColumnCursor.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/protocol/QwpTimestampColumnCursor.java
@@ -25,6 +25,7 @@
 package io.questdb.cutlass.qwp.protocol;
 
 import io.questdb.std.Unsafe;
+import org.jetbrains.annotations.TestOnly;
 
 /**
  * Streaming cursor for TIMESTAMP and TIMESTAMP_NANOS columns.
@@ -100,6 +101,11 @@ public final class QwpTimestampColumnCursor implements QwpColumnCursor {
         secondTimestamp = 0;
         valueCount = 0;
         resetRowPosition();
+    }
+
+    @TestOnly
+    public int getGorillaCacheCapacity() {
+        return gorillaDecodedValues.length;
     }
 
     /**
@@ -262,6 +268,14 @@ public final class QwpTimestampColumnCursor implements QwpColumnCursor {
                         // maximum so that corrupted Gorilla data cannot read
                         // arbitrarily far into subsequent columns' data.
                         int remainingValues = valueCount - 2;
+                        long minimumGorillaBytes = (remainingValues + 7L) >>> 3;
+                        if (remainingBytes < minimumGorillaBytes) {
+                            throw QwpParseException.create(
+                                    QwpParseException.ErrorCode.INSUFFICIENT_DATA,
+                                    "timestamp column data truncated: " + remainingValues
+                                            + " Gorilla values require at least " + minimumGorillaBytes + " bytes"
+                            );
+                        }
                         int maxGorillaBytes = (int) ((remainingValues * 36L + 7) / 8);
                         int gorillaDataLength = Math.min(remainingBytes, maxGorillaBytes);
 
@@ -312,6 +326,13 @@ public final class QwpTimestampColumnCursor implements QwpColumnCursor {
      */
     public boolean supportsDirectAccess() {
         return !gorillaEnabled;
+    }
+
+    void releaseCachedResources() {
+        clear();
+        if (gorillaDecodedValues.length > INITIAL_GORILLA_CAPACITY) {
+            gorillaDecodedValues = new long[INITIAL_GORILLA_CAPACITY];
+        }
     }
 
     private int getOffset(long dataAddress, int dataLength, int offset) throws QwpParseException {

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpIngressProcessorState.java
@@ -50,6 +50,7 @@ import io.questdb.std.QuietCloseable;
 import io.questdb.std.Unsafe;
 import io.questdb.std.str.StringSink;
 import io.questdb.std.str.Utf8s;
+import org.jetbrains.annotations.TestOnly;
 
 /**
  * State management for QWP v1 processing.
@@ -490,6 +491,11 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
 
     public Status getStatus() {
         return currentStatus;
+    }
+
+    @TestOnly
+    public QwpStreamingDecoder getStreamingDecoder() {
+        return streamingDecoder;
     }
 
     /**
@@ -1192,6 +1198,9 @@ public class QwpIngressProcessorState implements QuietCloseable, ConnectionAware
             }
 
         } catch (QwpParseException e) {
+            if (e.getErrorCode() != QwpParseException.ErrorCode.DELTA_DICT_GAP) {
+                streamingDecoder.releaseCachedResources();
+            }
             LOG.error().$('[').$(fd).$("] QWP v1 parse error: ").$(e.getFlyweightMessage()).$();
             reject(statusForParseError(e.getErrorCode()), e.getFlyweightMessage(), fd);
         } catch (CommitFailedException e) {

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/QwpStreamingDecoder.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/QwpStreamingDecoder.java
@@ -139,4 +139,8 @@ public class QwpStreamingDecoder implements QuietCloseable {
     public void reset() {
         messageCursor.clear();
     }
+
+    void releaseCachedResources() {
+        messageCursor.releaseCachedResources();
+    }
 }

--- a/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressRequestDecoder.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/server/egress/QwpEgressRequestDecoder.java
@@ -179,7 +179,10 @@ public class QwpEgressRequestDecoder {
             throw QwpParseException.instance(QwpParseException.ErrorCode.INSUFFICIENT_DATA).put("QUERY_REQUEST: sql_len out of range: ").put(sqlLen);
         }
         sql.clear();
-        Utf8s.utf8ToUtf16(p, p + sqlLen, sql);
+        if (!Utf8s.utf8ToUtf16(p, p + sqlLen, sql)) {
+            throw QwpParseException.instance(QwpParseException.ErrorCode.INSUFFICIENT_DATA)
+                    .put("QUERY_REQUEST: SQL contains invalid UTF-8");
+        }
         p += sqlLen;
 
         QwpVarint.decode(p, limit, varintScratch);
@@ -373,7 +376,10 @@ public class QwpEgressRequestDecoder {
                     // Reuse stringBindScratch -- StrBindVariable.setValue copies the CharSequence
                     // into its own utf16Sink, so the scratch can be freely reused for the next bind.
                     stringBindScratch.clear();
-                    Utf8s.utf8ToUtf16(p, p + strLen, stringBindScratch);
+                    if (!Utf8s.utf8ToUtf16(p, p + strLen, stringBindScratch)) {
+                        throw QwpParseException.instance(QwpParseException.ErrorCode.INSUFFICIENT_DATA)
+                                .put("bind ").put(index).put(": SYMBOL contains invalid UTF-8");
+                    }
                     bindVars.setStr(index, stringBindScratch);
                     p += strLen;
                 }

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpCursorBoundsCheckTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpCursorBoundsCheckTest.java
@@ -296,6 +296,36 @@ public class QwpCursorBoundsCheckTest {
     }
 
     @Test
+    public void testMessageCursorRejectsRowCountWithSignBitSet() throws Exception {
+        assertMemoryLeak(() -> {
+            byte[] message = new byte[]{
+                    'Q', 'W', 'P', '1', 1, 0, 1, 0, 21, 0, 0, 0,
+                    5, 'c', 'r', 'a', 's', 'h',
+                    (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x88,
+                    (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, 0x01,
+                    1, 1, 's', TYPE_VARCHAR, 0
+            };
+            Assert.assertEquals(33, message.length);
+
+            long address = Unsafe.malloc(message.length, MemoryTag.NATIVE_DEFAULT);
+            try {
+                copyToNative(message, address);
+                QwpMessageCursor cursor = new QwpMessageCursor();
+                cursor.of(address, message.length, null);
+
+                try {
+                    cursor.nextTable();
+                    Assert.fail("expected QwpParseException for unsigned rowCount exceeding max");
+                } catch (QwpParseException e) {
+                    Assert.assertEquals(QwpParseException.ErrorCode.ROW_COUNT_EXCEEDED, e.getErrorCode());
+                }
+            } finally {
+                Unsafe.free(address, message.length, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
     public void testMessageCursorRejectsPayloadLongerThanMessageLength() throws Exception {
         assertMemoryLeak(() -> {
             int messageLength = HEADER_SIZE;

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressRequestDecoderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressRequestDecoderTest.java
@@ -796,6 +796,59 @@ public class QwpEgressRequestDecoderTest {
         });
     }
 
+    @Test
+    public void testRejectsMalformedSqlUtf8() throws Exception {
+        runWithBuf(64, (buf, bindVars, decoder) -> {
+            byte[] malformedSql = {'S', 'E', 'L', 'E', 'C', 'T', ' ', '1', (byte) 0xC3};
+            int len = writeQueryRequest(buf, 1L, malformedSql, 0L, 0);
+            try {
+                decoder.decodeQueryRequest(buf, len, bindVars);
+                Assert.fail("malformed SQL UTF-8 accepted as [" + decoder.sql + "]");
+            } catch (QwpParseException expected) {
+                Assert.assertTrue(expected.getFlyweightMessage().toString().contains("SQL"));
+            }
+
+            len = writeBindScaffold(buf, 0);
+            decoder.decodeQueryRequest(buf, len, bindVars);
+            Assert.assertEquals("SELECT 1", decoder.sql.toString());
+        });
+    }
+
+    @Test
+    public void testRejectsMalformedSymbolUtf8() throws Exception {
+        runWithBuf(64, (buf, bindVars, decoder) -> {
+            int len = writeBindScaffold(buf, 1);
+            long p = buf + len;
+            p = writeNonNullBind(p, QwpConstants.TYPE_SYMBOL);
+            Unsafe.putInt(p, 0);
+            p += 4;
+            Unsafe.putInt(p, 4);
+            p += 4;
+            Unsafe.putByte(p++, (byte) 'a');
+            Unsafe.putByte(p++, (byte) 'b');
+            Unsafe.putByte(p++, (byte) 'c');
+            Unsafe.putByte(p++, (byte) 0xC3);
+            try {
+                decoder.decodeQueryRequest(buf, (int) (p - buf), bindVars);
+                Assert.fail("malformed SYMBOL UTF-8 accepted as [" + bindVars.getFunction(0).getStrA(null) + "]");
+            } catch (QwpParseException expected) {
+                Assert.assertTrue(expected.getFlyweightMessage().toString().contains("SYMBOL"));
+            }
+
+            len = writeBindScaffold(buf, 1);
+            p = buf + len;
+            p = writeNonNullBind(p, QwpConstants.TYPE_SYMBOL);
+            Unsafe.putInt(p, 0);
+            p += 4;
+            Unsafe.putInt(p, 2);
+            p += 4;
+            Unsafe.putByte(p++, (byte) 'o');
+            Unsafe.putByte(p++, (byte) 'k');
+            decoder.decodeQueryRequest(buf, (int) (p - buf), bindVars);
+            Assert.assertEquals("ok", bindVars.getFunction(0).getStrA(null).toString());
+        });
+    }
+
     /**
      * Regression: initial_credit must be rejected if negative. A varint with the sign
      * bit set would otherwise propagate to flow-control accounting.

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressCacheRetentionTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpIngressCacheRetentionTest.java
@@ -1,0 +1,147 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.qwp;
+
+import io.questdb.cairo.security.AllowAllSecurityContext;
+import io.questdb.client.cutlass.qwp.client.GlobalSymbolDictionary;
+import io.questdb.client.cutlass.qwp.client.QwpWebSocketEncoder;
+import io.questdb.client.cutlass.qwp.protocol.QwpTableBuffer;
+import io.questdb.cutlass.http.DefaultHttpServerConfiguration;
+import io.questdb.cutlass.http.processors.LineHttpProcessorConfiguration;
+import io.questdb.cutlass.qwp.protocol.QwpMessageCursor;
+import io.questdb.cutlass.qwp.server.QwpIngressProcessorState;
+import io.questdb.cutlass.qwp.server.QwpStreamingDecoder;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.Unsafe;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static io.questdb.client.cutlass.qwp.protocol.QwpConstants.TYPE_DOUBLE_ARRAY;
+
+public class QwpIngressCacheRetentionTest extends AbstractCairoTest {
+
+    private static final long ARRAY_CACHE_BASELINE_BYTES = 64L * (Long.BYTES + 2L * Integer.BYTES);
+
+    @Test
+    public void testDictionaryGapRetainsInflatedDecoderCache() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+                QwpMessageCursor message = inflateArrayCache(state.getStreamingDecoder());
+                long retainedCacheBytes = message.getRetainedCacheBytes();
+                Assert.assertTrue(retainedCacheBytes > ARRAY_CACHE_BASELINE_BYTES);
+
+                try (QwpWebSocketEncoder encoder = new QwpWebSocketEncoder()) {
+                    encoder.beginMessage(0, new GlobalSymbolDictionary(), 1, 1);
+                    int size = encoder.finishMessage();
+                    long address = encoder.getBuffer().getBufferPtr();
+                    state.addData(address, address + size);
+                }
+                state.processMessage();
+
+                Assert.assertEquals(QwpIngressProcessorState.Status.DICTIONARY_GAP, state.getStatus());
+                Assert.assertEquals(retainedCacheBytes, message.getRetainedCacheBytes());
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    @Test
+    public void testDisconnectRetainsInflatedDecoderCache() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+                QwpStreamingDecoder decoder = state.getStreamingDecoder();
+                QwpMessageCursor message = inflateArrayCache(decoder);
+                long retainedCacheBytes = message.getRetainedCacheBytes();
+                Assert.assertTrue(retainedCacheBytes > ARRAY_CACHE_BASELINE_BYTES);
+
+                state.onDisconnected();
+
+                Assert.assertEquals(retainedCacheBytes, message.getRetainedCacheBytes());
+                state.of(2, AllowAllSecurityContext.INSTANCE);
+                Assert.assertSame(decoder, state.getStreamingDecoder());
+                Assert.assertSame(message, inflateArrayCache(state.getStreamingDecoder()));
+                Assert.assertEquals(retainedCacheBytes, message.getRetainedCacheBytes());
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    @Test
+    public void testParseFailureReleasesInflatedDecoderCaches() throws Exception {
+        assertMemoryLeak(() -> {
+            LineHttpProcessorConfiguration lineConfig =
+                    new DefaultHttpServerConfiguration.DefaultLineHttpProcessorConfiguration(configuration);
+            QwpIngressProcessorState state = new QwpIngressProcessorState(1024, 4096, engine, lineConfig);
+            try {
+                state.of(1, AllowAllSecurityContext.INSTANCE);
+                QwpMessageCursor message = inflateArrayCache(state.getStreamingDecoder());
+                Assert.assertTrue(message.getRetainedCacheBytes() > ARRAY_CACHE_BASELINE_BYTES);
+
+                long malformedMessage = Unsafe.malloc(1, MemoryTag.NATIVE_DEFAULT);
+                try {
+                    Unsafe.putByte(malformedMessage, (byte) 0);
+                    state.addData(malformedMessage, malformedMessage + 1);
+                } finally {
+                    Unsafe.free(malformedMessage, 1, MemoryTag.NATIVE_DEFAULT);
+                }
+                state.processMessage();
+
+                Assert.assertEquals(QwpIngressProcessorState.Status.PARSE_ERROR, state.getStatus());
+                Assert.assertEquals(ARRAY_CACHE_BASELINE_BYTES, message.getRetainedCacheBytes());
+            } finally {
+                state.onDisconnected();
+                state.close();
+            }
+        });
+    }
+
+    private static QwpMessageCursor inflateArrayCache(QwpStreamingDecoder decoder) throws Exception {
+        try (QwpTableBuffer buffer = new QwpTableBuffer("cache_release");
+             QwpWebSocketEncoder encoder = new QwpWebSocketEncoder()) {
+            QwpTableBuffer.ColumnBuffer column = buffer.getOrCreateColumn("a", TYPE_DOUBLE_ARRAY, true);
+            for (int i = 0; i < 65; i++) {
+                column.addDoubleArray(new double[]{i});
+                buffer.nextRow();
+            }
+            int size = encoder.encode(buffer);
+            QwpMessageCursor message = decoder.decode(encoder.getBuffer().getBufferPtr(), size);
+            message.nextTable();
+            return message;
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpParserCacheRetentionTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpParserCacheRetentionTest.java
@@ -1,0 +1,516 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.qwp;
+
+import io.questdb.client.cutlass.qwp.client.QwpWebSocketEncoder;
+import io.questdb.client.cutlass.qwp.protocol.QwpTableBuffer;
+import io.questdb.cutlass.qwp.protocol.QwpArrayColumnCursor;
+import io.questdb.cutlass.qwp.protocol.QwpConstants;
+import io.questdb.cutlass.qwp.protocol.QwpMessageCursor;
+import io.questdb.cutlass.qwp.protocol.QwpNullBitmap;
+import io.questdb.cutlass.qwp.protocol.QwpParseException;
+import io.questdb.cutlass.qwp.protocol.QwpSymbolColumnCursor;
+import io.questdb.cutlass.qwp.protocol.QwpTableBlockCursor;
+import io.questdb.cutlass.qwp.protocol.QwpTimestampColumnCursor;
+import io.questdb.cutlass.qwp.protocol.QwpVarint;
+import io.questdb.cutlass.qwp.server.QwpStreamingDecoder;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.ObjList;
+import io.questdb.std.Unsafe;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_DOUBLE_ARRAY;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_SYMBOL;
+import static io.questdb.cutlass.qwp.protocol.QwpConstants.TYPE_TIMESTAMP;
+
+public class QwpParserCacheRetentionTest {
+
+    private static final long ARRAY_CACHE_BASELINE_BYTES = 64L * (Long.BYTES + 2L * Integer.BYTES);
+    private static final long GORILLA_CACHE_BASELINE_BYTES = 1024L * Long.BYTES;
+    private static final long SYMBOL_INDEX_CACHE_BASELINE_BYTES = 16L * Integer.BYTES;
+
+    @Test
+    public void testAllNullArrayDoesNotGrowRowCaches() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            final int rowCount = 1_000_000;
+            final int dataLength = 1 + QwpNullBitmap.sizeInBytes(rowCount);
+            long address = Unsafe.malloc(dataLength, MemoryTag.NATIVE_DEFAULT);
+            try {
+                Unsafe.putByte(address, (byte) 1);
+                Unsafe.setMemory(address + 1, dataLength - 1, (byte) 0xFF);
+                QwpArrayColumnCursor cursor = new QwpArrayColumnCursor();
+                Assert.assertEquals(dataLength, cursor.of(address, dataLength, rowCount, TYPE_DOUBLE_ARRAY));
+                Assert.assertEquals(64, cursor.getRowCacheCapacity());
+                Assert.assertEquals(ARRAY_CACHE_BASELINE_BYTES, cursor.getRowCacheBytes());
+                for (int i = 0; i < rowCount; i++) {
+                    Assert.assertTrue(cursor.advanceRow());
+                    Assert.assertTrue(cursor.isNull());
+                }
+            } finally {
+                Unsafe.free(address, dataLength, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testArrayPreflightAcceptsExactLowerBound() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            final int rowCount = 65;
+            final int bitmapSize = QwpNullBitmap.sizeInBytes(rowCount);
+            final int dataLength = 1 + bitmapSize + 5;
+            long address = Unsafe.malloc(dataLength, MemoryTag.NATIVE_DEFAULT);
+            try {
+                Unsafe.putByte(address, (byte) 1);
+                Unsafe.setMemory(address + 1, bitmapSize, (byte) 0xFF);
+                QwpNullBitmapTestUtil.clearNull(address + 1, 64);
+                Unsafe.putByte(address + 1 + bitmapSize, (byte) 1);
+                Unsafe.putInt(address + 2 + bitmapSize, 0);
+
+                QwpArrayColumnCursor cursor = new QwpArrayColumnCursor();
+                Assert.assertEquals(dataLength, cursor.of(address, dataLength, rowCount, TYPE_DOUBLE_ARRAY));
+                Assert.assertTrue(cursor.getRowCacheCapacity() >= rowCount);
+                for (int i = 0; i < 64; i++) {
+                    Assert.assertTrue(cursor.advanceRow());
+                    Assert.assertTrue(cursor.isNull());
+                }
+                Assert.assertFalse(cursor.advanceRow());
+                Assert.assertFalse(cursor.isNull());
+                Assert.assertEquals(1, cursor.getNDims());
+                Assert.assertEquals(0, cursor.getDimSize(0));
+                Assert.assertEquals(0, cursor.getTotalElements());
+            } finally {
+                Unsafe.free(address, dataLength, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testArrayRejectsMissingNullBitmapFlagBeforeGrowingRowCaches() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            QwpArrayColumnCursor cursor = new QwpArrayColumnCursor();
+            QwpParseException exception = Assert.assertThrows(QwpParseException.class, () ->
+                    cursor.of(0, 0, 1_000_000, TYPE_DOUBLE_ARRAY));
+            assertInsufficientData(exception, "expected null bitmap flag");
+            Assert.assertEquals(64, cursor.getRowCacheCapacity());
+            Assert.assertEquals(ARRAY_CACHE_BASELINE_BYTES, cursor.getRowCacheBytes());
+        });
+    }
+
+    @Test
+    public void testArrayRejectsOneByteBelowGrowthLowerBound() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            final int rowCount = 65;
+            final int rowDataLength = rowCount * 5 - 1;
+            final int dataLength = 1 + rowDataLength;
+            long address = Unsafe.malloc(dataLength, MemoryTag.NATIVE_DEFAULT);
+            try {
+                Unsafe.putByte(address, (byte) 0);
+                Unsafe.setMemory(address + 1, rowDataLength, (byte) 0);
+
+                QwpArrayColumnCursor cursor = new QwpArrayColumnCursor();
+                QwpParseException exception = Assert.assertThrows(QwpParseException.class, () ->
+                        cursor.of(address, dataLength, rowCount, TYPE_DOUBLE_ARRAY));
+                assertInsufficientData(exception, "65 non-null rows require at least 325 bytes");
+                Assert.assertEquals(64, cursor.getRowCacheCapacity());
+                Assert.assertEquals(ARRAY_CACHE_BASELINE_BYTES, cursor.getRowCacheBytes());
+            } finally {
+                Unsafe.free(address, dataLength, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testArrayRejectsTinyPayloadBeforeGrowingRowCaches() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            long address = Unsafe.malloc(1, MemoryTag.NATIVE_DEFAULT);
+            try {
+                Unsafe.putByte(address, (byte) 0);
+                QwpArrayColumnCursor cursor = new QwpArrayColumnCursor();
+                QwpParseException exception = Assert.assertThrows(QwpParseException.class, () ->
+                        cursor.of(address, 1, 1_000_000, TYPE_DOUBLE_ARRAY));
+                assertInsufficientData(exception, "non-null rows require at least");
+                Assert.assertEquals(64, cursor.getRowCacheCapacity());
+                Assert.assertEquals(ARRAY_CACHE_BASELINE_BYTES, cursor.getRowCacheBytes());
+            } finally {
+                Unsafe.free(address, 1, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testArrayRejectsTruncatedNullBitmapBeforeGrowingRowCaches() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            long address = Unsafe.malloc(1, MemoryTag.NATIVE_DEFAULT);
+            try {
+                Unsafe.putByte(address, (byte) 1);
+                QwpArrayColumnCursor cursor = new QwpArrayColumnCursor();
+                QwpParseException exception = Assert.assertThrows(QwpParseException.class, () ->
+                        cursor.of(address, 1, 1_000_000, TYPE_DOUBLE_ARRAY));
+                assertInsufficientData(exception, "expected null bitmap");
+                Assert.assertEquals(64, cursor.getRowCacheCapacity());
+                Assert.assertEquals(ARRAY_CACHE_BASELINE_BYTES, cursor.getRowCacheBytes());
+            } finally {
+                Unsafe.free(address, 1, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testDecoderReusableAfterColdRelease() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (QwpTableBuffer failedBuffer = new QwpTableBuffer("cache_release");
+                 QwpTableBuffer validBuffer = new QwpTableBuffer("cache_reuse");
+                 QwpWebSocketEncoder encoder = new QwpWebSocketEncoder();
+                 QwpStreamingDecoder decoder = new QwpStreamingDecoder()) {
+                QwpTableBuffer.ColumnBuffer failedArray = failedBuffer.getOrCreateColumn("a", TYPE_DOUBLE_ARRAY, true);
+                QwpTableBuffer.ColumnBuffer failedSymbol = failedBuffer.getOrCreateColumn("s", TYPE_SYMBOL, true);
+                QwpTableBuffer.ColumnBuffer failedTimestamp = failedBuffer.getOrCreateColumn("ts", TYPE_TIMESTAMP, true);
+                for (int i = 0; i < 4_097; i++) {
+                    failedArray.addDoubleArray(new double[]{i});
+                    failedSymbol.addSymbol("symbol_" + i);
+                    failedTimestamp.addLong(1_000L * i);
+                    failedBuffer.nextRow();
+                }
+
+                int failedSize = encoder.encode(failedBuffer);
+                long failedAddress = encoder.getBuffer().getBufferPtr();
+                Unsafe.putShort(failedAddress + QwpConstants.HEADER_OFFSET_TABLE_COUNT, (short) 2);
+
+                QwpMessageCursor message = decoder.decode(failedAddress, failedSize);
+                message.nextTable();
+                Assert.assertTrue(
+                        message.getRetainedCacheBytes()
+                                > ARRAY_CACHE_BASELINE_BYTES
+                                + SYMBOL_INDEX_CACHE_BASELINE_BYTES
+                                + GORILLA_CACHE_BASELINE_BYTES
+                );
+                Assert.assertThrows(QwpParseException.class, message::nextTable);
+                Assert.assertEquals(
+                        ARRAY_CACHE_BASELINE_BYTES
+                                + SYMBOL_INDEX_CACHE_BASELINE_BYTES
+                                + GORILLA_CACHE_BASELINE_BYTES,
+                        message.getRetainedCacheBytes()
+                );
+
+                QwpTableBuffer.ColumnBuffer validArray = validBuffer.getOrCreateColumn("a", TYPE_DOUBLE_ARRAY, true);
+                QwpTableBuffer.ColumnBuffer validSymbol = validBuffer.getOrCreateColumn("s", TYPE_SYMBOL, true);
+                QwpTableBuffer.ColumnBuffer validTimestamp = validBuffer.getOrCreateColumn("ts", TYPE_TIMESTAMP, true);
+                double[][] arrays = {{1.25, 2.5}, {-3.75}, {42.0, 43.0, 44.0}};
+                String[] symbols = {"alpha", "beta", "gamma"};
+                long[] timestamps = {1_000L, 2_000L, 3_000L};
+                for (int i = 0; i < arrays.length; i++) {
+                    validArray.addDoubleArray(arrays[i]);
+                    validSymbol.addSymbol(symbols[i]);
+                    validTimestamp.addLong(timestamps[i]);
+                    validBuffer.nextRow();
+                }
+
+                int validSize = encoder.encode(validBuffer);
+                QwpMessageCursor reusedMessage = decoder.decode(encoder.getBuffer().getBufferPtr(), validSize);
+                Assert.assertSame(message, reusedMessage);
+                QwpTableBlockCursor table = reusedMessage.nextTable();
+                QwpTimestampColumnCursor timestampCursor = table.getTimestampColumn(2);
+                Assert.assertEquals(1, timestampCursor.getGorillaDecodeCount());
+                for (int row = 0; row < arrays.length; row++) {
+                    Assert.assertTrue(table.hasNextRow());
+                    table.nextRow();
+
+                    QwpArrayColumnCursor arrayCursor = table.getArrayColumn(0);
+                    Assert.assertEquals(1, arrayCursor.getNDims());
+                    Assert.assertEquals(arrays[row].length, arrayCursor.getDimSize(0));
+                    Assert.assertEquals(arrays[row].length, arrayCursor.getTotalElements());
+                    for (int element = 0; element < arrays[row].length; element++) {
+                        Assert.assertEquals(
+                                arrays[row][element],
+                                Unsafe.getDouble(arrayCursor.getValuesAddress() + (long) element * Double.BYTES),
+                                0.0
+                        );
+                    }
+
+                    Assert.assertEquals(symbols[row], table.getSymbolColumn(1).getSymbolCharSequence().toString());
+                    Assert.assertEquals(timestamps[row], timestampCursor.getTimestamp());
+                }
+                Assert.assertFalse(table.hasNextRow());
+            }
+        });
+    }
+
+    @Test
+    public void testDeltaSymbolRejectsOneMissingIndexBeforeGrowingIndexCache() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            final int rowCount = 17;
+            final int indexCount = rowCount - 1;
+            final int dataLength = 1 + indexCount;
+            long address = Unsafe.malloc(dataLength, MemoryTag.NATIVE_DEFAULT);
+            try {
+                Unsafe.setMemory(address, dataLength, (byte) 0);
+                ObjList<String> connectionDict = new ObjList<>();
+                connectionDict.add("only");
+
+                QwpSymbolColumnCursor cursor = new QwpSymbolColumnCursor();
+                QwpParseException exception = Assert.assertThrows(QwpParseException.class, () ->
+                        cursor.of(address, dataLength, rowCount, connectionDict));
+                assertInsufficientData(exception, "17 indices require at least 17 bytes");
+                Assert.assertEquals(16, cursor.getDecodedIndexCacheCapacity());
+            } finally {
+                Unsafe.free(address, dataLength, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testDeltaSymbolRejectsTinyPayloadBeforeGrowingIndexCache() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            long address = Unsafe.malloc(1, MemoryTag.NATIVE_DEFAULT);
+            try {
+                Unsafe.putByte(address, (byte) 0);
+                ObjList<String> connectionDict = new ObjList<>();
+                connectionDict.add("only");
+                QwpSymbolColumnCursor cursor = new QwpSymbolColumnCursor();
+                QwpParseException exception = Assert.assertThrows(QwpParseException.class, () ->
+                        cursor.of(address, 1, 1_000_000, connectionDict));
+                assertInsufficientData(exception, "indices require at least");
+                Assert.assertEquals(16, cursor.getDecodedIndexCacheCapacity());
+            } finally {
+                Unsafe.free(address, 1, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testGorillaCacheReleasedAfterLateTableFailure() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (QwpTableBuffer buffer = new QwpTableBuffer("cache_release");
+                 QwpWebSocketEncoder encoder = new QwpWebSocketEncoder()) {
+                QwpTableBuffer.ColumnBuffer timestampColumn = buffer.getOrCreateColumn("ts", TYPE_TIMESTAMP, true);
+                for (int i = 0; i < 4_097; i++) {
+                    timestampColumn.addLong(1_000L * i);
+                    buffer.nextRow();
+                }
+
+                int size = encoder.encode(buffer);
+                long address = encoder.getBuffer().getBufferPtr();
+                Unsafe.putShort(address + QwpConstants.HEADER_OFFSET_TABLE_COUNT, (short) 2);
+
+                QwpMessageCursor cursor = new QwpMessageCursor();
+                cursor.of(address, size, null);
+                cursor.nextTable();
+                Assert.assertTrue(cursor.getRetainedCacheBytes() > 1024L * Long.BYTES);
+                Assert.assertThrows(QwpParseException.class, cursor::nextTable);
+                Assert.assertEquals(GORILLA_CACHE_BASELINE_BYTES, cursor.getRetainedCacheBytes());
+            }
+        });
+    }
+
+    @Test
+    public void testGorillaRejectsOneByteBelowGrowthLowerBound() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            final int rowCount = 1_027;
+            final int remainingValues = rowCount - 2;
+            final int gorillaDataLength = 128;
+            final int dataLength = 1 + 1 + 2 * Long.BYTES + gorillaDataLength;
+            long address = Unsafe.malloc(dataLength, MemoryTag.NATIVE_DEFAULT);
+            try {
+                Unsafe.setMemory(address, dataLength, (byte) 0);
+                Unsafe.putByte(address + 1, QwpTimestampColumnCursor.ENCODING_GORILLA);
+                Unsafe.putLong(address + 2, 1_000);
+                Unsafe.putLong(address + 10, 2_000);
+
+                QwpTimestampColumnCursor cursor = new QwpTimestampColumnCursor();
+                QwpParseException exception = Assert.assertThrows(QwpParseException.class, () ->
+                        cursor.of(address, dataLength, rowCount, TYPE_TIMESTAMP, true));
+                assertInsufficientData(exception, remainingValues + " Gorilla values require at least 129 bytes");
+                Assert.assertEquals(1024, cursor.getGorillaCacheCapacity());
+            } finally {
+                Unsafe.free(address, dataLength, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testGorillaRejectsTinyPayloadBeforeGrowingDecodeCache() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            long address = Unsafe.malloc(18, MemoryTag.NATIVE_DEFAULT);
+            try {
+                Unsafe.putByte(address, (byte) 0);
+                Unsafe.putByte(address + 1, QwpTimestampColumnCursor.ENCODING_GORILLA);
+                Unsafe.putLong(address + 2, 1_000);
+                Unsafe.putLong(address + 10, 2_000);
+                QwpTimestampColumnCursor cursor = new QwpTimestampColumnCursor();
+                QwpParseException exception = Assert.assertThrows(QwpParseException.class, () ->
+                        cursor.of(address, 18, 1_000_000, TYPE_TIMESTAMP, true));
+                assertInsufficientData(exception, "Gorilla values require at least");
+                Assert.assertEquals(1024, cursor.getGorillaCacheCapacity());
+            } finally {
+                Unsafe.free(address, 18, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testLaterColumnFailureReleasesPreviouslyGrownCaches() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (QwpTableBuffer buffer = new QwpTableBuffer("cache_release");
+                 QwpWebSocketEncoder encoder = new QwpWebSocketEncoder()) {
+                QwpTableBuffer.ColumnBuffer arrayColumn = buffer.getOrCreateColumn("a", TYPE_DOUBLE_ARRAY, true);
+                QwpTableBuffer.ColumnBuffer symbolColumn = buffer.getOrCreateColumn("s", TYPE_SYMBOL, true);
+                for (int i = 0; i < 4_097; i++) {
+                    arrayColumn.addDoubleArray(new double[]{i});
+                    symbolColumn.addSymbol("symbol_" + i);
+                    buffer.nextRow();
+                }
+
+                int size = encoder.encode(buffer);
+                var writer = encoder.getBuffer();
+                long address = writer.getBufferPtr();
+                Unsafe.putInt(
+                        address + QwpConstants.HEADER_OFFSET_PAYLOAD_LENGTH,
+                        size - QwpConstants.HEADER_SIZE - 1
+                );
+
+                QwpMessageCursor cursor = new QwpMessageCursor();
+                cursor.of(address, size - 1, null);
+                Assert.assertThrows(QwpParseException.class, cursor::nextTable);
+                Assert.assertEquals(
+                        ARRAY_CACHE_BASELINE_BYTES + SYMBOL_INDEX_CACHE_BASELINE_BYTES,
+                        cursor.getRetainedCacheBytes()
+                );
+            }
+        });
+    }
+
+    @Test
+    public void testLaterTableFailureReleasesPreviouslyGrownCaches() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (QwpTableBuffer buffer = new QwpTableBuffer("cache_release");
+                 QwpWebSocketEncoder encoder = new QwpWebSocketEncoder()) {
+                QwpTableBuffer.ColumnBuffer arrayColumn = buffer.getOrCreateColumn("a", TYPE_DOUBLE_ARRAY, true);
+                for (int i = 0; i < 4_097; i++) {
+                    arrayColumn.addDoubleArray(new double[]{i});
+                    buffer.nextRow();
+                }
+
+                int size = encoder.encode(buffer);
+                var writer = encoder.getBuffer();
+                long address = writer.getBufferPtr();
+                Unsafe.putShort(address + QwpConstants.HEADER_OFFSET_TABLE_COUNT, (short) 2);
+
+                QwpMessageCursor cursor = new QwpMessageCursor();
+                cursor.of(address, size, null);
+                cursor.nextTable();
+                Assert.assertTrue(cursor.getRetainedCacheBytes() > 2_048);
+                Assert.assertThrows(QwpParseException.class, cursor::nextTable);
+                Assert.assertEquals(ARRAY_CACHE_BASELINE_BYTES, cursor.getRetainedCacheBytes());
+            }
+        });
+    }
+
+    @Test
+    public void testStandardSymbolRejectsImpossibleDictionaryBeforeGrowingFlyweights() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            final int dictionarySize = 500_000;
+            final int dataLength = 500_004;
+            long address = Unsafe.malloc(dataLength, MemoryTag.NATIVE_DEFAULT);
+            try {
+                long p = address;
+                Unsafe.putByte(p++, (byte) 0);
+                p = QwpVarint.encode(p, dictionarySize);
+                Assert.assertEquals(address + 4, p);
+                Unsafe.setMemory(p, dictionarySize, (byte) 0);
+                p += dictionarySize;
+                Assert.assertEquals(address + dataLength, p);
+
+                QwpSymbolColumnCursor cursor = new QwpSymbolColumnCursor();
+                QwpParseException exception = Assert.assertThrows(QwpParseException.class, () ->
+                        cursor.of(address, dataLength, 1));
+                assertInsufficientData(exception, "dictionary entries and indices require at least");
+                Assert.assertEquals(0, cursor.getDictionaryCacheSize());
+            } finally {
+                Unsafe.free(address, dataLength, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testStandardSymbolRejectsMissingIndicesBeforeGrowingIndexCache() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            final int rowCount = 17;
+            final int stringLength = rowCount;
+            final int dataLength = 3 + stringLength;
+            long address = Unsafe.malloc(dataLength, MemoryTag.NATIVE_DEFAULT);
+            try {
+                long p = address;
+                Unsafe.putByte(p++, (byte) 0);
+                p = QwpVarint.encode(p, 1);
+                p = QwpVarint.encode(p, stringLength);
+                Unsafe.setMemory(p, stringLength, (byte) 'a');
+                p += stringLength;
+                Assert.assertEquals(address + dataLength, p);
+
+                QwpSymbolColumnCursor cursor = new QwpSymbolColumnCursor();
+                QwpParseException exception = Assert.assertThrows(QwpParseException.class, () ->
+                        cursor.of(address, dataLength, rowCount));
+                assertInsufficientData(exception, "indices require at least");
+                Assert.assertEquals(16, cursor.getDecodedIndexCacheCapacity());
+            } finally {
+                Unsafe.free(address, dataLength, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testSymbolCacheReleasedAfterLateTableFailure() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (QwpTableBuffer buffer = new QwpTableBuffer("cache_release");
+                 QwpWebSocketEncoder encoder = new QwpWebSocketEncoder()) {
+                QwpTableBuffer.ColumnBuffer symbolColumn = buffer.getOrCreateColumn("s", TYPE_SYMBOL, true);
+                for (int i = 0; i < 4_097; i++) {
+                    symbolColumn.addSymbol("symbol_" + i);
+                    buffer.nextRow();
+                }
+
+                int size = encoder.encode(buffer);
+                long address = encoder.getBuffer().getBufferPtr();
+                Unsafe.putShort(address + QwpConstants.HEADER_OFFSET_TABLE_COUNT, (short) 2);
+
+                QwpMessageCursor cursor = new QwpMessageCursor();
+                cursor.of(address, size, null);
+                QwpSymbolColumnCursor symbolCursor = cursor.nextTable().getSymbolColumn(0);
+                Object inflatedDictionaryCache = symbolCursor.getDictionaryCacheIdentity();
+                Assert.assertTrue(cursor.getRetainedCacheBytes() > SYMBOL_INDEX_CACHE_BASELINE_BYTES);
+                Assert.assertThrows(QwpParseException.class, cursor::nextTable);
+                Assert.assertNotSame(inflatedDictionaryCache, symbolCursor.getDictionaryCacheIdentity());
+                Assert.assertEquals(SYMBOL_INDEX_CACHE_BASELINE_BYTES, cursor.getRetainedCacheBytes());
+            }
+        });
+    }
+
+    private static void assertInsufficientData(QwpParseException exception, String messageFragment) {
+        Assert.assertEquals(QwpParseException.ErrorCode.INSUFFICIENT_DATA, exception.getErrorCode());
+        Assert.assertTrue(exception.getFlyweightMessage().toString().contains(messageFragment));
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpTableHeaderTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpTableHeaderTest.java
@@ -106,6 +106,24 @@ public class QwpTableHeaderTest {
     }
 
     @Test
+    public void testColumnCountWithSignBitSet() {
+        long columnCount = 0x8000000001000000L;
+        byte[] buf = encodeTableHeader("test", 0, columnCount);
+
+        long address = copyToDirectMemory(buf);
+        try {
+            QwpTableHeader header = new QwpTableHeader();
+            header.parse(address, buf.length);
+            Assert.fail("Expected exception for unsigned column count exceeding max");
+        } catch (QwpParseException e) {
+            Assert.assertEquals(QwpParseException.ErrorCode.COLUMN_COUNT_EXCEEDED, e.getErrorCode());
+            Assert.assertTrue(e.getMessage().contains(Long.toUnsignedString(columnCount)));
+        } finally {
+            Unsafe.free(address, buf.length, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
     public void testParseMultipleTableHeaders() throws QwpParseException {
         // Create buffer with two consecutive table headers
         byte[] header1 = encodeTableHeader("table1", 100, 5);
@@ -310,6 +328,24 @@ public class QwpTableHeaderTest {
     }
 
     @Test
+    public void testRowCountWithSignBitSet() {
+        long rowCount = 0x8000000080000000L;
+        byte[] buf = encodeTableHeader("test", rowCount, 1);
+
+        long address = copyToDirectMemory(buf);
+        try {
+            QwpTableHeader header = new QwpTableHeader();
+            header.parse(address, buf.length);
+            Assert.fail("Expected exception for unsigned row count exceeding max");
+        } catch (QwpParseException e) {
+            Assert.assertEquals(QwpParseException.ErrorCode.ROW_COUNT_EXCEEDED, e.getErrorCode());
+            Assert.assertTrue(e.getMessage().contains(Long.toUnsignedString(rowCount)));
+        } finally {
+            Unsafe.free(address, buf.length, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
     public void testRowCountZero() throws QwpParseException {
         byte[] buf = encodeTableHeader("test", 0, 5);
 
@@ -459,7 +495,7 @@ public class QwpTableHeaderTest {
         return address;
     }
 
-    private byte[] encodeTableHeader(String tableName, long rowCount, int columnCount) {
+    private byte[] encodeTableHeader(String tableName, long rowCount, long columnCount) {
         byte[] nameBytes = tableName.getBytes(StandardCharsets.UTF_8);
         int size = QwpVarint.encodedLength(nameBytes.length) +
                 nameBytes.length +

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketProtocolTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/e2e/QwpWebSocketProtocolTest.java
@@ -152,6 +152,37 @@ public class QwpWebSocketProtocolTest extends AbstractQwpWebSocketTest {
     }
 
     @Test
+    public void testRowCountWithSignBitSetIsRejectedWithoutCrashingServer() throws Exception {
+        runInContext((port) -> {
+            try (Socket socket = new Socket("localhost", port)) {
+                socket.setSoTimeout(5000);
+                performWebSocketHandshake(socket, port);
+
+                OutputStream out = socket.getOutputStream();
+                out.write(createMaskedFrame(WebSocketOpcode.BINARY, buildSignBitRowCountMessage(), true));
+                out.flush();
+
+                byte[] payload = readBinaryFramePayload(socket.getInputStream());
+                Assert.assertEquals(QwpConstants.STATUS_PARSE_ERROR, payload[0]);
+                Assert.assertTrue("Parse-error payload is too short: " + payload.length, payload.length >= 11);
+                int msgLen = (payload[9] & 0xFF) | ((payload[10] & 0xFF) << 8);
+                Assert.assertEquals("Parse-error payload must be status(1)+seq(8)+len(2)+msg(msgLen)",
+                        11 + msgLen, payload.length);
+                String msg = new String(payload, 11, msgLen, StandardCharsets.UTF_8);
+                Assert.assertTrue("Expected row-count rejection, got: " + msg,
+                        msg.contains("row count exceeds maximum: 9223372039002259456"));
+            }
+
+            // The malformed frame used to crash the JVM in an unsafe column cursor.
+            // A fresh upgrade verifies that the server remains available after rejecting it.
+            try (Socket socket = new Socket("localhost", port)) {
+                socket.setSoTimeout(5000);
+                performWebSocketHandshake(socket, port);
+            }
+        });
+    }
+
+    @Test
     public void testFragmentedBinaryFrameRejected() throws Exception {
         // A binary frame with FIN=0 is what a proxy sends when it splits a large
         // binary message.
@@ -575,6 +606,16 @@ public class QwpWebSocketProtocolTest extends AbstractQwpWebSocketTest {
         } finally {
             Unsafe.free(address, totalSize, MemoryTag.NATIVE_DEFAULT);
         }
+    }
+
+    private static byte[] buildSignBitRowCountMessage() {
+        return new byte[]{
+                'Q', 'W', 'P', '1', 1, 0, 1, 0, 21, 0, 0, 0,
+                5, 'c', 'r', 'a', 's', 'h',
+                (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x88,
+                (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, 0x01,
+                1, 1, 's', QwpConstants.TYPE_VARCHAR, 0
+        };
     }
 
     private static String computeAcceptKey(String key) throws Exception {


### PR DESCRIPTION
Protocol hardening against misbehaving clients. 

Reject row and column counts with the sign bit set before narrowing them to signed values. This prevents malformed QWP messages from reaching column cursors.