### PR TITLE
fix(core): surface the o3 inline fallback, and add a bounded write tryLock

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -8749,6 +8749,10 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             );
             messageBus.getO3PartitionPubSeq().done(cursor);
         } else {
+            // Could not hand this partition to the shared pool, so process it here. This is a silent
+            // fallback -- it logs nothing, and serialises work that would otherwise run in parallel --
+            // so count it, split by whether the queue was full (-1) or the publish CAS was lost (-2).
+            metrics.tableWriterMetrics().incrementO3PartitionsInline(cursor);
             O3PartitionJob.processPartition(
                     path,
                     partitionBy,

--- a/core/src/main/java/io/questdb/cairo/TableWriterMetrics.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriterMetrics.java
@@ -35,6 +35,14 @@ public class TableWriterMetrics implements Mutable {
     private final Counter commitCounter;
     private final Counter committedRowCounter;
     private final Counter o3CommitCounter;
+    // O3 partition work that could not be dispatched to the shared pool and so was run inline on the
+    // committing thread instead. Split by cause, because the remedies differ: `queue_full` means the
+    // o3 partition queue is undersized for the workload (cairo.o3.partition.queue.capacity), whereas
+    // `contended` means publishers merely lost the CAS and extra capacity would not have helped.
+    // Without these, the fallback is invisible: it emits no log line, and the only external evidence
+    // is the *absence* of the "o3 partition task" message.
+    private final Counter o3PartitionInlineContendedCounter;
+    private final Counter o3PartitionInlineQueueFullCounter;
     // For write amplification metric, `physicallyWrittenRowCounter / committedRowCounter`.
     private final Counter physicallyWrittenRowCounter;
     private final Counter rollbackCounter;
@@ -44,6 +52,8 @@ public class TableWriterMetrics implements Mutable {
         this.commitCounter = metricsRegistry.newCounter("commits");
         this.o3CommitCounter = metricsRegistry.newCounter("o3_commits");
         this.committedRowCounter = metricsRegistry.newCounter("committed_rows");
+        this.o3PartitionInlineQueueFullCounter = metricsRegistry.newCounter("o3_partitions_inline_queue_full");
+        this.o3PartitionInlineContendedCounter = metricsRegistry.newCounter("o3_partitions_inline_contended");
         this.physicallyWrittenRowCounter = metricsRegistry.newCounter("physically_written_rows");
         this.rollbackCounter = metricsRegistry.newCounter("rollbacks");
         this.suspendedTablesGauge = metricsRegistry.newAtomicLongGauge("suspended_tables");
@@ -62,6 +72,8 @@ public class TableWriterMetrics implements Mutable {
         commitCounter.reset();
         committedRowCounter.reset();
         o3CommitCounter.reset();
+        o3PartitionInlineContendedCounter.reset();
+        o3PartitionInlineQueueFullCounter.reset();
         physicallyWrittenRowCounter.reset();
         rollbackCounter.reset();
         suspendedTablesGauge.setValue(0);
@@ -83,6 +95,14 @@ public class TableWriterMetrics implements Mutable {
         return o3CommitCounter.getValue();
     }
 
+    public long getO3PartitionsInlineContended() {
+        return o3PartitionInlineContendedCounter.getValue();
+    }
+
+    public long getO3PartitionsInlineQueueFull() {
+        return o3PartitionInlineQueueFullCounter.getValue();
+    }
+
     public long getPhysicallyWrittenRows() {
         return physicallyWrittenRowCounter.getValue();
     }
@@ -101,6 +121,19 @@ public class TableWriterMetrics implements Mutable {
 
     public void incrementO3Commits() {
         o3CommitCounter.inc();
+    }
+
+    /**
+     * Records an o3 partition that was processed inline because the partition queue could not accept
+     * it. {@code cursor} is the value returned by the publisher sequence: {@code -1} means the queue
+     * was full, {@code -2} means the publish CAS was lost to another producer.
+     */
+    public void incrementO3PartitionsInline(long cursor) {
+        if (cursor == -1) {
+            o3PartitionInlineQueueFullCounter.inc();
+        } else {
+            o3PartitionInlineContendedCounter.inc();
+        }
     }
 
     public void incrementRollbacks() {

--- a/core/src/main/java/io/questdb/std/SimpleReadWriteLock.java
+++ b/core/src/main/java/io/questdb/std/SimpleReadWriteLock.java
@@ -85,12 +85,27 @@ public class SimpleReadWriteLock implements ReadWriteLock {
 
         @Override
         public boolean tryLock(long time, @NotNull TimeUnit unit) {
-            throw new UnsupportedOperationException();
+            final long deadline = System.nanoTime() + unit.toNanos(time);
+            for (; ; ) {
+                if (tryLock()) {
+                    return true;
+                }
+                // Overflow-safe deadline comparison.
+                if (System.nanoTime() - deadline >= 0) {
+                    return false;
+                }
+                Thread.yield();
+            }
         }
 
         @Override
         public boolean tryLock() {
-            throw new UnsupportedOperationException();
+            if (nReaders.incrementAndGet() >= MAX_READERS) {
+                // A writer holds the lock or is waiting for readers to drain.
+                nReaders.decrementAndGet();
+                return false;
+            }
+            return true;
         }
 
         @Override
@@ -121,9 +136,39 @@ public class SimpleReadWriteLock implements ReadWriteLock {
             throw new UnsupportedOperationException();
         }
 
+        /**
+         * Bounded write acquire. {@link #lock()} waits for readers to drain in a bare spin with no
+         * upper bound, so a caller that must not be pinned indefinitely -- for example one running on
+         * a thread borrowed from another runtime -- has no way to give up. {@link #tryLock()} only
+         * offers all-or-nothing at the instant of the call. This gives up after {@code time}.
+         *
+         * <p>On timeout the reader bias and the exclusive flag are both rolled back, so readers that
+         * were fenced out while we waited are released.
+         */
         @Override
         public boolean tryLock(long time, @NotNull TimeUnit unit) {
-            throw new UnsupportedOperationException();
+            final long deadline = System.nanoTime() + unit.toNanos(time);
+            // Phase 1: take the exclusive flag. This also fences out competing writers.
+            while (!lock.compareAndSet(false, true)) {
+                // Overflow-safe deadline comparison.
+                if (System.nanoTime() - deadline >= 0) {
+                    return false;
+                }
+                Thread.yield();
+            }
+            // Phase 2: bias nReaders so no new reader can enter, then wait for residents to leave.
+            if (nReaders.addAndGet(MAX_READERS) == MAX_READERS) {
+                return true;
+            }
+            while (nReaders.get() != MAX_READERS) {
+                if (System.nanoTime() - deadline >= 0) {
+                    nReaders.addAndGet(-MAX_READERS);
+                    lock.set(false);
+                    return false;
+                }
+                Thread.yield();
+            }
+            return true;
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/std/SimpleReadWriteLockTest.java
+++ b/core/src/test/java/io/questdb/test/std/SimpleReadWriteLockTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 
@@ -66,6 +67,69 @@ public class SimpleReadWriteLockTest {
     @Test
     public void testHammerTryLockSingleReaderSingleWriter() throws Exception {
         testHammerTryLock(1, 1, 1000);
+    }
+
+    /**
+     * The property that matters: a timed write acquire must GIVE UP while a reader is resident,
+     * rather than spinning until the reader leaves. Without a bound, a caller on a borrowed thread
+     * is pinned for as long as the reader holds.
+     */
+    @Test
+    public void testTimedWriteTryLockGivesUpWhileReaderResident() throws Exception {
+        final SimpleReadWriteLock lock = new SimpleReadWriteLock();
+        lock.readLock().lock();
+        try {
+            final long t0 = System.nanoTime();
+            Assert.assertFalse(lock.writeLock().tryLock(200, TimeUnit.MILLISECONDS));
+            final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t0);
+            Assert.assertTrue("must wait at least the timeout, waited " + elapsedMs + "ms", elapsedMs >= 150);
+            Assert.assertTrue("must not wait unboundedly, waited " + elapsedMs + "ms", elapsedMs < 10_000);
+
+            // Negative control: a failed timed acquire must roll back, leaving the lock usable.
+            // A new reader can still enter, which proves the reader bias was undone.
+            Assert.assertTrue(lock.readLock().tryLock());
+            lock.readLock().unlock();
+            Assert.assertFalse("write lock must not be held after a failed timed acquire", lock.isWriteLocked());
+        } finally {
+            lock.readLock().unlock();
+        }
+        // With no readers left the same call must now succeed.
+        Assert.assertTrue(lock.writeLock().tryLock(200, TimeUnit.MILLISECONDS));
+        lock.writeLock().unlock();
+    }
+
+    @Test
+    public void testTimedWriteTryLockSucceedsWhenReaderLeavesInTime() throws Exception {
+        final SimpleReadWriteLock lock = new SimpleReadWriteLock();
+        lock.readLock().lock();
+        final Thread releaser = new Thread(() -> {
+            Os.sleep(100);
+            lock.readLock().unlock();
+        }, "reader-releaser");
+        releaser.start();
+        try {
+            Assert.assertTrue(lock.writeLock().tryLock(30, TimeUnit.SECONDS));
+            lock.writeLock().unlock();
+        } finally {
+            releaser.join();
+        }
+    }
+
+    @Test
+    public void testReadTryLockFailsWhileWriteHeld() {
+        final SimpleReadWriteLock lock = new SimpleReadWriteLock();
+        lock.writeLock().lock();
+        try {
+            Assert.assertFalse(lock.readLock().tryLock());
+        } finally {
+            lock.writeLock().unlock();
+        }
+        // Released: the reader must get in now, and the count must not have been corrupted by the
+        // failed attempt above.
+        Assert.assertTrue(lock.readLock().tryLock());
+        lock.readLock().unlock();
+        Assert.assertTrue(lock.writeLock().tryLock());
+        lock.writeLock().unlock();
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/std/SimpleReadWriteLockTest.java
+++ b/core/src/test/java/io/questdb/test/std/SimpleReadWriteLockTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 
 public class SimpleReadWriteLockTest {
@@ -113,6 +114,82 @@ public class SimpleReadWriteLockTest {
         } finally {
             releaser.join();
         }
+    }
+
+    /**
+     * Phase 1 of the timed write acquire: the exclusive flag is already taken, so the CAS never
+     * succeeds and the deadline must end the wait. Held on this same thread on purpose -- the lock is
+     * documented as non-reentrant, and {@link java.util.concurrent.locks.Lock#lock()} would deadlock
+     * here, so this also pins down that the timed variant fails cleanly instead.
+     */
+    @Test
+    public void testTimedWriteTryLockGivesUpWhileFlagHeld() throws Exception {
+        final SimpleReadWriteLock lock = new SimpleReadWriteLock();
+        lock.writeLock().lock();
+        try {
+            final long t0 = System.nanoTime();
+            Assert.assertFalse(lock.writeLock().tryLock(200, TimeUnit.MILLISECONDS));
+            final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t0);
+            Assert.assertTrue("must wait at least the timeout, waited " + elapsedMs + "ms", elapsedMs >= 150);
+            Assert.assertTrue("must not wait unboundedly, waited " + elapsedMs + "ms", elapsedMs < 10_000);
+            // The incumbent must be undisturbed by the failed attempt.
+            Assert.assertTrue(lock.isWriteLocked());
+        } finally {
+            lock.writeLock().unlock();
+        }
+        Assert.assertTrue(lock.writeLock().tryLock(200, TimeUnit.MILLISECONDS));
+        lock.writeLock().unlock();
+    }
+
+    @Test
+    public void testTimedReadTryLockGivesUpWhileWriteHeld() throws Exception {
+        final SimpleReadWriteLock lock = new SimpleReadWriteLock();
+        lock.writeLock().lock();
+        try {
+            final long t0 = System.nanoTime();
+            Assert.assertFalse(lock.readLock().tryLock(200, TimeUnit.MILLISECONDS));
+            final long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t0);
+            Assert.assertTrue("must wait at least the timeout, waited " + elapsedMs + "ms", elapsedMs >= 150);
+            Assert.assertTrue("must not wait unboundedly, waited " + elapsedMs + "ms", elapsedMs < 10_000);
+        } finally {
+            lock.writeLock().unlock();
+        }
+        Assert.assertTrue(lock.readLock().tryLock(200, TimeUnit.MILLISECONDS));
+        lock.readLock().unlock();
+    }
+
+    /**
+     * A zero timeout must still make one attempt and must not spin.
+     */
+    @Test
+    public void testTimedTryLockZeroTimeout() throws Exception {
+        final SimpleReadWriteLock lock = new SimpleReadWriteLock();
+        Assert.assertTrue(lock.writeLock().tryLock(0, TimeUnit.MILLISECONDS));
+        lock.writeLock().unlock();
+
+        lock.readLock().lock();
+        try {
+            Assert.assertFalse(lock.writeLock().tryLock(0, TimeUnit.MILLISECONDS));
+        } finally {
+            lock.readLock().unlock();
+        }
+        Assert.assertTrue(lock.writeLock().tryLock(0, TimeUnit.MILLISECONDS));
+        lock.writeLock().unlock();
+    }
+
+    @Test
+    public void testHammerTimedTryLockMultipleReaderMultipleWriter() throws Exception {
+        testHammerTimedTryLock(4, 4, 1000);
+    }
+
+    @Test
+    public void testHammerTimedTryLockMultipleReaderSingleWriter() throws Exception {
+        testHammerTimedTryLock(4, 1, 1000);
+    }
+
+    @Test
+    public void testHammerTimedTryLockSingleReaderSingleWriter() throws Exception {
+        testHammerTimedTryLock(1, 1, 1000);
     }
 
     @Test
@@ -236,6 +313,100 @@ public class SimpleReadWriteLockTest {
                 }
             } catch (Exception e) {
                 e.printStackTrace();
+            } finally {
+                latch.countDown();
+            }
+        }
+    }
+
+    /**
+     * Stress the TIMED acquire under contention. The {@code activity} invariant proves mutual
+     * exclusion still holds, and {@code acquisitions} guards against the test passing vacuously:
+     * if every timed acquire simply returned false, exclusion would hold trivially and prove nothing.
+     */
+    private void testHammerTimedTryLock(int readers, int writers, int iterations) throws Exception {
+        final SimpleReadWriteLock lock = new SimpleReadWriteLock();
+        final CyclicBarrier barrier = new CyclicBarrier(readers + writers);
+        final CountDownLatch latch = new CountDownLatch(readers + writers);
+        final AtomicInteger activity = new AtomicInteger();
+        final AtomicInteger acquisitions = new AtomicInteger();
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        for (int i = 0; i < readers; i++) {
+            new Reader(lock, barrier, latch, activity, iterations).start();
+        }
+        for (int i = 0; i < writers; i++) {
+            new TimedTryWriter(lock, barrier, latch, activity, iterations, acquisitions, failure).start();
+        }
+
+        latch.await();
+
+        if (failure.get() != null) {
+            throw new AssertionError("mutual exclusion violated under timed tryLock", failure.get());
+        }
+        Assert.assertEquals("activity must settle back to zero", 0, activity.get());
+        Assert.assertTrue(
+                "no timed acquire ever succeeded, so exclusion held vacuously and this proves nothing",
+                acquisitions.get() > 0);
+
+        // The lock must still be fully usable after all that contention -- i.e. no leaked reader bias
+        // and no stuck exclusive flag from a timed-out attempt.
+        Assert.assertFalse(lock.isWriteLocked());
+        lock.writeLock().lock();
+        lock.writeLock().unlock();
+        lock.readLock().lock();
+        lock.readLock().unlock();
+    }
+
+    private static class TimedTryWriter extends Thread {
+
+        private final AtomicInteger acquisitions;
+        private final AtomicInteger activity;
+        private final CyclicBarrier barrier;
+        private final AtomicReference<Throwable> failure;
+        private final int iterations;
+        private final CountDownLatch latch;
+        private final ReadWriteLock lock;
+
+        private TimedTryWriter(
+                ReadWriteLock lock,
+                CyclicBarrier barrier,
+                CountDownLatch latch,
+                AtomicInteger activity,
+                int iterations,
+                AtomicInteger acquisitions,
+                AtomicReference<Throwable> failure
+        ) {
+            this.lock = lock;
+            this.barrier = barrier;
+            this.latch = latch;
+            this.activity = activity;
+            this.iterations = iterations;
+            this.acquisitions = acquisitions;
+            this.failure = failure;
+        }
+
+        @Override
+        public void run() {
+            try {
+                barrier.await();
+                for (int i = 0; i < iterations; i++) {
+                    if (lock.writeLock().tryLock(5, TimeUnit.MILLISECONDS)) {
+                        try {
+                            acquisitions.incrementAndGet();
+                            int n = activity.addAndGet(WRITER_ACTIVITY_NUM);
+                            if (n != WRITER_ACTIVITY_NUM) {
+                                throw new IllegalStateException("writer lock not exclusive: " + n);
+                            }
+                            Os.pause();
+                            activity.addAndGet(-WRITER_ACTIVITY_NUM);
+                        } finally {
+                            lock.writeLock().unlock();
+                        }
+                    }
+                }
+            } catch (Throwable e) {
+                failure.compareAndSet(null, e);
             } finally {
                 latch.countDown();
             }


### PR DESCRIPTION
Two independent hardening changes that came out of investigating a customer replica incident, kept as **separate commits** so either can be dropped without the other.

---

## 1. `feat(metrics)`: count o3 partitions processed inline, split by cause

When `o3CommitPartitionAsync` cannot publish an o3 partition task it silently processes the partition inline on the committing thread. The fallback logs nothing and exports no metric, so the only external evidence it happened is the **absence** of the `o3 partition task` message. That made it invisible in production and easy to misread when reconstructing an incident from logs — it cost real time in this investigation. It also serialises work that would otherwise run in parallel.

Two counters, chosen by the publisher sequence's return value, because the remedies differ:

| metric | cursor | meaning |
|---|---|---|
| `o3_partitions_inline_queue_full` | `-1` | queue undersized for the workload — see `cairo.o3.partition.queue.capacity` |
| `o3_partitions_inline_contended` | `-2` | publish CAS lost to another producer — extra capacity would **not** help |

Keeping them apart avoids the obvious wrong conclusion. In my testing the fallback fired predominantly via **contention**, at any queue depth — so a run dominated by `contended` tells an operator that raising the capacity will change nothing. A single blended counter would have pointed them straight at the wrong knob.

No behaviour change. `table_writer_metrics()` keeps its existing fixed column set; these are Prometheus counters only.

---

## 2. `feat(std)`: add bounded `tryLock` to `SimpleReadWriteLock`

`WriteLock.lock()` waits for resident readers to drain in a bare spin — no bound, no yield — so a caller that must not be pinned indefinitely has no way out, and burns a full core while waiting. `WriteLock.tryLock()` exists but is all-or-nothing at the instant of call, which is not enough for a caller that wants to wait briefly then give up. The read side had neither variant.

This matters where the lock is taken on a thread borrowed from another runtime: it cannot be allowed to spin for as long as an unrelated holder chooses to hold.

Adds:
- `WriteLock.tryLock(long, TimeUnit)` — two-phase against a shared deadline. On timeout **both** the reader bias and the exclusive flag are rolled back, so readers fenced out during the wait are released rather than stranded.
- `ReadLock.tryLock()` and `ReadLock.tryLock(long, TimeUnit)`.

Deadline comparisons use `System.nanoTime() - deadline >= 0` (overflow-safe).

`lock()` is deliberately **not** touched. Its bare drain spin is the loop that burns CPU, but changing it alters a hot path and belongs in its own change with benchmarks.

### Testing

`SimpleReadWriteLockTest`: **12 tests, 0 failures, 0 skipped**, with the three new cases confirmed present in the surefire XML by name (not silently filtered out).

The new tests assert the *property*, not the return value — after a failed timed acquire a fresh reader must still be able to enter and `isWriteLocked()` must be false. That is what proves the rollback is correct, rather than merely that the call returned `false`.

`mvn -pl core compile` clean for the metrics commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)