### PR TITLE
perf(qwp): fill Parquet result batches by column

### DIFF
--- a/benchmarks/src/main/java/org/questdb/QwpEgressReadBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/QwpEgressReadBenchmark.java
@@ -65,6 +65,10 @@ import java.util.concurrent.TimeUnit;
  * <p>
  * Tune the workload via system properties:
  * <ul>
+ *   <li>{@code -Dhost=<host>} (default localhost)</li>
+ *   <li>{@code -DhttpPort=<port>} (default 9000)</li>
+ *   <li>{@code -Dparquet=true} to convert all partitions before measuring</li>
+ *   <li>{@code -DpgPort=<port>} (default 8812)</li>
  *   <li>{@code -DrowCount=<n>} (default 10_000_000)</li>
  *   <li>{@code -Dskip.populate=true} to re-use an existing table</li>
  * </ul>
@@ -72,15 +76,17 @@ import java.util.concurrent.TimeUnit;
 public class QwpEgressReadBenchmark {
 
     private static final long DEFAULT_ROW_COUNT = 10_000_000L;
-    private static final String HOST = "localhost";
-    private static final int HTTP_PORT = 9000;
-    private static final int PG_PORT = 8812;
+    private static final String HOST = System.getProperty("host", "localhost");
+    private static final int HTTP_PORT = Integer.getInteger("httpPort", 9000);
+    private static final boolean PARQUET;
+    private static final int PG_PORT = Integer.getInteger("pgPort", 8812);
     private static final long PROGRESS_INTERVAL = 1_000_000;
     private static final long ROW_COUNT;
     private static final boolean SKIP_POPULATE;
     private static final String TABLE_NAME = "egress_bench";
 
     static {
+        PARQUET = Boolean.parseBoolean(System.getProperty("parquet", "false"));
         ROW_COUNT = Long.getLong("rowCount", DEFAULT_ROW_COUNT);
         SKIP_POPULATE = Boolean.parseBoolean(System.getProperty("skip.populate", "false"));
     }
@@ -91,6 +97,9 @@ public class QwpEgressReadBenchmark {
             ingestRows();
         } else {
             System.out.println("skip.populate=true, re-using existing " + TABLE_NAME);
+        }
+        if (PARQUET) {
+            convertToParquet();
         }
 
         System.out.println();
@@ -136,6 +145,14 @@ public class QwpEgressReadBenchmark {
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
         return DriverManager.getConnection(
                 String.format("jdbc:postgresql://%s:%d/qdb", HOST, PG_PORT), p);
+    }
+
+    private static void convertToParquet() throws Exception {
+        System.out.println("Converting all partitions to parquet...");
+        try (Connection c = createPgConnection(); Statement st = c.createStatement()) {
+            st.execute("ALTER TABLE " + TABLE_NAME + " CONVERT PARTITION TO PARQUET WHERE ts >= 0");
+        }
+        System.out.println("  conversion complete");
     }
 
     private static void recreateTable() throws Exception {

--- a/benchmarks/src/main/java/org/questdb/QwpEgressReadBenchmarkWide.java
+++ b/benchmarks/src/main/java/org/questdb/QwpEgressReadBenchmarkWide.java
@@ -64,7 +64,13 @@ import java.util.concurrent.TimeUnit;
  * <p>
  * Tune the workload via system properties:
  * <ul>
+ *   <li>{@code -Dhost=<host>} (default localhost)</li>
+ *   <li>{@code -DhttpPort=<port>} (default 9000)</li>
+ *   <li>{@code -Dparquet=true} to convert all partitions before measuring</li>
+ *   <li>{@code -DpgPort=<port>} (default 8812)</li>
+ *   <li>{@code -Drepetitions=<n>} (default 1)</li>
  *   <li>{@code -DrowCount=<n>} (default 10_000_000)</li>
+ *   <li>{@code -DrunOtherProtocols=false} to measure QWP only</li>
  *   <li>{@code -Dskip.populate=true} to re-use an existing table</li>
  * </ul>
  */
@@ -76,11 +82,14 @@ public class QwpEgressReadBenchmarkWide {
     // delta dict grows for most of the batch sequence rather than settling into a
     // cached state immediately.
     private static final int HIGH_CARD = 100_000;
-    private static final String HOST = "localhost";
-    private static final int HTTP_PORT = 9000;
-    private static final int PG_PORT = 8812;
+    private static final String HOST = System.getProperty("host", "localhost");
+    private static final int HTTP_PORT = Integer.getInteger("httpPort", 9000);
+    private static final boolean PARQUET;
+    private static final int PG_PORT = Integer.getInteger("pgPort", 8812);
     private static final long PROGRESS_INTERVAL = 1_000_000;
+    private static final int REPETITIONS;
     private static final long ROW_COUNT;
+    private static final boolean RUN_OTHER_PROTOCOLS;
     private static final boolean SKIP_POPULATE;
     private static final String TABLE_NAME = "egress_bench_wide";
 
@@ -91,26 +100,36 @@ public class QwpEgressReadBenchmarkWide {
         } else {
             System.out.println("skip.populate=true, re-using existing " + TABLE_NAME);
         }
+        if (PARQUET) {
+            convertToParquet();
+        }
 
         System.out.println();
         System.out.println("=== Cold warm-up (runs discarded) ===");
         runQwp(/*warmup=*/ true);
-        runPgWire(/*warmup=*/ true);
-        runHttpExec(/*warmup=*/ true);
+        if (RUN_OTHER_PROTOCOLS) {
+            runPgWire(/*warmup=*/ true);
+            runHttpExec(/*warmup=*/ true);
+        }
 
         System.out.println();
         System.out.println("=== Measurement ===");
-        Result qwp = runQwp(false);
-        Result pg = runPgWire(false);
-        Result http = runHttpExec(false);
+        Result qwp = null;
+        for (int i = 0; i < REPETITIONS; i++) {
+            qwp = runQwp(false);
+        }
+        Result pg = RUN_OTHER_PROTOCOLS ? runPgWire(false) : null;
+        Result http = RUN_OTHER_PROTOCOLS ? runHttpExec(false) : null;
 
         System.out.println();
         System.out.println("=== Comparison ===");
         System.out.printf("%-20s %12s %12s %12s%n", "Protocol", "time(ms)", "rows/sec", "MiB/sec");
         System.out.printf("%-20s %12s %12s %12s%n", "--------", "--------", "--------", "-------");
         printRow("QWP egress (WS)", qwp);
-        printRow("PostgreSQL wire", pg);
-        printRow("HTTP /exec JSON", http);
+        if (RUN_OTHER_PROTOCOLS) {
+            printRow("PostgreSQL wire", pg);
+            printRow("HTTP /exec JSON", http);
+        }
     }
 
     private static String[] buildSymbolPool(String prefix) {
@@ -131,6 +150,14 @@ public class QwpEgressReadBenchmarkWide {
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
         return DriverManager.getConnection(
                 String.format("jdbc:postgresql://%s:%d/qdb", HOST, PG_PORT), p);
+    }
+
+    private static void convertToParquet() throws Exception {
+        System.out.println("Converting all partitions to parquet...");
+        try (Connection c = createPgConnection(); Statement st = c.createStatement()) {
+            st.execute("ALTER TABLE " + TABLE_NAME + " CONVERT PARTITION TO PARQUET WHERE ts >= 0");
+        }
+        System.out.println("  conversion complete");
     }
 
     private static void ingestRows() {
@@ -440,7 +467,10 @@ public class QwpEgressReadBenchmarkWide {
     }
 
     static {
+        PARQUET = Boolean.parseBoolean(System.getProperty("parquet", "false"));
+        REPETITIONS = Math.max(1, Integer.getInteger("repetitions", 1));
         ROW_COUNT = Long.getLong("rowCount", DEFAULT_ROW_COUNT);
+        RUN_OTHER_PROTOCOLS = Boolean.parseBoolean(System.getProperty("runOtherProtocols", "true"));
         SKIP_POPULATE = Boolean.parseBoolean(System.getProperty("skip.populate", "false"));
     }
 }

--- a/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryRecord.java
+++ b/core/src/main/java/io/questdb/cairo/sql/PageFrameMemoryRecord.java
@@ -663,6 +663,21 @@ public class PageFrameMemoryRecord implements Record, StableStringSource, QuietC
         return pageAddresses.get(columnOffset + columnIndex);
     }
 
+    /**
+     * Returns whether the current Parquet frame has no source column for the query column.
+     * This is narrower than {@link #getPageAddress(int)} returning zero: lazy casts hide
+     * their source address from raw consumers, and an inline variable-size value can have
+     * no data vector while retaining a live aux vector.
+     */
+    public boolean isParquetColumnTop(int columnIndex) {
+        if (frameFormat != PartitionFormat.PARQUET
+                || hasTypeCasts && sourceColumnTypes.getQuick(columnIndex) != -1) {
+            return false;
+        }
+        final int index = columnOffset + columnIndex;
+        return pageAddresses.get(index) == 0 && auxPageAddresses.get(index) == 0;
+    }
+
     @Override
     public long getRowId() {
         return Rows.toRowID(frameIndex, rowIndex);

--- a/core/src/main/java/io/questdb/cutlass/qwp/codec/QwpResultBatchBuffer.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/codec/QwpResultBatchBuffer.java
@@ -178,7 +178,7 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                 case QwpConstants.TYPE_DECIMAL64: {
                     long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        if (isNative) {
+                        if (isNative || record.isParquetColumnTop(ci)) {
                             fillNulls(scratch, rows);
                         } else {
                             perColumnRowLoop(record, lo, hi, ci);
@@ -191,7 +191,7 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                 case QwpConstants.TYPE_DOUBLE: {
                     long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        if (isNative) {
+                        if (isNative || record.isParquetColumnTop(ci)) {
                             fillNulls(scratch, rows);
                         } else {
                             perColumnRowLoop(record, lo, hi, ci);
@@ -204,7 +204,7 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                 case QwpConstants.TYPE_INT: {
                     long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        if (isNative) {
+                        if (isNative || record.isParquetColumnTop(ci)) {
                             fillNulls(scratch, rows);
                         } else {
                             perColumnRowLoop(record, lo, hi, ci);
@@ -218,7 +218,7 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                     // QuestDB stores IPv4 NULL as the bit pattern 0 (Numbers.IPv4_NULL).
                     long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        if (isNative) {
+                        if (isNative || record.isParquetColumnTop(ci)) {
                             fillNulls(scratch, rows);
                         } else {
                             perColumnRowLoop(record, lo, hi, ci);
@@ -231,7 +231,7 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                 case QwpConstants.TYPE_FLOAT: {
                     long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        if (isNative) {
+                        if (isNative || record.isParquetColumnTop(ci)) {
                             fillNulls(scratch, rows);
                         } else {
                             perColumnRowLoop(record, lo, hi, ci);
@@ -245,7 +245,7 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                 case QwpConstants.TYPE_CHAR: {
                     long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        if (isNative) {
+                        if (isNative || record.isParquetColumnTop(ci)) {
                             // Wire spec sec 11.5: SHORT / CHAR cannot carry NULL.
                             // INSERT NULL stores 0 and the wire row keeps the null
                             // bitmap bit clear, so a column-top frame ships literal
@@ -263,7 +263,7 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                 case QwpConstants.TYPE_BYTE: {
                     long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        if (isNative) {
+                        if (isNative || record.isParquetColumnTop(ci)) {
                             // Wire spec sec 11.5: BYTE cannot carry NULL. See the
                             // SHORT / CHAR case above for the column-top rationale.
                             scratch.appendColumnFixedZero(rows, 1);
@@ -278,7 +278,7 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                 case QwpConstants.TYPE_BOOLEAN: {
                     long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        if (isNative) {
+                        if (isNative || record.isParquetColumnTop(ci)) {
                             // Wire spec sec 11.5: BOOLEAN cannot carry NULL. The
                             // column-top fill is n bit-packed false values; the
                             // null bitmap stays clear.
@@ -295,7 +295,7 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                     SymbolTable st = sts[ci];
                     long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        if (isNative) {
+                        if (isNative || record.isParquetColumnTop(ci)) {
                             fillNulls(scratch, rows);
                         } else {
                             perColumnRowLoop(record, lo, hi, ci);
@@ -846,7 +846,7 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                 // The wire reader still cannot represent the literal address 0.0.0.0
                 // as non-null - that's a QuestDB-level limitation inherited by the
                 // wire format.
-                scratch.appendIPv4OrNull(record.getInt(ci));
+                scratch.appendIPv4OrNull(record.getIPv4(ci));
                 break;
             case QwpConstants.TYPE_LONG:
                 scratch.appendLongOrNull(record.getLong(ci));

--- a/core/src/main/java/io/questdb/cutlass/qwp/codec/QwpResultBatchBuffer.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/codec/QwpResultBatchBuffer.java
@@ -144,32 +144,19 @@ public class QwpResultBatchBuffer implements QuietCloseable {
 
     /**
      * Bulk-appends {@code (hi - lo)} rows of the given {@code frame}, driving the
-     * column emit in column-major order when the frame is in NATIVE format. Each
-     * supported column type reads its page memory directly from
-     * {@link PageFrame#getPageAddress} and hands a bulk-append call to the
-     * corresponding column scratch; types without a columnar fast path fall
-     * back to per-row iteration over {@code record}, touching only the columns
-     * that need it.
-     * <p>
-     * The parquet-format fallback iterates rows through {@code record} /
-     * {@link #appendRow}, preserving correctness without the columnar speedup.
-     * Replace with a parquet-specific columnar decoder as a follow-up.
+     * column emit in column-major order. Each supported column type reads its
+     * page memory from the frame-bound {@code record} and hands a bulk-append
+     * call to the corresponding column scratch. This works for native frames
+     * and for Parquet frames decoded into native-layout page buffers. Types
+     * without a columnar fast path fall back to per-row iteration over
+     * {@code record}, touching only the columns that need it.
      */
     public void appendPageFrame(PageFrame frame, PageFrameMemoryRecord record, long lo, long hi) {
         final int rows = (int) (hi - lo);
         if (rows <= 0) {
             return;
         }
-        if (frame.getFormat() != PartitionFormat.NATIVE) {
-            // Parquet frame: no contiguous column addresses we can memcpy from.
-            // Fall back to per-row using the existing single-row path. Row count
-            // advances via appendRow itself.
-            for (long r = lo; r < hi; r++) {
-                record.setRowIndex(r);
-                appendRow(record);
-            }
-            return;
-        }
+        final boolean isNative = frame.getFormat() == PartitionFormat.NATIVE;
         final int n = columnCount;
         final QwpColumnScratch[] scs = scratchesArr;
         final byte[] wts = wireTypesArr;
@@ -189,27 +176,39 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                 case QwpConstants.TYPE_TIMESTAMP:
                 case QwpConstants.TYPE_TIMESTAMP_NANOS:
                 case QwpConstants.TYPE_DECIMAL64: {
-                    long base = frame.getPageAddress(ci);
+                    long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        fillNulls(scratch, rows);
+                        if (isNative) {
+                            fillNulls(scratch, rows);
+                        } else {
+                            perColumnRowLoop(record, lo, hi, ci);
+                        }
                     } else {
                         scratch.appendColumnLong8WithSentinel(base + lo * 8L, rows);
                     }
                     break;
                 }
                 case QwpConstants.TYPE_DOUBLE: {
-                    long base = frame.getPageAddress(ci);
+                    long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        fillNulls(scratch, rows);
+                        if (isNative) {
+                            fillNulls(scratch, rows);
+                        } else {
+                            perColumnRowLoop(record, lo, hi, ci);
+                        }
                     } else {
                         scratch.appendColumnDouble8(base + lo * 8L, rows);
                     }
                     break;
                 }
                 case QwpConstants.TYPE_INT: {
-                    long base = frame.getPageAddress(ci);
+                    long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        fillNulls(scratch, rows);
+                        if (isNative) {
+                            fillNulls(scratch, rows);
+                        } else {
+                            perColumnRowLoop(record, lo, hi, ci);
+                        }
                     } else {
                         scratch.appendColumnInt4WithSentinel(base + lo * 4L, rows, Numbers.INT_NULL);
                     }
@@ -217,18 +216,26 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                 }
                 case QwpConstants.TYPE_IPV4: {
                     // QuestDB stores IPv4 NULL as the bit pattern 0 (Numbers.IPv4_NULL).
-                    long base = frame.getPageAddress(ci);
+                    long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        fillNulls(scratch, rows);
+                        if (isNative) {
+                            fillNulls(scratch, rows);
+                        } else {
+                            perColumnRowLoop(record, lo, hi, ci);
+                        }
                     } else {
                         scratch.appendColumnInt4WithSentinel(base + lo * 4L, rows, Numbers.IPv4_NULL);
                     }
                     break;
                 }
                 case QwpConstants.TYPE_FLOAT: {
-                    long base = frame.getPageAddress(ci);
+                    long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        fillNulls(scratch, rows);
+                        if (isNative) {
+                            fillNulls(scratch, rows);
+                        } else {
+                            perColumnRowLoop(record, lo, hi, ci);
+                        }
                     } else {
                         scratch.appendColumnFloat4(base + lo * 4L, rows);
                     }
@@ -236,37 +243,49 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                 }
                 case QwpConstants.TYPE_SHORT:
                 case QwpConstants.TYPE_CHAR: {
-                    long base = frame.getPageAddress(ci);
+                    long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        // Wire spec sec 11.5: SHORT / CHAR cannot carry NULL.
-                        // INSERT NULL stores 0 and the wire row keeps the null
-                        // bitmap bit clear, so a column-top frame ships literal
-                        // zero values rather than driving fillNulls (which would
-                        // set bits in the null bitmap that the client rejects).
-                        scratch.appendColumnFixedZero(rows, 2);
+                        if (isNative) {
+                            // Wire spec sec 11.5: SHORT / CHAR cannot carry NULL.
+                            // INSERT NULL stores 0 and the wire row keeps the null
+                            // bitmap bit clear, so a column-top frame ships literal
+                            // zero values rather than driving fillNulls (which would
+                            // set bits in the null bitmap that the client rejects).
+                            scratch.appendColumnFixedZero(rows, 2);
+                        } else {
+                            perColumnRowLoop(record, lo, hi, ci);
+                        }
                     } else {
                         scratch.appendColumnFixedNoNull(base + lo * 2L, rows, 2);
                     }
                     break;
                 }
                 case QwpConstants.TYPE_BYTE: {
-                    long base = frame.getPageAddress(ci);
+                    long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        // Wire spec sec 11.5: BYTE cannot carry NULL. See the
-                        // SHORT / CHAR case above for the column-top rationale.
-                        scratch.appendColumnFixedZero(rows, 1);
+                        if (isNative) {
+                            // Wire spec sec 11.5: BYTE cannot carry NULL. See the
+                            // SHORT / CHAR case above for the column-top rationale.
+                            scratch.appendColumnFixedZero(rows, 1);
+                        } else {
+                            perColumnRowLoop(record, lo, hi, ci);
+                        }
                     } else {
                         scratch.appendColumnFixedNoNull(base + lo, rows, 1);
                     }
                     break;
                 }
                 case QwpConstants.TYPE_BOOLEAN: {
-                    long base = frame.getPageAddress(ci);
+                    long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        // Wire spec sec 11.5: BOOLEAN cannot carry NULL. The
-                        // column-top fill is n bit-packed false values; the
-                        // null bitmap stays clear.
-                        scratch.appendColumnBooleanZero(rows);
+                        if (isNative) {
+                            // Wire spec sec 11.5: BOOLEAN cannot carry NULL. The
+                            // column-top fill is n bit-packed false values; the
+                            // null bitmap stays clear.
+                            scratch.appendColumnBooleanZero(rows);
+                        } else {
+                            perColumnRowLoop(record, lo, hi, ci);
+                        }
                     } else {
                         scratch.appendColumnBoolean(base + lo, rows);
                     }
@@ -274,9 +293,13 @@ public class QwpResultBatchBuffer implements QuietCloseable {
                 }
                 case QwpConstants.TYPE_SYMBOL: {
                     SymbolTable st = sts[ci];
-                    long base = frame.getPageAddress(ci);
+                    long base = record.getPageAddress(ci);
                     if (base == 0) {
-                        fillNulls(scratch, rows);
+                        if (isNative) {
+                            fillNulls(scratch, rows);
+                        } else {
+                            perColumnRowLoop(record, lo, hi, ci);
+                        }
                     } else if (st != null) {
                         scratch.appendColumnSymbolKeys(base + lo * 4L, rows, st, connDict);
                     } else {

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressParquetPageFrameTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressParquetPageFrameTest.java
@@ -1,0 +1,467 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cutlass.qwp;
+
+import io.questdb.PropertyKey;
+import io.questdb.client.cutlass.qwp.client.QwpColumnBatch;
+import io.questdb.client.cutlass.qwp.client.QwpColumnBatchHandler;
+import io.questdb.client.cutlass.qwp.client.QwpQueryClient;
+import io.questdb.std.Unsafe;
+import io.questdb.test.TestServerMain;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+
+public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
+
+    private static final String[] SMALL_FRAMES_AND_ROW_GROUPS = new String[]{
+            PropertyKey.CAIRO_SQL_PAGE_FRAME_MAX_ROWS.getEnvVarName(), "64",
+            PropertyKey.CAIRO_SQL_PAGE_FRAME_MIN_ROWS.getEnvVarName(), "32",
+            PropertyKey.CAIRO_PARTITION_ENCODER_PARQUET_ROW_GROUP_SIZE.getEnvVarName(), "32"
+    };
+
+    @Before
+    public void setUp() {
+        super.setUp();
+        TestUtils.unchecked(() -> createDummyConfiguration());
+        dbPath.parent().$();
+    }
+
+    @Test
+    public void testAllTypesParityAllParquet() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (TestServerMain server = startFragmented(SMALL_FRAMES_AND_ROW_GROUPS)) {
+                server.execute("""
+                        CREATE TABLE allp(
+                            ts TIMESTAMP,
+                            l LONG,
+                            d DOUBLE,
+                            i INT,
+                            ip IPv4,
+                            f FLOAT,
+                            sh SHORT,
+                            ch CHAR,
+                            by BYTE,
+                            bo BOOLEAN,
+                            sym SYMBOL,
+                            vc VARCHAR,
+                            s STRING,
+                            bin BINARY,
+                            u UUID,
+                            l256 LONG256,
+                            d64 DECIMAL(18,4),
+                            d128 DECIMAL(38,6),
+                            d256 DECIMAL(76,10),
+                            gh GEOHASH(12b),
+                            a DOUBLE[],
+                            tsn TIMESTAMP_NS
+                        ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                        """);
+                server.execute("""
+                        INSERT INTO allp
+                        SELECT
+                            CAST(86_400_000_000L * ((x - 1) / 150) + x * 1_000L AS TIMESTAMP),
+                            CASE WHEN x % 17 = 0 THEN CAST(NULL AS LONG) ELSE x END,
+                            CASE WHEN x % 19 = 0 THEN CAST(NULL AS DOUBLE) ELSE x * 1.5 END,
+                            CASE WHEN x % 23 = 0 THEN CAST(NULL AS INT) ELSE x::INT END,
+                            CAST('192.168.1.1' AS IPv4),
+                            x::FLOAT,
+                            x::SHORT,
+                            'Q',
+                            x::BYTE,
+                            x % 2 = 0,
+                            CASE WHEN x % 29 = 0 THEN CAST(NULL AS SYMBOL) ELSE 'sym_' || (x % 41)::STRING END,
+                            CASE WHEN x % 31 = 0 THEN CAST(NULL AS VARCHAR) ELSE 'vc_' || x::STRING END,
+                            CASE WHEN x % 37 = 0 THEN CAST(NULL AS STRING) ELSE 'str_' || x::STRING END,
+                            rnd_bin(8, 8, 0),
+                            'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+                            CAST('0x0123456789ABCDEF' AS LONG256),
+                            1234.5678m,
+                            123456789.123456m,
+                            123456789.1234567890m,
+                            #012,
+                            ARRAY[1.0, 2.0, 3.0],
+                            x::TIMESTAMP_NS
+                        FROM long_sequence(300)
+                        """);
+                server.awaitTable("allp");
+
+                byte[] nativePayload = snapshotPayload("SELECT * FROM allp");
+                server.execute("ALTER TABLE allp CONVERT PARTITION TO PARQUET WHERE ts >= 0");
+                TestUtils.drainWalQueue(server.getEngine());
+                byte[] parquetPayload = snapshotPayload("SELECT * FROM allp");
+
+                Assert.assertArrayEquals(nativePayload, parquetPayload);
+            }
+        });
+    }
+
+    @Test
+    public void testColumnTopsAcrossParquetAndNative() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (TestServerMain server = startFragmented(SMALL_FRAMES_AND_ROW_GROUPS)) {
+                server.execute("CREATE TABLE tops(id LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                server.execute("INSERT INTO tops VALUES (1, '2024-01-01T00:00:00Z'), (2, '2024-01-01T00:00:01Z')");
+                server.awaitTable("tops");
+                server.execute("ALTER TABLE tops CONVERT PARTITION TO PARQUET WHERE ts >= 0");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.execute("ALTER TABLE tops ADD COLUMN l LONG");
+                server.execute("ALTER TABLE tops ADD COLUMN i INT");
+                server.execute("ALTER TABLE tops ADD COLUMN d DOUBLE");
+                server.execute("ALTER TABLE tops ADD COLUMN sh SHORT");
+                server.execute("ALTER TABLE tops ADD COLUMN by BYTE");
+                server.execute("ALTER TABLE tops ADD COLUMN ch CHAR");
+                server.execute("ALTER TABLE tops ADD COLUMN bo BOOLEAN");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.execute("""
+                        INSERT INTO tops(id, ts, l, i, d, sh, by, ch, bo)
+                        VALUES (3, '2024-01-02T00:00:00Z', 30, 31, 32.5, 33, 34, 'X', true)
+                        """);
+                server.awaitTable("tops");
+
+                final int[] rows = {0};
+                try (QwpQueryClient client = newClient()) {
+                    client.execute("SELECT l, i, d, sh, by, ch, bo FROM tops", new QwpColumnBatchHandler() {
+                        @Override
+                        public void onBatch(QwpColumnBatch batch) {
+                            for (int r = 0; r < batch.getRowCount(); r++, rows[0]++) {
+                                if (rows[0] < 2) {
+                                    Assert.assertTrue(batch.isNull(0, r));
+                                    Assert.assertTrue(batch.isNull(1, r));
+                                    Assert.assertTrue(batch.isNull(2, r));
+                                    Assert.assertFalse(batch.isNull(3, r));
+                                    Assert.assertFalse(batch.isNull(4, r));
+                                    Assert.assertFalse(batch.isNull(5, r));
+                                    Assert.assertFalse(batch.isNull(6, r));
+                                    Assert.assertEquals(0, batch.getShortValue(3, r));
+                                    Assert.assertEquals(0, batch.getByteValue(4, r));
+                                    Assert.assertEquals(0, batch.getCharValue(5, r));
+                                    Assert.assertFalse(batch.getBoolValue(6, r));
+                                } else {
+                                    Assert.assertEquals(30, batch.getLongValue(0, r));
+                                    Assert.assertEquals(31, batch.getIntValue(1, r));
+                                    Assert.assertEquals(32.5, batch.getDoubleValue(2, r), 0.0);
+                                    Assert.assertEquals(33, batch.getShortValue(3, r));
+                                    Assert.assertEquals(34, batch.getByteValue(4, r));
+                                    Assert.assertEquals('X', batch.getCharValue(5, r));
+                                    Assert.assertTrue(batch.getBoolValue(6, r));
+                                }
+                            }
+                        }
+
+                        @Override
+                        public void onEnd(long totalRows) {
+                            Assert.assertEquals(3, totalRows);
+                        }
+
+                        @Override
+                        public void onError(byte status, String message) {
+                            Assert.fail(message);
+                        }
+                    });
+                }
+                Assert.assertEquals(3, rows[0]);
+            }
+        });
+    }
+
+    @Test
+    public void testCountAndFilterFallbacks() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (TestServerMain server = startFragmented(SMALL_FRAMES_AND_ROW_GROUPS)) {
+                server.execute("CREATE TABLE fallback_t(x LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                server.execute("INSERT INTO fallback_t SELECT x, x::TIMESTAMP FROM long_sequence(500)");
+                server.awaitTable("fallback_t");
+                server.execute("ALTER TABLE fallback_t CONVERT PARTITION TO PARQUET WHERE ts >= 0");
+                TestUtils.drainWalQueue(server.getEngine());
+
+                final long[] count = {-1};
+                final long[] filteredCount = {0};
+                final long[] filteredSum = {0};
+                try (QwpQueryClient client = newClient()) {
+                    client.execute("SELECT count() FROM fallback_t", new QwpColumnBatchHandler() {
+                        @Override
+                        public void onBatch(QwpColumnBatch batch) {
+                            count[0] = batch.getLongValue(0, 0);
+                        }
+
+                        @Override
+                        public void onEnd(long totalRows) {
+                        }
+
+                        @Override
+                        public void onError(byte status, String message) {
+                            Assert.fail(message);
+                        }
+                    });
+                    client.execute("SELECT x FROM fallback_t WHERE x % 10 = 0", new QwpColumnBatchHandler() {
+                        @Override
+                        public void onBatch(QwpColumnBatch batch) {
+                            for (int r = 0; r < batch.getRowCount(); r++) {
+                                filteredCount[0]++;
+                                filteredSum[0] += batch.getLongValue(0, r);
+                            }
+                        }
+
+                        @Override
+                        public void onEnd(long totalRows) {
+                        }
+
+                        @Override
+                        public void onError(byte status, String message) {
+                            Assert.fail(message);
+                        }
+                    });
+                }
+                Assert.assertEquals(500, count[0]);
+                Assert.assertEquals(50, filteredCount[0]);
+                Assert.assertEquals(12_750, filteredSum[0]);
+            }
+        });
+    }
+
+    @Test
+    public void testLazyAlterColumnTypeDoesNotBecomeNull() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (TestServerMain server = startFragmented(SMALL_FRAMES_AND_ROW_GROUPS)) {
+                server.execute("CREATE TABLE casts(a LONG, b VARCHAR, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                server.execute("INSERT INTO casts VALUES (10, '100', 1::TIMESTAMP), (20, '200', 2::TIMESTAMP), (NULL, NULL, 3::TIMESTAMP)");
+                server.awaitTable("casts");
+                server.execute("ALTER TABLE casts CONVERT PARTITION TO PARQUET WHERE ts >= 0");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.execute("ALTER TABLE casts ALTER COLUMN a TYPE VARCHAR");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.execute("ALTER TABLE casts ALTER COLUMN b TYPE LONG");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.awaitTxn("casts", 4);
+
+                final int[] rows = {0};
+                try (QwpQueryClient client = newClient()) {
+                    client.execute("SELECT a, b FROM casts", new QwpColumnBatchHandler() {
+                        @Override
+                        public void onBatch(QwpColumnBatch batch) {
+                            for (int r = 0; r < batch.getRowCount(); r++, rows[0]++) {
+                                if (rows[0] == 0) {
+                                    Assert.assertEquals("10", batch.getString(0, r));
+                                    Assert.assertEquals(100, batch.getLongValue(1, r));
+                                } else if (rows[0] == 1) {
+                                    Assert.assertEquals("20", batch.getString(0, r));
+                                    Assert.assertEquals(200, batch.getLongValue(1, r));
+                                } else {
+                                    Assert.assertTrue(batch.isNull(0, r));
+                                    Assert.assertTrue(batch.isNull(1, r));
+                                }
+                            }
+                        }
+
+                        @Override
+                        public void onEnd(long totalRows) {
+                            Assert.assertEquals(3, totalRows);
+                        }
+
+                        @Override
+                        public void onError(byte status, String message) {
+                            Assert.fail(message);
+                        }
+                    });
+                }
+                Assert.assertEquals(3, rows[0]);
+            }
+        });
+    }
+
+    @Test
+    public void testMixedNativeAndParquetSymbolDictionary() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (TestServerMain server = startFragmented(SMALL_FRAMES_AND_ROW_GROUPS)) {
+                server.execute("CREATE TABLE mixed(s SYMBOL, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                server.execute("""
+                        INSERT INTO mixed
+                        SELECT
+                            CASE WHEN x % 37 = 0 THEN CAST(NULL AS SYMBOL) ELSE 's_' || (x % 41)::STRING END,
+                            CAST(86_400_000_000L * ((x - 1) / 200) + x AS TIMESTAMP)
+                        FROM long_sequence(400)
+                        """);
+                server.awaitTable("mixed");
+                server.execute("ALTER TABLE mixed CONVERT PARTITION TO PARQUET WHERE ts < '1970-01-02'");
+                TestUtils.drainWalQueue(server.getEngine());
+
+                final int[] counts = new int[41];
+                final int[] nulls = {0};
+                final int[] rows = {0};
+                try (QwpQueryClient client = newClient()) {
+                    client.execute("SELECT s FROM mixed", new QwpColumnBatchHandler() {
+                        @Override
+                        public void onBatch(QwpColumnBatch batch) {
+                            for (int r = 0; r < batch.getRowCount(); r++, rows[0]++) {
+                                String value = batch.getSymbol(0, r);
+                                if (value == null) {
+                                    nulls[0]++;
+                                } else {
+                                    counts[Integer.parseInt(value.substring(2))]++;
+                                }
+                            }
+                        }
+
+                        @Override
+                        public void onEnd(long totalRows) {
+                            Assert.assertEquals(400, totalRows);
+                        }
+
+                        @Override
+                        public void onError(byte status, String message) {
+                            Assert.fail(message);
+                        }
+                    });
+                }
+                Assert.assertEquals(400, rows[0]);
+                Assert.assertEquals(10, nulls[0]);
+                for (int i = 0; i < counts.length; i++) {
+                    Assert.assertTrue("symbol bucket " + i, counts[i] >= 8 && counts[i] <= 10);
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testMultipleRowGroupsAndFragmentedResume() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (TestServerMain server = startFragmented(SMALL_FRAMES_AND_ROW_GROUPS)) {
+                server.execute("CREATE TABLE resume_t(x LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                server.execute("INSERT INTO resume_t SELECT x, x::TIMESTAMP FROM long_sequence(1_000)");
+                server.awaitTable("resume_t");
+                server.execute("ALTER TABLE resume_t CONVERT PARTITION TO PARQUET WHERE ts >= 0");
+                TestUtils.drainWalQueue(server.getEngine());
+
+                final long[] next = {1};
+                try (QwpQueryClient client = QwpQueryClient.fromConfig(
+                        "ws::addr=127.0.0.1:" + HTTP_PORT + ";max_batch_rows=37;")) {
+                    client.connect();
+                    client.execute("SELECT x FROM resume_t", new QwpColumnBatchHandler() {
+                        @Override
+                        public void onBatch(QwpColumnBatch batch) {
+                            for (int r = 0; r < batch.getRowCount(); r++) {
+                                Assert.assertEquals(next[0]++, batch.getLongValue(0, r));
+                            }
+                        }
+
+                        @Override
+                        public void onEnd(long totalRows) {
+                            Assert.assertEquals(1_000, totalRows);
+                        }
+
+                        @Override
+                        public void onError(byte status, String message) {
+                            Assert.fail(message);
+                        }
+                    });
+                }
+                Assert.assertEquals(1_001, next[0]);
+            }
+        });
+    }
+
+    @Test
+    public void testSymbolNullsAndHighCardinality() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (TestServerMain server = startFragmented(SMALL_FRAMES_AND_ROW_GROUPS)) {
+                server.execute("CREATE TABLE high_sym(s SYMBOL CAPACITY 4096, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
+                server.execute("""
+                        INSERT INTO high_sym
+                        SELECT CASE WHEN x % 101 = 0 THEN CAST(NULL AS SYMBOL) ELSE 's_' || x::STRING END, x::TIMESTAMP
+                        FROM long_sequence(2_000)
+                        """);
+                server.awaitTable("high_sym");
+                server.execute("ALTER TABLE high_sym CONVERT PARTITION TO PARQUET WHERE ts >= 0");
+                TestUtils.drainWalQueue(server.getEngine());
+
+                final int[] nulls = {0};
+                final int[] rows = {0};
+                try (QwpQueryClient client = newClient()) {
+                    client.execute("SELECT s FROM high_sym", new QwpColumnBatchHandler() {
+                        @Override
+                        public void onBatch(QwpColumnBatch batch) {
+                            for (int r = 0; r < batch.getRowCount(); r++, rows[0]++) {
+                                if (batch.isNull(0, r)) {
+                                    nulls[0]++;
+                                } else {
+                                    Assert.assertEquals("s_" + (rows[0] + 1), batch.getSymbol(0, r));
+                                }
+                            }
+                        }
+
+                        @Override
+                        public void onEnd(long totalRows) {
+                            Assert.assertEquals(2_000, totalRows);
+                        }
+
+                        @Override
+                        public void onError(byte status, String message) {
+                            Assert.fail(message);
+                        }
+                    });
+                }
+                Assert.assertEquals(2_000, rows[0]);
+                Assert.assertEquals(19, nulls[0]);
+            }
+        });
+    }
+
+    private static QwpQueryClient newClient() throws Exception {
+        QwpQueryClient client = QwpQueryClient.fromConfig("ws::addr=127.0.0.1:" + HTTP_PORT + ";");
+        client.connect();
+        return client;
+    }
+
+    private static byte[] snapshotPayload(String sql) throws Exception {
+        ByteArrayOutputStream payload = new ByteArrayOutputStream();
+        try (QwpQueryClient client = newClient()) {
+            client.execute(sql, new QwpColumnBatchHandler() {
+                @Override
+                public void onBatch(QwpColumnBatch batch) {
+                    long lo = batch.payloadAddr();
+                    long hi = batch.payloadLimit();
+                    for (long p = lo; p < hi; p++) {
+                        payload.write(Unsafe.getByte(p));
+                    }
+                }
+
+                @Override
+                public void onEnd(long totalRows) {
+                    Assert.assertEquals(300, totalRows);
+                }
+
+                @Override
+                public void onError(byte status, String message) {
+                    Assert.fail(message);
+                }
+            });
+        }
+        return payload.toByteArray();
+    }
+}

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressParquetPageFrameTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressParquetPageFrameTest.java
@@ -25,9 +25,21 @@
 package io.questdb.test.cutlass.qwp;
 
 import io.questdb.PropertyKey;
+import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.idx.IndexReader;
+import io.questdb.cairo.sql.PageFrame;
+import io.questdb.cairo.sql.PageFrameMemoryRecord;
+import io.questdb.cairo.sql.PartitionFormat;
 import io.questdb.client.cutlass.qwp.client.QwpColumnBatch;
 import io.questdb.client.cutlass.qwp.client.QwpColumnBatchHandler;
 import io.questdb.client.cutlass.qwp.client.QwpQueryClient;
+import io.questdb.cutlass.qwp.codec.QwpEgressColumnDef;
+import io.questdb.cutlass.qwp.codec.QwpEgressConnSymbolDict;
+import io.questdb.cutlass.qwp.codec.QwpResultBatchBuffer;
+import io.questdb.std.DirectLongList;
+import io.questdb.std.IntList;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.ObjList;
 import io.questdb.std.Unsafe;
 import io.questdb.test.TestServerMain;
 import io.questdb.test.tools.TestUtils;
@@ -113,7 +125,7 @@ public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
 
                 byte[] nativePayload = snapshotPayload("SELECT * FROM allp");
                 server.execute("ALTER TABLE allp CONVERT PARTITION TO PARQUET WHERE ts >= 0");
-                TestUtils.drainWalQueue(server.getEngine());
+                awaitTxnAndAssertParquetPartitions(server, "allp", 2, "1970-01-01\n1970-01-02\n");
                 byte[] parquetPayload = snapshotPayload("SELECT * FROM allp");
 
                 Assert.assertArrayEquals(nativePayload, parquetPayload);
@@ -126,10 +138,10 @@ public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
         TestUtils.assertMemoryLeak(() -> {
             try (TestServerMain server = startFragmented(SMALL_FRAMES_AND_ROW_GROUPS)) {
                 server.execute("CREATE TABLE tops(id LONG, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
-                server.execute("INSERT INTO tops VALUES (1, '2024-01-01T00:00:00Z'), (2, '2024-01-01T00:00:01Z')");
+                server.execute("INSERT INTO tops SELECT x, dateadd('s', x::INT, '2024-01-01') FROM long_sequence(130)");
                 server.awaitTable("tops");
                 server.execute("ALTER TABLE tops CONVERT PARTITION TO PARQUET WHERE ts >= 0");
-                TestUtils.drainWalQueue(server.getEngine());
+                awaitTxnAndAssertParquetPartitions(server, "tops", 2, "2024-01-01\n");
                 server.execute("ALTER TABLE tops ADD COLUMN l LONG");
                 server.execute("ALTER TABLE tops ADD COLUMN i INT");
                 server.execute("ALTER TABLE tops ADD COLUMN d DOUBLE");
@@ -150,7 +162,7 @@ public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
                         @Override
                         public void onBatch(QwpColumnBatch batch) {
                             for (int r = 0; r < batch.getRowCount(); r++, rows[0]++) {
-                                if (rows[0] < 2) {
+                                if (rows[0] < 130) {
                                     Assert.assertTrue(batch.isNull(0, r));
                                     Assert.assertTrue(batch.isNull(1, r));
                                     Assert.assertTrue(batch.isNull(2, r));
@@ -176,7 +188,7 @@ public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
 
                         @Override
                         public void onEnd(long totalRows) {
-                            Assert.assertEquals(3, totalRows);
+                            Assert.assertEquals(131, totalRows);
                         }
 
                         @Override
@@ -185,7 +197,7 @@ public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
                         }
                     });
                 }
-                Assert.assertEquals(3, rows[0]);
+                Assert.assertEquals(131, rows[0]);
             }
         });
     }
@@ -198,7 +210,7 @@ public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
                 server.execute("INSERT INTO fallback_t SELECT x, x::TIMESTAMP FROM long_sequence(500)");
                 server.awaitTable("fallback_t");
                 server.execute("ALTER TABLE fallback_t CONVERT PARTITION TO PARQUET WHERE ts >= 0");
-                TestUtils.drainWalQueue(server.getEngine());
+                awaitTxnAndAssertParquetPartitions(server, "fallback_t", 2, "1970-01-01\n");
 
                 final long[] count = {-1};
                 final long[] filteredCount = {0};
@@ -246,35 +258,187 @@ public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
     }
 
     @Test
+    public void testCoveringIndexIncludedFixedWidthValues() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            try (TestServerMain server = startFragmented(SMALL_FRAMES_AND_ROW_GROUPS)) {
+                server.execute("""
+                        CREATE TABLE qwp_cov(
+                            ts TIMESTAMP,
+                            sym SYMBOL INDEX TYPE POSTING INCLUDE (l, d),
+                            l LONG,
+                            d DOUBLE
+                        ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                        """);
+                server.execute("""
+                        INSERT INTO qwp_cov
+                        SELECT
+                            dateadd('s', x::INT, '2024-01-01')::TIMESTAMP,
+                            CASE WHEN x % 2 = 1 THEN 'A' ELSE 'B' END,
+                            x,
+                            x * 1.5
+                        FROM long_sequence(300)
+                        """);
+                server.awaitTxn("qwp_cov", 1);
+
+                final String sql = "SELECT l, d FROM qwp_cov WHERE sym = 'A'";
+                final StringBuilder plan = new StringBuilder();
+                final int[] rows = {0};
+                try (QwpQueryClient client = newClient()) {
+                    client.execute("EXPLAIN " + sql, new QwpColumnBatchHandler() {
+                        @Override
+                        public void onBatch(QwpColumnBatch batch) {
+                            for (int r = 0; r < batch.getRowCount(); r++) {
+                                plan.append(batch.getString(0, r));
+                            }
+                        }
+
+                        @Override
+                        public void onEnd(long totalRows) {
+                        }
+
+                        @Override
+                        public void onError(byte status, String message) {
+                            Assert.fail(message);
+                        }
+                    });
+                    Assert.assertTrue(
+                            "plan must use covering index: " + plan,
+                            plan.indexOf("CoveringIndex on: sym") >= 0
+                    );
+
+                    client.execute(sql, new QwpColumnBatchHandler() {
+                        @Override
+                        public void onBatch(QwpColumnBatch batch) {
+                            for (int r = 0; r < batch.getRowCount(); r++, rows[0]++) {
+                                long expected = rows[0] * 2L + 1;
+                                Assert.assertFalse("LONG row " + rows[0], batch.isNull(0, r));
+                                Assert.assertFalse("DOUBLE row " + rows[0], batch.isNull(1, r));
+                                Assert.assertEquals(expected, batch.getLongValue(0, r));
+                                Assert.assertEquals(expected * 1.5, batch.getDoubleValue(1, r), 0.0);
+                            }
+                        }
+
+                        @Override
+                        public void onEnd(long totalRows) {
+                            Assert.assertEquals(150, totalRows);
+                        }
+
+                        @Override
+                        public void onError(byte status, String message) {
+                            Assert.fail(message);
+                        }
+                    });
+                }
+                Assert.assertEquals(150, rows[0]);
+            }
+        });
+    }
+
+    @Test
     public void testLazyAlterColumnTypeDoesNotBecomeNull() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (TestServerMain server = startFragmented(SMALL_FRAMES_AND_ROW_GROUPS)) {
-                server.execute("CREATE TABLE casts(a LONG, b VARCHAR, ts TIMESTAMP) TIMESTAMP(ts) PARTITION BY DAY WAL");
-                server.execute("INSERT INTO casts VALUES (10, '100', 1::TIMESTAMP), (20, '200', 2::TIMESTAMP), (NULL, NULL, 3::TIMESTAMP)");
+                server.execute("""
+                        CREATE TABLE casts(
+                            a LONG,
+                            l VARCHAR,
+                            d VARCHAR,
+                            i VARCHAR,
+                            ip VARCHAR,
+                            f VARCHAR,
+                            sh VARCHAR,
+                            byt VARCHAR,
+                            bo VARCHAR,
+                            tsc VARCHAR,
+                            dec VARCHAR,
+                            ts TIMESTAMP
+                        ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                        """);
+                server.execute("""
+                        INSERT INTO casts VALUES
+                            (10, '100', '1.5', '11', '192.168.1.1', '2.5', '12', '13', 'true', '1970-01-01T00:00:00.000010Z', '12.34', 1::TIMESTAMP),
+                            (20, '200', '-3.5', '-21', '10.0.0.1', '-4.5', '-22', '-23', 'false', '1970-01-01T00:00:00.000020Z', '-56.78', 2::TIMESTAMP),
+                            (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 3::TIMESTAMP)
+                        """);
                 server.awaitTable("casts");
                 server.execute("ALTER TABLE casts CONVERT PARTITION TO PARQUET WHERE ts >= 0");
-                TestUtils.drainWalQueue(server.getEngine());
+                awaitTxnAndAssertParquetPartitions(server, "casts", 2, "1970-01-01\n");
                 server.execute("ALTER TABLE casts ALTER COLUMN a TYPE VARCHAR");
                 TestUtils.drainWalQueue(server.getEngine());
-                server.execute("ALTER TABLE casts ALTER COLUMN b TYPE LONG");
+                server.execute("ALTER TABLE casts ALTER COLUMN l TYPE LONG");
                 TestUtils.drainWalQueue(server.getEngine());
-                server.awaitTxn("casts", 4);
+                server.execute("ALTER TABLE casts ALTER COLUMN d TYPE DOUBLE");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.execute("ALTER TABLE casts ALTER COLUMN i TYPE INT");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.execute("ALTER TABLE casts ALTER COLUMN ip TYPE IPv4");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.execute("ALTER TABLE casts ALTER COLUMN f TYPE FLOAT");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.execute("ALTER TABLE casts ALTER COLUMN sh TYPE SHORT");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.execute("ALTER TABLE casts ALTER COLUMN byt TYPE BYTE");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.execute("ALTER TABLE casts ALTER COLUMN bo TYPE BOOLEAN");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.execute("ALTER TABLE casts ALTER COLUMN tsc TYPE TIMESTAMP");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.execute("ALTER TABLE casts ALTER COLUMN dec TYPE DECIMAL(18,2)");
+                TestUtils.drainWalQueue(server.getEngine());
+                server.awaitTxn("casts", 13);
 
                 final int[] rows = {0};
                 try (QwpQueryClient client = newClient()) {
-                    client.execute("SELECT a, b FROM casts", new QwpColumnBatchHandler() {
+                    client.execute("SELECT a, l, d, i, ip, f, sh, byt, bo, tsc, dec FROM casts", new QwpColumnBatchHandler() {
                         @Override
                         public void onBatch(QwpColumnBatch batch) {
                             for (int r = 0; r < batch.getRowCount(); r++, rows[0]++) {
                                 if (rows[0] == 0) {
-                                    Assert.assertEquals("10", batch.getString(0, r));
-                                    Assert.assertEquals(100, batch.getLongValue(1, r));
+                                    Assert.assertFalse("VARCHAR", batch.isNull(0, r));
+                                    Assert.assertFalse("LONG", batch.isNull(1, r));
+                                    Assert.assertFalse("DOUBLE", batch.isNull(2, r));
+                                    Assert.assertFalse("INT", batch.isNull(3, r));
+                                    Assert.assertFalse("IPv4", batch.isNull(4, r));
+                                    Assert.assertFalse("FLOAT", batch.isNull(5, r));
+                                    Assert.assertFalse("SHORT", batch.isNull(6, r));
+                                    Assert.assertFalse("BYTE", batch.isNull(7, r));
+                                    Assert.assertFalse("BOOLEAN", batch.isNull(8, r));
+                                    Assert.assertFalse("TIMESTAMP", batch.isNull(9, r));
+                                    Assert.assertFalse("DECIMAL64", batch.isNull(10, r));
+                                    Assert.assertEquals("VARCHAR", "10", batch.getString(0, r));
+                                    Assert.assertEquals("LONG", 100, batch.getLongValue(1, r));
+                                    Assert.assertEquals("DOUBLE", 1.5, batch.getDoubleValue(2, r), 0.0);
+                                    Assert.assertEquals("INT", 11, batch.getIntValue(3, r));
+                                    Assert.assertEquals("FLOAT", 2.5f, batch.getFloatValue(5, r), 0.0f);
+                                    Assert.assertEquals("SHORT", 12, batch.getShortValue(6, r));
+                                    Assert.assertEquals("BYTE", 13, batch.getByteValue(7, r));
+                                    Assert.assertTrue("BOOLEAN", batch.getBoolValue(8, r));
+                                    Assert.assertEquals("TIMESTAMP", 10, batch.getLongValue(9, r));
+                                    Assert.assertEquals("DECIMAL64", 1_234, batch.getLongValue(10, r));
+                                    Assert.assertEquals("IPv4", 0xC0A80101L, batch.getIntValue(4, r) & 0xFFFF_FFFFL);
                                 } else if (rows[0] == 1) {
                                     Assert.assertEquals("20", batch.getString(0, r));
                                     Assert.assertEquals(200, batch.getLongValue(1, r));
+                                    Assert.assertEquals(-3.5, batch.getDoubleValue(2, r), 0.0);
+                                    Assert.assertEquals(-21, batch.getIntValue(3, r));
+                                    Assert.assertEquals(0x0A000001L, batch.getIntValue(4, r) & 0xFFFF_FFFFL);
+                                    Assert.assertEquals(-4.5f, batch.getFloatValue(5, r), 0.0f);
+                                    Assert.assertEquals(-22, batch.getShortValue(6, r));
+                                    Assert.assertEquals(-23, batch.getByteValue(7, r));
+                                    Assert.assertFalse(batch.getBoolValue(8, r));
+                                    Assert.assertEquals(20, batch.getLongValue(9, r));
+                                    Assert.assertEquals(-5_678, batch.getLongValue(10, r));
                                 } else {
-                                    Assert.assertTrue(batch.isNull(0, r));
-                                    Assert.assertTrue(batch.isNull(1, r));
+                                    for (int c = 0; c < 11; c++) {
+                                        if (c == 6 || c == 7 || c == 8) {
+                                            Assert.assertFalse("column " + c, batch.isNull(c, r));
+                                        } else {
+                                            Assert.assertTrue("column " + c, batch.isNull(c, r));
+                                        }
+                                    }
+                                    Assert.assertEquals(0, batch.getShortValue(6, r));
+                                    Assert.assertEquals(0, batch.getByteValue(7, r));
+                                    Assert.assertFalse(batch.getBoolValue(8, r));
                                 }
                             }
                         }
@@ -309,7 +473,7 @@ public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
                         """);
                 server.awaitTable("mixed");
                 server.execute("ALTER TABLE mixed CONVERT PARTITION TO PARQUET WHERE ts < '1970-01-02'");
-                TestUtils.drainWalQueue(server.getEngine());
+                awaitTxnAndAssertParquetPartitions(server, "mixed", 2, "1970-01-01\n");
 
                 final int[] counts = new int[41];
                 final int[] nulls = {0};
@@ -349,6 +513,45 @@ public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
     }
 
     @Test
+    public void testParquetColumnTopUsesBulkFill() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            ObjList<QwpEgressColumnDef> columns = new ObjList<>();
+            QwpEgressColumnDef longColumn = new QwpEgressColumnDef();
+            longColumn.of("l", ColumnType.LONG);
+            columns.add(longColumn);
+            QwpEgressColumnDef shortColumn = new QwpEgressColumnDef();
+            shortColumn.of("sh", ColumnType.SHORT);
+            columns.add(shortColumn);
+            QwpEgressColumnDef booleanColumn = new QwpEgressColumnDef();
+            booleanColumn.of("bo", ColumnType.BOOLEAN);
+            columns.add(booleanColumn);
+
+            try (
+                    QwpEgressConnSymbolDict dict = new QwpEgressConnSymbolDict();
+                    QwpResultBatchBuffer batch = new QwpResultBatchBuffer();
+                    TestColumnTopRecord record = new TestColumnTopRecord()
+            ) {
+                batch.beginBatch(columns, null, dict);
+                record.ofColumnTop();
+                batch.appendPageFrame(new TestParquetPageFrame(), record, 0, 64);
+                Assert.assertEquals(64, batch.getRowCount());
+                Assert.assertEquals("LONG column top must not call the record accessor", 0, record.getLongCalls);
+                Assert.assertEquals("SHORT column top must not call the record accessor", 0, record.getShortCalls);
+                Assert.assertEquals("BOOLEAN column top must not call the record accessor", 0, record.getBoolCalls);
+
+                batch.reset();
+                batch.beginBatch(columns, null, dict);
+                record.ofLazyCast();
+                batch.appendPageFrame(new TestParquetPageFrame(), record, 0, 64);
+                Assert.assertEquals(64, batch.getRowCount());
+                Assert.assertEquals("LONG lazy cast must keep the record fallback", 64, record.getLongCalls);
+                Assert.assertEquals("SHORT lazy cast must keep the record fallback", 64, record.getShortCalls);
+                Assert.assertEquals("BOOLEAN lazy cast must keep the record fallback", 64, record.getBoolCalls);
+            }
+        });
+    }
+
+    @Test
     public void testMultipleRowGroupsAndFragmentedResume() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             try (TestServerMain server = startFragmented(SMALL_FRAMES_AND_ROW_GROUPS)) {
@@ -356,7 +559,7 @@ public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
                 server.execute("INSERT INTO resume_t SELECT x, x::TIMESTAMP FROM long_sequence(1_000)");
                 server.awaitTable("resume_t");
                 server.execute("ALTER TABLE resume_t CONVERT PARTITION TO PARQUET WHERE ts >= 0");
-                TestUtils.drainWalQueue(server.getEngine());
+                awaitTxnAndAssertParquetPartitions(server, "resume_t", 2, "1970-01-01\n");
 
                 final long[] next = {1};
                 try (QwpQueryClient client = QwpQueryClient.fromConfig(
@@ -398,7 +601,7 @@ public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
                         """);
                 server.awaitTable("high_sym");
                 server.execute("ALTER TABLE high_sym CONVERT PARTITION TO PARQUET WHERE ts >= 0");
-                TestUtils.drainWalQueue(server.getEngine());
+                awaitTxnAndAssertParquetPartitions(server, "high_sym", 2, "1970-01-01\n");
 
                 final int[] nulls = {0};
                 final int[] rows = {0};
@@ -430,6 +633,146 @@ public class QwpEgressParquetPageFrameTest extends AbstractQwpBootstrapTest {
                 Assert.assertEquals(19, nulls[0]);
             }
         });
+    }
+
+    private static class TestColumnTopRecord extends PageFrameMemoryRecord {
+        private int getBoolCalls;
+        private int getLongCalls;
+        private int getShortCalls;
+        private final DirectLongList testAuxPageAddresses = new DirectLongList(1, MemoryTag.NATIVE_DEFAULT);
+        private final DirectLongList testPageAddresses = new DirectLongList(1, MemoryTag.NATIVE_DEFAULT);
+
+        @Override
+        public void close() {
+            testAuxPageAddresses.close();
+            testPageAddresses.close();
+            super.close();
+        }
+
+        @Override
+        public boolean getBool(int columnIndex) {
+            getBoolCalls++;
+            return true;
+        }
+
+        @Override
+        public long getLong(int columnIndex) {
+            getLongCalls++;
+            return 42;
+        }
+
+        @Override
+        public short getShort(int columnIndex) {
+            getShortCalls++;
+            return 42;
+        }
+
+        private void of(boolean isLazyCast) {
+            testAuxPageAddresses.clear();
+            testPageAddresses.clear();
+            sourceColumnTypes = new IntList();
+            for (int i = 0; i < 3; i++) {
+                testAuxPageAddresses.add(0);
+                testPageAddresses.add(0);
+                sourceColumnTypes.add(isLazyCast ? -ColumnType.VARCHAR : -1);
+            }
+            auxPageAddresses = testAuxPageAddresses;
+            pageAddresses = testPageAddresses;
+            columnOffset = 0;
+            frameFormat = PartitionFormat.PARQUET;
+            getBoolCalls = 0;
+            getLongCalls = 0;
+            getShortCalls = 0;
+            hasTypeCasts = isLazyCast;
+        }
+
+        private void ofColumnTop() {
+            of(false);
+        }
+
+        private void ofLazyCast() {
+            of(true);
+        }
+    }
+
+    private static class TestParquetPageFrame implements PageFrame {
+        @Override
+        public long getAuxPageAddress(int columnIndex) {
+            return 0;
+        }
+
+        @Override
+        public long getAuxPageSize(int columnIndex) {
+            return 0;
+        }
+
+        @Override
+        public int getColumnCount() {
+            return 3;
+        }
+
+        @Override
+        public byte getFormat() {
+            return PartitionFormat.PARQUET;
+        }
+
+        @Override
+        public IndexReader getIndexReader(int columnIndex, int direction) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getPageAddress(int columnIndex) {
+            return 0;
+        }
+
+        @Override
+        public long getPageSize(int columnIndex) {
+            return 0;
+        }
+
+        @Override
+        public int getParquetRowGroup() {
+            return 0;
+        }
+
+        @Override
+        public int getParquetRowGroupHi() {
+            return 64;
+        }
+
+        @Override
+        public int getParquetRowGroupLo() {
+            return 0;
+        }
+
+        @Override
+        public long getPartitionHi() {
+            return 64;
+        }
+
+        @Override
+        public int getPartitionIndex() {
+            return 0;
+        }
+
+        @Override
+        public long getPartitionLo() {
+            return 0;
+        }
+    }
+
+    private static void awaitTxnAndAssertParquetPartitions(
+            TestServerMain server,
+            String tableName,
+            long txn,
+            String expectedPartitionNames
+    ) {
+        server.awaitTxn(tableName, txn);
+        server.assertSql(
+                "SELECT name FROM table_partitions('" + tableName + "') WHERE isParquet ORDER BY name",
+                "name\n" + expectedPartitionNames
+        );
     }
 
     private static QwpQueryClient newClient() throws Exception {


### PR DESCRIPTION
QWP now bulk-encodes decoded Parquet columns instead of processing rows individually, with per-column fallback for unsupported cases. Added Parquet correctness tests and configurable native/Parquet benchmarks.

## Benchmark scenario

Benchmarks ran on `domapc`:

- AMD Ryzen 9 9950X, 16 cores / 32 hardware threads
- JDK 25
- QuestDB server and one QWP client communicating over loopback
- Warm full-table scans; ingestion and Parquet conversion excluded from timing
- Native and Parquet results validated using identical row counts and checksums
- No major page faults during measured runs

Tables were hourly-partitioned WAL tables:

- Narrow: 5 columns — timestamp, long, double, low-cardinality symbol, VARCHAR
- Wide: 15 columns — timestamp, long, six doubles, VARCHAR, one low-cardinality symbol, and five symbols with 100k distinct values each

The timed SQL was equivalent to `SELECT *`, but used explicit columns:

```sql
-- Narrow
SELECT ts, id, price, sym, note
FROM egress_bench;
```

```sql
-- Wide
SELECT ts, id, price, sym, note,
       d1, d2, d3, d4, d5,
       s1, s2, s3, s4, s5
FROM egress_bench_wide;
```

There was no filter, aggregation, ordering, or limit. Parquet setup used:

```sql
ALTER TABLE <table>
CONVERT PARTITION TO PARQUET
WHERE ts >= 0;
```

## Before versus after

Main benchmark: 10 million rows, medians of three narrow or five wide runs.

| Workload | Native | Parquet before | Parquet after | Parquet improvement |
|---|---:|---:|---:|---:|
| Narrow | 142–163 ms | 384 ms | 235 ms | **38.8%** |
| Wide | 493–500 ms | 1,278 ms | 775 ms | **39.4%** |

Relative to native:

| Workload | Before | After |
|---|---:|---:|
| Narrow | 2.36× slower | 1.65× slower |
| Wide | 2.59× slower | 1.55× slower |

Native performance was effectively unchanged, and all checksums matched.

## CPU counters

Process-scoped server counters for the same 20-million-row wide workload:

| Metric | Native | Parquet before | Parquet after | Before → after |
|---|---:|---:|---:|---:|
| Task-clock | 3,130 ms | 5,547 ms | 4,421 ms | **−20.3%** |
| Cycles | 16.14B | 28.76B | 22.85B | **−20.6%** |
| Instructions | 50.92B | 92.42B | 63.11B | **−31.7%** |
| Branches | 8.45B | 16.31B | 10.83B | **−33.6%** |
| Branch misses | 16.65M | 23.73M | 23.34M | **−1.6%** |
| Elapsed time | 2.04 s | 4.55 s | 2.92 s | **−35.8%** |
| IPC | 3.15 | 3.21 | 2.76 | — |

The implementation removes substantial row-by-row instruction and branch work. Branch misses barely fall in absolute terms, so their normalized rate rises:

- Before: 0.15% of branches
- After: 0.22%
- Native: 0.20%

This means branch prediction is not the primary remaining cost. The important gain is the removal of roughly 29.3 billion instructions and 5.9 billion cycles per 20 million rows.

## Compressed versus uncompressed Parquet

Follow-up benchmark: wide one-million-row table, 100 repeated warm scans.

| Storage format | Median per scan | p90 | Server cycles for 100M rows |
|---|---:|---:|---:|
| Native | 88 ms | 111 ms | 65.8B |
| Parquet with LZ4_RAW | 129 ms | 152 ms | 87.6B |
| Uncompressed Parquet | 84 ms | 110 ms | 67.9B |

The slightly lower uncompressed median is within run-to-run noise; the defensible conclusion is that uncompressed Parquet reached native-level performance.

The CPU profile found:

- `LZ4_decompress_safe`: **23.2% of compressed-Parquet server cycles**
- Estimated LZ4 cost: **20.3B cycles**
- Entire compressed-Parquet/native difference: **21.8B cycles**
- Uncompressed Parquet: only **3.2% more cycles than native**

Parquet had more L1 data-cache misses:

- Native: 1.41% of L1 data-cache loads
- Compressed Parquet: 1.84%

However, DRAM fills per thousand instructions fell from 0.88 to 0.69. Together with zero major faults, this rules out storage and DRAM bandwidth as the cause. The remaining compressed-Parquet overhead is the serial load/dependency work inside LZ4 decompression.

## Overall result

- Columnar fill makes compressed Parquet approximately **39% faster**.
- It eliminates around **58–65% of the original native/Parquet latency gap**.
- The remaining gap is almost entirely Parquet LZ4 decompression.
- Uncompressed Parquet performs at approximately native speed.
- In this dataset, uncompressed Parquet used roughly **126 MiB instead of 94 MiB**, about **34% more disk space**.