### PR TITLE
fix(core): fix materialized views never refreshing after ALTER ... SET REFRESH

### DIFF
--- a/core/src/main/java/io/questdb/cairo/mv/MatViewStateStoreImpl.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewStateStoreImpl.java
@@ -108,12 +108,13 @@ public class MatViewStateStoreImpl implements MatViewStateStore {
 
         lastNotifiedTxnByTableName.computeIfAbsent(viewDefinition.getBaseTableName(), createLastNotifiedTxn);
 
-        // Publish a timer creation task.
-        // We need timer(s) in all cases, but immediate non-period view.
-        if (viewDefinition.getRefreshType() != MatViewDefinition.REFRESH_TYPE_IMMEDIATE || viewDefinition.getPeriodLength() > 0) {
-            final MatViewTimerTask timerTask = tlTimerTask.get();
-            timerTaskQueue.enqueue(timerTask.ofAdd(viewToken));
-        }
+        // Publish a timer creation task unconditionally. Which timers, if any, a view needs is
+        // decided by MatViewTimerJob.addTimers() from the definition alone, and it creates nothing
+        // for an immediate, non-period view. That rule belongs in one place: encoding it here too
+        // used to keep such a view out of the timer queue entirely, so a later ALTER ... SET
+        // REFRESH could not register the timers its new definition asked for.
+        final MatViewTimerTask timerTask = tlTimerTask.get();
+        timerTaskQueue.enqueue(timerTask.ofAdd(viewToken));
 
         return state;
     }

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewStateStoreImpl.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewStateStoreImpl.java
@@ -108,13 +108,12 @@ public class MatViewStateStoreImpl implements MatViewStateStore {
 
         lastNotifiedTxnByTableName.computeIfAbsent(viewDefinition.getBaseTableName(), createLastNotifiedTxn);
 
-        // Publish a timer creation task unconditionally. Which timers, if any, a view needs is
-        // decided by MatViewTimerJob.addTimers() from the definition alone, and it creates nothing
-        // for an immediate, non-period view. That rule belongs in one place: encoding it here too
-        // used to keep such a view out of the timer queue entirely, so a later ALTER ... SET
-        // REFRESH could not register the timers its new definition asked for.
-        final MatViewTimerTask timerTask = tlTimerTask.get();
-        timerTaskQueue.enqueue(timerTask.ofAdd(viewToken));
+        // Publish a timer creation task.
+        // We need timer(s) in all cases, but immediate non-period view.
+        if (viewDefinition.getRefreshType() != MatViewDefinition.REFRESH_TYPE_IMMEDIATE || viewDefinition.getPeriodLength() > 0) {
+            final MatViewTimerTask timerTask = tlTimerTask.get();
+            timerTaskQueue.enqueue(timerTask.ofAdd(viewToken));
+        }
 
         return state;
     }

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewTimerJob.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewTimerJob.java
@@ -379,9 +379,14 @@ public class MatViewTimerJob extends SynchronizedJob {
                     removeTimers(viewToken);
                     break;
                 case MatViewTimerTask.UPDATE:
-                    if (removeTimers(viewToken)) {
-                        addTimers(viewToken, nowUs);
-                    }
+                    // Register the new timers even when the view had none. An immediate,
+                    // non-period view registers no timers at all, so gating addTimers() on
+                    // removeTimers() finding something would drop the timers of a view that
+                    // ALTER ... SET REFRESH has just switched to timer or period refresh, and
+                    // that view would never refresh again. addTimers() itself decides what the
+                    // new definition needs, so it is a no-op when the view stays immediate.
+                    removeTimers(viewToken);
+                    addTimers(viewToken, nowUs);
                     break;
                 case MatViewTimerTask.RETRY:
                     // A refresh was deferred after a transient "table busy" error. Queue a

--- a/core/src/main/java/io/questdb/cairo/mv/MatViewTimerJob.java
+++ b/core/src/main/java/io/questdb/cairo/mv/MatViewTimerJob.java
@@ -349,19 +349,18 @@ public class MatViewTimerJob extends SynchronizedJob {
         retryEntryPool.add(entry);
     }
 
-    private boolean removeTimers(TableToken viewToken) {
+    private void removeTimers(TableToken viewToken) {
         filteredDirName = viewToken.getDirName();
         try {
             // Remove all timers for the given view, if any.
             if (timerQueue.removeIf(filterByDirName)) {
                 LOG.info().$("unregistered timers for materialized view [view=").$(viewToken).I$();
-                return true;
+                return;
             }
         } finally {
             filteredDirName = null;
         }
         LOG.info().$("timers for materialized view not found [view=").$(viewToken).I$();
-        return false;
     }
 
     @Override
@@ -380,11 +379,11 @@ public class MatViewTimerJob extends SynchronizedJob {
                     break;
                 case MatViewTimerTask.UPDATE:
                     // Register the new timers even when the view had none. An immediate,
-                    // non-period view registers no timers at all, so gating addTimers() on
-                    // removeTimers() finding something would drop the timers of a view that
-                    // ALTER ... SET REFRESH has just switched to timer or period refresh, and
-                    // that view would never refresh again. addTimers() itself decides what the
-                    // new definition needs, so it is a no-op when the view stays immediate.
+                    // non-period view holds no timers, so gating addTimers() on removeTimers()
+                    // finding something would drop the timers of a view that ALTER ... SET REFRESH
+                    // has just switched to timer, period or manual refresh, leaving it with no
+                    // refresh mechanism at all. addTimers() decides what the new definition needs,
+                    // so it is a no-op when the view stays immediate and non-period.
                     removeTimers(viewToken);
                     addTimers(viewToken, nowUs);
                     break;

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -710,30 +710,92 @@ public class MatViewTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testAlterRefreshImmediateToPeriod() throws Exception {
-        // Same defect as testAlterRefreshImmediateToTimer, reached through the period timer:
-        // an immediate, non-period view has no timers, so adding a period to it has to register
-        // the period timer from scratch.
+    public void testAlterRefreshImmediateToManual() throws Exception {
+        // The same missing registration, seen through the refresh intervals update timer. A manual
+        // view is not expected to refresh, so nothing looks wrong, yet without that timer
+        // refreshIntervalsBaseTxn never advances and WalPurgeJob.getSafeToPurgeUpToTxn keeps the
+        // base table's purge floor pinned at the last refresh, so base table WAL segments
+        // accumulate for as long as the view stays manual.
         assertMemoryLeak(() -> {
+            currentMicros = parseFloorPartialTimestamp("2024-01-01T00:00:00.000000Z");
             executeWithRewriteTimestamp(
-                    "CREATE TABLE base_price (" +
-                            "sym VARCHAR, price DOUBLE, ts #TIMESTAMP" +
-                            ") TIMESTAMP(ts) PARTITION BY DAY WAL"
+                    "create table base_price (" +
+                            "sym varchar, price double, ts #TIMESTAMP" +
+                            ") timestamp(ts) partition by DAY WAL"
             );
-            currentMicros = parseFloorPartialTimestamp("2000-01-01T00:00:00.000000Z");
             execute(
-                    "CREATE MATERIALIZED VIEW price_1h REFRESH IMMEDIATE AS " +
-                            "SELECT sym, last(price) AS price, ts FROM base_price SAMPLE BY 1h"
+                    "create materialized view price_1h refresh immediate as " +
+                            "select sym, last(price) as price, ts from base_price sample by 1h"
             );
 
             final MatViewTimerJob timerJob = new MatViewTimerJob(engine);
             drainMatViewTimerQueue(timerJob);
             drainQueues();
 
-            execute("INSERT INTO base_price(sym, price, ts) VALUES('gbpusd', 1.320, '2000-01-01T02:01')");
+            execute("insert into base_price(sym, price, ts) values('gbpusd', 1.320, '2024-09-10T12:01')");
             drainQueues();
 
-            assertQuery("price_1h ORDER BY sym")
+            final TableToken viewToken = engine.verifyTableName("price_1h");
+            final MatViewStateStoreImpl stateStore = (MatViewStateStoreImpl) engine.getMatViewStateStore();
+            final MatViewState state = stateStore.getViewState(viewToken);
+            Assert.assertNotNull(state);
+            final long refreshedTxn = state.getLastRefreshBaseTxn();
+            Assert.assertTrue("precondition: immediate refresh has run", refreshedTxn > -1);
+
+            execute("alter materialized view price_1h set refresh manual;");
+            drainQueues();
+            drainMatViewTimerQueue(timerJob);
+
+            // base table transactions that the manual view will never refresh
+            execute("insert into base_price(sym, price, ts) values('gbpusd', 1.321, '2024-09-10T13:02')");
+            execute("insert into base_price(sym, price, ts) values('gbpusd', 1.322, '2024-09-10T14:02')");
+            drainWalQueue();
+
+            // tick past the refresh intervals update period
+            currentMicros += Micros.DAY_MICROS;
+            drainMatViewTimerQueue(timerJob);
+            drainQueues();
+
+            Assert.assertEquals(
+                    "the manual view must not refresh on its own",
+                    refreshedTxn,
+                    state.getLastRefreshBaseTxn()
+            );
+            // the refresh intervals update timer registered by the ALTER must have cached the new
+            // intervals; that is what lets WalPurgeJob move its floor past the last refresh
+            Assert.assertTrue(
+                    "refreshIntervalsBaseTxn must advance past the last refresh [intervalsBaseTxn=" +
+                            state.getRefreshIntervalsBaseTxn() + ", lastRefreshBaseTxn=" + refreshedTxn + ']',
+                    state.getRefreshIntervalsBaseTxn() > refreshedTxn
+            );
+        });
+    }
+
+    @Test
+    public void testAlterRefreshImmediateToPeriod() throws Exception {
+        // Same defect as testAlterRefreshImmediateToTimer, reached through the period timer:
+        // an immediate, non-period view has no timers, so adding a period to it has to register
+        // the period timer from scratch.
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp(
+                    "create table base_price (" +
+                            "sym varchar, price double, ts #TIMESTAMP" +
+                            ") timestamp(ts) partition by DAY WAL"
+            );
+            currentMicros = parseFloorPartialTimestamp("2000-01-01T00:00:00.000000Z");
+            execute(
+                    "create materialized view price_1h refresh immediate as " +
+                            "select sym, last(price) as price, ts from base_price sample by 1h"
+            );
+
+            final MatViewTimerJob timerJob = new MatViewTimerJob(engine);
+            drainMatViewTimerQueue(timerJob);
+            drainQueues();
+
+            execute("insert into base_price(sym, price, ts) values('gbpusd', 1.320, '2000-01-01T02:01')");
+            drainQueues();
+
+            assertQuery("price_1h order by sym")
                     .expectSize()
                     .noLeakCheck()
                     .returns(replaceExpectedTimestamp("""
@@ -741,16 +803,16 @@ public class MatViewTest extends AbstractCairoTest {
                             gbpusd\t1.32\t2000-01-01T02:00:00.000000Z
                             """));
 
-            execute("ALTER MATERIALIZED VIEW price_1h SET REFRESH IMMEDIATE PERIOD (LENGTH 4h);");
+            execute("alter materialized view price_1h set refresh immediate period (length 4h);");
             drainQueues();
 
             // the view is a period view now, so a row in the incomplete period must not show up yet
-            execute("INSERT INTO base_price(sym, price, ts) VALUES('gbpusd', 1.323, '2000-01-01T05:01')");
+            execute("insert into base_price(sym, price, ts) values('gbpusd', 1.323, '2000-01-01T05:01')");
             currentMicros = parseFloorPartialTimestamp("2000-01-01T07:59:59.999999Z");
             drainMatViewTimerQueue(timerJob);
             drainQueues();
 
-            assertQuery("price_1h ORDER BY sym")
+            assertQuery("price_1h order by sym")
                     .expectSize()
                     .noLeakCheck()
                     .returns(replaceExpectedTimestamp("""
@@ -763,7 +825,7 @@ public class MatViewTest extends AbstractCairoTest {
             drainMatViewTimerQueue(timerJob);
             drainQueues();
 
-            assertQuery("price_1h ORDER BY sym")
+            assertQuery("price_1h order by sym")
                     .expectSize()
                     .noLeakCheck()
                     .returns(replaceExpectedTimestamp("""
@@ -782,14 +844,14 @@ public class MatViewTest extends AbstractCairoTest {
         // applies and no timer ever fires.
         assertMemoryLeak(() -> {
             executeWithRewriteTimestamp(
-                    "CREATE TABLE base_price (" +
-                            "sym VARCHAR, price DOUBLE, ts #TIMESTAMP" +
-                            ") TIMESTAMP(ts) PARTITION BY DAY WAL"
+                    "create table base_price (" +
+                            "sym varchar, price double, ts #TIMESTAMP" +
+                            ") timestamp(ts) partition by DAY WAL"
             );
             execute(
-                    "CREATE MATERIALIZED VIEW price_1h REFRESH IMMEDIATE AS (" +
-                            "SELECT sym, last(price) AS price, ts FROM base_price SAMPLE BY 1h" +
-                            ") PARTITION BY DAY"
+                    "create materialized view price_1h refresh immediate as (" +
+                            "select sym, last(price) as price, ts from base_price sample by 1h" +
+                            ") partition by day"
             );
 
             final String start = "1999-01-01T01:01:01.842574Z";
@@ -799,14 +861,14 @@ public class MatViewTest extends AbstractCairoTest {
             drainQueues();
 
             execute(
-                    "INSERT INTO base_price(sym, price, ts) VALUES('gbpusd', 1.320, '2024-09-10T12:01')" +
+                    "insert into base_price(sym, price, ts) values('gbpusd', 1.320, '2024-09-10T12:01')" +
                             ",('gbpusd', 1.323, '2024-09-10T12:02')" +
                             ",('jpyusd', 103.21, '2024-09-10T12:02')"
             );
             drainQueues();
 
             // immediate refresh drives the view while it is still immediate
-            assertQuery("price_1h ORDER BY sym")
+            assertQuery("price_1h order by sym")
                     .expectSize()
                     .noLeakCheck()
                     .returns(replaceExpectedTimestamp("""
@@ -815,12 +877,12 @@ public class MatViewTest extends AbstractCairoTest {
                             jpyusd\t103.21\t2024-09-10T12:00:00.000000Z
                             """));
 
-            execute("ALTER MATERIALIZED VIEW price_1h SET REFRESH EVERY 1m START '" + start + "';");
+            execute("alter materialized view price_1h set refresh every 1m start '" + start + "';");
             drainQueues();
 
-            final String matViewsSql = "SELECT view_name, refresh_type, view_status, " +
+            final String matViewsSql = "select view_name, refresh_type, view_status, " +
                     "timer_start, timer_interval, timer_interval_unit " +
-                    "FROM materialized_views";
+                    "from materialized_views";
             assertQuery(matViewsSql)
                     .noRandomAccess()
                     .noLeakCheck()
@@ -830,10 +892,10 @@ public class MatViewTest extends AbstractCairoTest {
                             """);
 
             // the view is no longer immediate, so this insert must not refresh it on its own
-            execute("INSERT INTO base_price(sym, price, ts) VALUES('gbpusd', 1.321, '2024-09-10T13:02')");
+            execute("insert into base_price(sym, price, ts) values('gbpusd', 1.321, '2024-09-10T13:02')");
             drainQueues();
 
-            assertQuery("price_1h ORDER BY sym")
+            assertQuery("price_1h order by sym")
                     .expectSize()
                     .noLeakCheck()
                     .returns(replaceExpectedTimestamp("""
@@ -847,7 +909,7 @@ public class MatViewTest extends AbstractCairoTest {
             drainMatViewTimerQueue(timerJob);
             drainQueues();
 
-            assertQuery("price_1h ORDER BY sym")
+            assertQuery("price_1h order by sym")
                     .expectSize()
                     .noLeakCheck()
                     .returns(replaceExpectedTimestamp("""

--- a/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/mv/MatViewTest.java
@@ -710,6 +710,156 @@ public class MatViewTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAlterRefreshImmediateToPeriod() throws Exception {
+        // Same defect as testAlterRefreshImmediateToTimer, reached through the period timer:
+        // an immediate, non-period view has no timers, so adding a period to it has to register
+        // the period timer from scratch.
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp(
+                    "CREATE TABLE base_price (" +
+                            "sym VARCHAR, price DOUBLE, ts #TIMESTAMP" +
+                            ") TIMESTAMP(ts) PARTITION BY DAY WAL"
+            );
+            currentMicros = parseFloorPartialTimestamp("2000-01-01T00:00:00.000000Z");
+            execute(
+                    "CREATE MATERIALIZED VIEW price_1h REFRESH IMMEDIATE AS " +
+                            "SELECT sym, last(price) AS price, ts FROM base_price SAMPLE BY 1h"
+            );
+
+            final MatViewTimerJob timerJob = new MatViewTimerJob(engine);
+            drainMatViewTimerQueue(timerJob);
+            drainQueues();
+
+            execute("INSERT INTO base_price(sym, price, ts) VALUES('gbpusd', 1.320, '2000-01-01T02:01')");
+            drainQueues();
+
+            assertQuery("price_1h ORDER BY sym")
+                    .expectSize()
+                    .noLeakCheck()
+                    .returns(replaceExpectedTimestamp("""
+                            sym\tprice\tts
+                            gbpusd\t1.32\t2000-01-01T02:00:00.000000Z
+                            """));
+
+            execute("ALTER MATERIALIZED VIEW price_1h SET REFRESH IMMEDIATE PERIOD (LENGTH 4h);");
+            drainQueues();
+
+            // the view is a period view now, so a row in the incomplete period must not show up yet
+            execute("INSERT INTO base_price(sym, price, ts) VALUES('gbpusd', 1.323, '2000-01-01T05:01')");
+            currentMicros = parseFloorPartialTimestamp("2000-01-01T07:59:59.999999Z");
+            drainMatViewTimerQueue(timerJob);
+            drainQueues();
+
+            assertQuery("price_1h ORDER BY sym")
+                    .expectSize()
+                    .noLeakCheck()
+                    .returns(replaceExpectedTimestamp("""
+                            sym\tprice\tts
+                            gbpusd\t1.32\t2000-01-01T02:00:00.000000Z
+                            """));
+
+            // the period timer registered by the ALTER must fire once the period completes
+            currentMicros = parseFloorPartialTimestamp("2000-01-01T08:00:00.000000Z");
+            drainMatViewTimerQueue(timerJob);
+            drainQueues();
+
+            assertQuery("price_1h ORDER BY sym")
+                    .expectSize()
+                    .noLeakCheck()
+                    .returns(replaceExpectedTimestamp("""
+                            sym\tprice\tts
+                            gbpusd\t1.32\t2000-01-01T02:00:00.000000Z
+                            gbpusd\t1.323\t2000-01-01T05:00:00.000000Z
+                            """));
+        });
+    }
+
+    @Test
+    public void testAlterRefreshImmediateToTimer() throws Exception {
+        // An immediate, non-period view has no timers registered with MatViewTimerJob, so switching
+        // it to timer refresh has to register them from scratch. Anything less leaves the view with
+        // correct-looking metadata and no refresh mechanism at all: immediate refresh no longer
+        // applies and no timer ever fires.
+        assertMemoryLeak(() -> {
+            executeWithRewriteTimestamp(
+                    "CREATE TABLE base_price (" +
+                            "sym VARCHAR, price DOUBLE, ts #TIMESTAMP" +
+                            ") TIMESTAMP(ts) PARTITION BY DAY WAL"
+            );
+            execute(
+                    "CREATE MATERIALIZED VIEW price_1h REFRESH IMMEDIATE AS (" +
+                            "SELECT sym, last(price) AS price, ts FROM base_price SAMPLE BY 1h" +
+                            ") PARTITION BY DAY"
+            );
+
+            final String start = "1999-01-01T01:01:01.842574Z";
+            currentMicros = parseFloorPartialTimestamp(start);
+            final MatViewTimerJob timerJob = new MatViewTimerJob(engine);
+            drainMatViewTimerQueue(timerJob);
+            drainQueues();
+
+            execute(
+                    "INSERT INTO base_price(sym, price, ts) VALUES('gbpusd', 1.320, '2024-09-10T12:01')" +
+                            ",('gbpusd', 1.323, '2024-09-10T12:02')" +
+                            ",('jpyusd', 103.21, '2024-09-10T12:02')"
+            );
+            drainQueues();
+
+            // immediate refresh drives the view while it is still immediate
+            assertQuery("price_1h ORDER BY sym")
+                    .expectSize()
+                    .noLeakCheck()
+                    .returns(replaceExpectedTimestamp("""
+                            sym\tprice\tts
+                            gbpusd\t1.323\t2024-09-10T12:00:00.000000Z
+                            jpyusd\t103.21\t2024-09-10T12:00:00.000000Z
+                            """));
+
+            execute("ALTER MATERIALIZED VIEW price_1h SET REFRESH EVERY 1m START '" + start + "';");
+            drainQueues();
+
+            final String matViewsSql = "SELECT view_name, refresh_type, view_status, " +
+                    "timer_start, timer_interval, timer_interval_unit " +
+                    "FROM materialized_views";
+            assertQuery(matViewsSql)
+                    .noRandomAccess()
+                    .noLeakCheck()
+                    .returns("""
+                            view_name\trefresh_type\tview_status\ttimer_start\ttimer_interval\ttimer_interval_unit
+                            price_1h\ttimer\tvalid\t1999-01-01T01:01:01.842574Z\t1\tMINUTE
+                            """);
+
+            // the view is no longer immediate, so this insert must not refresh it on its own
+            execute("INSERT INTO base_price(sym, price, ts) VALUES('gbpusd', 1.321, '2024-09-10T13:02')");
+            drainQueues();
+
+            assertQuery("price_1h ORDER BY sym")
+                    .expectSize()
+                    .noLeakCheck()
+                    .returns(replaceExpectedTimestamp("""
+                            sym\tprice\tts
+                            gbpusd\t1.323\t2024-09-10T12:00:00.000000Z
+                            jpyusd\t103.21\t2024-09-10T12:00:00.000000Z
+                            """));
+
+            // the timer registered by the ALTER must now fire and pick the new row up
+            currentMicros += Micros.MINUTE_MICROS;
+            drainMatViewTimerQueue(timerJob);
+            drainQueues();
+
+            assertQuery("price_1h ORDER BY sym")
+                    .expectSize()
+                    .noLeakCheck()
+                    .returns(replaceExpectedTimestamp("""
+                            sym\tprice\tts
+                            gbpusd\t1.323\t2024-09-10T12:00:00.000000Z
+                            gbpusd\t1.321\t2024-09-10T13:00:00.000000Z
+                            jpyusd\t103.21\t2024-09-10T12:00:00.000000Z
+                            """));
+        });
+    }
+
+    @Test
     public void testAlterRefreshLimit() throws Exception {
         assertMemoryLeak(() -> {
             executeWithRewriteTimestamp(


### PR DESCRIPTION
## What

`ALTER MATERIALIZED VIEW <v> SET REFRESH ...` on a view created `REFRESH IMMEDIATE` updated the view's metadata but never registered a refresh timer. All three targets are affected:

- `SET REFRESH EVERY <interval>` — the view stopped refreshing altogether
- `SET REFRESH IMMEDIATE PERIOD (LENGTH ...)` — the period timer was never registered
- `SET REFRESH MANUAL` — a manual view is not meant to auto-refresh, so nothing looked wrong, but its refresh intervals update timer was never registered either, and the base table stopped purging WAL (see Impact)

## Cause

`MatViewTimerJob.runSerially()` handled a timer `UPDATE` task by calling `addTimers()` only if `removeTimers()` had found an existing timer:

```java
case MatViewTimerTask.UPDATE:
    if (removeTimers(viewToken)) {
        addTimers(viewToken, nowUs);
    }
    break;
```

That gate holds for any view that already owns a timer, which is why the existing coverage passes: `testAlterRefreshTimer1` starts from `every 1h`, and `testAlterRefreshTimer2` plus every `testAlterRefreshParams*` case goes through `testAlterRefreshParamsToTarget`, which always starts from `refresh manual`. The whole ALTER matrix was blind to the immediate origin.

An immediate, non-period view owns no timer at all: `MatViewStateStoreImpl.addViewState` enqueued an `ADD` task only when the view was non-immediate or carried a period, so the view was absent from the timer queue.

For that view the `ALTER` wrote the definition file, updated the graph and the state store, enqueued the `UPDATE` task, and then dropped it — `removeTimers()` found nothing, returned false, `addTimers()` never ran.

## Impact

**Timer and period views: the view stops refreshing, silently.** It was no longer immediate, so base table commits stopped driving it, and no timer existed to fire it. Nothing in the observable state said so:

- `materialized_views()` reported `refresh_type` `timer`, the configured `timer_interval`, `timer_start` equal to the ALTER timestamp, `view_status` valid and a null `invalidation_reason`
- `last_refresh_finish_timestamp` froze at the ALTER timestamp
- `base_table_txn - refresh_base_table_txn` grew without bound
- `wal_tables()` stayed clean, nothing suspended
- `REFRESH MATERIALIZED VIEW <v> FULL` still worked and caught the view up, after which it froze again
- views left on `REFRESH IMMEDIATE` on the same instance were unaffected

**All three targets, manual included: the base table stops purging WAL.** `addTimers()` also creates the `UPDATE_REFRESH_INTERVALS` timer for every non-immediate view, and that timer is what advances `refreshIntervalsBaseTxn`. `WalPurgeJob.getSafeToPurgeUpToTxn` clamps the purge floor to `max(lastRefreshBaseTxn, refreshIntervalsBaseTxn)`; with the timer missing neither advances, so the base table's WAL segments are retained from the ALTER onwards for as long as the view keeps that refresh type. On a `SET REFRESH MANUAL` view this is the *only* symptom — the view is expected not to refresh, so unbounded WAL growth is all that shows.

Restarting the instance cleared it, because hydration goes through `createViewState`, which saw the new refresh type and took the `ADD` path. The condition returned on the next such `ALTER`.

Found on a deployment where six views were switched from `REFRESH IMMEDIATE` to `REFRESH EVERY 5m` and silently stopped refreshing from that moment, ending up several million transactions behind their base tables.

## Fix

Call `removeTimers()` and `addTimers()` unconditionally for `UPDATE`. `addTimers()` already derives what the new definition needs and creates nothing for a view that stays immediate and non-period, and `removeTimers()` clears the view's timers first, so no duplicates accumulate. `removeTimers()` now returns `void`, since no caller reads the result any more.

The change is confined to the `UPDATE` branch. Views that already owned timers take the same path as before — remove, then add — so timer/period/manual origins are unaffected. The cost is one extra `addTimers()` call per `ALTER ... SET REFRESH` on an immediate view, where it returns without creating anything.

The deeper asymmetry is that `MatViewStateStoreImpl.addViewState` re-derives "an immediate, non-period view needs no timers", a rule `addTimers()` already derives from the definition — that duplicate is what kept such a view out of the timer queue to begin with. Removing it is a separate change and not needed here: with this fix in place and `addViewState` untouched, all three new tests pass. Left for its own PR so this one stays a targeted fix on a startup and role-promote path.

## Test plan

Three new tests in `MatViewTest`, one per ALTER target, each starting from `REFRESH IMMEDIATE`:

- `testAlterRefreshImmediateToTimer` — creates a view `REFRESH IMMEDIATE`, confirms immediate refresh drives it, switches it to `REFRESH EVERY 1m`, confirms an insert alone no longer refreshes it, then ticks the timer and confirms the new row lands.
- `testAlterRefreshImmediateToPeriod` — same shape through the period timer, adding `PERIOD (LENGTH 4h)` and confirming the period timer fires on period completion.
- `testAlterRefreshImmediateToManual` — switches to `REFRESH MANUAL`, confirms the view does not refresh on its own, and asserts `refreshIntervalsBaseTxn` advances past the last data refresh, which is what releases `WalPurgeJob`'s floor.

Negative controls, run locally on Linux / JDK 25:

- with the `if (removeTimers(...))` gate restored, all three new tests fail and `testAlterRefreshTimer1` / `testAlterRefreshTimer2` still pass — the new tests are non-vacuous and the existing ones never covered this
- `MatView*Test,CreateMatViewTest,BaseTableMatViewStateTest,DependentViewGraphAndStateStoreTest,WalPurgeJobTest` — green
- enterprise, against a real `s3s-fs` mock: `MatViewReplicationTest,MatViewSwitchInvariantsTest,MatViewInvalidateQuiesceWedgeTest,MatViewInvalidateRepromoteLosslessTest` — 34 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)