### PR TITLE
fix(qwp): treat NullMemoryCMR.INT_NULL as NULL in appendIPv4OrNull

### DIFF
--- a/core/src/main/java/io/questdb/cutlass/qwp/codec/QwpColumnScratch.java
+++ b/core/src/main/java/io/questdb/cutlass/qwp/codec/QwpColumnScratch.java
@@ -672,7 +672,9 @@ final class QwpColumnScratch implements QuietCloseable {
         // QuestDB stores IPv4 NULL as the bit pattern 0 (Numbers.IPv4_NULL). The wire
         // format cannot represent the literal address 0.0.0.0 as non-null - QuestDB-level
         // limitation inherited by the wire format.
-        if (v == Numbers.IPv4_NULL) {
+        // A column-top (absent column) returns Numbers.INT_NULL (0x80000000) from
+        // NullMemoryCMR.getInt, so we must check both sentinels.
+        if (v == Numbers.IPv4_NULL || v == Numbers.INT_NULL) {
             appendNull();
         } else {
             appendInt(v);

--- a/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressColumnTopNonNullableTypesTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/QwpEgressColumnTopNonNullableTypesTest.java
@@ -203,6 +203,24 @@ public class QwpEgressColumnTopNonNullableTypesTest extends AbstractBootstrapTes
         });
     }
 
+
+    @Test
+    public void testIPv4ColumnTopShipsNull() throws Exception {
+        // IPv4 column-top rows must surface as NULL, not as 128.0.0.0.
+        // NullMemoryCMR.getInt returns Numbers.INT_NULL (0x80000000) for absent
+        // columns, which differs from Numbers.IPv4_NULL (0). The fix in
+        // appendIPv4OrNull must reconcile both sentinels.
+        runColumnTopTest("IPv4", (batch, rowsBefore) -> {
+            int n = batch.getRowCount();
+            for (int r = 0; r < n; r++) {
+                int abs = rowsBefore + r;
+                Assert.assertTrue(
+                        "IPv4 row " + abs + " (column-top) must report null",
+                        batch.isNull(0, r));
+            }
+        });
+    }
+
     /**
      * Drives the column-top scenario for {@code typeName}: creates a WAL
      * table with only a TIMESTAMP, ingests {@link #COLUMN_TOP_ROWS} rows


### PR DESCRIPTION
When a column is absent (column top, added via ALTER TABLE ADD COLUMN after data was written), `NullMemoryCMR.getInt` returns `Numbers.INT_NULL` (`0x80000000`), not `Numbers.IPv4_NULL` (`0`). The `appendIPv4OrNull` method only checked for the latter sentinel, so the value was emitted as non-NULL, causing the wire to carry `128.0.0.0` for every row whose IPv4 column had no backing storage.

### Fix

Add `v == Numbers.INT_NULL` to the null-sentinel check in `appendIPv4OrNull`. Both sentinels now map to the same null bitmap entry.

### Regression test

`testIPv4ColumnTopShipsNull` in `QwpEgressColumnTopNonNullableTypesTest.java` inserts rows into a WAL table, adds an IPv4 column, then reads the column over QWP and asserts every row is `isNull == true`.

Fixes #7507