### PR TITLE
chore(build): stop requiring alphabetical member ordering

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -578,7 +578,7 @@ of the two categories it lands in, per the magnitude rule in Step 4.
 - No third-party Java dependencies on data paths
 
 ### QuestDB coding standards
-- Class members grouped by kind (static vs instance) and visibility, sorted alphabetically
+- Class members grouped by kind (static vs instance) and visibility
 - Boolean names use `is...` / `has...` prefix
 - Modern Java features: enhanced switch, multiline strings, pattern variables in instanceof
 

--- a/.codex/skills/review-pr/SKILL.md
+++ b/.codex/skills/review-pr/SKILL.md
@@ -577,7 +577,7 @@ of the two categories it lands in, per the magnitude rule in Step 4.
 - No third-party Java dependencies on data paths
 
 ### QuestDB coding standards
-- Class members grouped by kind (static vs instance) and visibility, sorted alphabetically
+- Class members grouped by kind (static vs instance) and visibility
 - Boolean names use `is...` / `has...` prefix
 - Modern Java features: enhanced switch, multiline strings, pattern variables in instanceof
 

--- a/.pi/skills/review-pr/SKILL.md
+++ b/.pi/skills/review-pr/SKILL.md
@@ -580,7 +580,7 @@ of the two categories it lands in, per the magnitude rule in Step 4.
 - No third-party Java dependencies on data paths
 
 ### QuestDB coding standards
-- Class members grouped by kind (static vs instance) and visibility, sorted alphabetically
+- Class members grouped by kind (static vs instance) and visibility
 - Boolean names use `is...` / `has...` prefix
 - Modern Java features: enhanced switch, multiline strings, pattern variables in instanceof
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,7 @@ time-series SQL extensions.
 
 ## Coding guidelines
 
-Java class members are grouped by kind (static vs. instance) and visibility, and
-sorted alphabetically. When adding new methods or fields, insert them in the
-correct alphabetical position among existing members of the same kind.
-
-Never insert `// ===` or `// ---` banner comments as section headings in any
-Java file — not in production code, not in test code. Methods are sorted
-alphabetically and will not stay grouped by category.
+Java class members are grouped by kind (static vs. instance) and visibility.
 
 Use the modern Java 17 features:
 


### PR DESCRIPTION
Removes the alphabetical member-ordering convention from the agent instructions and from the `review-pr` skill's coding-standards checklist.

We keep accumulating breakages of this rule, with no visible consequences. Let's remove the rule.