### PR TITLE
feat(build): arm64 Marketplace AMI, plus kernel pin, build-volume and first-boot password fixes

### DIFF
--- a/pkg/ami/marketplace/Makefile
+++ b/pkg/ami/marketplace/Makefile
@@ -4,6 +4,11 @@
 
 AWS_REGION 		?= eu-west-1
 
+# Build a single architecture, e.g. ONLY=questdb-ami-amazon-linux-2023-arm64.
+# Both architectures are built when unset.
+ONLY 			?=
+PACKER_ONLY		= $(if $(ONLY),-only=$(ONLY),)
+
 packer ?= packer
 git    ?= git
 aws    ?= aws
@@ -15,6 +20,7 @@ install_aws_plugin:
 build: QUESTDB_VERSION?=$(shell $(git) rev-parse --short HEAD)-snapshot
 build:
 	$(packer) build \
+	$(PACKER_ONLY) \
 	-var ami_regions=$(AMI_REGIONS) \
 	-var questdb_version=$(QUESTDB_VERSION) \
 	packer.json
@@ -23,6 +29,7 @@ build_release: QUESTDB_VERSION?=$(shell $(git) symbolic-ref -q --short HEAD || g
 build_release: AMI_REGIONS?=$(shell export AWS_REGION=$(AWS_REGION); $(aws) ec2 describe-regions | $(jq) -r '.Regions | map(.RegionName) | join(",")')
 build_release:
 	$(packer) build \
+	$(PACKER_ONLY) \
 	-var ami_regions=$(AMI_REGIONS) \
 	-var questdb_version=$(QUESTDB_VERSION) \
 	-var ami_groups=all \

--- a/pkg/ami/marketplace/assets/systemd.service
+++ b/pkg/ami/marketplace/assets/systemd.service
@@ -3,6 +3,9 @@ Description=QuestDB
 Documentation=https://www.questdb.io/docs/introduction
 Wants=network-online.target
 After=network-online.target
+# cloud-init's per-boot script seeds the generated pg.password into server.conf;
+# starting before it finishes would load the placeholder instead.
+After=cloud-final.service
 RequiresMountsFor=/var/lib/questdb
 
 [Service]

--- a/pkg/ami/marketplace/build.bash
+++ b/pkg/ami/marketplace/build.bash
@@ -28,7 +28,12 @@ set -euxo pipefail
 QUESTDB_DATA_DIR=/var/lib/questdb
 GRAALVM_VERSION=25.0.2
 GRAALVM_HOME=/usr/lib/jvm/graalvm-community-java25
-GRAALVM_TARBALL=graalvm-community-jdk-${GRAALVM_VERSION}_linux-x64_bin.tar.gz
+case "$(uname -m)" in
+    x86_64)  GRAALVM_ARCH=x64 ;;
+    aarch64) GRAALVM_ARCH=aarch64 ;;
+    *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+GRAALVM_TARBALL=graalvm-community-jdk-${GRAALVM_VERSION}_linux-${GRAALVM_ARCH}_bin.tar.gz
 
 # Install dependencies
 sudo dnf update -y -q

--- a/pkg/ami/marketplace/packer.json
+++ b/pkg/ami/marketplace/packer.json
@@ -23,7 +23,7 @@
         "filters": {
           "virtualization-type": "hvm",
           "architecture": "x86_64",
-          "name": "al2023-ami-202*-x86_64",
+          "name": "al2023-ami-202*-kernel-6.18-x86_64",
           "block-device-mapping.volume-type": "gp3",
           "root-device-type": "ebs"
         },
@@ -31,6 +31,16 @@
         "most_recent": true
       },
       "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/xvdb",
+          "volume_size": 50,
+          "delete_on_termination": true,
+          "volume_type": "gp3",
+          "iops": 3000,
+          "throughput": 250
+        }
+      ],
+      "ami_block_device_mappings": [
         {
           "device_name": "/dev/xvdb",
           "volume_size": 50,
@@ -63,7 +73,7 @@
         "filters": {
           "virtualization-type": "hvm",
           "architecture": "arm64",
-          "name": "al2023-ami-202*-arm64",
+          "name": "al2023-ami-202*-kernel-6.18-arm64",
           "block-device-mapping.volume-type": "gp3",
           "root-device-type": "ebs"
         },
@@ -71,6 +81,16 @@
         "most_recent": true
       },
       "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/xvdb",
+          "volume_size": 50,
+          "delete_on_termination": true,
+          "volume_type": "gp3",
+          "iops": 3000,
+          "throughput": 250
+        }
+      ],
+      "ami_block_device_mappings": [
         {
           "device_name": "/dev/xvdb",
           "volume_size": 50,

--- a/pkg/ami/marketplace/packer.json
+++ b/pkg/ami/marketplace/packer.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Packer Template for demo. Based on Amazon Linux 2023",
+  "_comment": "Packer template for the AWS Marketplace AMI. Amazon Linux 2023, x86_64 and arm64",
   "variables": {
     "base_ami_name": "questdb",
     "region": "eu-west-1",
@@ -9,7 +9,7 @@
   },
   "builders": [
     {
-      "name": "questdb-ami-amazon-linux-2023",
+      "name": "questdb-ami-amazon-linux-2023-x86_64",
       "ami_name": "{{ user `base_ami_name` }}-{{ user `questdb_version` }}-al2023-x86_64-ebs",
       "ami_description": "An Amazon Linux 2023 instance with QuestDB-{{ user `questdb_version` }} installed and running",
       "ami_regions": "{{user `ami_regions`}}",
@@ -46,6 +46,46 @@
         "OS_Version": "Amazon Linux 2023",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
         "Name": "{{ user `base_ami_name` }}-{{ user `questdb_version` }}-al2023-x86_64-ebs"
+      }
+    },
+    {
+      "name": "questdb-ami-amazon-linux-2023-arm64",
+      "ami_name": "{{ user `base_ami_name` }}-{{ user `questdb_version` }}-al2023-arm64-ebs",
+      "ami_description": "An Amazon Linux 2023 instance with QuestDB-{{ user `questdb_version` }} installed and running",
+      "ami_regions": "{{user `ami_regions`}}",
+      "ami_groups": "{{user `ami_groups`}}",
+      "instance_type": "t4g.large",
+      "region": "{{user `region`}}",
+      "type": "amazon-ebs",
+      "force_deregister": "true",
+      "force_delete_snapshot": "true",
+      "source_ami_filter": {
+        "filters": {
+          "virtualization-type": "hvm",
+          "architecture": "arm64",
+          "name": "al2023-ami-202*-arm64",
+          "block-device-mapping.volume-type": "gp3",
+          "root-device-type": "ebs"
+        },
+        "owners": ["137112412989"],
+        "most_recent": true
+      },
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/xvdb",
+          "volume_size": 50,
+          "delete_on_termination": false,
+          "volume_type": "gp3",
+          "iops": 3000,
+          "throughput": 250
+        }
+      ],
+
+      "ssh_username": "ec2-user",
+      "tags": {
+        "OS_Version": "Amazon Linux 2023",
+        "Base_AMI_Name": "{{ .SourceAMIName }}",
+        "Name": "{{ user `base_ami_name` }}-{{ user `questdb_version` }}-al2023-arm64-ebs"
       }
     }
   ],

--- a/pkg/ami/marketplace/scripts/1-per-boot.sh
+++ b/pkg/ami/marketplace/scripts/1-per-boot.sh
@@ -24,11 +24,13 @@
 #
 ################################################################################
 
-if [ ! -f "/var/lib/questdb/conf/server.conf" ]; then
+if grep -q PG_PASSWORD_REPLACE /var/lib/questdb/conf/server.conf 2>/dev/null; then
 # setting variables in subshell for cloudinit script
   { PASS=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-32}; echo;); }
   sed -i "s/PG_PASSWORD_REPLACE/$PASS/g" /var/lib/questdb/conf/server.conf
 fi
 
 systemctl enable questdb
-systemctl start questdb
+# --no-block: questdb.service is ordered After=cloud-final.service, and this
+# script runs inside cloud-final. A blocking start would deadlock the two.
+systemctl start --no-block questdb


### PR DESCRIPTION
## What

Adds an arm64 (Graviton) builder to the AWS Marketplace AMI pipeline in `pkg/ami/marketplace/`, and fixes three pre-existing issues found while testing it. All three affect the published x86_64 AMI equally.

## Why arm64

The Marketplace AMI has only ever been built for x86_64, so the listing offers no Graviton instance types at all (its allowlist tops out at `m6i`/`c6i`/`r6i`/`r7a`, and is stale in general — that's a separate listing-side fix).

Nothing about QuestDB blocks it. `questdb.jar` already ships `io/questdb/bin/linux-aarch64/libquestdb.so` and `libquestdbr.so`, and the `no-jre` tarball we install is architecture-agnostic, so no new release artifact is needed.

## Commits

**1. arm64 builder**

- `packer.json` — second builder `questdb-ami-amazon-linux-2023-arm64`: arm64 AL2023 source AMI, built on `t4g.large`. The existing builder is renamed to `...-x86_64` for symmetry (the name wasn't referenced anywhere else).
- `build.bash` — select the GraalVM tarball from `uname -m`. The aarch64 build is published on the same GraalVM CE release we already pull from. Everything else (dnf packages, ext4 data volume, systemd, sysctl, questdb user) is architecture-neutral and untouched.
- `Makefile` — `ONLY=<builder name>` restricts a run to one architecture: `make build ONLY=questdb-ami-amazon-linux-2023-arm64`.

**2. Kernel pin and build-volume leak**

- AL2023 publishes its kernel 6.1, 6.12 and 6.18 variants with *identical* creation timestamps, so `most_recent` picked between them arbitrarily — an unpinned build selected `kernel-6.12` while AWS's own `kernel-default` SSM pointer resolves to `kernel-6.18`. Now pinned to the kernel AWS defaults to. **This needs a manual bump when AWS moves the default forward.**
- `delete_on_termination: false` on the launch instance meant every build left an unattached 50 GB volume behind, which packer's own cleanup missed. The launch volume is now reclaimed, while the `false` is carried through to the *published* AMI explicitly via `ami_block_device_mappings`, so customer data still survives instance termination as before.

**3. First-boot password generation**

`scripts/1-per-boot.sh` guards the password generation on the *absence* of `server.conf` — but that is the very file it rewrites, and the AMI bakes it onto the data volume. The branch never ran, so every instance kept the literal `PG_PASSWORD_REPLACE` placeholder from the template. This dates to `b57c410280`, where the fix for re-randomising on every reboot overshot into never randomising at all.

Guarding on the placeholder instead is correct and idempotent across reboots. Ordering needed fixing too: `questdb.service` is enabled at build time, so systemd was racing cloud-init for the config file and only lost because the JVM takes several seconds to read it. The unit is now ordered `After=cloud-final.service` (where cloud-init runs per-boot scripts), and the script starts it with `--no-block` — a synchronous `systemctl start` from inside `cloud-final` deadlocks against that ordering.

## Testing

`packer validate` passes for both builders (packer 1.15.4, amazon plugin 1.8.2 — legacy JSON is still accepted).

Built for real in a dev account, eu-west-1, and booted on a `t4g.large` after each change. Final state:

| Check | Result |
|---|---|
| Arch / OS | `aarch64`, Amazon Linux 2023.12, kernel `6.18.x` |
| JVM | `OpenJDK 25.0.2 GraalVM CE 25.0.2+10.1` (aarch64 tarball selected by `uname -m`) |
| Data volume | `/dev/nvme1n1` → `/var/lib/questdb`, ext4, 49G, `conf/` populated |
| Boot ordering | `server.conf` rewritten → `cloud-final` exits → `questdb` starts; no systemd jobs left waiting |
| Password | 32-char generated value on disk; pg wire **rejects** the placeholder and **accepts** the generated one |
| `questdb.service` | `enabled`, `active` |
| Listening | `0.0.0.0:9000` HTTP, `0.0.0.0:8812` pg wire, `0.0.0.0:9003` min/health |
| Query | `select build()` → `QuestDB 10.0.0, JDK 25.0.2, Commit d71e25a5` |
| Health | `GET :9003/status` → 200 |

The query executing at all exercises the `linux-aarch64` native library end to end.

The volume fix was specifically checked for the failure mode where `ami_block_device_mappings` replaces the snapshot with a blank volume: the resulting AMI's `/dev/xvdb` still carries a real `CreateImage` snapshot with `DeleteOnTermination: false`, and mounts populated.

All test resources (instances, AMIs, snapshots, volumes, temp keypairs and security groups) have been cleaned up.

## Listing-side follow-up (not in this PR)

Nothing in the repo encodes these; they need AWS Marketplace Management Portal changes:

1. **Add Graviton instance types** via *Add instance*, and confirm with Seller Ops whether one AMI product can carry public x86_64 and arm64 versions simultaneously or whether it needs a second listing.
2. **Fix the recommended security group.** It currently opens 22, 8812, 9000 and 9009 tcp+udp. `assets/server.conf` sets `line.tcp.enabled=false` and `line.udp.enabled=false`, so nothing listens on 9009 — while `http.min.enabled` defaults to true, so 9003 *is* listening and is not opened. It should be 9000, 8812 and 9003. QWP needs nothing extra: ingress and egress are registered unconditionally on the HTTP port, and the only separate QWP listener (`qwp.udp.*`, port 9007) is disabled by default and should stay that way on a public image.
3. **The declared OS is still `Amazon Linux 2.0.20210318.0`**, which hasn't been true since the move to AL2023.

Existing instances launched from previously published AMIs keep the placeholder password until an operator changes it, so the listing fix probably wants a customer-facing note alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)