### PR TITLE
fix(core): prevent false live view invalidation during concurrent refresh

### DIFF
--- a/core/src/main/java/io/questdb/cairo/lv/LiveViewRefreshJob.java
+++ b/core/src/main/java/io/questdb/cairo/lv/LiveViewRefreshJob.java
@@ -294,6 +294,12 @@ public class LiveViewRefreshJob implements Job, QuietCloseable {
     // One-shot (self-clears on fire); always null in production.
     @TestOnly
     private Runnable simulateBaseApplyDuringRederiveForTest;
+    // Test-only: when armed, the fallback scan runs this action after reading the base
+    // sequencer head and before evaluating the ahead guard. Lets a test publish and refresh
+    // the next base commit in exactly that interval instead of relying on thread timing.
+    // One-shot (self-clears on fire); always null in production.
+    @TestOnly
+    private Runnable simulateBaseCommitAfterAheadGuardBaseTxnReadForTest;
     // Test-only: an extra closeable whose close() throws. consumeBaseMetadataCloseFaultForTest
     // closes it and returns the resulting throwable as the primary of the very freeBestEffort call
     // that closes the pooled base metadata, so the fault lands in closeFailure exactly where a real
@@ -550,6 +556,15 @@ public class LiveViewRefreshJob implements Job, QuietCloseable {
     @TestOnly
     public void setSimulateBaseApplyDuringRederiveForTest(Runnable action) {
         this.simulateBaseApplyDuringRederiveForTest = action;
+    }
+
+    /**
+     * Test-only: arms a one-shot action that the fallback scan runs after reading the base
+     * sequencer head and before evaluating the live-view-ahead guard. Production never calls this.
+     */
+    @TestOnly
+    public void setSimulateBaseCommitAfterAheadGuardBaseTxnReadForTest(Runnable action) {
+        this.simulateBaseCommitAfterAheadGuardBaseTxnReadForTest = action;
     }
 
     /**
@@ -8178,11 +8193,22 @@ public class LiveViewRefreshJob implements Job, QuietCloseable {
             // mirroring the mat-view "view is ahead of base table and cannot be synchronized" guard in
             // CairoEngine.loadMatViewIntoStore. A strict no-op on a healthy node, where a view never
             // outruns the base it derives from.
+            // Read the view watermark first. A refresh publishes it only after consuming the
+            // corresponding sequencer transaction, so observing that volatile write before reading
+            // the monotonic base head yields a coherent pair. Reading base first lets another worker
+            // advance the view between the reads and manufactures a false ahead state from two
+            // different points in time.
+            final long lastProcessedSeqTxn = instance.getLastProcessedSeqTxn();
             final long baseSeqLastTxn = engine.getTableSequencerAPI().lastTxn(baseToken);
-            if (instance.getLastProcessedSeqTxn() > baseSeqLastTxn) {
+            final Runnable aheadGuardAction = simulateBaseCommitAfterAheadGuardBaseTxnReadForTest;
+            if (aheadGuardAction != null) {
+                simulateBaseCommitAfterAheadGuardBaseTxnReadForTest = null;
+                aheadGuardAction.run();
+            }
+            if (lastProcessedSeqTxn > baseSeqLastTxn) {
                 LOG.error().$("live view is ahead of base table and cannot be synchronized [view=")
                         .$(instance.getLiveViewToken())
-                        .$(", lastProcessedSeqTxn=").$(instance.getLastProcessedSeqTxn())
+                        .$(", lastProcessedSeqTxn=").$(lastProcessedSeqTxn)
                         .$(", baseTableTxn=").$(baseSeqLastTxn)
                         .I$();
                 engine.invalidateLiveView(instance, "live view is ahead of base table and cannot be synchronized");

--- a/core/src/main/java/io/questdb/cairo/lv/LiveViewRefreshJob.java
+++ b/core/src/main/java/io/questdb/cairo/lv/LiveViewRefreshJob.java
@@ -294,12 +294,17 @@ public class LiveViewRefreshJob implements Job, QuietCloseable {
     // One-shot (self-clears on fire); always null in production.
     @TestOnly
     private Runnable simulateBaseApplyDuringRederiveForTest;
-    // Test-only: when armed, the fallback scan runs this action after reading the base
-    // sequencer head and before evaluating the ahead guard. Lets a test publish and refresh
-    // the next base commit in exactly that interval instead of relying on thread timing.
+    // Test-only: when armed, the fallback scan runs this action BETWEEN the ahead guard's two
+    // reads - after the view watermark read, before the base sequencer head read. That interval
+    // is the contract, not a convenience: it is the window a concurrent refresh worker used to
+    // race, so a test can publish and refresh the next base commit there instead of relying on
+    // thread timing. Keep the call between the two reads. Moving it outside them, or reordering
+    // the reads across it, makes the guard sample a coherent pair either way and silently strips
+    // testConcurrentRefreshCannotInvalidateFromStaleBaseHead of its power to tell the two orders
+    // apart.
     // One-shot (self-clears on fire); always null in production.
     @TestOnly
-    private Runnable simulateBaseCommitAfterAheadGuardBaseTxnReadForTest;
+    private Runnable simulateBaseCommitBetweenAheadGuardReadsForTest;
     // Test-only: an extra closeable whose close() throws. consumeBaseMetadataCloseFaultForTest
     // closes it and returns the resulting throwable as the primary of the very freeBestEffort call
     // that closes the pooled base metadata, so the fault lands in closeFailure exactly where a real
@@ -559,12 +564,23 @@ public class LiveViewRefreshJob implements Job, QuietCloseable {
     }
 
     /**
-     * Test-only: arms a one-shot action that the fallback scan runs after reading the base
-     * sequencer head and before evaluating the live-view-ahead guard. Production never calls this.
+     * Test-only: arms a one-shot action that the fallback scan runs BETWEEN the two reads feeding
+     * the live-view-ahead guard - after the view watermark read, after which it blocks the scan,
+     * and before the base sequencer head read. The interval is what the arming test asserts on:
+     * a commit published there is visible to the base-head read but not to the already-captured
+     * watermark, which is exactly the asymmetry that distinguishes the correct read order from
+     * the racy one. Relocating this call outside the two reads leaves
+     * {@code testConcurrentRefreshCannotInvalidateFromStaleBaseHead} green under a read-order
+     * swap that fully restores the race.
+     * <p>
+     * Unlike {@link #setSimulateBaseApplyDuringRederiveForTest}, the action runs with no refresh
+     * latch held and no enclosing {@code catch}, so it may block and a throwable it raises
+     * propagates out of {@code Job.run()} to the caller rather than being swallowed. Production
+     * never calls this.
      */
     @TestOnly
-    public void setSimulateBaseCommitAfterAheadGuardBaseTxnReadForTest(Runnable action) {
-        this.simulateBaseCommitAfterAheadGuardBaseTxnReadForTest = action;
+    public void setSimulateBaseCommitBetweenAheadGuardReadsForTest(Runnable action) {
+        this.simulateBaseCommitBetweenAheadGuardReadsForTest = action;
     }
 
     /**
@@ -8197,14 +8213,17 @@ public class LiveViewRefreshJob implements Job, QuietCloseable {
             // corresponding sequencer transaction, so observing that volatile write before reading
             // the monotonic base head yields a coherent pair. Reading base first lets another worker
             // advance the view between the reads and manufactures a false ahead state from two
-            // different points in time.
+            // different points in time. Monotonicity is what makes the order sufficient rather than
+            // merely narrower: TableTransactionLog.lastTxn is a volatile field over an append-only
+            // log, and lastTxn() reads it under the sequencer READ lock, so it cannot observe the
+            // appender's half-published state.
             final long lastProcessedSeqTxn = instance.getLastProcessedSeqTxn();
-            final long baseSeqLastTxn = engine.getTableSequencerAPI().lastTxn(baseToken);
-            final Runnable aheadGuardAction = simulateBaseCommitAfterAheadGuardBaseTxnReadForTest;
+            final Runnable aheadGuardAction = simulateBaseCommitBetweenAheadGuardReadsForTest;
             if (aheadGuardAction != null) {
-                simulateBaseCommitAfterAheadGuardBaseTxnReadForTest = null;
+                simulateBaseCommitBetweenAheadGuardReadsForTest = null;
                 aheadGuardAction.run();
             }
+            final long baseSeqLastTxn = engine.getTableSequencerAPI().lastTxn(baseToken);
             if (lastProcessedSeqTxn > baseSeqLastTxn) {
                 LOG.error().$("live view is ahead of base table and cannot be synchronized [view=")
                         .$(instance.getLiveViewToken())

--- a/core/src/test/java/io/questdb/test/cairo/lv/LiveViewConcurrencyTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/lv/LiveViewConcurrencyTest.java
@@ -462,12 +462,26 @@ public class LiveViewConcurrencyTest extends AbstractLiveViewTest {
                 stateStore.notifyBaseRefreshed(staleTask, staleTask.seqTxn);
             }
 
+            // The idle fallback scan is sharded by table id (LiveViewRegistry.getShardedViews), so the
+            // fallback worker reaches the ahead guard only for the views it owns. It owns this one today
+            // - setUpCairo resets the table id generator per test, making base=1 and lv=2 - but pin the
+            // assumption here. Without this, a fixture edit that shifts lv's id (one more CREATE TABLE
+            // ahead of it) would surface as the 30s baseHeadRead timeout below, which names the latch
+            // rather than the shard it actually lost.
+            final int fallbackWorkerId = 0;
+            final int workerCount = 2;
+            Assert.assertEquals(
+                    "the fallback worker must own the lv shard, or its scan never reaches the ahead guard",
+                    fallbackWorkerId,
+                    Math.floorMod(instance.getLiveViewToken().getTableId(), workerCount)
+            );
+
             final CountDownLatch baseHeadRead = new CountDownLatch(1);
             final CountDownLatch releaseFallback = new CountDownLatch(1);
             final ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
             try (
-                    LiveViewRefreshJob fallbackJob = new LiveViewRefreshJob(0, 2, engine, 1);
-                    LiveViewRefreshJob notificationJob = new LiveViewRefreshJob(1, 2, engine, 1)
+                    LiveViewRefreshJob fallbackJob = new LiveViewRefreshJob(fallbackWorkerId, workerCount, engine, 1);
+                    LiveViewRefreshJob notificationJob = new LiveViewRefreshJob(1, workerCount, engine, 1)
             ) {
                 fallbackJob.setSimulateBaseCommitAfterAheadGuardBaseTxnReadForTest(() -> {
                     baseHeadRead.countDown();

--- a/core/src/test/java/io/questdb/test/cairo/lv/LiveViewConcurrencyTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/lv/LiveViewConcurrencyTest.java
@@ -432,10 +432,13 @@ public class LiveViewConcurrencyTest extends AbstractLiveViewTest {
     @Test
     public void testConcurrentRefreshCannotInvalidateFromStaleBaseHead() throws Exception {
         // The fallback worker used to read the base head first and the volatile view watermark
-        // second, without the per-view refresh latch. Freeze it between those reads, publish a new
-        // base commit, and let a notification worker consume that commit. The fallback then has an
-        // old base head and a new view watermark, but that mixed-time pair must not durably
-        // invalidate the healthy view.
+        // second, without the per-view refresh latch. Freeze it BETWEEN those two reads, publish a
+        // new base commit, and let a notification worker consume that commit. The freeze point is
+        // what gives this test its force: the commit lands after one operand is captured and before
+        // the other, so the two read orders disagree. In the correct order the watermark is already
+        // captured (old) and the base head is read after (new), which is coherent; in the racy order
+        // the base head is captured (old) and the watermark is read after (new), and that mixed-time
+        // pair durably invalidates a healthy view. Assert the view survives.
         assertMemoryLeak(() -> {
             setCurrentMicros(0);
             execute("CREATE TABLE base (ts TIMESTAMP, x LONG) TIMESTAMP(ts) PARTITION BY DAY WAL");
@@ -466,7 +469,7 @@ public class LiveViewConcurrencyTest extends AbstractLiveViewTest {
             // fallback worker reaches the ahead guard only for the views it owns. It owns this one today
             // - setUpCairo resets the table id generator per test, making base=1 and lv=2 - but pin the
             // assumption here. Without this, a fixture edit that shifts lv's id (one more CREATE TABLE
-            // ahead of it) would surface as the 30s baseHeadRead timeout below, which names the latch
+            // ahead of it) would surface as the 30s guardReadsSplit timeout below, which names the latch
             // rather than the shard it actually lost.
             final int fallbackWorkerId = 0;
             final int workerCount = 2;
@@ -476,15 +479,15 @@ public class LiveViewConcurrencyTest extends AbstractLiveViewTest {
                     Math.floorMod(instance.getLiveViewToken().getTableId(), workerCount)
             );
 
-            final CountDownLatch baseHeadRead = new CountDownLatch(1);
+            final CountDownLatch guardReadsSplit = new CountDownLatch(1);
             final CountDownLatch releaseFallback = new CountDownLatch(1);
             final ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
             try (
                     LiveViewRefreshJob fallbackJob = new LiveViewRefreshJob(fallbackWorkerId, workerCount, engine, 1);
                     LiveViewRefreshJob notificationJob = new LiveViewRefreshJob(1, workerCount, engine, 1)
             ) {
-                fallbackJob.setSimulateBaseCommitAfterAheadGuardBaseTxnReadForTest(() -> {
-                    baseHeadRead.countDown();
+                fallbackJob.setSimulateBaseCommitBetweenAheadGuardReadsForTest(() -> {
+                    guardReadsSplit.countDown();
                     try {
                         if (!releaseFallback.await(30, TimeUnit.SECONDS)) {
                             throw new AssertionError("timed out waiting to release fallback scan");
@@ -499,7 +502,7 @@ public class LiveViewConcurrencyTest extends AbstractLiveViewTest {
                         fallbackJob.processNotificationsForTest();
                     } catch (Throwable t) {
                         errors.add(t);
-                        baseHeadRead.countDown();
+                        guardReadsSplit.countDown();
                     } finally {
                         Path.clearThreadLocals();
                     }
@@ -507,8 +510,8 @@ public class LiveViewConcurrencyTest extends AbstractLiveViewTest {
                 fallbackThread.start();
                 try {
                     Assert.assertTrue(
-                            "fallback scan did not stop after reading the base head",
-                            baseHeadRead.await(30, TimeUnit.SECONDS)
+                            "fallback scan did not stop between the two ahead-guard reads",
+                            guardReadsSplit.await(30, TimeUnit.SECONDS)
                     );
                     if (!errors.isEmpty()) {
                         throw new RuntimeException("fallback scan thread failed", errors.peek());

--- a/core/src/test/java/io/questdb/test/cairo/lv/LiveViewConcurrencyTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/lv/LiveViewConcurrencyTest.java
@@ -36,6 +36,7 @@ import io.questdb.cairo.lv.ForwardingLiveViewStateStore;
 import io.questdb.cairo.lv.LiveViewInMemoryTier;
 import io.questdb.cairo.lv.LiveViewInstance;
 import io.questdb.cairo.lv.LiveViewRefreshJob;
+import io.questdb.cairo.lv.LiveViewRefreshTask;
 import io.questdb.cairo.lv.LiveViewStateStore;
 import io.questdb.cairo.security.AllowAllSecurityContext;
 import io.questdb.cairo.sql.AtomicBooleanCircuitBreaker;
@@ -426,6 +427,102 @@ public class LiveViewConcurrencyTest extends AbstractLiveViewTest {
         // their from-scratch recomputes.
         final Rnd rnd = TestUtils.generateRandom(LOG);
         assertMemoryLeak(() -> runMultiViewConcurrent(rnd, 4, 800));
+    }
+
+    @Test
+    public void testConcurrentRefreshCannotInvalidateFromStaleBaseHead() throws Exception {
+        // The fallback worker used to read the base head first and the volatile view watermark
+        // second, without the per-view refresh latch. Freeze it between those reads, publish a new
+        // base commit, and let a notification worker consume that commit. The fallback then has an
+        // old base head and a new view watermark, but that mixed-time pair must not durably
+        // invalidate the healthy view.
+        assertMemoryLeak(() -> {
+            setCurrentMicros(0);
+            execute("CREATE TABLE base (ts TIMESTAMP, x LONG) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("""
+                    CREATE LIVE VIEW lv FLUSH EVERY 1s START FROM NOW AS
+                    SELECT ts, x, count(*) OVER (
+                        PARTITION BY 0
+                        ORDER BY ts
+                        ROWS BETWEEN 1_000_000 PRECEDING AND CURRENT ROW
+                    ) AS rn
+                    FROM base
+                    """);
+
+            final LiveViewInstance instance = engine.getLiveViewRegistry().getViewInstance("lv");
+            Assert.assertNotNull(instance);
+            try (LiveViewRefreshJob seedJob = new LiveViewRefreshJob(0, engine, 1)) {
+                driveSeedToCompletion(seedJob, "lv");
+            }
+            Assert.assertFalse("the seeded view must start healthy", instance.isInvalid());
+            final long processedBefore = instance.getLastProcessedSeqTxn();
+            final LiveViewStateStore stateStore = engine.getLiveViewStateStore();
+            final LiveViewRefreshTask staleTask = new LiveViewRefreshTask();
+            while (stateStore.tryDequeueRefreshTask(staleTask)) {
+                stateStore.notifyBaseRefreshed(staleTask, staleTask.seqTxn);
+            }
+
+            final CountDownLatch baseHeadRead = new CountDownLatch(1);
+            final CountDownLatch releaseFallback = new CountDownLatch(1);
+            final ConcurrentLinkedQueue<Throwable> errors = new ConcurrentLinkedQueue<>();
+            try (
+                    LiveViewRefreshJob fallbackJob = new LiveViewRefreshJob(0, 2, engine, 1);
+                    LiveViewRefreshJob notificationJob = new LiveViewRefreshJob(1, 2, engine, 1)
+            ) {
+                fallbackJob.setSimulateBaseCommitAfterAheadGuardBaseTxnReadForTest(() -> {
+                    baseHeadRead.countDown();
+                    try {
+                        if (!releaseFallback.await(30, TimeUnit.SECONDS)) {
+                            throw new AssertionError("timed out waiting to release fallback scan");
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new AssertionError("fallback scan interrupted", e);
+                    }
+                });
+                final Thread fallbackThread = new Thread(() -> {
+                    try {
+                        fallbackJob.processNotificationsForTest();
+                    } catch (Throwable t) {
+                        errors.add(t);
+                        baseHeadRead.countDown();
+                    } finally {
+                        Path.clearThreadLocals();
+                    }
+                }, "lv-stale-base-head-scan");
+                fallbackThread.start();
+                try {
+                    Assert.assertTrue(
+                            "fallback scan did not stop after reading the base head",
+                            baseHeadRead.await(30, TimeUnit.SECONDS)
+                    );
+                    if (!errors.isEmpty()) {
+                        throw new RuntimeException("fallback scan thread failed", errors.peek());
+                    }
+                    execute("INSERT INTO base VALUES ('2026-06-01T00:00:00.000000Z', 1)");
+                    Assert.assertTrue("the notification worker must consume the new commit",
+                            notificationJob.processNotificationsForTest());
+                    Assert.assertTrue(
+                            "the notification worker must advance the view before the fallback resumes",
+                            instance.getLastProcessedSeqTxn() > processedBefore
+                    );
+                } finally {
+                    releaseFallback.countDown();
+                    fallbackThread.join(30_000);
+                }
+                Assert.assertFalse("fallback scan thread did not finish", fallbackThread.isAlive());
+            }
+            if (!errors.isEmpty()) {
+                throw new RuntimeException("fallback scan thread failed", errors.peek());
+            }
+
+            Assert.assertFalse(
+                    "a fresh base commit processed concurrently with the fallback scan must not invalidate the live view",
+                    instance.isInvalid()
+            );
+            execute("DROP LIVE VIEW lv");
+            execute("DROP TABLE base");
+        });
     }
 
     @Test


### PR DESCRIPTION
## What

Prevent an idle live-view fallback scan from durably invalidating a healthy view while another refresh worker processes a new base-table commit.

Found while root-causing [`SwitchFuzzTest` in build 261681](https://dev.azure.com/questdb/questdb/_build/results?buildId=261681) on #7487. The race exists on `master`; that PR changed the scheduling that exposed it but did not introduce the guard.

## Root cause

`LiveViewRefreshJob.scanForLaggingViews()` validates restored/replicated state by invalidating a view whose processed sequencer txn is ahead of its base table. The guard sampled the two independently published values in this order:

1. base sequencer head;
2. volatile view watermark.

A notification worker could publish and refresh the next base txn between those reads. The fallback worker would then compare an old base head with the new view watermark — for example `(view=1, base=0)` — and persist a false `view is ahead of base table` invalidation.

The fuzz seeds reproduce the same operations reliably, but not the worker scheduling, so seed replay alone cannot pin this failure.

## Fix

Read and retain the view watermark first, then read the monotonic base sequencer head, and use those same retained values for both the comparison and diagnostic log.

A refresh publishes the watermark only after consuming the corresponding base sequencer txn. Therefore, if the first read observes a newer watermark, the following base-head read cannot legitimately be older. This removes the impossible old-base/new-view pair without adding a hot-path lock. Genuine restored/replicated ahead states still take the existing invalidation path.

## Regression coverage

`LiveViewConcurrencyTest.testConcurrentRefreshCannotInvalidateFromStaleBaseHead` uses two refresh jobs and deterministic latches to force the former interleaving:

- pause the fallback scan between the ahead guard's two reads;
- commit and refresh the next txn on a notification worker;
- resume the fallback and assert that the view remains healthy.

The pause point is what carries the regression value, so it is a contract rather than a convenience. A commit published there is visible to the base-head read but not to the already-captured watermark, which is the asymmetry that separates the two read orders. Swapping the two read statements therefore fails the test with the intended `(lastProcessedSeqTxn=1, baseTableTxn=0)` false invalidation. Had the pause sat after both reads, that shape would have restored the race with the test still green.

The cover is not total. A revert that deletes the retained watermark local and inlines `instance.getLastProcessedSeqTxn()` back into the `if` leaves the pause above both reads, restores the base read order, and the test still passes; so does moving the pause below both reads. Both shapes need a second deliberate edit, because the error log consumes the retained local and deleting it alone does not compile. The comments on the field and its setter state the placement constraint, but nothing enforces it mechanically.

The test uses no sleeps, propagates worker failures, joins the worker, and runs under `assertMemoryLeak()`.

## Testing

- `LiveViewConcurrencyTest`: 26 tests passed
- `LiveViewSmokeTest#testLiveViewAheadOfBaseInvalidates`: passed
- `LiveViewTest#testIdleScanShardsRegistryAcrossWorkers+testIdleScanRefreshesOnlyTheOwnedShard+testMultiWorkerPoolConvergesAllViews`: 3 tests passed

No submodule pointer is changed by this PR.

