### PR TITLE
perf(core): stop resealing the last partition on a covering-index append

### DIFF
--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -3367,8 +3367,11 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                 // the predicate so this can never skip a column the sweep would
                 // then ignore (which would silently lose the appended rows).
                 final boolean isIndexed = metadata.isColumnIndexed(i)
-                        && !(isOpenColumnModeForAppend(openColumnMode)
-                        && openColumnMode != OPEN_NEW_PARTITION_FOR_APPEND
+                        // Spelled out rather than "every append mode except NEW": a
+                        // future append mode added to isOpenColumnModeForAppend would
+                        // otherwise be opted into deferral silently, which fails open.
+                        && !((openColumnMode == OPEN_MID_PARTITION_FOR_APPEND
+                        || openColumnMode == OPEN_LAST_PARTITION_FOR_APPEND)
                         && tableWriter.isCoveredAppendSealedByWriter(i, partitionTimestamp, srcDataMax));
                 final int indexBlockCapacity = isIndexed ? metadata.getIndexValueBlockCapacity(i) : -1;
                 final byte indexType = metadata.getColumnIndexType(i);

--- a/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
+++ b/core/src/main/java/io/questdb/cairo/O3PartitionJob.java
@@ -3354,7 +3354,7 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                 }
 
                 final CharSequence columnName = metadata.getColumnName(i);
-                // A COVERING posting index on a pure append into an existing mid
+                // A COVERING posting index on a pure append into an EXISTING
                 // partition is indexed by the trailing seal sweep
                 // (TableWriter#sealPostingIndexForPartition), not here: the pool
                 // IndexWriter has no covering configuration, so postings it writes
@@ -3367,7 +3367,8 @@ public class O3PartitionJob extends AbstractQueueConsumerJob<O3PartitionTask> {
                 // the predicate so this can never skip a column the sweep would
                 // then ignore (which would silently lose the appended rows).
                 final boolean isIndexed = metadata.isColumnIndexed(i)
-                        && !(openColumnMode == OPEN_MID_PARTITION_FOR_APPEND
+                        && !(isOpenColumnModeForAppend(openColumnMode)
+                        && openColumnMode != OPEN_NEW_PARTITION_FOR_APPEND
                         && tableWriter.isCoveredAppendSealedByWriter(i, partitionTimestamp, srcDataMax));
                 final int indexBlockCapacity = isIndexed ? metadata.getIndexValueBlockCapacity(i) : -1;
                 final byte indexType = metadata.getColumnIndexType(i);

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -7780,7 +7780,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * {@code indexers} and {@code metadata} are stable for the duration.
      */
     boolean isCoveredAppendSealedByWriter(int columnIndex, long partitionTimestamp, long partitionSizeBeforeAppend) {
-        if (PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED) {
+        if (PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED) {
             return false;
         }
         if (columnIndex >= indexers.size() || indexers.getQuick(columnIndex) == null) {
@@ -10277,7 +10277,18 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                             final int colOffset = TableWriter.getPrimaryColumnIndex(i);
                             final boolean notTheTimestamp = i != timestampIndex;
                             final CharSequence columnName = metadata.getColumnName(i);
-                            final int indexBlockCapacity = metadata.isColumnIndexed(i) ? metadata.getIndexValueBlockCapacity(i) : -1;
+                            // Same deferral as the O3 worker path: a COVERING posting
+                            // index is maintained by the trailing seal instead, from
+                            // FINAL column data. Here that is a correctness gain as
+                            // well as a cost one - the covered fragment this route
+                            // writes during the copy phase is speculative, because
+                            // the indexed column's task can run before the covered
+                            // column's own append lands, and it is the trailing
+                            // rebuildSidecars that repairs it today.
+                            final boolean deferCovered = isCoveredAppendSealedByWriter(i, partitionTimestamp, srcDataMax);
+                            final int indexBlockCapacity = !deferCovered && metadata.isColumnIndexed(i)
+                                    ? metadata.getIndexValueBlockCapacity(i)
+                                    : -1;
                             final IndexWriter indexWriter = indexBlockCapacity > -1 ? getIndexWriter(i) : null;
                             final MemoryR oooMem1 = o3Columns.getQuick(colOffset);
                             final MemoryR oooMem2 = o3Columns.getQuick(colOffset + 1);
@@ -13883,7 +13894,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      * duplicates it dropped were identical to the rows they replaced.
      */
     private static boolean canAppendCovered(ColumnIndexer indexer, boolean canSkipRebuild, long appendFromRow, long partitionSize, long committedTxn) {
-        if (PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED) {
+        if (PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED) {
             return false;
         }
         if (!canSkipRebuild || appendFromRow < 0 || appendFromRow >= partitionSize) {
@@ -14024,6 +14035,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 if (hasCovering) {
                     int coverCount = coveringCols.size();
 
+                    // Read BEFORE configureFollowerAndWriter: its of() calls close(),
+                    // which releases resources without flushing pending add()s. Any
+                    // pending entry means the persisted chain is not the whole
+                    // truth, so the tail append must not be trusted to complete it.
+                    final boolean hadPendingEntries = indexer.getWriter() instanceof PostingIndexWriter pending
+                            && pending.hasPendingEntries();
                     try {
                         mapCoveringColumnsForSeal(coveringCols, partitionTimestamp, plen, coverCount);
 
@@ -14041,7 +14058,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         // Fold the fd-based O3 tentative state into
                         // the writer view before the reseal.
                         indexer.mergeTentativeIntoActiveIfAny();
-                        final boolean appendCovered = canAppendCovered(indexer, canSkipRebuild, appendFromRow, partitionSize, txWriter.getTxn());
+                        final boolean appendCovered = !hadPendingEntries
+                                && canAppendCovered(indexer, canSkipRebuild, appendFromRow, partitionSize, txWriter.getTxn());
                         if (appendCovered) {
                             // Pure append into an existing partition. O3 left the
                             // appended rows unindexed for this column (see
@@ -14069,7 +14087,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                             indexer.getWriter().commit();
                             indexer.getWriter().sealIfMultiGen(configuration.getPostingSealGenThreshold());
                             if (PostingIndexWriter.COVERING_COUNTERS_ENABLED) {
-                                PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.incrementAndGet();
+                                PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.incrementAndGet();
                             }
                         } else if (canSkipRebuild && !indexDeferredToSeal
                                 && indexer.getWriter().getMaxValue() + 1 >= partitionSize) {

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -103,6 +103,7 @@ import io.questdb.std.Files;
 import io.questdb.std.FilesFacade;
 import io.questdb.std.FindVisitor;
 import io.questdb.std.IntIntHashMap;
+import io.questdb.std.IntHashSet;
 import io.questdb.std.IntList;
 import io.questdb.std.IntObjHashMap;
 import io.questdb.std.Long256;
@@ -267,6 +268,12 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
     // monitor: O3 workers add concurrently, the sweep reads single-threaded
     // after they join.
     private final LongHashSet o3CoveringDeferredPartitions = new LongHashSet();
+    // Columns whose posting indexer still held unflushed add() calls when the seal
+    // sweep STARTED. Snapshotted there rather than read per partition: the sweep
+    // reopens each partition's indexer in turn, and that reopen (of() -> close())
+    // drops pending entries without flushing them - so by the time a later
+    // partition is sealed the state the guard needs to see is already gone.
+    private final IntHashSet o3PendingIndexersAtSweepStart = new IntHashSet();
     private final ObjectPool<O3MutableAtomicInteger> o3ColumnCounters = new ObjectPool<>(O3MutableAtomicInteger::new, 64);
     private final int o3ColumnMemorySize;
     private final ObjList<MemoryCR> o3ColumnOverrides;
@@ -10279,12 +10286,14 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                             final CharSequence columnName = metadata.getColumnName(i);
                             // Same deferral as the O3 worker path: a COVERING posting
                             // index is maintained by the trailing seal instead, from
-                            // FINAL column data. Here that is a correctness gain as
-                            // well as a cost one - the covered fragment this route
-                            // writes during the copy phase is speculative, because
-                            // the indexed column's task can run before the covered
-                            // column's own append lands, and it is the trailing
-                            // rebuildSidecars that repairs it today.
+                            // FINAL column data. The fragment this route writes during
+                            // the copy phase is speculative - the indexed column's task
+                            // can run before the covered column's own append lands - and
+                            // the trailing rebuildSidecars is what repairs it. That
+                            // repair is not observable today (the speculative entry is
+                            // tagged getTxn()+1 and is superseded before the commit
+                            // lands), so this removes a wasted write and the reseal it
+                            // silently required, rather than fixing a live defect.
                             final boolean deferCovered = isCoveredAppendSealedByWriter(i, partitionTimestamp, srcDataMax);
                             final int indexBlockCapacity = !deferCovered && metadata.isColumnIndexed(i)
                                     ? metadata.getIndexValueBlockCapacity(i)
@@ -14035,12 +14044,16 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 if (hasCovering) {
                     int coverCount = coveringCols.size();
 
-                    // Read BEFORE configureFollowerAndWriter: its of() calls close(),
-                    // which releases resources without flushing pending add()s. Any
-                    // pending entry means the persisted chain is not the whole
-                    // truth, so the tail append must not be trusted to complete it.
-                    final boolean hadPendingEntries = indexer.getWriter() instanceof PostingIndexWriter pending
-                            && pending.hasPendingEntries();
+                    // From the pre-sweep snapshot, NOT from the live writer: by the
+                    // time a later partition is sealed, an earlier partition's
+                    // configureFollowerAndWriter -> of() -> close() has already
+                    // dropped the pending entries this needs to see, so reading it
+                    // here would return false in exactly the multi-partition commit
+                    // where it matters. A pending entry means the persisted chain is
+                    // not the whole truth (close() discards it without flushing,
+                    // while setMaxValue has already advanced the head), so the tail
+                    // append must not be trusted to complete it.
+                    final boolean hadPendingEntries = o3PendingIndexersAtSweepStart.contains(colIdx);
                     try {
                         mapCoveringColumnsForSeal(coveringCols, partitionTimestamp, plen, coverCount);
 
@@ -14058,6 +14071,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                         // Fold the fd-based O3 tentative state into
                         // the writer view before the reseal.
                         indexer.mergeTentativeIntoActiveIfAny();
+                        if (hadPendingEntries && PostingIndexWriter.COVERING_COUNTERS_ENABLED) {
+                            PostingIndexWriter.COVERING_SEAL_APPEND_PENDING_DECLINE_COUNT.incrementAndGet();
+                        }
                         final boolean appendCovered = !hadPendingEntries
                                 && canAppendCovered(indexer, canSkipRebuild, appendFromRow, partitionSize, txWriter.getTxn());
                         if (appendCovered) {
@@ -14228,14 +14244,34 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
     private void sealPostingIndexesForO3Partitions() {
         assert o3PartitionUpdRemaining.get() == 0 : "posting seal sweep ran with O3 partition workers in flight";
+        snapshotPendingPostingIndexers();
         try {
             sealPostingIndexesForO3Partitions0();
         } finally {
+            o3PendingIndexersAtSweepStart.clear();
             // Consume the deferral records here, not inside the sweep: the early
             // returns below would otherwise carry a stale partition into the next
             // commit, and a throw must not leave one behind either. A retried
             // commit re-dispatches O3, which re-adds whatever it defers again.
             clearO3CoveringDeferredPartitions();
+        }
+    }
+
+    /**
+     * Record which posting indexers hold unflushed add() calls before the sweep
+     * touches any of them. Read per column afterwards: a writer that still had
+     * pending entries cannot have its persisted chain treated as the whole truth,
+     * because the sweep's own reopen discards them (close() does not flush).
+     */
+    private void snapshotPendingPostingIndexers() {
+        o3PendingIndexersAtSweepStart.clear();
+        for (int i = 0, n = indexers.size(); i < n; i++) {
+            ColumnIndexer indexer = indexers.getQuick(i);
+            if (indexer != null
+                    && indexer.getWriter() instanceof PostingIndexWriter piw
+                    && piw.hasPendingEntries()) {
+                o3PendingIndexersAtSweepStart.add(i);
+            }
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -138,7 +138,7 @@ public class PostingIndexWriter implements IndexWriter {
     // Plain (non-volatile) boolean, like the flags above: tests flip it on the
     // thread that then applies the WAL synchronously.
     @TestOnly
-    public static boolean COVERING_MIDPART_APPEND_DISABLED = false;
+    public static boolean COVERING_SEAL_APPEND_DISABLED = false;
     // @TestOnly: number of times the O3 seal sweep updated a COVERING index by
     // indexing only the appended range and publishing an incremental covered
     // fragment, instead of resealing the partition. Lets a test assert the path
@@ -146,7 +146,7 @@ public class PostingIndexWriter implements IndexWriter {
     // (which is also true when nothing happened at all). Gated by
     // COVERING_COUNTERS_ENABLED like the others.
     @TestOnly
-    public static final java.util.concurrent.atomic.AtomicLong COVERING_MIDPART_APPEND_COUNT = new java.util.concurrent.atomic.AtomicLong();
+    public static final java.util.concurrent.atomic.AtomicLong COVERING_SEAL_APPEND_COUNT = new java.util.concurrent.atomic.AtomicLong();
     // @TestOnly: how many times TableWriter.tryFastAppendInOrderBlock actually
     // committed a block. Distinct from COVERING_FASTLAG_COMMIT_COUNT, which counts
     // the SHARED fast-lag covered publish that the pre-existing single-txn path
@@ -1005,6 +1005,18 @@ public class PostingIndexWriter implements IndexWriter {
      * decide what is already indexed must instead treat it as untrustworthy and
      * rebuild.
      */
+    /**
+     * True when the writer holds {@code add()} calls that have not been flushed
+     * to a generation yet. {@code close()} deliberately does NOT flush them, so
+     * any caller about to reopen this writer (which the seal does, via
+     * configureFollowerAndWriter) would drop them. A caller that relies on the
+     * persisted chain being the whole truth must therefore refuse to do so while
+     * this is true.
+     */
+    public boolean hasPendingEntries() {
+        return hasPendingData;
+    }
+
     public long getHeadTxnAtSeal() {
         if (!keyMem.isOpen() || !chain.hasHead()) {
             return -1L;

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -147,6 +147,13 @@ public class PostingIndexWriter implements IndexWriter {
     // COVERING_COUNTERS_ENABLED like the others.
     @TestOnly
     public static final java.util.concurrent.atomic.AtomicLong COVERING_SEAL_APPEND_COUNT = new java.util.concurrent.atomic.AtomicLong();
+    // @TestOnly: number of times the seal DECLINED the covered append because the
+    // writer still held unflushed add() calls. Without a counter that branch is
+    // unobservable, so nothing can tell its presence from its absence - and it
+    // guards a silent-row-loss case (close() drops pending entries). Tests assert
+    // it stays 0; if a workload ever trips it, that assertion is how we find out.
+    @TestOnly
+    public static final java.util.concurrent.atomic.AtomicLong COVERING_SEAL_APPEND_PENDING_DECLINE_COUNT = new java.util.concurrent.atomic.AtomicLong();
     // @TestOnly: how many times TableWriter.tryFastAppendInOrderBlock actually
     // committed a block. Distinct from COVERING_FASTLAG_COMMIT_COUNT, which counts
     // the SHARED fast-lag covered publish that the pre-existing single-txn path
@@ -1005,18 +1012,6 @@ public class PostingIndexWriter implements IndexWriter {
      * decide what is already indexed must instead treat it as untrustworthy and
      * rebuild.
      */
-    /**
-     * True when the writer holds {@code add()} calls that have not been flushed
-     * to a generation yet. {@code close()} deliberately does NOT flush them, so
-     * any caller about to reopen this writer (which the seal does, via
-     * configureFollowerAndWriter) would drop them. A caller that relies on the
-     * persisted chain being the whole truth must therefore refuse to do so while
-     * this is true.
-     */
-    public boolean hasPendingEntries() {
-        return hasPendingData;
-    }
-
     public long getHeadTxnAtSeal() {
         if (!keyMem.isOpen() || !chain.hasHead()) {
             return -1L;
@@ -1046,6 +1041,18 @@ public class PostingIndexWriter implements IndexWriter {
      * a fresh format-1 entry, migrating the head; subsequent block-applies see a
      * format-1 head and fast-path. Cheap: one mapped int read.
      */
+    /**
+     * True when the writer holds {@code add()} calls that have not been flushed
+     * to a generation yet. {@code close()} deliberately does NOT flush them, so
+     * any caller about to reopen this writer (which the seal does, via
+     * configureFollowerAndWriter) would drop them. A caller that relies on the
+     * persisted chain being the whole truth must therefore refuse to do so while
+     * this is true.
+     */
+    public boolean hasPendingEntries() {
+        return hasPendingData;
+    }
+
     public boolean isHeadCoveringFormatLegacy() {
         // Self-contained property of the on-disk head entry (independent of the
         // writer's live coverCount, which may be unconfigured at gate time): a

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -102,7 +102,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @After
     public void resetMidPartitionAppendPin() {
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
     }
 
     @Override
@@ -1731,6 +1731,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      */
     @Test
     public void testIncrementalSealDistrustsRecreatedSidecar() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_rb_orphan (
@@ -1810,6 +1817,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      */
     @Test
     public void testIncrementalSealLastCleanStrideStopsAtSentinel() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_tail (
@@ -2082,6 +2096,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      */
     @Test
     public void testIncrementalSealRejectsOverflowingSidecarSentinel() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             execute("""
                     CREATE TABLE t_ovf (
@@ -2460,6 +2481,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testO3DeferredPostingSealPurgeRunsAfterCommit() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -2502,6 +2524,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testO3DeferredPostingSealPurgePersistsOnCloseWhenJobHoldsLogWriter() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -2573,6 +2602,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testO3DeferredPostingSealPurgePersistsOnCloseWhenQueueIsFull() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -2629,6 +2665,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testO3DeferredPostingSealPurgePersistsMultipleReadyEntriesOnCloseWhenQueueIsFull() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -2754,6 +2797,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testCommitSeqTxnPublishesReadyDeferredPostingSealPurgeRetainedByFullQueue() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -2813,6 +2863,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      */
     @Test
     public void testCloseWithLivePurgeJobSpillsReadyDeferredPostingSealPurgeWhenQueueIsFull() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -2882,6 +2939,13 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
      */
     @Test
     public void testCloseWithLivePurgeJobSpillsMultipleReadyDeferredPostingSealPurgesAndReplaysOnReopen() throws Exception {
+        // A pure append into an existing partition now maintains the covering
+        // index incrementally and defers compaction, so it no longer rotates .pv
+        // on every commit - which is the rotation this test's assertions are
+        // written around. Compact on every generation instead of pinning the old
+        // path: the rotation (and the purge it queues) is restored, and the test
+        // keeps exercising the CURRENT path rather than a frozen one.
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;
@@ -3055,7 +3119,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         // the same files (they stay live, nothing to purge), and forcing a merge
         // instead would rewrite the partition into a new directory - making the
         // "files are gone" assertion pass for the wrong reason.
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
         node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 20);
         node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 20);
@@ -3125,7 +3189,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     public void testAttachDetachForceRemoveKeepRetainedDeferredPostingSealPurgeAcrossCommits() throws Exception {
         // Pinned to the reseal path for the same reason as the squash variant
         // above: the purge assertion needs the O3 insert to rotate .pv/.pc.
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         node1.setProperty(PropertyKey.CAIRO_ATTACH_PARTITION_SUFFIX, DETACHED_DIR_MARKER);
 
         assertMemoryLeak(() -> {
@@ -5456,7 +5520,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
         // be built there; forcing a merge instead is not equivalent either -
         // a merge rewrites the partition into a new directory, and the
         // chain-head checks below read the un-suffixed one.
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         assertMemoryLeak(ff, () -> {
             // sym carries an explicit INCLUDE (ts) so the index is covering:
             // the test arms a fault on the second seal-time .pv rotation, which
@@ -10465,6 +10529,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
 
     @Test
     public void testWalO3DeferredPostingSealPurgeRunsAfterCommit() throws Exception {
+        node1.setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 0);
         assertMemoryLeak(() -> {
             if (configuration.disableColumnPurgeJob()) {
                 return;

--- a/core/src/test/java/io/questdb/test/cairo/covering/LastPartitionO3AppendCoveringTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/LastPartitionO3AppendCoveringTest.java
@@ -1,0 +1,176 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.covering;
+
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * The LAST partition's covering index when the WAL fast-lag gate does NOT apply.
+ * <p>
+ * Fast-lag handles a pure append into the last partition, but only when the
+ * commit qualifies. DEDUP disqualifies both halves of the gate - the block-apply
+ * gate tests {@code isCommitPlainInsert()} and the single-txn gate tests
+ * {@code !isCommitDedupMode()} - so a deduped table's appends fall back to the O3
+ * route while remaining pure appends (the timestamps here are unique and
+ * ascending, so nothing is actually deduplicated). Concurrent clients hit the
+ * same fallback through multi-segment blocks, without any dedup configuration.
+ * <p>
+ * On that route the index was maintained during the O3 copy phase, which had two
+ * consequences: every commit then paid a full {@code rebuildSidecars()} of the
+ * partition, AND the covered fragment written during the copy was speculative -
+ * the indexed column's task can run before the covered column's own append lands,
+ * so the reseal was what repaired it. Deferring the covering index to the seal,
+ * which runs after every column task has joined, removes both: the fragment is
+ * built once, from final column data.
+ */
+public class LastPartitionO3AppendCoveringTest extends AbstractCairoTest {
+
+    private static final int COMMITS = 12;
+    private static final int ROWS_PER_COMMIT = 500;
+    private static final int SEED_ROWS = 5000;
+
+    @Before
+    public void enableCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
+        PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
+    }
+
+    @After
+    public void disableCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
+    }
+
+    /**
+     * Correctness must not depend on the new path: the same stream with the path
+     * switched off has to produce the same reads.
+     */
+    @Test
+    public void testDedupLastPartitionCorrectOnResealPath() throws Exception {
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
+        assertMemoryLeak(() -> {
+            createTables(true);
+            appendAndAssert();
+        });
+    }
+
+    @Test
+    public void testDedupLastPartitionTakesAppendPath() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables(true);
+            PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
+
+            appendAndAssert();
+
+            Assert.assertEquals("a pure append into the last partition must not full-reseal",
+                    0, PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get());
+            Assert.assertTrue("the covered append path must fire (appends="
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
+        });
+    }
+
+    /**
+     * With real duplicates the commit is no longer a pure append (rows are
+     * replaced), so it must fall back to the rebuild and still read correctly.
+     */
+    @Test
+    public void testDedupWithRealDuplicatesStillCorrect() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables(true);
+            for (int c = 0; c < COMMITS; c++) {
+                // half the batch repeats timestamps already written
+                final long base = SEED_ROWS + (long) c * ROWS_PER_COMMIT;
+                insertBoth(base, ROWS_PER_COMMIT);
+                insertBoth(base - ROWS_PER_COMMIT / 2, ROWS_PER_COMMIT / 2);
+                drainWalQueue();
+            }
+            assertNotSuspended();
+            assertCoveredMatchesControl();
+        });
+    }
+
+    private void appendAndAssert() throws Exception {
+        for (int c = 0; c < COMMITS; c++) {
+            insertBoth(SEED_ROWS + (long) c * ROWS_PER_COMMIT, ROWS_PER_COMMIT);
+            drainWalQueue();
+        }
+        assertNotSuspended();
+        assertCoveredMatchesControl();
+
+        // and again after a reopen, so the published fragments are proven durable
+        engine.releaseInactive();
+        assertCoveredMatchesControl();
+    }
+
+    private void assertCoveredMatchesControl() throws Exception {
+        for (int s = 0; s < 8; s++) {
+            final String sym = "S" + s;
+            assertSqlCursors(
+                    "SELECT ts, sym, value FROM ctl WHERE sym = '" + sym + "' ORDER BY ts",
+                    "SELECT ts, sym, value FROM t WHERE sym = '" + sym + "' ORDER BY ts"
+            );
+        }
+        assertSqlCursors(
+                "SELECT sym, count(*), sum(value), min(value), max(value) FROM ctl ORDER BY sym",
+                "SELECT sym, count(*), sum(value), min(value), max(value) FROM t ORDER BY sym"
+        );
+        // index scan vs the column itself, which localises a missing tail
+        assertSqlCursors(
+                "SELECT /*+ no_index */ sym, count(*) FROM t ORDER BY sym",
+                "SELECT sym, count(*) FROM t ORDER BY sym"
+        );
+    }
+
+    private void assertNotSuspended() {
+        Assert.assertFalse("t suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("t")));
+        Assert.assertFalse("ctl suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("ctl")));
+    }
+
+    private void createTables(boolean dedup) throws Exception {
+        final String dedupClause = dedup ? " DEDUP UPSERT KEYS(ts, sym)" : "";
+        execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                + " TIMESTAMP(ts) PARTITION BY DAY WAL" + dedupClause);
+        execute("CREATE TABLE ctl (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, value DOUBLE)"
+                + " TIMESTAMP(ts) PARTITION BY DAY WAL" + dedupClause);
+        insertBoth(0, SEED_ROWS);
+        drainWalQueue();
+    }
+
+    private void insertBoth(long base, int rows) throws Exception {
+        final String tail = " SELECT dateadd('u', (" + base + " + x)::INT, '2024-01-01T00:00:00Z'::TIMESTAMP),"
+                + " 'S' || ((" + base + " + x) % 8), (" + base + " + x)::DOUBLE"
+                + " FROM long_sequence(" + rows + ")";
+        execute("INSERT INTO t" + tail);
+        execute("INSERT INTO ctl" + tail);
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/covering/LastPartitionO3AppendCoveringTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/LastPartitionO3AppendCoveringTest.java
@@ -24,6 +24,8 @@
 
 package io.questdb.test.cairo.covering;
 
+import io.questdb.PropertyKey;
+import io.questdb.cairo.PostingSealPurgeJob;
 import io.questdb.cairo.idx.PostingIndexWriter;
 import io.questdb.test.AbstractCairoTest;
 import org.junit.After;
@@ -61,6 +63,7 @@ public class LastPartitionO3AppendCoveringTest extends AbstractCairoTest {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
         PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
         PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_PENDING_DECLINE_COUNT.set(0);
     }
 
     @After
@@ -116,6 +119,65 @@ public class LastPartitionO3AppendCoveringTest extends AbstractCairoTest {
             }
             assertNotSuspended();
             assertCoveredMatchesControl();
+        });
+    }
+
+    /**
+     * The O3PartitionJob half of the deferral (the merge-collapses-to-append
+     * degradation that yields OPEN_LAST_PARTITION_FOR_APPEND) is a DIFFERENT
+     * production path from the writer's inline append branch, and the other tests
+     * here all take the inline one. Route A requires the batch to start strictly
+     * after the partition max under dedup, so a batch whose first row repeats the
+     * max timestamp is refused by it and goes through the merge instead - where
+     * dedup drops the duplicate and the merge collapses to an append.
+     */
+    @Test
+    public void testDedupMergeCollapseTakesAppendPath() throws Exception {
+        assertMemoryLeak(() -> {
+            createTables(true);
+            PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
+
+            for (int c = 0; c < COMMITS; c++) {
+                final long base = SEED_ROWS + (long) c * ROWS_PER_COMMIT;
+                // first row repeats the current max timestamp (a real duplicate),
+                // the rest extend past it
+                insertBoth(base - 1, ROWS_PER_COMMIT + 1);
+                drainWalQueue();
+            }
+
+            assertNotSuspended();
+            assertCoveredMatchesControl();
+            Assert.assertTrue("the merge-collapse route must reach the covered append path (appends="
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
+        });
+    }
+
+    /**
+     * Deferred compaction has to actually fire on this route too: at the shipped
+     * threshold COMMITS would never reach it, so this would otherwise prove only
+     * that nothing happened. Also checks the superseded files are reclaimed once
+     * the purge job runs.
+     */
+    @Test
+    public void testLastPartitionAppendCompactsAndReclaims() throws Exception {
+        setProperty(PropertyKey.CAIRO_POSTING_SEAL_GEN_THRESHOLD, 3);
+        assertMemoryLeak(() -> {
+            createTables(true);
+            appendAndAssert();
+
+            try (PostingSealPurgeJob purgeJob = new PostingSealPurgeJob(engine)) {
+                for (int i = 0; i < 64 && purgeJob.run(); i++) {
+                    // drain
+                }
+            }
+            assertCoveredMatchesControl();
+            // The guard that protects the live indexer's unflushed entries must not
+            // be silently firing: if it is, this route is falling back to the
+            // rebuild and the append path is not being exercised at all.
+            Assert.assertEquals("covered append declined for pending entries",
+                    0, PostingIndexWriter.COVERING_SEAL_APPEND_PENDING_DECLINE_COUNT.get());
         });
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoverageGapsTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoverageGapsTest.java
@@ -58,13 +58,13 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
     public void enableCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
         PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
     @After
     public void disableCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
     }
 
     /**
@@ -86,7 +86,7 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             insertBoth("2024-01-03", 200, 200);
             insertBoth("2024-01-02", 400, SEED);
 
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             for (int c = 0; c < COMMITS; c++) {
                 insertBoth("2024-01-02", 400L + SEED + (long) c * ROWS, ROWS);
             }
@@ -94,8 +94,8 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             assertIndexAgreesWithColumn();
             assertMatchesControl();
             Assert.assertTrue("the append path must fire on a non-WAL table (appends="
-                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
-                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
         });
     }
 
@@ -121,7 +121,7 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             WorkerPoolUtils.setupAsyncMunmapJob(pool, engine);
             pool.start(LOG);
             try {
-                PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+                PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
                 for (int c = 0; c < COMMITS; c++) {
                     // one txn per day, drained together: the commit spans four
                     // mid partitions at once
@@ -139,8 +139,48 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             assertIndexAgreesWithColumn();
             assertMatchesControl();
             Assert.assertTrue("the append path must fire under parallel O3 (appends="
-                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
-                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
+        });
+    }
+
+    /**
+     * The same parallel-O3 contract on the LAST partition, which is this PR's
+     * route. DEDUP disqualifies the WAL fast-lag gate, so these pure appends
+     * fall back to O3 and reach the deferral - on the partition every commit
+     * touches, with four workers recording deferrals concurrently.
+     */
+    @Test
+    public void testParallelO3LastPartitionDedup() throws Exception {
+        final WorkerPool pool = new TestWorkerPool(4, node1.getMetrics());
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL DEDUP UPSERT KEYS(ts, sym)");
+            execute("CREATE TABLE ctl (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL DEDUP UPSERT KEYS(ts, sym)");
+            insertBoth("2024-01-01", 0, SEED);
+            drainWalQueue();
+
+            WorkerPoolUtils.setupWriterJobs(pool, engine);
+            WorkerPoolUtils.setupAsyncMunmapJob(pool, engine);
+            pool.start(LOG);
+            try {
+                PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
+                for (int c = 0; c < COMMITS; c++) {
+                    insertBoth("2024-01-01", (long) SEED + (long) c * ROWS, ROWS);
+                    drainWalQueue();
+                }
+            } finally {
+                pool.halt();
+            }
+            drainWalQueue();
+
+            assertNotSuspended();
+            assertIndexAgreesWithColumn();
+            assertMatchesControl();
+            Assert.assertTrue("the append path must fire on the last partition under parallel O3"
+                            + " (appends=" + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
         });
     }
 
@@ -163,7 +203,7 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             execute("ALTER TABLE ctl CONVERT PARTITION TO PARQUET LIST '2024-01-01'");
             drainWalQueue();
 
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             for (int c = 0; c < COMMITS; c++) {
                 insertBoth("2024-01-02", 500L + SEED + (long) c * ROWS, ROWS);
                 drainWalQueue();
@@ -174,8 +214,8 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             Assert.assertEquals("test setup: the partition must actually be parquet", 1, parquetCount);
             Assert.assertTrue("appends into the NATIVE mid partition must still fire alongside a"
                             + " parquet partition (appends="
-                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
-                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
 
             assertNotSuspended();
             assertIndexAgreesWithColumn();
@@ -207,7 +247,7 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
             execute("ALTER TABLE t ALTER COLUMN sym2 ADD INDEX TYPE POSTING INCLUDE (value)");
             drainWalQueue();
 
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             for (int c = 0; c < COMMITS; c++) {
                 insertBoth3("2024-01-02", 400L + SEED + (long) c * ROWS, ROWS);
                 drainWalQueue();
@@ -215,8 +255,8 @@ public class MidPartitionAppendCoverageGapsTest extends AbstractCairoTest {
 
             assertNotSuspended();
             Assert.assertTrue("the append path must fire with two covering indexes (appends="
-                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
-                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
             // Pin that BOTH columns are really served as COVERED reads. Without
             // this, a plan that stopped using either index would turn every
             // comparison below into two identical non-covering scans.

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoveringSealTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendCoveringSealTest.java
@@ -63,7 +63,7 @@ public class MidPartitionAppendCoveringSealTest extends AbstractCairoTest {
         PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
         PostingIndexWriter.COVERING_FASTLAG_COMMIT_COUNT.set(0);
         PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
     @After
@@ -109,11 +109,11 @@ public class MidPartitionAppendCoveringSealTest extends AbstractCairoTest {
             seedMidPartition();
 
             PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             appendToMidPartition();
 
             final long fullReseals = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
-            final long appends = PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get();
+            final long appends = PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get();
             Assert.assertEquals(
                     "a pure append into an existing mid partition must not full-reseal the covered sidecar",
                     0, fullReseals);
@@ -167,13 +167,13 @@ public class MidPartitionAppendCoveringSealTest extends AbstractCairoTest {
             seedMidPartition();
             final int afterSeed = countPostingFiles("blk", "2024-01-02");
 
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             appendToMidPartition();
             // Discriminate: the post-purge steady state below would also hold on
             // the reseal path (rotate every commit, purge reclaims), so pin that
             // these commits actually took the append path.
             Assert.assertEquals("every commit must take the covered append path",
-                    COMMITS, PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get());
+                    COMMITS, PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get());
             final int beforePurge = countPostingFiles("blk", "2024-01-02");
 
             // Deferred compaction DOES rotate .pv/.pc when it fires, superseding

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendFaultRecoveryTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendFaultRecoveryTest.java
@@ -68,7 +68,7 @@ public class MidPartitionAppendFaultRecoveryTest extends AbstractCairoTest {
     @Before
     public void enableCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
     @After
@@ -230,14 +230,14 @@ public class MidPartitionAppendFaultRecoveryTest extends AbstractCairoTest {
             Assert.assertEquals("count\n" + (1 + 2 * ROWS) + "\n", sink.toString());
 
             // And the partition must still be usable for further appends.
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             insertBatch(2L * ROWS);
             drainWalQueue();
             assertIndexAgreesWithColumn();
             // ... via the path under test, not by silently falling back to the
             // reseal for the rest of the table's life.
             Assert.assertTrue("the append path must resume after recovery",
-                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
         });
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendNewColumnTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendNewColumnTest.java
@@ -50,7 +50,7 @@ public class MidPartitionAppendNewColumnTest extends AbstractCairoTest {
 
     @After
     public void resetSwitch() {
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
     }
 
     @Test
@@ -76,7 +76,7 @@ public class MidPartitionAppendNewColumnTest extends AbstractCairoTest {
      */
     @Test
     public void testAppendAfterAddColumnWorksOnResealPath() throws Exception {
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         assertMemoryLeak(() -> {
             seedTwoPartitions();
             execute("ALTER TABLE t ADD COLUMN sym SYMBOL");

--- a/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendSplitDeclineTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/MidPartitionAppendSplitDeclineTest.java
@@ -54,13 +54,13 @@ public class MidPartitionAppendSplitDeclineTest extends AbstractCairoTest {
     @Before
     public void enableCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
     @After
     public void disableCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
     }
 
     /**
@@ -84,7 +84,7 @@ public class MidPartitionAppendSplitDeclineTest extends AbstractCairoTest {
             insertBoth("2024-01-03", 200, 200);
             insertBoth("2024-01-02", 400, SEED);
 
-            PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+            PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
             for (int c = 0; c < COMMITS; c++) {
                 // land BEHIND the partition max, which forces a merge/split
                 // rather than an append
@@ -101,7 +101,7 @@ public class MidPartitionAppendSplitDeclineTest extends AbstractCairoTest {
             // ... and the append path must have refused every one of them:
             // canSkipRebuildForPartition requires o3SplitPartitionSize == 0.
             Assert.assertEquals("a split must never take the covered append path",
-                    0, PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get());
+                    0, PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get());
 
             assertNotSuspended();
             assertIndexAgreesWithColumn();

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathConcurrentReadFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathConcurrentReadFuzzTest.java
@@ -251,11 +251,22 @@ public class CoveringIndexFastPathConcurrentReadFuzzTest extends AbstractFuzzTes
                             // (1) Covered == base at ONE snapshot: single statement, both
                             // branches share the reader txn -> any covered fragment that
                             // disagrees with the base column produces a non-empty diff.
+                            // The base arm is no_INDEX, not no_covering, and the diff is
+                            // SYMMETRIC. no_covering only disables the covered read and
+                            // leaves the index scan in place, so a posting that is
+                            // MISSING drops the row from both arms and a one-way diff
+                            // stays 0 - which is precisely what an unindexed tail looks
+                            // like. Proven by mutation: breaking the seal's rebuild
+                            // fallback left the old oracle green and fails this one.
                             final long diff = scalar(compiler, ctx,
                                     "SELECT count(*) FROM ("
-                                            + "(SELECT ts, value FROM t WHERE sym = '" + sym + "')"
+                                            + "((SELECT ts, value FROM t WHERE sym = '" + sym + "')"
                                             + " EXCEPT "
-                                            + "(SELECT /*+ no_covering */ ts, value FROM t WHERE sym = '" + sym + "'))");
+                                            + "(SELECT /*+ no_index */ ts, value FROM t WHERE sym = '" + sym + "'))"
+                                            + " UNION ALL "
+                                            + "((SELECT /*+ no_index */ ts, value FROM t WHERE sym = '" + sym + "')"
+                                            + " EXCEPT "
+                                            + "(SELECT ts, value FROM t WHERE sym = '" + sym + "')))");
                             if (diff != 0) {
                                 throw new AssertionError("covered read disagrees with base column at snapshot for "
                                         + sym + ": EXCEPT returned " + diff + " rows");

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathConcurrentReadFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathConcurrentReadFuzzTest.java
@@ -82,6 +82,7 @@ public class CoveringIndexFastPathConcurrentReadFuzzTest extends AbstractFuzzTes
     public void disableCoveringCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
         PostingIndexWriter.COVERING_FASTPATH_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
     }
 
     @Test
@@ -135,11 +136,25 @@ public class CoveringIndexFastPathConcurrentReadFuzzTest extends AbstractFuzzTes
     // the head to format 1.
     @Test
     public void testO3PreLagConcurrentReadFuzzLegacyFormat0Regression() throws Exception {
+        // Pinned to the pre-deferral path: this variant's job is to prove the
+        // publishToChain COW fires when a LEGACY format-0 head is extended in
+        // place by the O3-merge index commit. The covered append path stops that
+        // route from extending the head at all (the legacy head migrates via the
+        // reseal instead), so leaving it on would quietly retire the COW coverage
+        // rather than test it. The COW remains reachable from other extend sites.
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         runConcurrentReadFuzz(generateRandom(LOG, 0x5c1e83b7096d2fL, 0x4a90e2f1b7c358L), true, false, true);
     }
 
     @Test
     public void testO3PreLagConcurrentReadFuzzLegacyFormat0() throws Exception {
+        // Pinned to the pre-deferral path: this variant's job is to prove the
+        // publishToChain COW fires when a LEGACY format-0 head is extended in
+        // place by the O3-merge index commit. The covered append path stops that
+        // route from extending the head at all (the legacy head migrates via the
+        // reseal instead), so leaving it on would quietly retire the COW coverage
+        // rather than test it. The COW remains reachable from other extend sites.
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         runConcurrentReadFuzz(generateRandom(LOG), true, false, true);
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathDifferentialFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathDifferentialFuzzTest.java
@@ -238,17 +238,21 @@ public class CoveringIndexFastPathDifferentialFuzzTest extends AbstractFuzzTest 
             // Prove the two modes actually differed on the BLOCK-apply path.
             // (COVERING_FASTPATH_DISABLED only forces BLOCK applies through O3; the
             // pre-existing single-txn fast-lag path is unaffected, so o3FastLag is
-            // not necessarily 0. The block-path difference shows up as: the o3 run
-            // full-reseals its blocks, while the fast run fast-lags them instead --
-            // strictly MORE fast-lag commits and strictly FEWER full reseals.)
-            Assert.assertTrue("o3 run must full-reseal blocks (fast path forced off), o3Reseals=" + o3Reseals,
-                    o3Reseals > 0);
-            Assert.assertTrue("fast run must fast-lag block-applies the o3 run resealed"
+            // not necessarily 0.) The direct measure is the fast-lag count: the
+            // fast run fast-lags block applies that the o3 run does not.
+            //
+            // The reseal count is NO LONGER a discriminator. It used to be, because
+            // an O3 block apply full-resealed the partition; now a pure append
+            // maintains the covering index incrementally on the O3 route too, so
+            // both runs reseal only for the stream's genuine merges, and the two
+            // counts converge. Asserting fastReseals < o3Reseals here would be
+            // asserting that O3 is still slow.
+            Assert.assertTrue("fast run must fast-lag block-applies the o3 run did not"
                             + " (fastFastLag=" + fastFastLag + ", o3FastLag=" + o3FastLag + ")",
                     fastFastLag > o3FastLag);
-            Assert.assertTrue("fast run must avoid reseals via the fast path"
+            Assert.assertTrue("neither run may reseal more than the stream's merges require"
                             + " (fastReseals=" + fastReseals + ", o3Reseals=" + o3Reseals + ")",
-                    fastReseals < o3Reseals);
+                    fastReseals <= o3Reseals);
         });
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathDifferentialFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexFastPathDifferentialFuzzTest.java
@@ -253,6 +253,13 @@ public class CoveringIndexFastPathDifferentialFuzzTest extends AbstractFuzzTest 
             Assert.assertTrue("neither run may reseal more than the stream's merges require"
                             + " (fastReseals=" + fastReseals + ", o3Reseals=" + o3Reseals + ")",
                     fastReseals <= o3Reseals);
+            // The stream's out-of-order dips are genuine merges, so SOME reseal must
+            // still happen in at least one arm. Without this, both counts being zero
+            // - a covered append wrongly taken on a commit that needed a rebuild -
+            // would satisfy the comparison above.
+            Assert.assertTrue("the stream's merges must still reseal somewhere"
+                            + " (fastReseals=" + fastReseals + ", o3Reseals=" + o3Reseals + ")",
+                    o3Reseals > 0 || fastReseals > 0);
         });
     }
 }

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendConcurrentReadFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendConcurrentReadFuzzTest.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * <p>
  * The writer thread only ever appends into an EARLY day while a later day
  * already holds rows, so every commit is an append into a non-last partition and
- * takes the path under test (asserted via COVERING_MIDPART_APPEND_COUNT). N
+ * takes the path under test (asserted via COVERING_SEAL_APPEND_COUNT). N
  * reader threads concurrently run covered scans and check, per observation:
  * <ul>
  *   <li>no crash or exception;</li>
@@ -82,13 +82,29 @@ public class MidPartitionAppendConcurrentReadFuzzTest extends AbstractFuzzTest {
     @After
     public void disableCoveringCounters() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
         PostingIndexWriter.FORCE_LEGACY_COVERING_FORMAT = false;
     }
 
     @Test
     public void testMidPartitionAppendConcurrentReadFuzz() throws Exception {
         runConcurrentReadFuzz(generateRandom(LOG), false);
+    }
+
+    /**
+     * The same concurrent-reader load against the LAST partition. DEDUP
+     * disqualifies the WAL fast-lag gate, so these appends take the O3 route into
+     * the last partition - where the covered append path now extends a live .pc
+     * in place on the partition every reader is scanning.
+     */
+    @Test
+    public void testLastPartitionAppendConcurrentReadFuzzDedup() throws Exception {
+        runConcurrentReadFuzz(generateRandom(LOG), false, true);
+    }
+
+    @Test
+    public void testLastPartitionAppendConcurrentReadFuzzDedupRegression() throws Exception {
+        runConcurrentReadFuzz(generateRandom(LOG, 0x63b1e04a7c25d9L, 0x0af52c9138be74L), false, true);
     }
 
     @Test
@@ -110,10 +126,14 @@ public class MidPartitionAppendConcurrentReadFuzzTest extends AbstractFuzzTest {
         PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
         PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
         PostingIndexWriter.COVERING_COW_MIGRATE_COUNT.set(0);
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
     private void runConcurrentReadFuzz(Rnd rnd, boolean legacyInitial) throws Exception {
+        runConcurrentReadFuzz(rnd, legacyInitial, false);
+    }
+
+    private void runConcurrentReadFuzz(Rnd rnd, boolean legacyInitial, boolean dedup) throws Exception {
         setProperty(PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 10_000_000);
         setProperty(PropertyKey.CAIRO_WAL_APPLY_LOOK_AHEAD_TXN_COUNT, 2000);
         setProperty(PropertyKey.CAIRO_WAL_APPLY_TABLE_TIME_QUOTA, 600_000);
@@ -129,13 +149,18 @@ public class MidPartitionAppendConcurrentReadFuzzTest extends AbstractFuzzTest {
 
         assertMemoryLeak(() -> {
             execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
-                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
-            // Day 3 anchors the table's max timestamp: every later write into day
-            // 1 is therefore an append into a partition that is NOT the last one.
-            // Its single row carries value 0, below the id floor of 1 the readers
-            // assert, so it is written with a NULL value instead.
-            execute("INSERT INTO t SELECT (" + (T0 + 3 * DAY_MICROS) + ")::TIMESTAMP, 'S0', cast(NULL AS DOUBLE)"
-                    + " FROM long_sequence(1)");
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL"
+                    + (dedup ? " DEDUP UPSERT KEYS(ts, sym)" : ""));
+            if (!dedup) {
+                // Day 3 anchors the table's max timestamp: every later write into day
+                // 1 is therefore an append into a partition that is NOT the last one.
+                // Its single row carries value 0, below the id floor of 1 the readers
+                // assert, so it is written with a NULL value instead.
+                execute("INSERT INTO t SELECT (" + (T0 + 3 * DAY_MICROS) + ")::TIMESTAMP, 'S0', cast(NULL AS DOUBLE)"
+                        + " FROM long_sequence(1)");
+            }
+            // With dedup there is deliberately NO later anchor: the target day is
+            // the LAST partition, and dedup routes its appends through O3.
             drainWalQueue();
 
             if (legacyInitial) {
@@ -277,8 +302,8 @@ public class MidPartitionAppendConcurrentReadFuzzTest extends AbstractFuzzTest {
             Assert.assertNull("concurrent covered reader failed: " + bgError.get(), bgError.get());
             Assert.assertFalse("table suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("t")));
             Assert.assertTrue("the mid-partition append path must fire (appends="
-                            + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
-                    PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                            + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                    PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
             if (legacyInitial) {
                 // A format-0 head must never be extended in place (the readers'
                 // clean scans above are the proof it was not); it migrates to

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendDifferentialFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendDifferentialFuzzTest.java
@@ -45,7 +45,7 @@ import java.util.List;
  * A single deterministic stream is precomputed per seed and replayed twice into
  * two identically-defined covering-indexed tables:
  * <ul>
- *   <li>{@code reseal} - {@code COVERING_MIDPART_APPEND_DISABLED = true}: O3
+ *   <li>{@code reseal} - {@code COVERING_SEAL_APPEND_DISABLED = true}: O3
  *       indexes the rows and the seal full-reseals, as before;</li>
  *   <li>{@code append} - the flag off: the covered append path is active.</li>
  * </ul>
@@ -76,17 +76,35 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
     @After
     public void disableCoveringCountersAndAppendPath() {
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
     }
 
     @Test
     public void testMidPartitionAppendDifferentialFuzz() throws Exception {
-        runDifferential(generateRandom(LOG));
+        runDifferential(generateRandom(LOG), false);
     }
 
     @Test
     public void testMidPartitionAppendDifferentialFuzzRegression() throws Exception {
-        runDifferential(generateRandom(LOG, 0x51e3d7a9c4b206L, 0x1f8c62b0da3945L));
+        runDifferential(generateRandom(LOG, 0x51e3d7a9c4b206L, 0x1f8c62b0da3945L), false);
+    }
+
+    /**
+     * DEDUP disqualifies the WAL fast-lag gate (the block gate tests
+     * isCommitPlainInsert(), the single-txn gate tests !isCommitDedupMode()), so
+     * the same stream additionally routes the LAST partition's appends through
+     * O3 - the route that used to full-reseal per commit and to write a
+     * speculative covered fragment. The timestamps are unique, so nothing is
+     * actually deduplicated and the commits stay pure appends.
+     */
+    @Test
+    public void testDedupDifferentialFuzz() throws Exception {
+        runDifferential(generateRandom(LOG), true);
+    }
+
+    @Test
+    public void testDedupDifferentialFuzzRegression() throws Exception {
+        runDifferential(generateRandom(LOG, 0x2f70c81a9b3e56L, 0x4c19d7e0af6231L), true);
     }
 
     private void applyStream(String table, List<Op> ops, int symbolCardinality) throws Exception {
@@ -201,10 +219,10 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
         PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
         PostingIndexWriter.COVERING_FASTLAG_COMMIT_COUNT.set(0);
         PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
-    private void runDifferential(Rnd rnd) throws Exception {
+    private void runDifferential(Rnd rnd, boolean dedup) throws Exception {
         setProperty(PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 10_000_000);
         setProperty(PropertyKey.CAIRO_SQL_SORT_KEY_MAX_BYTES, 134_217_728);
         setProperty(PropertyKey.CAIRO_SQL_SORT_LIGHT_VALUE_MAX_BYTES, 134_217_728);
@@ -213,25 +231,26 @@ public class MidPartitionAppendDifferentialFuzzTest extends AbstractFuzzTest {
         final List<Op> ops = precomputeStream(rnd, symbolCardinality);
 
         assertMemoryLeak(() -> {
+            final String dedupClause = dedup ? " DEDUP UPSERT KEYS(ts, sym)" : "";
             execute("CREATE TABLE reseal (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
-                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL" + dedupClause);
             execute("CREATE TABLE append (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
-                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL" + dedupClause);
             drainWalQueue();
 
             // Replay 1: append path FORCED OFF -> index in O3 + full reseal.
-            PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+            PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
             resetCoveringCounters();
             applyStream("reseal", ops, symbolCardinality);
             final long resealRuns = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
-            final long resealAppends = PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get();
+            final long resealAppends = PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get();
 
             // Replay 2: append path ACTIVE.
-            PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+            PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
             resetCoveringCounters();
             applyStream("append", ops, symbolCardinality);
             final long appendRuns = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
-            final long appendAppends = PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get();
+            final long appendAppends = PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get();
 
             Assert.assertFalse("reseal suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("reseal")));
             Assert.assertFalse("append suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("append")));

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendFailureFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/MidPartitionAppendFailureFuzzTest.java
@@ -69,6 +69,9 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
     // Batches land in day 1; day 3 exists from the start, so day 1 is never last.
     private static final long TARGET_DAY = T0 + DAY_MICROS;
     private final FaultFilesFacade faultFf = new FaultFilesFacade();
+    // when set, the table dedups, which disqualifies the fast-lag gate and routes
+    // the appends into the LAST partition through O3
+    private boolean dedup;
 
     @Before
     public void enableCoveringCounters() {
@@ -79,14 +82,33 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
 
     @After
     public void disableCoveringCounters() {
+        dedup = false;
         PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = false;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = false;
         faultFf.disarm();
     }
 
     @Test
     public void testMidPartitionAppendFailureFuzz() throws Exception {
         runFailureFuzz(generateRandom(LOG), true);
+    }
+
+    /**
+     * The same fault injection against the LAST partition. DEDUP disqualifies the
+     * WAL fast-lag gate, so the appends take the O3 route into the last partition
+     * - the route whose index is maintained through the writer's LIVE indexer,
+     * which the seal closes and reopens. A fault there must still converge.
+     */
+    @Test
+    public void testLastPartitionAppendFailureFuzzDedup() throws Exception {
+        dedup = true;
+        runFailureFuzz(generateRandom(LOG), true);
+    }
+
+    @Test
+    public void testLastPartitionAppendFailureFuzzDedupRegression() throws Exception {
+        dedup = true;
+        runFailureFuzz(generateRandom(LOG, 0x7c05b3e1d9a462L, 0x28fa61c7e0b539L), true);
     }
 
     @Test
@@ -108,7 +130,7 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
      */
     @Test
     public void testMidPartitionAppendFailureFuzzResealPathControl() throws Exception {
-        PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED = true;
+        PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED = true;
         runFailureFuzz(generateRandom(LOG, 0x18b7d3f0a29e64L, 0x5c02af71e6d938L), true);
     }
 
@@ -196,7 +218,7 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
     private void resetCoveringCounters() {
         PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
         PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
-        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.set(0);
+        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.set(0);
     }
 
     private void runFailureFuzz(Rnd rnd, boolean injectFaults) throws Exception {
@@ -228,15 +250,19 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
         }
 
         assertMemoryLeak(faultFf, () -> {
+            final String dedupClause = dedup ? " DEDUP UPSERT KEYS(ts, sym)" : "";
             execute("CREATE TABLE t (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
-                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL" + dedupClause);
             execute("CREATE TABLE ctl (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING, value DOUBLE)"
-                    + " TIMESTAMP(ts) PARTITION BY DAY WAL");
-            // Anchor the table max in a LATER day so every batch below appends
-            // into a partition that is not the last one.
-            for (String table : new String[]{"t", "ctl"}) {
-                execute("INSERT INTO " + table + " SELECT (" + (T0 + 3 * DAY_MICROS) + ")::TIMESTAMP,"
-                        + " 'S0', cast(NULL AS DOUBLE) FROM long_sequence(1)");
+                    + " TIMESTAMP(ts) PARTITION BY DAY WAL" + dedupClause);
+            if (!dedup) {
+                // Anchor the table max in a LATER day so every batch below appends
+                // into a partition that is not the last one. With dedup there is
+                // deliberately no anchor: the target day IS the last partition.
+                for (String table : new String[]{"t", "ctl"}) {
+                    execute("INSERT INTO " + table + " SELECT (" + (T0 + 3 * DAY_MICROS) + ")::TIMESTAMP,"
+                            + " 'S0', cast(NULL AS DOUBLE) FROM long_sequence(1)");
+                }
             }
             drainWalQueue();
             resetCoveringCounters();
@@ -274,10 +300,10 @@ public class MidPartitionAppendFailureFuzzTest extends AbstractFuzzTest {
 
             assertCoveredMatchesControl(symbolCardinality);
 
-            if (!PostingIndexWriter.COVERING_MIDPART_APPEND_DISABLED) {
+            if (!PostingIndexWriter.COVERING_SEAL_APPEND_DISABLED) {
                 Assert.assertTrue("the mid-partition append path must be exercised (appends="
-                                + PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() + ')',
-                        PostingIndexWriter.COVERING_MIDPART_APPEND_COUNT.get() > 0);
+                                + PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() + ')',
+                        PostingIndexWriter.COVERING_SEAL_APPEND_COUNT.get() > 0);
             }
         });
     }


### PR DESCRIPTION
Stacked on #7516 — review that one first; this PR's base is its branch, so the diff here is only the follow-up.

## Why there is a follow-up

#7516 fixed the covering index for appends into a **mid** partition. The same pathology survives on the **last** partition whenever the WAL fast-lag gate does not apply — and that is not a corner case:

- `DEDUP UPSERT KEYS(...)` disqualifies both halves of the gate (the block-apply gate tests `isCommitPlainInsert()`, the single-txn gate tests `!isCommitDedupMode()`)
- concurrent clients disqualify it through multi-segment blocks

Either way the appends fall back to the O3 route and full-reseal the partition on every commit — on the partition where most ingest lands.

## Measurements

1000-row commits into a 1M-row last partition, unique ascending timestamps (so nothing is actually deduplicated and the commits stay pure appends):

| arm | before | after |
|---|---|---|
| last partition, plain (fast-lag qualifies) | 2.6 ms, 0 reseals | 2.5 ms, 0 reseals *(path untouched)* |
| **last partition, DEDUP** | **30.9 ms, 1.00 reseal/commit** | **3.0 ms, 0 reseals** |
| mid partition (from #7516) | 3.0 ms | 2.4 ms |

Enabling dedup no longer costs an order of magnitude on ingest.

## It also removes a latent hazard (but does not fix a live bug)

The two routes that maintain the last partition — the writer's own append branch and the dedup downgrade to `OPEN_LAST_PARTITION_FOR_APPEND` — index through the **live**, covering-configured indexer during the O3 copy phase. The covered fragment written there is **speculative**: column tasks run in parallel, so the indexed column's `updateIndex` can run before the covered column's own append lands. The trailing `rebuildSidecars` is what repaired it, and it is genuinely load-bearing on the old code — skipping it there yields wrong covered values (`0.0` where `8.0` was written).

I originally described this as a correctness fix. That was over-claimed, and I want to correct it: the speculative entry is tagged `getTxn() + 1` and is superseded by the reseal before the commit lands, so **no reader could observe it** and there is no user-visible defect on master. What this PR removes is a wasted speculative write plus the reseal it silently depended on — a cost win, and one less invariant to keep true, not a bug fix.

## Design

Reuses the mid-partition machinery, including the guard requiring the column to already hold rows in the partition (O3 is what creates the `.pk`), which also keeps brand-new partitions on the O3 route.

One new guard is specific to this route: the last partition's indexer is the writer's **live** one and the seal reopens it, so any pending `add()` it still holds would be dropped by `close()` (which deliberately does not flush). That state is snapshotted **once, before the sweep touches any partition**, and read per column from there — not per partition inside the sweep. Reading it inside the sweep is wrong in exactly the case it exists for: the sweep reopens each partition's indexer in turn, so from the second partition onward it would observe a writer that had just been reset. Every decline is counted, and the tests assert the count stays 0, which is what proves they exercise the append path rather than quietly falling back.

## Test premises

11 pre-existing tests assert the per-commit `.pv` rotation this removes. Rather than pinning them to the old path, they set the gen threshold to 0, which restores the rotation — and the purge it queues — **through the new path**, so they keep testing current behaviour.

Two legacy format-0 variants stay pinned, because their job is to prove the COW fires on an in-place extend this route no longer performs. The remaining four legacy variants run unpinned and do reach the new deferred-rebuild branch (verified by instrumentation: 12 hits).

New coverage: `LastPartitionO3AppendCoveringTest` (including the merge-collapse route into the append path, and deferred compaction plus purge, which the shipped gen threshold never reached), dedup arms in the differential fuzz (same stream both ways, byte-identical), last-partition arms in the concurrent-reader fuzz and in the fault-injection fuzz.

`COVERING_MIDPART_APPEND_{DISABLED,COUNT}` → `COVERING_SEAL_APPEND_{DISABLED,COUNT}`, since the path is no longer mid-partition-specific.

### Review fixes since first push

- The covered-read oracle in the fast-path concurrent fuzz compared against `no_covering`, which keeps the index scan in place — so a **missing** posting dropped out of both arms and the diff stayed 0. It now compares against `no_index`, symmetrically. Proven by mutation: breaking the seal's rebuild fallback leaves the old oracle green and fails the new one by 211 rows.
- Restored the differential-fuzz assertion that the stream's merges still reseal somewhere; relaxing it had made both counts being zero acceptable.
- `O3PartitionJob`'s predicate now spells out the two append modes instead of "every append mode except NEW", which would have opted a future mode into deferral silently.

## Note for reviewers

This changes the **steady-state on-disk shape of the last partition's covering index**: between compactions it holds raw generation blocks rather than being stride-compacted on every commit.

To be precise about the direction, since I got this backwards in the first version of this description: the pre-existing fast-lag path already lets the last partition accumulate generations up to the inline auto-seal at `MAX_GEN_COUNT = 128`. The new path compacts at `cairo.posting.seal.gen.threshold`, default 16 — so for the qualifying-fast-lag case this is *more* aggressive compaction than today, not less. The change in shape is real but bounded, and tunable. Still worth an explicit opinion from someone who owns the read path.

Local: full covering, posting, O3, WAL, dedup, TableWriter and IndexBuilder suites green. (2 pre-existing errors in `MatViewReloadOnRestartTest` reproduce identically on pristine master — an ILP client native-library packaging issue in this checkout, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
