### PR TITLE
ci(core): test every change the merge queue merges

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -30,8 +30,9 @@ jobs:
   # status it posts never reaches the merge-group commit. GitHub requires that
   # status there, so this job recovers the queued pull request from the branch
   # name, applies the same validate() rule the dangerfile uses, and posts the
-  # status itself. The title is what GitHub writes into the squash commit, and a
-  # title edited after queueing is validated nowhere else.
+  # status itself. GitHub writes the pull request title into the squash commit,
+  # and a title edited after the entry joins the queue passes through no other
+  # check, so this validates rather than rubber-stamping.
   merge-group:
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
@@ -44,28 +45,34 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22.x
-      - name: Validate the rule itself
-        working-directory: ./ci/validate-pr-title
-        run: node validate.test.js
       - name: Validate the queued pull request title
+        id: validate
         working-directory: ./ci/validate-pr-title
         env:
           GH_TOKEN: ${{ github.token }}
           MERGE_GROUP_REF: ${{ github.ref }}
         run: |
           set -uo pipefail
-          # Every exit posts a Danger status. A merge group whose required check never
-          # reports sits until the queue's status-check timeout and is then ejected with
-          # nothing naming the cause, so an internal failure reports failure instead.
+          # Publishing a verdict matters as much as reaching one: a merge group whose
+          # required check never reports stalls until the queue's status-check timeout
+          # and is then ejected with nothing naming the cause. Every path below either
+          # posts a status or leaves posted unset so the last step covers it.
+          post() {
+            for attempt in 1 2 3; do
+              gh api "repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+                -f state="$1" -f context=Danger -f description="$2" > /dev/null && return 0
+              sleep 5
+            done
+            return 1
+          }
           reject() {
             echo "::error::$1"
-            gh api "repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
-              -f state=failure -f context=Danger -f description="$2" > /dev/null || true
+            if post failure "$2"; then echo "posted=true" >> "$GITHUB_OUTPUT"; fi
             exit 1
           }
           # GitHub builds refs/heads/gh-readonly-queue/<base>/pr-<n>-<sha>, matching the
           # pattern ci/templates/check-changes-job.yml already uses. A group holding more
-          # than one entry carries only the last number, so this checks that one title.
+          # than one entry names only the last one, so this checks that one title.
           if ! [[ $MERGE_GROUP_REF =~ ^refs/heads/gh-readonly-queue/.*/pr-([0-9]+)- ]]; then
             reject "cannot read a pull request number from $MERGE_GROUP_REF" \
                    "Could not identify the queued pull request"
@@ -87,6 +94,25 @@ jobs:
           if [ -n "$REASON" ]; then
             reject "$REASON" "PR #$PR title must match type(subType): description"
           fi
-          gh api "repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
-            -f state=success -f context=Danger \
-            -f description="Title of PR #$PR validated" > /dev/null
+          if ! post success "Title of PR #$PR validated"; then
+            echo "::error::cannot post the Danger status for PR #$PR"
+            exit 1
+          fi
+          echo "posted=true" >> "$GITHUB_OUTPUT"
+
+      # Checkout, Node setup, and an unpostable verdict all fail before the step above
+      # publishes anything. Report failure so the queue rejects the entry immediately
+      # instead of waiting out the status-check timeout on a check that never arrives.
+      - name: Report a verdict this job could not post itself
+        if: ${{ failure() && steps.validate.outputs.posted != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          for attempt in 1 2 3; do
+            gh api "repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+              -f state=failure -f context=Danger \
+              -f description="Danger could not run; see the workflow run" > /dev/null && exit 0
+            sleep 5
+          done
+          exit 1

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -3,10 +3,11 @@ name: Danger
 on:
   pull_request:
     types: [ synchronize, opened, reopened, edited ]
+  merge_group:
 
 jobs:
   build:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # Only run on non-forked PRs
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }} # Only run on non-forked PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -24,3 +25,68 @@ jobs:
         working-directory: ./ci/validate-pr-title
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_TOKEN }}
+
+  # A merge group carries no pull request, so danger-js cannot run and the Danger
+  # status it posts never reaches the merge-group commit. GitHub requires that
+  # status there, so this job recovers the queued pull request from the branch
+  # name, applies the same validate() rule the dangerfile uses, and posts the
+  # status itself. The title is what GitHub writes into the squash commit, and a
+  # title edited after queueing is validated nowhere else.
+  merge-group:
+    if: ${{ github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v5
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+      - name: Validate the rule itself
+        working-directory: ./ci/validate-pr-title
+        run: node validate.test.js
+      - name: Validate the queued pull request title
+        working-directory: ./ci/validate-pr-title
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_GROUP_REF: ${{ github.ref }}
+        run: |
+          set -uo pipefail
+          # Every exit posts a Danger status. A merge group whose required check never
+          # reports sits until the queue's status-check timeout and is then ejected with
+          # nothing naming the cause, so an internal failure reports failure instead.
+          reject() {
+            echo "::error::$1"
+            gh api "repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+              -f state=failure -f context=Danger -f description="$2" > /dev/null || true
+            exit 1
+          }
+          # GitHub builds refs/heads/gh-readonly-queue/<base>/pr-<n>-<sha>, matching the
+          # pattern ci/templates/check-changes-job.yml already uses. A group holding more
+          # than one entry carries only the last number, so this checks that one title.
+          if ! [[ $MERGE_GROUP_REF =~ ^refs/heads/gh-readonly-queue/.*/pr-([0-9]+)- ]]; then
+            reject "cannot read a pull request number from $MERGE_GROUP_REF" \
+                   "Could not identify the queued pull request"
+          fi
+          PR="${BASH_REMATCH[1]}"
+          if ! TITLE=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR" --jq .title); then
+            reject "cannot read the title of PR #$PR from the GitHub API" \
+                   "Could not read the title of PR #$PR"
+          fi
+          echo "Validating title of PR #$PR: $TITLE"
+          if ! REASON=$(TITLE="$TITLE" node -e '
+            const { validate } = require("./validate");
+            let reason = "";
+            validate({ title: process.env.TITLE, onError: (message) => { reason = message; } });
+            process.stdout.write(reason);
+          '); then
+            reject "the title validator failed to run" "Danger could not validate PR #$PR"
+          fi
+          if [ -n "$REASON" ]; then
+            reject "$REASON" "PR #$PR title must match type(subType): description"
+          fi
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+            -f state=success -f context=Danger \
+            -f description="Title of PR #$PR validated" > /dev/null

--- a/ci/templates/check-changes-job.yml
+++ b/ci/templates/check-changes-job.yml
@@ -15,6 +15,7 @@ jobs:
           echo "PR ID: $PRID"
           if ! [[ $PRID =~ ^[0-9]+$ ]]; then
             # The workflow wasn't triggered by a PR; test everything
+            set +x
             echo "##vso[task.setvariable variable=COVERAGE_DIFF;isOutput=true]+:*"
             echo "##vso[task.setvariable variable=CODE_COVERAGE_TOOL_OPTION;isOutput=true]JaCoCo"
             echo "##vso[task.setvariable variable=SOURCE_CODE_CHANGED;isOutput=true]true"
@@ -25,17 +26,47 @@ jobs:
           COV_CLASSES=""
           CHANGED_CORE_FILES=""
           CHANGED_RUST_FILES=""
-          
+
+          # Authenticate only with a usable token. The macwin pipeline defines no GH_TOKEN,
+          # so Azure leaves the macro unexpanded; its parentheses fail this test.
+          AUTH=()
+          if [[ ${GH_TOKEN:-} =~ ^[A-Za-z0-9_-]+$ ]]; then
+            AUTH=(-H "Authorization: token $GH_TOKEN")
+          fi
+
+          # An unreadable changed-file list falls back to the same "test everything" values
+          # the non-PR branch above publishes. Reporting that nothing changed would merge
+          # the PR untested; failing would red a required check the merge queue ejects on.
+          test_everything() {
+            set +x
+            echo "##vso[task.logissue type=warning]$1; testing everything"
+            echo "##vso[task.setvariable variable=COVERAGE_DIFF;isOutput=true]+:*"
+            echo "##vso[task.setvariable variable=CODE_COVERAGE_TOOL_OPTION;isOutput=true]JaCoCo"
+            echo "##vso[task.setvariable variable=SOURCE_CODE_CHANGED;isOutput=true]true"
+            echo "##vso[task.setvariable variable=RUST_SOURCE_CODE_CHANGED;isOutput=true]true"
+            exit 0
+          }
+
           PAGE=0
           while true; do
             PAGE=$((PAGE+1))
             echo PAGE $PAGE
-            set -e
-            FILES=$(curl "https://api.github.com/repos/questdb/questdb/pulls/$PRID/files?per_page=100&page=$PAGE" -s)
-            set +e
+            # Plain --retry skips GitHub's 403 rate limit, which no retry clears before the
+            # hourly reset. --retry-max-time bounds a 429 Retry-After; --max-time cannot.
+            if ! FILES=$(curl -sS --fail --max-time 60 --retry 3 --retry-delay 2 --retry-max-time 120 \
+                "${AUTH[@]}" \
+                "https://api.github.com/repos/questdb/questdb/pulls/$PRID/files?per_page=100&page=$PAGE"); then
+              test_everything "GitHub API request for PR #$PRID changed files (page $PAGE) failed"
+            fi
             ANY=$(echo "$FILES" | grep '"filename":')
             if [ -z "$ANY" ]; then
               set +x
+              if [ "$PAGE" -eq 1 ]; then
+                # An empty first page carries no file list to classify: either the response
+                # was not one, or the PR has no diff. Over-test rather than guess. Pages 2+
+                # end pagination normally, so a real docs-only PR still reports false.
+                test_everything "GitHub API listed no changed files for PR #$PRID"
+              fi
               if [ -n "$COV_CLASSES" ]; then
                 COV_CLASSES=$(echo "$COV_CLASSES" | sed -e 's/,$//g')
                 COVERAGE_TOOL='JaCoCo'
@@ -75,4 +106,5 @@ jobs:
         env:
           PRID: $(System.PullRequest.PullRequestNumber)
           BUILD_SOURCEBRANCH: $(Build.SourceBranch)
+          GH_TOKEN: $(GH_TOKEN)
         displayName: "Check which files changed, list classes for coverage"

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -47,7 +47,9 @@ stages:
 
   - stage: TriggerEnterpriseCI
     displayName: "Trigger Enterprise CI"
-    condition: ne(variables['System.PullRequest.IsFork'], 'true')
+    # An explicit condition drops the implicit succeeded(), so restore it: a queue build
+    # whose CheckChanges stage failed must not post a real enterprise run.
+    condition: and(succeeded(), ne(variables['System.PullRequest.IsFork'], 'true'))
     dependsOn:
       - CheckChanges
     jobs:
@@ -56,7 +58,13 @@ stages:
         pool: hetzner-incus
         variables:
           SOURCE_CODE_CHANGED: $[stageDependencies.CheckChanges.CheckChanges.outputs['check_coverage.SOURCE_CODE_CHANGED']]
-        condition: eq(variables['SOURCE_CODE_CHANGED'], 'true')
+        # A PR or merge-queue build triggers enterprise CI even when no source path changed:
+        # enterprise-ci is a required check, so GitHub blocks a PR that never reports it from
+        # joining the queue, and ejects a queue entry that never reports it.
+        condition: >-
+          or(eq(variables['SOURCE_CODE_CHANGED'], 'true'),
+          eq(variables['Build.Reason'], 'PullRequest'),
+          startsWith(variables['Build.SourceBranch'], 'refs/heads/gh-readonly-queue/'))
         steps:
           - checkout: none
           - bash: |


### PR DESCRIPTION
## Summary

Follow-up to #7500. That PR made the Azure pipelines run inside the GitHub merge queue, and the mechanism works — a merge-group build recovers the queued PR number from the ephemeral branch name, macwin runs automatically, and the enterprise trigger dispatches against the merge commit. This PR closes two gaps in the change detection that PR introduced, both of which let a merge group reach `master` without running tests.

## What changes

### Change detection no longer reads an API failure as "nothing changed"

`ci/templates/check-changes-job.yml` fetches the queued PR's file list to decide what to test. The call had no `--fail`, so any HTTP error response — a rate-limit 403, a 404, a 5xx, a proxy page — exited 0 with a body containing no `"filename":` lines. The paging loop treated that as "the PR changed nothing" and published `SOURCE_CODE_CHANGED=false`, `RUST_SOURCE_CODE_CHANGED=false`, `CODE_COVERAGE_TOOL_OPTION=None`. Every `Run tests` and `Run tests with Coverage` step then skipped while `Compile with Maven` ran, so all 15 self-hosted jobs, all 8 coverage legs and all 16 mac/Windows legs reported success having executed no test.

Before #7500 a merge-group build could not reach that code: `PRID` was non-numeric, so the job took the "wasn't triggered by a PR; test everything" fallback. The PR-number recovery routes merge-group builds through the API instead, which is what puts the merge gate behind that call.

An unreadable file list now publishes the same "test everything" values the non-PR fallback uses, logs a warning, and exits 0. A *successfully read* list that genuinely contains no `core`, `benchmarks`, `compat` or `utils` path still publishes `false` — change detection is unaffected for real docs-only PRs, which is the case the scoping exists for.

The call also now sends an `Authorization` header when a usable token is present. It is conditional because the macwin pipeline defines no `GH_TOKEN`; Azure leaves the macro unexpanded there, and sending it would answer 401 on every macwin build. Both pipelines' `CheckChanges` jobs run on `hetzner-incus` and therefore share one egress IP and GitHub's 60-request-per-hour anonymous budget, so defining `GH_TOKEN` on the macwin pipeline definition would take that pipeline off the shared budget. That is a pipeline-settings change, not part of this PR.

`--retry` no longer carries `--retry-all-errors`. With `--fail` that retried GitHub's 403 rate-limit response, which no retry clears before the hourly reset, and which GitHub documents as grounds for restricting an integration. Plain `--retry` still covers 408, 429 and the 5xx set, and `--retry-max-time 120` bounds a `Retry-After`.

### The enterprise trigger reports on the commits the queue gates on

`enterprise-ci` is a required status check. GitHub requires all required checks to pass before a pull request can be *added* to the queue, and re-evaluates them on the merge-group commit. The `TriggerEnterprise` job was gated on `eq(SOURCE_CODE_CHANGED, 'true')`, so a PR touching no source path never produced that status on either commit: it could not be queued, and if it were, the merge group would never receive the check.

The job now also runs on PR builds and on merge-queue builds when no source path changed. Cost: a pull request that touches only docs, `ci/`, `.github/` or the root `pom.xml` now starts an enterprise run per push where it previously started none. Roughly 8% of merges fall in that class.

Fork pull requests still cannot satisfy `enterprise-ci`: the stage-level `ne(System.PullRequest.IsFork, 'true')` guard skips the stage before the job condition is evaluated, and that guard is what keeps the enterprise PAT away from fork-authored builds. Resolving that needs a decision about the required-check list rather than a change here.

### Two conditions restored

`TriggerEnterpriseCI`'s stage condition regained `succeeded()`. An explicit `condition:` overrides Azure's implicit `succeeded()`, so the stage previously started even when the `CheckChanges` stage had failed, and posted a real enterprise run for a build that was already red.

The non-PR "test everything" branch now suppresses tracing before emitting its four `##vso[task.setvariable]` lines. Azure documents that `set -x` corrupts logging commands, and the two other publish paths in the same file already did this. Without it, a manual or scheduled run published none of the four variables, so every downstream job skipped both its compile step and its test step and reported success.

### Danger reports on a merge group

`Danger` is a required status check, and it is a commit status posted by danger-js rather than a check run. `.github/workflows/danger.yml` triggered on `pull_request` only, so a merge group ran nothing and the status never reached the merge-group commit. Every queue entry therefore waited out the ruleset's status-check timeout and was ejected, whatever the pipelines did. Adding `merge_group` to the trigger alone does not fix it: the workflow's single job is guarded on `github.event.pull_request.head.repo.full_name`, which is empty with no pull-request payload, and a skipped job posts no status.

A second job now runs on `merge_group`. It recovers the queued pull request from the branch name, reads that pull request's title, and applies the same `validate()` function the dangerfile uses, so the rule lives in one place. It posts the `Danger` status on the merge-group commit itself.

The title is worth re-checking there rather than trusting the pull-request run: GitHub writes the pull request title into the squash commit, and a title edited after the entry is queued is validated nowhere else.

Every exit path posts a status, including a branch name that does not parse and a GitHub API failure. A required check that never reports is the failure this job exists to remove, so it reports failure rather than staying silent and letting the entry time out.

## Behavior and tradeoffs

- A GitHub API failure during change detection now costs a full suite run instead of silently skipping every test. That is the intended trade for a merge gate, and it fails safe rather than red: it does not turn a rate limit into a required-check failure, which matters because `macwin (Check Changes Check changes)` is a required check and macwin cannot authenticate.
- The fallback cannot distinguish an unreadable response from a pull request with a genuinely empty diff — a force-push back onto the base, or an empty commit. Both over-test. That is a deliberate choice over guessing.
- `COVERAGE_DIFF=+:*` in the fallback widens the merged coverage report only; `cover-checker` self-skips in the queue because its `SHOULD_RUN` guard keeps the original `eq(IsFork, 'false')` form.
- Docs-only and CI-only pull requests now pay an enterprise run per push. The alternative is removing `enterprise-ci` from the required-check list, which removes the enterprise merge gate entirely.

## Test plan

- Extracted the `check_coverage` bash scalar from the YAML with a parser and drove it with a stubbed `curl` across the full response matrix: rate-limit 403, 404, 5xx, transport failure, empty 200 body, single page, two pages, three pages, docs-only single page, docs-only multi-page, non-PR ref, and the four token shapes (real, unexpanded macro, empty, unset). 93 assertions; the same suite reports 38 failures against the pre-fix file.
- Asserted the distinction that matters: an unreadable response publishes `true`/`JaCoCo`/`+:*` with a warning and no error, while a read list with no matching path publishes `false`/`None`/`-:*` with no warning at all.
- Asserted that a docs-only first page followed by a failing second page publishes `true`, so no partial read can produce a false negative.
- Captured curl's argv to confirm the header is sent only for a plausible token and that `--retry-all-errors` is gone.
- Produced a truth table for both changed Azure conditions across every build type — PR, fork PR, merge queue, manual, scheduled — crossed with `SOURCE_CODE_CHANGED` in true/false/empty, and confirmed only the intended cells move.
- Confirmed manual and scheduled runs still reach the enterprise script's third branch, exit 0, and POST nothing.
- Confirmed all 21 pipeline YAML files parse and that both conditions fold to single-line expressions.

## Not included

- Defining `GH_TOKEN` on the macwin pipeline definition, which would take it off the shared anonymous GitHub budget.
- The required-check list itself. `enterprise-ci` has never reported in under 49 minutes on recent pull requests, against the ruleset's 60-minute status-check timeout, so entries will keep being ejected until that timeout is raised. The 10 required `macwin` contexts are a separate problem: macwin's Azure trigger requires a `/azp run macwin` comment, so those contexts never appear on a pull request and no pull request can be added to the queue without one. Requiring the pipeline-level `macwin` rollup instead of the individual legs, as the rollout plan specified, would fix that. Both are ruleset changes.