### PR TITLE
perf(core): stop resealing the partition on a covering-index append

### DIFF
--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -3133,7 +3133,18 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                             timestampMergeIndexSize
                     );
                 } else if (tableWriter.isCommitDedupMode()) {
-                    final long tempIndexAddr = Unsafe.malloc(tempIndexSize, MemoryTag.NATIVE_O3);
+                    // Publish the buffer to timestampMergeIndexAddr/Size IMMEDIATELY,
+                    // before anything that can throw. getDedupRows() opens the
+                    // partition's dedup key column, so it throws on a full disk, an
+                    // exhausted fd limit or an I/O error - and while the buffer is
+                    // held only in a local, the catch below cannot reach it: it frees
+                    // timestampMergeIndexAddr, which would still be 0. That leaked
+                    // mergeRowCount * 16 bytes of NATIVE_O3 per failed commit, for
+                    // the life of the process. Owning it from the start makes the
+                    // existing cleanup correct by construction rather than by the
+                    // caller remembering a second free path.
+                    timestampMergeIndexAddr = Unsafe.malloc(tempIndexSize, MemoryTag.NATIVE_O3);
+                    timestampMergeIndexSize = tempIndexSize;
                     final DedupColumnCommitAddresses dedupCommitAddresses = tableWriter.getDedupCommitAddresses();
                     final Path tempTablePath = Path.getThreadLocal(tableWriter.getConfiguration().getDbRoot()).concat(tableWriter.getTableToken());
 
@@ -3151,10 +3162,17 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                             dedupColSinkAddr,
                             tableWriter,
                             tempTablePath,
-                            tempIndexAddr
+                            timestampMergeIndexAddr
+                    );
+                    // realloc from the CURRENT size, then record the new one, so the
+                    // pair stays consistent for the free even if this shrinks.
+                    timestampMergeIndexAddr = Unsafe.realloc(
+                            timestampMergeIndexAddr,
+                            timestampMergeIndexSize,
+                            dedupRows * TIMESTAMP_MERGE_ENTRY_BYTES,
+                            MemoryTag.NATIVE_O3
                     );
                     timestampMergeIndexSize = dedupRows * TIMESTAMP_MERGE_ENTRY_BYTES;
-                    timestampMergeIndexAddr = Unsafe.realloc(tempIndexAddr, tempIndexSize, timestampMergeIndexSize, MemoryTag.NATIVE_O3);
                     final long duplicateCount = mergeRowCount - dedupRows;
                     boolean appendOnly = false;
                     if (duplicateCount > 0) {

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -3367,8 +3367,11 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                 // the predicate so this can never skip a column the sweep would
                 // then ignore (which would silently lose the appended rows).
                 final boolean isIndexed = metadata.isColumnIndexed(i)
-                        && !(isOpenColumnModeForAppend(openColumnMode)
-                        && openColumnMode != OPEN_NEW_PARTITION_FOR_APPEND
+                        // Spelled out rather than "every append mode except NEW": a
+                        // future append mode added to isOpenColumnModeForAppend would
+                        // otherwise be opted into deferral silently, which fails open.
+                        && !((openColumnMode == OPEN_MID_PARTITION_FOR_APPEND
+                        || openColumnMode == OPEN_LAST_PARTITION_FOR_APPEND)
                         && tableWriter.isCoveredAppendSealedByWriter(i, partitionTimestamp, srcDataMax));
                 final int indexBlockCapacity = isIndexed ? metadata.getIndexValueBlockCapacity(i) : -1;
                 final byte indexType = metadata.getColumnIndexType(i);

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -3354,7 +3354,21 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                 }
 
                 final CharSequence columnName = metadata.getColumnName(i);
-                final boolean isIndexed = metadata.isColumnIndexed(i);
+                // A COVERING posting index on a pure append into an existing mid
+                // partition is indexed by the trailing seal sweep
+                // (TableWriter#sealPostingIndexForPartition), not here: the pool
+                // IndexWriter has no covering configuration, so postings it writes
+                // carry no covered values and the seal has to regenerate the whole
+                // partition's sidecar to supply them. Leaving the appended rows
+                // unindexed here lets that seal index only the appended range and
+                // publish an incremental covered fragment - O(new rows) instead of
+                // O(partition rows) per commit. Signalled the same way an unindexed
+                // column is: no indexer and indexBlockCapacity -1. The writer owns
+                // the predicate so this can never skip a column the sweep would
+                // then ignore (which would silently lose the appended rows).
+                final boolean isIndexed = metadata.isColumnIndexed(i)
+                        && !(openColumnMode == OPEN_MID_PARTITION_FOR_APPEND
+                        && tableWriter.isCoveredAppendSealedByWriter(i, partitionTimestamp, srcDataMax));
                 final int indexBlockCapacity = isIndexed ? metadata.getIndexValueBlockCapacity(i) : -1;
                 final byte indexType = metadata.getColumnIndexType(i);
                 if (openColumnMode == OPEN_LAST_PARTITION_FOR_APPEND || openColumnMode == OPEN_LAST_PARTITION_FOR_MERGE) {

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -3354,7 +3354,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                 }
 
                 final CharSequence columnName = metadata.getColumnName(i);
-                // A COVERING posting index on a pure append into an existing mid
+                // A COVERING posting index on a pure append into an EXISTING
                 // partition is indexed by the trailing seal sweep
                 // (TableWriter#sealPostingIndexForPartition), not here: the pool
                 // IndexWriter has no covering configuration, so postings it writes
@@ -3367,7 +3367,8 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                 // the predicate so this can never skip a column the sweep would
                 // then ignore (which would silently lose the appended rows).
                 final boolean isIndexed = metadata.isColumnIndexed(i)
-                        && !(openColumnMode == OPEN_MID_PARTITION_FOR_APPEND
+                        && !(isOpenColumnModeForAppend(openColumnMode)
+                        && openColumnMode != OPEN_NEW_PARTITION_FOR_APPEND
                         && tableWriter.isCoveredAppendSealedByWriter(i, partitionTimestamp, srcDataMax));
                 final int indexBlockCapacity = isIndexed ? metadata.getIndexValueBlockCapacity(i) : -1;
                 final byte indexType = metadata.getColumnIndexType(i);

--- a/core/src/main/java/io/questdb/cairo/SymbolColumnIndexer.java
+++ b/core/src/main/java/io/questdb/cairo/SymbolColumnIndexer.java
@@ -190,18 +190,29 @@ public class SymbolColumnIndexer implements ColumnIndexer, Mutable {
         writer.rollbackConditionally(loRow);
 
         long lo = Math.max(loRow, columnTop);
-        int bufferCount = (int) (((hiRow - lo) * 4 - 1) / bufferSize + 1);
-        for (int i = 0; i < bufferCount; i++) {
+        // Loop on the row cursor, not on a precomputed buffer count: a SHORT read
+        // (0 <= read < bytesToRead) advances `lo` by less than one buffer, and a
+        // fixed iteration count would then leave the tail of [loRow, hiRow)
+        // unindexed while setMaxValue below still claims the whole range. That
+        // used to be repaired by the next commit's full reseal; the covered
+        // append path (TableWriter#sealPostingIndexForPartition) now treats
+        // maxValue as the authority for where the next append starts, so the gap
+        // would be permanent and silent.
+        while (lo < hiRow) {
             long fileOffset = (lo - columnTop) * 4;
             long bytesToRead = Math.min(bufferSize, (hiRow - lo) * 4);
             long read = ff.read(dataColumnFd, buffer, bytesToRead, fileOffset);
-            if (read == -1) {
+            if (read < 4) {
+                // -1 is an error; 0 (or a partial int) means the column file is
+                // shorter than the partition claims - both leave rows unindexed,
+                // and neither can be made progress on by looping again.
                 throw CairoException.critical(ff.errno()).put("could not read symbol column during indexing [fd=").put(dataColumnFd)
                         .put(", fileOffset=").put(fileOffset)
                         .put(", bytesToRead=").put(bytesToRead)
+                        .put(", read=").put(read)
                         .put(']');
             }
-            long pHi = buffer + read;
+            long pHi = buffer + (read & ~3L);
             for (long p = buffer; p < pHi; p += 4, lo++) {
                 writer.add(TableUtils.toIndexKey(Unsafe.getInt(p)), lo);
             }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -7780,7 +7780,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * {@code indexers} and {@code metadata} are stable for the duration.
      */
     boolean isCoveredAppendSealedByWriter(int columnIndex, long partitionTimestamp, long partitionSizeBeforeAppend) {
-        if (PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED) {
+        if (PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED) {
             return false;
         }
         if (columnIndex >= indexers.size() || indexers.getQuick(columnIndex) == null) {
@@ -10277,7 +10277,18 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                             final int colOffset = TableWriter.getPrimaryColumnIndex(i);
                             final boolean notTheTimestamp = i != timestampIndex;
                             final CharSequence columnName = metadata.getColumnName(i);
-                            final int indexBlockCapacity = metadata.isColumnIndexed(i) ? metadata.getIndexValueBlockCapacity(i) : -1;
+                            // Same deferral as the O3 worker path: a COVERING posting
+                            // index is maintained by the trailing seal instead, from
+                            // FINAL column data. Here that is a correctness gain as
+                            // well as a cost one - the covered fragment this route
+                            // writes during the copy phase is speculative, because
+                            // the indexed column's task can run before the covered
+                            // column's own append lands, and it is the trailing
+                            // rebuildSidecars that repairs it today.
+                            final boolean deferCovered = isCoveredAppendSealedByWriter(i, partitionTimestamp, srcDataMax);
+                            final int indexBlockCapacity = !deferCovered && metadata.isColumnIndexed(i)
+                                    ? metadata.getIndexValueBlockCapacity(i)
+                                    : -1;
                             final IndexWriter indexWriter = indexBlockCapacity > -1 ? getIndexWriter(i) : null;
                             final MemoryR oooMem1 = o3Columns.getQuick(colOffset);
                             final MemoryR oooMem2 = o3Columns.getQuick(colOffset + 1);
@@ -13883,7 +13894,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * duplicates it dropped were identical to the rows they replaced.
      */
     private static boolean canAppendCovered(ColumnIndexer indexer, boolean canSkipRebuild, long appendFromRow, long partitionSize, long committedTxn) {
-        if (PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED) {
+        if (PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED) {
             return false;
         }
         if (!canSkipRebuild || appendFromRow < 0 || appendFromRow >= partitionSize) {
@@ -14024,6 +14035,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 if (hasCovering) {
                     int coverCount = coveringCols.size();
 
+                    // Read BEFORE configureFollowerAndWriter: its of() calls close(),
+                    // which releases resources without flushing pending add()s. Any
+                    // pending entry means the persisted chain is not the whole
+                    // truth, so the tail append must not be trusted to complete it.
+                    final boolean hadPendingEntries = indexer.getWriter() instanceof PostingIndexWriter pending
+                            && pending.hasPendingEntries();
                     try {
                         mapCoveringColumnsForSeal(coveringCols, partitionTimestamp, plen, coverCount);
 
@@ -14041,7 +14058,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         // Fold the fd-based O3 tentative state into
                         // the writer view before the reseal.
                         indexer.mergeTentativeIntoActiveIfAny();
-                        final boolean appendCovered = canAppendCovered(indexer, canSkipRebuild, appendFromRow, partitionSize, txWriter.getTxn());
+                        final boolean appendCovered = !hadPendingEntries
+                                && canAppendCovered(indexer, canSkipRebuild, appendFromRow, partitionSize, txWriter.getTxn());
                         if (appendCovered) {
                             // Pure append into an existing partition. O3 left the
                             // appended rows unindexed for this column (see
@@ -14069,7 +14087,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                             indexer.getWriter().commit();
                             indexer.getWriter().sealIfMultiGen(configuration.getPostingSealGenThreshold());
                             if (PostingIndexWriter.COVERING_COUNTERS_ENABLED) {
-                                PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.incrementAndGet();
+                                PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.incrementAndGet();
                             }
                         } else if (canSkipRebuild && !indexDeferredToSeal
                                 && indexer.getWriter().getMaxValue() + 1 >= partitionSize) {

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -103,6 +103,7 @@ import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.FindVisitor;
 import io.questdb.std.IntIntHashMap;
+import io.questdb.std.IntHashSet;
 import io.questdb.std.IntList;
 import io.questdb.std.IntObjHashMap;
 import io.questdb.std.Long256;
@@ -267,6 +268,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     // monitor: O3 workers add concurrently, the sweep reads single-threaded
     // after they join.
     private final LongHashSet o3CoveringDeferredPartitions = new LongHashSet();
+    // Columns whose posting indexer still held unflushed add() calls when the seal
+    // sweep STARTED. Snapshotted there rather than read per partition: the sweep
+    // reopens each partition's indexer in turn, and that reopen (of() -> close())
+    // drops pending entries without flushing them - so by the time a later
+    // partition is sealed the state the guard needs to see is already gone.
+    private final IntHashSet o3PendingIndexersAtSweepStart = new IntHashSet();
     private final ObjectPool<O3MutableAtomicInteger> o3ColumnCounters = new ObjectPool<>(O3MutableAtomicInteger::new, 64);
     private final int o3ColumnMemorySize;
     private final ObjList<MemoryCR> o3ColumnOverrides;
@@ -10279,12 +10286,14 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                             final CharSequence columnName = metadata.getColumnName(i);
                             // Same deferral as the O3 worker path: a COVERING posting
                             // index is maintained by the trailing seal instead, from
-                            // FINAL column data. Here that is a correctness gain as
-                            // well as a cost one - the covered fragment this route
-                            // writes during the copy phase is speculative, because
-                            // the indexed column's task can run before the covered
-                            // column's own append lands, and it is the trailing
-                            // rebuildSidecars that repairs it today.
+                            // FINAL column data. The fragment this route writes during
+                            // the copy phase is speculative - the indexed column's task
+                            // can run before the covered column's own append lands - and
+                            // the trailing rebuildSidecars is what repairs it. That
+                            // repair is not observable today (the speculative entry is
+                            // tagged getTxn()+1 and is superseded before the commit
+                            // lands), so this removes a wasted write and the reseal it
+                            // silently required, rather than fixing a live defect.
                             final boolean deferCovered = isCoveredAppendSealedByWriter(i, partitionTimestamp, srcDataMax);
                             final int indexBlockCapacity = !deferCovered && metadata.isColumnIndexed(i)
                                     ? metadata.getIndexValueBlockCapacity(i)
@@ -14035,12 +14044,16 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 if (hasCovering) {
                     int coverCount = coveringCols.size();
 
-                    // Read BEFORE configureFollowerAndWriter: its of() calls close(),
-                    // which releases resources without flushing pending add()s. Any
-                    // pending entry means the persisted chain is not the whole
-                    // truth, so the tail append must not be trusted to complete it.
-                    final boolean hadPendingEntries = indexer.getWriter() instanceof PostingIndexWriter pending
-                            && pending.hasPendingEntries();
+                    // From the pre-sweep snapshot, NOT from the live writer: by the
+                    // time a later partition is sealed, an earlier partition's
+                    // configureFollowerAndWriter -> of() -> close() has already
+                    // dropped the pending entries this needs to see, so reading it
+                    // here would return false in exactly the multi-partition commit
+                    // where it matters. A pending entry means the persisted chain is
+                    // not the whole truth (close() discards it without flushing,
+                    // while setMaxValue has already advanced the head), so the tail
+                    // append must not be trusted to complete it.
+                    final boolean hadPendingEntries = o3PendingIndexersAtSweepStart.contains(colIdx);
                     try {
                         mapCoveringColumnsForSeal(coveringCols, partitionTimestamp, plen, coverCount);
 
@@ -14058,6 +14071,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         // Fold the fd-based O3 tentative state into
                         // the writer view before the reseal.
                         indexer.mergeTentativeIntoActiveIfAny();
+                        if (hadPendingEntries && PostingIndexWriter.COVERING_COUNTERS_ENABLED) {
+                            PostingIndexWriter.COVERING_SEAL_APPEND_PENDING_DECLINE_COUNT.incrementAndGet();
+                        }
                         final boolean appendCovered = !hadPendingEntries
                                 && canAppendCovered(indexer, canSkipRebuild, appendFromRow, partitionSize, txWriter.getTxn());
                         if (appendCovered) {
@@ -14228,14 +14244,34 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
     private void sealPostingIndexesForO3Partitions() {
         assert o3PartitionUpdRemaining.get() == 0 : "posting seal sweep ran with O3 partition workers in flight";
+        snapshotPendingPostingIndexers();
         try {
             sealPostingIndexesForO3Partitions0();
         } finally {
+            o3PendingIndexersAtSweepStart.clear();
             // Consume the deferral records here, not inside the sweep: the early
             // returns below would otherwise carry a stale partition into the next
             // commit, and a throw must not leave one behind either. A retried
             // commit re-dispatches O3, which re-adds whatever it defers again.
             clearO3CoveringDeferredPartitions();
+        }
+    }
+
+    /**
+     * Record which posting indexers hold unflushed add() calls before the sweep
+     * touches any of them. Read per column afterwards: a writer that still had
+     * pending entries cannot have its persisted chain treated as the whole truth,
+     * because the sweep's own reopen discards them (close() does not flush).
+     */
+    private void snapshotPendingPostingIndexers() {
+        o3PendingIndexersAtSweepStart.clear();
+        for (int i = 0, n = indexers.size(); i < n; i++) {
+            ColumnIndexer indexer = indexers.getQuick(i);
+            if (indexer != null
+                    && indexer.getWriter() instanceof PostingIndexWriter piw
+                    && piw.hasPendingEntries()) {
+                o3PendingIndexersAtSweepStart.add(i);
+            }
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -106,6 +106,7 @@ import io.questdb.std.IntIntHashMap;
 import io.questdb.std.IntList;
 import io.questdb.std.IntObjHashMap;
 import io.questdb.std.Long256;
+import io.questdb.std.LongHashSet;
 import io.questdb.std.LongList;
 import io.questdb.std.LowerCaseCharSequenceIntHashMap;
 import io.questdb.std.MemoryTag;
@@ -256,6 +257,16 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     private final int mkDirMode;
     private final ObjList<Runnable> nullSetters;
     private final ObjectPool<O3Basket> o3BasketPool = new ObjectPool<>(O3Basket::new, 64);
+    // Partitions for which an O3 worker left a COVERING posting index to the
+    // seal sweep (see #isCoveredAppendSealedByWriter); read by the sweep once
+    // every worker has joined, and cleared there. For a partition in this set
+    // the sweep may not treat the on-disk chain as already complete. Kept
+    // per-partition rather than per-commit so a mixed commit - a mid-partition
+    // append plus a last-partition append in the same batch - does not push the
+    // partition O3 DID index onto the expensive rebuild. Guarded by its own
+    // monitor: O3 workers add concurrently, the sweep reads single-threaded
+    // after they join.
+    private final LongHashSet o3CoveringDeferredPartitions = new LongHashSet();
     private final ObjectPool<O3MutableAtomicInteger> o3ColumnCounters = new ObjectPool<>(O3MutableAtomicInteger::new, 64);
     private final int o3ColumnMemorySize;
     private final ObjList<MemoryCR> o3ColumnOverrides;
@@ -7751,6 +7762,73 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         return false;
     }
 
+    /**
+     * True when a pure O3 append into an existing partition may leave this
+     * column's index to the trailing seal sweep
+     * ({@link #sealPostingIndexForPartition(long, boolean, long)}), which
+     * indexes just the appended range and publishes an incremental covered
+     * fragment instead of resealing the partition.
+     * <p>
+     * Only COVERING posting indexes benefit (a plain posting index is already
+     * appended cheaply by the O3 worker), and the answer must be false whenever
+     * anything would stop that sweep from reaching the column - no POSTING
+     * index, no covering columns, or no indexer instance to run it - because
+     * skipping the O3-side index write for a column the sweep then ignores
+     * would silently leave the appended rows unindexed.
+     * <p>
+     * Called from O3 workers while the writer owns the commit, so
+     * {@code indexers} and {@code metadata} are stable for the duration.
+     */
+    boolean isCoveredAppendSealedByWriter(int columnIndex, long partitionTimestamp, long partitionSizeBeforeAppend) {
+        if (PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED) {
+            return false;
+        }
+        if (columnIndex >= indexers.size() || indexers.getQuick(columnIndex) == null) {
+            return false;
+        }
+        // The column must ALREADY have index files in this partition. O3 is what
+        // creates them: for a column's first rows in a partition the copy job
+        // opens the posting index with isInit=true (O3CopyJob's
+        // openFromO3Context(row == 0)), and that is what writes the .pk. The seal
+        // cannot stand in for it - it opens an EXISTING index and throws "index
+        // does not exist" otherwise - and it would not even skip the column,
+        // because updateO3ColumnTops replaces the -1 column top with a real one
+        // before the sweep reads it. Reachable via ADD COLUMN on an older
+        // partition, and via ADD INDEX, which skips partitions where the column
+        // has no data (indexHistoricPartitions' ff.exists(dFile(...)) guard).
+        // A column top of -1, or at/past the pre-append size, means this
+        // partition holds no rows for the column yet, so it may have no .pk.
+        long columnTop = columnVersionWriter.getColumnTop(partitionTimestamp, columnIndex);
+        if (columnTop == -1L || columnTop >= partitionSizeBeforeAppend) {
+            return false;
+        }
+        if (metadata.getColumnType(columnIndex) <= 0
+                || !metadata.isColumnIndexed(columnIndex)
+                || !IndexType.isPosting(metadata.getColumnIndexType(columnIndex))) {
+            return false;
+        }
+        IntList coveringCols = metadata.getColumnMetadata(columnIndex).getCoveringColumnIndices();
+        if (coveringCols == null || coveringCols.size() == 0) {
+            return false;
+        }
+        // Record that this partition's index work is being left to the seal, so
+        // the seal cannot decide its on-disk chain is already complete. It must
+        // not trust getMaxValue() for that: a commit that failed after index()
+        // but before the gen was published leaves the head's MAX_VALUE advanced
+        // with no matching postings, and with O3 no longer indexing, nothing
+        // else would ever write them. Added from O3 workers, read by the seal
+        // after every worker has joined, cleared when the sweep is done.
+        // LongHashSet's noEntryKey is -1: adding it would write the sentinel and
+        // contains(-1) would then answer false. The sweep never asks about -1
+        // (it guards partitionTimestamp != -1L), and no real partition floors to
+        // it, but the coupling is worth stating.
+        assert partitionTimestamp != -1L : "partition timestamp collides with the LongHashSet sentinel";
+        synchronized (o3CoveringDeferredPartitions) {
+            o3CoveringDeferredPartitions.add(partitionTimestamp);
+        }
+        return true;
+    }
+
     private boolean hasPostingIndex() {
         for (int i = 0; i < columnCount; i++) {
             if (metadata.getColumnType(i) > 0 && metadata.isColumnIndexed(i)
@@ -13778,6 +13856,68 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     }
 
     /**
+     * True when a COVERING posting index can be brought up to date by indexing
+     * only {@code [appendFromRow, partitionSize)} and publishing the matching
+     * covered fragment, instead of resealing the whole partition.
+     * <p>
+     * Requires (a) the caller proved this commit is pure-append for the
+     * partition, (b) the persisted chain ends exactly where the appended range
+     * begins - so this really is a tail and no earlier rowid is missing or
+     * stale - and (c) a non-legacy covering head, because a format-0 head
+     * cannot be extended in place (aliased footer, concurrent covered-read
+     * OOB); for those the reseal runs and rewrites the head as format 1, so
+     * the NEXT commit appends.
+     * <p>
+     * (b) also fails, deliberately, whenever O3 DID index the column here (a
+     * new partition, parquet): then {@code getMaxValue()} has already advanced
+     * past {@code appendFromRow} and the full path runs. Note the dedup
+     * downgrade is NOT such a case - it rewrites the open-column mode to
+     * MID_APPEND before the O3-side predicate runs, so it is deferred like any
+     * other append, which is sound because the downgrade only fires when the
+     * duplicates it dropped were identical to the rows they replaced.
+     */
+    private static boolean canAppendCovered(ColumnIndexer indexer, boolean canSkipRebuild, long appendFromRow, long partitionSize, long committedTxn) {
+        if (PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED) {
+            return false;
+        }
+        if (!canSkipRebuild || appendFromRow < 0 || appendFromRow >= partitionSize) {
+            return false;
+        }
+        IndexWriter writer = indexer.getWriter();
+        if (!(writer instanceof PostingIndexWriter piw)) {
+            return false;
+        }
+        // THE load-bearing check, not merely an optimisation gate. A mid
+        // partition has no reopen-time recovery backstop: the chain recovery
+        // walk (setCurrentTableTxn) and openPartition's rollbackConditionally
+        // both run for the LAST partition only, so a generation this path
+        // published for a txn that never committed stays on disk. That is
+        // harmless in itself - readers below the committed txn cannot see it,
+        // and its rowids are all >= partitionSize so the reader's frame bound
+        // filters them - but the seal must never stack another generation on
+        // top of it. index() persists MAX_VALUE = partitionSize-1 through
+        // updateHeadMaxValue even when the commit that followed died, so an
+        // abandoned attempt surfaces here as getMaxValue() being AHEAD of
+        // appendFromRow and is declined. The caller then rebuilds from the
+        // column data and rotates the chain, which is what finally makes the
+        // abandoned generation unreachable.
+        if (writer.getMaxValue() + 1 != appendFromRow) {
+            return false;
+        }
+        // Defence in depth for the same case, and the only guard for a head
+        // rotated (not extended) by an uncommitted attempt: a newest generation
+        // tagged above the committed txn may be partial in ways getMaxValue()
+        // cannot show. Appending onto it would keep the damage; the rebuild the
+        // caller falls back to regenerates postings and covered values from the
+        // column files. (The reseal path tolerates such a head because it
+        // rewrites the sidecars wholesale - this path does not.)
+        if (piw.getHeadTxnAtSeal() > committedTxn) {
+            return false;
+        }
+        return !piw.isHeadCoveringFormatLegacy();
+    }
+
+    /**
      * Per-partition helper for {@link #sealPostingIndexesForO3Partitions()}.
      * Opens each posting-index column on the given partition, folds any O3
      * tentative state into the active view, rolls back stale rowids left over
@@ -13793,9 +13933,13 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * false, the chain must be rebuilt from the column .d file because some
      * earlier write may have left stale {@code (key, rowId)} pairs.
      *
+     * @param appendFromRow first row this commit appended to the partition, or
+     *                      -1 when the commit was not a pure append. Lets a
+     *                      COVERING index update just that tail; see
+     *                      {@link #canAppendCovered(ColumnIndexer, boolean, long, long, long)}.
      * @return true if at least one column indexer was touched.
      */
-    private boolean sealPostingIndexForPartition(long partitionTimestamp, boolean canSkipRebuild) {
+    private boolean sealPostingIndexForPartition(long partitionTimestamp, boolean canSkipRebuild, long appendFromRow) {
         // Invariant: posting seal runs only after every O3 partition worker has
         // joined (finishO3Commit / post-await, or a writer-thread squash). It reads
         // the just-written partition column data and rotates value files; a worker
@@ -13826,6 +13970,13 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
 
         boolean processed = false;
+        // Did an O3 worker leave THIS partition's covering index to this sweep?
+        // Read once: the workers have all joined (asserted above), so the set is
+        // stable for the rest of the call.
+        final boolean indexDeferredToSeal;
+        synchronized (o3CoveringDeferredPartitions) {
+            indexDeferredToSeal = o3CoveringDeferredPartitions.contains(partitionTimestamp);
+        }
         long partitionNameTxn = setStateForTimestamp(path, partitionTimestamp);
         int plen = path.size();
         // For new partitions created during O3, the partition directory may
@@ -13884,18 +14035,60 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         // Fold the fd-based O3 tentative state into
                         // the writer view before the reseal.
                         indexer.mergeTentativeIntoActiveIfAny();
-                        if (canSkipRebuild) {
-                            // Pure-append O3 commit: no rowid in
+                        final boolean appendCovered = canAppendCovered(indexer, canSkipRebuild, appendFromRow, partitionSize, txWriter.getTxn());
+                        if (appendCovered) {
+                            // Pure append into an existing partition. O3 left the
+                            // appended rows unindexed for this column (see
+                            // #isCoveredAppendSealedByWriter), so the whole
+                            // update is a tail: index ONLY [appendFromRow,
+                            // partitionSize) into the writer's pending buffers and
+                            // commit, which flushes them as one new gen and appends
+                            // the matching covered fragment to .pc - O(new rows).
+                            // Compaction is deferred to the gen threshold, exactly
+                            // like the non-covering branch below, instead of
+                            // rewriting the partition's .pv/.pc on every commit.
+                            // Covering must be configured BEFORE the flush: commit()
+                            // -> flushAllPending -> writeSidecarGenData reads the
+                            // covered column addresses mapped above.
+                            indexer.configureCovering(o3SealAddrs, o3SealAuxAddrs, o3SealTops, o3SealShifts, coveringCols, o3SealTypes, coverCount,
+                                    metadata.getTimestampIndex());
+                            indexer.setCoveredColumnNameTxns(o3SealNameTxns);
+                            indexer.setCoveredColumnAddrSizes(o3SealMappedSizes, o3SealAuxMappedSizes);
+                            long dataFd = openRO(ff, dFile(path.trimTo(plen), colName, colNameTxn), LOG);
+                            try {
+                                indexer.index(ff, dataFd, appendFromRow, partitionSize);
+                            } finally {
+                                ff.close(dataFd);
+                            }
+                            indexer.getWriter().commit();
+                            indexer.getWriter().sealIfMultiGen(configuration.getPostingSealGenThreshold());
+                            if (PostingIndexWriter.COVERING_COUNTERS_ENABLED) {
+                                PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.incrementAndGet();
+                            }
+                        } else if (canSkipRebuild && !indexDeferredToSeal
+                                && indexer.getWriter().getMaxValue() + 1 >= partitionSize) {
+                            // Pure-append O3 commit AND the persisted chain
+                            // already covers every row: no rowid in
                             // [columnTop, partitionSize) was rewritten,
-                            // so the persisted chain has no in-range
-                            // stale (key, rowId) pairs. The cheap
+                            // so the chain has no in-range stale
+                            // (key, rowId) pairs. The cheap
                             // rollbackConditionally evicts any entries
-                            // past partitionSize (typically a no-op for
-                            // pure append because getMaxValue() <
-                            // partitionSize) and the trailing
+                            // past partitionSize and the trailing
                             // rebuildSidecars publishes the chain as is.
                             indexer.getWriter().rollbackConditionally(partitionSize);
                         } else {
+                            // Also reached when O3 left this column's index to
+                            // the seal (see #isCoveredAppendSealedByWriter) and
+                            // the append branch above declined - a legacy
+                            // format-0 head, or a chain left inconsistent by an
+                            // attempt that never committed. The appended rows
+                            // are then indexed NOWHERE else, and getMaxValue()
+                            // cannot be used to tell: a failure between index()
+                            // and the gen publish leaves the head's MAX_VALUE
+                            // advanced over postings that were never written.
+                            // So rebuild from the column data, which is always
+                            // the truth; it also rewrites a legacy head as
+                            // format 1, letting the NEXT commit append.
                             // Rebuild the chain from the column data file.
                             // rollbackConditionally(partitionSize) only
                             // evicts entries past the new partition size; it
@@ -13916,6 +14109,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                                 ff.close(dataFd);
                             }
                             indexer.getWriter().commitDense();
+                        }
+                        if (appendCovered) {
+                            // The append branch already published its gen and
+                            // covered fragment through commit(); a trailing
+                            // rebuildSidecars would undo the saving.
+                            continue;
                         }
                         // Pass the writer-space timestamp index so the
                         // O3 reseal preserves the linear-prediction
@@ -14005,6 +14204,24 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
     private void sealPostingIndexesForO3Partitions() {
         assert o3PartitionUpdRemaining.get() == 0 : "posting seal sweep ran with O3 partition workers in flight";
+        try {
+            sealPostingIndexesForO3Partitions0();
+        } finally {
+            // Consume the deferral records here, not inside the sweep: the early
+            // returns below would otherwise carry a stale partition into the next
+            // commit, and a throw must not leave one behind either. A retried
+            // commit re-dispatches O3, which re-adds whatever it defers again.
+            clearO3CoveringDeferredPartitions();
+        }
+    }
+
+    private void clearO3CoveringDeferredPartitions() {
+        synchronized (o3CoveringDeferredPartitions) {
+            o3CoveringDeferredPartitions.clear();
+        }
+    }
+
+    private void sealPostingIndexesForO3Partitions0() {
         // O3 rebuilds posting indexes via pool IndexWriters that have no covering
         // configuration and never seal (FD-based close skips seal). Re-open each
         // affected partition's posting index, seal it (converting sparse gens to
@@ -14041,11 +14258,18 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     && o3SplitPartitionSize == 0
                     && newPartitionSize >= oldPartitionSize;
 
-            if (partitionTimestamp != -1L && sealPostingIndexForPartition(partitionTimestamp, canSkipRebuildForPartition)) {
+            // Pure append: the rows this commit added to the partition are exactly
+            // [oldPartitionSize, newPartitionSize), so a COVERING index can index
+            // that tail instead of resealing the partition. -1 = not a pure append.
+            long appendFromRow = canSkipRebuildForPartition && newPartitionSize > oldPartitionSize
+                    ? oldPartitionSize
+                    : -1L;
+
+            if (partitionTimestamp != -1L && sealPostingIndexForPartition(partitionTimestamp, canSkipRebuildForPartition, appendFromRow)) {
                 anyPartitionProcessed = true;
             }
             if (dataPartitionTimestamp != -1L && dataPartitionTimestamp != partitionTimestamp
-                    && sealPostingIndexForPartition(dataPartitionTimestamp, false)) {
+                    && sealPostingIndexForPartition(dataPartitionTimestamp, false, -1L)) {
                 anyPartitionProcessed = true;
             }
         }
@@ -14507,7 +14731,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         // so distress it before propagating so the pool replaces it instead of
         // handing it back to the next caller.
         try {
-            if (sealPostingIndexForPartition(targetPartition, false)) {
+            if (sealPostingIndexForPartition(targetPartition, false, -1L)) {
                 restorePostingIndexersToLastPartition();
             }
         } catch (Throwable e) {

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -7400,6 +7400,15 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             metrics.tableWriterMetrics().incrementO3Commits();
         } finally {
             o3FinishInFlight = false;
+            // The sweep clears its own deferral records, but it does not run at
+            // all when o3InError is set - and the O3 workers may already have
+            // recorded a deferral before a later partition's task threw. Clearing
+            // here as well keeps the set scoped to exactly one commit whether or
+            // not the sweep ran. A carried-over entry is only a cost bug (it
+            // forces the rebuild branch for an unrelated partition; canAppendCovered
+            // never consults the set), but the invariant is cheaper to hold than
+            // to reason about.
+            clearO3CoveringDeferredPartitions();
         }
     }
 
@@ -13979,6 +13988,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         // Did an O3 worker leave THIS partition's covering index to this sweep?
         // Read once: the workers have all joined (asserted above), so the set is
         // stable for the rest of the call.
+        // Keyed by partition, consumed per column. With two covering columns in
+        // one partition where only one defers - the other's first rows land in
+        // this very append, so its columnTop is not below the pre-append size -
+        // the non-deferred column is pushed onto the rebuild branch too. Cost
+        // only, never wrong, and it does not persist: once both columns have rows
+        // in the partition, both defer.
         final boolean indexDeferredToSeal;
         synchronized (o3CoveringDeferredPartitions) {
             indexDeferredToSeal = o3CoveringDeferredPartitions.contains(partitionTimestamp);
@@ -14217,6 +14232,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             // returns below would otherwise carry a stale partition into the next
             // commit, and a throw must not leave one behind either. A retried
             // commit re-dispatches O3, which re-adds whatever it defers again.
+            // This does NOT cover the case where the sweep is skipped altogether
+            // (o3InError) - finishO3Commit's own finally clears the set for that.
             clearO3CoveringDeferredPartitions();
         }
     }

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -138,7 +138,7 @@ public class PostingIndexWriter implements IndexWriter {
     // Plain (non-volatile) boolean, like the flags above: tests flip it on the
     // thread that then applies the WAL synchronously.
     @TestOnly
-    public static boolean COVERING_MIDPART_APPEND_DISABLED = false;
+    public static boolean COVERING_SEAL_APPEND_DISABLED = false;
     // @TestOnly: number of times the O3 seal sweep updated a COVERING index by
     // indexing only the appended range and publishing an incremental covered
     // fragment, instead of resealing the partition. Lets a test assert the path
@@ -146,7 +146,7 @@ public class PostingIndexWriter implements IndexWriter {
     // (which is also true when nothing happened at all). Gated by
     // COVERING_COUNTERS_ENABLED like the others.
     @TestOnly
-    public static final java.util.concurrent.atomic.AtomicLong COVERING_MIDPART_APPEND_COUNT = new java.util.concurrent.atomic.AtomicLong();
+    public static final java.util.concurrent.atomic.AtomicLong COVERING_SEAL_APPEND_COUNT = new java.util.concurrent.atomic.AtomicLong();
     // @TestOnly: how many times TableWriter.tryFastAppendInOrderBlock actually
     // committed a block. Distinct from COVERING_FASTLAG_COMMIT_COUNT, which counts
     // the SHARED fast-lag covered publish that the pre-existing single-txn path
@@ -1005,6 +1005,18 @@ public class PostingIndexWriter implements IndexWriter {
      * decide what is already indexed must instead treat it as untrustworthy and
      * rebuild.
      */
+    /**
+     * True when the writer holds {@code add()} calls that have not been flushed
+     * to a generation yet. {@code close()} deliberately does NOT flush them, so
+     * any caller about to reopen this writer (which the seal does, via
+     * configureFollowerAndWriter) would drop them. A caller that relies on the
+     * persisted chain being the whole truth must therefore refuse to do so while
+     * this is true.
+     */
+    public boolean hasPendingEntries() {
+        return hasPendingData;
+    }
+
     public long getHeadTxnAtSeal() {
         if (!keyMem.isOpen() || !chain.hasHead()) {
             return -1L;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -128,6 +128,25 @@ public class PostingIndexWriter implements IndexWriter {
     // thread that sets the flag, so there is no cross-thread visibility hazard.
     @TestOnly
     public static boolean COVERING_FASTPATH_DISABLED = false;
+    // @TestOnly override: when true, a pure O3 append into an existing partition
+    // does NOT take the covered append path (index only the appended range at
+    // seal time + incremental covered fragment). O3 indexes the rows as before
+    // and the seal full-reseals. Lets the differential fuzz apply the SAME
+    // stream both ways and assert byte-identical results, and lets a regression
+    // be attributed to the append path. Default false -> never set in
+    // production, so the JIT elides the always-false guard.
+    // Plain (non-volatile) boolean, like the flags above: tests flip it on the
+    // thread that then applies the WAL synchronously.
+    @TestOnly
+    public static boolean COVERING_MIDPART_APPEND_DISABLED = false;
+    // @TestOnly: number of times the O3 seal sweep updated a COVERING index by
+    // indexing only the appended range and publishing an incremental covered
+    // fragment, instead of resealing the partition. Lets a test assert the path
+    // FIRED rather than infer it from COVERING_FULL_RESEAL_COUNT staying 0
+    // (which is also true when nothing happened at all). Gated by
+    // COVERING_COUNTERS_ENABLED like the others.
+    @TestOnly
+    public static final java.util.concurrent.atomic.AtomicLong COVERING_MIDPART_APPEND_COUNT = new java.util.concurrent.atomic.AtomicLong();
     // @TestOnly: how many times TableWriter.tryFastAppendInOrderBlock actually
     // committed a block. Distinct from COVERING_FASTLAG_COMMIT_COUNT, which counts
     // the SHARED fast-lag covered publish that the pre-existing single-txn path
@@ -973,6 +992,38 @@ public class PostingIndexWriter implements IndexWriter {
     // from the writer's live coverCount.
     private int headStoredCoveringFormat() {
         return PostingIndexChainEntry.unpackCoveringFormat(keyMem.getInt(chain.getHeadEntryOffset() + PostingIndexUtils.V2_ENTRY_OFFSET_COVERING_FORMAT));
+    }
+
+    /**
+     * The table {@code _txn} the live chain head's most recent generation was
+     * tagged with, or {@code -1} when there is no head. A value ABOVE the
+     * committed table txn means the newest publish came from an attempt that
+     * never committed (its writer was distressed before {@code txWriter.commit}
+     * landed). Such a head cannot simply be dropped at seal time - a commit in
+     * flight tags its own publishes the same way, so the two are
+     * indistinguishable there - which means any caller that READS the chain to
+     * decide what is already indexed must instead treat it as untrustworthy and
+     * rebuild.
+     */
+    public long getHeadTxnAtSeal() {
+        if (!keyMem.isOpen() || !chain.hasHead()) {
+            return -1L;
+        }
+        if (genCount <= 0) {
+            // No generation, so no "most recent generation" to report. Returning
+            // the entry-level value here would hand back exactly the stale
+            // slot[0] reading this method exists to avoid.
+            return -1L;
+        }
+        // The NEWEST gen's slot, not the entry-level value: the latter is
+        // slot[0]'s, and extendHead deliberately never rewrites slot[0]
+        // (see its "(newGenCount-1)'s gen-dir slot never overwrites it"
+        // note), so an entry extended in place still reports the txn of its
+        // FIRST gen. That is precisely the shape an in-place append leaves,
+        // which is the shape callers here need to judge. Gen-dir TXN_AT_SEAL
+        // is monotonic (enforced by checkGenDirMonotonic), so the last slot
+        // is the most recent publish.
+        return keyMem.getLong(resolveHeadGenDirOffset(genCount - 1) + PostingIndexUtils.GEN_DIR_OFFSET_TXN_AT_SEAL);
     }
 
     /**

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -147,6 +147,13 @@ public class PostingIndexWriter implements IndexWriter {
     // COVERING_COUNTERS_ENABLED like the others.
     @TestOnly
     public static final java.util.concurrent.atomic.AtomicLong COVERING_SEAL_APPEND_COUNT = new java.util.concurrent.atomic.AtomicLong();
+    // @TestOnly: number of times the seal DECLINED the covered append because the
+    // writer still held unflushed add() calls. Without a counter that branch is
+    // unobservable, so nothing can tell its presence from its absence - and it
+    // guards a silent-row-loss case (close() drops pending entries). Tests assert
+    // it stays 0; if a workload ever trips it, that assertion is how we find out.
+    @TestOnly
+    public static final java.util.concurrent.atomic.AtomicLong COVERING_SEAL_APPEND_PENDING_DECLINE_COUNT = new java.util.concurrent.atomic.AtomicLong();
     // @TestOnly: how many times TableWriter.tryFastAppendInOrderBlock actually
     // committed a block. Distinct from COVERING_FASTLAG_COMMIT_COUNT, which counts
     // the SHARED fast-lag covered publish that the pre-existing single-txn path
@@ -1005,18 +1012,6 @@ public class PostingIndexWriter implements IndexWriter {
      * decide what is already indexed must instead treat it as untrustworthy and
      * rebuild.
      */
-    /**
-     * True when the writer holds {@code add()} calls that have not been flushed
-     * to a generation yet. {@code close()} deliberately does NOT flush them, so
-     * any caller about to reopen this writer (which the seal does, via
-     * configureFollowerAndWriter) would drop them. A caller that relies on the
-     * persisted chain being the whole truth must therefore refuse to do so while
-     * this is true.
-     */
-    public boolean hasPendingEntries() {
-        return hasPendingData;
-    }
-
     public long getHeadTxnAtSeal() {
         if (!keyMem.isOpen() || !chain.hasHead()) {
             return -1L;
@@ -1046,6 +1041,18 @@ public class PostingIndexWriter implements IndexWriter {
      * a fresh format-1 entry, migrating the head; subsequent block-applies see a
      * format-1 head and fast-path. Cheap: one mapped int read.
      */
+    /**
+     * True when the writer holds {@code add()} calls that have not been flushed
+     * to a generation yet. {@code close()} deliberately does NOT flush them, so
+     * any caller about to reopen this writer (which the seal does, via
+     * configureFollowerAndWriter) would drop them. A caller that relies on the
+     * persisted chain being the whole truth must therefore refuse to do so while
+     * this is true.
+     */
+    public boolean hasPendingEntries() {
+        return hasPendingData;
+    }
+
     public boolean isHeadCoveringFormatLegacy() {
         // Self-contained property of the on-disk head entry (independent of the
         // writer's live coverCount, which may be unconfigured at gate time): a

--- a/core/src/test/java/io/questdb/test/cairo/O3DedupMergeIndexLeakTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/O3DedupMergeIndexLeakTest.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo;
+
+import io.questdb.std.str.Utf8s;
+import io.questdb.std.str.LPSZ;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.std.TestFilesFacadeImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A DEDUP commit with additional key columns builds its timestamp merge index in
+ * a temporary buffer, then reallocs it down to the deduplicated row count:
+ *
+ * <pre>
+ *     tempIndexAddr = Unsafe.malloc(tempIndexSize, NATIVE_O3);
+ *     dedupRows = getDedupRows(..., tempIndexAddr);      // opens the key column
+ *     timestampMergeIndexAddr = Unsafe.realloc(tempIndexAddr, ...);
+ * </pre>
+ * <p>
+ * {@code getDedupRows} opens the partition's dedup key column, so it can throw.
+ * Until the realloc, the buffer is reachable only through the local - the
+ * enclosing handler frees {@code timestampMergeIndexAddr}, which is still 0 - so
+ * the throw leaks {@code mergeRowCount * 16} bytes of NATIVE_O3 per failed
+ * commit, permanently, for the life of the process.
+ * <p>
+ * Found by fault-injection fuzzing, where it surfaced as a ~7% flake attributed
+ * to whichever test happened to be running. It is not specific to covering
+ * indexes; any DEDUP table with a non-timestamp key hits it whenever a merge
+ * commit fails while reading that key column - a full disk, a hit fd limit, or
+ * an I/O error.
+ */
+public class O3DedupMergeIndexLeakTest extends AbstractCairoTest {
+
+    /**
+     * The leak is detected by {@code assertMemoryLeak}'s NATIVE_O3 tag check, so
+     * the test body only has to make the failing merge happen; there is no
+     * explicit leak assertion to get wrong.
+     */
+    @Test
+    public void testFailedDedupKeyColumnOpenDoesNotLeakMergeIndex() throws Exception {
+        final AtomicBoolean armed = new AtomicBoolean();
+        final AtomicBoolean fired = new AtomicBoolean();
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public long openRO(LPSZ name) {
+                // The dedup key column read inside the merge. Only this one:
+                // failing every sym.d open would break the seed as well.
+                // The dedup key column of the PARTITION, read inside the merge.
+                // Scoped to the partition directory so a WAL segment's sym.d -
+                // which is read while building the commit, before the merge even
+                // starts - cannot consume the one-shot fault instead.
+                if (armed.get() && name != null
+                        && Utf8s.containsAscii(name, "2024-01-02")
+                        && Utf8s.endsWithAscii(name, "sym.d")) {
+                    armed.set(false);
+                    fired.set(true);
+                    return -1;
+                }
+                return super.openRO(name);
+            }
+        };
+
+        assertMemoryLeak(ff, () -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL, value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL DEDUP UPSERT KEYS(ts, sym)");
+            // Day 1 and day 3 first, so day 2 is a MID partition. A mid-partition
+            // O3 write always goes through the merge; a write into the LAST
+            // partition can be absorbed by the lag path and never merge at all,
+            // which is why the first version of this test reached nothing.
+            execute("INSERT INTO t VALUES ('2024-01-01T00:00:00.000000Z', 'S0', 1.0)");
+            execute("INSERT INTO t VALUES ('2024-01-03T00:00:00.000000Z', 'S0', 3.0)");
+            execute("INSERT INTO t SELECT dateadd('u', x::INT, '2024-01-02T00:00:00Z'::TIMESTAMP),"
+                    + " 'S' || (x % 4), x::DOUBLE FROM long_sequence(5000)");
+            drainWalQueue();
+
+            armed.set(true);
+            // Lands INSIDE the seed's range, so this is a merge, and the dedup
+            // key (sym) forces the additional-keys path that reads the partition
+            // column. On a WAL table the failure suspends the table rather than
+            // throwing from INSERT.
+            execute("INSERT INTO t SELECT dateadd('u', (2000 + x)::INT, '2024-01-02T00:00:00Z'::TIMESTAMP),"
+                    + " 'S' || (x % 4), (100000 + x)::DOUBLE FROM long_sequence(500)");
+            drainWalQueue();
+            Assert.assertTrue("the injected fault never fired, so nothing was tested", fired.get());
+
+            // Drop the distressed writer so every other allocation it owns is
+            // released; whatever the tag check then reports is the leak itself.
+            engine.releaseAllWriters();
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -79,6 +79,7 @@ import io.questdb.tasks.PostingSealPurgeTask;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.std.TestFilesFacadeImpl;
 import io.questdb.test.tools.TestUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
@@ -98,6 +99,11 @@ import static io.questdb.cairo.TableUtils.*;
  * conditions are marked with comments describing what they need.
  */
 public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
+
+    @After
+    public void resetMidPartitionAppendPin() {
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+    }
 
     @Override
     public void setUp() {
@@ -3043,6 +3049,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testSquashPartitionsKeepsRetainedDeferredPostingSealPurgeAcrossSuccessfulCommit() throws Exception {
+        // Pinned to the reseal path: the assertion is that the .pv/.pc captured
+        // below are eventually purged, which requires the O3 insert to ROTATE
+        // them. A pure append now publishes an incremental covered fragment into
+        // the same files (they stay live, nothing to purge), and forcing a merge
+        // instead would rewrite the partition into a new directory - making the
+        // "files are gone" assertion pass for the wrong reason.
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
         node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
         node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 20);
         node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 20);
@@ -3110,6 +3123,9 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testAttachDetachForceRemoveKeepRetainedDeferredPostingSealPurgeAcrossCommits() throws Exception {
+        // Pinned to the reseal path for the same reason as the squash variant
+        // above: the purge assertion needs the O3 insert to rotate .pv/.pc.
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
         node1.setProperty(PropertyKey.CAIRO_ATTACH_PARTITION_SUFFIX, DETACHED_DIR_MARKER);
 
         assertMemoryLeak(() -> {
@@ -5431,6 +5447,16 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
             }
         };
 
+        // Pinned to the reseal path: this test targets a partial-seal FAILURE
+        // during the covering reseal (the path every merge, split, squash and
+        // parquet commit still takes), and both its fault injection and its
+        // assertions are expressed in terms of the .pv rotation that reseal
+        // performs. The covered append path a pure append now takes publishes an
+        // incremental fragment into the SAME .pv instead, so the scenario cannot
+        // be built there; forcing a merge instead is not equivalent either -
+        // a merge rewrites the partition into a new directory, and the
+        // chain-head checks below read the un-suffixed one.
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
         assertMemoryLeak(ff, () -> {
             // sym carries an explicit INCLUDE (ts) so the index is covering:
             // the test arms a fault on the second seal-time .pv rotation, which

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -102,7 +102,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @After
     public void resetMidPartitionAppendPin() {
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
     }
 
     @Override
@@ -1731,6 +1731,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      */
     @Test
     public void testIncrementalSealDistrustsRecreatedSidecar() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_rb_orphan (
@@ -1810,6 +1817,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      */
     @Test
     public void testIncrementalSealLastCleanStrideStopsAtSentinel() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_tail (
@@ -2082,6 +2096,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      */
     @Test
     public void testIncrementalSealRejectsOverflowingSidecarSentinel() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_ovf (
@@ -2460,6 +2481,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testO3DeferredPostingSealPurgeRunsAfterCommit() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -2502,6 +2524,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testO3DeferredPostingSealPurgePersistsOnCloseWhenJobHoldsLogWriter() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -2573,6 +2602,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testO3DeferredPostingSealPurgePersistsOnCloseWhenQueueIsFull() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -2629,6 +2665,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testO3DeferredPostingSealPurgePersistsMultipleReadyEntriesOnCloseWhenQueueIsFull() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -2754,6 +2797,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testCommitSeqTxnPublishesReadyDeferredPostingSealPurgeRetainedByFullQueue() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -2813,6 +2863,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      */
     @Test
     public void testCloseWithLivePurgeJobSpillsReadyDeferredPostingSealPurgeWhenQueueIsFull() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -2882,6 +2939,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      */
     @Test
     public void testCloseWithLivePurgeJobSpillsMultipleReadyDeferredPostingSealPurgesAndReplaysOnReopen() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -3055,7 +3119,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         // the same files (they stay live, nothing to purge), and forcing a merge
         // instead would rewrite the partition into a new directory - making the
         // "files are gone" assertion pass for the wrong reason.
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
         node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 20);
         node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 20);
@@ -3125,7 +3189,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     public void testAttachDetachForceRemoveKeepRetainedDeferredPostingSealPurgeAcrossCommits() throws Exception {
         // Pinned to the reseal path for the same reason as the squash variant
         // above: the purge assertion needs the O3 insert to rotate .pv/.pc.
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         node1.setProperty(PropertyKey.CAIRO_ATTACH_PARTITION_SUFFIX, DETACHED_DIR_MARKER);
 
         assertMemoryLeak(() -> {
@@ -5456,7 +5520,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         // be built there; forcing a merge instead is not equivalent either -
         // a merge rewrites the partition into a new directory, and the
         // chain-head checks below read the un-suffixed one.
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         assertMemoryLeak(ff, () -> {
             // sym carries an explicit INCLUDE (ts) so the index is covering:
             // the test arms a fault on the second seal-time .pv rotation, which
@@ -10465,6 +10529,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testWalO3DeferredPostingSealPurgeRunsAfterCommit() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;

--- a/core/src/test/java/io/questdb/test/cairo/covering/LastPartitionO3AppendCoveringTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/LastPartitionO3AppendCoveringTest.java
@@ -1,0 +1,176 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.covering;
+
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * The LAST partition's covering index when the WAL fast-lag gate does NOT apply.
+ * <p>
+ * Fast-lag handles a pure append into the last partition, but only when the
+ * commit qualifies. DEDUP disqualifies both halves of the gate - the block-apply
+ * gate tests {@code isCommitPlainInsert()} and the single-txn gate tests
+ * {@code !isCommitDedupMode()} - so a deduped table's appends fall back to the O3
+ * route while remaining pure appends (the timestamps here are unique and
+ * ascending, so nothing is actually deduplicated). Concurrent clients hit the
+ * same fallback through multi-segment blocks, without any dedup configuration.
+ * <p>
+ * On that route the index was maintained during the O3 copy phase, which had two
+ * consequences: every commit then paid a full {@code rebuildSidecars()} of the
+ * partition, AND the covered fragment written during the copy was speculative -
+ * the indexed column's task can run before the covered column's own append lands,
+ * so the reseal was what repaired it. Deferring the covering index to the seal,
+ * which runs after every column task has joined, removes both: the fragment is
+ * built once, from final column data.
+ */
+public class LastPartitionO3AppendCoveringTest extends AbstractCairoTest {
+
+    private static final int COMMITS = 12;
+    private static final int ROWS_PER_COMMIT = 500;
+    private static final int SEED_ROWS = 5000;
+
+    @Before
+    public void enableCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
+        PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
+    }
+
+    @After
+    public void disableCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
+    }
+
+    /**
+     * Correctness must not depend on the new path: the same stream with the path
+     * switched off has to produce the same reads.
+     */
+    @Test
+    public void testDedupLastPartitionCorrectOnResealPath() throws Exception {
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
+        assertMemoryLeak(() -> {
+            createTables(true);
+            appendAndAssert();
+        });
+    }
+
+    @Test
+    public void testDedupLastPartitionTakesAppendPath() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables(true);
+            PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
+
+            appendAndAssert();
+
+            Assert.assertEquals("a pure append into the last partition must not full-reseal",
+                    0, PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get());
+            Assert.assertTrue("the covered append path must fire (appends="
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
+        });
+    }
+
+    /**
+     * With real duplicates the commit is no longer a pure append (rows are
+     * replaced), so it must fall back to the rebuild and still read correctly.
+     */
+    @Test
+    public void testDedupWithRealDuplicatesStillCorrect() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables(true);
+            for (int c = 0; c < COMMITS; c++) {
+                // half the batch repeats timestamps already written
+                final long base = SEED_ROWS + (long) c * ROWS_PER_COMMIT;
+                insertBoth(base, ROWS_PER_COMMIT);
+                insertBoth(base - ROWS_PER_COMMIT / 2, ROWS_PER_COMMIT / 2);
+                drainWalQueue();
+            }
+            assertNotSuspended();
+            assertCoveredMatchesControl();
+        });
+    }
+
+    private void appendAndAssert() throws Exception {
+        for (int c = 0; c < COMMITS; c++) {
+            insertBoth(SEED_ROWS + (long) c * ROWS_PER_COMMIT, ROWS_PER_COMMIT);
+            drainWalQueue();
+        }
+        assertNotSuspended();
+        assertCoveredMatchesControl();
+
+        // and again after a reopen, so the published fragments are proven durable
+        engine.releaseInactive();
+        assertCoveredMatchesControl();
+    }
+
+    private void assertCoveredMatchesControl() throws Exception {
+        for (int s = 0; s < 8; s++) {
+            final String sym = "S" + s;
+            assertSqlCursors(
+                    "SELECT ts, sym, value FROM ctl WHERE sym = '" + sym + "' ORDER BY ts",
+                    "SELECT ts, sym, value FROM t WHERE sym = '" + sym + "' ORDER BY ts"
+            );
+        }
+        assertSqlCursors(
+                "SELECT sym, count(*), sum(value), min(value), max(value) FROM ctl ORDER BY sym",
+                "SELECT sym, count(*), sum(value), min(value), max(value) FROM t ORDER BY sym"
+        );
+        // index scan vs the column itself, which localises a missing tail
+        assertSqlCursors(
+                "SELECT /*+ no_index */ sym, count(*) FROM t ORDER BY sym",
+                "SELECT sym, count(*) FROM t ORDER BY sym"
+        );
+    }
+
+    private void assertNotSuspended() {
+        Assert.assertFalse("t suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("t")));
+        Assert.assertFalse("ctl suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("ctl")));
+    }
+
+    private void createTables(boolean dedup) throws Exception {
+        final String dedupClause = dedup ? " DEDUP UPSERT KEYS(ts, sym)" : "";
+        execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                + " TIMESTAMP(ts) PARTITION BY DAY WAL" + dedupClause);
+        execute("CREATE TABLE ctl (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, value DOUBLE)"
+                + " TIMESTAMP(ts) PARTITION BY DAY WAL" + dedupClause);
+        insertBoth(0, SEED_ROWS);
+        drainWalQueue();
+    }
+
+    private void insertBoth(long base, int rows) throws Exception {
+        final String tail = " SELECT dateadd('u', (" + base + " + x)::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),"
+                + " 'S' || ((" + base + " + x) % 8), (" + base + " + x)::DOUBLE"
+                + " FROM long_sequence(" + rows + ")";
+        execute("INSERT INTO t" + tail);
+        execute("INSERT INTO ctl" + tail);
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/covering/LastPartitionO3AppendCoveringTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/LastPartitionO3AppendCoveringTest.java
@@ -24,6 +24,8 @@
 
 package io.questdb.test.cairo.covering;
 
+import io.questdb.PropertyKey;
+import io.questdb.cairo.PostingSealPurgeJob;
 import io.questdb.cairo.idx.PostingIndexWriter;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.After;
@@ -61,6 +63,7 @@ public class LastPartitionO3AppendCoveringTest extends AbstractCairoTest {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
         PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
         PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_PENDING_DECLINE_COUNT.set(0);
     }
 
     @After
@@ -116,6 +119,65 @@ public class LastPartitionO3AppendCoveringTest extends AbstractCairoTest {
             }
             assertNotSuspended();
             assertCoveredMatchesControl();
+        });
+    }
+
+    /**
+     * The O3PartitionJob half of the deferral (the merge-collapses-to-append
+     * degradation that yields OPEN_LAST_PARTITION_FOR_APPEND) is a DIFFERENT
+     * production path from the writer's inline append branch, and the other tests
+     * here all take the inline one. Route A requires the batch to start strictly
+     * after the partition max under dedup, so a batch whose first row repeats the
+     * max timestamp is refused by it and goes through the merge instead - where
+     * dedup drops the duplicate and the merge collapses to an append.
+     */
+    @Test
+    public void testDedupMergeCollapseTakesAppendPath() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables(true);
+            PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
+
+            for (int c = 0; c < COMMITS; c++) {
+                final long base = SEED_ROWS + (long) c * ROWS_PER_COMMIT;
+                // first row repeats the current max timestamp (a real duplicate),
+                // the rest extend past it
+                insertBoth(base - 1, ROWS_PER_COMMIT + 1);
+                drainWalQueue();
+            }
+
+            assertNotSuspended();
+            assertCoveredMatchesControl();
+            Assert.assertTrue("the merge-collapse route must reach the covered append path (appends="
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
+        });
+    }
+
+    /**
+     * Deferred compaction has to actually fire on this route too: at the shipped
+     * threshold COMMITS would never reach it, so this would otherwise prove only
+     * that nothing happened. Also checks the superseded files are reclaimed once
+     * the purge job runs.
+     */
+    @Test
+    public void testLastPartitionAppendCompactsAndReclaims() throws Exception {
+        setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 3);
+        assertMemoryLeak(() -> {
+            createTables(true);
+            appendAndAssert();
+
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                for (int i = 0; i < 64 && purgeJob.run(); i++) {
+                    // drain
+                }
+            }
+            assertCoveredMatchesControl();
+            // The guard that protects the live indexer's unflushed entries must not
+            // be silently firing: if it is, this route is falling back to the
+            // rebuild and the append path is not being exercised at all.
+            Assert.assertEquals("covered append declined for pending entries",
+                    0, PostingIndexWriter.COVERING_SEAL_APPEND_PENDING_DECLINE_COUNT.get());
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoverageGapsTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoverageGapsTest.java
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.covering;
+
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.mp.WorkerPool;
+import io.questdb.mp.WorkerPoolUtils;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.mp.TestWorkerPool;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * The paths a level-3 review found the mid-partition covered-append tests never
+ * reach. Each was traced as correct by inspection; that is exactly why they are
+ * worth a test, because nothing here was verified by execution before.
+ * <p>
+ * Every test compares the covering table against a control table carrying a
+ * plain (non-covering) POSTING index over the identical stream, and additionally
+ * compares the index scan against a {@code no_index} full scan of the covering
+ * table itself. The first catches a wrong covered value, the second a missing
+ * posting - {@code no_covering} catches neither, because it keeps the index scan
+ * in place.
+ */
+public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
+
+    private static final int COMMITS = 8;
+    private static final int ROWS = 400;
+    private static final int SEED = 3000;
+
+    @Before
+    public void enableCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
+        PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+    }
+
+    @After
+    public void disableCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+    }
+
+    /**
+     * BYPASS WAL. Every other test on this path is WAL, and a non-WAL commit
+     * reaches commit00 -> o3Commit through a different entry path with no WAL
+     * re-apply behind it, so a seal failure surfaces as a throwing INSERT rather
+     * than a suspended table.
+     */
+    @Test
+    public void testBypassWalMidPartitionAppend() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+            execute("CREATE TABLE ctl (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+
+            // day 1 and day 3 exist, so day 2 is a MID partition.
+            insertBoth("2024-01-01", 0, 200);
+            insertBoth("2024-01-03", 200, 200);
+            insertBoth("2024-01-02", 400, SEED);
+
+            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            for (int c = 0; c < COMMITS; c++) {
+                insertBoth("2024-01-02", 400L + SEED + (long) c * ROWS, ROWS);
+            }
+
+            assertIndexAgreesWithColumn();
+            assertMatchesControl();
+            Assert.assertTrue("the append path must fire on a non-WAL table (appends="
+                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+        });
+    }
+
+    /**
+     * O3 runs on real worker threads instead of inline on the writer thread.
+     * {@code o3CoveringDeferredPartitions} is written by the O3 workers and read
+     * by the single-threaded sweep after they join; with the pool never started,
+     * that contract was asserted in a comment and exercised by nothing. Several
+     * partitions per commit, so multiple workers record deferrals concurrently.
+     */
+    @Test
+    public void testParallelO3WorkersRecordDeferralsSafely() throws Exception {
+        final WorkerPool pool = new TestWorkerPool(4, node1.getMetrics());
+        assertMemoryLeak(() -> {
+            createWalTables();
+            // seed four days, so a single commit can touch several mid partitions
+            for (int d = 1; d <= 5; d++) {
+                insertBoth("2024-01-0" + d, (long) d * 10_000, 800);
+            }
+            drainWalQueue();
+
+            WorkerPoolUtils.setupWriterJobs(pool, engine);
+            WorkerPoolUtils.setupAsyncMunmapJob(pool, engine);
+            pool.start(LOG);
+            try {
+                PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+                for (int c = 0; c < COMMITS; c++) {
+                    // one txn per day, drained together: the commit spans four
+                    // mid partitions at once
+                    for (int d = 1; d <= 4; d++) {
+                        insertBoth("2024-01-0" + d, (long) d * 10_000 + 800 + (long) c * ROWS, ROWS);
+                    }
+                    drainWalQueue();
+                }
+            } finally {
+                pool.halt();
+            }
+            drainWalQueue();
+
+            assertNotSuspended();
+            assertIndexAgreesWithColumn();
+            assertMatchesControl();
+            Assert.assertTrue("the append path must fire under parallel O3 (appends="
+                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+        });
+    }
+
+    /**
+     * A PARQUET partition in the table. The guard reasons that parquet lands in
+     * the "O3 already indexed it" case and is declined through getMaxValue();
+     * that reasoning had no test. Appends continue into a NATIVE mid partition
+     * while an earlier partition is parquet.
+     */
+    @Test
+    public void testAppendWithParquetPartitionPresent() throws Exception {
+        assertMemoryLeak(() -> {
+            createWalTables();
+            insertBoth("2024-01-01", 0, 500);
+            insertBoth("2024-01-02", 500, SEED);
+            insertBoth("2024-01-03", 5000, 500);
+            drainWalQueue();
+
+            execute("ALTER TABLE t CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            execute("ALTER TABLE ctl CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
+            drainWalQueue();
+
+            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            for (int c = 0; c < COMMITS; c++) {
+                insertBoth("2024-01-02", 500L + SEED + (long) c * ROWS, ROWS);
+                drainWalQueue();
+            }
+
+            final long parquetCount = selectLong(
+                    "SELECT count() FROM table_partitions('t') WHERE isParquet = true");
+            Assert.assertEquals("test setup: the partition must actually be parquet", 1, parquetCount);
+            Assert.assertTrue("appends into the NATIVE mid partition must still fire alongside a"
+                            + " parquet partition (appends="
+                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+
+            assertNotSuspended();
+            assertIndexAgreesWithColumn();
+            assertMatchesControl();
+        });
+    }
+
+    /**
+     * TWO indexed covering columns on one table. The deferral set is keyed per
+     * PARTITION but consumed per COLUMN, so a partition where one column defers
+     * and the other does not is the case where those two granularities disagree.
+     * The second index is added later, which is what makes them disagree: on the
+     * first commit after ADD INDEX, sym2's column top is not below the pre-append
+     * size, so it cannot defer while sym can.
+     */
+    @Test
+    public void testTwoIndexedCoveringColumnsWithStaggeredIndex() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value),"
+                    + " sym2 SYMBOL, value DOUBLE) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE ctl (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING,"
+                    + " sym2 SYMBOL, value DOUBLE) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            insertBoth3("2024-01-01", 0, 200);
+            insertBoth3("2024-01-03", 200, 200);
+            insertBoth3("2024-01-02", 400, SEED);
+            drainWalQueue();
+
+            // sym2 becomes a second COVERING posting index only now
+            execute("ALTER TABLE t ALTER COLUMN sym2 ADD INDEX TYPE POSTING INCLUDE (value)");
+            drainWalQueue();
+
+            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            for (int c = 0; c < COMMITS; c++) {
+                insertBoth3("2024-01-02", 400L + SEED + (long) c * ROWS, ROWS);
+                drainWalQueue();
+            }
+
+            assertNotSuspended();
+            Assert.assertTrue("the append path must fire with two covering indexes (appends="
+                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+            // Pin that BOTH columns are really served as COVERED reads. Without
+            // this, a plan that stopped using either index would turn every
+            // comparison below into two identical non-covering scans.
+            assertQuery("SELECT ts, sym, value FROM t WHERE sym = 'S1' ORDER BY value")
+                    .noLeakCheck()
+                    .assertsPlanContaining("CoveringIndex on: sym with: ts, value");
+            assertQuery("SELECT ts, sym2, value FROM t WHERE sym2 = 'K1' ORDER BY value")
+                    .noLeakCheck()
+                    .assertsPlanContaining("CoveringIndex on: sym2 with: ts, value");
+            // both indexes must agree with a full scan
+            for (int s = 0; s < 4; s++) {
+                assertSqlCursors(
+                        "SELECT /*+ no_index */ ts, sym, value FROM t WHERE sym = 'S" + s + "' ORDER BY ts",
+                        "SELECT ts, sym, value FROM t WHERE sym = 'S" + s + "' ORDER BY ts"
+                );
+                assertSqlCursors(
+                        "SELECT /*+ no_index */ ts, sym2, value FROM t WHERE sym2 = 'K" + s + "' ORDER BY ts",
+                        "SELECT ts, sym2, value FROM t WHERE sym2 = 'K" + s + "' ORDER BY ts"
+                );
+            }
+            assertSqlCursors(
+                    "SELECT ts, sym, sym2, value FROM ctl ORDER BY ts, value",
+                    "SELECT ts, sym, sym2, value FROM t ORDER BY ts, value"
+            );
+        });
+    }
+
+    private long selectLong(CharSequence sql) throws Exception {
+        try (RecordCursorFactory factory = select(sql);
+             RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+            Assert.assertTrue("query must return one row [sql=" + sql + ']', cursor.hasNext());
+            return cursor.getRecord().getLong(0);
+        }
+    }
+
+    private void assertIndexAgreesWithColumn() throws Exception {
+        // Filtered and per-symbol: an unfiltered keyed group-by compiles to the
+        // same plan with and without no_index, so it cannot detect anything.
+        for (int s = 0; s < 4; s++) {
+            assertSqlCursors(
+                    "SELECT /*+ no_index */ ts, sym, value FROM t WHERE sym = 'S" + s + "' ORDER BY ts",
+                    "SELECT ts, sym, value FROM t WHERE sym = 'S" + s + "' ORDER BY ts"
+            );
+        }
+    }
+
+    private void assertMatchesControl() throws Exception {
+        assertSqlCursors(
+                "SELECT ts, sym, value FROM ctl ORDER BY ts, value",
+                "SELECT ts, sym, value FROM t ORDER BY ts, value"
+        );
+        assertSqlCursors(
+                "SELECT sym, count(*), sum(value), min(value), max(value) FROM ctl ORDER BY sym",
+                "SELECT sym, count(*), sum(value), min(value), max(value) FROM t ORDER BY sym"
+        );
+    }
+
+    private void assertNotSuspended() {
+        Assert.assertFalse("t suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("t")));
+        Assert.assertFalse("ctl suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("ctl")));
+    }
+
+    private void createWalTables() throws Exception {
+        execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+        execute("CREATE TABLE ctl (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, value DOUBLE)"
+                + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+    }
+
+    private void insertBoth(String day, long v0, int rows) throws Exception {
+        insertBothAt(day, v0, v0, rows);
+    }
+
+    /**
+     * {@code tsBaseMicros} is the timestamp base and is deliberately INDEPENDENT
+     * of {@code v0}, which only feeds sym and value. Deriving the timestamp from
+     * v0 pushes the rows past the partition max, turning an intended O3 write
+     * into a plain append - which is how the split test first ran green while
+     * producing no splits at all.
+     */
+    private void insertBothAt(String day, long tsBaseMicros, long v0, int rows) throws Exception {
+        final String tail = " SELECT dateadd('u', (" + tsBaseMicros + " + x)::INT,"
+                + " '" + day + "T00:00:00Z'::TIMESTAMP), 'S' || ((" + v0 + " + x) % 4),"
+                + " (" + v0 + " + x)::DOUBLE FROM long_sequence(" + rows + ")";
+        execute("INSERT INTO t" + tail);
+        execute("INSERT INTO ctl" + tail);
+    }
+
+    private void insertBoth3(String day, long v0, int rows) throws Exception {
+        final String tail = " SELECT dateadd('u', (" + v0 + " + x)::INT,"
+                + " '" + day + "T00:00:00Z'::TIMESTAMP), 'S' || ((" + v0 + " + x) % 4),"
+                + " 'K' || ((" + v0 + " + x) % 4), (" + v0 + " + x)::DOUBLE"
+                + " FROM long_sequence(" + rows + ")";
+        execute("INSERT INTO t" + tail);
+        execute("INSERT INTO ctl" + tail);
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoverageGapsTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoverageGapsTest.java
@@ -58,13 +58,13 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
     public void enableCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
         PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
     @After
     public void disableCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
     }
 
     /**
@@ -86,7 +86,7 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             insertBoth("2024-01-03", 200, 200);
             insertBoth("2024-01-02", 400, SEED);
 
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             for (int c = 0; c < COMMITS; c++) {
                 insertBoth("2024-01-02", 400L + SEED + (long) c * ROWS, ROWS);
             }
@@ -94,8 +94,8 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             assertIndexAgreesWithColumn();
             assertMatchesControl();
             Assert.assertTrue("the append path must fire on a non-WAL table (appends="
-                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
-                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
         });
     }
 
@@ -121,7 +121,7 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             WorkerPoolUtils.setupAsyncMunmapJob(pool, engine);
             pool.start(LOG);
             try {
-                PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+                PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
                 for (int c = 0; c < COMMITS; c++) {
                     // one txn per day, drained together: the commit spans four
                     // mid partitions at once
@@ -139,8 +139,48 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             assertIndexAgreesWithColumn();
             assertMatchesControl();
             Assert.assertTrue("the append path must fire under parallel O3 (appends="
-                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
-                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
+        });
+    }
+
+    /**
+     * The same parallel-O3 contract on the LAST partition, which is this PR's
+     * route. DEDUP disqualifies the WAL fast-lag gate, so these pure appends
+     * fall back to O3 and reach the deferral - on the partition every commit
+     * touches, with four workers recording deferrals concurrently.
+     */
+    @Test
+    public void testParallelO3LastPartitionDedup() throws Exception {
+        final WorkerPool pool = new TestWorkerPool(4, node1.getMetrics());
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL DEDUP UPSERT KEYS(ts, sym)");
+            execute("CREATE TABLE ctl (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL DEDUP UPSERT KEYS(ts, sym)");
+            insertBoth("2024-01-01", 0, SEED);
+            drainWalQueue();
+
+            WorkerPoolUtils.setupWriterJobs(pool, engine);
+            WorkerPoolUtils.setupAsyncMunmapJob(pool, engine);
+            pool.start(LOG);
+            try {
+                PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
+                for (int c = 0; c < COMMITS; c++) {
+                    insertBoth("2024-01-01", (long) SEED + (long) c * ROWS, ROWS);
+                    drainWalQueue();
+                }
+            } finally {
+                pool.halt();
+            }
+            drainWalQueue();
+
+            assertNotSuspended();
+            assertIndexAgreesWithColumn();
+            assertMatchesControl();
+            Assert.assertTrue("the append path must fire on the last partition under parallel O3"
+                            + " (appends=" + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
         });
     }
 
@@ -163,7 +203,7 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             execute("ALTER TABLE ctl CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
             drainWalQueue();
 
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             for (int c = 0; c < COMMITS; c++) {
                 insertBoth("2024-01-02", 500L + SEED + (long) c * ROWS, ROWS);
                 drainWalQueue();
@@ -174,8 +214,8 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             Assert.assertEquals("test setup: the partition must actually be parquet", 1, parquetCount);
             Assert.assertTrue("appends into the NATIVE mid partition must still fire alongside a"
                             + " parquet partition (appends="
-                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
-                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
 
             assertNotSuspended();
             assertIndexAgreesWithColumn();
@@ -207,7 +247,7 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             execute("ALTER TABLE t ALTER COLUMN sym2 ADD INDEX TYPE POSTING INCLUDE (value)");
             drainWalQueue();
 
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             for (int c = 0; c < COMMITS; c++) {
                 insertBoth3("2024-01-02", 400L + SEED + (long) c * ROWS, ROWS);
                 drainWalQueue();
@@ -215,8 +255,8 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
 
             assertNotSuspended();
             Assert.assertTrue("the append path must fire with two covering indexes (appends="
-                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
-                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
             // Pin that BOTH columns are really served as COVERED reads. Without
             // this, a plan that stopped using either index would turn every
             // comparison below into two identical non-covering scans.

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoveringSealTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoveringSealTest.java
@@ -63,7 +63,7 @@ public class MidPartitionAppendCoveringSealTest extends AbstractCairoTest {
         PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
         PostingIndexWriter.COVERING_FASTLAG_COMMIT_COUNT.set(0);
         PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
     @After
@@ -109,11 +109,11 @@ public class MidPartitionAppendCoveringSealTest extends AbstractCairoTest {
             seedMidPartition();
 
             PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             appendToMidPartition();
 
             final long fullReseals = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
-            final long appends = PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get();
+            final long appends = PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get();
             Assert.assertEquals(
                     "a pure append into an existing mid partition must not full-reseal the covered sidecar",
                     0, fullReseals);
@@ -167,13 +167,13 @@ public class MidPartitionAppendCoveringSealTest extends AbstractCairoTest {
             seedMidPartition();
             final int afterSeed = countPostingFiles("blk", "2024-01-02");
 
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             appendToMidPartition();
             // Discriminate: the post-purge steady state below would also hold on
             // the reseal path (rotate every commit, purge reclaims), so pin that
             // these commits actually took the append path.
             Assert.assertEquals("every commit must take the covered append path",
-                    COMMITS, PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get());
+                    COMMITS, PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get());
             final int beforePurge = countPostingFiles("blk", "2024-01-02");
 
             // Deferred compaction DOES rotate .pv/.pc when it fires, superseding

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoveringSealTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoveringSealTest.java
@@ -69,6 +69,9 @@ public class MidPartitionAppendCoveringSealTest extends AbstractCairoTest {
     @After
     public void disableCoveringCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+        // Static kill-switch: a test that sets it and throws before restoring it
+        // would silently disable the append path for every test that runs after.
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
     }
 
     /**
@@ -213,9 +216,16 @@ public class MidPartitionAppendCoveringSealTest extends AbstractCairoTest {
             seedMidPartition();
             final long seedTxn = headTxnAtSeal();
 
+            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
             appendToMidPartition();
             final long afterAppendTxn = headTxnAtSeal();
 
+            // Pin the path FIRST. The reseal rotates the head every commit, so
+            // txnAtSeal advances there too and the assertion below is green even
+            // with the append path switched off - i.e. it would pass without ever
+            // exercising the in-place extend whose semantics it exists to pin.
+            Assert.assertEquals("every commit must take the mid-partition append path",
+                    COMMITS, PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get());
             Assert.assertTrue("head txnAtSeal must advance with in-place appends [seed=" + seedTxn
                             + ", afterAppends=" + afterAppendTxn + ']',
                     afterAppendTxn > seedTxn);

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoveringSealTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoveringSealTest.java
@@ -1,0 +1,332 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.covering;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.PostingSealPurgeJob;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableUtils;
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.std.str.Path;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+/**
+ * A commit that only APPENDS rows to an existing, non-last partition (partitions
+ * A and C exist, the rows land at the end of B) takes the append-only O3 path
+ * for the data columns - {@code OPEN_MID_PARTITION_FOR_APPEND}, no partition
+ * copy. The covering POSTING index must follow suit: publish an incremental
+ * covered fragment for the appended rows and defer compaction, instead of
+ * resealing the whole partition's .pv/.pc on every commit
+ * ({@code COVERING_FULL_RESEAL_COUNT} must stay 0).
+ * <p>
+ * On unmodified code {@code TableWriter#sealPostingIndexForPartition} calls
+ * {@code rebuildSidecars()} unconditionally on the covering branch, so every
+ * commit full-reseals and cost grows with the size of the partition.
+ */
+public class MidPartitionAppendCoveringSealTest extends AbstractCairoTest {
+
+    private static final int COMMITS = 12;
+    private static final int ROWS_PER_COMMIT = 200;
+    private static final int SEED_ROWS = 4000;
+
+    @Before
+    public void enableCoveringCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
+        PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_FASTLAG_COMMIT_COUNT.set(0);
+        PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+    }
+
+    @After
+    public void disableCoveringCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+    }
+
+    /**
+     * Correctness guard for the O3 paths the append fast path must NOT change:
+     * rows that land BEFORE the partition's max timestamp force a merge, which
+     * still rebuilds the index from the column data.
+     */
+    @Test
+    public void testMidPartitionOutOfOrderStillCorrect() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            seedMidPartition();
+
+            // Interleave: every batch writes rows BEHIND the current partition
+            // max, so the commit is a genuine O3 merge into the mid partition.
+            for (int c = 0; c < COMMITS; c++) {
+                final long base = 10L + c;
+                insert("blk", "SELECT dateadd('u', (" + base + " + x * 7)::INT, '2024-01-02T00:00:00Z'::TIMESTAMP)," +
+                        " 'S' || (x % 8), (1000000 + " + base + " + x)::DOUBLE FROM long_sequence(50)");
+                insert("ctl", "SELECT dateadd('u', (" + base + " + x * 7)::INT, '2024-01-02T00:00:00Z'::TIMESTAMP)," +
+                        " 'S' || (x % 8), (1000000 + " + base + " + x)::DOUBLE FROM long_sequence(50)");
+                drainWalQueue();
+            }
+
+            assertNotSuspended();
+            assertCoveredMatchesControl();
+        });
+    }
+
+    @Test
+    public void testMidPartitionPureAppendDoesNotFullReseal() throws Exception {
+        // Cross the deferred-compaction threshold several times during the run,
+        // so this covers the append -> compaction-seal -> append transition and
+        // not just a run short enough that compaction never fires.
+        setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 3);
+        assertMemoryLeak(() -> {
+            createTables();
+            seedMidPartition();
+
+            PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            appendToMidPartition();
+
+            final long fullReseals = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
+            final long appends = PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get();
+            Assert.assertEquals(
+                    "a pure append into an existing mid partition must not full-reseal the covered sidecar",
+                    0, fullReseals);
+            // Assert the path FIRED rather than infer it from the absence of
+            // reseals, which is also true when nothing happened at all.
+            Assert.assertEquals(
+                    "every commit must take the covered append path",
+                    COMMITS, appends);
+
+            assertNotSuspended();
+            assertCoveredMatchesControl();
+        });
+    }
+
+    @Test
+    public void testMidPartitionPureAppendSurvivesReopen() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            seedMidPartition();
+            appendToMidPartition();
+
+            // Drop every cached writer/reader so the next read re-opens the
+            // posting index from disk: proves the incrementally published
+            // chain entry and its covered fragments are durable, not just
+            // consistent in the writer's memory.
+            engine.releaseInactive();
+
+            assertNotSuspended();
+            assertCoveredMatchesControl();
+        });
+    }
+
+    /**
+     * The append path publishes into the LIVE .pv/.pc instead of rotating them,
+     * so the superseded-file purge that the reseal path drives never runs for
+     * these commits. That is only safe if nothing accumulates: assert the
+     * partition's posting-index file set stays bounded no matter how many
+     * commits land, and that the reseal path's own bookkeeping (deferred
+     * compaction at the gen threshold) keeps it that way.
+     */
+    @Test
+    public void testMidPartitionPureAppendDoesNotAccumulateSealFiles() throws Exception {
+        // The default gen threshold is 16, so COMMITS appends would never reach
+        // the deferred compaction and this test would prove only that nothing
+        // happened. Lower it so the run crosses it several times: the point is
+        // that compaction reclaims what the appends published, not that appends
+        // publish little.
+        setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 3);
+        assertMemoryLeak(() -> {
+            createTables();
+            seedMidPartition();
+            final int afterSeed = countPostingFiles("blk", "2024-01-02");
+
+            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            appendToMidPartition();
+            // Discriminate: the post-purge steady state below would also hold on
+            // the reseal path (rotate every commit, purge reclaims), so pin that
+            // these commits actually took the append path.
+            Assert.assertEquals("every commit must take the covered append path",
+                    COMMITS, PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get());
+            final int beforePurge = countPostingFiles("blk", "2024-01-02");
+
+            // Deferred compaction DOES rotate .pv/.pc when it fires, superseding
+            // the previous versions; reclaiming those is the purge job's job, and
+            // it does not run in this harness. Drive it, then assert the steady
+            // state - that is the claim worth making: appends publish in place,
+            // periodic compaction rotates, and nothing accumulates.
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                for (int i = 0; i < 64 && purgeJob.run(); i++) {
+                    // drain
+                }
+            }
+            final int afterPurge = countPostingFiles("blk", "2024-01-02");
+
+            Assert.assertTrue(
+                    "posting index files must not grow per commit [afterSeed=" + afterSeed
+                            + ", after" + COMMITS + "commits=" + beforePurge
+                            + ", afterPurge=" + afterPurge + ']',
+                    afterPurge <= afterSeed + 4);
+            assertCoveredMatchesControl();
+        });
+    }
+
+    /**
+     * The append path extends the chain head in place, and
+     * {@link PostingIndexWriter#getHeadTxnAtSeal()} is what tells a head left by
+     * an attempt that never committed from one a commit produced. Entry-level
+     * txnAtSeal is slot[0]'s and extendHead never rewrites slot[0], so reading
+     * it would report the txn of the partition's FIRST generation forever -
+     * making that guard silently inert. Pin the semantic: after appends, the
+     * value must track the latest commit, not the seed.
+     */
+    @Test
+    public void testHeadTxnAtSealTracksTheLatestAppend() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables();
+            seedMidPartition();
+            final long seedTxn = headTxnAtSeal();
+
+            appendToMidPartition();
+            final long afterAppendTxn = headTxnAtSeal();
+
+            Assert.assertTrue("head txnAtSeal must advance with in-place appends [seed=" + seedTxn
+                            + ", afterAppends=" + afterAppendTxn + ']',
+                    afterAppendTxn > seedTxn);
+        });
+    }
+
+    private long headTxnAtSeal() {
+        TableToken tt = engine.verifyTableName("blk");
+        try (Path path = new Path()) {
+            path.of(configuration.getDbRoot()).concat(tt).concat("2024-01-02");
+            try (PostingIndexWriter w = new PostingIndexWriter(configuration)) {
+                w.of(path, "sym", TableUtils.COLUMN_NAME_TXN_NONE);
+                return w.getHeadTxnAtSeal();
+            }
+        }
+    }
+
+    private void appendToMidPartition() throws Exception {
+        for (int c = 0; c < COMMITS; c++) {
+            final long base = SEED_ROWS + (long) c * ROWS_PER_COMMIT;
+            final String tail = "SELECT dateadd('u', (" + base + " + x)::INT, '2024-01-02T00:00:00Z'::TIMESTAMP)," +
+                    " 'S' || ((" + base + " + x) % 8), (" + base + " + x)::DOUBLE" +
+                    " FROM long_sequence(" + ROWS_PER_COMMIT + ")";
+            insert("blk", tail);
+            insert("ctl", tail);
+            drainWalQueue();
+        }
+    }
+
+    /**
+     * Compares every covered read against the non-covering control table, which
+     * holds identical data behind a plain POSTING index. `value` is globally
+     * unique, so ORDER BY value is deterministic.
+     */
+    private void assertCoveredMatchesControl() throws Exception {
+        // Pin that these comparisons actually go THROUGH the covering index. A
+        // plan change that stopped using it would make every assertion below
+        // compare two non-covering scans and quietly lose the point of the test.
+        assertQuery("SELECT ts, sym, value FROM blk WHERE sym = 'S1' ORDER BY value")
+                .noLeakCheck()
+                // "with:" is what makes it a COVERED read - the plan lists the
+                // covered columns (the designated timestamp is covered too).
+                .assertsPlanContaining("CoveringIndex on: sym with: ts, value");
+        for (int s = 0; s < 8; s++) {
+            final String sym = "S" + s;
+            assertSqlCursors(
+                    "SELECT ts, sym, value FROM ctl WHERE sym = '" + sym + "' ORDER BY value",
+                    "SELECT ts, sym, value FROM blk WHERE sym = '" + sym + "' ORDER BY value"
+            );
+        }
+        assertSqlCursors(
+                "SELECT sym, count(value), sum(value), min(value), max(value) FROM ctl ORDER BY sym",
+                "SELECT sym, count(value), sum(value), min(value), max(value) FROM blk ORDER BY sym"
+        );
+        assertSqlCursors("SELECT count() FROM ctl", "SELECT count() FROM blk");
+    }
+
+    private int countPostingFiles(String table, String day) {
+        TableToken tt = engine.verifyTableName(table);
+        File tableDir = new File(configuration.getDbRoot().toString(), tt.getDirName());
+        File[] dirs = tableDir.listFiles((d, n) -> n.startsWith(day));
+        int count = 0;
+        Assert.assertNotNull("partition dir for " + day + " must exist", dirs);
+        for (File dir : dirs) {
+            File[] files = dir.listFiles((d, n) -> n.contains(".pv") || n.contains(".pc") || n.contains(".pk"));
+            if (files != null) {
+                count += files.length;
+            }
+        }
+        return count;
+    }
+
+    private void assertNotSuspended() throws Exception {
+        assertQuery("SELECT name, suspended FROM wal_tables() WHERE name IN ('blk','ctl') ORDER BY name")
+                .noLeakCheck()
+                .returns("name\tsuspended\nblk\tfalse\nctl\tfalse\n");
+    }
+
+    private void createTables() throws Exception {
+        execute("""
+                CREATE TABLE blk (
+                    ts TIMESTAMP,
+                    sym SYMBOL INDEX TYPE POSTING INCLUDE (value),
+                    value DOUBLE
+                ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                """);
+        execute("""
+                CREATE TABLE ctl (
+                    ts TIMESTAMP,
+                    sym SYMBOL INDEX TYPE POSTING,
+                    value DOUBLE
+                ) TIMESTAMP(ts) PARTITION BY DAY WAL
+                """);
+    }
+
+    private void insert(String table, String selectTail) throws Exception {
+        execute("INSERT INTO " + table + " " + selectTail);
+    }
+
+    /**
+     * Partition A (day 1) and partition C (day 4) bracket the target partition
+     * B (day 2), so every subsequent write into day 2 is an O3 commit into an
+     * existing, non-last partition.
+     */
+    private void seedMidPartition() throws Exception {
+        for (String t : new String[]{"blk", "ctl"}) {
+            execute("INSERT INTO " + t + " VALUES ('2024-01-01T00:00:00.000000Z', 'S0', -1.0)");
+            execute("INSERT INTO " + t + " VALUES ('2024-01-04T00:00:00.000000Z', 'S0', -2.0)");
+            insert(t, "SELECT dateadd('u', x::INT, '2024-01-02T00:00:00Z'::TIMESTAMP)," +
+                    " 'S' || (x % 8), x::DOUBLE FROM long_sequence(" + SEED_ROWS + ")");
+        }
+        drainWalQueue();
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendFaultRecoveryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendFaultRecoveryTest.java
@@ -1,0 +1,243 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.covering;
+
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.std.str.LPSZ;
+import io.questdb.std.str.Utf8s;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.std.TestFilesFacadeImpl;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Deterministic counterpart to {@code MidPartitionAppendFailureFuzzTest}: ONE
+ * commit appends into an existing mid partition, ONE filesystem op fails during
+ * the covered publish, and the table then has to recover.
+ * <p>
+ * This is the scenario that makes the covered append path structurally
+ * different from the reseal it replaces. The reseal rewrote the partition's
+ * sidecars wholesale every commit, so a failed attempt was repaired by the next
+ * one. The append path is now the ONLY writer of those postings, and a failure
+ * between {@code index()} and the generation publish leaves the chain head's
+ * MAX_VALUE advanced over postings that were never written - so a seal that
+ * trusted {@code getMaxValue()} would skip re-indexing them and the rows would
+ * be missing from every index scan, permanently and silently.
+ * <p>
+ * The assertion is deliberately index-vs-base on the SAME table rather than a
+ * comparison against a control table: it localises the damage (an index scan
+ * that finds fewer rows than the column does) instead of merely reporting that
+ * two tables differ.
+ */
+public class MidPartitionAppendFaultRecoveryTest extends AbstractCairoTest {
+
+    private static final long DAY = 24L * 60 * 60 * 1_000_000L;
+    private static final int ROWS = 200;
+    private static final long T0 = 1_700_000_000_000_000L / DAY * DAY;
+    private final AtomicBoolean armed = new AtomicBoolean();
+    // fd of the file the read fault is aimed at, latched at open time
+    private final java.util.concurrent.atomic.AtomicLong targetFd = new java.util.concurrent.atomic.AtomicLong(-1);
+
+    @Before
+    public void enableCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
+        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+    }
+
+    @After
+    public void disableCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+    }
+
+    @Test
+    public void testFaultOnCoveredSidecarOpenRecovers() throws Exception {
+        runOne(".pc", false);
+    }
+
+    @Test
+    public void testFaultOnPostingValuesOpenRecovers() throws Exception {
+        runOne(".pv", false);
+    }
+
+    @Test
+    public void testFaultOnSymbolColumnOpenRecovers() throws Exception {
+        runOne("sym.d", false);
+    }
+
+    /**
+     * Faults the READ rather than the open, which is the only thing that
+     * exercises SymbolColumnIndexer#index's short-read guard on this path.
+     */
+    @Test
+    public void testFaultOnSymbolColumnReadRecovers() throws Exception {
+        runOne("sym.d", true);
+    }
+
+    private void assertIndexAgreesWithColumn() throws Exception {
+        // Every symbol: what the index scan finds must equal what a scan of the
+        // column itself finds. A tail the seal failed to index shows up here as
+        // a smaller count, which comparing covered values alone would miss.
+        assertSqlCursors(
+                "SELECT /*+ no_index */ sym, count(*), sum(value) FROM t ORDER BY sym",
+                "SELECT sym, count(*), sum(value) FROM t ORDER BY sym"
+        );
+        // ... and the covered values themselves must match the base column.
+        assertSqlCursors(
+                "SELECT /*+ no_covering */ ts, sym, value FROM t WHERE sym = 'S1' ORDER BY ts",
+                "SELECT ts, sym, value FROM t WHERE sym = 'S1' ORDER BY ts"
+        );
+    }
+
+    private void insertBatch(long v0) throws Exception {
+        execute("INSERT INTO t SELECT (" + (T0 + DAY + 1 + v0 * 1000) + " + x * 1000)::TIMESTAMP,"
+                + " 'S' || ((" + v0 + " + x) % 4), (" + v0 + " + x)::DOUBLE FROM long_sequence(" + ROWS + ")");
+    }
+
+    private void runOne(String target, boolean faultRead) throws Exception {
+        ff = new TestFilesFacadeImpl() {
+            @Override
+            public boolean close(long fd) {
+                // Descriptor numbers are recycled; a stale latch would fault an
+                // unrelated file.
+                targetFd.compareAndSet(fd, -1);
+                return super.close(fd);
+            }
+
+            @Override
+            public long openRO(LPSZ name) {
+                if (faultRead) {
+                    if (matches(name) && targetFd.get() < 0) {
+                        long fd = super.openRO(name);
+                        if (fd >= 0) {
+                            targetFd.set(fd); // fault its first read instead
+                        }
+                        return fd;
+                    }
+                } else if (shouldFail(name)) {
+                    return -1;
+                }
+                return super.openRO(name);
+            }
+
+            @Override
+            public long openRW(LPSZ name, int opts) {
+                if (!faultRead && shouldFail(name)) {
+                    return -1;
+                }
+                return super.openRW(name, opts);
+            }
+
+            @Override
+            public long read(long fd, long buf, long len, long offset) {
+                if (faultRead && armed.get() && fd == targetFd.get() && fd >= 0) {
+                    armed.set(false); // one shot
+                    targetFd.set(-1);
+                    return 0; // short read: the tail would be silently unindexed
+                }
+                return super.read(fd, buf, len, offset);
+            }
+
+            private boolean matches(LPSZ name) {
+                // Never fault WAL segments: the transaction log must stay
+                // durable, so the commit is guaranteed to be replayed.
+                return armed.get() && name != null
+                        && !Utf8s.containsAscii(name, "wal")
+                        && Utf8s.containsAscii(name, target);
+            }
+
+            private boolean shouldFail(LPSZ name) {
+                if (matches(name)) {
+                    armed.set(false); // one shot
+                    return true;
+                }
+                return false;
+            }
+        };
+        assertMemoryLeak(ff, () -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+            // A later day anchors the table max, so the writes below append into
+            // a partition that is not the last one.
+            execute("INSERT INTO t SELECT (" + (T0 + 3 * DAY) + ")::TIMESTAMP, 'S0', 1.0 FROM long_sequence(1)");
+            insertBatch(0);
+            drainWalQueue();
+
+            // The commit that fails mid-publish.
+            armed.set(true);
+            insertBatch(ROWS);
+            try {
+                drainWalQueue();
+            } catch (Throwable ignore) {
+                // surfaces as a failed apply; recovery is what this test asserts
+            }
+            // The fault must actually have fired, otherwise this is a plain
+            // append test wearing a fault test's name.
+            Assert.assertFalse("fault never fired", armed.get());
+            armed.set(false);
+            targetFd.set(-1);
+
+            final TableToken tt = engine.verifyTableName("t");
+            for (int i = 0; i < 50 && engine.getTableSequencerAPI().isSuspended(tt); i++) {
+                engine.releaseInactive();
+                try {
+                    execute("ALTER TABLE t RESUME WAL");
+                } catch (Throwable ignore) {
+                    // retry
+                }
+                try {
+                    drainWalQueue();
+                } catch (Throwable ignore) {
+                    // retry
+                }
+            }
+            engine.releaseInactive();
+            drainWalQueue();
+
+            Assert.assertFalse("table must recover, not stay suspended",
+                    engine.getTableSequencerAPI().isSuspended(tt));
+            assertIndexAgreesWithColumn();
+
+            // WAL durability means the failed commit must eventually land in
+            // full - 1 anchor row + two batches.
+            printSql("SELECT count() FROM t");
+            Assert.assertEquals("count\n" + (1 + 2 * ROWS) + "\n", sink.toString());
+
+            // And the partition must still be usable for further appends.
+            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            insertBatch(2L * ROWS);
+            drainWalQueue();
+            assertIndexAgreesWithColumn();
+            // ... via the path under test, not by silently falling back to the
+            // reseal for the rest of the table's life.
+            Assert.assertTrue("the append path must resume after recovery",
+                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+        });
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendFaultRecoveryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendFaultRecoveryTest.java
@@ -68,7 +68,7 @@ public class MidPartitionAppendFaultRecoveryTest extends AbstractCairoTest {
     @Before
     public void enableCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
     @After
@@ -230,14 +230,14 @@ public class MidPartitionAppendFaultRecoveryTest extends AbstractCairoTest {
             Assert.assertEquals("count\n" + (1 + 2 * ROWS) + "\n", sink.toString());
 
             // And the partition must still be usable for further appends.
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             insertBatch(2L * ROWS);
             drainWalQueue();
             assertIndexAgreesWithColumn();
             // ... via the path under test, not by silently falling back to the
             // reseal for the rest of the table's life.
             Assert.assertTrue("the append path must resume after recovery",
-                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
         });
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendFaultRecoveryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendFaultRecoveryTest.java
@@ -104,11 +104,23 @@ public class MidPartitionAppendFaultRecoveryTest extends AbstractCairoTest {
         // Every symbol: what the index scan finds must equal what a scan of the
         // column itself finds. A tail the seal failed to index shows up here as
         // a smaller count, which comparing covered values alone would miss.
-        assertSqlCursors(
-                "SELECT /*+ no_index */ sym, count(*), sum(value) FROM t ORDER BY sym",
-                "SELECT sym, count(*), sum(value) FROM t ORDER BY sym"
-        );
-        // ... and the covered values themselves must match the base column.
+        //
+        // The comparison MUST be per-symbol and filtered. An unfiltered keyed
+        // group-by ignores no_index entirely - verified by EXPLAIN, both sides
+        // compile to the identical vectorized GroupBy over a full PageFrame scan
+        // - so the pair that used to live here compared a plan with itself and
+        // could not fail. With WHERE sym = ? the hint bites: no_index plans an
+        // "Async JIT Filter" full scan, the unhinted side a "CoveringIndex" scan.
+        for (int s = 0; s < 4; s++) {
+            assertSqlCursors(
+                    "SELECT /*+ no_index */ ts, sym, value FROM t WHERE sym = 'S" + s + "' ORDER BY ts",
+                    "SELECT ts, sym, value FROM t WHERE sym = 'S" + s + "' ORDER BY ts"
+            );
+        }
+        // ... and the covered values themselves must match the base column. This
+        // arm stays no_covering deliberately: it drops only the covered read and
+        // keeps the "Index forward scan on: sym", so it isolates a WRONG covered
+        // value from a MISSING posting, which the loop above catches instead.
         assertSqlCursors(
                 "SELECT /*+ no_covering */ ts, sym, value FROM t WHERE sym = 'S1' ORDER BY ts",
                 "SELECT ts, sym, value FROM t WHERE sym = 'S1' ORDER BY ts"

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendNewColumnTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendNewColumnTest.java
@@ -1,0 +1,126 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.covering;
+
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * The covered append path may only skip the O3-side index write for a column
+ * whose partition ALREADY has index files. O3 is what creates them: for the
+ * first rows a column ever has in a partition the copy job opens the posting
+ * index with {@code isInit = true} (O3CopyJob's {@code openFromO3Context(row == 0)}),
+ * which is what writes the {@code .pk}. The seal cannot stand in for that - it
+ * opens an EXISTING index and throws "index does not exist" otherwise - and it
+ * does not even skip the column, because {@code updateO3ColumnTops} has by then
+ * replaced the column top of -1 with a real one.
+ * <p>
+ * Both DDL shapes below leave a covering-indexed column with no index files in
+ * an older partition; the next append into that partition then has to create
+ * them. If the append path claims the column, the commit fails, the writer is
+ * distressed and a WAL table suspends - and re-applying reproduces it, so it
+ * never heals.
+ */
+public class MidPartitionAppendNewColumnTest extends AbstractCairoTest {
+
+    @After
+    public void resetSwitch() {
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+    }
+
+    @Test
+    public void testAppendAfterAddColumnThenAddIndex() throws Exception {
+        assertMemoryLeak(() -> {
+            seedTwoPartitions();
+            execute("ALTER TABLE t ADD COLUMN sym SYMBOL");
+            drainWalQueue();
+            // ADD INDEX skips a partition with no data for the column (the
+            // ff.exists(dFile(...)) guard in indexHistoricPartitions), so the
+            // mid partition still has no .pk afterwards.
+            execute("ALTER TABLE t ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (value)");
+            drainWalQueue();
+
+            appendIntoMidPartitionAndAssert();
+        });
+    }
+
+    /**
+     * Negative control: with the append path switched off the same DDL and the
+     * same append must work, proving any failure above belongs to the append
+     * path and not to the DDL sequence.
+     */
+    @Test
+    public void testAppendAfterAddColumnWorksOnResealPath() throws Exception {
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+        assertMemoryLeak(() -> {
+            seedTwoPartitions();
+            execute("ALTER TABLE t ADD COLUMN sym SYMBOL");
+            drainWalQueue();
+            execute("ALTER TABLE t ALTER COLUMN sym ADD INDEX TYPE POSTING INCLUDE (value)");
+            drainWalQueue();
+
+            appendIntoMidPartitionAndAssert();
+        });
+    }
+
+    private void appendIntoMidPartitionAndAssert() throws Exception {
+        // Appends into day 2, which is NOT the last partition (day 4 exists) and
+        // which holds no rows for `sym` yet.
+        execute("INSERT INTO t VALUES ('2024-01-02T23:00:00.000000Z', 1.5, 'S1')");
+        execute("INSERT INTO t VALUES ('2024-01-02T23:00:01.000000Z', 2.5, 'S2')");
+        drainWalQueue();
+
+        Assert.assertFalse("table must not suspend",
+                engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("t")));
+
+        // The index must find exactly what the column holds.
+        assertSqlCursors(
+                "SELECT /*+ no_index */ ts, sym, value FROM t WHERE sym = 'S1' ORDER BY ts",
+                "SELECT ts, sym, value FROM t WHERE sym = 'S1' ORDER BY ts"
+        );
+        printSql("SELECT count() FROM t WHERE sym = 'S1'");
+        Assert.assertEquals("count\n1\n", sink.toString());
+
+        // ... and the partition must keep working for further appends.
+        execute("INSERT INTO t VALUES ('2024-01-02T23:00:02.000000Z', 3.5, 'S1')");
+        drainWalQueue();
+        assertSqlCursors(
+                "SELECT /*+ no_index */ ts, sym, value FROM t WHERE sym = 'S1' ORDER BY ts",
+                "SELECT ts, sym, value FROM t WHERE sym = 'S1' ORDER BY ts"
+        );
+    }
+
+    private void seedTwoPartitions() throws Exception {
+        execute("CREATE TABLE t (ts TIMESTAMP, value DOUBLE) TIMESTAMP(ts) PARTITION BY DAY WAL");
+        execute("INSERT INTO t SELECT dateadd('u', x::INT, '2024-01-02T00:00:00Z'::TIMESTAMP)," +
+                " x::DOUBLE FROM long_sequence(1000)");
+        // a later day, so day 2 is a mid partition from here on
+        execute("INSERT INTO t VALUES ('2024-01-04T00:00:00.000000Z', -1.0)");
+        drainWalQueue();
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendNewColumnTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendNewColumnTest.java
@@ -50,7 +50,7 @@ public class MidPartitionAppendNewColumnTest extends AbstractCairoTest {
 
     @After
     public void resetSwitch() {
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
     }
 
     @Test
@@ -76,7 +76,7 @@ public class MidPartitionAppendNewColumnTest extends AbstractCairoTest {
      */
     @Test
     public void testAppendAfterAddColumnWorksOnResealPath() throws Exception {
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         assertMemoryLeak(() -> {
             seedTwoPartitions();
             execute("ALTER TABLE t ADD COLUMN sym SYMBOL");

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendSplitDeclineTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendSplitDeclineTest.java
@@ -54,13 +54,13 @@ public class MidPartitionAppendSplitDeclineTest extends AbstractCairoTest {
     @Before
     public void enableCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
     @After
     public void disableCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
     }
 
     /**
@@ -84,7 +84,7 @@ public class MidPartitionAppendSplitDeclineTest extends AbstractCairoTest {
             insertBoth("2024-01-03", 200, 200);
             insertBoth("2024-01-02", 400, SEED);
 
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             for (int c = 0; c < COMMITS; c++) {
                 // land BEHIND the partition max, which forces a merge/split
                 // rather than an append
@@ -101,7 +101,7 @@ public class MidPartitionAppendSplitDeclineTest extends AbstractCairoTest {
             // ... and the append path must have refused every one of them:
             // canSkipRebuildForPartition requires o3SplitPartitionSize == 0.
             Assert.assertEquals("a split must never take the covered append path",
-                    0, PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get());
+                    0, PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get());
 
             assertNotSuspended();
             assertIndexAgreesWithColumn();

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendSplitDeclineTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendSplitDeclineTest.java
@@ -91,7 +91,7 @@ public class MidPartitionAppendSplitDeclineTest extends AbstractCairoTest {
                 // near the END of a large partition: a big untouched prefix and
                 // a small rewritten suffix is the shape that splits
                 insertBothAt("2024-01-02", (long) SEED - 900L + (long) c * 7L, 100_000L + (long) c * ROWS, ROWS);
-                }
+            }
 
             // Setup discriminator: without this the test passes when no split
             // ever happened, i.e. while testing nothing it names.

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendSplitDeclineTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendSplitDeclineTest.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.covering;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.mp.WorkerPool;
+import io.questdb.mp.WorkerPoolUtils;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.mp.TestWorkerPool;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * O3 partition SPLIT declines the covered append path, in its own class ON
+ * PURPOSE: the split properties below are static overrides and are only reset in
+ * {@code @AfterClass}, so leaving them in the shared class silently turned every
+ * later test's mid-partition write into a split. That made three sibling tests
+ * report "append path never fired" while individually green - a leak that is
+ * much easier to prevent structurally than to remember.
+ */
+public class MidPartitionAppendSplitDeclineTest extends AbstractCairoTest {
+
+    private static final int COMMITS = 8;
+    private static final int ROWS = 400;
+    private static final int SEED = 40000;
+
+    @Before
+    public void enableCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
+        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+    }
+
+    @After
+    public void disableCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+    }
+
+    /**
+     * O3 PARTITION SPLIT. canSkipRebuildForPartition requires
+     * {@code o3SplitPartitionSize == 0}, so a split must decline the append path
+     * and rebuild - untested in either direction. The split threshold is dropped
+     * far below the partition size so ordinary O3 writes split rather than
+     * rewrite.
+     */
+    @Test
+    public void testPartitionSplitDeclinesAndStaysCorrect() throws Exception {
+        // All three are required. Without MID_PARTITION_MAX_SPLITS a mid
+        // partition never splits at all, which is how the first version of this
+        // test passed while producing zero splits.
+        node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
+        node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 20);
+        node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 20);
+        assertMemoryLeak(() -> {
+            createWalTables();
+            insertBoth("2024-01-01", 0, 200);
+            insertBoth("2024-01-03", 200, 200);
+            insertBoth("2024-01-02", 400, SEED);
+
+            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            for (int c = 0; c < COMMITS; c++) {
+                // land BEHIND the partition max, which forces a merge/split
+                // rather than an append
+                // near the END of a large partition: a big untouched prefix and
+                // a small rewritten suffix is the shape that splits
+                insertBothAt("2024-01-02", (long) SEED - 900L + (long) c * 7L, 100_000L + (long) c * ROWS, ROWS);
+                }
+
+            // Setup discriminator: without this the test passes when no split
+            // ever happened, i.e. while testing nothing it names.
+            final long partitions = selectLong("SELECT count() FROM table_partitions('t')");
+            Assert.assertTrue("test setup: the O3 writes must actually SPLIT the partition, count="
+                    + partitions, partitions > 3);
+            // ... and the append path must have refused every one of them:
+            // canSkipRebuildForPartition requires o3SplitPartitionSize == 0.
+            Assert.assertEquals("a split must never take the covered append path",
+                    0, PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get());
+
+            assertNotSuspended();
+            assertIndexAgreesWithColumn();
+            assertMatchesControl();
+        });
+    }
+
+
+    private void assertIndexAgreesWithColumn() throws Exception {
+        for (int s = 0; s < 4; s++) {
+            assertSqlCursors(
+                    "SELECT /*+ no_index */ ts, sym, value FROM t WHERE sym = 'S" + s + "' ORDER BY ts",
+                    "SELECT ts, sym, value FROM t WHERE sym = 'S" + s + "' ORDER BY ts"
+            );
+        }
+    }
+
+    private void assertMatchesControl() throws Exception {
+        assertSqlCursors(
+                "SELECT ts, sym, value FROM ctl ORDER BY ts, value",
+                "SELECT ts, sym, value FROM t ORDER BY ts, value"
+        );
+    }
+
+    private void assertNotSuspended() {
+        // BYPASS WAL has no sequencer: a failed commit throws from INSERT instead.
+    }
+
+    private void createWalTables() throws Exception {
+        // BYPASS WAL: splits are observable directly here. On a WAL table the
+        // apply path squashes them back, so table_partitions() cannot be used to
+        // prove a split ever happened.
+        execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                + " TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+        execute("CREATE TABLE ctl (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, value DOUBLE)"
+                + " TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL");
+    }
+
+    private long selectLong(CharSequence sql) throws Exception {
+        try (RecordCursorFactory factory = select(sql);
+             RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+            Assert.assertTrue("query must return one row [sql=" + sql + ']', cursor.hasNext());
+            return cursor.getRecord().getLong(0);
+        }
+    }
+
+    private void insertBoth(String day, long v0, int rows) throws Exception {
+        insertBothAt(day, v0, v0, rows);
+    }
+
+    /**
+     * tsBaseMicros is the timestamp base and is deliberately INDEPENDENT of v0,
+     * which only feeds sym and value. Deriving the timestamp from v0 pushes the
+     * rows past the partition max, turning an intended O3 write into a plain
+     * append - which is how this test first ran green producing no splits.
+     */
+    private void insertBothAt(String day, long tsBaseMicros, long v0, int rows) throws Exception {
+        final String tail = " SELECT dateadd('u', (" + tsBaseMicros + " + x)::INT,"
+                + " '" + day + "T00:00:00Z'::TIMESTAMP), 'S' || ((" + v0 + " + x) % 4),"
+                + " (" + v0 + " + x)::DOUBLE FROM long_sequence(" + rows + ")";
+        execute("INSERT INTO t" + tail);
+        execute("INSERT INTO ctl" + tail);
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathConcurrentReadFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathConcurrentReadFuzzTest.java
@@ -251,11 +251,22 @@ public class CoveringIndexFastPathConcurrentReadFuzzTest extends AbstractFuzzTes
                             // (1) Covered == base at ONE snapshot: single statement, both
                             // branches share the reader txn -> any covered fragment that
                             // disagrees with the base column produces a non-empty diff.
+                            // The base arm is no_INDEX, not no_covering, and the diff is
+                            // SYMMETRIC. no_covering only disables the covered read and
+                            // leaves the index scan in place, so a posting that is
+                            // MISSING drops the row from both arms and a one-way diff
+                            // stays 0 - which is precisely what an unindexed tail looks
+                            // like. Proven by mutation: breaking the seal's rebuild
+                            // fallback left the old oracle green and fails this one.
                             final long diff = scalar(compiler, ctx,
                                     "SELECT count(*) FROM ("
-                                            + "(SELECT ts, value FROM t WHERE sym = '" + sym + "')"
+                                            + "((SELECT ts, value FROM t WHERE sym = '" + sym + "')"
                                             + " EXCEPT "
-                                            + "(SELECT /*+ no_covering */ ts, value FROM t WHERE sym = '" + sym + "'))");
+                                            + "(SELECT /*+ no_index */ ts, value FROM t WHERE sym = '" + sym + "'))"
+                                            + " UNION ALL "
+                                            + "((SELECT /*+ no_index */ ts, value FROM t WHERE sym = '" + sym + "')"
+                                            + " EXCEPT "
+                                            + "(SELECT ts, value FROM t WHERE sym = '" + sym + "')))");
                             if (diff != 0) {
                                 throw new AssertionError("covered read disagrees with base column at snapshot for "
                                         + sym + ": EXCEPT returned " + diff + " rows");

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathConcurrentReadFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathConcurrentReadFuzzTest.java
@@ -82,6 +82,7 @@ public class CoveringIndexFastPathConcurrentReadFuzzTest extends AbstractFuzzTes
     public void disableCoveringCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
         PostingIndexWriter.COVERING_FASTPATH_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
     }
 
     @Test
@@ -135,11 +136,25 @@ public class CoveringIndexFastPathConcurrentReadFuzzTest extends AbstractFuzzTes
     // the head to format 1.
     @Test
     public void testO3PreLagConcurrentReadFuzzLegacyFormat0Regression() throws Exception {
+        // Pinned to the pre-deferral path: this variant's job is to prove the
+        // publishToChain COW fires when a LEGACY format-0 head is extended in
+        // place by the O3-merge index commit. The covered append path stops that
+        // route from extending the head at all (the legacy head migrates via the
+        // reseal instead), so leaving it on would quietly retire the COW coverage
+        // rather than test it. The COW remains reachable from other extend sites.
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         runConcurrentReadFuzz(generateRandom(LOG, 0x5c1e83b7096d2fL, 0x4a90e2f1b7c358L), true, false, true);
     }
 
     @Test
     public void testO3PreLagConcurrentReadFuzzLegacyFormat0() throws Exception {
+        // Pinned to the pre-deferral path: this variant's job is to prove the
+        // publishToChain COW fires when a LEGACY format-0 head is extended in
+        // place by the O3-merge index commit. The covered append path stops that
+        // route from extending the head at all (the legacy head migrates via the
+        // reseal instead), so leaving it on would quietly retire the COW coverage
+        // rather than test it. The COW remains reachable from other extend sites.
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         runConcurrentReadFuzz(generateRandom(LOG), true, false, true);
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathDifferentialFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathDifferentialFuzzTest.java
@@ -238,17 +238,21 @@ public class CoveringIndexFastPathDifferentialFuzzTest extends AbstractFuzzTest 
             // Prove the two modes actually differed on the BLOCK-apply path.
             // (COVERING_FASTPATH_DISABLED only forces BLOCK applies through O3; the
             // pre-existing single-txn fast-lag path is unaffected, so o3FastLag is
-            // not necessarily 0. The block-path difference shows up as: the o3 run
-            // full-reseals its blocks, while the fast run fast-lags them instead --
-            // strictly MORE fast-lag commits and strictly FEWER full reseals.)
-            Assert.assertTrue("o3 run must full-reseal blocks (fast path forced off), o3Reseals=" + o3Reseals,
-                    o3Reseals > 0);
-            Assert.assertTrue("fast run must fast-lag block-applies the o3 run resealed"
+            // not necessarily 0.) The direct measure is the fast-lag count: the
+            // fast run fast-lags block applies that the o3 run does not.
+            //
+            // The reseal count is NO LONGER a discriminator. It used to be, because
+            // an O3 block apply full-resealed the partition; now a pure append
+            // maintains the covering index incrementally on the O3 route too, so
+            // both runs reseal only for the stream's genuine merges, and the two
+            // counts converge. Asserting fastReseals < o3Reseals here would be
+            // asserting that O3 is still slow.
+            Assert.assertTrue("fast run must fast-lag block-applies the o3 run did not"
                             + " (fastFastLag=" + fastFastLag + ", o3FastLag=" + o3FastLag + ")",
                     fastFastLag > o3FastLag);
-            Assert.assertTrue("fast run must avoid reseals via the fast path"
+            Assert.assertTrue("neither run may reseal more than the stream's merges require"
                             + " (fastReseals=" + fastReseals + ", o3Reseals=" + o3Reseals + ")",
-                    fastReseals < o3Reseals);
+                    fastReseals <= o3Reseals);
         });
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathDifferentialFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathDifferentialFuzzTest.java
@@ -253,6 +253,13 @@ public class CoveringIndexFastPathDifferentialFuzzTest extends AbstractFuzzTest 
             Assert.assertTrue("neither run may reseal more than the stream's merges require"
                             + " (fastReseals=" + fastReseals + ", o3Reseals=" + o3Reseals + ")",
                     fastReseals <= o3Reseals);
+            // The stream's out-of-order dips are genuine merges, so SOME reseal must
+            // still happen in at least one arm. Without this, both counts being zero
+            // - a covered append wrongly taken on a commit that needed a rebuild -
+            // would satisfy the comparison above.
+            Assert.assertTrue("the stream's merges must still reseal somewhere"
+                            + " (fastReseals=" + fastReseals + ", o3Reseals=" + o3Reseals + ")",
+                    o3Reseals > 0 || fastReseals > 0);
         });
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendConcurrentReadFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendConcurrentReadFuzzTest.java
@@ -176,17 +176,22 @@ public class MidPartitionAppendConcurrentReadFuzzTest extends AbstractFuzzTest {
                             final String sym = "S" + rrnd.nextInt(symbolCardinality);
                             final long floor = rowFloor.get();
 
-                            // Covered == base at ONE snapshot. SYMMETRIC: a
-                            // one-way EXCEPT only catches rows the covered scan
-                            // invents, not rows it is MISSING - which is exactly
-                            // what an unindexed tail looks like.
+                            // Covered == base at ONE snapshot. SYMMETRIC, and the
+                            // base arm is no_INDEX: a one-way EXCEPT only catches
+                            // rows the covered scan invents, not rows it is
+                            // MISSING, and no_covering would not catch the missing
+                            // ones either - it drops only the covered read and
+                            // keeps the "Index forward scan on: sym" (verified by
+                            // EXPLAIN), so an absent posting disappears from BOTH
+                            // arms. no_index plans a real full scan, which is the
+                            // only arm that can see an unindexed tail.
                             final long diff = scalar(compiler, ctx,
                                     "SELECT count(*) FROM ("
                                             + "((SELECT ts, value FROM t WHERE sym = '" + sym + "')"
                                             + " EXCEPT "
-                                            + "(SELECT /*+ no_covering */ ts, value FROM t WHERE sym = '" + sym + "'))"
+                                            + "(SELECT /*+ no_index */ ts, value FROM t WHERE sym = '" + sym + "'))"
                                             + " UNION ALL "
-                                            + "((SELECT /*+ no_covering */ ts, value FROM t WHERE sym = '" + sym + "')"
+                                            + "((SELECT /*+ no_index */ ts, value FROM t WHERE sym = '" + sym + "')"
                                             + " EXCEPT "
                                             + "(SELECT ts, value FROM t WHERE sym = '" + sym + "')))");
                             if (diff != 0) {
@@ -194,6 +199,10 @@ public class MidPartitionAppendConcurrentReadFuzzTest extends AbstractFuzzTest {
                                         + sym + ": EXCEPT returned " + diff + " rows");
                             }
 
+                            // EXCEPT is set-based, so a DUPLICATED posting is
+                            // invisible above: the extra row collapses into the
+                            // one already there. Counting is duplicate-sensitive
+                            // and closes that half of the oracle.
                             final long total;
                             final long covMax;
                             final long covMin;
@@ -276,6 +285,23 @@ public class MidPartitionAppendConcurrentReadFuzzTest extends AbstractFuzzTest {
 
             Assert.assertNull("concurrent covered reader failed: " + bgError.get(), bgError.get());
             Assert.assertFalse("table suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("t")));
+
+            // Duplicate-sensitive, and it belongs HERE rather than in the reader
+            // loop. EXCEPT is set-based, so a posting duplicated by an append
+            // collapses into the row already there and the in-loop diff cannot
+            // see it; a row-by-row cursor comparison can. It cannot run while the
+            // writer is live, though: two arms of one statement are not
+            // guaranteed to share a snapshot - verified by a negative control
+            // where BOTH arms were the identical query and still disagreed by
+            // ~50 rows under concurrent commits. With the readers joined and the
+            // last drain complete, nothing is in flight and the comparison is
+            // exact.
+            for (int s = 0; s < symbolCardinality; s++) {
+                assertSqlCursors(
+                        "SELECT /*+ no_index */ ts, sym, value FROM t WHERE sym = 'S" + s + "' ORDER BY ts",
+                        "SELECT ts, sym, value FROM t WHERE sym = 'S" + s + "' ORDER BY ts"
+                );
+            }
             Assert.assertTrue("the mid-partition append path must fire (appends="
                             + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
                     PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendConcurrentReadFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendConcurrentReadFuzzTest.java
@@ -1,0 +1,320 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.fuzz;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.cairo.sql.RecordCursor;
+import io.questdb.cairo.sql.RecordCursorFactory;
+import io.questdb.griffin.SqlCompiler;
+import io.questdb.griffin.SqlExecutionContextImpl;
+import io.questdb.std.Rnd;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Concurrent-reader fuzz for the mid-partition covered append path. The append
+ * path extends a LIVE .pc in place (a fresh gen slot at the partition's existing
+ * seal txn) rather than rotating the file the way the reseal does, so a reader
+ * holding an older mapping of that .pc is exactly the hazard to prove safe -
+ * the same failure mode that the block-apply fast path had to close on the last
+ * partition.
+ * <p>
+ * The writer thread only ever appends into an EARLY day while a later day
+ * already holds rows, so every commit is an append into a non-last partition and
+ * takes the path under test (asserted via COVERING_MIDPART_APPEND_COUNT). N
+ * reader threads concurrently run covered scans and check, per observation:
+ * <ul>
+ *   <li>no crash or exception;</li>
+ *   <li>covered == base at the reader's OWN snapshot, via a single-statement
+ *       {@code (covered) EXCEPT (no_covering)} diff - any torn, stale or
+ *       out-of-bounds covered fragment shows up as rows;</li>
+ *   <li>snapshot-safe bounds: covered {@code max(value)} never exceeds the id
+ *       ceiling published before the drain, {@code min(value) >= 1}, and the
+ *       total row count never goes backwards.</li>
+ * </ul>
+ * The legacy variant seeds a format-0 (aliased-footer) covering head first: the
+ * append path must refuse it (that head cannot be extended in place) and leave
+ * it to the reseal, which migrates it to format 1 - after which appends resume.
+ */
+public class MidPartitionAppendConcurrentReadFuzzTest extends AbstractFuzzTest {
+
+    private static final long DAY_MICROS = 24L * 60 * 60 * 1_000_000L;
+    // Anchored to a day boundary so "target day" arithmetic is exact.
+    private static final long T0 = 1_700_000_000_000_000L / DAY_MICROS * DAY_MICROS;
+    // Writes go into day 1; day 3 exists throughout, so day 1 is never last.
+    private static final long TARGET_DAY = T0 + DAY_MICROS;
+
+    @Before
+    public void enableCoveringCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
+        resetCoveringCounters();
+    }
+
+    @After
+    public void disableCoveringCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.FORCE_LEGACY_COVERING_FORMAT = false;
+    }
+
+    @Test
+    public void testMidPartitionAppendConcurrentReadFuzz() throws Exception {
+        runConcurrentReadFuzz(generateRandom(LOG), false);
+    }
+
+    @Test
+    public void testMidPartitionAppendConcurrentReadFuzzLegacyFormat0() throws Exception {
+        runConcurrentReadFuzz(generateRandom(LOG), true);
+    }
+
+    @Test
+    public void testMidPartitionAppendConcurrentReadFuzzLegacyFormat0Regression() throws Exception {
+        runConcurrentReadFuzz(generateRandom(LOG, 0x2b91f4c7e0a63dL, 0x74d0a3e19c5b82L), true);
+    }
+
+    @Test
+    public void testMidPartitionAppendConcurrentReadFuzzRegression() throws Exception {
+        runConcurrentReadFuzz(generateRandom(LOG, 0x6f2a09d5b3c184L, 0x0e57c1b93da462L), false);
+    }
+
+    private void resetCoveringCounters() {
+        PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_COW_MIGRATE_COUNT.set(0);
+        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+    }
+
+    private void runConcurrentReadFuzz(Rnd rnd, boolean legacyInitial) throws Exception {
+        setProperty(PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 10_000_000);
+        setProperty(PropertyKey.CAIRO_WAL_APPLY_LOOK_AHEAD_TXN_COUNT, 2000);
+        setProperty(PropertyKey.CAIRO_WAL_APPLY_TABLE_TIME_QUOTA, 600_000);
+
+        final int symbolCardinality = 3 + rnd.nextInt(6);
+        final int readerCount = 3 + rnd.nextInt(3);
+        // Enough commits to cross the gen threshold several times, so the
+        // deferred compaction (seal) also runs while readers are active.
+        final int rounds = 120 + rnd.nextInt(80);
+        final int nullMod = 7 + rnd.nextInt(20);
+        // {id, ts within the target day}
+        final long[] writeCursor = {1L, TARGET_DAY + 1};
+
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+            // Day 3 anchors the table's max timestamp: every later write into day
+            // 1 is therefore an append into a partition that is NOT the last one.
+            // Its single row carries value 0, below the id floor of 1 the readers
+            // assert, so it is written with a NULL value instead.
+            execute("INSERT INTO t SELECT (" + (T0 + 3 * DAY_MICROS) + ")::TIMESTAMP, 'S0', cast(NULL AS DOUBLE)"
+                    + " FROM long_sequence(1)");
+            drainWalQueue();
+
+            if (legacyInitial) {
+                PostingIndexWriter.FORCE_LEGACY_COVERING_FORMAT = true;
+                try {
+                    for (int b = 0; b < 6; b++) {
+                        writeBatch(writeCursor, 30 + rnd.nextInt(60), 1 + rnd.nextInt(1000), symbolCardinality, nullMod);
+                        drainWalQueue();
+                    }
+                } finally {
+                    PostingIndexWriter.FORCE_LEGACY_COVERING_FORMAT = false;
+                }
+            } else {
+                // Seed the target partition so the measured commits append to an
+                // existing (not newly created) partition.
+                writeBatch(writeCursor, 500, 100, symbolCardinality, nullMod);
+                drainWalQueue();
+            }
+            resetCoveringCounters();
+
+            final AtomicReference<Throwable> bgError = new AtomicReference<>();
+            final AtomicBoolean stop = new AtomicBoolean();
+            final AtomicLong rowFloor = new AtomicLong(0);
+            final AtomicLong idCeiling = new AtomicLong(0);
+
+            final Thread[] readers = new Thread[readerCount];
+            for (int r = 0; r < readerCount; r++) {
+                readers[r] = new Thread(() -> {
+                    final Rnd rrnd = new Rnd();
+                    try (
+                            SqlExecutionContextImpl ctx = new SqlExecutionContextImpl(engine, 1)
+                                    .with(configuration.getFactoryProvider().getSecurityContextFactory().getRootContext(),
+                                            null, null, -1, null);
+                            SqlCompiler compiler = engine.getSqlCompiler()
+                    ) {
+                        long prevTotal = 0;
+                        while (!stop.get() && bgError.get() == null) {
+                            final String sym = "S" + rrnd.nextInt(symbolCardinality);
+                            final long floor = rowFloor.get();
+
+                            // Covered == base at ONE snapshot. SYMMETRIC: a
+                            // one-way EXCEPT only catches rows the covered scan
+                            // invents, not rows it is MISSING - which is exactly
+                            // what an unindexed tail looks like.
+                            final long diff = scalar(compiler, ctx,
+                                    "SELECT count(*) FROM ("
+                                            + "((SELECT ts, value FROM t WHERE sym = '" + sym + "')"
+                                            + " EXCEPT "
+                                            + "(SELECT /*+ no_covering */ ts, value FROM t WHERE sym = '" + sym + "'))"
+                                            + " UNION ALL "
+                                            + "((SELECT /*+ no_covering */ ts, value FROM t WHERE sym = '" + sym + "')"
+                                            + " EXCEPT "
+                                            + "(SELECT ts, value FROM t WHERE sym = '" + sym + "')))");
+                            if (diff != 0) {
+                                throw new AssertionError("covered read disagrees with base column at snapshot for "
+                                        + sym + ": EXCEPT returned " + diff + " rows");
+                            }
+
+                            final long total;
+                            final long covMax;
+                            final long covMin;
+                            try (RecordCursorFactory f = compiler.compile(
+                                    "SELECT count(*), max(value), min(value) FROM t WHERE sym = '" + sym + "'",
+                                    ctx).getRecordCursorFactory();
+                                 RecordCursor cur = f.getCursor(ctx)) {
+                                if (cur.hasNext()) {
+                                    total = cur.getRecord().getLong(0);
+                                    final double mx = cur.getRecord().getDouble(1);
+                                    final double mn = cur.getRecord().getDouble(2);
+                                    covMax = Double.isNaN(mx) ? -1 : (long) mx;
+                                    covMin = Double.isNaN(mn) ? Long.MAX_VALUE : (long) mn;
+                                } else {
+                                    total = 0;
+                                    covMax = -1;
+                                    covMin = Long.MAX_VALUE;
+                                }
+                            }
+                            // Ceiling read AFTER the covered read: ids only grow and the
+                            // ceiling is published before each drain, so this is an upper
+                            // bound on anything that snapshot can hold.
+                            final long ceiling = idCeiling.get();
+                            if (ceiling > 0 && covMax > ceiling) {
+                                throw new AssertionError("covered max(value)=" + covMax + " for " + sym
+                                        + " exceeds the id ceiling " + ceiling
+                                        + " (rows past published coverage / garbage)");
+                            }
+                            if (total > 0 && covMin != Long.MAX_VALUE && covMin < 1) {
+                                throw new AssertionError("covered min(value)=" + covMin + " for " + sym
+                                        + " is below 1 (stale/garbage covered fragment)");
+                            }
+
+                            final long grandTotal = scalar(compiler, ctx, "SELECT count(*) FROM t");
+                            if (grandTotal < floor) {
+                                throw new AssertionError("total count " + grandTotal + " fell below committed floor " + floor);
+                            }
+                            if (grandTotal < prevTotal) {
+                                throw new AssertionError("total count went backwards: " + prevTotal + " -> " + grandTotal);
+                            }
+                            prevTotal = grandTotal;
+
+                            // Drive the covered record cursor itself (crash surface).
+                            try (RecordCursorFactory f = compiler.compile(
+                                    "SELECT ts, sym, value FROM t WHERE sym = '" + sym + "' ORDER BY value LIMIT 32",
+                                    ctx).getRecordCursorFactory();
+                                 RecordCursor cur = f.getCursor(ctx)) {
+                                //noinspection StatementWithEmptyBody
+                                while (cur.hasNext()) {
+                                    cur.getRecord().getDouble(2);
+                                }
+                            }
+                        }
+                    } catch (Throwable e) {
+                        bgError.set(e);
+                    }
+                }, "midpart-append-reader-" + r);
+                readers[r].setDaemon(true);
+                readers[r].start();
+            }
+
+            try {
+                for (int round = 0; round < rounds && bgError.get() == null; round++) {
+                    final int txns = 1 + rnd.nextInt(4);
+                    for (int t = 0; t < txns; t++) {
+                        writeBatch(writeCursor, 10 + rnd.nextInt(200), 1 + rnd.nextInt(1000), symbolCardinality, nullMod);
+                    }
+                    // Ceiling BEFORE the drain (ids only grow), floor AFTER.
+                    idCeiling.set(writeCursor[0] - 1);
+                    drainWalQueue();
+                    rowFloor.set(1);
+                }
+            } finally {
+                stop.set(true);
+                for (Thread th : readers) {
+                    th.join(60_000);
+                    Assert.assertFalse("reader thread did not terminate", th.isAlive());
+                }
+            }
+
+            Assert.assertNull("concurrent covered reader failed: " + bgError.get(), bgError.get());
+            Assert.assertFalse("table suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("t")));
+            Assert.assertTrue("the mid-partition append path must fire (appends="
+                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+            if (legacyInitial) {
+                // A format-0 head must never be extended in place (the readers'
+                // clean scans above are the proof it was not); it migrates to
+                // format 1 through the reseal or the publishToChain COW.
+                Assert.assertTrue("legacy format-0 head must migrate (fullReseals="
+                                + PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get()
+                                + ", cowMigrates=" + PostingIndexWriter.COVERING_COW_MIGRATE_COUNT.get() + ')',
+                        PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get() > 0
+                                || PostingIndexWriter.COVERING_COW_MIGRATE_COUNT.get() > 0);
+            }
+        });
+    }
+
+    private long scalar(SqlCompiler compiler, SqlExecutionContextImpl ctx, String sql) throws Exception {
+        try (RecordCursorFactory f = compiler.compile(sql, ctx).getRecordCursorFactory();
+             RecordCursor cur = f.getCursor(ctx)) {
+            return cur.hasNext() ? cur.getRecord().getLong(0) : 0;
+        }
+    }
+
+    /**
+     * Appends one ascending batch into the target (mid) partition, advancing the
+     * shared {id, ts} cursor. Values are the globally ascending id, so the
+     * readers' monotonic and ceiling checks hold.
+     */
+    private void writeBatch(long[] cursor, int rows, long step, int symbolCardinality, int nullMod) throws Exception {
+        final long v0 = cursor[0] - 1;
+        final long startTs = cursor[1];
+        execute("INSERT INTO t SELECT (" + startTs + " + x * " + step + ")::TIMESTAMP AS ts,"
+                + " 'S' || ((" + v0 + " + x) % " + symbolCardinality + ") AS sym,"
+                + " CASE WHEN ((" + v0 + " + x) % " + nullMod + ") = 0 THEN cast(NULL AS DOUBLE)"
+                + " ELSE (" + v0 + " + x)::DOUBLE END AS value FROM long_sequence(" + rows + ")");
+        cursor[0] = v0 + rows + 1;
+        cursor[1] = startTs + (long) rows * step;
+        // The batch must stay inside the target day, else it would create a new
+        // last partition and stop exercising the mid-partition path.
+        Assert.assertTrue("stream left the target partition", cursor[1] < TARGET_DAY + DAY_MICROS);
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendConcurrentReadFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendConcurrentReadFuzzTest.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * <p>
  * The writer thread only ever appends into an EARLY day while a later day
  * already holds rows, so every commit is an append into a non-last partition and
- * takes the path under test (asserted via COVERING_MIDPART_APPEND_COUNT). N
+ * takes the path under test (asserted via COVERING_SEAL_APPEND_COUNT). N
  * reader threads concurrently run covered scans and check, per observation:
  * <ul>
  *   <li>no crash or exception;</li>
@@ -82,13 +82,29 @@ public class MidPartitionAppendConcurrentReadFuzzTest extends AbstractFuzzTest {
     @After
     public void disableCoveringCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
         PostingIndexWriter.FORCE_LEGACY_COVERING_FORMAT = false;
     }
 
     @Test
     public void testMidPartitionAppendConcurrentReadFuzz() throws Exception {
         runConcurrentReadFuzz(generateRandom(LOG), false);
+    }
+
+    /**
+     * The same concurrent-reader load against the LAST partition. DEDUP
+     * disqualifies the WAL fast-lag gate, so these appends take the O3 route into
+     * the last partition - where the covered append path now extends a live .pc
+     * in place on the partition every reader is scanning.
+     */
+    @Test
+    public void testLastPartitionAppendConcurrentReadFuzzDedup() throws Exception {
+        runConcurrentReadFuzz(generateRandom(LOG), false, true);
+    }
+
+    @Test
+    public void testLastPartitionAppendConcurrentReadFuzzDedupRegression() throws Exception {
+        runConcurrentReadFuzz(generateRandom(LOG, 0x63b1e04a7c25d9L, 0x0af52c9138be74L), false, true);
     }
 
     @Test
@@ -110,10 +126,14 @@ public class MidPartitionAppendConcurrentReadFuzzTest extends AbstractFuzzTest {
         PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
         PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
         PostingIndexWriter.COVERING_COW_MIGRATE_COUNT.set(0);
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
     private void runConcurrentReadFuzz(Rnd rnd, boolean legacyInitial) throws Exception {
+        runConcurrentReadFuzz(rnd, legacyInitial, false);
+    }
+
+    private void runConcurrentReadFuzz(Rnd rnd, boolean legacyInitial, boolean dedup) throws Exception {
         setProperty(PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 10_000_000);
         setProperty(PropertyKey.CAIRO_WAL_APPLY_LOOK_AHEAD_TXN_COUNT, 2000);
         setProperty(PropertyKey.CAIRO_WAL_APPLY_TABLE_TIME_QUOTA, 600_000);
@@ -129,13 +149,18 @@ public class MidPartitionAppendConcurrentReadFuzzTest extends AbstractFuzzTest {
 
         assertMemoryLeak(() -> {
             execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
-                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
-            // Day 3 anchors the table's max timestamp: every later write into day
-            // 1 is therefore an append into a partition that is NOT the last one.
-            // Its single row carries value 0, below the id floor of 1 the readers
-            // assert, so it is written with a NULL value instead.
-            execute("INSERT INTO t SELECT (" + (T0 + 3 * DAY_MICROS) + ")::TIMESTAMP, 'S0', cast(NULL AS DOUBLE)"
-                    + " FROM long_sequence(1)");
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL"
+                    + (dedup ? " DEDUP UPSERT KEYS(ts, sym)" : ""));
+            if (!dedup) {
+                // Day 3 anchors the table's max timestamp: every later write into day
+                // 1 is therefore an append into a partition that is NOT the last one.
+                // Its single row carries value 0, below the id floor of 1 the readers
+                // assert, so it is written with a NULL value instead.
+                execute("INSERT INTO t SELECT (" + (T0 + 3 * DAY_MICROS) + ")::TIMESTAMP, 'S0', cast(NULL AS DOUBLE)"
+                        + " FROM long_sequence(1)");
+            }
+            // With dedup there is deliberately NO later anchor: the target day is
+            // the LAST partition, and dedup routes its appends through O3.
             drainWalQueue();
 
             if (legacyInitial) {
@@ -277,8 +302,8 @@ public class MidPartitionAppendConcurrentReadFuzzTest extends AbstractFuzzTest {
             Assert.assertNull("concurrent covered reader failed: " + bgError.get(), bgError.get());
             Assert.assertFalse("table suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("t")));
             Assert.assertTrue("the mid-partition append path must fire (appends="
-                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
-                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
             if (legacyInitial) {
                 // A format-0 head must never be extended in place (the readers'
                 // clean scans above are the proof it was not); it migrates to

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendDifferentialFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendDifferentialFuzzTest.java
@@ -81,25 +81,60 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
 
     @Test
     public void testMidPartitionAppendDifferentialFuzz() throws Exception {
-        runDifferential(generateRandom(LOG));
+        runDifferential(generateRandom(LOG), false);
     }
 
     @Test
     public void testMidPartitionAppendDifferentialFuzzRegression() throws Exception {
-        runDifferential(generateRandom(LOG, 0x51e3d7a9c4b206L, 0x1f8c62b0da3945L));
+        runDifferential(generateRandom(LOG, 0x51e3d7a9c4b206L, 0x1f8c62b0da3945L), false);
     }
 
-    private void applyStream(String table, List<Op> ops, int symbolCardinality) throws Exception {
+    /**
+     * Var-size covered columns (STRING and VARCHAR). Every other test here covers
+     * only fixed-width DOUBLE, but the append path publishes an INCREMENTAL
+     * covered fragment: it hands the aux (index) addresses and mapped sizes to
+     * writeSidecarGenData and appends a slice, where the reseal it replaces
+     * rewrote the sidecar wholesale. The offset arithmetic for the incremental
+     * case is therefore genuinely different code, and it was the largest piece of
+     * new write logic with no coverage. Both var-size layouts are included
+     * because STRING and VARCHAR do not share an aux representation.
+     */
+    @Test
+    public void testMidPartitionAppendDifferentialFuzzVarSize() throws Exception {
+        runDifferential(generateRandom(LOG), true);
+    }
+
+    @Test
+    public void testMidPartitionAppendDifferentialFuzzVarSizeRegression() throws Exception {
+        runDifferential(generateRandom(LOG, 0x2c9b41f7e05a83L, 0x6d13ea82c4f507L), true);
+    }
+
+    private void applyStream(String table, List<Op> ops, int symbolCardinality, boolean varSize) throws Exception {
         for (int i = 0, n = ops.size(); i < n; i++) {
             Op op = ops.get(i);
             if (op.truncate) {
                 execute("TRUNCATE TABLE " + table);
             } else {
                 final String valueExpr = "(" + op.v0 + " + x)::DOUBLE";
+                // Lengths must VARY (and include NULL and empty), or every aux
+                // offset is uniform and an incremental-offset error still lines up.
+                // Three length classes plus the digit-count drift of the id, so
+                // consecutive rows differ in width; the empty-string class shares
+                // an offset with its neighbour, which is where an off-by-one in
+                // the incremental aux write shows up.
+                final String pad = "CASE WHEN ((" + op.v0 + " + x) % 3) = 0 THEN 'aaaaaaaaaaaaaaaaaaaa'"
+                        + " WHEN ((" + op.v0 + " + x) % 3) = 1 THEN 'bb' ELSE '' END";
+                final String varCols = varSize
+                        ? ", CASE WHEN ((" + op.v0 + " + x) % " + op.nullMod + ") = 1 THEN cast(NULL AS STRING)"
+                        + " ELSE (" + pad + ") || (" + op.v0 + " + x)::STRING END AS s"
+                        + ", CASE WHEN ((" + op.v0 + " + x) % " + op.nullMod + ") = 2 THEN cast(NULL AS VARCHAR)"
+                        + " ELSE (('\u00e9' || (" + pad + ")) || (" + op.v0 + " + x)::STRING)::VARCHAR END AS v"
+                        : "";
                 execute("INSERT INTO " + table
                         + " SELECT (" + op.startTs + " + x * " + op.step + ")::TIMESTAMP AS ts,"
                         + " 'S' || ((" + op.v0 + " + x) % " + symbolCardinality + ") AS sym,"
                         + " CASE WHEN ((" + op.v0 + " + x) % " + op.nullMod + ") = 0 THEN cast(NULL AS DOUBLE) ELSE " + valueExpr + " END AS value"
+                        + varCols
                         + " FROM long_sequence(" + op.rows + ")");
             }
             if (op.drainAfter) {
@@ -108,17 +143,18 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
         }
     }
 
-    private void assertTablesIdentical(int symbolCardinality) throws Exception {
+    private void assertTablesIdentical(int symbolCardinality, boolean varSize) throws Exception {
+        final String cols = varSize ? "ts, sym, value, s, v" : "ts, sym, value";
         assertSqlCursors(
-                "SELECT ts, sym, value FROM reseal ORDER BY ts, sym, value",
-                "SELECT ts, sym, value FROM append ORDER BY ts, sym, value"
+                "SELECT " + cols + " FROM reseal ORDER BY ts, sym, value",
+                "SELECT " + cols + " FROM append ORDER BY ts, sym, value"
         );
         for (int s = 0; s < symbolCardinality; s++) {
             final String sym = "S" + s;
             // Covered reads through the covering index, per symbol.
             assertSqlCursors(
-                    "SELECT ts, sym, value FROM reseal WHERE sym = '" + sym + "' ORDER BY value",
-                    "SELECT ts, sym, value FROM append WHERE sym = '" + sym + "' ORDER BY value"
+                    "SELECT " + cols + " FROM reseal WHERE sym = '" + sym + "' ORDER BY value",
+                    "SELECT " + cols + " FROM append WHERE sym = '" + sym + "' ORDER BY value"
             );
             assertSqlCursors(
                     "SELECT ts, sym FROM reseal WHERE sym = '" + sym + "' AND value IS NULL ORDER BY ts",
@@ -204,7 +240,7 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
         PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
     }
 
-    private void runDifferential(Rnd rnd) throws Exception {
+    private void runDifferential(Rnd rnd, boolean varSize) throws Exception {
         setProperty(PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 10_000_000);
         setProperty(PropertyKey.CAIRO_SQL_SORT_KEY_MAX_BYTES, 134_217_728);
         setProperty(PropertyKey.CAIRO_SQL_SORT_LIGHT_VALUE_MAX_BYTES, 134_217_728);
@@ -213,23 +249,25 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
         final List<Op> ops = precomputeStream(rnd, symbolCardinality);
 
         assertMemoryLeak(() -> {
-            execute("CREATE TABLE reseal (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
-                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
-            execute("CREATE TABLE append (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
-                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+            final String schema = varSize
+                    ? " (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value, s, v),"
+                    + " value DOUBLE, s STRING, v VARCHAR)"
+                    : " (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)";
+            execute("CREATE TABLE reseal" + schema + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE append" + schema + " TIMESTAMP(ts) PARTITION BY DAY WAL");
             drainWalQueue();
 
             // Replay 1: append path FORCED OFF -> index in O3 + full reseal.
             PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
             resetCoveringCounters();
-            applyStream("reseal", ops, symbolCardinality);
+            applyStream("reseal", ops, symbolCardinality, varSize);
             final long resealRuns = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
             final long resealAppends = PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get();
 
             // Replay 2: append path ACTIVE.
             PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
             resetCoveringCounters();
-            applyStream("append", ops, symbolCardinality);
+            applyStream("append", ops, symbolCardinality, varSize);
             final long appendRuns = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
             final long appendAppends = PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get();
 
@@ -237,7 +275,7 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
             Assert.assertFalse("append suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("append")));
 
             // THE proof: identical results regardless of path.
-            assertTablesIdentical(symbolCardinality);
+            assertTablesIdentical(symbolCardinality, varSize);
 
             // ... and the two runs really did take different paths.
             Assert.assertEquals("forced-off run must never take the append path", 0, resealAppends);

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendDifferentialFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendDifferentialFuzzTest.java
@@ -126,9 +126,9 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
                         + " WHEN ((" + op.v0 + " + x) % 3) = 1 THEN 'bb' ELSE '' END";
                 final String varCols = varSize
                         ? ", CASE WHEN ((" + op.v0 + " + x) % " + op.nullMod + ") = 1 THEN cast(NULL AS STRING)"
-                        + " ELSE (" + pad + ") || (" + op.v0 + " + x)::STRING END AS s"
-                        + ", CASE WHEN ((" + op.v0 + " + x) % " + op.nullMod + ") = 2 THEN cast(NULL AS VARCHAR)"
-                        + " ELSE (('\u00e9' || (" + pad + ")) || (" + op.v0 + " + x)::STRING)::VARCHAR END AS v"
+                          + " ELSE (" + pad + ") || (" + op.v0 + " + x)::STRING END AS s"
+                          + ", CASE WHEN ((" + op.v0 + " + x) % " + op.nullMod + ") = 2 THEN cast(NULL AS VARCHAR)"
+                          + " ELSE (('\u00e9' || (" + pad + ")) || (" + op.v0 + " + x)::STRING)::VARCHAR END AS v"
                         : "";
                 execute("INSERT INTO " + table
                         + " SELECT (" + op.startTs + " + x * " + op.step + ")::TIMESTAMP AS ts,"
@@ -251,7 +251,7 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
         assertMemoryLeak(() -> {
             final String schema = varSize
                     ? " (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value, s, v),"
-                    + " value DOUBLE, s STRING, v VARCHAR)"
+                      + " value DOUBLE, s STRING, v VARCHAR)"
                     : " (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)";
             execute("CREATE TABLE reseal" + schema + " TIMESTAMP(ts) PARTITION BY DAY WAL");
             execute("CREATE TABLE append" + schema + " TIMESTAMP(ts) PARTITION BY DAY WAL");

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendDifferentialFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendDifferentialFuzzTest.java
@@ -45,7 +45,7 @@ import java.util.List;
  * A single deterministic stream is precomputed per seed and replayed twice into
  * two identically-defined covering-indexed tables:
  * <ul>
- *   <li>{@code reseal} - {@code COVERING_MIDPART_APPEND_DISABLED = true}: O3
+ *   <li>{@code reseal} - {@code COVERING_SEAL_APPEND_DISABLED = true}: O3
  *       indexes the rows and the seal full-reseals, as before;</li>
  *   <li>{@code append} - the flag off: the covered append path is active.</li>
  * </ul>
@@ -76,17 +76,35 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
     @After
     public void disableCoveringCountersAndAppendPath() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
     }
 
     @Test
     public void testMidPartitionAppendDifferentialFuzz() throws Exception {
-        runDifferential(generateRandom(LOG));
+        runDifferential(generateRandom(LOG), false);
     }
 
     @Test
     public void testMidPartitionAppendDifferentialFuzzRegression() throws Exception {
-        runDifferential(generateRandom(LOG, 0x51e3d7a9c4b206L, 0x1f8c62b0da3945L));
+        runDifferential(generateRandom(LOG, 0x51e3d7a9c4b206L, 0x1f8c62b0da3945L), false);
+    }
+
+    /**
+     * DEDUP disqualifies the WAL fast-lag gate (the block gate tests
+     * isCommitPlainInsert(), the single-txn gate tests !isCommitDedupMode()), so
+     * the same stream additionally routes the LAST partition's appends through
+     * O3 - the route that used to full-reseal per commit and to write a
+     * speculative covered fragment. The timestamps are unique, so nothing is
+     * actually deduplicated and the commits stay pure appends.
+     */
+    @Test
+    public void testDedupDifferentialFuzz() throws Exception {
+        runDifferential(generateRandom(LOG), true);
+    }
+
+    @Test
+    public void testDedupDifferentialFuzzRegression() throws Exception {
+        runDifferential(generateRandom(LOG, 0x2f70c81a9b3e56L, 0x4c19d7e0af6231L), true);
     }
 
     private void applyStream(String table, List<Op> ops, int symbolCardinality) throws Exception {
@@ -201,10 +219,10 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
         PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
         PostingIndexWriter.COVERING_FASTLAG_COMMIT_COUNT.set(0);
         PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
-    private void runDifferential(Rnd rnd) throws Exception {
+    private void runDifferential(Rnd rnd, boolean dedup) throws Exception {
         setProperty(PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 10_000_000);
         setProperty(PropertyKey.CAIRO_SQL_SORT_KEY_MAX_BYTES, 134_217_728);
         setProperty(PropertyKey.CAIRO_SQL_SORT_LIGHT_VALUE_MAX_BYTES, 134_217_728);
@@ -213,25 +231,26 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
         final List<Op> ops = precomputeStream(rnd, symbolCardinality);
 
         assertMemoryLeak(() -> {
+            final String dedupClause = dedup ? " DEDUP UPSERT KEYS(ts, sym)" : "";
             execute("CREATE TABLE reseal (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
-                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL" + dedupClause);
             execute("CREATE TABLE append (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
-                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL" + dedupClause);
             drainWalQueue();
 
             // Replay 1: append path FORCED OFF -> index in O3 + full reseal.
-            PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+            PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
             resetCoveringCounters();
             applyStream("reseal", ops, symbolCardinality);
             final long resealRuns = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
-            final long resealAppends = PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get();
+            final long resealAppends = PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get();
 
             // Replay 2: append path ACTIVE.
-            PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+            PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
             resetCoveringCounters();
             applyStream("append", ops, symbolCardinality);
             final long appendRuns = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
-            final long appendAppends = PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get();
+            final long appendAppends = PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get();
 
             Assert.assertFalse("reseal suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("reseal")));
             Assert.assertFalse("append suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("append")));

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendDifferentialFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendDifferentialFuzzTest.java
@@ -1,0 +1,273 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.fuzz;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.std.Rnd;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Differential equivalence proof for the mid-partition covered append path: a
+ * pure O3 append into an existing, non-last partition now indexes only the
+ * appended range and publishes an incremental covered fragment
+ * (TableWriter#sealPostingIndexForPartition) instead of resealing the whole
+ * partition.
+ * <p>
+ * A single deterministic stream is precomputed per seed and replayed twice into
+ * two identically-defined covering-indexed tables:
+ * <ul>
+ *   <li>{@code reseal} - {@code COVERING_MIDPART_APPEND_DISABLED = true}: O3
+ *       indexes the rows and the seal full-reseals, as before;</li>
+ *   <li>{@code append} - the flag off: the covered append path is active.</li>
+ * </ul>
+ * Both must produce identical base content and identical covered reads. The run
+ * also asserts the two modes genuinely differed (the append run takes the append
+ * path and reseals strictly less), so a silently-disabled path cannot pass.
+ * <p>
+ * The stream writes into SEVERAL days at once with a day always present after
+ * the one being written, which is what makes the writes mid-partition appends;
+ * it also mixes in out-of-order dips (real O3 merges) and truncates so the two
+ * paths are compared across the transitions between them, not just in steady
+ * state.
+ */
+public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
+
+    private static final long DAY_MICROS = 24L * 60 * 60 * 1_000_000L;
+    // Day 0 is the anchor: every other day is written into while day (DAYS-1)
+    // already holds rows, so those writes land in a non-last partition.
+    private static final int DAYS = 4;
+    private static final long T0 = 1_700_000_000_000_000L / DAY_MICROS * DAY_MICROS;
+
+    @Before
+    public void enableCoveringCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
+        resetCoveringCounters();
+    }
+
+    @After
+    public void disableCoveringCountersAndAppendPath() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+    }
+
+    @Test
+    public void testMidPartitionAppendDifferentialFuzz() throws Exception {
+        runDifferential(generateRandom(LOG));
+    }
+
+    @Test
+    public void testMidPartitionAppendDifferentialFuzzRegression() throws Exception {
+        runDifferential(generateRandom(LOG, 0x51e3d7a9c4b206L, 0x1f8c62b0da3945L));
+    }
+
+    private void applyStream(String table, List<Op> ops, int symbolCardinality) throws Exception {
+        for (int i = 0, n = ops.size(); i < n; i++) {
+            Op op = ops.get(i);
+            if (op.truncate) {
+                execute("TRUNCATE TABLE " + table);
+            } else {
+                final String valueExpr = "(" + op.v0 + " + x)::DOUBLE";
+                execute("INSERT INTO " + table
+                        + " SELECT (" + op.startTs + " + x * " + op.step + ")::TIMESTAMP AS ts,"
+                        + " 'S' || ((" + op.v0 + " + x) % " + symbolCardinality + ") AS sym,"
+                        + " CASE WHEN ((" + op.v0 + " + x) % " + op.nullMod + ") = 0 THEN cast(NULL AS DOUBLE) ELSE " + valueExpr + " END AS value"
+                        + " FROM long_sequence(" + op.rows + ")");
+            }
+            if (op.drainAfter) {
+                drainWalQueue();
+            }
+        }
+    }
+
+    private void assertTablesIdentical(int symbolCardinality) throws Exception {
+        assertSqlCursors(
+                "SELECT ts, sym, value FROM reseal ORDER BY ts, sym, value",
+                "SELECT ts, sym, value FROM append ORDER BY ts, sym, value"
+        );
+        for (int s = 0; s < symbolCardinality; s++) {
+            final String sym = "S" + s;
+            // Covered reads through the covering index, per symbol.
+            assertSqlCursors(
+                    "SELECT ts, sym, value FROM reseal WHERE sym = '" + sym + "' ORDER BY value",
+                    "SELECT ts, sym, value FROM append WHERE sym = '" + sym + "' ORDER BY value"
+            );
+            assertSqlCursors(
+                    "SELECT ts, sym FROM reseal WHERE sym = '" + sym + "' AND value IS NULL ORDER BY ts",
+                    "SELECT ts, sym FROM append WHERE sym = '" + sym + "' AND value IS NULL ORDER BY ts"
+            );
+        }
+        assertSqlCursors(
+                "SELECT sym, sum(value), count(value), count(*), min(value), max(value) FROM reseal ORDER BY sym",
+                "SELECT sym, sum(value), count(value), count(*), min(value), max(value) FROM append ORDER BY sym"
+        );
+    }
+
+    /**
+     * Per-day append cursors: each op appends after the chosen day's current
+     * max, so writes into days 0..DAYS-2 are pure appends into a partition that
+     * is not the last one. 15% of ops dip behind the day's max instead, which
+     * is a genuine O3 merge and must take the unchanged reseal path.
+     */
+    private List<Op> precomputeStream(Rnd rnd, int symbolCardinality) {
+        final List<Op> ops = new ArrayList<>();
+        final long[] dayCursor = new long[DAYS];
+        for (int d = 0; d < DAYS; d++) {
+            dayCursor[d] = T0 + d * DAY_MICROS;
+        }
+        long valueCursor = 0;
+
+        // Seed every day (ascending) so all DAYS partitions exist before the
+        // measured ops: without the later day present, a write into day d would
+        // be a last-partition append, which is a different path.
+        for (int d = 0; d < DAYS; d++) {
+            final int rows = 200 + rnd.nextInt(800);
+            ops.add(new Op(false, dayCursor[d], valueCursor, rows, 1 + rnd.nextInt(50), 3 + rnd.nextInt(20), d == DAYS - 1));
+            valueCursor += rows;
+            dayCursor[d] += (long) rows * 50 + 1;
+        }
+
+        final int rounds = 30 + rnd.nextInt(30);
+        for (int round = 0; round < rounds; round++) {
+            final int txnsInRound = 1 + rnd.nextInt(5);
+            for (int t = 0; t < txnsInRound; t++) {
+                final int day = rnd.nextInt(DAYS);
+                final int rows = 20 + rnd.nextInt(500);
+                final long step = 1 + rnd.nextInt(200);
+                final int nullMod = 3 + rnd.nextInt(20);
+                final boolean dip = rnd.nextInt(100) < 15;
+                final long dayStart = T0 + (long) day * DAY_MICROS;
+                long startTs = dayCursor[day];
+                if (dip) {
+                    // Land behind the day's max (but inside the day) -> O3 merge.
+                    final long back = 1 + rnd.nextInt(1 + (int) Math.min(Integer.MAX_VALUE, startTs - dayStart));
+                    startTs = Math.max(dayStart, startTs - back);
+                }
+                final boolean drainAfter = t == txnsInRound - 1;
+                ops.add(new Op(false, startTs, valueCursor, rows, step, nullMod, drainAfter));
+                valueCursor += rows;
+                // Keep the whole batch inside its day so the op cannot spill into
+                // the next partition (which would create/extend a later day and
+                // change which partition is last).
+                final long batchMax = startTs + (long) rows * step;
+                final long dayEnd = dayStart + DAY_MICROS - 1;
+                dayCursor[day] = Math.max(dayCursor[day], Math.min(batchMax + 1, dayEnd));
+            }
+            if (rnd.nextInt(100) < 4) {
+                ops.add(new Op(true, 0, 0, 0, 0, 0, true));
+                // After a truncate the days must be re-seeded, else subsequent
+                // writes recreate partitions in arbitrary order.
+                for (int d = 0; d < DAYS; d++) {
+                    dayCursor[d] = T0 + (long) d * DAY_MICROS;
+                    final int rows = 100 + rnd.nextInt(300);
+                    ops.add(new Op(false, dayCursor[d], valueCursor, rows, 40, 7, d == DAYS - 1));
+                    valueCursor += rows;
+                    dayCursor[d] += (long) rows * 40 + 1;
+                }
+            }
+        }
+        return ops;
+    }
+
+    private void resetCoveringCounters() {
+        PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_FASTLAG_COMMIT_COUNT.set(0);
+        PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+    }
+
+    private void runDifferential(Rnd rnd) throws Exception {
+        setProperty(PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 10_000_000);
+        setProperty(PropertyKey.CAIRO_SQL_SORT_KEY_MAX_BYTES, 134_217_728);
+        setProperty(PropertyKey.CAIRO_SQL_SORT_LIGHT_VALUE_MAX_BYTES, 134_217_728);
+
+        final int symbolCardinality = 3 + rnd.nextInt(14);
+        final List<Op> ops = precomputeStream(rnd, symbolCardinality);
+
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE reseal (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE append (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+            drainWalQueue();
+
+            // Replay 1: append path FORCED OFF -> index in O3 + full reseal.
+            PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+            resetCoveringCounters();
+            applyStream("reseal", ops, symbolCardinality);
+            final long resealRuns = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
+            final long resealAppends = PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get();
+
+            // Replay 2: append path ACTIVE.
+            PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+            resetCoveringCounters();
+            applyStream("append", ops, symbolCardinality);
+            final long appendRuns = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
+            final long appendAppends = PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get();
+
+            Assert.assertFalse("reseal suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("reseal")));
+            Assert.assertFalse("append suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("append")));
+
+            // THE proof: identical results regardless of path.
+            assertTablesIdentical(symbolCardinality);
+
+            // ... and the two runs really did take different paths.
+            Assert.assertEquals("forced-off run must never take the append path", 0, resealAppends);
+            Assert.assertTrue("append run must take the append path, appends=" + appendAppends, appendAppends > 0);
+            Assert.assertTrue("forced-off run must full-reseal, reseals=" + resealRuns, resealRuns > 0);
+            Assert.assertTrue("append run must reseal less than the forced-off run"
+                            + " (append=" + appendRuns + ", reseal=" + resealRuns + ')',
+                    appendRuns < resealRuns);
+        });
+    }
+
+    // One replayed operation. Absolute startTs / v0 make the two replays a pure
+    // function of this list.
+    private static final class Op {
+        final boolean drainAfter;
+        final int nullMod;
+        final int rows;
+        final long startTs;
+        final long step;
+        final boolean truncate;
+        final long v0;
+
+        Op(boolean truncate, long startTs, long v0, int rows, long step, int nullMod, boolean drainAfter) {
+            this.truncate = truncate;
+            this.startTs = startTs;
+            this.v0 = v0;
+            this.rows = rows;
+            this.step = step;
+            this.nullMod = nullMod;
+            this.drainAfter = drainAfter;
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendFailureFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendFailureFuzzTest.java
@@ -1,0 +1,427 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.fuzz;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.std.Rnd;
+import io.questdb.std.str.LPSZ;
+import io.questdb.std.str.Utf8s;
+import io.questdb.test.std.TestFilesFacadeImpl;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Failure-injection fuzz for the mid-partition covered append path. A seeded
+ * {@link io.questdb.std.FilesFacade} fails one filesystem op (open / mmap /
+ * allocate) on the covering table's apply-path index files - the covered sidecar
+ * {@code .pc}, the posting values {@code .pv}, or the partition {@code value.d}
+ * - while commits append into an existing, non-last partition. Faults never
+ * touch WAL segment files, so the transaction log stays durable and the stream
+ * must eventually apply in full.
+ * <p>
+ * A non-covering control table receives the same stream with no faults. After
+ * each fault the writer is reopened and the table resumed until it converges;
+ * the invariant is that the covering table ends unsuspended with covered reads
+ * equal to the control's base column for every committed row. The append path
+ * publishes into a LIVE .pc rather than rotating it, so a fault mid-publish must
+ * still leave no partial or garbage covered fragment behind.
+ */
+public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
+
+    private static final long DAY_MICROS = 24L * 60 * 60 * 1_000_000L;
+    private static final int MODE_ALLOC = 2;
+    private static final int MODE_MMAP = 1;
+    private static final int MODE_OPEN = 0;
+    // Fails the read the append path issues over the symbol column it is
+    // indexing, which no other mode can reach.
+    private static final int MODE_READ = 3;
+    private static final int TARGET_SYM_D = 4;
+    private static final long T0 = 1_700_000_000_000_000L / DAY_MICROS * DAY_MICROS;
+    // Batches land in day 1; day 3 exists from the start, so day 1 is never last.
+    private static final long TARGET_DAY = T0 + DAY_MICROS;
+    private final FaultFilesFacade faultFf = new FaultFilesFacade();
+
+    @Before
+    public void enableCoveringCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
+        resetCoveringCounters();
+        faultFf.disarm();
+    }
+
+    @After
+    public void disableCoveringCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        faultFf.disarm();
+    }
+
+    @Test
+    public void testMidPartitionAppendFailureFuzz() throws Exception {
+        runFailureFuzz(generateRandom(LOG), true);
+    }
+
+    @Test
+    public void testMidPartitionAppendFailureFuzzNoFaultControl() throws Exception {
+        // Harness self-check: with faults disabled the run must converge cleanly.
+        runFailureFuzz(generateRandom(LOG), false);
+    }
+
+    @Test
+    public void testMidPartitionAppendFailureFuzzRegression() throws Exception {
+        runFailureFuzz(generateRandom(LOG, 0x18b7d3f0a29e64L, 0x5c02af71e6d938L), true);
+    }
+
+    /**
+     * Same seed, same faults, but the append path is forced OFF so the run takes
+     * the unchanged index-in-O3 + reseal route. Discriminates a genuine
+     * crash-safety regression in the append path from a property of the O3
+     * mid-partition path (or of this harness) that predates it.
+     */
+    @Test
+    public void testMidPartitionAppendFailureFuzzResealPathControl() throws Exception {
+        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+        runFailureFuzz(generateRandom(LOG, 0x18b7d3f0a29e64L, 0x5c02af71e6d938L), true);
+    }
+
+    private void applyBatch(String table, Op op, int symbolCardinality) throws Exception {
+        final String valueExpr = "(" + op.v0 + " + x)::DOUBLE";
+        execute("INSERT INTO " + table
+                + " SELECT (" + op.startTs + " + x * " + op.step + ")::TIMESTAMP AS ts,"
+                + " 'S' || ((" + op.v0 + " + x) % " + symbolCardinality + ") AS sym,"
+                + " CASE WHEN ((" + op.v0 + " + x) % " + op.nullMod + ") = 0 THEN cast(NULL AS DOUBLE) ELSE " + valueExpr + " END AS value"
+                + " FROM long_sequence(" + op.rows + ")");
+    }
+
+    private void assertCoveredMatchesControl(int symbolCardinality) throws Exception {
+        for (int s = 0; s < symbolCardinality; s++) {
+            final String sym = "S" + s;
+            assertSqlCursors(
+                    "SELECT ts, sym, value FROM ctl WHERE sym = '" + sym + "' ORDER BY value",
+                    "SELECT ts, sym, value FROM t WHERE sym = '" + sym + "' ORDER BY value"
+            );
+            assertSqlCursors(
+                    "SELECT ts, sym FROM ctl WHERE sym = '" + sym + "' AND value IS NULL ORDER BY ts",
+                    "SELECT ts, sym FROM t WHERE sym = '" + sym + "' AND value IS NULL ORDER BY ts"
+            );
+        }
+        assertSqlCursors(
+                "SELECT sym, sum(value), count(value), count(*), min(value), max(value) FROM ctl ORDER BY sym",
+                "SELECT sym, sum(value), count(value), count(*), min(value), max(value) FROM t ORDER BY sym"
+        );
+    }
+
+    private void drainQuietly() {
+        try {
+            drainWalQueue();
+        } catch (Throwable ignore) {
+            // A fault surfaces as a failed apply; recovery is asserted below.
+        }
+    }
+
+    /**
+     * Ascending batches confined to the target day, with an occasional dip
+     * behind its max (a real O3 merge, which must keep taking the reseal path).
+     */
+    private List<Op> precomputeStream(Rnd rnd) {
+        final List<Op> ops = new ArrayList<>();
+        long tsCursor = TARGET_DAY + 1;
+        long valueCursor = 0;
+        final int rounds = 20 + rnd.nextInt(20);
+        for (int round = 0; round < rounds; round++) {
+            final int rows = 50 + rnd.nextInt(500);
+            final long step = 1 + rnd.nextInt(500);
+            final int nullMod = 3 + rnd.nextInt(20);
+            final boolean dip = rnd.nextInt(100) < 12;
+            final long backOff = dip ? Math.min(tsCursor - TARGET_DAY - 1, (long) (1 + rnd.nextInt(5)) * step * rows) : 0;
+            final long startTs = tsCursor - backOff;
+            ops.add(new Op(startTs, valueCursor, rows, step, nullMod));
+            valueCursor += rows;
+            final long batchMaxTs = startTs + (long) rows * step;
+            if (batchMaxTs > tsCursor) {
+                tsCursor = batchMaxTs;
+            }
+            Assert.assertTrue("stream left the target partition", tsCursor < TARGET_DAY + DAY_MICROS);
+        }
+        return ops;
+    }
+
+    private void recover(TableToken tt) {
+        faultFf.disarm();
+        int guard = 0;
+        while (guard++ < 200) {
+            engine.releaseInactive();
+            if (engine.getTableSequencerAPI().isSuspended(tt)) {
+                try {
+                    execute("ALTER TABLE " + tt.getTableName() + " RESUME WAL");
+                } catch (Exception ignore) {
+                    // fall through and retry the drain
+                }
+            }
+            drainQuietly();
+            if (!engine.getTableSequencerAPI().isSuspended(tt)) {
+                return;
+            }
+        }
+    }
+
+    private void resetCoveringCounters() {
+        PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+    }
+
+    private void runFailureFuzz(Rnd rnd, boolean injectFaults) throws Exception {
+        setProperty(PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 10_000_000);
+        setProperty(PropertyKey.CAIRO_WAL_APPLY_LOOK_AHEAD_TXN_COUNT, 2000);
+        setProperty(PropertyKey.CAIRO_WAL_APPLY_TABLE_TIME_QUOTA, 600_000);
+
+        final int symbolCardinality = 3 + rnd.nextInt(14);
+        final List<Op> ops = precomputeStream(rnd);
+        final boolean[] armRound = new boolean[ops.size()];
+        final int[] modeRound = new int[ops.size()];
+        final int[] targetRound = new int[ops.size()];
+        final int[] skipRound = new int[ops.size()];
+        for (int i = 0; i < ops.size(); i++) {
+            armRound[i] = injectFaults && rnd.nextInt(100) < 70;
+            modeRound[i] = rnd.nextInt(4);
+            // 3 = _txn fails the commit AFTER the seal has already published the
+            // appended generation - the one window this path made structurally
+            // different from the reseal it replaces, since a mid partition has no
+            // reopen-time recovery walk to undo the publish.
+            targetRound[i] = rnd.nextInt(5); // 0=.pc, 1=.pv, 2=value.d, 3=_txn, 4=sym.d
+            // Only sym.d is consumed through ff.read (SymbolColumnIndexer#index);
+            // every other target is mmapped, so pairing MODE_READ with them would
+            // latch an fd whose read fault can never fire.
+            if (modeRound[i] == MODE_READ) {
+                targetRound[i] = TARGET_SYM_D;
+            }
+            skipRound[i] = rnd.nextInt(3);
+        }
+
+        assertMemoryLeak(faultFf, () -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+            execute("CREATE TABLE ctl (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+            // Anchor the table max in a LATER day so every batch below appends
+            // into a partition that is not the last one.
+            for (String table : new String[]{"t", "ctl"}) {
+                execute("INSERT INTO " + table + " SELECT (" + (T0 + 3 * DAY_MICROS) + ")::TIMESTAMP,"
+                        + " 'S0', cast(NULL AS DOUBLE) FROM long_sequence(1)");
+            }
+            drainWalQueue();
+            resetCoveringCounters();
+
+            final TableToken tToken = engine.verifyTableName("t");
+
+            // Phase 1: clean oracle.
+            for (int i = 0; i < ops.size(); i++) {
+                applyBatch("ctl", ops.get(i), symbolCardinality);
+            }
+            drainWalQueue();
+
+            // Phase 2: covering table under fault injection + recovery.
+            for (int i = 0; i < ops.size(); i++) {
+                applyBatch("t", ops.get(i), symbolCardinality);
+                if (armRound[i]) {
+                    faultFf.arm(modeRound[i], targetRound[i], skipRound[i]);
+                }
+                drainQuietly();
+                recover(tToken);
+            }
+            recover(tToken);
+
+            Assert.assertFalse("covering table must recover (not suspended)",
+                    engine.getTableSequencerAPI().isSuspended(tToken));
+
+            // Localise a divergence before comparing against the control: is the
+            // covering table's INDEX short (rows the index scan cannot find) or
+            // is its DATA short (rows never applied)?
+            assertSqlCursors(
+                    "SELECT /*+ no_index */ sym, count(*) FROM t ORDER BY sym",
+                    "SELECT sym, count(*) FROM t ORDER BY sym"
+            );
+            assertSqlCursors("SELECT count() FROM ctl", "SELECT count() FROM t");
+
+            assertCoveredMatchesControl(symbolCardinality);
+
+            if (!PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED) {
+                Assert.assertTrue("the mid-partition append path must be exercised (appends="
+                                + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
+                        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+            }
+        });
+    }
+
+    // One precomputed insert batch, replayed into both tables.
+    private static final class Op {
+        final int nullMod;
+        final int rows;
+        final long startTs;
+        final long step;
+        final long v0;
+
+        Op(long startTs, long v0, int rows, long step, int nullMod) {
+            this.startTs = startTs;
+            this.v0 = v0;
+            this.rows = rows;
+            this.step = step;
+            this.nullMod = nullMod;
+        }
+    }
+
+    // Seeded one-shot fault injector over the covering table's index files.
+    // Versioned seal files carry a .{txn} suffix, so match on "contains".
+    private static final class FaultFilesFacade extends TestFilesFacadeImpl {
+        private volatile boolean armed = false;
+        private volatile int mode;
+        private volatile int skip;
+        private volatile long targetFd = -1;
+        private volatile int targetKind;
+
+        void arm(int mode, int targetKind, int skip) {
+            this.mode = mode;
+            this.targetKind = targetKind;
+            this.skip = skip;
+            this.targetFd = -1;
+            this.armed = true;
+        }
+
+        void disarm() {
+            this.armed = false;
+            this.targetFd = -1;
+        }
+
+        @Override
+        public boolean allocate(long fd, long size) {
+            if (armed && mode == MODE_ALLOC && fd == targetFd && targetFd >= 0) {
+                disarm();
+                return false;
+            }
+            return super.allocate(fd, size);
+        }
+
+        @Override
+        public long mmap(long fd, long len, long offset, int flags, int memoryTag) {
+            if (armed && mode == MODE_MMAP && fd == targetFd && targetFd >= 0) {
+                disarm();
+                return -1;
+            }
+            return super.mmap(fd, len, offset, flags, memoryTag);
+        }
+
+        // The covered append path reads the symbol column through openRO + read
+        // (SymbolColumnIndexer#index) rather than the openRW/mmap the reseal
+        // used, so faulting only openRW/mmap/allocate would leave the new I/O
+        // untested.
+        @Override
+        public long openRO(LPSZ name) {
+            if (armed && matches(name)) {
+                if (mode == MODE_OPEN && skip-- <= 0) {
+                    disarm();
+                    return -1;
+                }
+                if (mode == MODE_READ && targetFd < 0 && skip-- <= 0) {
+                    long fd = super.openRO(name);
+                    if (fd >= 0) {
+                        targetFd = fd; // stays armed until the read fires
+                    }
+                    return fd;
+                }
+            }
+            return super.openRO(name);
+        }
+
+        @Override
+        public long openRW(LPSZ name, int opts) {
+            if (armed && matches(name)) {
+                if (mode == MODE_OPEN) {
+                    if (skip-- <= 0) {
+                        disarm();
+                        return -1;
+                    }
+                } else if (targetFd < 0 && skip-- <= 0) {
+                    long fd = super.openRW(name, opts);
+                    if (fd >= 0) {
+                        targetFd = fd;
+                    }
+                    return fd;
+                }
+            }
+            return super.openRW(name, opts);
+        }
+
+        @Override
+        public boolean close(long fd) {
+            // Release the latch: descriptor numbers are recycled, and a stale
+            // targetFd would fault an unrelated file - possibly a WAL segment
+            // that matches() is written to protect.
+            if (fd == targetFd) {
+                targetFd = -1;
+            }
+            return super.close(fd);
+        }
+
+        @Override
+        public long read(long fd, long buf, long len, long offset) {
+            if (armed && mode == MODE_READ && fd == targetFd && targetFd >= 0) {
+                disarm();
+                return -1;
+            }
+            return super.read(fd, buf, len, offset);
+        }
+
+        private boolean matches(LPSZ name) {
+            if (Utf8s.containsAscii(name, "wal")) {
+                return false; // never fault WAL segments
+            }
+            switch (targetKind) {
+                case 0:
+                    return Utf8s.containsAscii(name, ".pc");
+                case 1:
+                    return Utf8s.containsAscii(name, ".pv");
+                case 2:
+                    return Utf8s.containsAscii(name, "value.d");
+                case 3:
+                    // The TABLE's _txn only. "_txn" as a substring also matches
+                    // the sequencer log (txn_seq/_txnlog, _txnlog.meta.*) and
+                    // _txn_scoreboard; faulting those would break the durability
+                    // premise this whole test rests on - that the transaction log
+                    // survives, so the stream must eventually apply in full.
+                    return Utf8s.endsWithAscii(name, "/_txn");
+                default:
+                    // the symbol column the append path re-reads to index its tail
+                    return Utf8s.containsAscii(name, "sym.d");
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendFailureFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendFailureFuzzTest.java
@@ -69,6 +69,9 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
     // Batches land in day 1; day 3 exists from the start, so day 1 is never last.
     private static final long TARGET_DAY = T0 + DAY_MICROS;
     private final FaultFilesFacade faultFf = new FaultFilesFacade();
+    // when set, the table dedups, which disqualifies the fast-lag gate and routes
+    // the appends into the LAST partition through O3
+    private boolean dedup;
 
     @Before
     public void enableCoveringCounters() {
@@ -79,14 +82,33 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
 
     @After
     public void disableCoveringCounters() {
+        dedup = false;
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
         faultFf.disarm();
     }
 
     @Test
     public void testMidPartitionAppendFailureFuzz() throws Exception {
         runFailureFuzz(generateRandom(LOG), true);
+    }
+
+    /**
+     * The same fault injection against the LAST partition. DEDUP disqualifies the
+     * WAL fast-lag gate, so the appends take the O3 route into the last partition
+     * - the route whose index is maintained through the writer's LIVE indexer,
+     * which the seal closes and reopens. A fault there must still converge.
+     */
+    @Test
+    public void testLastPartitionAppendFailureFuzzDedup() throws Exception {
+        dedup = true;
+        runFailureFuzz(generateRandom(LOG), true);
+    }
+
+    @Test
+    public void testLastPartitionAppendFailureFuzzDedupRegression() throws Exception {
+        dedup = true;
+        runFailureFuzz(generateRandom(LOG, 0x7c05b3e1d9a462L, 0x28fa61c7e0b539L), true);
     }
 
     @Test
@@ -108,7 +130,7 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
      */
     @Test
     public void testMidPartitionAppendFailureFuzzResealPathControl() throws Exception {
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         runFailureFuzz(generateRandom(LOG, 0x18b7d3f0a29e64L, 0x5c02af71e6d938L), true);
     }
 
@@ -196,7 +218,7 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
     private void resetCoveringCounters() {
         PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
         PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
     private void runFailureFuzz(Rnd rnd, boolean injectFaults) throws Exception {
@@ -228,15 +250,19 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
         }
 
         assertMemoryLeak(faultFf, () -> {
+            final String dedupClause = dedup ? " DEDUP UPSERT KEYS(ts, sym)" : "";
             execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
-                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL" + dedupClause);
             execute("CREATE TABLE ctl (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, value DOUBLE)"
-                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
-            // Anchor the table max in a LATER day so every batch below appends
-            // into a partition that is not the last one.
-            for (String table : new String[]{"t", "ctl"}) {
-                execute("INSERT INTO " + table + " SELECT (" + (T0 + 3 * DAY_MICROS) + ")::TIMESTAMP,"
-                        + " 'S0', cast(NULL AS DOUBLE) FROM long_sequence(1)");
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL" + dedupClause);
+            if (!dedup) {
+                // Anchor the table max in a LATER day so every batch below appends
+                // into a partition that is not the last one. With dedup there is
+                // deliberately no anchor: the target day IS the last partition.
+                for (String table : new String[]{"t", "ctl"}) {
+                    execute("INSERT INTO " + table + " SELECT (" + (T0 + 3 * DAY_MICROS) + ")::TIMESTAMP,"
+                            + " 'S0', cast(NULL AS DOUBLE) FROM long_sequence(1)");
+                }
             }
             drainWalQueue();
             resetCoveringCounters();
@@ -274,10 +300,10 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
 
             assertCoveredMatchesControl(symbolCardinality);
 
-            if (!PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED) {
+            if (!PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED) {
                 Assert.assertTrue("the mid-partition append path must be exercised (appends="
-                                + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
-                        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                                + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendFailureFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendFailureFuzzTest.java
@@ -226,6 +226,13 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
             }
             skipRound[i] = rnd.nextInt(3);
         }
+        int armed = 0;
+        for (boolean a : armRound) {
+            if (a) {
+                armed++;
+            }
+        }
+        final int armedRounds = armed;
 
         assertMemoryLeak(faultFf, () -> {
             execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
@@ -266,10 +273,17 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
             // Localise a divergence before comparing against the control: is the
             // covering table's INDEX short (rows the index scan cannot find) or
             // is its DATA short (rows never applied)?
-            assertSqlCursors(
-                    "SELECT /*+ no_index */ sym, count(*) FROM t ORDER BY sym",
-                    "SELECT sym, count(*) FROM t ORDER BY sym"
-            );
+            //
+            // Filtered and per-symbol, because an unfiltered keyed group-by
+            // ignores no_index: both sides compile to the same vectorized GroupBy
+            // over a full scan (verified by EXPLAIN), so the unfiltered form
+            // compared a plan with itself and could never localise anything.
+            for (int s = 0; s < symbolCardinality; s++) {
+                assertSqlCursors(
+                        "SELECT /*+ no_index */ ts, sym, value FROM t WHERE sym = 'S" + s + "' ORDER BY ts",
+                        "SELECT ts, sym, value FROM t WHERE sym = 'S" + s + "' ORDER BY ts"
+                );
+            }
             assertSqlCursors("SELECT count() FROM ctl", "SELECT count() FROM t");
 
             assertCoveredMatchesControl(symbolCardinality);
@@ -278,6 +292,20 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
                 Assert.assertTrue("the mid-partition append path must be exercised (appends="
                                 + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
                         PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+            }
+
+            // Without this the run silently degrades into the no-fault control:
+            // arming is only an intent, and every match is by file name, so a
+            // rename or a mode that never reaches its callsite would leave the
+            // whole crash-safety premise untested while everything above stays
+            // green. Require a real fraction of the armed rounds to have fired,
+            // not merely one - a single fire would satisfy ">0" while the other
+            // modes were all inert (which is exactly how the MODE_READ latch bug
+            // hid).
+            if (injectFaults) {
+                Assert.assertTrue("faults were armed but never fired (armed=" + armedRounds
+                                + ", fired=" + faultFf.fired() + ')',
+                        faultFf.fired() >= Math.max(1, armedRounds / 4));
             }
         });
     }
@@ -302,6 +330,7 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
     // Seeded one-shot fault injector over the covering table's index files.
     // Versioned seal files carry a .{txn} suffix, so match on "contains".
     private static final class FaultFilesFacade extends TestFilesFacadeImpl {
+        private final java.util.concurrent.atomic.AtomicInteger firedCount = new java.util.concurrent.atomic.AtomicInteger();
         private volatile boolean armed = false;
         private volatile int mode;
         private volatile int skip;
@@ -321,10 +350,23 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
             this.targetFd = -1;
         }
 
+        // Arming is not firing. Every arm site below can silently fail to match -
+        // a renamed file, a mode that never reaches its callsite, a stale latch -
+        // and the run then degrades into the no-fault control while still passing
+        // every assertion. Count the fires so that cannot happen unnoticed.
+        void fire() {
+            firedCount.incrementAndGet();
+            disarm();
+        }
+
+        int fired() {
+            return firedCount.get();
+        }
+
         @Override
         public boolean allocate(long fd, long size) {
             if (armed && mode == MODE_ALLOC && fd == targetFd && targetFd >= 0) {
-                disarm();
+                fire();
                 return false;
             }
             return super.allocate(fd, size);
@@ -333,7 +375,7 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
         @Override
         public long mmap(long fd, long len, long offset, int flags, int memoryTag) {
             if (armed && mode == MODE_MMAP && fd == targetFd && targetFd >= 0) {
-                disarm();
+                fire();
                 return -1;
             }
             return super.mmap(fd, len, offset, flags, memoryTag);
@@ -347,7 +389,7 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
         public long openRO(LPSZ name) {
             if (armed && matches(name)) {
                 if (mode == MODE_OPEN && skip-- <= 0) {
-                    disarm();
+                    fire();
                     return -1;
                 }
                 if (mode == MODE_READ && targetFd < 0 && skip-- <= 0) {
@@ -366,10 +408,16 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
             if (armed && matches(name)) {
                 if (mode == MODE_OPEN) {
                     if (skip-- <= 0) {
-                        disarm();
+                        fire();
                         return -1;
                     }
-                } else if (targetFd < 0 && skip-- <= 0) {
+                } else if ((mode == MODE_MMAP || mode == MODE_ALLOC) && targetFd < 0 && skip-- <= 0) {
+                    // Restricted to the mmap/alloc modes. Latching here for
+                    // MODE_READ too meant the writer's own openRW of sym.d (which
+                    // happens long before the seal's openRO) claimed the latch,
+                    // openRO's MODE_READ branch was then skipped, and the read
+                    // fault could no longer fire - so the SymbolColumnIndexer
+                    // short-read path was armed far more often than it was hit.
                     long fd = super.openRW(name, opts);
                     if (fd >= 0) {
                         targetFd = fd;
@@ -394,7 +442,7 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
         @Override
         public long read(long fd, long buf, long len, long offset) {
             if (armed && mode == MODE_READ && fd == targetFd && targetFd >= 0) {
-                disarm();
+                fire();
                 return -1;
             }
             return super.read(fd, buf, len, offset);


### PR DESCRIPTION
Fixes the covering POSTING index paying a full `rebuildSidecars()` of the partition on **every** commit that appends into an existing partition — first for mid partitions, then for the last partition on the routes where the WAL fast-lag gate does not apply.

Originally two stacked PRs; #7517 is folded in here. Stacked on a non-master base the Azure pipeline never triggered, so the last-partition half had zero CI test coverage — one PR into master gets the full suite.

## The problem

With partitions A and C present, writing into B goes through the O3 route. The O3 copy phase maintained the covering index inline, and the trailing seal then rebuilt the whole partition's sidecars — O(partition) per commit, on a pure append.

The same pathology survives on the **last** partition whenever fast-lag is disqualified, which is not a corner case:

- `DEDUP UPSERT KEYS(...)` disqualifies both halves of the gate (block-apply tests `isCommitPlainInsert()`, single-txn tests `!isCommitDedupMode()`)
- concurrent clients disqualify it through multi-segment blocks

## The change

`isCoveredAppendSealedByWriter()` tells `O3PartitionJob` to skip indexing a covering column during the copy phase; the trailing seal instead appends the tail — `configureCovering` → `openRO(dFile)` → `indexer.index(ff, dataFd, appendFromRow, partitionSize)` → `commit()` → `sealIfMultiGen(threshold)` — and skips the rebuild.

Gated by `canAppendCovered()`: kill-switch, `canSkipRebuild`, `appendFromRow` in range, `getMaxValue() + 1 == appendFromRow`, `getHeadTxnAtSeal() <= committedTxn`, and a non-legacy head. The guard also requires the column to already hold rows in the partition (`columnTop != -1 && columnTop < partitionSizeBeforeAppend`) — a partition skipped by `ADD COLUMN` / `ADD INDEX` has no `.pk`, and without this the seal throws and permanently suspends the WAL table.

## Measurements

1000-row commits, unique ascending timestamps (nothing is actually deduplicated — the commits stay pure appends):

| arm | before | after |
|---|---|---|
| mid partition | 3.0 ms | 2.4 ms |
| **last partition, DEDUP** | **30.9 ms, 1.00 reseal/commit** | **3.0 ms, 0 reseals** |
| last partition, plain (fast-lag qualifies) | 2.6 ms, 0 reseals | 2.5 ms, 0 reseals *(path untouched)* |

Enabling dedup no longer costs an order of magnitude on ingest.

## What this is not

An earlier draft called the last-partition half a correctness fix, on the grounds that the covered fragment written during the copy phase is speculative — column tasks run in parallel, so the indexed column's `updateIndex` can precede the covered column's own append, and the reseal is what repaired it. The reseal is genuinely load-bearing on the old code (skipping it there yields `0.0` where `8.0` was written), but the speculative entry is tagged `getTxn() + 1` and superseded before the commit lands, so **no reader can observe it**. This removes a wasted write and the reseal it silently depended on — not a user-visible bug.

## Also fixed here: a pre-existing `NATIVE_O3` leak

Strengthening the fault injector (the `openRW` fd latch was claiming `MODE_READ`, so the seal's `openRO` never armed) exposed a real leak in the DEDUP O3 merge path:

```java
tempIndexAddr = Unsafe.malloc(tempIndexSize, NATIVE_O3);
dedupRows = getDedupRows(..., tempIndexAddr);   // opens the key column — can throw
timestampMergeIndexAddr = Unsafe.realloc(tempIndexAddr, ...);
```

`getDedupRows` opens the partition's dedup key column, so it throws on a full disk, an exhausted fd limit or an I/O error. Until the realloc the buffer is reachable only through the local — the enclosing handler frees `timestampMergeIndexAddr`, still `0`. Every failed merge commit leaked `mergeRowCount * 16` bytes permanently, on a path a retrying WAL apply can take repeatedly. Any `DEDUP UPSERT KEYS` table with a non-timestamp key is affected.

Fixed by publishing the allocation before anything that can throw, so the existing cleanup owns it by construction. `O3DedupMergeIndexLeakTest` reproduces it deterministically — without the fix it reports exactly the 16000 bytes the merge index allocated.

## Tests

New: `MidPartitionAppendCoveringSealTest`, `MidPartitionAppendNewColumnTest`, `MidPartitionAppendFaultRecoveryTest`, `LastPartitionO3AppendCoveringTest`, `MidPartitionAppendCoverageGapsTest`, `MidPartitionAppendSplitDeclineTest`, `O3DedupMergeIndexLeakTest`, and differential / concurrent-read / failure fuzz classes.

Coverage deliberately includes the contexts these paths never otherwise reach: parallel O3 (verified by instrumentation to run the guard on four distinct worker threads), `BYPASS WAL`, a parquet partition present, O3 partition split (which must decline), two indexed covering columns with a staggered `ADD INDEX`, and var-size STRING/VARCHAR covered columns — the last being the incremental aux-index arithmetic, the largest piece of genuinely new write logic.

Every one of those carries a setup discriminator, because three of them first passed while testing nothing: the split test produced no splits at all, and the parquet and two-column tests asserted nothing about the path firing.

11 pre-existing tests that assert the per-commit `.pv` rotation this removes are not pinned to the old path; they set the gen threshold to 0, which restores the rotation **through the new path**.

Local: 2371 tests green across covering, posting, O3, WAL, dedup, TableWriter and IndexBuilder suites.
