### PR TITLE
ci(core): report diff coverage for changes going through the merge queue

### DIFF
--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -361,13 +361,36 @@ stages:
               # cover-checker is able to automatically retrieve the diff from the Github Rest API.
               # Unfortunately, it happpens that the Rest API responses are missing the patch field for some files
               # which excludes these files from being covered.
-              git fetch origin $(System.PullRequest.targetBranchName)
-              git diff origin/$(System.PullRequest.targetBranchName)..HEAD > pr.diff
+              # A merge-queue build carries no PR context, so recover the PR and the base the
+              # entry was built on from the queue ref. Diffing against that commit excludes
+              # what other entries merged while this one waited.
+              if [[ "$BUILD_SOURCEBRANCH" =~ ^refs/heads/gh-readonly-queue/(.*)/pr-([0-9]+)-([0-9a-f]{40})$ ]]; then
+                BASE_BRANCH="${BASH_REMATCH[1]}"
+                PR_NUMBER="${BASH_REMATCH[2]}"
+                DIFF_BASE="${BASH_REMATCH[3]}"
+                # GitHub deletes the ref that made this commit reachable once that entry merges.
+                if ! git fetch --depth=1 origin "$DIFF_BASE"; then
+                  git fetch origin "$BASE_BRANCH"
+                  DIFF_BASE="origin/$BASE_BRANCH"
+                fi
+              elif [[ "$PR_NUMBER_MACRO" =~ ^[0-9]+$ ]]; then
+                PR_NUMBER="$PR_NUMBER_MACRO"
+                git fetch origin "$TARGET_BRANCH"
+                DIFF_BASE="origin/$TARGET_BRANCH"
+              else
+                echo "Neither a PR nor a merge-queue build ($BUILD_SOURCEBRANCH); skipping the diff coverage report"
+                exit 0
+              fi
+              git diff "$DIFF_BASE"..HEAD > pr.diff
 
               $JAVA_HOME_25_X64/bin/java -jar \
                 $(Build.SourcesDirectory)/ci/cover-checker-1.5.0-all.jar \
                 -dt file -d pr.diff \
-                $COVER_ARGS --repo "questdb/questdb" --pr $(System.PullRequest.PullRequestNumber) \
+                $COVER_ARGS --repo "questdb/questdb" --pr "$PR_NUMBER" \
                 -t $(DIFF_COVER_THRESHOLD_PCT) --github-token $(GH_TOKEN)
             displayName: "Post combined report to GitHub"
             condition: eq(variables['SHOULD_RUN'], 'true')
+            env:
+              BUILD_SOURCEBRANCH: $(Build.SourceBranch)
+              PR_NUMBER_MACRO: $(System.PullRequest.PullRequestNumber)
+              TARGET_BRANCH: $(System.PullRequest.targetBranchName)


### PR DESCRIPTION
## Problem

The `Post combined report to GitHub` step in `ci/test-pipeline.yml` fails on every merge-queue build:

```
/home/.../bash: line 11: System.PullRequest.targetBranchName: command not found
```

The step embeds PR macros directly in its bash body:

```bash
git fetch origin $(System.PullRequest.targetBranchName)
git diff origin/$(System.PullRequest.targetBranchName)..HEAD > pr.diff
...  --pr $(System.PullRequest.PullRequestNumber)
```

A merge-queue build runs on `refs/heads/gh-readonly-queue/<base>/pr-<n>-<sha>` with `Build.Reason=IndividualCI`, so it carries no pull-request context. Azure leaves those macros unexpanded, bash reads the surviving `$(...)` as command substitution, and tries to run `System.PullRequest.targetBranchName` as a program.

`New pull request (Coverage Report Coverage Report)` is a required check, and the step failure propagates Task to Job to Phase to Stage. A merge-queue entry can therefore never go green: it waits out `check_response_timeout_minutes` and GitHub ejects it.

The first queued entry did not show this. `CoverageReports` depends on `SelfHostedRunTestsCoverageBranches`, which failed on that attempt, so the stage was skipped rather than run. Build 260791 is the first merge-queue build whose tests passed, and it failed here instead.

## Change

The step now takes the macros through `env:` rather than expanding them into the script text. An unexpanded macro reaching an environment variable is inert — it is a literal string value, never evaluated — so the same absent-variable case that crashes today becomes a value the script can test. The enterprise trigger stage in the same file already uses this pattern.

With the values available as ordinary variables, the step resolves what to diff against per build kind:

- Merge-queue build: recovers the pull request number and the base commit from the queue ref, and diffs against that commit.
- Pull-request build: unchanged. Fetches the target branch and diffs against `origin/<target>`.
- Anything else (a manual or scheduled run with no pull request): logs the branch and exits 0 without posting.

For a merge-queue build the base commit is a more accurate diff base than `origin/<target>`. It is the commit the entry was built on, so the diff holds this pull request's contribution alone. `origin/master` would additionally contain whatever other entries merged while this one waited in the queue, which inflates the diff and moves the coverage percentage for reasons unrelated to the author's change.

That commit stops being reachable once its own entry merges and GitHub deletes the ref, so a failed fetch falls back to the queue's base branch instead of failing the step. At the current `max_entries_to_build: 1` the base is always the branch head at enqueue time and the fallback should not trigger; it matters if the queue is later configured to build entries speculatively.

## Tradeoffs

- cover-checker posts its comment against `--pr`, so a pull request that goes through the queue now receives a second coverage comment reporting post-merge coverage. Suppressing it in the queue was the alternative, but the threshold check is what makes this a useful required check, and cover-checker gates and comments in the same invocation.
- The fallback path trades accuracy for liveness. If the base commit is unreachable, the diff is taken against the branch head and can include other entries' changes, over-reporting the diff. The step reports something slightly wrong rather than blocking the queue.
- A manual or scheduled run now silently skips the report where it previously failed. Nothing is lost — it never produced a report — but there is no longer an error drawing attention to a run that produced no coverage comment.
- The queue-ref format is now parsed in two places (`TriggerEnterprise` already does it). A change to GitHub's naming scheme would need both updated.

## Test plan

- YAML parses (`yaml.safe_load`).
- A harness extracts the step's real bash from the YAML with a YAML parser, stubs `git`, and drives it under `set -eu` across five inputs: a queue ref with a reachable base, a queue ref whose base fetch fails, a queue ref on a non-`master` base branch, a normal pull-request build, and a manual `master` build. All five exit 0 and resolve the pull request number and diff base as intended.
- Against the current `master` the same harness reproduces the reported failure on the queue-ref inputs.
- Confirmed on build 260791 that the failing task is `Post combined report to GitHub` and that it fails the `Coverage Report` stage.
- Remaining verification is a live queue entry, which needs this on `master` first.