### PR TITLE
perf(core): speed up partitioned window aggregates and live view refresh

### DIFF
--- a/benchmarks/src/main/java/org/questdb/WindowMapFusionBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/WindowMapFusionBenchmark.java
@@ -166,23 +166,34 @@ import java.util.Locale;
  * skips anything. The {@code skips/row} column is where the answer is legible; a shape with no
  * skippable group reports zero there in both arms.
  *
+ * <h2>Why this runs with {@code -ea}</h2>
+ * The {@code lookups/row}, {@code skips/row} and {@code updates/row} columns read counters
+ * {@code WindowMapState} keeps behind {@code assert}, so that a server never pays for them on a
+ * path it runs once per row of every window query. This benchmark needs them, so it refuses to
+ * start without assertions and every command line below passes {@code -ea}.
+ * <p>
+ * What that costs the timings is a field increment per row, and only in the fused arm - an
+ * unfused plan binds no group and so runs no counter at all. The fused-versus-unfused ratios
+ * this benchmark exists to report are therefore biased against fusion by however much that
+ * increment costs, and a fused win it reports is a floor rather than an estimate.
+ *
  * <h2>Build and run</h2>
  * <pre>
  * mvn -pl benchmarks -am package -o -DskipTests -Dmaven.test.skip=true
  *
  * # the whole acceptance matrix at both shipped entry-size settings
- * java --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -Xmx8g \
+ * java -ea --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -Xmx8g \
  *     -cp benchmarks/target/benchmarks.jar \
  *     org.questdb.WindowMapFusionBenchmark
  *
  * # one shape, one key type, the transition measurement of case 4
- * java --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -Xmx8g \
+ * java -ea --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -Xmx8g \
  *     -cp benchmarks/target/benchmarks.jar \
  *     org.questdb.WindowMapFusionBenchmark \
  *     --shape=count-count --key-type=int --entry-size=11,16
  *
  * # case 11: both cached factories, including the two-pass shapes
- * java --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -Xmx8g \
+ * java -ea --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -Xmx8g \
  *     -cp benchmarks/target/benchmarks.jar \
  *     org.questdb.WindowMapFusionBenchmark \
  *     --cursor=cached,cached-light --key-type=int --entry-size=32
@@ -200,6 +211,7 @@ public class WindowMapFusionBenchmark {
     private static final long TS_STEP_MICROS = 1_000L;
 
     public static void main(String[] args) throws Exception {
+        requireAssertions();
         long rows = 2_000_000L;
         String keysArg = "1000,1000000";
         String keyTypesArg = "int,symbol,string,varchar";
@@ -655,6 +667,27 @@ public class WindowMapFusionBenchmark {
      * is not one. The bound groups' lookup and update counts are measured; a function on its own
      * map contributes the structural one-per-row, since the private path carries no counter.
      */
+    /**
+     * Refuses to run without assertions, because the structural columns would silently read zero.
+     * <p>
+     * {@code WindowMapState} keeps its lookup, update and skip tallies behind {@code assert} so a
+     * server pays nothing for them on a per-row path. That makes {@code -ea} this benchmark's
+     * business rather than the JVM's default, and a run that quietly reported {@code 0.00}
+     * lookups/row would read as a fusion result rather than a missing flag.
+     */
+    private static void requireAssertions() {
+        boolean enabled = false;
+        //noinspection AssertWithSideEffects,ConstantValue
+        assert enabled = true;
+        //noinspection ConstantValue
+        if (!enabled) {
+            throw new IllegalStateException(
+                    "WindowMapFusionBenchmark needs -ea: the lookups/row, skips/row and updates/row "
+                            + "columns read assert-gated counters and would report zero without it"
+            );
+        }
+    }
+
     private static void captureStructure(Arm arm, WindowProbe factory, long rows) {
         final LinkedHashMap<String, Integer> implementations = new LinkedHashMap<>();
         final ObjList<WindowAccumulatorPlan> plans = factory.plans;

--- a/benchmarks/src/main/java/org/questdb/WindowMapFusionBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/WindowMapFusionBenchmark.java
@@ -67,10 +67,9 @@ import java.util.Locale;
  * function on a private map, at both configured
  * {@code cairo.sql.unordered.map.max.entry.size} settings that ship.
  * <p>
- * Every arm reports the numbers the acceptance plan asks for - ns/row, the query's peak and
- * retained <b>tracked</b> native bytes, how many maps were open and of which implementation, the
- * configured entry-size limit, and the per-row lookup, accumulator-update and argument-evaluation
- * counts - so a win can be read as a structural fact rather than inferred from a clock.
+ * Every arm reports timing and throughput, the query's peak and retained <b>tracked</b> native
+ * bytes, how many maps were open and of which implementation, and the configured entry-size limit,
+ * so a win can be read alongside the structural facts rather than inferred from a clock alone.
  *
  * <h2>The two arms</h2>
  * {@code cairo.sql.window.map.fusion.enabled} is the control. With it off the query compiles the
@@ -78,16 +77,6 @@ import java.util.Locale;
  * with it on the group owns one map and makes the row's one lookup. The two arms run the same SQL
  * over the same table in the same JVM, and their output checksums must be equal - a mismatch fails
  * the run rather than being reported, because a faster wrong answer is not a measurement.
- *
- * <h2>Where the counters come from</h2>
- * The fused arm's lookup and update counts are {@link WindowMapState}'s own
- * {@code @TestOnly} counters. The unfused arm has none to read: a private partition map is probed
- * inside each function's {@code computeNext} and nothing counts it. Its numbers are therefore
- * structural - one lookup, one accumulator update and one argument evaluation per row per function
- * that owns an open map - which is exact for the families this benchmark drives, each of which
- * probes once and reads its argument once per row. The same derivation covers a residual function
- * sitting beside a bound group. Adding production counters to the private path for a measurement is
- * what step 3.2 declined to do for its own rule, and the same reasoning holds here.
  *
  * <h2>Cases 4 and 12: fusing across a Map-implementation change</h2>
  * Co-location widens the value and can push a group onto an {@code OrderedMap} that every member
@@ -163,21 +152,7 @@ import java.util.Locale;
  * whether that skip pays is how often the argument is absent, which is what this option varies:
  * {@code --null-pct=0,50,90,99,100} makes {@code x} NULL on that percentage of rows and {@code y}
  * NULL on the same percentage offset by 37, so a two-argument group has to refuse both before it
- * skips anything. The {@code skips/row} column is where the answer is legible; a shape with no
- * skippable group reports zero there in both arms.
- *
- * <h2>What the structural columns cost</h2>
- * The {@code lookups/row}, {@code skips/row} and {@code updates/row} columns read counters
- * {@code WindowMapState} keeps only under {@code -Dquestdb.window.map.counters=true}, so that a
- * server never pays for them on a path it runs once per row of every window query. {@code main()}
- * sets that property for itself, so no command line below has to.
- * <p>
- * What it costs these timings is a field increment per row, and only in the fused arm - an
- * unfused plan binds no group and so runs no counter at all. The fused-versus-unfused ratios
- * this benchmark exists to report are therefore biased against fusion by however much that
- * increment costs, and a fused win it reports is a floor rather than an estimate. Running with
- * the property unset removes the bias and the structural columns together, which is a fair
- * timing and no evidence.
+ * skips anything.
  *
  * <h2>Build and run</h2>
  * <pre>
@@ -213,7 +188,6 @@ public class WindowMapFusionBenchmark {
     private static final long TS_STEP_MICROS = 1_000L;
 
     public static void main(String[] args) throws Exception {
-        configureStructuralCounters(args);
         long rows = 2_000_000L;
         String keysArg = "1000,1000000";
         String keyTypesArg = "int,symbol,string,varchar";
@@ -248,8 +222,6 @@ public class WindowMapFusionBenchmark {
                 warmups = Integer.parseInt(arg.substring(10));
             } else if (arg.startsWith("--runs=")) {
                 runs = Integer.parseInt(arg.substring(7));
-            } else if (arg.startsWith("--counters=")) {
-                // configureStructuralCounters(args) consumed and validated it before this loop.
             } else {
                 throw new IllegalArgumentException("unknown argument: " + arg);
             }
@@ -329,7 +301,7 @@ public class WindowMapFusionBenchmark {
 
             final List<String> table = new ArrayList<>();
             table.add("shape\tcursor\tkey\tkeys\tnullPct\tmaxEntry\tfusion\tplans\tgroups\tmaps\tmapImpl"
-                    + "\tcomps\tslots\tlookups/row\tskips/row\tupdates/row\targs/row\tns/row\trows/s"
+                    + "\tcomps\tslots\tns/row\trows/s"
                     + "\tpeakKiB\tretainedKiB\tchecksum");
             System.out.println(table.get(0));
 
@@ -494,18 +466,6 @@ public class WindowMapFusionBenchmark {
         return values;
     }
 
-    /**
-     * One counter-derived column, or {@code n/a} where this run kept no counters. Never {@code
-     * 0.00} in that case: a zero there reads as a measured absence of lookups, which is the one
-     * thing it does not mean.
-     */
-    private static String perRow(long total, long rows) {
-        if (!WindowMapState.areCountersEnabled()) {
-            return "n/a";
-        }
-        return String.format(Locale.ROOT, "%.2f", total / (double) rows);
-    }
-
     private static String row(
             Shape shape,
             Cursor cursor,
@@ -518,7 +478,7 @@ public class WindowMapFusionBenchmark {
     ) {
         return String.format(
                 Locale.ROOT,
-                "%s\t%s\t%s\t%d\t%d\t%d\t%s\t%d\t%d\t%d\t%s\t%d\t%d\t%s\t%s\t%s\t%.2f"
+                "%s\t%s\t%s\t%d\t%d\t%d\t%s\t%d\t%d\t%d\t%s\t%d\t%d"
                         + "\t%.1f\t%.0f\t%d\t%d\t%d",
                 shape.name,
                 cursor.name,
@@ -533,10 +493,6 @@ public class WindowMapFusionBenchmark {
                 arm.mapImplementation,
                 arm.components,
                 arm.slots,
-                perRow(arm.lookups, arm.rows),
-                perRow(arm.skips, arm.rows),
-                perRow(arm.updates, arm.rows),
-                arm.argumentEvaluations / (double) arm.rows,
                 arm.nanos / (double) arm.rows,
                 arm.rows / (arm.nanos / 1e9),
                 arm.peakBytes / 1024,
@@ -676,54 +632,13 @@ public class WindowMapFusionBenchmark {
     }
 
     /**
-     * Decides whether this run keeps {@code WindowMapState}'s structural counters, and does it
-     * before anything has had a chance to load that class.
-     * <p>
-     * They are gated on a {@code static final} read of {@code questdb.window.map.counters} rather
-     * than left always-on, because they sit on a per-row path a server runs for every window
-     * query, and a server runs with {@code -ea} - so an {@code assert} would not have gated them.
-     * Setting the property here rather than asking for it on the command line is safe for one
-     * reason only: {@code WindowMapState} is initialized on first use, and the only classes
-     * initialized before this call are this one and its supertypes, none of which touch it. The
-     * read-back below is what keeps that reasoning honest - if some future static field loads the
-     * class earlier, this fails loudly instead of reporting a fusion result made of zeroes.
-     * <p>
-     * {@code --counters=off} leaves the property alone, which is how to time the two arms with
-     * nothing on the fused arm's per-row path that the server would not run. The structural
-     * columns then report {@code n/a} rather than zero, because a run that cannot count is not a
-     * run that counted nothing.
-     */
-    private static void configureStructuralCounters(String[] args) {
-        boolean enabled = true;
-        for (String arg : args) {
-            if ("--counters=off".equals(arg)) {
-                enabled = false;
-            } else if ("--counters=on".equals(arg)) {
-                enabled = true;
-            } else if (arg.startsWith("--counters=")) {
-                throw new IllegalArgumentException("--counters must be one of on, off: " + arg);
-            }
-        }
-        if (enabled) {
-            System.setProperty("questdb.window.map.counters", "true");
-        }
-        if (WindowMapState.areCountersEnabled() != enabled) {
-            throw new IllegalStateException(
-                    "WindowMapState was initialized before its counters could be configured; pass "
-                            + "-Dquestdb.window.map.counters=" + enabled + " on the command line instead"
-            );
-        }
-    }
-
-    /**
      * Captures the structural facts of the drain that just finished, while the cursor is still
-     * open: a close resets the group counters and frees the maps this reads.
+     * open: a close frees the maps this reads.
      * <p>
      * A map is counted where it actually holds backing, so a bound function's dormant private map
-     * is not one. The bound groups' lookup and update counts are measured; a function on its own
-     * map contributes the structural one-per-row, since the private path carries no counter.
+     * is not one.
      */
-    private static void captureStructure(Arm arm, WindowProbe factory, long rows) {
+    private static void captureStructure(Arm arm, WindowProbe factory) {
         final LinkedHashMap<String, Integer> implementations = new LinkedHashMap<>();
         final ObjList<WindowAccumulatorPlan> plans = factory.plans;
         arm.plans = plans == null ? 0 : plans.size();
@@ -732,19 +647,9 @@ public class WindowMapFusionBenchmark {
             for (int i = 0, n = states.size(); i < n; i++) {
                 final WindowMapState state = states.getQuick(i);
                 arm.groups++;
-                if (WindowMapState.areCountersEnabled()) {
-                    arm.lookups += state.getLookupCount();
-                    arm.skips += state.getSkippedRowCount();
-                    arm.updates += state.getContributorUpdateCount();
-                }
                 final WindowAccumulatorPlan plan = state.getPlan();
                 arm.components += plan.getComponentCount();
                 arm.slots += plan.getSlotCount();
-                for (int c = 0, m = plan.getComponentCount(); c < m; c++) {
-                    if (WindowAccumulatorDescriptor.familyTakesArgument(plan.getComponent(c).getFamily())) {
-                        arm.argumentEvaluations += rows;
-                    }
-                }
                 if (state.isMapOpen()) {
                     arm.openMaps++;
                     implementations.merge(state.getMapImplementation(), 1, Integer::sum);
@@ -760,24 +665,11 @@ public class WindowMapFusionBenchmark {
             }
             arm.openMaps++;
             implementations.merge(map.getClass().getSimpleName(), 1, Integer::sum);
-            // Twice a row for a whole-partition two-pass function: pass 1 probes to accumulate and
-            // pass 2 probes again to read the finished state back. Once for everything else, which
-            // computes and writes its output in the one pass.
-            arm.lookups += function.getPassCount() > WindowFunction.ONE_PASS ? 2 * rows : rows;
-            arm.updates += rows;
             // Its own standalone image, which is what makes the components and slots column
             // comparable across the two arms: three private (sum, nonNullCount)-shaped states are
             // three components and five slots whether or not a group would fold them into one.
             arm.components++;
             arm.slots += WindowAccumulatorDescriptor.familySlotCount(function.windowAccumulatorFamily());
-            // Exact for the families here, each of which reads its argument once per row inside
-            // the same computeNext that probes. It is a declaration rather than a measurement, so
-            // a function that reads an argument without declaring an accumulator family reports
-            // none: the whole-partition shapes are exactly that, and every one of them evaluates
-            // its argument once a row in pass 1.
-            if (function.windowAccumulatorArgument() != null) {
-                arm.argumentEvaluations += rows;
-            }
         }
         final StringBuilder sink = new StringBuilder();
         for (java.util.Map.Entry<String, Integer> entry : implementations.entrySet()) {
@@ -833,7 +725,7 @@ public class WindowMapFusionBenchmark {
                 arm.checksum = digest;
                 arm.retainedBytes = tracker.getUsed();
                 arm.peakBytes = sampler.peak();
-                captureStructure(arm, windowFactory, rows);
+                captureStructure(arm, windowFactory);
             } finally {
                 sampler.watch(null);
             }
@@ -842,10 +734,9 @@ public class WindowMapFusionBenchmark {
     }
 
     /**
-     * The three lists a report row is read off, taken once per arm because they are the factory's
-     * own and outlive its cursors. The counters behind them are not: they live on the
-     * {@link WindowMapState}s, which a close resets, so {@code captureStructure} still has to run
-     * while the cursor is open.
+     * The three lists a report row reads from belong to the factory and outlive its cursors.
+     * {@code captureStructure} still runs while the cursor is open because the cursor allocates
+     * the maps and makes them observable.
      */
     private static final class WindowProbe {
         final ObjList<WindowFunction> functions;
@@ -865,20 +756,16 @@ public class WindowMapFusionBenchmark {
 
     private static final class Arm {
         String mapImplementation = "none";
-        long argumentEvaluations;
         long checksum;
         int components;
         int groups;
-        long lookups;
         long nanos;
         int openMaps;
         long peakBytes;
         int plans;
         long retainedBytes;
         long rows;
-        long skips;
         int slots;
-        long updates;
     }
 
     /**
@@ -1103,8 +990,7 @@ public class WindowMapFusionBenchmark {
          * behind one key instead of merging them. It is the row that separates the merge from
          * co-location, and the one where the refused-row skip is a joint decision - a row counts
          * as refused only when neither column offers a finite value, so
-         * {@code --null-pct=90} skips rather less than 0.90 of the rows here and the
-         * {@code skips/row} column says how much less.
+         * {@code --null-pct=90} skips rather less than 0.90 of the rows here.
          * <p>
          * A wider fused value than {@link #PARTITION_SUM_AVG}'s, so an INT-keyed group crosses
          * {@code --entry-size=32} onto an {@code OrderedMap} while its unfused members keep an

--- a/benchmarks/src/main/java/org/questdb/WindowMapFusionBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/WindowMapFusionBenchmark.java
@@ -148,12 +148,23 @@ import java.util.Locale;
  *     then the streaming one exactly and the forcing is the sort, which every arm pays for and
  *     which is large enough at these row counts to compress the ratio between them.</li>
  * </ul>
- * The two {@code partition-*} shapes need neither: they are whole-partition two-pass functions and
- * so are cached by construction. They are also what the next step of the design would fuse and
- * cannot fuse yet - no whole-partition family declares an accumulator, so both fusion arms of a
- * {@code partition-*} shape run the same code, like the single-sum control. What they measure is
- * the cost that rewrite stands to remove: {@code partition-sum-avg-count} is three maps and six
- * probes a row, and {@code partition-avg} is the one map and two probes a fused group would leave.
+ * The four {@code partition-*} shapes need neither: they are whole-partition two-pass functions
+ * and so are cached by construction. Three of them fuse - a whole-partition {@code sum},
+ * {@code avg} and {@code count} are three readings of one {@code (sum, nonNullCount)} pair, so
+ * {@code partition-sum-avg-count} is three maps and six probes a row unfused against one map and
+ * two fused - and {@code partition-avg} does not, because one fusible function is not a group. It
+ * is the map work a fused {@code partition-sum-avg-count} is left with, which is what makes it that
+ * shape's floor.
+ *
+ * <h2>{@code --null-pct}: the refused-row population</h2>
+ * A whole-partition group's pass 1 does map work for a row before its contributors decide the row
+ * was never their business, and a group whose components can all be predicated skips that work for
+ * a row every one of them refuses - see {@code WindowMapState.isPass1SkipEnabled}. What decides
+ * whether that skip pays is how often the argument is absent, which is what this option varies:
+ * {@code --null-pct=0,50,90,99,100} makes {@code x} NULL on that percentage of rows and {@code y}
+ * NULL on the same percentage offset by 37, so a two-argument group has to refuse both before it
+ * skips anything. The {@code skips/row} column is where the answer is legible; a shape with no
+ * skippable group reports zero there in both arms.
  *
  * <h2>Build and run</h2>
  * <pre>
@@ -197,6 +208,7 @@ public class WindowMapFusionBenchmark {
         String fusionArg = "both";
         String cursorsArg = "streaming";
         String cachedBucketArg = "natural";
+        String nullPctArg = "0";
         int warmups = 1;
         int runs = 3;
         for (String arg : args) {
@@ -216,6 +228,8 @@ public class WindowMapFusionBenchmark {
                 cursorsArg = arg.substring(9);
             } else if (arg.startsWith("--cached-bucket=")) {
                 cachedBucketArg = arg.substring(16);
+            } else if (arg.startsWith("--null-pct=")) {
+                nullPctArg = arg.substring(11);
             } else if (arg.startsWith("--warmups=")) {
                 warmups = Integer.parseInt(arg.substring(10));
             } else if (arg.startsWith("--runs=")) {
@@ -230,6 +244,12 @@ public class WindowMapFusionBenchmark {
 
         final List<Long> cardinalities = parseLongs(keysArg, "--keys");
         final List<Integer> entrySizes = parseInts(entrySizesArg, "--entry-size");
+        final List<Integer> nullPercentages = parseInts(nullPctArg, "--null-pct");
+        for (int nullPct : nullPercentages) {
+            if (nullPct < 0 || nullPct > 100) {
+                throw new IllegalArgumentException("--null-pct must be between 0 and 100: " + nullPct);
+            }
+        }
         final List<KeyType> keyTypes = new ArrayList<>();
         for (String name : keyTypesArg.split(",")) {
             keyTypes.add(KeyType.of(name.trim()));
@@ -277,21 +297,24 @@ public class WindowMapFusionBenchmark {
 
             System.out.printf(
                     Locale.ROOT,
-                    "# rows=%d keys=%s keyTypes=%s entrySizes=%s shapes=%s fusion=%s cursors=%s"
-                            + " cachedBucket=%s warmups=%d runs=%d%n",
-                    rows, keysArg, keyTypesArg, entrySizesArg, shapesArg, fusionArg, cursorsArg,
-                    cachedBucketArg, warmups, runs
+                    "# rows=%d keys=%s keyTypes=%s entrySizes=%s nullPct=%s shapes=%s fusion=%s"
+                            + " cursors=%s cachedBucket=%s warmups=%d runs=%d%n",
+                    rows, keysArg, keyTypesArg, entrySizesArg, nullPctArg, shapesArg, fusionArg,
+                    cursorsArg, cachedBucketArg, warmups, runs
             );
 
             for (KeyType keyType : keyTypes) {
                 for (long keys : cardinalities) {
-                    engine.execute(createTableSql(keyType, keys, rows), sqlCtx);
+                    for (int nullPct : nullPercentages) {
+                        engine.execute(createTableSql(keyType, keys, rows, nullPct), sqlCtx);
+                    }
                 }
             }
 
             final List<String> table = new ArrayList<>();
-            table.add("shape\tcursor\tkey\tkeys\tmaxEntry\tfusion\tplans\tgroups\tmaps\tmapImpl\tcomps\tslots"
-                    + "\tlookups/row\tupdates/row\targs/row\tns/row\trows/s\tpeakKiB\tretainedKiB\tchecksum");
+            table.add("shape\tcursor\tkey\tkeys\tnullPct\tmaxEntry\tfusion\tplans\tgroups\tmaps\tmapImpl"
+                    + "\tcomps\tslots\tlookups/row\tskips/row\tupdates/row\targs/row\tns/row\trows/s"
+                    + "\tpeakKiB\tretainedKiB\tchecksum");
             System.out.println(table.get(0));
 
             try (PeakSampler sampler = new PeakSampler()) {
@@ -306,43 +329,54 @@ public class WindowMapFusionBenchmark {
                         }
                         for (KeyType keyType : keyTypes) {
                             for (long keys : cardinalities) {
-                                for (int entrySize : entrySizes) {
-                                    final Arm[] best = new Arm[fusionSettings.length];
-                                    // Forward then backward over the settings, keeping each one's
-                                    // fastest drain. One arm always runs into a JIT state the other
-                                    // left behind, and a fixed order would charge that to whichever
-                                    // arm goes first every time; alternating gives each of them the
-                                    // warm position once. Pointless with a single setting, so the
-                                    // second pass only runs when there are two to alternate.
-                                    final int passes = fusionSettings.length > 1 ? 2 : 1;
-                                    for (int pass = 0; pass < passes; pass++) {
-                                        for (int i = 0; i < fusionSettings.length; i++) {
-                                            final int index = pass == 0 ? i : fusionSettings.length - 1 - i;
-                                            configuration.setSqlUnorderedMapMaxEntrySize(entrySize);
-                                            configuration.setSqlWindowMapFusionEnabled(fusionSettings[index]);
-                                            configuration.setSqlWindowCachedLightEnabled(cursor == Cursor.CACHED_LIGHT);
-                                            final Arm arm = runArm(
-                                                    engine, sqlCtx, sampler, shape, cursor, orderedBucket,
-                                                    keyType, keys, rows, warmups, runs
-                                            );
-                                            if (best[index] == null || arm.nanos < best[index].nanos) {
-                                                best[index] = arm;
+                                for (int nullPct : nullPercentages) {
+                                    for (int entrySize : entrySizes) {
+                                        final Arm[] best = new Arm[fusionSettings.length];
+                                        // Forward then backward over the settings, keeping each
+                                        // one's fastest drain. One arm always runs into a JIT
+                                        // state the other left behind, and a fixed order would
+                                        // charge that to whichever arm goes first every time;
+                                        // alternating gives each of them the warm position once.
+                                        // Pointless with a single setting, so the second pass only
+                                        // runs when there are two to alternate.
+                                        final int passes = fusionSettings.length > 1 ? 2 : 1;
+                                        for (int pass = 0; pass < passes; pass++) {
+                                            for (int i = 0; i < fusionSettings.length; i++) {
+                                                final int index = pass == 0
+                                                        ? i
+                                                        : fusionSettings.length - 1 - i;
+                                                configuration.setSqlUnorderedMapMaxEntrySize(entrySize);
+                                                configuration.setSqlWindowMapFusionEnabled(fusionSettings[index]);
+                                                configuration.setSqlWindowCachedLightEnabled(
+                                                        cursor == Cursor.CACHED_LIGHT
+                                                );
+                                                final Arm arm = runArm(
+                                                        engine, sqlCtx, sampler, shape, cursor,
+                                                        orderedBucket, keyType, keys, nullPct, rows,
+                                                        warmups, runs
+                                                );
+                                                if (best[index] == null || arm.nanos < best[index].nanos) {
+                                                    best[index] = arm;
+                                                }
                                             }
                                         }
-                                    }
-                                    for (int i = 0; i < fusionSettings.length; i++) {
-                                        if (best[i].checksum != best[0].checksum) {
-                                            throw new IllegalStateException(
-                                                    "fused and unfused answers differ for " + shape.name + "/"
-                                                            + cursor.name + "/" + keyType.name + "/keys=" + keys
-                                                            + "/maxEntry=" + entrySize
+                                        for (int i = 0; i < fusionSettings.length; i++) {
+                                            if (best[i].checksum != best[0].checksum) {
+                                                throw new IllegalStateException(
+                                                        "fused and unfused answers differ for "
+                                                                + shape.name + "/" + cursor.name + "/"
+                                                                + keyType.name + "/keys=" + keys
+                                                                + "/nullPct=" + nullPct
+                                                                + "/maxEntry=" + entrySize
+                                                );
+                                            }
+                                            final String row = row(
+                                                    shape, cursor, keyType, keys, nullPct, entrySize,
+                                                    fusionSettings[i], best[i]
                                             );
+                                            table.add(row);
+                                            System.out.println(row);
                                         }
-                                        final String row = row(
-                                                shape, cursor, keyType, keys, entrySize, fusionSettings[i], best[i]
-                                        );
-                                        table.add(row);
-                                        System.out.println(row);
                                     }
                                 }
                             }
@@ -372,14 +406,35 @@ public class WindowMapFusionBenchmark {
      * data. The row number is aliased out of {@code long_sequence} first: an expression over
      * {@code x} projected as {@code x} would be a column name resolving to two things.
      */
-    private static String createTableSql(KeyType keyType, long keys, long rows) {
-        return "create table " + tableName(keyType, keys) + " as (select"
+    private static String createTableSql(KeyType keyType, long keys, long rows, int nullPct) {
+        return "create table " + tableName(keyType, keys, nullPct) + " as (select"
                 + " (" + START_TS + " + rn * " + TS_STEP_MICROS + ")::timestamp as ts,"
                 + " " + keyType.keyExpression("((rn - 1) % " + keys + ")") + " as k,"
-                + " (rn % 997)::double as x,"
-                + " (rn % 991)::double as y"
+                + " " + nullableDouble("(rn % 997)::double", nullPct, 0) + " as x,"
+                + " " + nullableDouble("(rn % 991)::double", nullPct, 37) + " as y"
                 + " from (select x as rn from long_sequence(" + rows + ")))"
                 + " timestamp(ts) partition by day";
+    }
+
+    /**
+     * Wraps a DOUBLE expression so it is absent on {@code nullPct} percent of the rows, with the
+     * absent rows displaced by {@code offset}.
+     * <p>
+     * The displacement is what makes a two-argument group's gate visible: such a group skips a row
+     * only where every one of its components refuses it, so {@code x} and {@code y} sharing a NULL
+     * pattern would make that gate indistinguishable from a one-argument group's. Zero is returned
+     * unwrapped rather than as a {@code case} that never fires, so the default run generates the
+     * data it always did.
+     */
+    private static String nullableDouble(String expression, int nullPct, int offset) {
+        if (nullPct <= 0) {
+            return expression;
+        }
+        if (nullPct >= 100) {
+            return "null::double";
+        }
+        return "case when (rn + " + offset + ") % 100 < " + nullPct
+                + " then null::double else " + expression + " end";
     }
 
     private static void deleteRecursively(Path dir) throws IOException {
@@ -428,17 +483,20 @@ public class WindowMapFusionBenchmark {
             Cursor cursor,
             KeyType keyType,
             long keys,
+            int nullPct,
             int entrySize,
             boolean fusion,
             Arm arm
     ) {
         return String.format(
                 Locale.ROOT,
-                "%s\t%s\t%s\t%d\t%d\t%s\t%d\t%d\t%d\t%s\t%d\t%d\t%.2f\t%.2f\t%.2f\t%.1f\t%.0f\t%d\t%d\t%d",
+                "%s\t%s\t%s\t%d\t%d\t%d\t%s\t%d\t%d\t%d\t%s\t%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f"
+                        + "\t%.1f\t%.0f\t%d\t%d\t%d",
                 shape.name,
                 cursor.name,
                 keyType.name,
                 keys,
+                nullPct,
                 entrySize,
                 fusion ? "on" : "off",
                 arm.plans,
@@ -448,6 +506,7 @@ public class WindowMapFusionBenchmark {
                 arm.components,
                 arm.slots,
                 arm.lookups / (double) arm.rows,
+                arm.skips / (double) arm.rows,
                 arm.updates / (double) arm.rows,
                 arm.argumentEvaluations / (double) arm.rows,
                 arm.nanos / (double) arm.rows,
@@ -472,11 +531,12 @@ public class WindowMapFusionBenchmark {
             boolean orderedBucket,
             KeyType keyType,
             long keys,
+            int nullPct,
             long rows,
             int warmups,
             int runs
     ) throws Exception {
-        final String sql = shape.sql(tableName(keyType, keys), cursor, orderedBucket, keys);
+        final String sql = shape.sql(tableName(keyType, keys, nullPct), cursor, orderedBucket, keys);
         RecordCursorFactory factory = null;
         try (SqlCompiler compiler = engine.getSqlCompiler()) {
             factory = compiler.compile(sql, sqlCtx).getRecordCursorFactory();
@@ -505,8 +565,8 @@ public class WindowMapFusionBenchmark {
         }
     }
 
-    private static String tableName(KeyType keyType, long keys) {
-        return "w_" + keyType.name + "_" + keys;
+    private static String tableName(KeyType keyType, long keys, int nullPct) {
+        return "w_" + keyType.name + "_" + keys + "_n" + nullPct;
     }
 
     /**
@@ -605,6 +665,7 @@ public class WindowMapFusionBenchmark {
                 final WindowMapState state = states.getQuick(i);
                 arm.groups++;
                 arm.lookups += state.getLookupCount();
+                arm.skips += state.getSkippedRowCount();
                 arm.updates += state.getContributorUpdateCount();
                 final WindowAccumulatorPlan plan = state.getPlan();
                 arm.components += plan.getComponentCount();
@@ -745,6 +806,7 @@ public class WindowMapFusionBenchmark {
         int plans;
         long retainedBytes;
         long rows;
+        long skips;
         int slots;
         long updates;
     }
@@ -944,18 +1006,41 @@ public class WindowMapFusionBenchmark {
         DISPERSION("dispersion", false),
         /**
          * The whole-partition {@code avg} on its own: one map and two probes a row, and no group,
-         * because one fusible function is not a group and no whole-partition family is fusible
-         * anyway. It is the map work a fused {@code partition-sum-avg-count} would be left with,
-         * which is what makes it the standing-in fused arm for the shape below.
+         * because one fusible function is not a group - moving a map is not removing one. It is the
+         * map work a fused {@code partition-sum-avg-count} is left with, so it is that shape's
+         * floor and, like the single-sum control, a row whose two arms run the same code.
          */
         PARTITION_AVG("partition-avg", true),
         /**
+         * Two whole-partition two-pass functions over one argument: two maps and four probes a row
+         * unfused against one map and two fused. The narrower of the two fusing whole-partition
+         * shapes, and the one the refused-row skip moves most - its whole group is the single
+         * {@code (sum, nonNullCount)} component, so a row with a non-finite {@code x} is a row the
+         * group has nothing at all to do for.
+         */
+        PARTITION_SUM_AVG("partition-sum-avg", true),
+        /**
          * Three whole-partition two-pass functions over one argument: three maps, six probes a row
          * - three in pass 1 and three in pass 2 - and three copies of a {@code (sum, count)} pair
-         * that a shared component would make one. It is what the non-destructive
-         * {@code preparePass2} step exists to fuse, and today it runs unfused on both arms.
+         * that a shared component makes one. It is what the non-destructive {@code preparePass2}
+         * step exists to fuse.
          */
         PARTITION_SUM_AVG_COUNT("partition-sum-avg-count", true),
+        /**
+         * {@link #PARTITION_SUM_AVG} with the two calls reading different columns, which is the
+         * one thing that changes: the same arithmetic over two arguments is two
+         * {@code (sum, nonNullCount)} components rather than one, so the group co-locates them
+         * behind one key instead of merging them. It is the row that separates the merge from
+         * co-location, and the one where the refused-row skip is a joint decision - a row counts
+         * as refused only when neither column offers a finite value, so
+         * {@code --null-pct=90} skips rather less than 0.90 of the rows here and the
+         * {@code skips/row} column says how much less.
+         * <p>
+         * A wider fused value than {@link #PARTITION_SUM_AVG}'s, so an INT-keyed group crosses
+         * {@code --entry-size=32} onto an {@code OrderedMap} while its unfused members keep an
+         * {@code Unordered4Map} each. Run it at 64 as well to hold the implementation constant.
+         */
+        PARTITION_SUM_AVG_TWO_ARGS("partition-sum-avg-two-args", true),
         /**
          * Case 6: the row-count family, and a {@code count} over the window's own partition key,
          * which is a guarded reading of it wherever the key type admits the guard.
@@ -1072,6 +1157,8 @@ public class WindowMapFusionBenchmark {
                 case DISPERSION -> "stddev_samp(x) over w, stddev_pop(x) over w, var_samp(x) over w, "
                         + "var_pop(x) over w, count(x) over w";
                 case PARTITION_AVG -> "avg(x) over w";
+                case PARTITION_SUM_AVG -> "sum(x) over w, avg(x) over w";
+                case PARTITION_SUM_AVG_TWO_ARGS -> "sum(x) over w, avg(y) over w";
                 case PARTITION_SUM_AVG_COUNT -> "sum(x) over w, avg(x) over w, count(x) over w";
                 case RANGE_FRAME_SUM_AVG -> "sum(x) over w, avg(x) over w";
                 case RANGE_FRAME_SUM_AVG_COUNT -> "sum(x) over w, avg(x) over w, count(x) over w";

--- a/benchmarks/src/main/java/org/questdb/WindowMapFusionBenchmark.java
+++ b/benchmarks/src/main/java/org/questdb/WindowMapFusionBenchmark.java
@@ -166,34 +166,36 @@ import java.util.Locale;
  * skips anything. The {@code skips/row} column is where the answer is legible; a shape with no
  * skippable group reports zero there in both arms.
  *
- * <h2>Why this runs with {@code -ea}</h2>
+ * <h2>What the structural columns cost</h2>
  * The {@code lookups/row}, {@code skips/row} and {@code updates/row} columns read counters
- * {@code WindowMapState} keeps behind {@code assert}, so that a server never pays for them on a
- * path it runs once per row of every window query. This benchmark needs them, so it refuses to
- * start without assertions and every command line below passes {@code -ea}.
+ * {@code WindowMapState} keeps only under {@code -Dquestdb.window.map.counters=true}, so that a
+ * server never pays for them on a path it runs once per row of every window query. {@code main()}
+ * sets that property for itself, so no command line below has to.
  * <p>
- * What that costs the timings is a field increment per row, and only in the fused arm - an
+ * What it costs these timings is a field increment per row, and only in the fused arm - an
  * unfused plan binds no group and so runs no counter at all. The fused-versus-unfused ratios
  * this benchmark exists to report are therefore biased against fusion by however much that
- * increment costs, and a fused win it reports is a floor rather than an estimate.
+ * increment costs, and a fused win it reports is a floor rather than an estimate. Running with
+ * the property unset removes the bias and the structural columns together, which is a fair
+ * timing and no evidence.
  *
  * <h2>Build and run</h2>
  * <pre>
  * mvn -pl benchmarks -am package -o -DskipTests -Dmaven.test.skip=true
  *
  * # the whole acceptance matrix at both shipped entry-size settings
- * java -ea --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -Xmx8g \
+ * java --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -Xmx8g \
  *     -cp benchmarks/target/benchmarks.jar \
  *     org.questdb.WindowMapFusionBenchmark
  *
  * # one shape, one key type, the transition measurement of case 4
- * java -ea --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -Xmx8g \
+ * java --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -Xmx8g \
  *     -cp benchmarks/target/benchmarks.jar \
  *     org.questdb.WindowMapFusionBenchmark \
  *     --shape=count-count --key-type=int --entry-size=11,16
  *
  * # case 11: both cached factories, including the two-pass shapes
- * java -ea --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -Xmx8g \
+ * java --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -Xmx8g \
  *     -cp benchmarks/target/benchmarks.jar \
  *     org.questdb.WindowMapFusionBenchmark \
  *     --cursor=cached,cached-light --key-type=int --entry-size=32
@@ -211,7 +213,7 @@ public class WindowMapFusionBenchmark {
     private static final long TS_STEP_MICROS = 1_000L;
 
     public static void main(String[] args) throws Exception {
-        requireAssertions();
+        configureStructuralCounters(args);
         long rows = 2_000_000L;
         String keysArg = "1000,1000000";
         String keyTypesArg = "int,symbol,string,varchar";
@@ -246,6 +248,8 @@ public class WindowMapFusionBenchmark {
                 warmups = Integer.parseInt(arg.substring(10));
             } else if (arg.startsWith("--runs=")) {
                 runs = Integer.parseInt(arg.substring(7));
+            } else if (arg.startsWith("--counters=")) {
+                // configureStructuralCounters(args) consumed and validated it before this loop.
             } else {
                 throw new IllegalArgumentException("unknown argument: " + arg);
             }
@@ -490,6 +494,18 @@ public class WindowMapFusionBenchmark {
         return values;
     }
 
+    /**
+     * One counter-derived column, or {@code n/a} where this run kept no counters. Never {@code
+     * 0.00} in that case: a zero there reads as a measured absence of lookups, which is the one
+     * thing it does not mean.
+     */
+    private static String perRow(long total, long rows) {
+        if (!WindowMapState.areCountersEnabled()) {
+            return "n/a";
+        }
+        return String.format(Locale.ROOT, "%.2f", total / (double) rows);
+    }
+
     private static String row(
             Shape shape,
             Cursor cursor,
@@ -502,7 +518,7 @@ public class WindowMapFusionBenchmark {
     ) {
         return String.format(
                 Locale.ROOT,
-                "%s\t%s\t%s\t%d\t%d\t%d\t%s\t%d\t%d\t%d\t%s\t%d\t%d\t%.2f\t%.2f\t%.2f\t%.2f"
+                "%s\t%s\t%s\t%d\t%d\t%d\t%s\t%d\t%d\t%d\t%s\t%d\t%d\t%s\t%s\t%s\t%.2f"
                         + "\t%.1f\t%.0f\t%d\t%d\t%d",
                 shape.name,
                 cursor.name,
@@ -517,9 +533,9 @@ public class WindowMapFusionBenchmark {
                 arm.mapImplementation,
                 arm.components,
                 arm.slots,
-                arm.lookups / (double) arm.rows,
-                arm.skips / (double) arm.rows,
-                arm.updates / (double) arm.rows,
+                perRow(arm.lookups, arm.rows),
+                perRow(arm.skips, arm.rows),
+                perRow(arm.updates, arm.rows),
                 arm.argumentEvaluations / (double) arm.rows,
                 arm.nanos / (double) arm.rows,
                 arm.rows / (arm.nanos / 1e9),
@@ -660,6 +676,46 @@ public class WindowMapFusionBenchmark {
     }
 
     /**
+     * Decides whether this run keeps {@code WindowMapState}'s structural counters, and does it
+     * before anything has had a chance to load that class.
+     * <p>
+     * They are gated on a {@code static final} read of {@code questdb.window.map.counters} rather
+     * than left always-on, because they sit on a per-row path a server runs for every window
+     * query, and a server runs with {@code -ea} - so an {@code assert} would not have gated them.
+     * Setting the property here rather than asking for it on the command line is safe for one
+     * reason only: {@code WindowMapState} is initialized on first use, and the only classes
+     * initialized before this call are this one and its supertypes, none of which touch it. The
+     * read-back below is what keeps that reasoning honest - if some future static field loads the
+     * class earlier, this fails loudly instead of reporting a fusion result made of zeroes.
+     * <p>
+     * {@code --counters=off} leaves the property alone, which is how to time the two arms with
+     * nothing on the fused arm's per-row path that the server would not run. The structural
+     * columns then report {@code n/a} rather than zero, because a run that cannot count is not a
+     * run that counted nothing.
+     */
+    private static void configureStructuralCounters(String[] args) {
+        boolean enabled = true;
+        for (String arg : args) {
+            if ("--counters=off".equals(arg)) {
+                enabled = false;
+            } else if ("--counters=on".equals(arg)) {
+                enabled = true;
+            } else if (arg.startsWith("--counters=")) {
+                throw new IllegalArgumentException("--counters must be one of on, off: " + arg);
+            }
+        }
+        if (enabled) {
+            System.setProperty("questdb.window.map.counters", "true");
+        }
+        if (WindowMapState.areCountersEnabled() != enabled) {
+            throw new IllegalStateException(
+                    "WindowMapState was initialized before its counters could be configured; pass "
+                            + "-Dquestdb.window.map.counters=" + enabled + " on the command line instead"
+            );
+        }
+    }
+
+    /**
      * Captures the structural facts of the drain that just finished, while the cursor is still
      * open: a close resets the group counters and frees the maps this reads.
      * <p>
@@ -667,27 +723,6 @@ public class WindowMapFusionBenchmark {
      * is not one. The bound groups' lookup and update counts are measured; a function on its own
      * map contributes the structural one-per-row, since the private path carries no counter.
      */
-    /**
-     * Refuses to run without assertions, because the structural columns would silently read zero.
-     * <p>
-     * {@code WindowMapState} keeps its lookup, update and skip tallies behind {@code assert} so a
-     * server pays nothing for them on a per-row path. That makes {@code -ea} this benchmark's
-     * business rather than the JVM's default, and a run that quietly reported {@code 0.00}
-     * lookups/row would read as a fusion result rather than a missing flag.
-     */
-    private static void requireAssertions() {
-        boolean enabled = false;
-        //noinspection AssertWithSideEffects,ConstantValue
-        assert enabled = true;
-        //noinspection ConstantValue
-        if (!enabled) {
-            throw new IllegalStateException(
-                    "WindowMapFusionBenchmark needs -ea: the lookups/row, skips/row and updates/row "
-                            + "columns read assert-gated counters and would report zero without it"
-            );
-        }
-    }
-
     private static void captureStructure(Arm arm, WindowProbe factory, long rows) {
         final LinkedHashMap<String, Integer> implementations = new LinkedHashMap<>();
         final ObjList<WindowAccumulatorPlan> plans = factory.plans;
@@ -697,9 +732,11 @@ public class WindowMapFusionBenchmark {
             for (int i = 0, n = states.size(); i < n; i++) {
                 final WindowMapState state = states.getQuick(i);
                 arm.groups++;
-                arm.lookups += state.getLookupCount();
-                arm.skips += state.getSkippedRowCount();
-                arm.updates += state.getContributorUpdateCount();
+                if (WindowMapState.areCountersEnabled()) {
+                    arm.lookups += state.getLookupCount();
+                    arm.skips += state.getSkippedRowCount();
+                    arm.updates += state.getContributorUpdateCount();
+                }
                 final WindowAccumulatorPlan plan = state.getPlan();
                 arm.components += plan.getComponentCount();
                 arm.slots += plan.getSlotCount();

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,8 +34,7 @@
         <outputPath>target</outputPath>
         <runtime.assembly>none</runtime.assembly>
         <javac.target>25</javac.target>
-        <argLine>-ea -Dfile.encoding=UTF-8 -XX:+UseParallelGC
-            --sun-misc-unsafe-memory-access=allow
+        <argLine>-ea -Dfile.encoding=UTF-8 -XX:+UseParallelGC --sun-misc-unsafe-memory-access=allow
             --enable-native-access=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED
             --add-opens=java.base/java.time.zone=ALL-UNNAMED --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,7 +34,12 @@
         <outputPath>target</outputPath>
         <runtime.assembly>none</runtime.assembly>
         <javac.target>25</javac.target>
-        <argLine>-ea -Dfile.encoding=UTF-8 -XX:+UseParallelGC --sun-misc-unsafe-memory-access=allow
+        <!-- questdb.window.map.counters keeps WindowMapState's structural counters, which the
+             window Map fusion tests assert on. It is off in a server because those counters sit
+             on a per-row path; -ea does not gate them, since every shipped artifact runs with
+             assertions on. -->
+        <argLine>-ea -Dquestdb.window.map.counters=true -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+            --sun-misc-unsafe-memory-access=allow
             --enable-native-access=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED
             --add-opens=java.base/java.time.zone=ALL-UNNAMED --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,11 +34,7 @@
         <outputPath>target</outputPath>
         <runtime.assembly>none</runtime.assembly>
         <javac.target>25</javac.target>
-        <!-- questdb.window.map.counters keeps WindowMapState's structural counters, which the
-             window Map fusion tests assert on. It is off in a server because those counters sit
-             on a per-row path; -ea does not gate them, since every shipped artifact runs with
-             assertions on. -->
-        <argLine>-ea -Dquestdb.window.map.counters=true -Dfile.encoding=UTF-8 -XX:+UseParallelGC
+        <argLine>-ea -Dfile.encoding=UTF-8 -XX:+UseParallelGC
             --sun-misc-unsafe-memory-access=allow
             --enable-native-access=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED

--- a/core/src/main/java/io/questdb/cairo/lv/LiveViewWindow.java
+++ b/core/src/main/java/io/questdb/cairo/lv/LiveViewWindow.java
@@ -946,15 +946,38 @@ public class LiveViewWindow implements QuietCloseable {
         MapValue value = key.createValue();
 
         final boolean isNewPartition = value.isNew();
+        if (isNewPartition) {
+            // First row for this partition - the anchor map didn't carry it yet. Write both
+            // flag slots explicitly rather than relying on createValue() value-byte
+            // zero-fill, which MapKey.createValue() promises nowhere and OrderedMap - the
+            // implementation MapFactory hands back for every key shape its unordered maps
+            // do not cover, multi-column partition keys included - does not provide: its
+            // clear() rewinds the heap append pointer and zeroes only the offsets table,
+            // and the Unsafe.malloc / Unsafe.realloc behind that heap return whatever the
+            // region already held, so a new entry can land on a departed entry's bytes.
+            // The unordered maps do memset their region today, but on their own terms
+            // rather than under a contract this code can lean on. A stale tombstone would
+            // make the anchor snapshot drop a live partition, and a stale stamp reading as
+            // the live cadence would have this row's own retry skip every mark the stamp
+            // stands for.
+            //
+            // Ahead of the first call that can throw rather than next to the reset the
+            // partition is about to take. createValue() has already published the entry, so
+            // it outlives a throw from the marks below and the retry reads these two slots
+            // off it - by which point isNew() answers false and says nothing about them.
+            value.putByte(SLOT_TOMBSTONE, (byte) 0);
+            value.putShort(SLOT_DIRTY_EPOCH, EPOCH_NONE);
+        }
         // The dirty map only has to name each key once per cadence, and the anchor value
         // in hand already says whether this key was named. Skipping on a match is what
         // keeps a repeat row from serializing the partition key a second time through the
         // sink, hashing it again and probing a second map for an entry that is already
-        // there. A new entry is never read - its slot was allocated, not written, and no
-        // Map implementation zero-fills a value - so isNewPartition short-circuits ahead
-        // of the load. That is also what keeps the sweep's eviction-and-revival path
-        // honest: eviction takes the anchor entry out, so a revived key arrives new and
-        // re-enters the dirty map, clearing the eviction marker it left behind.
+        // there. isNewPartition short-circuits ahead of the load: the block above has just
+        // seeded a new entry's stamp with EPOCH_NONE, which no cadence matches, so the load
+        // would only pay for an answer the flag already has. That is also what keeps the
+        // sweep's eviction-and-revival path honest: eviction takes the anchor entry out, so
+        // a revived key arrives new and re-enters the dirty map, clearing the eviction
+        // marker it left behind.
         //
         // Every window function's own dirty set answers to the same stamp - see the flag
         // handed to markPartitionAlive below - so this one anchor-value load stands in
@@ -997,18 +1020,11 @@ public class LiveViewWindow implements QuietCloseable {
         trackFrontier(currentAnchor);
         final boolean shouldReset = initialized == 0 || lastAnchor != currentAnchor;
 
-        if (isNewPartition) {
-            // First row for this partition - anchor map didn't carry it yet. Functions
-            // either have no per-partition state yet (in which case resetPartition is
-            // a no-op) or have stale state from a prior partition that was evicted -
-            // resetting it is the safe default. Write a 0 tombstone slot explicitly
-            // rather than relying on createValue() value-byte zero-fill, which
-            // OrderedMap does not guarantee (Unsafe.realloc / Unsafe.malloc / clear()
-            // can all leave stale bytes in the heap region the new entry lands on);
-            // a stale 1 would make the anchor snapshot drop a live partition.
-            value.putByte(SLOT_TOMBSTONE, (byte) 0);
-        }
-
+        // The branch takes a row that crossed to a new anchor value, and - through
+        // initialized == 0 - every new partition. Resetting a new partition is deliberate:
+        // its functions either have no per-partition state yet (in which case
+        // resetPartition is a no-op) or carry stale state from a prior partition the sweep
+        // evicted, and resetting it is the safe default.
         if (shouldReset) {
             for (int i = 0, n = functions.size(); i < n; i++) {
                 functions.getQuick(i).resetPartition(record);
@@ -1036,9 +1052,11 @@ public class LiveViewWindow implements QuietCloseable {
         // first use through the per-view tracker, so the mark can throw on a breach of
         // cairo.live.view.refresh.memory.limit.bytes; a stamp already standing would have
         // the retry read this row as marked and leave that function's set one key short of
-        // what its rows moved - which the seal cannot tell from a complete set. Nothing
-        // between the load above and here touches the anchor map, so the handle still
-        // addresses this key's entry.
+        // what its rows moved - which the seal cannot tell from a complete set. A key
+        // created by this row leans on the same ordering through the EPOCH_NONE its own
+        // block above seeded: without it the retry would read whatever the heap held.
+        // Nothing between the load above and here touches the anchor map, so the handle
+        // still addresses this key's entry.
         if (isFirstCadenceTouch) {
             value.putShort(SLOT_DIRTY_EPOCH, checkpointDirtyEpoch);
         }

--- a/core/src/main/java/io/questdb/cairo/lv/LiveViewWindow.java
+++ b/core/src/main/java/io/questdb/cairo/lv/LiveViewWindow.java
@@ -964,15 +964,28 @@ public class LiveViewWindow implements QuietCloseable {
         //
         // What one stamp can stand for F + 1 sets is that no row is processed between a
         // function's dirty set being emptied and this counter moving on. Every path that
-        // empties one empties the anchor's in the same breath, functions first and the
-        // anchor last: the seal (LiveViewCheckpointTimelineStoreWriter publishes, then
-        // hands onCheckpointPersisted to the anchor and to each function), the checkpoint
-        // restore and the repair overlay (both rehydrate the functions, then the anchor),
-        // and the head-miss replay (LiveViewRefreshJob.clearWindowState). A function
-        // rebound on its own - reset() frees its dirty set without reaching this window at
-        // all - pins itself to a complete freeze until the next onCheckpointPersisted,
-        // which is a seal, which resyncs the pair; the set it builds in between is one the
-        // seal never reads.
+        // empties a function's set either moves this counter on in the same synchronous
+        // block or latches that function onto a complete freeze. The seal
+        // (LiveViewCheckpointTimelineStoreWriter) hands onCheckpointPersisted to the anchor
+        // and to each checkpoint-capable function, and this window's own
+        // clearCheckpointDirtyAnchorMap moves the counter on there. The checkpoint restore
+        // (LiveViewCheckpointTimelineStoreReader) and the repair overlay
+        // (LiveViewCheckpointScratchOverlay, through LiveViewFunctionSnapshot) each hand
+        // every checkpoint-capable function onCheckpointRestoreBegin, which latches the full
+        // scan, and rewind this window through beginCheckpointRestore / restore, which move
+        // the counter on; the reader alone then lifts that latch again with
+        // onCheckpointPersisted, on the anchor and on each function other than the
+        // ring-shaped and scalar ones, and only when it read this generation's timeline
+        // head. The head-miss replay (LiveViewRefreshJob.clearWindowState) rewinds each
+        // function through toTop() and this window through toTop(), which does the same. The
+        // cursor-stack toTop() empties every function's set and leaves this map, its stamps
+        // and this counter standing - AnchorDispatchingCursor routes it to onCursorReopen -
+        // but BasePartitionedWindowFunction.toTop() latches isCheckpointFullScanRequired and
+        // drops the baseline generation there, and freezeFunction reads both before it takes
+        // a dirty map, so the seal full-scans that function instead. A function rebound on
+        // its own - reset() frees its dirty set without reaching this window at all -
+        // latches the same flag, so the set it builds before the next onCheckpointPersisted
+        // is one the seal never reads.
         final boolean isFirstCadenceTouch = isNewPartition
                 || value.getShort(SLOT_DIRTY_EPOCH) != checkpointDirtyEpoch;
         if (isFirstCadenceTouch) {

--- a/core/src/main/java/io/questdb/cairo/lv/LiveViewWindow.java
+++ b/core/src/main/java/io/questdb/cairo/lv/LiveViewWindow.java
@@ -955,9 +955,28 @@ public class LiveViewWindow implements QuietCloseable {
         // of the load. That is also what keeps the sweep's eviction-and-revival path
         // honest: eviction takes the anchor entry out, so a revived key arrives new and
         // re-enters the dirty map, clearing the eviction marker it left behind.
-        if (isNewPartition || value.getShort(SLOT_DIRTY_EPOCH) != checkpointDirtyEpoch) {
+        //
+        // Every window function's own dirty set answers to the same stamp - see the flag
+        // handed to markPartitionAlive below - so this one anchor-value load stands in
+        // for the whole view's per-row dirty marking rather than for the anchor's alone.
+        // A view with F functions used to serialize the partition key and probe a second
+        // map F + 1 times per row; it now does so F + 1 times per key per cadence.
+        //
+        // What one stamp can stand for F + 1 sets is that no row is processed between a
+        // function's dirty set being emptied and this counter moving on. Every path that
+        // empties one empties the anchor's in the same breath, functions first and the
+        // anchor last: the seal (LiveViewCheckpointTimelineStoreWriter publishes, then
+        // hands onCheckpointPersisted to the anchor and to each function), the checkpoint
+        // restore and the repair overlay (both rehydrate the functions, then the anchor),
+        // and the head-miss replay (LiveViewRefreshJob.clearWindowState). A function
+        // rebound on its own - reset() frees its dirty set without reaching this window at
+        // all - pins itself to a complete freeze until the next onCheckpointPersisted,
+        // which is a seal, which resyncs the pair; the set it builds in between is one the
+        // seal never reads.
+        final boolean isFirstCadenceTouch = isNewPartition
+                || value.getShort(SLOT_DIRTY_EPOCH) != checkpointDirtyEpoch;
+        if (isFirstCadenceTouch) {
             markCheckpointPartitionDirty(record, isNewPartition);
-            value.putShort(SLOT_DIRTY_EPOCH, checkpointDirtyEpoch);
         }
         final byte initialized = isNewPartition ? 0 : value.getByte(SLOT_INITIALIZED);
         final long lastAnchor = initialized == 0 ? 0 : value.getLong(SLOT_ANCHOR_VALUE);
@@ -996,7 +1015,19 @@ public class LiveViewWindow implements QuietCloseable {
         // advanced past its bucket -- by which point its accumulator is no longer
         // needed (the next in-order row starts a fresh bucket; late rows replay).
         for (int i = 0, n = functions.size(); i < n; i++) {
-            functions.getQuick(i).markPartitionAlive(record);
+            functions.getQuick(i).markPartitionAlive(record, isFirstCadenceTouch);
+        }
+
+        // The stamp goes in last, once every mark the flag stood for has been made rather
+        // than before the loop that makes them. A function's dirty set is allocated on
+        // first use through the per-view tracker, so the mark can throw on a breach of
+        // cairo.live.view.refresh.memory.limit.bytes; a stamp already standing would have
+        // the retry read this row as marked and leave that function's set one key short of
+        // what its rows moved - which the seal cannot tell from a complete set. Nothing
+        // between the load above and here touches the anchor map, so the handle still
+        // addresses this key's entry.
+        if (isFirstCadenceTouch) {
+            value.putShort(SLOT_DIRTY_EPOCH, checkpointDirtyEpoch);
         }
 
         // Frontier sweep is the last act on the row: compact() rebuilds the anchor map

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -11971,9 +11971,10 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             // thread-safe (Func.isThreadSafe() == false). That is safe only because a union base is
             // serial: it supports neither page frames, filter stealing nor time frames, so no parallel
             // operator (async filter, parallel GROUP BY) ever clones or snapshots this projection.
-            // Enforce the invariant unconditionally rather than with an assert. QuestDB's own artifacts
-            // all run with -ea, so an assert would fire for them, but an embedding is free to disable
-            // assertions - and a future page-frame-capable union must fail loudly for it too, instead of
+            // Enforce the invariant unconditionally rather than with an assert. QuestDB's Docker,
+            // shell-script and AMI launchers pass -ea, so an assert would fire for them, but the
+            // Windows service wrapper passes none and an embedding is free to disable assertions -
+            // and a future page-frame-capable union must fail loudly for those too, instead of
             // shipping a stale, empty dictionary snapshot to a worker.
             if (unionFactory.supportsPageFrameCursor()
                     || unionFactory.supportsFilterStealing()

--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -11971,9 +11971,10 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             // thread-safe (Func.isThreadSafe() == false). That is safe only because a union base is
             // serial: it supports neither page frames, filter stealing nor time frames, so no parallel
             // operator (async filter, parallel GROUP BY) ever clones or snapshots this projection.
-            // Enforce the invariant unconditionally rather than with an assert: -ea strips asserts in
-            // production, and a future page-frame-capable union must fail loudly here instead of shipping
-            // a stale, empty dictionary snapshot to a worker.
+            // Enforce the invariant unconditionally rather than with an assert. QuestDB's own artifacts
+            // all run with -ea, so an assert would fire for them, but an embedding is free to disable
+            // assertions - and a future page-frame-capable union must fail loudly for it too, instead of
+            // shipping a stale, empty dictionary snapshot to a worker.
             if (unionFactory.supportsPageFrameCursor()
                     || unionFactory.supportsFilterStealing()
                     || unionFactory.supportsTimeFrameCursor()) {

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/AbstractStdDevDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/AbstractStdDevDoubleWindowFunctionFactory.java
@@ -1372,8 +1372,8 @@ public abstract class AbstractStdDevDoubleWindowFunctionFactory extends Abstract
         private final ArrayColumnTypes mapValueTypes;
         private final String name;
         private double stddev = Double.NaN;
-        // Welford's other two slots in LiveViewWindow's fused map value. The base class
-        // caches the counter, which every family has; these two are this family's own.
+        // Welford's other two slots in the fused map value WindowMapState owns. The base
+        // class caches the counter, which every family has; these two are this family's own.
         private int windowStateM2Slot = -1;
         private int windowStateMeanSlot = -1;
 

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/AvgDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/AvgDoubleWindowFunctionFactory.java
@@ -1029,7 +1029,11 @@ public class AvgDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
         }
 
         @Override
-        public void markPartitionAlive(Record record) {
+        public void markPartitionAlive(Record record, boolean isFirstCadenceTouch) {
+            // The flag goes unread on purpose: this override keeps no checkpoint dirty
+            // set, so every seal full-scans it. See BasePartitionedWindowFunction's
+            // markCheckpointPartitionDirty - naming some of a cadence's keys and not the
+            // rest is the one outcome that is worse than naming none.
             if (tombstoneValueIndex < 0 || tombstoneCount == 0) {
                 return;
             }
@@ -1647,7 +1651,11 @@ public class AvgDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
         }
 
         @Override
-        public void markPartitionAlive(Record record) {
+        public void markPartitionAlive(Record record, boolean isFirstCadenceTouch) {
+            // The flag goes unread on purpose: this override keeps no checkpoint dirty
+            // set, so every seal full-scans it. See BasePartitionedWindowFunction's
+            // markCheckpointPartitionDirty - naming some of a cadence's keys and not the
+            // rest is the one outcome that is worse than naming none.
             if (tombstoneValueIndex < 0 || tombstoneCount == 0) {
                 return;
             }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/BasePartitionedBivariateWindowFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/BasePartitionedBivariateWindowFunction.java
@@ -109,7 +109,11 @@ public abstract class BasePartitionedBivariateWindowFunction extends BaseBivaria
     }
 
     @Override
-    public void markPartitionAlive(Record record) {
+    public void markPartitionAlive(Record record, boolean isFirstCadenceTouch) {
+        // The flag goes unread on purpose: this override keeps no checkpoint dirty
+        // set, so every seal full-scans it. See BasePartitionedWindowFunction's
+        // markCheckpointPartitionDirty - naming some of a cadence's keys and not the
+        // rest is the one outcome that is worse than naming none.
         if (tombstoneValueIndex < 0 || tombstoneCount == 0) {
             return;
         }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/BasePartitionedWindowFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/BasePartitionedWindowFunction.java
@@ -223,8 +223,8 @@ public abstract class BasePartitionedWindowFunction extends BaseWindowFunction
      * maintain a dirty set of its own, which is exactly the population that never freezes
      * incrementally anyway. It never creates the dirty set: only
      * {@link #markCheckpointPartitionDirty(Record)} does, so a function whose
-     * {@link #markPartitionAlive(Record)} never marks cannot be handed the incremental
-     * path by the sweep alone.
+     * {@link #markPartitionAlive(Record, boolean)} never marks cannot be handed the
+     * incremental path by the sweep alone.
      */
     @Override
     public boolean markCheckpointPartitionEvicted(Record record, RecordSink keySink) {
@@ -257,13 +257,21 @@ public abstract class BasePartitionedWindowFunction extends BaseWindowFunction
      * fires when at least one tombstoned entry exists, which means
      * processRow saw an anchor cross on some partition in the recent past.
      * <p>
+     * The dirty mark rides on {@code isFirstCadenceTouch} rather than on every row.
+     * That flag is the anchor's, read off a value the caller had already loaded, so a
+     * repeat row inside one cadence costs neither the key serialization the mark's sink
+     * does nor the probe into the dirty map that follows it. What the set has to name is
+     * every key whose state moved since the last publication, and the first row of a
+     * cadence names the key every later row of that cadence moves - see
+     * {@link #markCheckpointPartitionDirty(Record)} for the whole contract.
+     * <p>
      * Subclasses that need to clear additional per-partition scratch state
      * may override; most do not. An override that keeps the checkpoint dirty
      * tracking must call {@link #markCheckpointPartitionDirty(Record)} on every
-     * path through the method - see that method's contract.
+     * flagged path through the method - see that method's contract.
      */
     @Override
-    public void markPartitionAlive(Record record) {
+    public void markPartitionAlive(Record record, boolean isFirstCadenceTouch) {
         if (isWindowStateOwned()) {
             // A fused function's own map stays closed, so it carries no tombstone bit to
             // clear and no dirty set to mark, and the group keeps neither. Defensive for
@@ -271,7 +279,9 @@ public abstract class BasePartitionedWindowFunction extends BaseWindowFunction
             // only caller and a live-view compile binds no function into a group.
             return;
         }
-        markCheckpointPartitionDirty(record);
+        if (isFirstCadenceTouch) {
+            markCheckpointPartitionDirty(record);
+        }
         if (tombstoneValueIndex < 0 || tombstoneCount == 0) {
             return;
         }
@@ -514,11 +524,14 @@ public abstract class BasePartitionedWindowFunction extends BaseWindowFunction
      * has the same key layout as the state map, so the existing partition sink can
      * populate it without allocating or serialising a key on every input row.
      * <p>
-     * <b>Call this on every path through {@link #markPartitionAlive(Record)} or on
-     * none at all.</b> A seal that finds a dirty map freezes exactly the keys it
-     * names and leaves every other entry of the persistent root alone, so a key
-     * whose state moved without being marked keeps the root's stale image - a wrong
-     * result that only surfaces on a restart. Opting out is fail-safe by
+     * <b>Call this on every {@code isFirstCadenceTouch} path through
+     * {@link #markPartitionAlive(Record, boolean)} or on none at all.</b> A seal that
+     * finds a dirty map freezes exactly the keys it names and leaves every other entry
+     * of the persistent root alone, so a key whose state moved without being marked
+     * keeps the root's stale image - a wrong result that only surfaces on a restart.
+     * The flag loses nothing the set needs: the anchor raises it on the first row a
+     * cadence sees for a partition and lowers it only once that row's marks are all
+     * made, so every key a cadence moves is named, once. Opting out is fail-safe by
      * construction: this is the only place the map is created and the only place
      * {@code hasCheckpointDirtyTracking} is set, so a function that never calls this
      * leaves {@link #getCheckpointDirtyPartitionMap()} null, has the sweep's eviction

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/BasePartitionedWindowFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/BasePartitionedWindowFunction.java
@@ -44,7 +44,6 @@ import io.questdb.std.LongList;
 import io.questdb.std.MemoryTracker;
 import io.questdb.std.Misc;
 import io.questdb.std.Numbers;
-import io.questdb.std.ObjList;
 import io.questdb.std.Vect;
 import org.jetbrains.annotations.Nullable;
 
@@ -151,11 +150,6 @@ public abstract class BasePartitionedWindowFunction extends BaseWindowFunction
         this.windowStateNonNullCountSlot = projection == null
                 ? -1
                 : projection.getFieldSlot(WindowAccumulatorDescriptor.FIELD_NON_NULL_COUNT);
-    }
-
-    @Override
-    public @Nullable ObjList<? extends Function> checkpointPartitionByFunctions() {
-        return partitionByRecord == null ? null : partitionByRecord.getFunctions();
     }
 
     @Override

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/RankFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/RankFunctionFactory.java
@@ -557,7 +557,11 @@ public class RankFunctionFactory extends AbstractWindowFunctionFactory {
         }
 
         @Override
-        public void markPartitionAlive(Record record) {
+        public void markPartitionAlive(Record record, boolean isFirstCadenceTouch) {
+            // The flag goes unread on purpose: this override keeps no checkpoint dirty
+            // set, so every seal full-scans it. See BasePartitionedWindowFunction's
+            // markCheckpointPartitionDirty - naming some of a cadence's keys and not the
+            // rest is the one outcome that is worse than naming none.
             if (tombstoneValueIndex < 0 || tombstoneCount == 0) {
                 return;
             }

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/RowNumberFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/RowNumberFunctionFactory.java
@@ -150,7 +150,7 @@ public class RowNumberFunctionFactory implements FunctionFactory {
         private long rowNumber;
         // Single-writer (refresh worker), not volatile.
         private long tombstoneCount;
-        // The row counter's slot in LiveViewWindow's fused map value, or -1 when this
+        // The row counter's slot in the fused map value WindowMapState owns, or -1 when this
         // function owns its state in the map above as it always has. Installed and
         // cleared by the window-state plan, both on the refresh worker.
         private int windowStateRowCountSlot = -1;
@@ -237,8 +237,8 @@ public class RowNumberFunctionFactory implements FunctionFactory {
         @Override
         public void retainPartitions(Map survivingKeys, RecordSink survivingKeySink) {
             if (isWindowStateOwned()) {
-                // The sweep rebuilt the window's fused map and the counter rode across
-                // inside the entries it kept. There is no second map to prune.
+                // A bound function keeps no partition map of its own: the group owns the
+                // one entry the counter lives in, and there is no second map to prune.
                 return;
             }
             // RowNumber implements WindowFunction directly (no BasePartitionedWindowFunction),

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/RowNumberFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/RowNumberFunctionFactory.java
@@ -372,7 +372,11 @@ public class RowNumberFunctionFactory implements FunctionFactory {
         }
 
         @Override
-        public void markPartitionAlive(Record record) {
+        public void markPartitionAlive(Record record, boolean isFirstCadenceTouch) {
+            // The flag goes unread on purpose: this override keeps no checkpoint dirty
+            // set, so every seal full-scans it. See BasePartitionedWindowFunction's
+            // markCheckpointPartitionDirty - naming some of a cadence's keys and not the
+            // rest is the one outcome that is worse than naming none.
             if (isWindowStateOwned()) {
                 // Nothing of this function's is tombstoned any more: the window keeps the
                 // one value this row touches alive, for the whole group.

--- a/core/src/main/java/io/questdb/griffin/engine/functions/window/SumDoubleWindowFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/window/SumDoubleWindowFunctionFactory.java
@@ -33,11 +33,9 @@ import io.questdb.cairo.lv.LiveViewSnapshotKeyCodec;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapFactory;
 import io.questdb.cairo.map.MapKey;
-import io.questdb.cairo.map.MapRecord;
 import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
-import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.VirtualRecord;
 import io.questdb.cairo.sql.WindowSPI;
 import io.questdb.cairo.vm.Vm;
@@ -335,27 +333,18 @@ public class SumDoubleWindowFunctionFactory extends AbstractWindowFunctionFactor
         }
 
         /**
-         * Writes the partition's sum back over itself, which is what this family's
-         * finalization amounts to. It stays an override rather than being dropped because
-         * inheriting {@code avg}'s would replace the sum with the average; and it stays
-         * skipped when bound for the same reason every bound function's does - the group
-         * keeps the raw pair and there is no map of this function's own to walk.
+         * Finalizes nothing: pass 1 already left the slot holding the sum this family answers
+         * with, and {@code getDouble} reads it straight back.
+         * <p>
+         * The method stays an override rather than being dropped because inheriting {@code avg}'s
+         * would divide the sum by the count and answer with the average. What its body used to do
+         * was walk every entry of the partition map to execute
+         * {@code value.putDouble(0, value.getDouble(0))} - a write of each slot back over itself -
+         * so a {@code sum() OVER (PARTITION BY k)} paid one full traversal of its map, between the
+         * two passes, that changed no byte of it.
          */
         @Override
         public void preparePass2() {
-            if (isWindowStateOwned()) {
-                return;
-            }
-            RecordCursor cursor = map.getCursor();
-            MapRecord record = map.getRecord();
-            while (cursor.hasNext()) {
-                MapValue value = record.getValue();
-                long count = value.getLong(1);
-                if (count > 0) {
-                    double sum = value.getDouble(0);
-                    value.putDouble(0, sum);
-                }
-            }
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/lv/LiveViewPageFrameCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/lv/LiveViewPageFrameCursor.java
@@ -434,11 +434,13 @@ public class LiveViewPageFrameCursor implements TablePageFrameCursor {
         final long diskSize = base.size();
         final long rawLeadStart = slotRowCount - slot.leadRowCount();
         // The overlap band is a suffix of the disk scan, so it cannot run negative. Assert to
-        // fail loudly, and clamp as well. The assert is what a server takes: every shipped
-        // artifact runs with -ea (docker-entrypoint.sh, questdb.sh, the AMI systemd unit), so it
-        // throws before the clamp is reached. The clamp covers an embedding that disables
-        // assertions, where a negative leadStart would inflate the seam's disk band past the
-        // scan.
+        // fail loudly, and clamp as well. The assert is what the Docker, shell-script and AMI
+        // launchers take: docker-entrypoint.sh, questdb.sh (which serves Linux, macOS and
+        // FreeBSD alike) and the AMI systemd unit all pass -ea, so it throws before the clamp
+        // is reached. The clamp is the production guard everywhere else - the Windows service
+        // wrapper (win64svc/src/questdb.c) hard-codes its JVM options and passes no -ea, and an
+        // embedding may disable assertions too - where a negative leadStart would inflate the
+        // seam's disk band past the scan.
         assert rawLeadStart >= 0 : "leadStart " + rawLeadStart + " is negative";
         final long leadStart = Math.max(0, rawLeadStart);
         // The intervals the base scan confines its rows to, if any. They select the mode as
@@ -455,9 +457,11 @@ public class LiveViewPageFrameCursor implements TablePageFrameCursor {
         // an unsized base degrade instead of mis-cutting.
         final boolean isSeamShape = !isDescending && intervals == null && diskSize >= 0;
         // Under the seam shape the overlap band is a suffix of the disk scan, so it cannot
-        // exceed it. Assert to fail loudly - which is what a server does, since every shipped
-        // artifact runs with -ea - and degrade to lead-only for an embedding that disables
-        // assertions. Without either, a negative cut makes every reader read diskRoutedRows as
+        // exceed it. Assert to fail loudly - which is what the Docker, shell-script and AMI
+        // launchers do, since they pass -ea - and degrade to lead-only wherever they do not:
+        // the Windows service wrapper passes no -ea (see the clamp above), and an embedding may
+        // disable assertions, so the degrade is a production guard there rather than a
+        // courtesy. Without either, a negative cut makes every reader read diskRoutedRows as
         // "cannot size", so the disk frames pass through in full AND the slot band is served on
         // top - rows emitted twice, with size() returning -1 so nothing cross-checks it.
         assert !isSeamShape || leadStart <= diskSize : "leadStart " + leadStart + " exceeds disk size " + diskSize;

--- a/core/src/main/java/io/questdb/griffin/engine/lv/LiveViewPageFrameCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/lv/LiveViewPageFrameCursor.java
@@ -434,8 +434,11 @@ public class LiveViewPageFrameCursor implements TablePageFrameCursor {
         final long diskSize = base.size();
         final long rawLeadStart = slotRowCount - slot.leadRowCount();
         // The overlap band is a suffix of the disk scan, so it cannot run negative. Assert to
-        // fail loudly under -ea, but clamp as well: -ea is off in production, and a negative
-        // leadStart inflates the seam's disk band past the scan.
+        // fail loudly, and clamp as well. The assert is what a server takes: every shipped
+        // artifact runs with -ea (docker-entrypoint.sh, questdb.sh, the AMI systemd unit), so it
+        // throws before the clamp is reached. The clamp covers an embedding that disables
+        // assertions, where a negative leadStart would inflate the seam's disk band past the
+        // scan.
         assert rawLeadStart >= 0 : "leadStart " + rawLeadStart + " is negative";
         final long leadStart = Math.max(0, rawLeadStart);
         // The intervals the base scan confines its rows to, if any. They select the mode as
@@ -452,10 +455,11 @@ public class LiveViewPageFrameCursor implements TablePageFrameCursor {
         // an unsized base degrade instead of mis-cutting.
         final boolean isSeamShape = !isDescending && intervals == null && diskSize >= 0;
         // Under the seam shape the overlap band is a suffix of the disk scan, so it cannot
-        // exceed it. Assert to fail loudly under -ea, and degrade to lead-only otherwise: with
-        // -ea off a negative cut makes every reader read diskRoutedRows as "cannot size", so the
-        // disk frames pass through in full AND the slot band is served on top - rows emitted
-        // twice, with size() returning -1 so nothing cross-checks it.
+        // exceed it. Assert to fail loudly - which is what a server does, since every shipped
+        // artifact runs with -ea - and degrade to lead-only for an embedding that disables
+        // assertions. Without either, a negative cut makes every reader read diskRoutedRows as
+        // "cannot size", so the disk frames pass through in full AND the slot band is served on
+        // top - rows emitted twice, with size() returning -1 so nothing cross-checks it.
         assert !isSeamShape || leadStart <= diskSize : "leadStart " + leadStart + " exceeds disk size " + diskSize;
         if (!isSeamShape || leadStart > diskSize) {
             // Lead-only: disk serves every row it kept and the slot adds the lead band

--- a/core/src/main/java/io/questdb/griffin/engine/window/CachedWindowMapGroups.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/CachedWindowMapGroups.java
@@ -302,8 +302,7 @@ public final class CachedWindowMapGroups implements QuietCloseable {
 
     /**
      * Every bound group, in no particular traversal order. It is the lifecycle list - what
-     * {@link #reopen} allocates and {@link #reset} hands back - and what a test reads the
-     * structural counters off.
+     * {@link #reopen} allocates and {@link #reset} hands back.
      */
     @TestOnly
     public ObjList<WindowMapState> getStates() {

--- a/core/src/main/java/io/questdb/griffin/engine/window/CachedWindowMapGroups.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/CachedWindowMapGroups.java
@@ -351,8 +351,28 @@ public final class CachedWindowMapGroups implements QuietCloseable {
         // thing only - the lowest position among equal candidates wins the contributor role -
         // and a bucket collects its members in SELECT order, so the two agree on which that is.
         final ObjList<WindowMapSpec> bucketSpecs = new ObjList<>(bucket.size());
+        final int specCount = specFunctions.size();
+        // Both lists run in SELECT order, so a member sits at or after the previous member's
+        // index and the search resumes there rather than at zero. It wraps, so a bucket that
+        // arrives in some other order - or holds a function these lists never carried - still
+        // gets the answer a scan from zero would give it, only after more compares. Restarting
+        // every member at zero made this quadratic in the window-function count.
+        int cursor = 0;
         for (int i = 0, n = bucket.size(); i < n; i++) {
-            bucketSpecs.add(specOf(bucket.getQuick(i), specFunctions, specs));
+            final WindowFunction function = bucket.getQuick(i);
+            WindowMapSpec spec = null;
+            for (int k = 0; k < specCount; k++) {
+                int j = cursor + k;
+                if (j >= specCount) {
+                    j -= specCount;
+                }
+                if (specFunctions.getQuick(j) == function) {
+                    spec = specs.getQuick(j);
+                    cursor = j + 1 < specCount ? j + 1 : 0;
+                    break;
+                }
+            }
+            bucketSpecs.add(spec);
         }
         return WindowAccumulatorPlanBuilder.compileGroups(bucket, bucketSpecs, chainTypes);
     }
@@ -374,16 +394,4 @@ public final class CachedWindowMapGroups implements QuietCloseable {
         return spec.getPass1ScanDirection() == WindowFunction.Pass1ScanDirection.FORWARD;
     }
 
-    private static @Nullable WindowMapSpec specOf(
-            @NotNull WindowFunction function,
-            @NotNull ObjList<WindowFunction> specFunctions,
-            @NotNull ObjList<WindowMapSpec> specs
-    ) {
-        for (int i = 0, n = specFunctions.size(); i < n; i++) {
-            if (specFunctions.getQuick(i) == function) {
-                return specs.getQuick(i);
-            }
-        }
-        return null;
-    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/window/CachedWindowMapGroups.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/CachedWindowMapGroups.java
@@ -354,8 +354,10 @@ public final class CachedWindowMapGroups implements QuietCloseable {
         // Both lists run in SELECT order, so a member sits at or after the previous member's
         // index and the search resumes there rather than at zero. It wraps, so a bucket that
         // arrives in some other order - or holds a function these lists never carried - still
-        // gets the answer a scan from zero would give it, only after more compares. Restarting
-        // every member at zero made this quadratic in the window-function count.
+        // gets the answer a scan from zero would give it, only after more compares. The resume
+        // telescopes within one bucket, not across them - this method resets cursor to zero on
+        // every call - so n single-member buckets still cost n(n+1)/2 compares between them, a
+        // compile-time price the query pays once.
         int cursor = 0;
         for (int i = 0, n = bucket.size(); i < n; i++) {
             final WindowFunction function = bucket.getQuick(i);

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowAccumulatorDescriptor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowAccumulatorDescriptor.java
@@ -1175,6 +1175,47 @@ public final class WindowAccumulatorDescriptor {
     }
 
     /**
+     * Whether a row this component's contribution predicate refuses leaves its state exactly as
+     * it was - so a group whose every component refuses a row has nothing to write for it, and
+     * {@link WindowMapState#computeNext} may leave that row's key out of the map altogether.
+     * <p>
+     * Deliberately narrower than "the predicate refuses the row", and the families it turns away
+     * are what say why:
+     * <ul>
+     *     <li>{@link #CONTRIBUTION_EVERY_ROW} has no refused row to be inert about, so a row
+     *     count and the two respect-nulls captures decline here through their predicate;</li>
+     *     <li>a <b>{@code last_value ignore nulls}</b> capture writes its slot on the first row of
+     *     a partition whatever that row held and only then begins refusing, so a refused row that
+     *     happens to be a partition's first one does change the state;</li>
+     *     <li>a <b>{@link #isRingBacked() ring-backed} bounded frame</b> allocates its ring on the
+     *     partition's first row and advances it on every row after, refused rows included,
+     *     because a refused row still occupies a position in the frame.</li>
+     * </ul>
+     * Only {@link #CONTRIBUTION_FINITE_DOUBLE} answers true, and that is the caller's constraint
+     * rather than a claim about the other predicates. The group evaluates the predicate itself,
+     * off the contributor's own argument, and {@code Numbers.isFinite(arg.getDouble(record))} is
+     * the whole of this one - where the type's own null test is a different expression per
+     * argument type and a second spelling of it here would be a second chance to disagree with
+     * the contributor. Families carrying the other kinds are inert in the same sense and may be
+     * admitted once a caller can evaluate them.
+     */
+    public boolean isRefusedRowInert() {
+        if (contributionKind != CONTRIBUTION_FINITE_DOUBLE) {
+            return false;
+        }
+        return switch (family) {
+            case FAMILY_DOUBLE_FIRST_NOT_NULL_VALUE,
+                 FAMILY_DOUBLE_KAHAN_SUM_COUNT,
+                 FAMILY_DOUBLE_MAX,
+                 FAMILY_DOUBLE_MIN,
+                 FAMILY_DOUBLE_SUM_COUNT,
+                 FAMILY_DOUBLE_WELFORD,
+                 FAMILY_NON_NULL_COUNT -> true;
+            default -> false;
+        };
+    }
+
+    /**
      * Whether this component's state continues outside the group's map value, in a ring of the
      * frame's own values that its <b>contributor</b> owns and the ring slots address.
      * <p>

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowAccumulatorDescriptor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowAccumulatorDescriptor.java
@@ -1198,6 +1198,24 @@ public final class WindowAccumulatorDescriptor {
      * argument type and a second spelling of it here would be a second chance to disagree with
      * the contributor. Families carrying the other kinds are inert in the same sense and may be
      * admitted once a caller can evaluate them.
+     * <p>
+     * Five of the seven families this admits run ahead of any caller that reaches them, and so
+     * this admission of them carries no coverage: {@link #FAMILY_DOUBLE_MAX},
+     * {@link #FAMILY_DOUBLE_MIN}, {@link #FAMILY_DOUBLE_WELFORD},
+     * {@link #FAMILY_DOUBLE_KAHAN_SUM_COUNT} and
+     * {@link #FAMILY_DOUBLE_FIRST_NOT_NULL_VALUE}. The skip needs a two-pass group - see
+     * {@link WindowMapState#isPass1SkipEnabled()} - and the whole-partition {@code avg},
+     * {@code sum} and {@code count} functions are the only two-pass ones that declare a family,
+     * which leaves {@link #FAMILY_DOUBLE_SUM_COUNT} and {@link #FAMILY_NON_NULL_COUNT} as the
+     * whole of what a skipping group holds today. Every class declaring one of the five sits on
+     * a cumulative {@code *OverUnboundedPartitionRowsFrame*} frame and reports
+     * {@link WindowFunction#ZERO_PASS}, while {@link WindowMapSpec#isSameSpec} keys a group by
+     * its pass count - so no group carrying one of them is ever two-pass. Their identity
+     * encodings themselves do run, wherever {@link WindowMapState#computeNext} resets a new
+     * entry of a group carrying one; what no caller reaches is those same encodings read back
+     * off the identity buffer a skipping group answers a whole-skipped partition from - see
+     * {@link WindowMapState#projectPass2} - and reaching that takes a production change rather
+     * than a test.
      */
     public boolean isRefusedRowInert() {
         if (contributionKind != CONTRIBUTION_FINITE_DOUBLE) {

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowAccumulatorPlanBuilder.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowAccumulatorPlanBuilder.java
@@ -232,12 +232,12 @@ public final class WindowAccumulatorPlanBuilder {
         ObjList<WindowAccumulatorPlan> plans = null;
         for (int b = 0, bn = builders.size(); b < bn; b++) {
             final WindowAccumulatorPlanBuilder builder = builders.getQuick(b);
+            final IntList members = builderMembers.getQuick(b);
             // Read before a single projection is added, because whether a count over the
             // partition key may join a row count depends on the group holding an unguarded
             // reading of that same row count - and the count may precede it in the SELECT
             // list. Everything else about a projection follows from the function alone.
-            final WindowFunction rowCountHost = rowCountHost(functions, specs, builder.spec);
-            final IntList members = builderMembers.getQuick(b);
+            final WindowFunction rowCountHost = rowCountHost(functions, members);
             for (int m = 0, mn = members.size(); m < mn; m++) {
                 final int i = members.getQuick(m);
                 addAccumulatorProjection(
@@ -446,17 +446,20 @@ public final class WindowAccumulatorPlanBuilder {
      * The gates are the same ones {@link #addAccumulatorProjection} applies, so this cannot
      * name a host that walk would decline, and the family half of the test is
      * {@link WindowAccumulatorCandidate#isRowCountHost}'s.
+     * <p>
+     * {@code members} is the group's own membership, which the bucketing pass already
+     * established, so this walks the group rather than the SELECT list and asks no function
+     * about its spec: bucketing means membership. Scanning all of {@code functions} here and
+     * re-testing {@code isSameSpec} made the phase quadratic in the window-function count -
+     * every group against every function - for an answer already in hand. Members arrive in
+     * ascending SELECT-list order, so the first host found is the same one either walk names.
      */
     private static @Nullable WindowFunction rowCountHost(
             ObjList<? extends Function> functions,
-            ObjList<WindowMapSpec> specs,
-            WindowMapSpec groupSpec
+            IntList members
     ) {
-        for (int i = 0, n = functions.size(); i < n; i++) {
-            final WindowMapSpec spec = i < specs.size() ? specs.getQuick(i) : null;
-            if (spec != null
-                    && groupSpec.isSameSpec(spec)
-                    && functions.getQuick(i) instanceof WindowFunction windowFunction
+        for (int m = 0, mn = members.size(); m < mn; m++) {
+            if (functions.getQuick(members.getQuick(m)) instanceof WindowFunction windowFunction
                     && isFusibleAccumulator(windowFunction)
                     && WindowAccumulatorCandidate.isRowCountHost(windowFunction)) {
                 return windowFunction;

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowFunction.java
@@ -264,11 +264,14 @@ public interface WindowFunction extends Function {
      * <p>
      * A function opts in by calling
      * {@link io.questdb.griffin.engine.functions.window.BasePartitionedWindowFunction#markCheckpointPartitionDirty}
-     * from {@link #markPartitionAlive(Record)}. That call must be unconditional or
-     * absent altogether: a partial mark leaves a changed key out of the map, and the
-     * seal then publishes a root that still names the key's stale state. Opting out
-     * is fail-safe - the map stays null, the seal full-scans, and correctness does
-     * not depend on the function at all.
+     * from {@link #markPartitionAlive(Record, boolean)} on exactly the rows its
+     * {@code isFirstCadenceTouch} flag names, or on no row at all: a partial mark leaves
+     * a changed key out of the map, and the seal then publishes a root that still names
+     * the key's stale state. Marking on the flag is what makes the set complete without
+     * being per-row - the flag is raised on the first row a cadence sees for a partition,
+     * and every later row of that cadence moves state the flagged row already named.
+     * Opting out is fail-safe - the map stays null, the seal full-scans, and correctness
+     * does not depend on the function at all.
      */
     @Nullable
     default Map getCheckpointDirtyPartitionMap() {
@@ -719,8 +722,22 @@ public interface WindowFunction extends Function {
      * tombstone bit. Implementations must be branchless on the common (no-tombstone)
      * case -- check the function-local tombstoneCount first and bail before the
      * Map lookup.
+     * <p>
+     * {@code isFirstCadenceTouch} carries the anchor's answer to "has this partition
+     * been named in the current checkpoint cadence yet?", which the caller reads off the
+     * anchor value it has already loaded. A function that keeps a checkpoint dirty set
+     * marks it into that set on exactly those rows - see
+     * {@link #getCheckpointDirtyPartitionMap()} for why that is complete - and so pays a
+     * key serialization and a second map probe once per partition per cadence rather
+     * than once per row. The tombstone clear above is not on the flag: the bit is set
+     * and cancelled on the same anchor-cross row, and its guard is a field load rather
+     * than a probe.
+     *
+     * @param record              the current base row
+     * @param isFirstCadenceTouch true when this is the first row the current checkpoint
+     *                            cadence has seen for this partition
      */
-    default void markPartitionAlive(Record record) {
+    default void markPartitionAlive(Record record, boolean isFirstCadenceTouch) {
     }
 
     /**

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowFunction.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowFunction.java
@@ -212,25 +212,6 @@ public interface WindowFunction extends Function {
         return null;
     }
 
-    /**
-     * The compiled PARTITION BY terms this function keys its per-partition state by, or
-     * null when it keeps no keyed state.
-     * <p>
-     * The reference is <b>non-owning</b>, exactly as
-     * {@link #windowAccumulatorArgument()}'s is: the window function owns its
-     * partition-by functions and frees them, and the compiler only reads their identity.
-     * What it reads them for is the one relation that holds between a call's argument and
-     * the window rather than between two calls - a {@code count(k)} over the column its
-     * own window partitions by, whose value is the partition's row count wherever
-     * {@code k} is present. Resolving the terms to base columns is the same proof
-     * {@code directColumnIndex} applies to an argument, so an expression term proves
-     * nothing and the relation is declined.
-     */
-    @Nullable
-    default ObjList<? extends Function> checkpointPartitionByFunctions() {
-        return null;
-    }
-
     default void computeNext(Record record) {
     }
 

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowMapState.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowMapState.java
@@ -161,10 +161,26 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     private final WindowAccumulatorPlan plan;
     private final int projectionCount;
     private final int unorderedMapMaxEntrySize;
-    private long lookupCount;
-    private long projectionWriteCount;
+    /**
+     * Pass-1 rows this group absorbed - every row it saw, less the ones
+     * {@link #isRowRefusedByEveryComponent} turned away. Assert-gated: see
+     * {@link #countContributedRow()}.
+     */
+    private long contributedRowCount;
+    /**
+     * Rows on which {@link #putIdentity} had to create an entry pass 1 never made. Assert-gated:
+     * see {@link #countIdentityRow()}.
+     */
+    private long identityRowCount;
+    /**
+     * Rows {@link #projectPass2} walked, which for a two-pass group is every row of the
+     * traversal and for a one-pass group is none. Assert-gated: see {@link #countPass2Row()}.
+     */
+    private long pass2RowCount;
+    /**
+     * Pass-1 rows every component refused. Assert-gated: see {@link #countSkippedRow()}.
+     */
     private long skippedRowCount;
-    private long updateCount;
 
     private WindowMapState(
             @NotNull CairoConfiguration configuration,
@@ -322,7 +338,7 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      */
     public void computeNext(Record record) {
         if (isPass1SkipEnabled && isRowRefusedByEveryComponent(record)) {
-            skippedRowCount++;
+            assert countSkippedRow();
             return;
         }
         final MapKey key = map.withKey();
@@ -340,20 +356,19 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
             for (int p = 0; p < projectionCount; p++) {
                 plan.getProjectionFunction(p).projectWindowState(record, value);
             }
-            projectionWriteCount += projectionCount;
         }
-        lookupCount++;
-        updateCount += componentCount;
+        assert countContributedRow();
     }
 
     /**
-     * The number of times a contributor absorbed a row, which is the lookup count times the
-     * component count. Beside {@link #getLookupCount()} it is what says a group removed
-     * updates rather than only maps.
+     * The number of times a contributor absorbed a row, which is the contributed row count
+     * times the component count. Beside {@link #getLookupCount()} it is what says a group
+     * removed updates rather than only maps. Answers only with assertions enabled - see
+     * {@link #countContributedRow()}.
      */
     @TestOnly
     public long getContributorUpdateCount() {
-        return updateCount;
+        return contributedRowCount * componentCount;
     }
 
     /**
@@ -362,10 +377,13 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      * A group that skips pass-1 rows probes fewer times than that, and once more than that for
      * every row of a partition pass 2 had to insert. Structural rather than timed: a lookup
      * reduction that is only visible in elapsed time is not a measurement.
+     * <p>
+     * Derived from the per-traversal tallies rather than counted at the probes, so it answers
+     * only with assertions enabled - see {@link #countContributedRow()}.
      */
     @TestOnly
     public long getLookupCount() {
-        return lookupCount;
+        return contributedRowCount + pass2RowCount + identityRowCount;
     }
 
     /**
@@ -382,15 +400,24 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         return plan;
     }
 
+    /**
+     * The number of projection writes the group made, which is the projection count times the
+     * rows the projecting traversal walked - pass 2's rows for a two-pass group, and pass 1's
+     * contributed rows for a one-pass group, which projects from the value it has just loaded.
+     * A skipped pass-1 row writes no projection either way: a one-pass group never skips, and a
+     * two-pass group projects the row in pass 2 off the identity entry {@link #putIdentity}
+     * makes for it. Answers only with assertions enabled - see {@link #countContributedRow()}.
+     */
     @TestOnly
     public long getProjectionWriteCount() {
-        return projectionWriteCount;
+        return (isTwoPass ? pass2RowCount : contributedRowCount) * projectionCount;
     }
 
     /**
      * The number of pass-1 rows the group left out of its map because every component refused
      * them. Zero for a group {@link #isPass1SkipEnabled()} does not hold for, and the structural
-     * evidence that the skip fired rather than merely compiled.
+     * evidence that the skip fired rather than merely compiled. Answers only with assertions
+     * enabled - see {@link #countContributedRow()}.
      */
     @TestOnly
     public long getSkippedRowCount() {
@@ -475,8 +502,7 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         for (int p = 0; p < projectionCount; p++) {
             plan.getProjectionFunction(p).projectWindowState(record, value);
         }
-        lookupCount++;
-        projectionWriteCount += projectionCount;
+        assert countPass2Row();
     }
 
     /**
@@ -557,6 +583,52 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     /**
+     * Tallies a pass-1 row the group absorbed.
+     * <p>
+     * The four {@code count*} methods carry the structural instrumentation the fusion tests and
+     * {@code WindowMapFusionBenchmark} read back, and every one of their call sites is an
+     * {@code assert} rather than a statement. A group's traversal methods run once per row of the
+     * query, so a plain field increment there would put the cost of measuring fusion onto every
+     * user of it; behind an {@code assert} the increment compiles to a read of the
+     * {@code $assertionsDisabled} static final, which HotSpot folds to a constant and removes the
+     * body with it. Tests get the counters because the surefire {@code argLine} runs {@code -ea};
+     * a server never does, and pays nothing.
+     * <p>
+     * Each returns {@code true} so the {@code assert} it sits in cannot fire.
+     */
+    private boolean countContributedRow() {
+        contributedRowCount++;
+        return true;
+    }
+
+    /**
+     * Tallies a row {@link #putIdentity} had to create an entry for. See
+     * {@link #countContributedRow()} for why this is assert-gated.
+     */
+    private boolean countIdentityRow() {
+        identityRowCount++;
+        return true;
+    }
+
+    /**
+     * Tallies a row {@link #projectPass2} walked. See {@link #countContributedRow()} for why this
+     * is assert-gated.
+     */
+    private boolean countPass2Row() {
+        pass2RowCount++;
+        return true;
+    }
+
+    /**
+     * Tallies a pass-1 row every component refused. See {@link #countContributedRow()} for why
+     * this is assert-gated.
+     */
+    private boolean countSkippedRow() {
+        skippedRowCount++;
+        return true;
+    }
+
+    /**
      * Whether no component of the group would absorb this row, which is what lets pass 1 leave
      * the row's key out of the map.
      * <p>
@@ -589,7 +661,7 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         final MapKey key = map.withKey();
         putKey(key, record);
         final MapValue value = key.createValue();
-        lookupCount++;
+        assert countIdentityRow();
         if (value.isNew()) {
             for (int c = 0; c < componentCount; c++) {
                 plan.getComponent(c).resetState(value, plan.getComponentSlotBase(c));
@@ -615,9 +687,9 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     private void resetStructuralCounters() {
-        lookupCount = 0;
-        updateCount = 0;
-        projectionWriteCount = 0;
+        contributedRowCount = 0;
+        identityRowCount = 0;
+        pass2RowCount = 0;
         skippedRowCount = 0;
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowMapState.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowMapState.java
@@ -139,6 +139,22 @@ import org.jetbrains.annotations.TestOnly;
  * concentrated where it is not.
  */
 public final class WindowMapState implements QuietCloseable, Reopenable {
+    /**
+     * Whether the group keeps the structural counters the fusion tests and
+     * {@code WindowMapFusionBenchmark} read back. Off unless
+     * {@code -Dquestdb.window.map.counters=true} is on the command line; the surefire
+     * {@code argLine} sets it, and the benchmark sets it for itself.
+     * <p>
+     * A {@code static final} rather than an {@code assert}, because every shipped artifact runs
+     * with assertions on - {@code core/docker-entrypoint.sh}, {@code core/src/main/bin/questdb.sh}
+     * and the AMI systemd unit all pass {@code -ea} - so assert-gating would have left the
+     * increments in the server's hot loop, which is the cost they exist to avoid. HotSpot folds a
+     * {@code static final} of an initialized class to a constant, so with the property unset every
+     * {@code if (COUNTERS_ENABLED)} below and the field write inside it leave the compiled code
+     * entirely. A group's traversal methods run once per row of the query, so that is the
+     * difference between measuring fusion and charging every user of it for the measurement.
+     */
+    private static final boolean COUNTERS_ENABLED = Boolean.getBoolean("questdb.window.map.counters");
     private final int componentCount;
     /**
      * The contributors' arguments, one per component, in component order - borrowed exactly as
@@ -163,22 +179,22 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     private final int unorderedMapMaxEntrySize;
     /**
      * Pass-1 rows this group absorbed - every row it saw, less the ones
-     * {@link #isRowRefusedByEveryComponent} turned away. Assert-gated: see
-     * {@link #countContributedRow()}.
+     * {@link #isRowRefusedByEveryComponent} turned away. Kept only under
+     * {@link #COUNTERS_ENABLED}.
      */
     private long contributedRowCount;
     /**
-     * Rows on which {@link #putIdentity} had to create an entry pass 1 never made. Assert-gated:
-     * see {@link #countIdentityRow()}.
+     * Partitions {@link #putIdentity} had to create an entry for, pass 1 having left every row of
+     * them out. Kept only under {@link #COUNTERS_ENABLED}.
      */
     private long identityRowCount;
     /**
      * Rows {@link #projectPass2} walked, which for a two-pass group is every row of the
-     * traversal and for a one-pass group is none. Assert-gated: see {@link #countPass2Row()}.
+     * traversal and for a one-pass group is none. Kept only under {@link #COUNTERS_ENABLED}.
      */
     private long pass2RowCount;
     /**
-     * Pass-1 rows every component refused. Assert-gated: see {@link #countSkippedRow()}.
+     * Pass-1 rows every component refused. Kept only under {@link #COUNTERS_ENABLED}.
      */
     private long skippedRowCount;
 
@@ -338,7 +354,9 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      */
     public void computeNext(Record record) {
         if (isPass1SkipEnabled && isRowRefusedByEveryComponent(record)) {
-            assert countSkippedRow();
+            if (COUNTERS_ENABLED) {
+                skippedRowCount++;
+            }
             return;
         }
         final MapKey key = map.withKey();
@@ -357,17 +375,19 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
                 plan.getProjectionFunction(p).projectWindowState(record, value);
             }
         }
-        assert countContributedRow();
+        if (COUNTERS_ENABLED) {
+            contributedRowCount++;
+        }
     }
 
     /**
      * The number of times a contributor absorbed a row, which is the contributed row count
      * times the component count. Beside {@link #getLookupCount()} it is what says a group
-     * removed updates rather than only maps. Answers only with assertions enabled - see
-     * {@link #countContributedRow()}.
+     * removed updates rather than only maps. Requires {@link #COUNTERS_ENABLED}.
      */
     @TestOnly
     public long getContributorUpdateCount() {
+        requireCounters();
         return contributedRowCount * componentCount;
     }
 
@@ -378,11 +398,12 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      * every row of a partition pass 2 had to insert. Structural rather than timed: a lookup
      * reduction that is only visible in elapsed time is not a measurement.
      * <p>
-     * Derived from the per-traversal tallies rather than counted at the probes, so it answers
-     * only with assertions enabled - see {@link #countContributedRow()}.
+     * Derived from the per-traversal tallies rather than counted at the probes themselves.
+     * Requires {@link #COUNTERS_ENABLED}.
      */
     @TestOnly
     public long getLookupCount() {
+        requireCounters();
         return contributedRowCount + pass2RowCount + identityRowCount;
     }
 
@@ -406,21 +427,23 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      * contributed rows for a one-pass group, which projects from the value it has just loaded.
      * A skipped pass-1 row writes no projection either way: a one-pass group never skips, and a
      * two-pass group projects the row in pass 2 off the identity entry {@link #putIdentity}
-     * makes for it. Answers only with assertions enabled - see {@link #countContributedRow()}.
+     * makes for it. Requires {@link #COUNTERS_ENABLED}.
      */
     @TestOnly
     public long getProjectionWriteCount() {
+        requireCounters();
         return (isTwoPass ? pass2RowCount : contributedRowCount) * projectionCount;
     }
 
     /**
      * The number of pass-1 rows the group left out of its map because every component refused
      * them. Zero for a group {@link #isPass1SkipEnabled()} does not hold for, and the structural
-     * evidence that the skip fired rather than merely compiled. Answers only with assertions
-     * enabled - see {@link #countContributedRow()}.
+     * evidence that the skip fired rather than merely compiled. Requires
+     * {@link #COUNTERS_ENABLED}.
      */
     @TestOnly
     public long getSkippedRowCount() {
+        requireCounters();
         return skippedRowCount;
     }
 
@@ -502,7 +525,9 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         for (int p = 0; p < projectionCount; p++) {
             plan.getProjectionFunction(p).projectWindowState(record, value);
         }
-        assert countPass2Row();
+        if (COUNTERS_ENABLED) {
+            pass2RowCount++;
+        }
     }
 
     /**
@@ -583,49 +608,13 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     /**
-     * Tallies a pass-1 row the group absorbed.
-     * <p>
-     * The four {@code count*} methods carry the structural instrumentation the fusion tests and
-     * {@code WindowMapFusionBenchmark} read back, and every one of their call sites is an
-     * {@code assert} rather than a statement. A group's traversal methods run once per row of the
-     * query, so a plain field increment there would put the cost of measuring fusion onto every
-     * user of it; behind an {@code assert} the increment compiles to a read of the
-     * {@code $assertionsDisabled} static final, which HotSpot folds to a constant and removes the
-     * body with it. Tests get the counters because the surefire {@code argLine} runs {@code -ea};
-     * a server never does, and pays nothing.
-     * <p>
-     * Each returns {@code true} so the {@code assert} it sits in cannot fire.
+     * Whether the structural counters are being kept, which is
+     * {@code -Dquestdb.window.map.counters=true} on this JVM's command line. Read by the
+     * benchmark, which needs them and would otherwise report a fusion result made of zeroes.
      */
-    private boolean countContributedRow() {
-        contributedRowCount++;
-        return true;
-    }
-
-    /**
-     * Tallies a row {@link #putIdentity} had to create an entry for. See
-     * {@link #countContributedRow()} for why this is assert-gated.
-     */
-    private boolean countIdentityRow() {
-        identityRowCount++;
-        return true;
-    }
-
-    /**
-     * Tallies a row {@link #projectPass2} walked. See {@link #countContributedRow()} for why this
-     * is assert-gated.
-     */
-    private boolean countPass2Row() {
-        pass2RowCount++;
-        return true;
-    }
-
-    /**
-     * Tallies a pass-1 row every component refused. See {@link #countContributedRow()} for why
-     * this is assert-gated.
-     */
-    private boolean countSkippedRow() {
-        skippedRowCount++;
-        return true;
+    @TestOnly
+    public static boolean areCountersEnabled() {
+        return COUNTERS_ENABLED;
     }
 
     /**
@@ -647,6 +636,20 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     /**
+     * Refuses to answer a counter the group was never told to keep.
+     * <p>
+     * Returning the zero the field still holds would be worse than useless: an assertion that a
+     * group skipped no rows, or made no lookups, passes on that zero whatever the group did.
+     */
+    private static void requireCounters() {
+        if (!COUNTERS_ENABLED) {
+            throw new IllegalStateException(
+                    "WindowMapState structural counters are off; run with -Dquestdb.window.map.counters=true"
+            );
+        }
+    }
+
+    /**
      * Creates the entry for a partition pass 1 skipped whole and puts every component of it to
      * identity, returning the value the caller's projections then read.
      * <p>
@@ -661,7 +664,9 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         final MapKey key = map.withKey();
         putKey(key, record);
         final MapValue value = key.createValue();
-        assert countIdentityRow();
+        if (COUNTERS_ENABLED) {
+            identityRowCount++;
+        }
         if (value.isNew()) {
             for (int c = 0; c < componentCount; c++) {
                 plan.getComponent(c).resetState(value, plan.getComponentSlotBase(c));

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowMapState.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowMapState.java
@@ -41,6 +41,7 @@ import io.questdb.cairo.sql.VirtualRecord;
 import io.questdb.std.BytecodeAssembler;
 import io.questdb.std.MemoryTracker;
 import io.questdb.std.Misc;
+import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 import io.questdb.std.QuietCloseable;
 import org.jetbrains.annotations.NotNull;
@@ -71,6 +72,20 @@ import org.jetbrains.annotations.TestOnly;
  * functions perform on their own maps - {@code avg}'s {@code preparePass2} overwrites the
  * sum slot a {@code sum} projection still needs - with arithmetic each projection does for
  * itself, off state the group never rewrites.
+ *
+ * <h2>What a refused row costs</h2>
+ * The one lookup a row is a saving over the several a group replaces, and it is not a saving
+ * over none. Unfused {@code sum} and {@code avg} test their DOUBLE argument before they touch
+ * their maps, so a NULL-heavy partition costs them an argument evaluation a row and no probe at
+ * all, while the fused sequence above writes the key, creates the value and dispatches to the
+ * contributor before the contributor decides the row was never its business. Measurement on
+ * mostly-NULL DOUBLE input found that unconditional work outweighed the probe the group
+ * consolidates, which is what {@link #isPass1SkipEnabled()} answers to: a two-pass group whose
+ * components are every one
+ * {@link WindowAccumulatorDescriptor#isRefusedRowInert() inert on a refused row} evaluates the
+ * predicate itself and leaves the row alone when the answer is no. That the group may then have
+ * no entry for a partition is pass 2's to settle - see {@link #projectPass2(Record)} - and it is
+ * the whole of what the skip changes about the map.
  *
  * <h2>Ownership</h2>
  * The group owns its map and its key projection and nothing else. The functions it binds keep
@@ -125,6 +140,14 @@ import org.jetbrains.annotations.TestOnly;
  */
 public final class WindowMapState implements QuietCloseable, Reopenable {
     private final int componentCount;
+    /**
+     * The contributors' arguments, one per component, in component order - borrowed exactly as
+     * {@link #keyRecord}'s terms are, and null unless {@link #isPass1SkipEnabled()} holds. Read
+     * only to evaluate the components' shared contribution predicate ahead of the map work; the
+     * window functions own these and free them.
+     */
+    private final ObjList<Function> contributorArguments;
+    private final boolean isPass1SkipEnabled;
     private final boolean isTwoPass;
     /**
      * The group's own wrapper over the borrowed PARTITION BY terms, or null when the key is
@@ -140,6 +163,7 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     private final int unorderedMapMaxEntrySize;
     private long lookupCount;
     private long projectionWriteCount;
+    private long skippedRowCount;
     private long updateCount;
 
     private WindowMapState(
@@ -160,6 +184,12 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         // Every member of a group agrees with its spec on how many passes the traversal takes,
         // so this is the group's pass structure and not one function's.
         this.isTwoPass = spec.getPassCount() > WindowFunction.ONE_PASS;
+        // Only a two-pass group can leave a row's key out of pass 1: a one-pass group projects
+        // from the value it just loaded, so it needs the entry for every row whether the row
+        // contributed to it or not.
+        final ObjList<Function> skipArguments = isTwoPass ? contributorArgumentsForSkip(plan) : null;
+        this.contributorArguments = skipArguments;
+        this.isPass1SkipEnabled = skipArguments != null;
         final ArrayColumnTypes keyTypes = new ArrayColumnTypes();
         appendKeyTypes(spec, keyTypes);
         final ObjList<? extends Function> keyFunctions = spec.getPartitionByFunctions();
@@ -281,8 +311,20 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      * a projection loop a row better off not running one. Which of the two this is follows
      * from the spec every member shares, so it is the group's shape rather than a caller's
      * choice.
+     * <p>
+     * A two-pass group whose components are all {@link WindowAccumulatorDescriptor#isRefusedRowInert()
+     * inert on a refused row} skips the whole sequence for a row not one of them would absorb -
+     * the key write, the lookup, the identity put and the contributor dispatch alike - because
+     * every one of those would leave the value exactly as it found it. What the row costs then
+     * is one evaluation of the shared contribution predicate, which is what the unfused
+     * functions charge a refused row and less than the fused probe was charging it. Pass 2
+     * answers for the partitions this leaves out of the map: see {@link #projectPass2}.
      */
     public void computeNext(Record record) {
+        if (isPass1SkipEnabled && isRowRefusedByEveryComponent(record)) {
+            skippedRowCount++;
+            return;
+        }
         final MapKey key = map.withKey();
         putKey(key, record);
         final MapValue value = key.createValue();
@@ -315,10 +357,11 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     /**
-     * The number of rows this group looked its key up for - one per row, however many outputs
-     * read the value back, and two per row for a two-pass group, which probes once in each
-     * traversal. Structural rather than timed: a lookup reduction that is only visible in
-     * elapsed time is not a measurement.
+     * The number of times this group looked a key up - one per row, however many outputs read
+     * the value back, and two per row for a two-pass group, which probes once in each traversal.
+     * A group that skips pass-1 rows probes fewer times than that, and once more than that for
+     * every row of a partition pass 2 had to insert. Structural rather than timed: a lookup
+     * reduction that is only visible in elapsed time is not a measurement.
      */
     @TestOnly
     public long getLookupCount() {
@@ -345,6 +388,16 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     /**
+     * The number of pass-1 rows the group left out of its map because every component refused
+     * them. Zero for a group {@link #isPass1SkipEnabled()} does not hold for, and the structural
+     * evidence that the skip fired rather than merely compiled.
+     */
+    @TestOnly
+    public long getSkippedRowCount() {
+        return skippedRowCount;
+    }
+
+    /**
      * The configured {@code cairo.sql.unordered.map.max.entry.size} this group's map was
      * selected under. It is 16 in {@code DefaultCairoConfiguration}, which embedded use and the
      * benchmarks take, and 32 by default in a server - enough to move a shape between
@@ -366,6 +419,17 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     /**
+     * Whether this group skips the pass-1 map work for a row every one of its components
+     * refuses. A compile-time fact: it holds for a two-pass group whose components are every one
+     * {@link WindowAccumulatorDescriptor#isRefusedRowInert() inert on a refused row}, and the
+     * group's pass 2 creates the entries it leaves out - see {@link #projectPass2}.
+     */
+    @TestOnly
+    public boolean isPass1SkipEnabled() {
+        return isPass1SkipEnabled;
+    }
+
+    /**
      * Whether this group's outputs are written by a second traversal - which is what makes it
      * the owner's business, since a two-pass group has to be driven from the pass-2 loop as
      * well as the pass-1 one. See {@link CachedWindowMapGroups}, the only owner that has both.
@@ -378,21 +442,36 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      * Materializes every output of a two-pass group from the accumulator pass 1 left final,
      * for the row {@code record} is positioned on.
      * <p>
-     * The lookup is a {@link MapKey#findValue()} rather than a {@code createValue()}: pass 1
-     * created an entry for every row the two passes walk - it creates one unconditionally,
-     * where a function's own {@code pass1} may not - so there is nothing here to insert, and
-     * inserting would grow a key domain that is supposed to be closed by now.
+     * The lookup is a {@link MapKey#findValue()}: pass 1 created an entry for every row the two
+     * passes walk - it creates one unconditionally, where a function's own {@code pass1} may
+     * not - so there is nothing to insert for a group that skips nothing, and inserting would
+     * grow a key domain that is supposed to be closed by now.
+     * <p>
+     * A group that does skip closes its key domain here instead, and only where the lookup
+     * misses. Pass 1 leaves out exactly the partitions nothing contributed to, so a missing
+     * entry is that partition's own answer rather than a lost one, and what it projects is the
+     * identity every component would still be sitting at had pass 1 created it - a NULL sum, a
+     * NULL average, a zero count. Creating it now rather than reading identity out of thin air
+     * is what keeps the projections reading a real value and the key domain the same one the
+     * unskipped group ends with, so the two bindings agree on the map's size as well as on its
+     * answers.
      * <p>
      * There is deliberately no accumulation. A projection reads slots and writes no state, so
      * running this over a row a second time is idempotent, which is what a cached cursor's
-     * random access and its second drain need.
+     * random access and its second drain need - and the create above is idempotent for the same
+     * reason, since the second visit finds the entry the first one left.
      */
     public void projectPass2(Record record) {
         final MapKey key = map.withKey();
         putKey(key, record);
-        final MapValue value = key.findValue();
-        // Pass 1 walked the same rows and created an entry for each, so the key is there.
-        assert value != null;
+        MapValue value = key.findValue();
+        if (value == null) {
+            // A group that skips nothing created an entry for every row the two passes walk, so
+            // only a skipping group can miss here - and it misses exactly on the partitions
+            // whose every row its components refused.
+            assert isPass1SkipEnabled;
+            value = putIdentity(record);
+        }
         for (int p = 0; p < projectionCount; p++) {
             plan.getProjectionFunction(p).projectWindowState(record, value);
         }
@@ -431,6 +510,42 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     /**
+     * Returns the contributors' arguments, in component order, for a plan whose pass 1 may skip
+     * a refused row - or null for one whose may not, which is the answer for every plan holding
+     * a component that is not
+     * {@link WindowAccumulatorDescriptor#isRefusedRowInert() inert on a refused row}.
+     * <p>
+     * One component that is not inert disables the skip for the whole group rather than for
+     * itself: the group makes one decision per row, and a row {@code sum(x)} refuses is still a
+     * row {@code count(*)} beside it counts.
+     * <p>
+     * The argument is the <b>contributor's</b> and not the component's, which is the same column
+     * read through the object that already reads it: an inert component's identity carries a
+     * direct column reference of the record's own type, and the contributor's own
+     * {@code accumulateWindowState} evaluates exactly this function. A contributor that reports
+     * no argument declines the group, which cannot happen for the families admitted here - every
+     * one of them takes an argument - and is the honest answer rather than a cast.
+     */
+    private static @Nullable ObjList<Function> contributorArgumentsForSkip(@NotNull WindowAccumulatorPlan plan) {
+        final int componentCount = plan.getComponentCount();
+        if (componentCount == 0) {
+            return null;
+        }
+        final ObjList<Function> arguments = new ObjList<>(componentCount);
+        for (int c = 0; c < componentCount; c++) {
+            if (!plan.getComponent(c).isRefusedRowInert()) {
+                return null;
+            }
+            final Function argument = plan.getContributor(c).windowAccumulatorArgument();
+            if (argument == null) {
+                return null;
+            }
+            arguments.add(argument);
+        }
+        return arguments;
+    }
+
+    /**
      * Hands every output of the group the slots it reads out of the shared value. Done once,
      * at compile time: a bound function's {@code computeNext} is a no-op from here on and its
      * private map stays closed, both of which the factory relies on for its whole life.
@@ -439,6 +554,48 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         for (int i = 0; i < projectionCount; i++) {
             plan.getProjectionFunction(i).bindWindowStateSlots(plan.getProjection(i));
         }
+    }
+
+    /**
+     * Whether no component of the group would absorb this row, which is what lets pass 1 leave
+     * the row's key out of the map.
+     * <p>
+     * The predicate is {@link WindowAccumulatorDescriptor#CONTRIBUTION_FINITE_DOUBLE}'s, which
+     * every component of a skipping group carries, so one expression answers for all of them.
+     * The walk stops at the first component that would absorb the row, so the dense case pays
+     * for one argument evaluation and the row goes on to the ordinary sequence.
+     */
+    private boolean isRowRefusedByEveryComponent(Record record) {
+        for (int c = 0; c < componentCount; c++) {
+            if (Numbers.isFinite(contributorArguments.getQuick(c).getDouble(record))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Creates the entry for a partition pass 1 skipped whole and puts every component of it to
+     * identity, returning the value the caller's projections then read.
+     * <p>
+     * A second key write rather than a {@code createValue()} on the key
+     * {@link #projectPass2(Record)} just looked up with: pass 2's hot path is the lookup that
+     * finds an entry, and a {@code findValue()} is the cheaper of the two ways to make it. What
+     * this costs is one extra key write on the rows of a partition no row contributed to, which
+     * is the population the skip exists for - and which {@link #getLookupCount()} counts, so the
+     * skip's saving is reported net of what it spends here rather than gross.
+     */
+    private MapValue putIdentity(Record record) {
+        final MapKey key = map.withKey();
+        putKey(key, record);
+        final MapValue value = key.createValue();
+        lookupCount++;
+        if (value.isNew()) {
+            for (int c = 0; c < componentCount; c++) {
+                plan.getComponent(c).resetState(value, plan.getComponentSlotBase(c));
+            }
+        }
+        return value;
     }
 
     /**
@@ -461,5 +618,6 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         lookupCount = 0;
         updateCount = 0;
         projectionWriteCount = 0;
+        skippedRowCount = 0;
     }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowMapState.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowMapState.java
@@ -139,22 +139,6 @@ import org.jetbrains.annotations.TestOnly;
  * concentrated where it is not.
  */
 public final class WindowMapState implements QuietCloseable, Reopenable {
-    /**
-     * Whether the group keeps the structural counters the fusion tests and
-     * {@code WindowMapFusionBenchmark} read back. Off unless
-     * {@code -Dquestdb.window.map.counters=true} is on the command line; the surefire
-     * {@code argLine} sets it, and the benchmark sets it for itself.
-     * <p>
-     * A {@code static final} rather than an {@code assert}, because every shipped artifact runs
-     * with assertions on - {@code core/docker-entrypoint.sh}, {@code core/src/main/bin/questdb.sh}
-     * and the AMI systemd unit all pass {@code -ea} - so assert-gating would have left the
-     * increments in the server's hot loop, which is the cost they exist to avoid. HotSpot folds a
-     * {@code static final} of an initialized class to a constant, so with the property unset every
-     * {@code if (COUNTERS_ENABLED)} below and the field write inside it leave the compiled code
-     * entirely. A group's traversal methods run once per row of the query, so that is the
-     * difference between measuring fusion and charging every user of it for the measurement.
-     */
-    private static final boolean COUNTERS_ENABLED = Boolean.getBoolean("questdb.window.map.counters");
     private final int componentCount;
     /**
      * The contributors' arguments, one per component, in component order - borrowed exactly as
@@ -177,27 +161,6 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     private final WindowAccumulatorPlan plan;
     private final int projectionCount;
     private final int unorderedMapMaxEntrySize;
-    /**
-     * Pass-1 rows this group absorbed - every row it saw, less the ones
-     * {@link #isRowRefusedByEveryComponent} turned away. Kept only under
-     * {@link #COUNTERS_ENABLED}.
-     */
-    private long contributedRowCount;
-    /**
-     * Partitions {@link #putIdentity} had to create an entry for, pass 1 having left every row of
-     * them out. Kept only under {@link #COUNTERS_ENABLED}.
-     */
-    private long identityRowCount;
-    /**
-     * Rows {@link #projectPass2} walked, which for a two-pass group is every row of the
-     * traversal and for a one-pass group is none. Kept only under {@link #COUNTERS_ENABLED}.
-     */
-    private long pass2RowCount;
-    /**
-     * Pass-1 rows every component refused. Kept only under {@link #COUNTERS_ENABLED}.
-     */
-    private long skippedRowCount;
-
     private WindowMapState(
             @NotNull CairoConfiguration configuration,
             @NotNull BytecodeAssembler asm,
@@ -310,7 +273,6 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         if (map.isOpen()) {
             map.clear();
         }
-        resetStructuralCounters();
     }
 
     @Override
@@ -354,9 +316,6 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      */
     public void computeNext(Record record) {
         if (isPass1SkipEnabled && isRowRefusedByEveryComponent(record)) {
-            if (COUNTERS_ENABLED) {
-                skippedRowCount++;
-            }
             return;
         }
         final MapKey key = map.withKey();
@@ -375,36 +334,6 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
                 plan.getProjectionFunction(p).projectWindowState(record, value);
             }
         }
-        if (COUNTERS_ENABLED) {
-            contributedRowCount++;
-        }
-    }
-
-    /**
-     * The number of times a contributor absorbed a row, which is the contributed row count
-     * times the component count. Beside {@link #getLookupCount()} it is what says a group
-     * removed updates rather than only maps. Requires {@link #COUNTERS_ENABLED}.
-     */
-    @TestOnly
-    public long getContributorUpdateCount() {
-        requireCounters();
-        return contributedRowCount * componentCount;
-    }
-
-    /**
-     * The number of times this group looked a key up - one per row, however many outputs read
-     * the value back, and two per row for a two-pass group, which probes once in each traversal.
-     * A group that skips pass-1 rows probes fewer times than that, and once more than that for
-     * every row of a partition pass 2 had to insert. Structural rather than timed: a lookup
-     * reduction that is only visible in elapsed time is not a measurement.
-     * <p>
-     * Derived from the per-traversal tallies rather than counted at the probes themselves.
-     * Requires {@link #COUNTERS_ENABLED}.
-     */
-    @TestOnly
-    public long getLookupCount() {
-        requireCounters();
-        return contributedRowCount + pass2RowCount + identityRowCount;
     }
 
     /**
@@ -417,34 +346,17 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         return map.getClass().getSimpleName();
     }
 
+    /**
+     * The number of distinct keys the group currently holds. Tests use this to observe the
+     * pass-1 key domain directly without adding work to the per-row production path.
+     */
+    @TestOnly
+    public long getMapSize() {
+        return map.size();
+    }
+
     public WindowAccumulatorPlan getPlan() {
         return plan;
-    }
-
-    /**
-     * The number of projection writes the group made, which is the projection count times the
-     * rows the projecting traversal walked - pass 2's rows for a two-pass group, and pass 1's
-     * contributed rows for a one-pass group, which projects from the value it has just loaded.
-     * A skipped pass-1 row writes no projection either way: a one-pass group never skips, and a
-     * two-pass group projects the row in pass 2 off the identity entry {@link #putIdentity}
-     * makes for it. Requires {@link #COUNTERS_ENABLED}.
-     */
-    @TestOnly
-    public long getProjectionWriteCount() {
-        requireCounters();
-        return (isTwoPass ? pass2RowCount : contributedRowCount) * projectionCount;
-    }
-
-    /**
-     * The number of pass-1 rows the group left out of its map because every component refused
-     * them. Zero for a group {@link #isPass1SkipEnabled()} does not hold for, and the structural
-     * evidence that the skip fired rather than merely compiled. Requires
-     * {@link #COUNTERS_ENABLED}.
-     */
-    @TestOnly
-    public long getSkippedRowCount() {
-        requireCounters();
-        return skippedRowCount;
     }
 
     /**
@@ -525,9 +437,6 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         for (int p = 0; p < projectionCount; p++) {
             plan.getProjectionFunction(p).projectWindowState(record, value);
         }
-        if (COUNTERS_ENABLED) {
-            pass2RowCount++;
-        }
     }
 
     /**
@@ -538,7 +447,6 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     @Override
     public void reopen() {
         map.reopen();
-        resetStructuralCounters();
     }
 
     /**
@@ -547,7 +455,6 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      */
     public void reset() {
         map.close();
-        resetStructuralCounters();
     }
 
     public void setMemoryTracker(@Nullable MemoryTracker tracker) {
@@ -608,16 +515,6 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     /**
-     * Whether the structural counters are being kept, which is
-     * {@code -Dquestdb.window.map.counters=true} on this JVM's command line. Read by the
-     * benchmark, which needs them and would otherwise report a fusion result made of zeroes.
-     */
-    @TestOnly
-    public static boolean areCountersEnabled() {
-        return COUNTERS_ENABLED;
-    }
-
-    /**
      * Whether no component of the group would absorb this row, which is what lets pass 1 leave
      * the row's key out of the map.
      * <p>
@@ -636,20 +533,6 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     /**
-     * Refuses to answer a counter the group was never told to keep.
-     * <p>
-     * Returning the zero the field still holds would be worse than useless: an assertion that a
-     * group skipped no rows, or made no lookups, passes on that zero whatever the group did.
-     */
-    private static void requireCounters() {
-        if (!COUNTERS_ENABLED) {
-            throw new IllegalStateException(
-                    "WindowMapState structural counters are off; run with -Dquestdb.window.map.counters=true"
-            );
-        }
-    }
-
-    /**
      * Creates the entry for a partition pass 1 skipped whole and puts every component of it to
      * identity, returning the value the caller's projections then read.
      * <p>
@@ -657,16 +540,12 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      * {@link #projectPass2(Record)} just looked up with: pass 2's hot path is the lookup that
      * finds an entry, and a {@code findValue()} is the cheaper of the two ways to make it. What
      * this costs is one extra key write on the rows of a partition no row contributed to, which
-     * is the population the skip exists for - and which {@link #getLookupCount()} counts, so the
-     * skip's saving is reported net of what it spends here rather than gross.
+     * is the population the skip exists for.
      */
     private MapValue putIdentity(Record record) {
         final MapKey key = map.withKey();
         putKey(key, record);
         final MapValue value = key.createValue();
-        if (COUNTERS_ENABLED) {
-            identityRowCount++;
-        }
         if (value.isNew()) {
             for (int c = 0; c < componentCount; c++) {
                 plan.getComponent(c).resetState(value, plan.getComponentSlotBase(c));
@@ -691,10 +570,4 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         }
     }
 
-    private void resetStructuralCounters() {
-        contributedRowCount = 0;
-        identityRowCount = 0;
-        pass2RowCount = 0;
-        skippedRowCount = 0;
-    }
 }

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowMapState.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowMapState.java
@@ -161,6 +161,7 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     private final WindowAccumulatorPlan plan;
     private final int projectionCount;
     private final int unorderedMapMaxEntrySize;
+
     private WindowMapState(
             @NotNull CairoConfiguration configuration,
             @NotNull BytecodeAssembler asm,

--- a/core/src/main/java/io/questdb/griffin/engine/window/WindowMapState.java
+++ b/core/src/main/java/io/questdb/griffin/engine/window/WindowMapState.java
@@ -38,12 +38,15 @@ import io.questdb.cairo.map.MapValue;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.VirtualRecord;
+import io.questdb.griffin.engine.groupby.FlyweightPackedMapValue;
 import io.questdb.std.BytecodeAssembler;
+import io.questdb.std.MemoryTag;
 import io.questdb.std.MemoryTracker;
 import io.questdb.std.Misc;
 import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 import io.questdb.std.QuietCloseable;
+import io.questdb.std.Unsafe;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.TestOnly;
@@ -83,9 +86,11 @@ import org.jetbrains.annotations.TestOnly;
  * consolidates, which is what {@link #isPass1SkipEnabled()} answers to: a two-pass group whose
  * components are every one
  * {@link WindowAccumulatorDescriptor#isRefusedRowInert() inert on a refused row} evaluates the
- * predicate itself and leaves the row alone when the answer is no. That the group may then have
- * no entry for a partition is pass 2's to settle - see {@link #projectPass2(Record)} - and it is
- * the whole of what the skip changes about the map.
+ * predicate itself and leaves the row alone when the answer is no. A partition every row of
+ * which the group refused then has no entry at all, and keeps none: pass 2 projects the
+ * components' identity off a buffer of the group's own - see {@link #projectPass2(Record)} - so
+ * the map a skipping group ends with holds the contributing partitions rather than every
+ * partition the traversal saw. That is the whole of what the skip changes about the map.
  *
  * <h2>Ownership</h2>
  * The group owns its map and its key projection and nothing else. The functions it binds keep
@@ -147,6 +152,15 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      * window functions own these and free them.
      */
     private final ObjList<Function> contributorArguments;
+    /**
+     * The value {@link #projectPass2(Record)} projects a missing partition off, over a buffer
+     * of the group's own rather than an entry of the map - or null unless
+     * {@link #isPass1SkipEnabled()} holds, which is the only way pass 2 can miss. One buffer
+     * serves every missing partition: what a partition nothing contributed to projects is the
+     * components' identity, and that does not vary by key.
+     */
+    private final FlyweightPackedMapValue identityValue;
+    private final long identityValueSize;
     private final boolean isPass1SkipEnabled;
     private final boolean isTwoPass;
     /**
@@ -161,6 +175,11 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     private final WindowAccumulatorPlan plan;
     private final int projectionCount;
     private final int unorderedMapMaxEntrySize;
+    /**
+     * The identity buffer's native address, or 0 while the group holds no backing. Allocated
+     * and freed with the map, so a closed cursor's group owns nothing.
+     */
+    private long identityValueAddress;
 
     private WindowMapState(
             @NotNull CairoConfiguration configuration,
@@ -212,6 +231,11 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         }
         final ArrayColumnTypes valueTypes = new ArrayColumnTypes();
         plan.buildMapValueTypes(valueTypes);
+        // Only a skipping group can miss in pass 2, so only one carries the flyweight the miss
+        // projects off. Its layout is this buffer's own and never the map's: nothing inserts it,
+        // and the components address it by slot exactly as they address an entry.
+        this.identityValue = isPass1SkipEnabled ? new FlyweightPackedMapValue(valueTypes) : null;
+        this.identityValueSize = isPass1SkipEnabled ? identityValue.getSizeInBytes() : 0;
         // Built before the map so a failure here cannot strand a tracked allocation.
         this.keySink = RecordSinkFactory.getInstance(configuration, asm, sinkTypes, keyColumnFilter, null);
         // Lazily opened, like every other tracker-aware window state: the owning cursor binds
@@ -279,6 +303,7 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     @Override
     public void close() {
         Misc.free(map);
+        freeIdentityValue();
     }
 
     /**
@@ -382,10 +407,22 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     /**
+     * Whether the group currently holds the buffer {@link #projectPass2(Record)} projects a
+     * missing partition off. Always false for a group whose pass 1 skips nothing, which needs
+     * none; for one whose pass 1 skips, it moves with the map, so it is what says a failed open
+     * or a closed cursor left the group holding nothing.
+     */
+    @TestOnly
+    public boolean isIdentityValueAllocated() {
+        return identityValueAddress != 0;
+    }
+
+    /**
      * Whether this group skips the pass-1 map work for a row every one of its components
      * refuses. A compile-time fact: it holds for a two-pass group whose components are every one
      * {@link WindowAccumulatorDescriptor#isRefusedRowInert() inert on a refused row}, and the
-     * group's pass 2 creates the entries it leaves out - see {@link #projectPass2}.
+     * group's pass 2 projects the partitions it leaves out off the identity buffer rather than
+     * putting them back in the map - see {@link #projectPass2}.
      */
     @TestOnly
     public boolean isPass1SkipEnabled() {
@@ -410,19 +447,27 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      * not - so there is nothing to insert for a group that skips nothing, and inserting would
      * grow a key domain that is supposed to be closed by now.
      * <p>
-     * A group that does skip closes its key domain here instead, and only where the lookup
-     * misses. Pass 1 leaves out exactly the partitions nothing contributed to, so a missing
-     * entry is that partition's own answer rather than a lost one, and what it projects is the
-     * identity every component would still be sitting at had pass 1 created it - a NULL sum, a
-     * NULL average, a zero count. Creating it now rather than reading identity out of thin air
-     * is what keeps the projections reading a real value and the key domain the same one the
-     * unskipped group ends with, so the two bindings agree on the map's size as well as on its
-     * answers.
+     * A group that does skip leaves the miss where it is. Pass 1 omits exactly the partitions
+     * nothing contributed to, so a missing entry is that partition's own answer rather than a
+     * lost one, and what it projects is the identity every component would still be sitting at
+     * had pass 1 created it - a NULL sum, a NULL average, a zero count. The projections read
+     * that identity off {@link #identityValue}, a buffer of the group's own, so the row costs
+     * one failed lookup and nothing else: no second key write, no {@code createValue()}, and no
+     * entry the map then carries for a partition that has no state to keep. That is the whole
+     * of the saving, and it is concentrated exactly where the skip already pays - a wide key
+     * domain whose rows are mostly refused, where materializing the misses cost an insertion a
+     * row and a map the size of the key domain rather than of the contributing partitions.
+     * <p>
+     * What it costs is that the two bindings no longer agree on the map's <b>size</b>: a
+     * skipping group's map holds the contributing partitions alone, where the unskipped one
+     * holds every partition the traversal saw. They agree on every answer, which is what the
+     * fused/unfused comparison rests on, and nothing but a test reads the size.
      * <p>
      * There is deliberately no accumulation. A projection reads slots and writes no state, so
      * running this over a row a second time is idempotent, which is what a cached cursor's
-     * random access and its second drain need - and the create above is idempotent for the same
-     * reason, since the second visit finds the entry the first one left.
+     * random access and its second drain need - and the identity path is idempotent by
+     * construction, since it reads a buffer put back to identity ahead of every projection loop
+     * that uses it.
      */
     public void projectPass2(Record record) {
         final MapKey key = map.withKey();
@@ -433,7 +478,7 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
             // only a skipping group can miss here - and it misses exactly on the partitions
             // whose every row its components refused.
             assert isPass1SkipEnabled;
-            value = putIdentity(record);
+            value = resetIdentityValue();
         }
         for (int p = 0; p < projectionCount; p++) {
             plan.getProjectionFunction(p).projectWindowState(record, value);
@@ -448,6 +493,17 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     @Override
     public void reopen() {
         map.reopen();
+        if (identityValue != null && identityValueAddress == 0) {
+            try {
+                identityValueAddress = Unsafe.malloc(identityValueSize, MemoryTag.NATIVE_DEFAULT);
+            } catch (Throwable th) {
+                // The map is already open by here, and an owner that never saw this group open
+                // has no reason to reset it - so give the backing back rather than strand it.
+                map.close();
+                throw th;
+            }
+            identityValue.of(identityValueAddress);
+        }
     }
 
     /**
@@ -456,6 +512,7 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
      */
     public void reset() {
         map.close();
+        freeIdentityValue();
     }
 
     public void setMemoryTracker(@Nullable MemoryTracker tracker) {
@@ -516,6 +573,17 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     /**
+     * Gives the identity buffer back, if the group holds one. Idempotent, because both
+     * {@link #reset()} and {@link #close()} run it and an owner may run both.
+     */
+    private void freeIdentityValue() {
+        if (identityValueAddress != 0) {
+            Unsafe.free(identityValueAddress, identityValueSize, MemoryTag.NATIVE_DEFAULT);
+            identityValueAddress = 0;
+        }
+    }
+
+    /**
      * Whether no component of the group would absorb this row, which is what lets pass 1 leave
      * the row's key out of the map.
      * <p>
@@ -534,28 +602,6 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
     }
 
     /**
-     * Creates the entry for a partition pass 1 skipped whole and puts every component of it to
-     * identity, returning the value the caller's projections then read.
-     * <p>
-     * A second key write rather than a {@code createValue()} on the key
-     * {@link #projectPass2(Record)} just looked up with: pass 2's hot path is the lookup that
-     * finds an entry, and a {@code findValue()} is the cheaper of the two ways to make it. What
-     * this costs is one extra key write on the rows of a partition no row contributed to, which
-     * is the population the skip exists for.
-     */
-    private MapValue putIdentity(Record record) {
-        final MapKey key = map.withKey();
-        putKey(key, record);
-        final MapValue value = key.createValue();
-        if (value.isNew()) {
-            for (int c = 0; c < componentCount; c++) {
-                plan.getComponent(c).resetState(value, plan.getComponentSlotBase(c));
-            }
-        }
-        return value;
-    }
-
-    /**
      * Writes the row's key onto {@code key}, through the compiled PARTITION BY terms where the
      * key is an expression and off the record's own columns where it is not.
      * <p>
@@ -571,4 +617,23 @@ public final class WindowMapState implements QuietCloseable, Reopenable {
         }
     }
 
+    /**
+     * Puts every component of the group's own buffer back to identity and hands it to
+     * {@link #projectPass2(Record)}, which is what a partition pass 1 skipped whole projects
+     * off instead of an entry of the map.
+     * <p>
+     * Put back on every miss rather than once per open, at a few slot stores a missed row. The
+     * projections that read it write no state, so a buffer put to identity once would answer
+     * for every miss the cursor makes - but that is a property of every projection family
+     * admitted to a skipping group rather than of this method, and one a family added later
+     * could quietly break, in a shape whose only symptom is one partition's output leaking into
+     * another's. Restoring it here costs less than the failed lookup that precedes it and
+     * leaves nothing to break.
+     */
+    private MapValue resetIdentityValue() {
+        for (int c = 0; c < componentCount; c++) {
+            plan.getComponent(c).resetState(identityValue, plan.getComponentSlotBase(c));
+        }
+        return identityValue;
+    }
 }

--- a/core/src/test/java/io/questdb/test/cairo/lv/LiveViewCheckpointIncrementalSealTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/lv/LiveViewCheckpointIncrementalSealTest.java
@@ -2258,20 +2258,26 @@ public class LiveViewCheckpointIncrementalSealTest extends AbstractLiveViewTest 
         }
 
         @Override
-        public void markPartitionAlive(Record record, boolean isFirstCadenceTouch) {
-            if (!isFirstCadenceTouch) {
-                return;
-            }
+        public void pass1(Record record, long recordOffset, WindowSPI spi) {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Counts what the base class's gate lets through, and refuses when the switch is on.
+         * The stub inherits {@link BasePartitionedWindowFunction#markPartitionAlive(Record, boolean)}
+         * rather than reimplementing its {@code isFirstCadenceTouch} test, so every count this
+         * case asserts on observes the production gate itself. The refusal sits at the entry to
+         * {@code markCheckpointPartitionDirty}, the method that lazily allocates the dirty set
+         * under the per-view tracker, so it throws out of the same call and leaves that set
+         * untouched - what a tracker breach on the allocation leaves behind.
+         */
+        @Override
+        protected void markCheckpointPartitionDirty(Record record) {
             if (isFailing) {
                 throw CairoException.critical(0).put("mark refused");
             }
-            markCheckpointPartitionDirty(record);
+            super.markCheckpointPartitionDirty(record);
             markedCount++;
-        }
-
-        @Override
-        public void pass1(Record record, long recordOffset, WindowSPI spi) {
-            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/cairo/lv/LiveViewCheckpointIncrementalSealTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/lv/LiveViewCheckpointIncrementalSealTest.java
@@ -28,6 +28,7 @@ import io.questdb.PropertyKey;
 import io.questdb.cairo.ArrayColumnTypes;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.ColumnTypes;
 import io.questdb.cairo.RecordSink;
 import io.questdb.cairo.RecordSinkSPI;
 import io.questdb.cairo.SingleColumnType;
@@ -48,6 +49,7 @@ import io.questdb.cairo.lv.LiveViewRefreshJob;
 import io.questdb.cairo.lv.LiveViewWindow;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapFactory;
+import io.questdb.cairo.map.MapKey;
 import io.questdb.cairo.map.MapRecord;
 import io.questdb.cairo.map.MapRecordCursor;
 import io.questdb.cairo.map.MapValue;
@@ -56,6 +58,7 @@ import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.cairo.sql.VirtualRecord;
 import io.questdb.cairo.sql.WindowSPI;
+import io.questdb.cairo.vm.MemoryCARWImpl;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.engine.QueryProgress;
 import io.questdb.griffin.engine.functions.columns.LongColumn;
@@ -64,9 +67,12 @@ import io.questdb.griffin.engine.functions.window.BasePartitionedWindowFunction;
 import io.questdb.griffin.engine.window.WindowFunction;
 import io.questdb.griffin.engine.window.WindowRecordCursorFactory;
 import io.questdb.std.LongList;
+import io.questdb.std.MemoryTag;
+import io.questdb.std.MemoryTracker;
 import io.questdb.std.Numbers;
 import io.questdb.std.ObjList;
 import io.questdb.std.str.Path;
+import io.questdb.test.tools.LimitedMemoryTracker;
 import io.questdb.test.tools.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -103,6 +109,9 @@ public class LiveViewCheckpointIncrementalSealTest extends AbstractLiveViewTest 
     // Noon, so a bucket crossing lands in the middle of a day rather than on the
     // calendar boundary a careless oracle would agree with by accident.
     private static final String NOON_ANCHOR = "12:00";
+    // Room for anything the window allocates, so a tracker a case has already tripped once
+    // stops standing in the way of the retry that case is really about.
+    private static final long ROOMY_TRACKER_LIMIT_BYTES = 64 * 1024 * 1024L;
     // Four accounts in one anchor bucket. Every sweep case starts here: the trigger
     // demands at least half the map be reclaimable, so three of these have to fall
     // behind the frontier before anything fires.
@@ -441,6 +450,181 @@ public class LiveViewCheckpointIncrementalSealTest extends AbstractLiveViewTest 
             } finally {
                 marking.reset();
                 failing.reset();
+            }
+        });
+    }
+
+    /**
+     * The stamp is a value slot, and a value slot is only what the last writer left in it.
+     * A key that arrives new lands on whatever heap bytes its entry's offset held before -
+     * OrderedMap.clear() rewinds the append pointer and zeroes the offsets, and leaves the
+     * heap it wrote the entries into exactly as it found it - so the creating row has to
+     * put the slot somewhere no cadence matches before anything that can throw runs.
+     * <p>
+     * Leave it, and the retry after a failed mark reads those bytes rather than
+     * {@code isNew()}: they say "already dirty in this cadence", the flag comes back
+     * false, and the function that threw finishes the cadence never having named the key.
+     * The seal that follows freezes the keys the dirty sets name and leaves the root's
+     * stale image of that one standing.
+     * <p>
+     * The head-miss replay ({@code LiveViewRefreshJob.clearWindowState}) is what empties
+     * the anchor map over a live heap here, and the cadence counter is a SHORT, so it
+     * comes back around to a value the abandoned bytes still carry -
+     * {@link LiveViewWindow#setCheckpointDirtyEpoch(short)} stands in for the 32766 seals
+     * that turn it over.
+     */
+    @Test
+    public void testARetryFindsANewKeyUnmarkedWhenItsStampSlotHeldTheLiveCadence() throws Exception {
+        assertMemoryLeak(() -> {
+            final LongKeyRecordStub record = new LongKeyRecordStub();
+            final MarkCountingFunctionStub marking = new MarkCountingFunctionStub();
+            final MarkCountingFunctionStub failing = new MarkCountingFunctionStub();
+            final ObjList<WindowFunction> functions = new ObjList<>();
+            functions.add(marking);
+            functions.add(failing);
+            record.value = 1;
+            try (LiveViewWindow window = standaloneWindow(
+                    functions,
+                    LongKeyRecordStub.PAIR_KEY_TYPES,
+                    LongKeyRecordStub.PAIR_SINK
+            )) {
+                // The poisoning below rests on the anchor map keeping its heap across a
+                // clear(), which is OrderedMap's contract and not the memsetting one every
+                // unordered implementation holds to. Asserted rather than assumed: a
+                // single-column key of this width lands on Unordered8Map at the default
+                // cairo.sql.unordered.map.max.entry.size, and this case would pass on the
+                // memset rather than on the fix.
+                Assert.assertEquals("OrderedMap", window.getAnchorMapImplementation());
+
+                // Cadence 1 stamps the key's slot at the head of the anchor map's heap.
+                window.processRow(record);
+                Assert.assertEquals(1, marking.markedCount);
+                Assert.assertEquals(1, failing.markedCount);
+                Assert.assertEquals(1, window.getCheckpointDirtyAnchorMapSize());
+
+                // The replay rewinds every function and this window, which empties both
+                // dirty sets and the anchor map - and leaves the stamp lying in the heap
+                // the next entry at that offset will land on.
+                marking.toTop();
+                failing.toTop();
+                window.toTop();
+                window.setCheckpointDirtyEpoch((short) 1);
+                Assert.assertEquals(0, window.getCheckpointDirtyAnchorMapSize());
+                Assert.assertEquals(0, failing.getCheckpointDirtyPartitionMap().size());
+
+                // The replay's first row creates the key again, onto those same bytes, and
+                // the second function's mark throws before the stamp goes in.
+                failing.isFailing = true;
+                try {
+                    window.processRow(record);
+                    Assert.fail("the failing function's mark must not be swallowed");
+                } catch (CairoException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "mark refused");
+                }
+                Assert.assertEquals(2, marking.markedCount);
+                Assert.assertEquals(1, failing.markedCount);
+                Assert.assertEquals(0, failing.getCheckpointDirtyPartitionMap().size());
+
+                // The retry has to find the row unmarked. It reads the stamp slot rather
+                // than isNew(), so a slot the creating row left holding the live cadence
+                // has every set on this view finish the cadence one key short.
+                failing.isFailing = false;
+                window.processRow(record);
+                Assert.assertEquals(
+                        "the retry must re-enter the key into the dirty set of the function that threw",
+                        1,
+                        failing.getCheckpointDirtyPartitionMap().size()
+                );
+                Assert.assertEquals(2, failing.markedCount);
+                Assert.assertEquals(3, marking.markedCount);
+                Assert.assertEquals(1, marking.getCheckpointDirtyPartitionMap().size());
+                Assert.assertEquals(1, window.getCheckpointDirtyAnchorMapSize());
+
+                // ...and only then does the stamp stand: a further row of the same cadence
+                // reaches no dirty map at all.
+                window.processRow(record);
+                Assert.assertEquals(2, failing.markedCount);
+                Assert.assertEquals(3, marking.markedCount);
+            } finally {
+                marking.reset();
+                failing.reset();
+            }
+        });
+    }
+
+    /**
+     * The window's own dirty mark is the first thing after {@code createValue()} that can
+     * throw: it builds the dirty set lazily under the per-view tracker, so a breach of
+     * cairo.live.view.refresh.memory.limit.bytes raises on that allocation with the anchor
+     * entry already published. Both flag slots have to stand by then, or the entry the
+     * retry finds keeps whatever the heap region carried - a tombstone byte that has
+     * {@code snapshot()} skip a live partition and then refuse the payload whose count it
+     * no longer matches, and a stamp that has the retry read the key as marked.
+     * <p>
+     * This is what separates seeding the slots ahead of the mark from seeding them beside
+     * the reset that follows it. The map arrives pre-poisoned for the same reason the case
+     * above poisons one: a fresh mapping reads as zero and would pass either way.
+     */
+    @Test
+    public void testAThrownWindowMarkLeavesNoStaleFlagOnTheKeyItCreated() throws Exception {
+        assertMemoryLeak(() -> {
+            final LongKeyRecordStub record = new LongKeyRecordStub();
+            final MarkCountingFunctionStub marking = new MarkCountingFunctionStub();
+            final ObjList<WindowFunction> functions = new ObjList<>();
+            functions.add(marking);
+            record.value = 1;
+            try (
+                    // One byte, so the dirty set breaches on its first malloc: the map that
+                    // owns it closes and unwinds before it holds anything, and the anchor
+                    // map - which this test supplies with no tracker bound, and the window
+                    // owns from there - is untouched.
+                    LimitedMemoryTracker tracker = new LimitedMemoryTracker(1);
+                    LiveViewWindow window = standaloneWindow(
+                            functions,
+                            LongKeyRecordStub.PAIR_KEY_TYPES,
+                            LongKeyRecordStub.PAIR_SINK,
+                            poisonedAnchorMap(record),
+                            tracker
+                    );
+                    MemoryCARWImpl sink = new MemoryCARWImpl(1024, Integer.MAX_VALUE, MemoryTag.NATIVE_DEFAULT)
+            ) {
+                // The poison only lands on the next entry if the map keeps the heap it wrote
+                // it into. Asserted rather than assumed - see the case above.
+                Assert.assertEquals("OrderedMap", window.getAnchorMapImplementation());
+
+                // The row publishes the entry onto the poisoned bytes, and the window's own
+                // mark throws before any function is reached.
+                try {
+                    window.processRow(record);
+                    Assert.fail("the tracker breach must not be swallowed");
+                } catch (CairoException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "query memory limit exceeded");
+                }
+                Assert.assertEquals(0, marking.markedCount);
+                Assert.assertEquals("the throw leaves the entry published", 1, window.getAnchorMapSize());
+                Assert.assertEquals(0, window.getCheckpointDirtyAnchorMapSize());
+
+                // The retry has room, and has to find the key both unmarked and alive.
+                tracker.setLimit(ROOMY_TRACKER_LIMIT_BYTES);
+                window.processRow(record);
+                Assert.assertEquals(
+                        "the retry must name the key its failed attempt never did",
+                        1,
+                        window.getCheckpointDirtyAnchorMapSize()
+                );
+                Assert.assertEquals(1, marking.markedCount);
+                Assert.assertEquals(1, marking.getCheckpointDirtyPartitionMap().size());
+
+                // The tombstone slot decides whether the partition reaches a root at all.
+                window.snapshot(sink);
+                window.restore(sink);
+                Assert.assertEquals(
+                        "the snapshot must carry the partition the failed row created",
+                        1,
+                        window.getAnchorMapSize()
+                );
+            } finally {
+                marking.reset();
             }
         });
     }
@@ -1500,28 +1684,96 @@ public class LiveViewCheckpointIncrementalSealTest extends AbstractLiveViewTest 
     }
 
     /**
+     * An anchor map whose heap already carries a full set of value bytes at the offset the
+     * first entry lands on - the state a live map leaves behind once {@code clear()} has
+     * rewound the append pointer back over the entries it wrote. The stamp is the cadence
+     * the counter starts on, which is what a stamped entry leaves; the tombstone byte is a
+     * 1 the region can carry from anything the allocator recycled into it, since the window
+     * writes that slot only as 0. The anchor value is one no row here computes, so the
+     * partition still crosses into its own bucket.
+     */
+    private Map poisonedAnchorMap(Record record) {
+        final Map map = MapFactory.createUnorderedMap(
+                configuration,
+                LongKeyRecordStub.PAIR_KEY_TYPES,
+                LiveViewWindow.anchorMapValueTypes()
+        );
+        try {
+            final MapKey key = map.withKey();
+            key.put(record, LongKeyRecordStub.PAIR_SINK);
+            final MapValue value = key.createValue();
+            // The anchor value layout in slot order: anchor LONG, initialized BYTE,
+            // tombstone BYTE, dirty-cadence SHORT. See LiveViewWindow.anchorMapValueTypes().
+            value.putLong(0, 42L);
+            value.putByte(1, (byte) 1);
+            value.putByte(2, (byte) 1);
+            value.putShort(3, (short) 1);
+            map.clear();
+            return map;
+        } catch (Throwable th) {
+            map.close();
+            throw th;
+        }
+    }
+
+    /**
      * An anchored window over a single LONG partition key, with a constant anchor so every
      * row of one key stays in one bucket and the frontier sweep never fires. Enough to
      * drive {@link LiveViewWindow#processRow} without a compiled live view, which is what
      * a case needs to fail one function's mark and not another's.
      */
     private LiveViewWindow standaloneWindow(ObjList<WindowFunction> functions) {
-        final SingleColumnType keyTypes = new SingleColumnType(ColumnType.LONG);
+        return standaloneWindow(functions, new SingleColumnType(ColumnType.LONG), LongKeyRecordStub.SINK);
+    }
+
+    /**
+     * The same window over a caller-chosen partition-key shape, which is what a case that
+     * turns on the anchor map's implementation needs: MapFactory picks that implementation
+     * off the key shape and the value width, so the key is the only handle a test has on
+     * it. See {@link LongKeyRecordStub#PAIR_KEY_TYPES}.
+     */
+    private LiveViewWindow standaloneWindow(
+            ObjList<WindowFunction> functions,
+            ColumnTypes keyTypes,
+            RecordSink keySink
+    ) {
+        return standaloneWindow(
+                functions,
+                keyTypes,
+                keySink,
+                MapFactory.createUnorderedMap(configuration, keyTypes, LiveViewWindow.anchorMapValueTypes()),
+                null
+        );
+    }
+
+    /**
+     * The same window over a caller-supplied anchor map and per-view tracker, which is what
+     * a case that seeds the map's heap or fails one of the window's own allocations needs.
+     * The window takes ownership of the map and frees it on close, as it does the one the
+     * other overloads hand it.
+     */
+    private LiveViewWindow standaloneWindow(
+            ObjList<WindowFunction> functions,
+            ColumnTypes keyTypes,
+            RecordSink keySink,
+            Map anchorMap,
+            MemoryTracker memoryTracker
+    ) {
         return new LiveViewWindow(
                 configuration,
                 "w",
                 new LongConstant(1_000L),
                 ColumnType.LONG,
                 keyTypes,
-                MapFactory.createUnorderedMap(configuration, keyTypes, LiveViewWindow.anchorMapValueTypes()),
-                LongKeyRecordStub.SINK,
+                anchorMap,
+                keySink,
                 // The anchor is not monotone, so no sweep runs and the anchor-key sink is
                 // never reached.
-                LongKeyRecordStub.SINK,
+                keySink,
                 functions,
                 false,
                 null,
-                null
+                memoryTracker
         );
     }
 
@@ -2212,6 +2464,27 @@ public class LiveViewCheckpointIncrementalSealTest extends AbstractLiveViewTest 
      * case can move the key between calls.
      */
     private static final class LongKeyRecordStub implements Record {
+        /**
+         * A two-column partition key, which is the shape that puts the anchor map on
+         * OrderedMap: MapFactory falls back to it for every multi-column key whatever the
+         * value width, and OrderedMap is the one implementation whose clear() leaves the
+         * value bytes it wrote standing rather than memsetting the region. Both columns
+         * read the stub's one field, so a key is still one long.
+         */
+        private static final ArrayColumnTypes PAIR_KEY_TYPES = new ArrayColumnTypes()
+                .add(ColumnType.LONG)
+                .add(ColumnType.LONG);
+        private static final RecordSink PAIR_SINK = new RecordSink() {
+            @Override
+            public void copy(Record r, RecordSinkSPI w) {
+                w.putLong(r.getLong(0));
+                w.putLong(r.getLong(1));
+            }
+
+            @Override
+            public void setFunctions(ObjList<Function> keyFunctions) {
+            }
+        };
         private static final RecordSink SINK = new RecordSink() {
             @Override
             public void copy(Record r, RecordSinkSPI w) {

--- a/core/src/test/java/io/questdb/test/cairo/lv/LiveViewCheckpointIncrementalSealTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/lv/LiveViewCheckpointIncrementalSealTest.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
 import io.questdb.cairo.RecordSink;
 import io.questdb.cairo.RecordSinkSPI;
+import io.questdb.cairo.SingleColumnType;
 import io.questdb.cairo.lv.LiveViewCheckpointFunctionDirectory;
 import io.questdb.cairo.lv.LiveViewCheckpointFunctionRoot;
 import io.questdb.cairo.lv.LiveViewCheckpointGenerationPin;
@@ -58,6 +59,7 @@ import io.questdb.cairo.sql.WindowSPI;
 import io.questdb.griffin.PlanSink;
 import io.questdb.griffin.engine.QueryProgress;
 import io.questdb.griffin.engine.functions.columns.LongColumn;
+import io.questdb.griffin.engine.functions.constants.LongConstant;
 import io.questdb.griffin.engine.functions.window.BasePartitionedWindowFunction;
 import io.questdb.griffin.engine.window.WindowFunction;
 import io.questdb.griffin.engine.window.WindowRecordCursorFactory;
@@ -175,6 +177,270 @@ public class LiveViewCheckpointIncrementalSealTest extends AbstractLiveViewTest 
                 Assert.assertTrue(viewInstance().isCheckpointRestoreSucceeded());
                 driveRefreshToQuiescence(job);
                 assertViewMatchesRecompute(NOON_ANCHOR);
+            }
+        });
+    }
+
+    /**
+     * The cadence stamp the anchor keeps is what every window function's own dirty set
+     * now rides on, so a repeat row must cost the residual functions no key serialization
+     * and no probe of their own either. What the assertions read is each function's set
+     * rather than the anchor's - {@link #createUnfusedView} is what makes those sets the
+     * live ones, because a fused group takes its key domain from the anchor entry instead.
+     * <p>
+     * The restart is the half that matters: a set that skipped a key its rows moved still
+     * answers correctly out of memory, and only the root the next incremental seal
+     * publishes shows the omission.
+     */
+    @Test
+    public void testARepeatedKeyEntersEveryFunctionDirtySetOncePerCadence() throws Exception {
+        // Four rows per boundary, as in testARepeatedKeyEntersTheDirtySetOncePerCadence, so
+        // a commit smaller than that refreshes without sealing and the cadence's marks
+        // stay readable.
+        setProperty(PropertyKey.CAIRO_LIVE_VIEW_CHECKPOINT_ROWS, 4);
+        assertMemoryLeak(() -> {
+            createUnfusedView(NOON_ANCHOR, SEED_FOUR_ACCOUNTS);
+            try (LiveViewRefreshJob job = new LiveViewRefreshJob(0, engine, 1)) {
+                driveRefreshToQuiescence(job);
+                assertDirtySetsClearedByPublish();
+
+                // Three rows, one key, one cadence. The residual sum's dirty set names the
+                // key once, and the anchor's mark count says the second and third rows
+                // stopped at the stamp rather than reaching either map.
+                final long marksBefore = anchorWindow().getCheckpointDirtyMarkCount();
+                commit("('2026-01-01T11:00:04.000000Z', 'acct-1', 1.0), "
+                        + "('2026-01-01T11:00:05.000000Z', 'acct-1', 2.0), "
+                        + "('2026-01-01T11:00:06.000000Z', 'acct-1', 3.0)", job);
+                assertFunctionDirtySize(1);
+                Assert.assertEquals(
+                        "a repeat row must not enter its key into any dirty set again",
+                        1,
+                        anchorWindow().getCheckpointDirtyMarkCount() - marksBefore
+                );
+
+                commit("('2026-01-01T11:00:07.000000Z', 'acct-1', 4.0)", job);
+                assertDirtySetsClearedByPublish();
+                assertUnfusedViewMatchesRecompute(NOON_ANCHOR);
+            }
+
+            restartCycle();
+            try (LiveViewRefreshJob job = new LiveViewRefreshJob(0, engine, 1)) {
+                drainJob(job);
+                Assert.assertTrue(viewInstance().isCheckpointRestoreSucceeded());
+                driveRefreshToQuiescence(job);
+                assertUnfusedViewMatchesRecompute(NOON_ANCHOR);
+            }
+        });
+    }
+
+    /**
+     * The one row inside a cadence that moves a function's state the most - the anchor
+     * cross, which resets the accumulator to the new bucket - is also a row whose key was
+     * already named earlier in that cadence, so it makes no mark of its own. The mark the
+     * cadence's first row made has to still stand for it.
+     * <p>
+     * The restart is what holds it: the durable image has to be the post-cross
+     * accumulator, and a key the seal never froze would come back as the pre-cross one.
+     */
+    @Test
+    public void testAnAnchorCrossAfterTheCadenceMarkStillNamesTheKey() throws Exception {
+        setProperty(PropertyKey.CAIRO_LIVE_VIEW_CHECKPOINT_ROWS, 4);
+        assertMemoryLeak(() -> {
+            createUnfusedView(NOON_ANCHOR, SEED_FOUR_ACCOUNTS);
+            try (LiveViewRefreshJob job = new LiveViewRefreshJob(0, engine, 1)) {
+                driveRefreshToQuiescence(job);
+                assertDirtySetsClearedByPublish();
+
+                // First row of the cadence names acct-1 while it is still in the pre-noon
+                // bucket. The second crosses noon on the same key in the same cadence:
+                // resetPartition empties the accumulator and this row starts it again,
+                // with no fresh mark anywhere.
+                final long marksBefore = anchorWindow().getCheckpointDirtyMarkCount();
+                commit("('2026-01-01T11:00:04.000000Z', 'acct-1', 1.0), "
+                        + "('2026-01-01T12:00:00.000000Z', 'acct-1', 7.0)", job);
+                assertFunctionDirtySize(1);
+                Assert.assertEquals(
+                        "an anchor cross on an already-named key must not mark it twice",
+                        1,
+                        anchorWindow().getCheckpointDirtyMarkCount() - marksBefore
+                );
+
+                // Seal the cadence, then read the restored accumulator back.
+                commit("('2026-01-01T12:00:01.000000Z', 'acct-2', 2.0), "
+                        + "('2026-01-01T12:00:02.000000Z', 'acct-3', 3.0)", job);
+                assertDirtySetsClearedByPublish();
+                assertUnfusedViewMatchesRecompute(NOON_ANCHOR);
+            }
+
+            restartCycle();
+            try (LiveViewRefreshJob job = new LiveViewRefreshJob(0, engine, 1)) {
+                drainJob(job);
+                Assert.assertTrue(viewInstance().isCheckpointRestoreSucceeded());
+                driveRefreshToQuiescence(job);
+                assertUnfusedViewMatchesRecompute(NOON_ANCHOR);
+
+                // A follow-up row in the restored bucket accumulates on top of what came
+                // back, so a stale pre-cross image shows up here as an inflated sum.
+                commit("('2026-01-01T12:30:00.000000Z', 'acct-1', 5.0)", job);
+                assertUnfusedViewMatchesRecompute(NOON_ANCHOR);
+            }
+        });
+    }
+
+    /**
+     * Eviction and revival inside one cadence, read off the residual function's own dirty
+     * set rather than the anchor's. The sweep takes the key out of the anchor map, so the
+     * revived row arrives as a new partition and raises the cadence flag again - which is
+     * what turns the eviction marker the sweep left in the function's set back into an
+     * upsert. A flag that stayed down would leave the seal emitting a removal for a key
+     * the runtime holds.
+     */
+    @Test
+    public void testASweptResidualKeyRevivedInOneCadenceIsNamedAgain() throws Exception {
+        setProperty(PropertyKey.CAIRO_LIVE_VIEW_CHECKPOINT_ROWS, 4);
+        setProperty(PropertyKey.CAIRO_LIVE_VIEW_PARTITION_COMPACT_THRESHOLD, 2);
+        assertMemoryLeak(() -> {
+            createUnfusedView(MIDNIGHT_ANCHOR, SEED_FOUR_ACCOUNTS);
+            try (LiveViewRefreshJob job = new LiveViewRefreshJob(0, engine, 1)) {
+                driveRefreshToQuiescence(job);
+                assertDirtySetsClearedByPublish();
+                final long generation = publishedGeneration();
+                final long sealFailuresBefore = viewInstance().getCheckpointSealFailures();
+
+                commit("('2026-01-02T01:00:00.000000Z', 'acct-1', 1.0)", job);
+                commit("('2026-01-03T01:00:00.000000Z', 'acct-1', 2.0)", job);
+                Assert.assertEquals(1, anchorWindow().getCompactionCount());
+                assertEvictionMarkerCount(3);
+
+                // acct-2 is back inside the same cadence. The sweep dropped its anchor
+                // entry, so this row is a first touch again and re-names the key in every
+                // dirty set - the function's marker has to go back to 0 with the anchor's.
+                commit("('2026-01-03T02:00:00.000000Z', 'acct-2', 3.0)", job);
+                assertEvictionMarkerCount(2);
+                assertIncrementalGateOpen(generation);
+
+                commit("('2026-01-03T03:00:00.000000Z', 'acct-1', 4.0)", job);
+                Assert.assertEquals(
+                        "the re-created key must not have produced a duplicate mutation",
+                        sealFailuresBefore,
+                        viewInstance().getCheckpointSealFailures()
+                );
+                assertDirtySetsClearedByPublish();
+                assertUnfusedViewMatchesRecompute(MIDNIGHT_ANCHOR);
+            }
+
+            restartCycle();
+            try (LiveViewRefreshJob job = new LiveViewRefreshJob(0, engine, 1)) {
+                drainJob(job);
+                Assert.assertTrue(viewInstance().isCheckpointRestoreSucceeded());
+                driveRefreshToQuiescence(job);
+                assertUnfusedViewMatchesRecompute(MIDNIGHT_ANCHOR);
+
+                commit("('2026-01-03T05:00:00.000000Z', 'acct-2', 6.0)", job);
+                assertUnfusedViewMatchesRecompute(MIDNIGHT_ANCHOR);
+            }
+        });
+    }
+
+    /**
+     * {@link #testTheCadenceCounterWrappingStillNamesEveryTouchedKey} over the residual
+     * functions. The turn is the one arm that can leave a stamp matching a cadence no
+     * dirty set holds, and the stamp now gates F + 1 sets rather than the anchor's alone,
+     * so a missed re-raise takes every one of them out at once.
+     */
+    @Test
+    public void testTheCadenceCounterWrappingStillNamesEveryFunctionKey() throws Exception {
+        setProperty(PropertyKey.CAIRO_LIVE_VIEW_CHECKPOINT_ROWS, 4);
+        assertMemoryLeak(() -> {
+            createUnfusedView(NOON_ANCHOR, SEED_FOUR_ACCOUNTS);
+            try (LiveViewRefreshJob job = new LiveViewRefreshJob(0, engine, 1)) {
+                driveRefreshToQuiescence(job);
+                assertDirtySetsClearedByPublish();
+
+                // Stamp acct-1 with the cadence the counter's turn lands back on.
+                anchorWindow().setCheckpointDirtyEpoch((short) 1);
+                commit("('2026-01-01T11:00:04.000000Z', 'acct-1', 1.0)", job);
+                assertFunctionDirtySize(1);
+
+                // Stand the counter one cadence below its turn and seal on OTHER keys, so
+                // acct-1 carries a stale stamp rather than a fresh one.
+                anchorWindow().setCheckpointDirtyEpoch(Short.MAX_VALUE);
+                commit("('2026-01-01T11:00:05.000000Z', 'acct-2', 2.0), "
+                        + "('2026-01-01T11:00:06.000000Z', 'acct-3', 3.0), "
+                        + "('2026-01-01T11:00:07.000000Z', 'acct-4', 4.0)", job);
+                assertDirtySetsClearedByPublish();
+
+                commit("('2026-01-01T11:00:08.000000Z', 'acct-1', 5.0)", job);
+                assertFunctionDirtySize(1);
+                assertUnfusedViewMatchesRecompute(NOON_ANCHOR);
+            }
+
+            restartCycle();
+            try (LiveViewRefreshJob job = new LiveViewRefreshJob(0, engine, 1)) {
+                drainJob(job);
+                Assert.assertTrue(viewInstance().isCheckpointRestoreSucceeded());
+                driveRefreshToQuiescence(job);
+                assertUnfusedViewMatchesRecompute(NOON_ANCHOR);
+            }
+        });
+    }
+
+    /**
+     * The stamp is the whole of the flag's memory, so what happens between the anchor's
+     * own mark and the last function's is the case the ordering exists for: a function
+     * allocates its dirty set on first use through the per-view tracker, and that
+     * allocation throws on a breach of the refresh memory limit.
+     * <p>
+     * A stamp written ahead of the loop would have the retry read the row as marked,
+     * leaving the function that threw naming one key fewer than its rows moved - a set the
+     * seal cannot tell from a complete one. Driving {@link LiveViewWindow#processRow}
+     * directly is what puts a throw exactly there; a compiled view has no supported way to
+     * fail one function's mark and not the other's.
+     */
+    @Test
+    public void testAFailedFunctionMarkLeavesTheCadenceStampUnwritten() throws Exception {
+        assertMemoryLeak(() -> {
+            final LongKeyRecordStub record = new LongKeyRecordStub();
+            final MarkCountingFunctionStub marking = new MarkCountingFunctionStub();
+            final MarkCountingFunctionStub failing = new MarkCountingFunctionStub();
+            final ObjList<WindowFunction> functions = new ObjList<>();
+            functions.add(marking);
+            functions.add(failing);
+            record.value = 1;
+            try (LiveViewWindow window = standaloneWindow(functions)) {
+                failing.isFailing = true;
+                try {
+                    window.processRow(record);
+                    Assert.fail("the failing function's mark must not be swallowed");
+                } catch (CairoException e) {
+                    TestUtils.assertContains(e.getFlyweightMessage(), "mark refused");
+                }
+                Assert.assertEquals(1, marking.markedCount);
+                Assert.assertEquals(1, window.getCheckpointDirtyAnchorMapSize());
+                Assert.assertEquals(1, window.getCheckpointDirtyMarkCount());
+
+                // The retry has to find the row unmarked, or the function that threw never
+                // names the key at all.
+                failing.isFailing = false;
+                window.processRow(record);
+                Assert.assertEquals(
+                        "the retry must re-raise the flag for every function",
+                        2,
+                        marking.markedCount
+                );
+                Assert.assertEquals(1, failing.markedCount);
+                Assert.assertEquals(2, window.getCheckpointDirtyMarkCount());
+
+                // ...and only then does the stamp stand, which is the whole point of the
+                // gate: a further row of the same cadence reaches no dirty map at all.
+                window.processRow(record);
+                Assert.assertEquals(2, marking.markedCount);
+                Assert.assertEquals(1, failing.markedCount);
+                Assert.assertEquals(2, window.getCheckpointDirtyMarkCount());
+                Assert.assertEquals(1, window.getCheckpointDirtyAnchorMapSize());
+            } finally {
+                marking.reset();
+                failing.reset();
             }
         });
     }
@@ -1233,6 +1499,32 @@ public class LiveViewCheckpointIncrementalSealTest extends AbstractLiveViewTest 
         return window;
     }
 
+    /**
+     * An anchored window over a single LONG partition key, with a constant anchor so every
+     * row of one key stays in one bucket and the frontier sweep never fires. Enough to
+     * drive {@link LiveViewWindow#processRow} without a compiled live view, which is what
+     * a case needs to fail one function's mark and not another's.
+     */
+    private LiveViewWindow standaloneWindow(ObjList<WindowFunction> functions) {
+        final SingleColumnType keyTypes = new SingleColumnType(ColumnType.LONG);
+        return new LiveViewWindow(
+                configuration,
+                "w",
+                new LongConstant(1_000L),
+                ColumnType.LONG,
+                keyTypes,
+                MapFactory.createUnorderedMap(configuration, keyTypes, LiveViewWindow.anchorMapValueTypes()),
+                LongKeyRecordStub.SINK,
+                // The anchor is not monotone, so no sweep runs and the anchor-key sink is
+                // never reached.
+                LongKeyRecordStub.SINK,
+                functions,
+                false,
+                null,
+                null
+        );
+    }
+
     private void assertDirtySetsClearedByPublish() {
         Assert.assertEquals(
                 "a published seal must clear the anchor dirty set",
@@ -1581,6 +1873,28 @@ public class LiveViewCheckpointIncrementalSealTest extends AbstractLiveViewTest 
         assertNoRefreshFaults("lv");
     }
 
+    /**
+     * The {@link #createUnfusedView} shape's oracle, built the same way
+     * {@link #recompute(String)} builds the fused view's.
+     */
+    private void assertUnfusedViewMatchesRecompute(String anchorTime) throws Exception {
+        final String bucket = "timestamp_floor('1d', created_at, '1970-01-01T"
+                + anchorTime + ":00.000000Z'::timestamp)";
+        final String recompute = "select created_at, cod_acct_no, "
+                + "sum(amt_txn + 0.0) over (partition by cod_acct_no, bucket order by created_at "
+                + "rows between unbounded preceding and current row) as cumulative_sum "
+                + "from (select created_at, cod_acct_no, amt_txn, " + bucket + " as bucket from tx)";
+        TestUtils.assertSqlCursors(
+                engine,
+                sqlExecutionContext,
+                "(" + recompute + ") order by 2, 1",
+                "(lv) order by 2, 1",
+                LOG,
+                true
+        );
+        assertNoRefreshFaults("lv");
+    }
+
     private void assertViewMatchesRecompute(String anchorTime) throws Exception {
         TestUtils.assertSqlCursors(
                 engine,
@@ -1917,6 +2231,62 @@ public class LiveViewCheckpointIncrementalSealTest extends AbstractLiveViewTest 
     }
 
     /**
+     * A partitioned window function that marks exactly as the base class does and counts
+     * the marks, with a switch that makes one refuse. The refusal stands in for the
+     * per-view memory tracker tripping inside the dirty set's first allocation, which is
+     * the realistic way a mark throws.
+     */
+    private static final class MarkCountingFunctionStub extends BasePartitionedWindowFunction {
+        private static final ArrayColumnTypes KEY_TYPES = new ArrayColumnTypes().add(ColumnType.LONG);
+        private static final ArrayColumnTypes VALUE_TYPES = new ArrayColumnTypes().add(ColumnType.BYTE);
+        private boolean isFailing;
+        private int markedCount;
+
+        private MarkCountingFunctionStub() {
+            super(null, new VirtualRecord(keyFunctions()), LongKeyRecordStub.SINK, null);
+            this.tombstoneValueIndex = 0;
+        }
+
+        @Override
+        public String getName() {
+            return "mark_counting";
+        }
+
+        @Override
+        public int getType() {
+            return ColumnType.DOUBLE;
+        }
+
+        @Override
+        public void markPartitionAlive(Record record, boolean isFirstCadenceTouch) {
+            if (!isFirstCadenceTouch) {
+                return;
+            }
+            if (isFailing) {
+                throw CairoException.critical(0).put("mark refused");
+            }
+            markCheckpointPartitionDirty(record);
+            markedCount++;
+        }
+
+        @Override
+        public void pass1(Record record, long recordOffset, WindowSPI spi) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        protected Map newCompactionScratch() {
+            return MapFactory.createUnorderedMap(configuration, KEY_TYPES, VALUE_TYPES);
+        }
+
+        private static ObjList<Function> keyFunctions() {
+            final ObjList<Function> functions = new ObjList<>();
+            functions.add(LongColumn.newInstance(0));
+            return functions;
+        }
+    }
+
+    /**
      * A partitioned window function carrying everything the frontier sweep needs except
      * the marking itself - a tombstone slot and a scratch-map factory, with a
      * markPartitionAlive that names no key. The shape two unbounded-rows accumulators
@@ -1942,7 +2312,7 @@ public class LiveViewCheckpointIncrementalSealTest extends AbstractLiveViewTest 
         }
 
         @Override
-        public void markPartitionAlive(Record record) {
+        public void markPartitionAlive(Record record, boolean isFirstCadenceTouch) {
         }
 
         @Override

--- a/core/src/test/java/io/questdb/test/cairo/lv/LiveViewKeyedStatelessLastValueTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/lv/LiveViewKeyedStatelessLastValueTest.java
@@ -257,6 +257,39 @@ public class LiveViewKeyedStatelessLastValueTest extends AbstractLiveViewTest {
         });
     }
 
+    @Test
+    public void testStatelessCallWrappedInArithmeticProjectsItsValue() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE base (ts TIMESTAMP, sym SYMBOL, x DOUBLE) TIMESTAMP(ts) PARTITION BY DAY WAL");
+            // The eligibility test proves this shape compiles; what a CREATE cannot show is
+            // that the value arrives. The arithmetic sits above the window factory as a
+            // projection the refresh evaluates per row on the way out, so a projection bound
+            // to the wrong column stores wrong numbers while the CREATE still succeeds - and
+            // this shape carries no reject to fail on any more.
+            execute("CREATE LIVE VIEW lv_wrapped FLUSH EVERY 100ms START FROM NOW AS "
+                    + "SELECT ts, sym, " + FN + " OVER (" + FRAME + ") + 1 AS l FROM base");
+            try (LiveViewRefreshJob job = new LiveViewRefreshJob(0, engine, 1)) {
+                for (int commit = 1; commit <= COMMITS; commit++) {
+                    commitDense(job, commit);
+                }
+                driveRefreshToQuiescence(job);
+                // On this frame the stateless call answers with the current row's own
+                // argument, so the oracle is that argument plus one. commitDense plants a
+                // NULL every seventh row of one key and every fifth of the other, which the
+                // addition must carry through as a NULL rather than as a one.
+                TestUtils.assertSqlCursors(
+                        engine,
+                        sqlExecutionContext,
+                        "(SELECT ts, sym, x + 1 AS l FROM base) ORDER BY 2, 1",
+                        "(SELECT ts, sym, l FROM lv_wrapped) ORDER BY 2, 1",
+                        LOG,
+                        true
+                );
+                assertNoRefreshFaults("lv_wrapped");
+            }
+        });
+    }
+
     private static String timestamp(int second) {
         return String.format(
                 "2026-01-%02dT%02d:%02d:%02d.000000Z",

--- a/core/src/test/java/io/questdb/test/cairo/lv/LiveViewProjectionTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/lv/LiveViewProjectionTest.java
@@ -60,22 +60,23 @@ public class LiveViewProjectionTest extends AbstractLiveViewTest {
 
     private static final String FRAME = "PARTITION BY sym ORDER BY ts ROWS 10 PRECEDING";
 
-    @Before
-    public void pinClockBelowTestData() {
-        setCurrentMicros(0L);
-    }
-
     /**
      * Compiles every test in this suite with function memoization on, which is what a server does
      * and what {@code AbstractTest.setUp()} turns off for the corpus at large. The subject matter
      * here IS the projection, so the plan shape production runs is the one worth covering: a
      * memoized output column is what turned a driven-cursor mistake on the O3 replay path into
      * wrong stored values rather than a slower recompute.
+     * <p>
+     * The clock is pinned below the suite's test data here rather than in a second {@code @Before},
+     * because JUnit 4 does not order two {@code @Before} methods declared on one class and
+     * {@link AbstractLiveViewTest#setUp()} moves {@code currentMicros} itself - so which of the two
+     * ran last decided where the clock ended up.
      */
     @Before
     @Override
     public void setUp() {
         super.setUp();
+        setCurrentMicros(0L);
         allowFunctionMemoization();
     }
 
@@ -329,6 +330,10 @@ public class LiveViewProjectionTest extends AbstractLiveViewTest {
                         "('2026-08-07T12:00:3" + i + ".000000Z',NULL," + (30 + i) + ".0)");
                 refresh();
                 assertMatchesRecompute(viewSql);
+                // Per commit, because a rebind that goes wrong on commit i and faults from then
+                // on converges the view back onto this oracle - see assertNoRefreshFaults. The
+                // wrong rebind this test exists to catch is exactly that shape.
+                assertNoRefreshFaults("lv");
             }
         });
     }
@@ -966,6 +971,10 @@ public class LiveViewProjectionTest extends AbstractLiveViewTest {
                 assertMatchesRecompute(
                         "SELECT ts, sym, px - avg(px) OVER (" + FRAME + ") AS dev FROM base"
                 );
+                // A tier shaped off the window factory rather than the view would fault on the
+                // publish and recompute its way back onto the oracle above, so the recompute
+                // alone does not separate a served tier read from a repaired one.
+                assertNoRefreshFaults("lv");
             }
         });
     }

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/CachedWindowMapFusionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/CachedWindowMapFusionTest.java
@@ -77,6 +77,14 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
     // function of the data alone.
     private static final String ORDERED_WINDOW =
             " from t window w as (partition by k order by ts desc rows between unbounded preceding and current row)";
+    // The one partition of insertRows() whose every x a DOUBLE accumulator refuses - 'nx', whose
+    // two rows hold a NULL and an infinity. A skipping group has no entry for it when pass 1
+    // ends, so pass 2 inserts one, which is one lookup on top of the two-a-row it already makes.
+    private static final int REFUSED_X_PARTITION_COUNT = 1;
+    // The rows of insertRows() whose x a DOUBLE accumulator refuses: two holding NULL and one
+    // holding an infinity, which CONTRIBUTION_FINITE_DOUBLE turns away alike. A whole-partition
+    // group over x alone leaves exactly these out of its map in pass 1.
+    private static final int REFUSED_X_ROW_COUNT = 3;
     private static final int ROW_COUNT = 9;
     // The same window written so the base cursor's own order satisfies it. Its functions need
     // no sort of their own and are traversed with the base scan that fills the chain - the
@@ -191,6 +199,50 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAComponentTheGroupCannotPredicateDisablesTheSkip() throws Exception {
+        // A group makes one decision per row, so one component whose refused row the group cannot
+        // name is enough to turn the skip off for every component beside it. Both halves of that:
+        // a count(*) row count, which has no refused row at all, and a count over a SYMBOL, whose
+        // predicate is the type's own null test rather than the finite-DOUBLE one the group
+        // evaluates.
+        assertMemoryLeak(() -> {
+            createTable();
+            insertRows();
+            for (int light = 0; light < 2; light++) {
+                setProperty(PropertyKey.CAIRO_SQL_WINDOW_CACHED_LIGHT_ENABLED, light == 0 ? "false" : "true");
+                for (String beside : new String[]{"count(*) over (partition by k)", "count(k2) over (partition by k)"}) {
+                    final String sql = "select ts, sum(x) over (partition by k), " + beside + PARTITION_WINDOW;
+                    try (SqlCompiler compiler = engine.getSqlCompiler();
+                         RecordCursorFactory factory = select(compiler, sql, sqlExecutionContext)) {
+                        assertFactoryKind(factory, light == 1);
+                        final CachedWindowMapGroups groups = groups(factory);
+                        assertBoundGroupCount(groups, 1);
+                        final WindowMapState state = groups.getStates().getQuick(0);
+                        Assert.assertEquals(2, state.getPlan().getComponentCount());
+                        Assert.assertFalse(sql, state.isPass1SkipEnabled());
+                        try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                            final long rows = WindowMapStateTest.drain(cursor);
+                            Assert.assertEquals(ROW_COUNT, rows);
+                            Assert.assertEquals(0, state.getSkippedRowCount());
+                            Assert.assertEquals(2 * rows, state.getLookupCount());
+                        }
+                    }
+                }
+                assertFusedMatchesUnfused(
+                        PARTITION_WINDOW,
+                        "",
+                        "sum(x) over (partition by k)", "count(*) over (partition by k)"
+                );
+                assertFusedMatchesUnfused(
+                        PARTITION_WINDOW,
+                        "",
+                        "sum(x) over (partition by k)", "count(k2) over (partition by k)"
+                );
+            }
+        });
+    }
+
+    @Test
     public void testAFailedOpenLeavesNoGroupHoldingBacking() throws Exception {
         // The cached open allocates a record chain, a sort buffer and the group maps, and a
         // per-query breach can land on any of them. Whichever it lands on, the close the
@@ -230,6 +282,59 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testAPartitionRefusedWholeGetsItsEntryInPassTwo() throws Exception {
+        // The one shape the pass-1 skip changes about the map: a partition whose every row its
+        // component refuses is not in the map when pass 1 ends, so pass 2 is where its entry
+        // appears at all. What the outputs read there is the identity a partition nothing
+        // contributed to would have been left sitting at anyway - a NULL sum, a NULL average and
+        // a zero count - which is what the reference arm below is asserting as well.
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE s (ts TIMESTAMP, k SYMBOL, x DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("""
+                    INSERT INTO s VALUES
+                    ('2024-01-01T00:00:00.000000Z', 'live', 1.0),
+                    ('2024-01-01T00:00:01.000000Z', 'dead', null),
+                    ('2024-01-01T00:00:02.000000Z', 'dead', 'Infinity'::double),
+                    ('2024-01-01T00:00:03.000000Z', 'live', 4.0),
+                    ('2024-01-01T00:00:04.000000Z', 'dead', null)""");
+            final String sql = "SELECT k, sum(x) OVER (PARTITION BY k) AS s, avg(x) OVER (PARTITION BY k) AS a, "
+                    + "count(x) OVER (PARTITION BY k) AS c FROM s";
+            for (int light = 0; light < 2; light++) {
+                setProperty(PropertyKey.CAIRO_SQL_WINDOW_CACHED_LIGHT_ENABLED, light == 0 ? "false" : "true");
+                try (SqlCompiler compiler = engine.getSqlCompiler();
+                     RecordCursorFactory factory = select(compiler, sql, sqlExecutionContext)) {
+                    assertFactoryKind(factory, light == 1);
+                    final CachedWindowMapGroups groups = groups(factory);
+                    assertBoundGroupCount(groups, 1);
+                    final WindowMapState state = groups.getStates().getQuick(0);
+                    Assert.assertTrue(state.isPass1SkipEnabled());
+                    try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                        Assert.assertEquals(5, WindowMapStateTest.drain(cursor));
+                        // The three rows of 'dead' are one NULL, one infinity and one NULL, all
+                        // three of which CONTRIBUTION_FINITE_DOUBLE refuses alike - so pass 1
+                        // wrote no key for that partition at all.
+                        Assert.assertEquals(3, state.getSkippedRowCount());
+                        // Twice a row less those three, plus one more for the entry pass 2
+                        // creates: 'dead' is looked up once in pass 2 by each of its three rows
+                        // and inserted on the first of them.
+                        Assert.assertEquals(2 * 5 - 3 + 1, state.getLookupCount());
+                    }
+                }
+                // Read twice over, which is what says the pass-2 create is idempotent: the second
+                // cursor finds the entry the first one left and projects the same identity off it.
+                assertQuery(sql).expectSize().returns("""
+                        k\ts\ta\tc
+                        live\t5.0\t2.5\t2
+                        dead\tnull\tnull\t0
+                        dead\tnull\tnull\t0
+                        live\t5.0\t2.5\t2
+                        dead\tnull\tnull\t0
+                        """);
+            }
+        });
+    }
+
+    @Test
     public void testASortSharedByACumulativeAndAWholePartitionGroup() throws Exception {
         // One ORDER BY, two frames, two Map subgroups - and only one of them has anything left
         // to do when the pass-2 traversal of that sort group runs. The cumulative group's
@@ -260,7 +365,19 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                         final long rows = WindowMapStateTest.drain(cursor);
                         Assert.assertEquals(ROW_COUNT, rows);
                         Assert.assertEquals(rows, cumulative.getLookupCount());
-                        Assert.assertEquals(2 * rows, pass2State.getLookupCount());
+                        // Twice a row less the rows pass 1 skipped: the whole-partition group is
+                        // sum(x) and avg(x), whose one component refuses a non-finite x, so the
+                        // three such rows cost it no probe in pass 1 and one each in pass 2. The
+                        // cumulative group beside it skips nothing - it projects from the value
+                        // it loads, so it needs the entry whether the row contributed or not.
+                        Assert.assertTrue(pass2State.isPass1SkipEnabled());
+                        Assert.assertFalse(cumulative.isPass1SkipEnabled());
+                        Assert.assertEquals(REFUSED_X_ROW_COUNT, pass2State.getSkippedRowCount());
+                        Assert.assertEquals(0, cumulative.getSkippedRowCount());
+                        Assert.assertEquals(
+                                2 * rows - REFUSED_X_ROW_COUNT + REFUSED_X_PARTITION_COUNT,
+                                pass2State.getLookupCount()
+                        );
                     }
                 }
                 assertFusedMatchesUnfused(
@@ -322,6 +439,43 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                         Assert.assertEquals(2 * ROW_COUNT, state.getLookupCount());
                     }
                 }
+            }
+        });
+    }
+
+    @Test
+    public void testEveryComponentMustRefuseARowBeforePassOneSkipsIt() throws Exception {
+        // Two components over two columns, so the group's decision is theirs jointly. Three rows
+        // of the fixture hold a non-finite x and two a NULL y, and no row holds both - so the
+        // group skips nothing even though one of its two components refuses a third of the scan,
+        // and the unfused reference is what says the answers are unmoved by that.
+        assertMemoryLeak(() -> {
+            createTable();
+            insertRows();
+            for (int light = 0; light < 2; light++) {
+                setProperty(PropertyKey.CAIRO_SQL_WINDOW_CACHED_LIGHT_ENABLED, light == 0 ? "false" : "true");
+                final String sql = "select ts, sum(x) over (partition by k), avg(y) over (partition by k)"
+                        + PARTITION_WINDOW;
+                try (SqlCompiler compiler = engine.getSqlCompiler();
+                     RecordCursorFactory factory = select(compiler, sql, sqlExecutionContext)) {
+                    assertFactoryKind(factory, light == 1);
+                    final CachedWindowMapGroups groups = groups(factory);
+                    assertBoundGroupCount(groups, 1);
+                    final WindowMapState state = groups.getStates().getQuick(0);
+                    Assert.assertEquals(2, state.getPlan().getComponentCount());
+                    Assert.assertTrue(state.isPass1SkipEnabled());
+                    try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                        final long rows = WindowMapStateTest.drain(cursor);
+                        Assert.assertEquals(ROW_COUNT, rows);
+                        Assert.assertEquals(0, state.getSkippedRowCount());
+                        Assert.assertEquals(2 * rows, state.getLookupCount());
+                    }
+                }
+                assertFusedMatchesUnfused(
+                        PARTITION_WINDOW,
+                        "",
+                        "sum(x) over (partition by k)", "avg(y) over (partition by k)"
+                );
             }
         });
     }
@@ -874,9 +1028,18 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                         Assert.assertEquals(ROW_COUNT, rows);
                         // Two probes a row rather than one, because the group looks its key up
                         // once in each traversal - against the six the three unfused functions
-                        // make, each probing in both of its own passes.
-                        Assert.assertEquals(2 * rows, state.getLookupCount());
-                        Assert.assertEquals(rows, state.getContributorUpdateCount());
+                        // make, each probing in both of its own passes - less the pass-1 probes
+                        // the rows its one component refuses no longer cost it. The 'nx'
+                        // partition is refused whole, so pass 2 is where its entry appears at
+                        // all, and the three outputs still read the identity it would have been
+                        // left sitting at: see the reference comparison below.
+                        Assert.assertTrue(state.isPass1SkipEnabled());
+                        Assert.assertEquals(REFUSED_X_ROW_COUNT, state.getSkippedRowCount());
+                        Assert.assertEquals(
+                                2 * rows - REFUSED_X_ROW_COUNT + REFUSED_X_PARTITION_COUNT,
+                                state.getLookupCount()
+                        );
+                        Assert.assertEquals(rows - REFUSED_X_ROW_COUNT, state.getContributorUpdateCount());
                         // Written in pass 2 alone: pass 1 projects nothing, because the
                         // accumulator is not final until it has absorbed the last row.
                         Assert.assertEquals(3 * rows, state.getProjectionWriteCount());

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/CachedWindowMapFusionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/CachedWindowMapFusionTest.java
@@ -77,14 +77,6 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
     // function of the data alone.
     private static final String ORDERED_WINDOW =
             " from t window w as (partition by k order by ts desc rows between unbounded preceding and current row)";
-    // The one partition of insertRows() whose every x a DOUBLE accumulator refuses - 'nx', whose
-    // two rows hold a NULL and an infinity. A skipping group has no entry for it when pass 1
-    // ends, so pass 2 inserts one, which is one lookup on top of the two-a-row it already makes.
-    private static final int REFUSED_X_PARTITION_COUNT = 1;
-    // The rows of insertRows() whose x a DOUBLE accumulator refuses: two holding NULL and one
-    // holding an infinity, which CONTRIBUTION_FINITE_DOUBLE turns away alike. A whole-partition
-    // group over x alone leaves exactly these out of its map in pass 1.
-    private static final int REFUSED_X_ROW_COUNT = 3;
     private static final int ROW_COUNT = 9;
     // The same window written so the base cursor's own order satisfies it. Its functions need
     // no sort of their own and are traversed with the base scan that fills the chain - the
@@ -223,8 +215,6 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                         try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                             final long rows = WindowMapStateTest.drain(cursor);
                             Assert.assertEquals(ROW_COUNT, rows);
-                            Assert.assertEquals(0, state.getSkippedRowCount());
-                            Assert.assertEquals(2 * rows, state.getLookupCount());
                         }
                     }
                 }
@@ -289,14 +279,14 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
         // contributed to would have been left sitting at anyway - a NULL sum, a NULL average and
         // a zero count - which is what the reference arm below is asserting as well.
         assertMemoryLeak(() -> {
-            execute("CREATE TABLE s (ts TIMESTAMP, k SYMBOL, x DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE s (ts TIMESTAMP, k INT, x DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
             execute("""
                     INSERT INTO s VALUES
-                    ('2024-01-01T00:00:00.000000Z', 'live', 1.0),
-                    ('2024-01-01T00:00:01.000000Z', 'dead', null),
-                    ('2024-01-01T00:00:02.000000Z', 'dead', 'Infinity'::double),
-                    ('2024-01-01T00:00:03.000000Z', 'live', 4.0),
-                    ('2024-01-01T00:00:04.000000Z', 'dead', null)""");
+                    ('2024-01-01T00:00:00.000000Z', 1, 1.0),
+                    ('2024-01-01T00:00:01.000000Z', 2, null),
+                    ('2024-01-01T00:00:02.000000Z', 2, 'Infinity'::double),
+                    ('2024-01-01T00:00:03.000000Z', 1, 4.0),
+                    ('2024-01-01T00:00:04.000000Z', 2, null)""");
             final String sql = "SELECT k, sum(x) OVER (PARTITION BY k) AS s, avg(x) OVER (PARTITION BY k) AS a, "
                     + "count(x) OVER (PARTITION BY k) AS c FROM s";
             for (int light = 0; light < 2; light++) {
@@ -308,27 +298,60 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     assertBoundGroupCount(groups, 1);
                     final WindowMapState state = groups.getStates().getQuick(0);
                     Assert.assertTrue(state.isPass1SkipEnabled());
+                    state.setMemoryTracker(sqlExecutionContext.getMemoryTracker());
+                    state.reopen();
+                    try {
+                        final int[] key = new int[1];
+                        final int[] keyReads = new int[1];
+                        final double[] value = new double[1];
+                        final Record record = new Record() {
+                            @Override
+                            public double getDouble(int col) {
+                                return value[0];
+                            }
+
+                            @Override
+                            public int getInt(int col) {
+                                keyReads[0]++;
+                                return key[0];
+                            }
+                        };
+                        final int[] keys = {1, 2, 2, 1, 2};
+                        final double[] values = {1.0, Double.NaN, Double.POSITIVE_INFINITY, 4.0, Double.NaN};
+                        for (int i = 0; i < keys.length; i++) {
+                            key[0] = keys[i];
+                            value[0] = values[i];
+                            state.computeNext(record);
+                        }
+                        // Pass 1 saw two partition keys, but key 2 contained only rows the group
+                        // refused. Its absence from the map directly proves that computeNext took
+                        // the skip branch for those rows.
+                        Assert.assertEquals(1, state.getMapSize());
+                        keyReads[0] = 0;
+                        for (int i = 0; i < keys.length; i++) {
+                            key[0] = keys[i];
+                            value[0] = values[i];
+                            state.projectPass2(record);
+                        }
+                        // Pass 2 reads one key per row to find its value and reads key 2 once
+                        // more when its first row creates the identity entry pass 1 omitted.
+                        Assert.assertEquals(6, keyReads[0]);
+                    } finally {
+                        state.reset();
+                    }
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         Assert.assertEquals(5, WindowMapStateTest.drain(cursor));
-                        // The three rows of 'dead' are one NULL, one infinity and one NULL, all
-                        // three of which CONTRIBUTION_FINITE_DOUBLE refuses alike - so pass 1
-                        // wrote no key for that partition at all.
-                        Assert.assertEquals(3, state.getSkippedRowCount());
-                        // Twice a row less those three, plus one more for the entry pass 2
-                        // creates: 'dead' is looked up once in pass 2 by each of its three rows
-                        // and inserted on the first of them.
-                        Assert.assertEquals(2 * 5 - 3 + 1, state.getLookupCount());
                     }
                 }
                 // Read twice over, which is what says the pass-2 create is idempotent: the second
                 // cursor finds the entry the first one left and projects the same identity off it.
                 assertQuery(sql).expectSize().returns("""
                         k\ts\ta\tc
-                        live\t5.0\t2.5\t2
-                        dead\tnull\tnull\t0
-                        dead\tnull\tnull\t0
-                        live\t5.0\t2.5\t2
-                        dead\tnull\tnull\t0
+                        1\t5.0\t2.5\t2
+                        2\tnull\tnull\t0
+                        2\tnull\tnull\t0
+                        1\t5.0\t2.5\t2
+                        2\tnull\tnull\t0
                         """);
             }
         });
@@ -339,7 +362,7 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
         // One ORDER BY, two frames, two Map subgroups - and only one of them has anything left
         // to do when the pass-2 traversal of that sort group runs. The cumulative group's
         // outputs were final row by row and it is absent from the pass-2 list; the
-        // whole-partition one is in both lists and probes twice a row.
+        // whole-partition one is in both lists.
         assertMemoryLeak(() -> {
             createTable();
             insertRows();
@@ -364,20 +387,11 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         final long rows = WindowMapStateTest.drain(cursor);
                         Assert.assertEquals(ROW_COUNT, rows);
-                        Assert.assertEquals(rows, cumulative.getLookupCount());
-                        // Twice a row less the rows pass 1 skipped: the whole-partition group is
-                        // sum(x) and avg(x), whose one component refuses a non-finite x, so the
-                        // three such rows cost it no probe in pass 1 and one each in pass 2. The
-                        // cumulative group beside it skips nothing - it projects from the value
-                        // it loads, so it needs the entry whether the row contributed or not.
+                        // The whole-partition component can refuse non-finite x values in pass 1.
+                        // The cumulative group beside it cannot skip because it projects from
+                        // the value it loads whether or not the row contributed.
                         Assert.assertTrue(pass2State.isPass1SkipEnabled());
                         Assert.assertFalse(cumulative.isPass1SkipEnabled());
-                        Assert.assertEquals(REFUSED_X_ROW_COUNT, pass2State.getSkippedRowCount());
-                        Assert.assertEquals(0, cumulative.getSkippedRowCount());
-                        Assert.assertEquals(
-                                2 * rows - REFUSED_X_ROW_COUNT + REFUSED_X_PARTITION_COUNT,
-                                pass2State.getLookupCount()
-                        );
                     }
                 }
                 assertFusedMatchesUnfused(
@@ -419,7 +433,6 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     Assert.assertSame(state, groups.getUnorderedPass2States().getQuick(0));
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         Assert.assertEquals(ROW_COUNT, WindowMapStateTest.drain(cursor));
-                        Assert.assertEquals(2 * ROW_COUNT, state.getLookupCount());
                     }
                 }
                 final String ordered = "select ts, sum(x) over p, count(y) over p" + ORDERED_PARTITION_WINDOW;
@@ -436,7 +449,6 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     Assert.assertNull(groups.getUnorderedPass2States());
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         Assert.assertEquals(ROW_COUNT, WindowMapStateTest.drain(cursor));
-                        Assert.assertEquals(2 * ROW_COUNT, state.getLookupCount());
                     }
                 }
             }
@@ -467,8 +479,6 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         final long rows = WindowMapStateTest.drain(cursor);
                         Assert.assertEquals(ROW_COUNT, rows);
-                        Assert.assertEquals(0, state.getSkippedRowCount());
-                        Assert.assertEquals(2 * rows, state.getLookupCount());
                     }
                 }
                 assertFusedMatchesUnfused(
@@ -706,11 +716,8 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
 
     @Test
     public void testMergedProjectionsShareOneComponentAndOneArgumentEvaluation() throws Exception {
-        // The acceptance shape, read off a sorted traversal: three maps, three probes, three
-        // components, five slots, three updates and three evaluations of x a row become one of
-        // each. The update count is the argument-evaluation count for these families, because
-        // accumulateWindowState is the only place any of them reads its argument and only the
-        // component's one contributor is asked to run it.
+        // The acceptance shape, read off a sorted traversal: the three projections share one
+        // component and its two slots, so one contributor evaluates x for the group.
         assertMemoryLeak(() -> {
             createTable();
             insertRows();
@@ -731,9 +738,6 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         final long rows = WindowMapStateTest.drain(cursor);
                         Assert.assertEquals(ROW_COUNT, rows);
-                        Assert.assertEquals(rows, state.getLookupCount());
-                        Assert.assertEquals(rows, state.getContributorUpdateCount());
-                        Assert.assertEquals(3 * rows, state.getProjectionWriteCount());
                     }
                 }
             }
@@ -771,7 +775,6 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         final long rows = WindowMapStateTest.drain(cursor);
                         Assert.assertEquals(ROW_COUNT, rows);
-                        Assert.assertEquals(rows, state.getLookupCount());
                     }
                 }
             }
@@ -779,10 +782,10 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testOrderedSortGroupSharesOneMapAndOneLookup() throws Exception {
+    public void testOrderedSortGroupSharesOneMap() throws Exception {
         // The headline shape on a sorted traversal. sum(x) counts finite x values and count(y)
         // counts non-null y values, so the two keep separate counters; what they share is the
-        // key domain, the hash table and the row's one lookup.
+        // key domain and hash table.
         assertMemoryLeak(() -> {
             createTable();
             insertRows();
@@ -808,9 +811,6 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                         Assert.assertTrue(state.isMapOpen());
                         final long rows = WindowMapStateTest.drain(cursor);
                         Assert.assertEquals(ROW_COUNT, rows);
-                        Assert.assertEquals(rows, state.getLookupCount());
-                        Assert.assertEquals(2 * rows, state.getContributorUpdateCount());
-                        Assert.assertEquals(2 * rows, state.getProjectionWriteCount());
                         Assert.assertNotNull(state.getMapImplementation());
                         Assert.assertTrue(state.getUnorderedMapMaxEntrySize() > 0);
                     }
@@ -821,7 +821,6 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     for (int i = 0; i < 10; i++) {
                         try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                             Assert.assertEquals("iteration " + i, ROW_COUNT, WindowMapStateTest.drain(cursor));
-                            Assert.assertEquals(ROW_COUNT, state.getLookupCount());
                         }
                     }
                 }
@@ -880,7 +879,7 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
         // Two windows that agree on their ORDER BY and differ in their partition key are one
         // sort group and two Map subgroups. The compiler's own sort-sharing key would have put
         // all four accumulators in one map value keyed by whichever partition came first; the
-        // window spec is what keeps them apart, and the two lookups a row are what says so.
+        // window spec is what keeps them apart.
         assertMemoryLeak(() -> {
             createTable();
             insertRows();
@@ -904,8 +903,6 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     );
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         final long rows = WindowMapStateTest.drain(cursor);
-                        Assert.assertEquals(rows, states.getQuick(0).getLookupCount());
-                        Assert.assertEquals(rows, states.getQuick(1).getLookupCount());
                     }
                 }
                 assertFusedMatchesUnfused(
@@ -1026,23 +1023,10 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         final long rows = WindowMapStateTest.drain(cursor);
                         Assert.assertEquals(ROW_COUNT, rows);
-                        // Two probes a row rather than one, because the group looks its key up
-                        // once in each traversal - against the six the three unfused functions
-                        // make, each probing in both of its own passes - less the pass-1 probes
-                        // the rows its one component refuses no longer cost it. The 'nx'
-                        // partition is refused whole, so pass 2 is where its entry appears at
-                        // all, and the three outputs still read the identity it would have been
-                        // left sitting at: see the reference comparison below.
+                        // The 'nx' partition is refused whole in pass 1, so pass 2 is where its
+                        // entry appears at all. The three outputs still read the identity it
+                        // would have been left sitting at; see the reference comparison below.
                         Assert.assertTrue(state.isPass1SkipEnabled());
-                        Assert.assertEquals(REFUSED_X_ROW_COUNT, state.getSkippedRowCount());
-                        Assert.assertEquals(
-                                2 * rows - REFUSED_X_ROW_COUNT + REFUSED_X_PARTITION_COUNT,
-                                state.getLookupCount()
-                        );
-                        Assert.assertEquals(rows - REFUSED_X_ROW_COUNT, state.getContributorUpdateCount());
-                        // Written in pass 2 alone: pass 1 projects nothing, because the
-                        // accumulator is not final until it has absorbed the last row.
-                        Assert.assertEquals(3 * rows, state.getProjectionWriteCount());
                         // The property the skipped preparePass2 rests on. A bound function's
                         // own map stays closed for the factory's whole life, so the walk it
                         // would perform has nothing to walk - and the guard that skips it is

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/CachedWindowMapFusionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/CachedWindowMapFusionTest.java
@@ -34,12 +34,16 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.engine.window.CachedWindowLightRecordCursorFactory;
 import io.questdb.griffin.engine.window.CachedWindowMapGroups;
 import io.questdb.griffin.engine.window.CachedWindowRecordCursorFactory;
+import io.questdb.griffin.engine.window.WindowAccumulatorDescriptor;
 import io.questdb.griffin.engine.window.WindowAccumulatorPlan;
 import io.questdb.griffin.engine.window.WindowFunction;
 import io.questdb.griffin.engine.window.WindowMapState;
 import io.questdb.griffin.engine.window.WindowRecordCursorFactory;
+import io.questdb.std.Chars;
 import io.questdb.std.LongList;
+import io.questdb.std.MemoryTag;
 import io.questdb.std.ObjList;
+import io.questdb.std.Unsafe;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.tools.TestUtils;
@@ -236,14 +240,25 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
     public void testAFailedOpenLeavesNoGroupHoldingBacking() throws Exception {
         // The cached open allocates a record chain, a sort buffer, the group maps and - for a
         // group whose pass 1 skips - the buffer its pass 2 projects a missing partition off. A
-        // per-query breach can land on any of them. Whichever it lands on, the close the failed
-        // open runs has to leave every group empty-handed, of both kinds of backing at once,
-        // which assertMemoryLeak measures and the successful drain afterwards says was not
-        // achieved by staying shut.
+        // per-query breach can land on the record chain, the sort buffer or the group maps: the
+        // cursor binds the per-query tracker on all three, and only an allocation carrying that
+        // tracker checks the cap. The skipping group's identity buffer takes Unsafe's untracked
+        // malloc overload, which checks the global RSS ceiling alone, so it is the one the cap
+        // cannot reach. Whichever it lands on, the close the failed open runs has to leave every
+        // group empty-handed, of both kinds of backing at once, which assertMemoryLeak measures
+        // and the successful drain afterwards says was not achieved by staying shut.
         //
-        // Both shapes, because they hold different things: the cumulative one owns a map alone,
-        // and the whole-partition one owns a map and an identity buffer that is freed on a
-        // different line.
+        // Both shapes, because a failed open has to leave both kinds of group holding nothing:
+        // the cumulative one owns a map alone, and the whole-partition one owns a map and an
+        // identity buffer that a different line frees.
+        //
+        // What the identity-buffer assertion below cannot say is that the buffer's own malloc
+        // failed. The cap in force here is the per-query one, and every allocation that carries
+        // the per-query tracker checks it - malloc and realloc alike - while the identity buffer
+        // takes the untracked overload, which answers to the global RSS ceiling alone. So this
+        // cap is not what can make that malloc fail, and what the assertion reads back is not
+        // the unwind of its failure. Reaching that failure needs a global RSS ceiling instead,
+        // which is what testAnIdentityBufferThatCannotBeAllocatedGivesTheMapBack arms.
         assertMemoryLeak(() -> {
             createTable();
             insertRows();
@@ -283,6 +298,124 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         Assert.assertEquals(ROW_COUNT, WindowMapStateTest.drain(cursor));
                     }
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testAnIdentityBufferThatCannotBeAllocatedGivesTheMapBack() throws Exception {
+        // reopen() allocates the map's backing and then, for a skipping group, the identity
+        // buffer - and only the second of those has an owner problem. The group is half-open
+        // when it fails, and a caller that never saw the group open has no reason to reset it,
+        // so reopen() closes the map itself on the way out.
+        //
+        // Driving the group directly is what makes that observable. A cursor's own close
+        // resets every group whatever reopen() managed, so an end-to-end breach reads the same
+        // whether or not reopen() unwinds; here nothing but reopen()'s own catch can close the
+        // map. The ceiling is the global RSS one rather than the per-query cap, because the cap
+        // reaches only allocations that carry the per-query tracker and the identity buffer
+        // takes the untracked overload - see testAFailedOpenLeavesNoGroupHoldingBacking.
+        assertMemoryLeak(() -> {
+            createTable();
+            insertRows();
+            setProperty(PropertyKey.CAIRO_SQL_WINDOW_CACHED_LIGHT_ENABLED, "false");
+            final String sql = "select ts, sum(x) over (partition by k), avg(x) over (partition by k)"
+                    + PARTITION_WINDOW;
+            try (SqlCompiler compiler = engine.getSqlCompiler();
+                 RecordCursorFactory factory = select(compiler, sql, sqlExecutionContext)) {
+                final CachedWindowMapGroups groups = groups(factory);
+                assertBoundGroupCount(groups, 1);
+                final WindowMapState state = groups.getStates().getQuick(0);
+                // Only a skipping group carries an identity buffer at all, so only one of them
+                // can reach the malloc under test.
+                Assert.assertTrue(
+                        "the group does not skip, so reopen() allocates no buffer",
+                        state.isPass1SkipEnabled()
+                );
+                Assert.assertFalse("the group allocated before a cursor opened it", state.isMapOpen());
+
+                // No memory tracker is bound, so the map's tracked malloc degrades to the
+                // untracked overload the buffer already takes, and the global ceiling armed
+                // below is the only limit either of them answers to.
+                //
+                // What one whole open costs, measured rather than assumed - the map's backing
+                // plus the buffer, both charged to the global RSS counter.
+                final long usedBeforeOpen = Unsafe.getRssMemUsed();
+                state.reopen();
+                final long openCost = Unsafe.getRssMemUsed() - usedBeforeOpen;
+                state.reset();
+                Assert.assertTrue("a successful open charged the RSS counter nothing", openCost > 0);
+
+                // A ceiling that admits the map and refuses the buffer sits somewhere in
+                // [0, openCost], and where exactly is how the two allocations split that cost -
+                // the map implementation's business rather than this test's. So walk the
+                // ceiling up a byte at a time and read which malloc broke it off the
+                // exception's own memoryTag: below the split the map's malloc is what breaks
+                // it, and the lowest ceiling the map clears is where the buffer's malloc breaks
+                // instead. Sweeping rather than computing the split is what
+                // keeps this off a byte-exact prediction of a counter the whole process shares:
+                // an allocation elsewhere only moves which byte the transition happens at, and
+                // the first breach that is not the map's is the one under test wherever it
+                // lands.
+                boolean hasMapMallocFailed = false;
+                boolean hasIdentityMallocFailed = false;
+                final long savedRssLimit = Unsafe.getRssMemLimit();
+                try {
+                    for (long slack = 0; slack <= openCost && !hasIdentityMallocFailed; slack++) {
+                        Unsafe.setRssMemLimit(Unsafe.getRssMemUsed() + slack);
+                        try {
+                            state.reopen();
+                        } catch (CairoException e) {
+                            Assert.assertTrue("expected an out-of-memory error", e.isOutOfMemory());
+                            TestUtils.assertContains(e.getFlyweightMessage(), "global RSS memory limit exceeded");
+                            if (Chars.contains(e.getFlyweightMessage(), "memoryTag=" + MemoryTag.NATIVE_DEFAULT + "]")) {
+                                hasIdentityMallocFailed = true;
+                                // The whole of what the branch exists for: reopen() allocated
+                                // the map's backing at the top of the same call, and gave it
+                                // back rather than leaving it on a group nobody has a reason
+                                // to reset.
+                                Assert.assertFalse(
+                                        "reopen() left the map open after the identity buffer's malloc failed",
+                                        state.isMapOpen()
+                                );
+                                Assert.assertFalse(state.isIdentityValueAllocated());
+                            } else {
+                                hasMapMallocFailed = true;
+                            }
+                        } finally {
+                            Unsafe.setRssMemLimit(savedRssLimit);
+                            // Whichever way the open went, the group holds nothing before the
+                            // next ceiling: a success allocated both and this hands both back,
+                            // and a breach left the group closed already.
+                            state.reset();
+                        }
+                    }
+                } finally {
+                    Unsafe.setRssMemLimit(savedRssLimit);
+                }
+                // The map's own breach is what says the tag still tells the two mallocs apart.
+                // Were the map to take NATIVE_DEFAULT too, every reading above would be the
+                // map's and the assertion this test rests on would never run.
+                Assert.assertTrue(
+                        "no ceiling in [0, " + openCost + "] broke on the map's malloc, so its memory tag "
+                                + "no longer distinguishes it from the identity buffer's",
+                        hasMapMallocFailed
+                );
+                Assert.assertTrue(
+                        "no ceiling in [0, " + openCost + "] made the identity buffer's malloc the failing one, "
+                                + "so the branch under test never ran",
+                        hasIdentityMallocFailed
+                );
+                // And the group is reusable: with the ceiling down the same reopen() allocates
+                // both again, which is what says the unwound open left it closed rather than
+                // inconsistent.
+                state.reopen();
+                Assert.assertTrue(state.isMapOpen());
+                Assert.assertTrue(state.isIdentityValueAllocated());
+                state.reset();
+                try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                    Assert.assertEquals(ROW_COUNT, WindowMapStateTest.drain(cursor));
                 }
             }
         });
@@ -949,7 +1082,7 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                             states.getQuick(0).getPlan().getSpec().isSameSpec(states.getQuick(1).getPlan().getSpec())
                     );
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
-                        final long rows = WindowMapStateTest.drain(cursor);
+                        WindowMapStateTest.drain(cursor);
                     }
                 }
                 assertFusedMatchesUnfused(
@@ -1042,15 +1175,23 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testEverySkipEligibleFamilyProjectsIdentityForARefusedPartition() throws Exception {
-        // Every projection family that can occur in a skip-enabled group, in one group, over a
-        // partition the group refused whole. The skip admits a family only when its component is
-        // inert on a refused row - sum, the compensated sum, the two DOUBLE extrema, the
-        // ignore-nulls first capture, Welford and the non-null count - so these are the outputs
-        // whose identity pass 2 now projects off a buffer rather than off an entry it creates.
-        // Each is worth naming: what identity means differs by family, and only the sum family's
-        // is a zeroed slice. The reference arm is the same output unfused, which computes the
-        // empty partition's answer through the family's own map instead.
+    public void testRefusedPartitionProjectsSumCountIdentityBesideResidualOutputs() throws Exception {
+        // The one identity a skipping group reaches today, projected for a partition pass 1
+        // refused whole, beside eight outputs the group declined. Under a whole-partition frame
+        // ksum, the two DOUBLE extrema, the ignore-nulls first capture and the four Welford
+        // outputs compile to their *OverPartitionFunction classes, and none of those declares an
+        // accumulator projection - so WindowAccumulatorCandidate.of turns each away and each
+        // answers the refused partition through its own map. What stays in the group is sum, avg
+        // and a count derived off the same counter slot: one FAMILY_DOUBLE_SUM_COUNT component,
+        // whose identity is the zeroed slice, which the plan assertions below pin down.
+        // isRefusedRowInert() admits seven families; this one and the non-null count are the
+        // only two any two-pass function declares, so this suite cannot build a skipping group
+        // that carries one of the other five. It does build ordinary groups that carry such a
+        // family - the extremum pair and the four Welford outputs over the cumulative window
+        // above are two - but every class declaring one of the five reports ZERO_PASS, so a
+        // group carrying one is never two-pass and never skips - see that method's javadoc.
+        // The reference arm is the same eleven outputs unfused, which compute the refused
+        // partition's answers through each function's own map instead.
         assertMemoryLeak(() -> {
             createTable();
             insertRows();
@@ -1080,6 +1221,28 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     final CachedWindowMapGroups groups = groups(factory);
                     assertBoundGroupCount(groups, 1);
                     final WindowMapState state = groups.getStates().getQuick(0);
+                    // The shape the group really has, which is the whole of what the identity
+                    // path here covers: one component, the sum family's, and its two slots.
+                    // Three of the eleven outputs project off it - sum, avg and the derived
+                    // count - and the assertion on how many functions the factory left bound is
+                    // what says the other eight sit outside.
+                    final WindowAccumulatorPlan plan = state.getPlan();
+                    Assert.assertEquals(1, plan.getComponentCount());
+                    Assert.assertEquals(
+                            WindowAccumulatorDescriptor.FAMILY_DOUBLE_SUM_COUNT,
+                            plan.getComponent(0).getFamily()
+                    );
+                    Assert.assertEquals(2, plan.getSlotCount());
+                    Assert.assertEquals(3, plan.getProjectionCount());
+                    final ObjList<WindowFunction> functions = windowFunctions(factory);
+                    Assert.assertEquals(outputs.length, functions.size());
+                    int boundCount = 0;
+                    for (int i = 0, n = functions.size(); i < n; i++) {
+                        if (functions.getQuick(i).isWindowStateOwned()) {
+                            boundCount++;
+                        }
+                    }
+                    Assert.assertEquals("the group's membership moved", 3, boundCount);
                     // The two properties that put these outputs on the identity path at all: the
                     // group is driven twice, and pass 1 is allowed to leave a refused row's key
                     // out of the map. Were a family here not inert on a refused row, the skip
@@ -1088,9 +1251,11 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     Assert.assertTrue(state.isPass1SkipEnabled());
                 }
                 assertFusedMatchesUnfused(PARTITION_WINDOW, "", outputs);
-                // And what identity is, family by family, written out: SQL NULL everywhere but
-                // the counter, which is exact and zero. These are the two rows the map no longer
-                // holds an entry to answer for, read twice over by the assertion itself.
+                // And what the refused partition answers, output by output: SQL NULL everywhere
+                // but the counter, which is exact and zero. The group projects the first three
+                // off its identity buffer and every other output computes its own; these are the
+                // two rows the map no longer holds an entry for, read twice over by the
+                // assertion itself.
                 assertQuery("""
                         SELECT * FROM (
                           SELECT k, sum(x) OVER w AS s, avg(x) OVER w AS a, ksum(x) OVER w AS ks,

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/CachedWindowMapFusionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/CachedWindowMapFusionTest.java
@@ -242,23 +242,29 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
         // group whose pass 1 skips - the buffer its pass 2 projects a missing partition off. A
         // per-query breach can land on the record chain, the sort buffer or the group maps: the
         // cursor binds the per-query tracker on all three, and only an allocation carrying that
-        // tracker checks the cap. The skipping group's identity buffer takes Unsafe's untracked
-        // malloc overload, which checks the global RSS ceiling alone, so it is the one the cap
-        // cannot reach. Whichever it lands on, the close the failed open runs has to leave every
-        // group empty-handed, of both kinds of backing at once, which assertMemoryLeak measures
-        // and the successful drain afterwards says was not achieved by staying shut.
+        // tracker checks the cap. Whichever it lands on, every group's map has to read shut
+        // afterwards - which the assertion below does - because the breach either beat of() to
+        // the group entirely or broke the group's own map.reopen(), which assigns the backing
+        // pointer isMapOpen() reads only once its malloc has returned. The close getCursor()
+        // runs on the failed open then hands back every allocation the open did make, which
+        // assertMemoryLeak measures and the successful drain afterwards says was not achieved
+        // by staying shut.
         //
         // Both shapes, because a failed open has to leave both kinds of group holding nothing:
         // the cumulative one owns a map alone, and the whole-partition one owns a map and an
-        // identity buffer that a different line frees.
+        // identity buffer.
         //
-        // What the identity-buffer assertion below cannot say is that the buffer's own malloc
-        // failed. The cap in force here is the per-query one, and every allocation that carries
-        // the per-query tracker checks it - malloc and realloc alike - while the identity buffer
-        // takes the untracked overload, which answers to the global RSS ceiling alone. So this
-        // cap is not what can make that malloc fail, and what the assertion reads back is not
-        // the unwind of its failure. Reaching that failure needs a global RSS ceiling instead,
-        // which is what testAnIdentityBufferThatCannotBeAllocatedGivesTheMapBack arms.
+        // The identity buffer is the one backing this cap says nothing about, so nothing here
+        // asserts over it. It takes Unsafe's untracked malloc overload, which answers to the
+        // global RSS ceiling alone, so the per-query cap cannot break that malloc itself - and no
+        // breach reaches it either, because reopen() allocates the map's backing first and the
+        // 64-byte cap below always breaks that tracked malloc. Every breach this test can reach
+        // therefore lands before the group holds a buffer at all, and an assertion over it would
+        // read back the zero it started from rather than any unwind. Two other tests cover the
+        // buffer where a failure does reach it: testAnIdentityBufferThatCannotBeAllocatedGivesTheMapBack
+        // arms a global RSS ceiling and reads reopen()'s own unwind, and
+        // testAPartitionRefusedWholeStaysOutOfTheMap reads reset() taking the buffer back off a
+        // group that holds one.
         assertMemoryLeak(() -> {
             createTable();
             insertRows();
@@ -287,10 +293,6 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                         for (int g = 0, n = states.size(); g < n; g++) {
                             final WindowMapState state = states.getQuick(g);
                             Assert.assertFalse("group " + g + " kept its map open", state.isMapOpen());
-                            Assert.assertFalse(
-                                    "group " + g + " kept its identity buffer",
-                                    state.isIdentityValueAllocated()
-                            );
                         }
                     }
                     Assert.assertEquals("busy reader count", 0, engine.getBusyReaderCount());
@@ -340,33 +342,55 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                 // below is the only limit either of them answers to.
                 //
                 // What one whole open costs, measured rather than assumed - the map's backing
-                // plus the buffer, both charged to the global RSS counter.
+                // plus the buffer, both charged to the global RSS counter. The buffer is the
+                // only allocation of the open that takes NATIVE_DEFAULT, so that tag's own
+                // counter splits the cost in two and says which ceilings the map still clears.
                 final long usedBeforeOpen = Unsafe.getRssMemUsed();
+                final long defaultTagBeforeOpen = Unsafe.getMemUsedByTag(MemoryTag.NATIVE_DEFAULT);
                 state.reopen();
                 final long openCost = Unsafe.getRssMemUsed() - usedBeforeOpen;
+                final long bufferCost = Unsafe.getMemUsedByTag(MemoryTag.NATIVE_DEFAULT) - defaultTagBeforeOpen;
+                final long mapCost = openCost - bufferCost;
                 state.reset();
                 Assert.assertTrue("a successful open charged the RSS counter nothing", openCost > 0);
+                Assert.assertTrue(
+                        "NATIVE_DEFAULT took " + bufferCost + " of the open's " + openCost + ", so the tag no "
+                                + "longer separates the identity buffer's cost from the map's",
+                        bufferCost > 0 && bufferCost < openCost
+                );
 
                 // A ceiling that admits the map and refuses the buffer sits somewhere in
                 // [0, openCost], and where exactly is how the two allocations split that cost -
-                // the map implementation's business rather than this test's. So walk the
-                // ceiling up a byte at a time and read which malloc broke it off the
-                // exception's own memoryTag: below the split the map's malloc is what breaks
-                // it, and the lowest ceiling the map clears is where the buffer's malloc breaks
-                // instead. Sweeping rather than computing the split is what
-                // keeps this off a byte-exact prediction of a counter the whole process shares:
-                // an allocation elsewhere only moves which byte the transition happens at, and
-                // the first breach that is not the map's is the one under test wherever it
-                // lands.
+                // which the tag counter above just measured. A ceiling of mapCost - 1 is the
+                // highest one the map's own malloc still has to break, and one of mapCost is the
+                // lowest that admits the map and leaves the buffer's malloc the first allocation
+                // over the line. So the walk starts on those two rather than climbing to them
+                // from zero: the counter belongs to the whole process, and every ceiling this
+                // arms below real usage is one another thread's allocation can break on instead.
+                //
+                // The measured split seeds the walk rather than predicting its answer. An
+                // allocation or a free elsewhere between the reading of the counter and the open
+                // moves the transition off the measured byte, so each probe reads which malloc
+                // actually broke the ceiling off the exception's own memoryTag and steps the
+                // next ceiling toward whichever breach is still missing. Two probes is what a
+                // still counter costs; the budget is headroom for a moving one, and the
+                // assertions below fail loudly rather than quietly if it runs out with a breach
+                // unseen.
+                final int probeBudget = 64;
                 boolean hasMapMallocFailed = false;
                 boolean hasIdentityMallocFailed = false;
+                long slack = mapCost - 1;
+                int probe = 0;
                 final long savedRssLimit = Unsafe.getRssMemLimit();
                 try {
-                    for (long slack = 0; slack <= openCost && !hasIdentityMallocFailed; slack++) {
+                    for (; probe < probeBudget && slack > 0
+                            && !(hasMapMallocFailed && hasIdentityMallocFailed); probe++) {
+                        boolean hasOpenBreached = false;
                         Unsafe.setRssMemLimit(Unsafe.getRssMemUsed() + slack);
                         try {
                             state.reopen();
                         } catch (CairoException e) {
+                            hasOpenBreached = true;
                             Assert.assertTrue("expected an out-of-memory error", e.isOutOfMemory());
                             TestUtils.assertContains(e.getFlyweightMessage(), "global RSS memory limit exceeded");
                             if (Chars.contains(e.getFlyweightMessage(), "memoryTag=" + MemoryTag.NATIVE_DEFAULT + "]")) {
@@ -390,6 +414,21 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                             // and a breach left the group closed already.
                             state.reset();
                         }
+                        // Step toward the breach still missing: halve the slack while the map's
+                        // is missing, since every ceiling below the split breaks the map's
+                        // malloc; walk up a byte at a time while the buffer's is missing and the
+                        // map still breaks, since that is where a counter that moved up carries
+                        // the transition - and clamp that step to mapCost, so a walk that halving
+                        // took below the measured split resumes at it rather than grinding back up
+                        // a byte at a time; and give a byte back when the open cleared the ceiling
+                        // outright, which says the transition moved the other way.
+                        if (!hasMapMallocFailed) {
+                            slack /= 2;
+                        } else if (hasOpenBreached) {
+                            slack = Math.max(slack + 1, mapCost);
+                        } else {
+                            slack--;
+                        }
                     }
                 } finally {
                     Unsafe.setRssMemLimit(savedRssLimit);
@@ -398,13 +437,19 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                 // Were the map to take NATIVE_DEFAULT too, every reading above would be the
                 // map's and the assertion this test rests on would never run.
                 Assert.assertTrue(
-                        "no ceiling in [0, " + openCost + "] broke on the map's malloc, so its memory tag "
-                                + "no longer distinguishes it from the identity buffer's",
+                        "the walk armed " + probe + " of its " + probeBudget + " ceilings around the measured map "
+                                + "cost " + mapCost + " and stopped at slack " + slack + " without one breaking on "
+                                + "the map's malloc, so it either ran out of probes against a counter the whole "
+                                + "process moves or the map's malloc now carries NATIVE_DEFAULT like the identity "
+                                + "buffer's (identity breach seen: " + hasIdentityMallocFailed + ")",
                         hasMapMallocFailed
                 );
                 Assert.assertTrue(
-                        "no ceiling in [0, " + openCost + "] made the identity buffer's malloc the failing one, "
-                                + "so the branch under test never ran",
+                        "the walk armed " + probe + " of its " + probeBudget + " ceilings around the measured map "
+                                + "cost " + mapCost + " and stopped at slack " + slack + " without one making the "
+                                + "identity buffer's malloc the failing one, so the branch under test never ran - "
+                                + "the walk either ran out of probes against a counter the whole process moves or "
+                                + "the buffer's malloc no longer carries NATIVE_DEFAULT",
                         hasIdentityMallocFailed
                 );
                 // And the group is reusable: with the ceiling down the same reopen() allocates

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/CachedWindowMapFusionTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/CachedWindowMapFusionTest.java
@@ -234,59 +234,84 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
 
     @Test
     public void testAFailedOpenLeavesNoGroupHoldingBacking() throws Exception {
-        // The cached open allocates a record chain, a sort buffer and the group maps, and a
-        // per-query breach can land on any of them. Whichever it lands on, the close the
-        // failed open runs has to leave every group empty-handed - which assertMemoryLeak
-        // measures and the successful drain afterwards says was not achieved by staying shut.
+        // The cached open allocates a record chain, a sort buffer, the group maps and - for a
+        // group whose pass 1 skips - the buffer its pass 2 projects a missing partition off. A
+        // per-query breach can land on any of them. Whichever it lands on, the close the failed
+        // open runs has to leave every group empty-handed, of both kinds of backing at once,
+        // which assertMemoryLeak measures and the successful drain afterwards says was not
+        // achieved by staying shut.
+        //
+        // Both shapes, because they hold different things: the cumulative one owns a map alone,
+        // and the whole-partition one owns a map and an identity buffer that is freed on a
+        // different line.
         assertMemoryLeak(() -> {
             createTable();
             insertRows();
             setProperty(PropertyKey.CAIRO_SQL_WINDOW_CACHED_LIGHT_ENABLED, "false");
-            try (SqlCompiler compiler = engine.getSqlCompiler();
-                 RecordCursorFactory factory = select(compiler, orderedSumAndCount(), sqlExecutionContext)) {
-                final CachedWindowMapGroups groups = groups(factory);
-                assertBoundGroupCount(groups, 1);
-                setProperty(PropertyKey.CAIRO_QUERY_MEMORY_LIMIT_BYTES, 64L);
-                for (int i = 0; i < 5; i++) {
+            final String skipping = "select ts, sum(x) over (partition by k), avg(x) over (partition by k)"
+                    + PARTITION_WINDOW;
+            for (String sql : new String[]{orderedSumAndCount(), skipping}) {
+                try (SqlCompiler compiler = engine.getSqlCompiler();
+                     RecordCursorFactory factory = select(compiler, sql, sqlExecutionContext)) {
+                    final CachedWindowMapGroups groups = groups(factory);
+                    assertBoundGroupCount(groups, 1);
+                    final boolean isSkipping = groups.getStates().getQuick(0).isPass1SkipEnabled();
+                    Assert.assertEquals(sql, sql.equals(skipping), isSkipping);
+                    setProperty(PropertyKey.CAIRO_QUERY_MEMORY_LIMIT_BYTES, 64L);
+                    for (int i = 0; i < 5; i++) {
+                        try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                            WindowMapStateTest.drain(cursor);
+                            Assert.fail("expected a per-query memory breach");
+                        } catch (CairoException e) {
+                            Assert.assertTrue(
+                                    "expected isOutOfMemory(), got: " + e.getFlyweightMessage(),
+                                    e.isOutOfMemory()
+                            );
+                        }
+                        final ObjList<WindowMapState> states = groups.getStates();
+                        for (int g = 0, n = states.size(); g < n; g++) {
+                            final WindowMapState state = states.getQuick(g);
+                            Assert.assertFalse("group " + g + " kept its map open", state.isMapOpen());
+                            Assert.assertFalse(
+                                    "group " + g + " kept its identity buffer",
+                                    state.isIdentityValueAllocated()
+                            );
+                        }
+                    }
+                    Assert.assertEquals("busy reader count", 0, engine.getBusyReaderCount());
+                    setProperty(PropertyKey.CAIRO_QUERY_MEMORY_LIMIT_BYTES, 0L);
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
-                        WindowMapStateTest.drain(cursor);
-                        Assert.fail("expected a per-query memory breach");
-                    } catch (CairoException e) {
-                        Assert.assertTrue(
-                                "expected isOutOfMemory(), got: " + e.getFlyweightMessage(),
-                                e.isOutOfMemory()
-                        );
+                        Assert.assertEquals(ROW_COUNT, WindowMapStateTest.drain(cursor));
                     }
-                    final ObjList<WindowMapState> states = groups.getStates();
-                    for (int g = 0, n = states.size(); g < n; g++) {
-                        Assert.assertFalse("group " + g + " kept its map open", states.getQuick(g).isMapOpen());
-                    }
-                }
-                Assert.assertEquals("busy reader count", 0, engine.getBusyReaderCount());
-                setProperty(PropertyKey.CAIRO_QUERY_MEMORY_LIMIT_BYTES, 0L);
-                try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
-                    Assert.assertEquals(ROW_COUNT, WindowMapStateTest.drain(cursor));
                 }
             }
         });
     }
 
     @Test
-    public void testAPartitionRefusedWholeGetsItsEntryInPassTwo() throws Exception {
+    public void testAPartitionRefusedWholeStaysOutOfTheMap() throws Exception {
         // The one shape the pass-1 skip changes about the map: a partition whose every row its
-        // component refuses is not in the map when pass 1 ends, so pass 2 is where its entry
-        // appears at all. What the outputs read there is the identity a partition nothing
-        // contributed to would have been left sitting at anyway - a NULL sum, a NULL average and
-        // a zero count - which is what the reference arm below is asserting as well.
+        // component refuses is not in the map when pass 1 ends, and pass 2 does not put it back.
+        // What the outputs read for it is the identity a partition nothing contributed to would
+        // have been left sitting at anyway - a NULL sum, a NULL average and a zero count - read
+        // off the group's own buffer, which is what the reference arm below is asserting as
+        // well. The map is therefore the contributing partitions rather than every partition the
+        // traversal saw, and a row of a refused-whole partition costs one failed lookup and no
+        // insertion.
         assertMemoryLeak(() -> {
             execute("CREATE TABLE s (ts TIMESTAMP, k INT, x DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+            // Two partitions refused whole rather than one, because one buffer serves every
+            // missing partition: were a projection to leave anything in it, key 3 would read
+            // what key 2 left there.
             execute("""
                     INSERT INTO s VALUES
                     ('2024-01-01T00:00:00.000000Z', 1, 1.0),
                     ('2024-01-01T00:00:01.000000Z', 2, null),
                     ('2024-01-01T00:00:02.000000Z', 2, 'Infinity'::double),
                     ('2024-01-01T00:00:03.000000Z', 1, 4.0),
-                    ('2024-01-01T00:00:04.000000Z', 2, null)""");
+                    ('2024-01-01T00:00:04.000000Z', 2, null),
+                    ('2024-01-01T00:00:05.000000Z', 3, null),
+                    ('2024-01-01T00:00:06.000000Z', 3, '-Infinity'::double)""");
             final String sql = "SELECT k, sum(x) OVER (PARTITION BY k) AS s, avg(x) OVER (PARTITION BY k) AS a, "
                     + "count(x) OVER (PARTITION BY k) AS c FROM s";
             for (int light = 0; light < 2; light++) {
@@ -316,35 +341,55 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                                 return key[0];
                             }
                         };
-                        final int[] keys = {1, 2, 2, 1, 2};
-                        final double[] values = {1.0, Double.NaN, Double.POSITIVE_INFINITY, 4.0, Double.NaN};
+                        final int[] keys = {1, 2, 2, 1, 2, 3, 3};
+                        final double[] values = {
+                                1.0, Double.NaN, Double.POSITIVE_INFINITY, 4.0, Double.NaN,
+                                Double.NaN, Double.NEGATIVE_INFINITY
+                        };
                         for (int i = 0; i < keys.length; i++) {
                             key[0] = keys[i];
                             value[0] = values[i];
                             state.computeNext(record);
                         }
-                        // Pass 1 saw two partition keys, but key 2 contained only rows the group
-                        // refused. Its absence from the map directly proves that computeNext took
-                        // the skip branch for those rows.
+                        // Pass 1 saw three partition keys, but keys 2 and 3 held only rows the
+                        // group refused. Their absence from the map directly proves that
+                        // computeNext took the skip branch for those rows.
                         Assert.assertEquals(1, state.getMapSize());
-                        keyReads[0] = 0;
-                        for (int i = 0; i < keys.length; i++) {
-                            key[0] = keys[i];
-                            value[0] = values[i];
-                            state.projectPass2(record);
+                        // Twice over, which is what says pass 2 leaves no state of its own: the
+                        // second drain reads the map the first one left and finds it unchanged,
+                        // which is what a cached cursor's random access and its second drain
+                        // both need.
+                        for (int pass = 0; pass < 2; pass++) {
+                            keyReads[0] = 0;
+                            for (int i = 0; i < keys.length; i++) {
+                                key[0] = keys[i];
+                                value[0] = values[i];
+                                state.projectPass2(record);
+                            }
+                            // One key read a row and no more: a miss projects the identity off
+                            // the group's own buffer, so it writes no second key and creates no
+                            // entry. The old shape read one key extra per refused-whole
+                            // partition and grew the map by one entry for each.
+                            Assert.assertEquals("pass " + pass, keys.length, keyReads[0]);
+                            // And the partitions the skip left out stay out. The map a skipping
+                            // group ends with holds the contributing partitions alone, which is
+                            // the whole saving on an input whose keys are mostly refused.
+                            Assert.assertEquals("pass " + pass, 1, state.getMapSize());
                         }
-                        // Pass 2 reads one key per row to find its value and reads key 2 once
-                        // more when its first row creates the identity entry pass 1 omitted.
-                        Assert.assertEquals(6, keyReads[0]);
+                        // The buffer is the group's for as long as its map is, which is what
+                        // the reset below then takes back.
+                        Assert.assertTrue(state.isIdentityValueAllocated());
                     } finally {
                         state.reset();
                     }
+                    Assert.assertFalse(state.isIdentityValueAllocated());
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
-                        Assert.assertEquals(5, WindowMapStateTest.drain(cursor));
+                        Assert.assertEquals(7, WindowMapStateTest.drain(cursor));
                     }
                 }
-                // Read twice over, which is what says the pass-2 create is idempotent: the second
-                // cursor finds the entry the first one left and projects the same identity off it.
+                // Read twice over, which is what says the identity projection is idempotent: the
+                // second cursor projects the same identity off the same buffer, for both of the
+                // partitions that have no entry to read it from.
                 assertQuery(sql).expectSize().returns("""
                         k\ts\ta\tc
                         1\t5.0\t2.5\t2
@@ -352,6 +397,8 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                         2\tnull\tnull\t0
                         1\t5.0\t2.5\t2
                         2\tnull\tnull\t0
+                        3\tnull\tnull\t0
+                        3\tnull\tnull\t0
                         """);
             }
         });
@@ -995,6 +1042,73 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testEverySkipEligibleFamilyProjectsIdentityForARefusedPartition() throws Exception {
+        // Every projection family that can occur in a skip-enabled group, in one group, over a
+        // partition the group refused whole. The skip admits a family only when its component is
+        // inert on a refused row - sum, the compensated sum, the two DOUBLE extrema, the
+        // ignore-nulls first capture, Welford and the non-null count - so these are the outputs
+        // whose identity pass 2 now projects off a buffer rather than off an entry it creates.
+        // Each is worth naming: what identity means differs by family, and only the sum family's
+        // is a zeroed slice. The reference arm is the same output unfused, which computes the
+        // empty partition's answer through the family's own map instead.
+        assertMemoryLeak(() -> {
+            createTable();
+            insertRows();
+            final String[] outputs = {
+                    "sum(x) over (partition by k)",
+                    "avg(x) over (partition by k)",
+                    "ksum(x) over (partition by k)",
+                    "max(x) over (partition by k)",
+                    "min(x) over (partition by k)",
+                    "first_value(x) ignore nulls over (partition by k)",
+                    "count(x) over (partition by k)",
+                    "var_samp(x) over (partition by k)",
+                    "var_pop(x) over (partition by k)",
+                    "stddev_samp(x) over (partition by k)",
+                    "stddev_pop(x) over (partition by k)",
+            };
+            final StringBuilder sql = new StringBuilder("select ts");
+            for (String output : outputs) {
+                sql.append(", ").append(output);
+            }
+            sql.append(PARTITION_WINDOW);
+            for (int light = 0; light < 2; light++) {
+                setProperty(PropertyKey.CAIRO_SQL_WINDOW_CACHED_LIGHT_ENABLED, light == 0 ? "false" : "true");
+                try (SqlCompiler compiler = engine.getSqlCompiler();
+                     RecordCursorFactory factory = select(compiler, sql.toString(), sqlExecutionContext)) {
+                    assertFactoryKind(factory, light == 1);
+                    final CachedWindowMapGroups groups = groups(factory);
+                    assertBoundGroupCount(groups, 1);
+                    final WindowMapState state = groups.getStates().getQuick(0);
+                    // The two properties that put these outputs on the identity path at all: the
+                    // group is driven twice, and pass 1 is allowed to leave a refused row's key
+                    // out of the map. Were a family here not inert on a refused row, the skip
+                    // would be off for the whole group and this test would prove nothing.
+                    Assert.assertTrue(state.isTwoPass());
+                    Assert.assertTrue(state.isPass1SkipEnabled());
+                }
+                assertFusedMatchesUnfused(PARTITION_WINDOW, "", outputs);
+                // And what identity is, family by family, written out: SQL NULL everywhere but
+                // the counter, which is exact and zero. These are the two rows the map no longer
+                // holds an entry to answer for, read twice over by the assertion itself.
+                assertQuery("""
+                        SELECT * FROM (
+                          SELECT k, sum(x) OVER w AS s, avg(x) OVER w AS a, ksum(x) OVER w AS ks,
+                                 max(x) OVER w AS mx, min(x) OVER w AS mn,
+                                 first_value(x) IGNORE NULLS OVER w AS fv, count(x) OVER w AS c,
+                                 var_samp(x) OVER w AS vs, var_pop(x) OVER w AS vp,
+                                 stddev_samp(x) OVER w AS ss, stddev_pop(x) OVER w AS sp
+                          FROM t WINDOW w AS (PARTITION BY k)
+                        ) WHERE k = 'nx'""").returns("""
+                        k\ts\ta\tks\tmx\tmn\tfv\tc\tvs\tvp\tss\tsp
+                        nx\tnull\tnull\tnull\tnull\tnull\tnull\t0\tnull\tnull\tnull\tnull
+                        nx\tnull\tnull\tnull\tnull\tnull\tnull\t0\tnull\tnull\tnull\tnull
+                        """);
+            }
+        });
+    }
+
+    @Test
     public void testWholePartitionSumAvgAndCountShareOneComponent() throws Exception {
         // The key regression case of this step, and the one the design named years before it
         // was built: unfused, avg's preparePass2 replaces each partition's sum slot with its
@@ -1023,9 +1137,9 @@ public class CachedWindowMapFusionTest extends AbstractCairoTest {
                     try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                         final long rows = WindowMapStateTest.drain(cursor);
                         Assert.assertEquals(ROW_COUNT, rows);
-                        // The 'nx' partition is refused whole in pass 1, so pass 2 is where its
-                        // entry appears at all. The three outputs still read the identity it
-                        // would have been left sitting at; see the reference comparison below.
+                        // The 'nx' partition is refused whole in pass 1 and stays out of the
+                        // map. The three outputs still read the identity it would have been left
+                        // sitting at; see the reference comparison below.
                         Assert.assertTrue(state.isPass1SkipEnabled());
                         // The property the skipped preparePass2 rests on. A bound function's
                         // own map stays closed for the factory's whole life, so the walk it

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowMapFusionFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowMapFusionFuzzTest.java
@@ -624,8 +624,8 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
             final String call = isSkipEnabledGroupRequired
                     ? SKIP_ENABLED_WHOLE_PARTITION_CALLS[o]
                     : frameKinds[w] != FRAME_WHOLE_PARTITION && rnd.nextInt(8) == 0
-                            ? RESIDUAL_CALLS[rnd.nextInt(RESIDUAL_CALLS.length)]
-                            : calls[rnd.nextInt(calls.length)];
+                      ? RESIDUAL_CALLS[rnd.nextInt(RESIDUAL_CALLS.length)]
+                      : calls[rnd.nextInt(calls.length)];
             sql.append(", ").append(call).append(" over ");
             if (rnd.nextBoolean()) {
                 sql.append('w').append(w);

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowMapFusionFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowMapFusionFuzzTest.java
@@ -30,6 +30,9 @@ import io.questdb.cairo.sql.RecordCursor;
 import io.questdb.cairo.sql.RecordCursorFactory;
 import io.questdb.griffin.SqlCompiler;
 import io.questdb.griffin.SqlException;
+import io.questdb.griffin.engine.window.CachedWindowLightRecordCursorFactory;
+import io.questdb.griffin.engine.window.CachedWindowMapGroups;
+import io.questdb.griffin.engine.window.CachedWindowRecordCursorFactory;
 import io.questdb.griffin.engine.window.WindowMapState;
 import io.questdb.griffin.engine.window.WindowRecordCursorFactory;
 import io.questdb.std.ObjList;
@@ -37,6 +40,7 @@ import io.questdb.std.Rnd;
 import io.questdb.std.str.StringSink;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.tools.TestUtils;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -93,6 +97,13 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
     private static final int FRAME_BOUNDED_RANGE = 3;
     private static final int FRAME_RANGE = 0;
     private static final int FRAME_ROWS = 1;
+    /**
+     * A window with no ORDER BY, whose every row is a peer and whose frame is therefore the whole
+     * partition. It is the only frame here whose functions are two-pass, so it is also the only
+     * one that reaches a cached cursor - and the only one whose group may leave a row out of its
+     * map in pass 1, which is the path this arm exists to compare.
+     */
+    private static final int FRAME_WHOLE_PARTITION = 4;
     private static final int ITERATIONS = 40;
     private static final String[] KEY_COLUMNS = {"ki", "ks", "kv"};
     /**
@@ -252,6 +263,34 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
             "first_value(ts)",
     };
     /**
+     * The calls a <b>whole-partition</b> window can fuse. A short list, and deliberately so: the
+     * extremum, dispersion, compensated-sum and capture implementations behind an unordered
+     * window are separate classes that declare no family, so what is left is the DOUBLE
+     * {@code (sum, nonNullCount)} pair, the counters that fold onto it, and the row count.
+     * <p>
+     * All three contribution predicates a two-pass group can carry are here, which is what makes
+     * the arm differential about the pass-1 skip rather than only about the answers: the DOUBLE
+     * calls, {@code count(xd)} and {@code count(ki)} refuse a row on {@code Numbers.isFinite},
+     * which a group can evaluate for itself and skip on; the SYMBOL, VARCHAR and DECIMAL counters
+     * refuse on their own type's null test, which it cannot; and {@code count(*)} refuses nothing
+     * at all. A query mixing them is one whose group must decline the skip it would take for the
+     * DOUBLE calls alone.
+     */
+    private static final String[] WHOLE_PARTITION_CALLS = {
+            "sum(xd)",
+            "sum(yd)",
+            "avg(xd)",
+            "avg(yd)",
+            "count(xd)",
+            "count(yd)",
+            "count(*)",
+            "count(ki)",
+            "count(ks)",
+            "count(kv)",
+            "count(xdec)",
+            "count(xdec128)",
+    };
+    /**
      * Calls no family describes. One of them lands in a query now and then so that a residual
      * function and a bound group share a cursor, which is what an ordinary query looks like.
      * <p>
@@ -278,6 +317,7 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             int boundIterations = 0;
             int boundGroups = 0;
+            long skippedRows = 0;
             for (int i = 0; i < ITERATIONS; i++) {
                 final String table = "t" + i;
                 final String data = createTable(table);
@@ -288,13 +328,14 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
                 final String sql = randomQuery(table);
                 final int[] groups = new int[1];
                 final int[] unfusedGroups = new int[1];
+                final long[] skipped = new long[1];
                 final String fused;
                 final String unfused;
                 try {
-                    fused = render(sql, groups);
+                    fused = render(sql, groups, skipped);
                     setProperty(PropertyKey.CAIRO_SQL_WINDOW_MAP_FUSION_ENABLED, "false");
                     try {
-                        unfused = render(sql, unfusedGroups);
+                        unfused = render(sql, unfusedGroups, null);
                     } finally {
                         setProperty(PropertyKey.CAIRO_SQL_WINDOW_MAP_FUSION_ENABLED, "true");
                     }
@@ -309,6 +350,7 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
                     boundIterations++;
                     boundGroups += groups[0];
                 }
+                skippedRows += skipped[0];
                 Assert.assertEquals(context(i, data, sql), unfused, fused);
             }
             // A generator that stopped producing fusible shapes - a family withdrawn, a decline
@@ -318,9 +360,18 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
                     "no iteration bound a window Map group, so nothing here was differential",
                     boundIterations > 0
             );
+            // The whole-partition arm's own liveness check. Every table this generator builds has
+            // a NULL-heavy DOUBLE column, so a run that drew even one whole-partition query over
+            // one skips rows - and a run that skipped none compared the two arms over a path the
+            // skip never took.
+            Assert.assertTrue(
+                    "no bound group skipped a pass-1 row, so the refused-row path was never taken",
+                    skippedRows > 0
+            );
             LOG.info().$("window map fusion fuzz [iterations=").$(ITERATIONS)
                     .$(", fusedIterations=").$(boundIterations)
                     .$(", boundGroups=").$(boundGroups)
+                    .$(", skippedRows=").$(skippedRows)
                     .I$();
         });
     }
@@ -337,12 +388,16 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
      * {@code toTop} and by nothing else, so a domain that survived one - or one cleared once
      * per bound member rather than once per group - shows up here and nowhere else in this
      * class.
+     *
+     * @param skipped receives how many pass-1 rows the bound groups left out of their maps, or
+     *                null when the caller does not read it. Counted while the cursor is open,
+     *                since closing it hands the group's map back and resets the counters with it
      */
-    private static String render(String sql, int[] groups) throws SqlException {
+    private static String render(String sql, int[] groups, long[] skipped) throws SqlException {
         try (SqlCompiler compiler = engine.getSqlCompiler();
              RecordCursorFactory factory = select(compiler, sql, sqlExecutionContext)) {
+            final ObjList<WindowMapState> states = windowMapStates(factory);
             if (groups != null) {
-                final ObjList<WindowMapState> states = windowMapStates(factory);
                 groups[0] = states == null ? 0 : states.size();
             }
             final StringSink first = new StringSink();
@@ -351,6 +406,11 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
                 CursorPrinter.println(cursor, factory.getMetadata(), first, true, false);
                 cursor.toTop();
                 CursorPrinter.println(cursor, factory.getMetadata(), second, true, false);
+                if (skipped != null && states != null) {
+                    for (int i = 0, n = states.size(); i < n; i++) {
+                        skipped[0] += states.getQuick(i).getSkippedRowCount();
+                    }
+                }
             }
             TestUtils.assertEquals(first, second);
             return first.toString();
@@ -361,13 +421,30 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
      * The bound groups of the window factory in {@code factory}'s chain, or null when the query
      * has none - a projection wrapper can sit above the window factory, so the search walks the
      * whole chain rather than unwrapping one known level.
+     * <p>
+     * All three window factories, because which one a query lands on is the compiler's answer
+     * rather than the generator's: one whole-partition call in the SELECT list is what declines
+     * the streaming fast path, and a run that read groups off the streaming factory alone would
+     * report every cached query as having bound none - which the differential assertion below
+     * would then pass without comparing anything.
      */
-    private static ObjList<WindowMapState> windowMapStates(RecordCursorFactory factory) {
+    private static @Nullable ObjList<WindowMapState> windowMapStates(RecordCursorFactory factory) {
         RecordCursorFactory root = factory;
-        while (root != null && !(root instanceof WindowRecordCursorFactory)) {
+        while (root != null) {
+            if (root instanceof WindowRecordCursorFactory f) {
+                return f.getWindowMapStates();
+            }
+            if (root instanceof CachedWindowRecordCursorFactory f) {
+                final CachedWindowMapGroups groups = f.getWindowMapGroups();
+                return groups == null ? null : groups.getStates();
+            }
+            if (root instanceof CachedWindowLightRecordCursorFactory f) {
+                final CachedWindowMapGroups groups = f.getWindowMapGroups();
+                return groups == null ? null : groups.getStates();
+            }
             root = root.getBaseFactory();
         }
-        return root == null ? null : ((WindowRecordCursorFactory) root).getWindowMapStates();
+        return null;
     }
 
     /**
@@ -465,21 +542,40 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
     }
 
     /**
-     * One random streaming query: one or two partitioned windows, two to five outputs spread over
-     * them in random order, each window referenced by name or spelled inline.
+     * One random query: one or two partitioned windows, two to five outputs spread over them in
+     * random order, each window referenced by name or spelled inline.
      * <p>
-     * Every window is partitioned and ordered by the designated timestamp the base is already
-     * scanned in, which is what keeps the query on the streaming path the group compiler runs
-     * under - and what a bounded RANGE frame requires outright, since one is compiled only where
-     * that order was dismissed. What varies is everything the group identity is a function of, the
-     * frame included: a cumulative ROWS or RANGE frame, or a bounded ROWS or RANGE one in each of
-     * the three geometries its ring comes in.
+     * A query is drawn as one of two kinds, because the two do not mix. A <b>streaming</b> query's
+     * windows are all partitioned and ordered by the designated timestamp the base is already
+     * scanned in, which is what keeps it on the streaming path - and what a bounded RANGE frame
+     * requires outright, since one is compiled only where that order was dismissed. A
+     * <b>whole-partition</b> query's windows carry no ORDER BY at all, so every row of a partition
+     * is a peer and every call over it is two-pass, which lands the query on a cached cursor
+     * instead. Drawing one kind per query rather than one per window is what keeps a bounded RANGE
+     * frame off a cursor that would not compile it.
+     * <p>
+     * What varies within a kind is everything the group identity is a function of, the frame
+     * included: a cumulative ROWS or RANGE frame, or a bounded ROWS or RANGE one in each of the
+     * three geometries its ring comes in.
      */
     private String randomQuery(String table) {
         final int windowCount = 1 + rnd.nextInt(2);
         final String[] specs = new String[windowCount];
         final int[] frameKinds = new int[windowCount];
+        final boolean wholePartition = rnd.nextInt(3) == 0;
         for (int w = 0; w < windowCount; w++) {
+            // A key is a column or an expression over one or two of them, and which it is
+            // decides how the group writes it: off the record's own columns, or through the
+            // compiled terms it borrows from a member. The expressions are deliberately ones
+            // whose value no column carries, so the two arms cannot agree by accident.
+            final String key = rnd.nextInt(4) == 0
+                    ? KEY_EXPRESSIONS[rnd.nextInt(KEY_EXPRESSIONS.length)]
+                    : KEY_COLUMNS[rnd.nextInt(KEY_COLUMNS.length)];
+            if (wholePartition) {
+                frameKinds[w] = FRAME_WHOLE_PARTITION;
+                specs[w] = "partition by " + key;
+                continue;
+            }
             final int roll = rnd.nextInt(8);
             frameKinds[w] = roll < 2
                     ? FRAME_RANGE
@@ -493,13 +589,6 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
             } else {
                 frame = "unbounded preceding and current row";
             }
-            // A key is a column or an expression over one or two of them, and which it is
-            // decides how the group writes it: off the record's own columns, or through the
-            // compiled terms it borrows from a member. The expressions are deliberately ones
-            // whose value no column carries, so the two arms cannot agree by accident.
-            final String key = rnd.nextInt(4) == 0
-                    ? KEY_EXPRESSIONS[rnd.nextInt(KEY_EXPRESSIONS.length)]
-                    : KEY_COLUMNS[rnd.nextInt(KEY_COLUMNS.length)];
             specs[w] = "partition by " + key
                     + " order by ts "
                     + (range ? "range" : "rows")
@@ -521,11 +610,14 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
                 case FRAME_ROWS:
                     calls = ROWS_FRAME_CALLS;
                     break;
+                case FRAME_WHOLE_PARTITION:
+                    calls = WHOLE_PARTITION_CALLS;
+                    break;
                 default:
                     calls = BOUNDED_ROWS_FRAME_CALLS;
                     break;
             }
-            final String call = rnd.nextInt(8) == 0
+            final String call = frameKinds[w] != FRAME_WHOLE_PARTITION && rnd.nextInt(8) == 0
                     ? RESIDUAL_CALLS[rnd.nextInt(RESIDUAL_CALLS.length)]
                     : calls[rnd.nextInt(calls.length)];
             sql.append(", ").append(call).append(" over ");

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowMapFusionFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowMapFusionFuzzTest.java
@@ -303,6 +303,11 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
             "first_value(xdec128)",
             "last_value(xdec) ignore nulls",
     };
+    private static final String[] SKIP_ENABLED_WHOLE_PARTITION_CALLS = {
+            "sum(xd)",
+            "avg(xd)",
+            "count(xd)",
+    };
     private Rnd rnd;
 
     @Override
@@ -317,7 +322,7 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
         assertMemoryLeak(() -> {
             int boundIterations = 0;
             int boundGroups = 0;
-            long skippedRows = 0;
+            int skipEnabledGroups = 0;
             for (int i = 0; i < ITERATIONS; i++) {
                 final String table = "t" + i;
                 final String data = createTable(table);
@@ -325,14 +330,18 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
                         PropertyKey.CAIRO_SQL_UNORDERED_MAP_MAX_ENTRY_SIZE,
                         ENTRY_SIZES[rnd.nextInt(ENTRY_SIZES.length)]
                 );
-                final String sql = randomQuery(table);
+                // Preserve all random draws unless the last iteration must supply the run's
+                // skip-enabled group. The assertion below still catches compiler or binding
+                // drift that makes this known-compatible shape ineligible.
+                final boolean isSkipEnabledGroupRequired = i == ITERATIONS - 1 && skipEnabledGroups == 0;
+                final String sql = randomQuery(table, isSkipEnabledGroupRequired);
                 final int[] groups = new int[1];
+                final int[] skipEnabled = new int[1];
                 final int[] unfusedGroups = new int[1];
-                final long[] skipped = new long[1];
                 final String fused;
                 final String unfused;
                 try {
-                    fused = render(sql, groups, skipped);
+                    fused = render(sql, groups, skipEnabled);
                     setProperty(PropertyKey.CAIRO_SQL_WINDOW_MAP_FUSION_ENABLED, "false");
                     try {
                         unfused = render(sql, unfusedGroups, null);
@@ -350,7 +359,7 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
                     boundIterations++;
                     boundGroups += groups[0];
                 }
-                skippedRows += skipped[0];
+                skipEnabledGroups += skipEnabled[0];
                 Assert.assertEquals(context(i, data, sql), unfused, fused);
             }
             // A generator that stopped producing fusible shapes - a family withdrawn, a decline
@@ -360,18 +369,14 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
                     "no iteration bound a window Map group, so nothing here was differential",
                     boundIterations > 0
             );
-            // The whole-partition arm's own liveness check. Every table this generator builds has
-            // a NULL-heavy DOUBLE column, so a run that drew even one whole-partition query over
-            // one skips rows - and a run that skipped none compared the two arms over a path the
-            // skip never took.
             Assert.assertTrue(
-                    "no bound group skipped a pass-1 row, so the refused-row path was never taken",
-                    skippedRows > 0
+                    "no bound group enabled pass-1 skipping, so the refused-row path was never eligible",
+                    skipEnabledGroups > 0
             );
             LOG.info().$("window map fusion fuzz [iterations=").$(ITERATIONS)
                     .$(", fusedIterations=").$(boundIterations)
                     .$(", boundGroups=").$(boundGroups)
-                    .$(", skippedRows=").$(skippedRows)
+                    .$(", skipEnabledGroups=").$(skipEnabledGroups)
                     .I$();
         });
     }
@@ -382,23 +387,27 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
 
     /**
      * Renders {@code sql} twice off one cursor, requires the two passes to agree, and reports
-     * how many Map groups the compile bound into {@code groups}.
+     * how many Map groups the compile bound into {@code groups} and how many of those enabled
+     * pass-1 skipping into {@code skipEnabled}.
      * <p>
      * The second pass is not a formality: a group's map is cleared by the cursor's
      * {@code toTop} and by nothing else, so a domain that survived one - or one cleared once
      * per bound member rather than once per group - shows up here and nowhere else in this
      * class.
-     *
-     * @param skipped receives how many pass-1 rows the bound groups left out of their maps, or
-     *                null when the caller does not read it. Counted while the cursor is open,
-     *                since closing it hands the group's map back and resets the counters with it
      */
-    private static String render(String sql, int[] groups, long[] skipped) throws SqlException {
+    private static String render(String sql, int[] groups, int[] skipEnabled) throws SqlException {
         try (SqlCompiler compiler = engine.getSqlCompiler();
              RecordCursorFactory factory = select(compiler, sql, sqlExecutionContext)) {
             final ObjList<WindowMapState> states = windowMapStates(factory);
             if (groups != null) {
                 groups[0] = states == null ? 0 : states.size();
+            }
+            if (skipEnabled != null && states != null) {
+                for (int i = 0, n = states.size(); i < n; i++) {
+                    if (states.getQuick(i).isPass1SkipEnabled()) {
+                        skipEnabled[0]++;
+                    }
+                }
             }
             final StringSink first = new StringSink();
             final StringSink second = new StringSink();
@@ -406,11 +415,6 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
                 CursorPrinter.println(cursor, factory.getMetadata(), first, true, false);
                 cursor.toTop();
                 CursorPrinter.println(cursor, factory.getMetadata(), second, true, false);
-                if (skipped != null && states != null) {
-                    for (int i = 0, n = states.size(); i < n; i++) {
-                        skipped[0] += states.getQuick(i).getSkippedRowCount();
-                    }
-                }
             }
             TestUtils.assertEquals(first, second);
             return first.toString();
@@ -558,11 +562,11 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
      * included: a cumulative ROWS or RANGE frame, or a bounded ROWS or RANGE one in each of the
      * three geometries its ring comes in.
      */
-    private String randomQuery(String table) {
-        final int windowCount = 1 + rnd.nextInt(2);
+    private String randomQuery(String table, boolean isSkipEnabledGroupRequired) {
+        final int windowCount = isSkipEnabledGroupRequired ? 1 : 1 + rnd.nextInt(2);
         final String[] specs = new String[windowCount];
         final int[] frameKinds = new int[windowCount];
-        final boolean wholePartition = rnd.nextInt(3) == 0;
+        final boolean wholePartition = isSkipEnabledGroupRequired || rnd.nextInt(3) == 0;
         for (int w = 0; w < windowCount; w++) {
             // A key is a column or an expression over one or two of them, and which it is
             // decides how the group writes it: off the record's own columns, or through the
@@ -595,10 +599,10 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
                     + " between "
                     + frame;
         }
-        final int outputs = 2 + rnd.nextInt(4);
+        final int outputs = isSkipEnabledGroupRequired ? SKIP_ENABLED_WHOLE_PARTITION_CALLS.length : 2 + rnd.nextInt(4);
         final StringBuilder sql = new StringBuilder("select ts");
         for (int o = 0; o < outputs; o++) {
-            final int w = rnd.nextInt(windowCount);
+            final int w = isSkipEnabledGroupRequired ? 0 : rnd.nextInt(windowCount);
             final String[] calls;
             switch (frameKinds[w]) {
                 case FRAME_RANGE:
@@ -617,9 +621,11 @@ public class WindowMapFusionFuzzTest extends AbstractCairoTest {
                     calls = BOUNDED_ROWS_FRAME_CALLS;
                     break;
             }
-            final String call = frameKinds[w] != FRAME_WHOLE_PARTITION && rnd.nextInt(8) == 0
-                    ? RESIDUAL_CALLS[rnd.nextInt(RESIDUAL_CALLS.length)]
-                    : calls[rnd.nextInt(calls.length)];
+            final String call = isSkipEnabledGroupRequired
+                    ? SKIP_ENABLED_WHOLE_PARTITION_CALLS[o]
+                    : frameKinds[w] != FRAME_WHOLE_PARTITION && rnd.nextInt(8) == 0
+                            ? RESIDUAL_CALLS[rnd.nextInt(RESIDUAL_CALLS.length)]
+                            : calls[rnd.nextInt(calls.length)];
             sql.append(", ").append(call).append(" over ");
             if (rnd.nextBoolean()) {
                 sql.append('w').append(w);

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowMapStateTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowMapStateTest.java
@@ -625,7 +625,7 @@ public class WindowMapStateTest extends AbstractCairoTest {
                         plan.getProjection(1).getComponentSlotBase()
                 );
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
-                    final long rows = drain(cursor);
+                    drain(cursor);
                 }
             }
             assertFusedMatchesUnfused("ksum(x) over w", "count(x) over w");
@@ -1552,14 +1552,14 @@ public class WindowMapStateTest extends AbstractCairoTest {
             try (SqlCompiler compiler = engine.getSqlCompiler();
                  RecordCursorFactory factory = select(compiler, twoWindows(), sqlExecutionContext)) {
                 final WindowRecordCursorFactory windowFactory = windowFactory(factory);
+                // Co-location is per window and never across windows.
                 assertBoundGroupCount(windowFactory, 2);
                 final ObjList<WindowMapState> states = windowFactory.getWindowMapStates();
                 Assert.assertFalse(
                         states.getQuick(0).getPlan().getSpec().isSameSpec(states.getQuick(1).getPlan().getSpec())
                 );
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
-                    final long rows = drain(cursor);
-                    // Co-location is per window and never across windows.
+                    drain(cursor);
                 }
             }
         });

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowMapStateTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowMapStateTest.java
@@ -807,6 +807,7 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 );
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
+                    Assert.assertEquals(ORDINARY_ROW_COUNT, rows);
                 }
             }
         });

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowMapStateTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowMapStateTest.java
@@ -162,7 +162,7 @@ public class WindowMapStateTest extends AbstractCairoTest {
         // Two windows over one key that differ in nothing but the frame. Their sums keep
         // different states - one gives values back and the other never does - so the two must not
         // meet, and what keeps them apart is the frame in the group's spec rather than anything
-        // about the families. Two groups, two maps, two lookups a row: this is the shape that
+        // about the families. Two groups and two maps: this is the shape that
         // would silently produce a cumulative total for a bounded output if the spec stopped
         // discriminating.
         assertMemoryLeak(() -> {
@@ -192,8 +192,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, states.getQuick(0).getLookupCount());
-                    Assert.assertEquals(rows, states.getQuick(1).getLookupCount());
                 }
             }
         });
@@ -235,8 +233,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, states.getQuick(0).getLookupCount());
-                    Assert.assertEquals(rows, states.getQuick(1).getLookupCount());
                 }
             }
         });
@@ -276,9 +272,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(2 * rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(2 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfusedOnWindow("t", RANGE_FRAME_WINDOW, "sum(x) over w", "count(x) over w");
@@ -357,10 +350,7 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
                     // One accumulator for two outputs, so the frame is maintained once.
-                    Assert.assertEquals(rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(2 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfusedOnWindow("t", RANGE_FRAME_WINDOW, "sum(x) over w", "avg(x) over w");
@@ -402,9 +392,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(2 * rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(2 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfusedOnWindow("t", ROWS_FRAME_WINDOW, "sum(x) over w", "count(x) over w");
@@ -453,10 +440,7 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
                     // One accumulator for two outputs, so the frame is maintained once.
-                    Assert.assertEquals(rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(2 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfusedOnWindow("t", ROWS_FRAME_WINDOW, "sum(x) over w", "avg(x) over w");
@@ -492,9 +476,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(2 * rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(3 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfused("sum(x) over w", "count(x) over w", "first_value(x) over w");
@@ -526,7 +507,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                     // A second execution starts from an empty key domain, so the running
                     // totals restart rather than continuing the first cursor's.
                     Assert.assertEquals(ORDINARY_ROW_COUNT, drain(cursor));
-                    Assert.assertEquals(ORDINARY_ROW_COUNT, state.getLookupCount());
                 }
             }
         });
@@ -622,10 +602,7 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
                     // One accumulator for two outputs, so x is read and compensated once.
-                    Assert.assertEquals(rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(2 * rows, state.getProjectionWriteCount());
                 }
             }
             // Both sums over one argument: five slots, and each total maintained by the
@@ -649,8 +626,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 );
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(2 * rows, state.getContributorUpdateCount());
                 }
             }
             assertFusedMatchesUnfused("ksum(x) over w", "count(x) over w");
@@ -697,9 +672,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(2 * rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(2 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfused("max(x) over w", "min(x) over w");
@@ -738,11 +710,8 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
                     // Two accumulators, four outputs: x is read once per component and not
                     // once per call.
-                    Assert.assertEquals(2 * rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(4 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfused(
@@ -786,9 +755,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(DECIMAL_KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(2 * rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(2 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfusedOn("td", "count(d128) over w", "max(d128) over w");
@@ -841,8 +807,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 );
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
-                    Assert.assertEquals(rows, states.getQuick(0).getLookupCount());
-                    Assert.assertEquals(rows, states.getQuick(1).getLookupCount());
                 }
             }
         });
@@ -872,8 +836,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(2 * rows, state.getContributorUpdateCount());
                 }
             }
             // And the answers are the unfused path's, over the shapes an expression key is
@@ -942,10 +904,7 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
                     // Two accumulators for three outputs: x is read once per component.
-                    Assert.assertEquals(2 * rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(3 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfused("sum(x) over w", "max(x) over w", "count(x) over w");
@@ -980,9 +939,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(CAPTURE_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(4 * rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(4 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfused(
@@ -1031,9 +987,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(3 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfused("count(*) over w", "row_number() over w", "count(k) over w");
@@ -1101,9 +1054,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(DECIMAL_KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(12 * rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(12 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfusedOn(
@@ -1251,9 +1201,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(4 * rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(4 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfused(
@@ -1321,11 +1268,10 @@ public class WindowMapStateTest extends AbstractCairoTest {
     }
 
     @Test
-    public void testSumAndCountShareOneMapAndOneLookup() throws Exception {
+    public void testSumAndCountShareOneMap() throws Exception {
         // The headline shape. sum(x) counts finite x values and count(y) counts non-null y
         // values, so the two disagree on every row where exactly one is absent and keep
-        // separate counters - what they share is the key domain, the hash table and the row's
-        // one lookup.
+        // separate counters - what they share is the key domain and hash table.
         assertMemoryLeak(() -> {
             createTable();
             insertOrdinaryRows();
@@ -1343,10 +1289,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(ORDINARY_ROW_COUNT, rows);
-                    // One lookup per row for both outputs, and one update per component.
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(2 * rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(2 * rows, state.getProjectionWriteCount());
                     // Reported together on purpose: MapFactory selects on the key and the
                     // widened value against this limit, so neither number explains the choice
                     // on its own.
@@ -1383,13 +1325,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    // One update a row for three outputs - and one evaluation of x with it.
-                    // accumulateWindowState is the only place any of these families reads its
-                    // argument, and only the component's one contributor is asked to run it,
-                    // so the update count is the argument-evaluation count for this shape.
-                    Assert.assertEquals(rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(3 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfused("sum(x) over w", "avg(x) over w", "count(x) over w");
@@ -1421,9 +1356,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(KEY_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(5 * rows, state.getProjectionWriteCount());
                 }
             }
             assertFusedMatchesUnfused(
@@ -1532,9 +1464,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
                     Assert.assertEquals(CAPTURE_SHAPE_ROW_COUNT, rows);
-                    Assert.assertEquals(rows, state.getLookupCount());
-                    Assert.assertEquals(3 * rows, state.getContributorUpdateCount());
-                    Assert.assertEquals(3 * rows, state.getProjectionWriteCount());
                 }
             }
             // The differential, and then the one answer it is worth naming outright: partition
@@ -1580,11 +1509,8 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 final StringSink second = new StringSink();
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     CursorPrinter.println(cursor, factory.getMetadata(), first, true, false);
-                    Assert.assertEquals(ORDINARY_ROW_COUNT, state.getLookupCount());
                     cursor.toTop();
-                    Assert.assertEquals(0, state.getLookupCount());
                     CursorPrinter.println(cursor, factory.getMetadata(), second, true, false);
-                    Assert.assertEquals(ORDINARY_ROW_COUNT, state.getLookupCount());
                 }
                 TestUtils.assertEquals(first, second);
             }
@@ -1633,10 +1559,7 @@ public class WindowMapStateTest extends AbstractCairoTest {
                 );
                 try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                     final long rows = drain(cursor);
-                    // Two key domains, two lookups a row: co-location is per window and never
-                    // across windows.
-                    Assert.assertEquals(rows, states.getQuick(0).getLookupCount());
-                    Assert.assertEquals(rows, states.getQuick(1).getLookupCount());
+                    // Co-location is per window and never across windows.
                 }
             }
         });
@@ -1673,7 +1596,6 @@ public class WindowMapStateTest extends AbstractCairoTest {
             Assert.assertEquals(mapImplementation, state.getMapImplementation());
             try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
                 CursorPrinter.println(cursor, factory.getMetadata(), localSink, true, false);
-                Assert.assertEquals(ORDINARY_ROW_COUNT, state.getLookupCount());
             }
         }
         return localSink.toString();

--- a/core/src/test/java/io/questdb/test/griffin/engine/window/WindowRangeFrameOverflowTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/window/WindowRangeFrameOverflowTest.java
@@ -64,16 +64,16 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
     // adjacent pair is far enough apart that the frame below admits some rows and not others.
     private static final String SERIES =
             "(SELECT generate_series ts, 1 k, generate_series::long x" +
-                    " FROM generate_series((-4611686018427387904)::timestamp, 4611686018427387904::timestamp, 2305843009213693952L))";
+                    " FROM generate_series((-4_611_686_018_427_387_904)::timestamp, 4_611_686_018_427_387_904::timestamp, 2_305_843_009_213_693_952L))";
     // 7e18 reaches back over three of the four steps but not over all four, so the last row's
     // frame must drop the first row and keep the other three.
-    private static final String WINDOW = " RANGE BETWEEN 7000000000000000000 PRECEDING AND CURRENT ROW)";
+    private static final String WINDOW = " RANGE BETWEEN 7_000_000_000_000_000_000 PRECEDING AND CURRENT ROW)";
     // The lagging shape, whose low bound is unbounded and whose high bound is what each row is
     // measured against. 8e18 is wider than the three steps between the first row and the fourth,
     // so the first row does not reach any frame until the last one - where the distance is the
     // 2^63 that overflows. Every other case here measures against the frame's low bound; this is
     // the one that measures against its high bound.
-    private static final String LAGGING_WINDOW = " RANGE BETWEEN UNBOUNDED PRECEDING AND 8000000000000000000 PRECEDING)";
+    private static final String LAGGING_WINDOW = " RANGE BETWEEN UNBOUNDED PRECEDING AND 8_000_000_000_000_000_000 PRECEDING)";
     // Three rows one second apart, the smallest table on which an empty frame and a cumulative
     // one differ at every row.
     private static final String THREE_ROWS = """
@@ -188,7 +188,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
             // truncate to exactly 0: the frame end silently became CURRENT ROW and the query ran
             // a running total rather than the lagging window asked for. On micros the narrowing
             // caps hours long before the multiply does, so the ceiling names 2^31 - 1 hours.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 4294967296 HOUR PRECEDING) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 4_294_967_296 HOUR PRECEDING) FROM tab")
                     .noLeakCheck()
                     .fails(74, "RANGE frame end is out of range for the designated timestamp [width=4294967296 hour, max=2147483647 hour]");
         });
@@ -201,7 +201,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
 
             // The high bound runs through the same conversion, and its error names the end of
             // the frame rather than the start.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 300000 DAY PRECEDING) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 300_000 DAY PRECEDING) FROM tab")
                     .noLeakCheck()
                     .fails(74, "RANGE frame end is out of range for the designated timestamp [width=300000 day, max=106751 day]");
         });
@@ -216,7 +216,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
             // a negative value that reads as a legal lagging end bound of the wrong magnitude -
             // about 49 thousand years rather than the 634 thousand asked for. Nothing caught this
             // one: the query returned rows over the narrower frame.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 20000000000000 SECOND PRECEDING) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 20_000_000_000_000 SECOND PRECEDING) FROM tab")
                     .noLeakCheck()
                     .fails(74, "RANGE frame end is out of range for the designated timestamp [width=20000000000000 second, max=9223372036854 second]");
         });
@@ -230,7 +230,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
             // One second past the ceiling wraps onto a positive value, which frame validation
             // then turned away as a FOLLOWING frame end - the right refusal for a cause the user
             // did not write. The width is now named instead.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 9223372036855 SECOND PRECEDING) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 9_223_372_036_855 SECOND PRECEDING) FROM tab")
                     .noLeakCheck()
                     .fails(74, "RANGE frame end is out of range for the designated timestamp [width=9223372036855 second, max=9223372036854 second]");
         });
@@ -243,7 +243,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
 
             // The conversion narrows days to int, so this width used to truncate to exactly 0:
             // the frame silently became CURRENT ROW and every window read one row.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 4294967296 DAY PRECEDING AND CURRENT ROW) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 4_294_967_296 DAY PRECEDING AND CURRENT ROW) FROM tab")
                     .noLeakCheck()
                     .fails(50, "RANGE frame start is out of range for the designated timestamp [width=4294967296 day, max=106751 day]");
         });
@@ -257,7 +257,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
             // 300000 days of nanoseconds wrapped onto a negative value, which reads as a legal
             // width of the wrong magnitude - about 236 years rather than the 821 asked for.
             // Nothing caught this one: the query returned rows over the narrower frame.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 300000 DAY PRECEDING AND CURRENT ROW) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 300_000 DAY PRECEDING AND CURRENT ROW) FROM tab")
                     .noLeakCheck()
                     .fails(50, "RANGE frame start is out of range for the designated timestamp [width=300000 day, max=106751 day]");
         });
@@ -271,7 +271,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
             // 200000 days of nanoseconds wrapped onto a positive value, which frame validation
             // then turned away as a FOLLOWING frame start - the right refusal for a cause the
             // user did not write. The width is now named instead.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 200000 DAY PRECEDING AND CURRENT ROW) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 200_000 DAY PRECEDING AND CURRENT ROW) FROM tab")
                     .noLeakCheck()
                     .fails(50, "RANGE frame start is out of range for the designated timestamp [width=200000 day, max=106751 day]");
         });
@@ -463,7 +463,8 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
             // ring's first read an offset into memory it never allocated, an AssertionError under
             // -ea and an unchecked read of native address 0 without it. Correcting the ROWS path
             // means rejecting an over-int width outright, which also rejects finite widths that
-            // compile today, so it belongs to a change of its own.
+            // compile today, so it belongs to a change of its own - tracked as questdb#7522, which
+            // this test will have to be changed rather than merely satisfied by.
             try {
                 printSql("SELECT ts, avg(j) OVER (ORDER BY ts" + WIDEST_LAGGING_END_ROWS + " FROM tab");
                 Assert.fail("expected ArithmeticException");
@@ -552,7 +553,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
 
             // Micros carry three orders of magnitude more days than nanos do, so the ceiling
             // has to follow the column's resolution rather than a fixed magnitude.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 106751991 DAY PRECEDING AND CURRENT ROW) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 106_751_991 DAY PRECEDING AND CURRENT ROW) FROM tab")
                     .noLeakCheck()
                     .timestamp("ts")
                     .noRandomAccess()
@@ -562,7 +563,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
                             1970-01-01T00:00:00.000000Z\t1.0
                             2261-01-01T00:00:00.000000Z\t3.0
                             """);
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 106751992 DAY PRECEDING AND CURRENT ROW) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 106_751_992 DAY PRECEDING AND CURRENT ROW) FROM tab")
                     .noLeakCheck()
                     .fails(50, "RANGE frame start is out of range for the designated timestamp [width=106751992 day, max=106751991 day]");
         });
@@ -578,7 +579,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
             // the ceiling has to follow the column's resolution at this end of the frame too. The
             // 9999 row's frame stops in the year 9177 and still reaches the 1970 row; the 1970
             // row's frame stops before anything was written.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 300000 DAY PRECEDING) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 300_000 DAY PRECEDING) FROM tab")
                     .noLeakCheck()
                     .timestamp("ts")
                     .noRandomAccess()
@@ -590,7 +591,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
                             """);
             // The widest end bound micros carry reaches back past every row, so both frames are
             // empty - the point is that it compiles at all.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 106751991 DAY PRECEDING) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 106_751_991 DAY PRECEDING) FROM tab")
                     .noLeakCheck()
                     .timestamp("ts")
                     .noRandomAccess()
@@ -600,7 +601,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
                             1970-01-01T00:00:00.000000Z\tnull
                             9999-01-01T00:00:00.000000Z\tnull
                             """);
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 106751992 DAY PRECEDING) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 106_751_992 DAY PRECEDING) FROM tab")
                     .noLeakCheck()
                     .fails(74, "RANGE frame end is out of range for the designated timestamp [width=106751992 day, max=106751991 day]");
         });
@@ -614,7 +615,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
 
             // 106751 days is the widest nanosecond frame that fits, and it reaches back over
             // the whole 291 years the two rows span: the second row sees both.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 106751 DAY PRECEDING AND CURRENT ROW) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 106_751 DAY PRECEDING AND CURRENT ROW) FROM tab")
                     .noLeakCheck()
                     .timestamp("ts")
                     .noRandomAccess()
@@ -624,7 +625,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
                             1970-01-01T00:00:00.000000000Z\t1.0
                             2261-01-01T00:00:00.000000000Z\t3.0
                             """);
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 106752 DAY PRECEDING AND CURRENT ROW) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN 106_752 DAY PRECEDING AND CURRENT ROW) FROM tab")
                     .noLeakCheck()
                     .fails(50, "RANGE frame start is out of range for the designated timestamp [width=106752 day, max=106751 day]");
         });
@@ -638,7 +639,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
 
             // 100000 days - 273 years - is a lagging end bound nanos do carry: the 2261 row's
             // frame stops in the year 1987 and still reaches the 1970 row.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 100000 DAY PRECEDING) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 100_000 DAY PRECEDING) FROM tab")
                     .noLeakCheck()
                     .timestamp("ts")
                     .noRandomAccess()
@@ -650,7 +651,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
                             """);
             // The widest end bound nanos carry reaches back past the 291 years the rows span, so
             // both frames are empty - the point is that it compiles at all.
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 106751 DAY PRECEDING) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 106_751 DAY PRECEDING) FROM tab")
                     .noLeakCheck()
                     .timestamp("ts")
                     .noRandomAccess()
@@ -660,7 +661,7 @@ public class WindowRangeFrameOverflowTest extends AbstractCairoTest {
                             1970-01-01T00:00:00.000000000Z\tnull
                             2261-01-01T00:00:00.000000000Z\tnull
                             """);
-            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 106752 DAY PRECEDING) FROM tab")
+            assertQuery("SELECT ts, sum(j) OVER (ORDER BY ts RANGE BETWEEN UNBOUNDED PRECEDING AND 106_752 DAY PRECEDING) FROM tab")
                     .noLeakCheck()
                     .fails(74, "RANGE frame end is out of range for the designated timestamp [width=106752 day, max=106751 day]");
         });


### PR DESCRIPTION
This PR speeds up whole-partition window aggregates over columns carrying many
NULL or non-finite values, cuts the per-row dirty-partition bookkeeping a live
view's incremental refresh does, and carries the review follow-ups deferred
from #7515.

## 1. Skip inert refused rows before map work

With window-map fusion enabled, a whole-partition group used to write its key,
create or find a map value, and dispatch every contributor before a contributor
rejected a NULL or non-finite argument. The unfused path checks the argument
first and does no map work for that row.

`WindowAccumulatorDescriptor.isRefusedRowInert()` identifies components whose
state is unchanged by a refused row. For a cached two-pass group made entirely
of those components, `WindowMapState` evaluates the shared predicate before the
map probe and returns when every component refuses the row. A group containing
any component that cannot use this rule keeps the original behavior.

A partition every row of which the group refused therefore has no entry when
pass 1 ends; section 2 covers what pass 2 does with it. Outputs are unchanged:
an untouched sum/average/count group projects NULL, NULL and zero. Streaming
groups are not affected.

Dense input gives up roughly two percentage points of the existing win because
an accepted row evaluates its argument once for the predicate and again in the
contributor. Reusing the pre-evaluated value would require a second typed
contributor entry point and is outside this PR.

## 2. Project the identity instead of materializing it

Pass 2 used to settle a partition omitted by pass 1 by creating it:
`putIdentity()` wrote the key a second time, called `createValue()` and put
every component to identity, so the projections had a value to read. On a wide
key domain whose rows are mostly refused that is an insertion per row, and it
leaves the map holding an entry for every partition the traversal saw rather
than for the partitions that contributed to it.

`WindowMapState.projectPass2()` now projects the miss off a buffer the group
owns - a `FlyweightPackedMapValue` over the plan's own value types, allocated
and freed with the map. `resetIdentityValue()` puts every component of that
buffer back to identity ahead of each projection loop that reads it, so the
answer does not depend on the projections leaving it alone. A missed row costs
one failed lookup and a few slot stores: no second key write, no
`createValue()`, and no entry retained for a partition with no state to keep.
The identity itself keeps coming from the components' own `resetState()`, so it
cannot drift from the accumulator's definition of an empty state.

One property changes. A skipping group's map now holds the contributing
partitions, where the unskipped binding holds every partition the traversal
saw, so the two bindings no longer agree on map size. They agree on every
answer, which is what the differential tests compare, and nothing outside a
test reads the size.

## Measurements

`WindowMapFusionBenchmark`, 1,000,000 rows, cached-light cursor, INT key,
`cairo.sql.unordered.map.max.entry.size=32`, three warmups and nine measured
runs, both branch revisions measured on one machine in one session. Fused and
unfused checksums matched in every arm. Cells whose code path section 2 does
not change drifted by up to about 5% between the two runs, which is the noise
floor for reading these tables.

`before` is the fused arm at 0d297bb (section 1 present, section 2 absent),
`after` is the fused arm at the head of this branch, and `unfused` is the
legacy per-function control measured at the head.

### 1,000,000 keys, ns/row

| shape | NULL% | before | after | unfused |
|---|---:|---:|---:|---:|
| `sum(x), avg(x)` | 0 | 191.4 | 194.6 | 421.5 |
| | 50 | 153.9 | 107.8 | 233.4 |
| | 90 | 145.7 | 67.3 | 85.2 |
| | 99 | 139.6 | 63.4 | 75.1 |
| | 100 | 139.6 | 50.1 | 53.8 |
| `sum(x), avg(x), count(x)` | 0 | 239.9 | 242.9 | 623.8 |
| | 50 | 191.7 | 151.7 | 466.4 |
| | 90 | 179.6 | 117.9 | 245.0 |
| | 99 | 175.0 | 106.8 | 189.9 |
| | 100 | 175.2 | 94.5 | 174.4 |

At 0% NULL there are no missing partitions to project, and those two cells move
by less than the noise band, as expected. The cells at and above 50% NULL are
where pass 2 was creating entries. Before section 2 the fused arm was slower
than the unfused control at 90%, 99% and 100% NULL for `sum, avg` - by up to
2.6x at 100% - and at parity with it for `sum, avg, count`; after it the fused
arm is ahead of the control in every measured cell.

### 1,000,000 keys, retained tracked memory, KiB

| shape | NULL% | before | after | unfused |
|---|---:|---:|---:|---:|
| `sum(x), avg(x)` | 0 | 65,156 | 65,156 | 106,116 |
| | 50 | 65,156 | 44,676 | 65,156 |
| | 90 | 65,156 | 29,316 | 34,436 |
| | 99 | 65,156 | 24,516 | 24,836 |
| | 100 | 65,156 | 24,199 | 24,201 |
| `sum(x), avg(x), count(x)` | 0 | 81,540 | 81,540 | 147,076 |
| | 50 | 81,540 | 61,060 | 106,116 |
| | 90 | 81,540 | 45,700 | 75,396 |
| | 99 | 81,540 | 40,900 | 65,796 |
| | 100 | 81,540 | 40,583 | 65,161 |

The fused map used to be sized by the key domain regardless of how many
partitions contributed, so it retained more than the unfused pair once most
rows were refused - 65,156 against 24,201 KiB at 100% NULL. It is now sized by
the contributing partitions and retains no more than the control anywhere.
Tracked peak follows the same shape: for `sum, avg` at 100% NULL it falls from
85,636 to 24,199 KiB.

### 1,000 keys

Every cell at 1,000 keys moved by less than the noise band, in both directions,
including the 0% NULL cells whose path is unchanged. The fused arm stays ahead
of the unfused control there: 50.3 against 53.9 ns/row for `sum, avg` at 100%
NULL, and 93.6 against 99.8 for `sum, avg, count`.

## 3. Remove runtime structural test counters

The PR initially added per-row lookup, skip, update, and projection counters to
`WindowMapState`, guarded by a JVM property. They were used only by tests and
the benchmark, and the derived values were mostly formulas over traversal
counts rather than direct observations. This revision removes the counters,
their getters and resets, the JVM property and Maven configuration, and the
benchmark's counter mode and structural counter columns entirely.

Tests retain behavioral and structural coverage without hot-path
instrumentation:

- a direct compiled-state test proves that pass 1 omits a fully refused
  partition by observing map size;
- the same test drives pass 2 and observes one partition-key read per row and a
  map size unchanged by the pass, which is what says a missing partition is
  projected rather than created;
- the differential fuzz test requires at least one skip-enabled bound group and
  supplies a compatible final randomized iteration only if earlier iterations
  did not generate one;
- fused and unfused results still have to match across two cursor passes.

The benchmark now reports timing, throughput, tracked peak/retained memory,
map/plan/component/slot structure, and checksums. It also drops `args/row`,
which was a static estimate and became inaccurate once the refused-row
predicate could evaluate an argument separately and short-circuit.

## 4. Remove a no-op sum map scan

`SumOverPartitionFunction.preparePass2()` walked every partition-map entry only
to write each sum slot back to itself. The override remains so it does not
inherit average's division logic, but its no-op body is removed.

## 5. Make group compilation linear

Two compile-time scans introduced in #7515 were quadratic in the window
function count. `WindowAccumulatorPlanBuilder.rowCountHost()` now uses the
bucket membership already available, and `CachedWindowMapGroups.specOf()`
resumes and wraps its scan instead of restarting from zero for every member.

## 6. Review follow-ups from #7515

- Live-view projection tests now assert that refreshes did not fault before
  comparing against a recompute, and their two unordered `@Before` methods are
  combined.
- A newly admitted keyed, stateless `last_value` expression now has a refresh
  and value regression test instead of only a create/drop eligibility check.
- ROWS-frame overflow literals, stale live-view comments, and incorrect
  production-assertion comments are cleaned up.
- The unused `checkpointPartitionByFunctions()` API and override are removed.

## 7. Mark live view dirty partitions once per cadence

This section is on the live-view incremental refresh path and is independent of
sections 1 and 2, which it shares a CI lineage with rather than a code path.

`LiveViewWindow.processRow()` called `markPartitionAlive()` on every window
function for every row. `BasePartitionedWindowFunction`'s implementation
serialized the partition key through its sink and probed its checkpoint dirty
map on each of those calls, so a view with `F` functions paid `F + 1` key
serializations and dirty-map probes per row - one per function plus the
anchor's own - however few distinct partitions the row stream touched. Live-view
compiles never fuse window functions, so this applied to a view's whole function
set rather than to a subset of it.

The dirty set is a membership set that a checkpoint publication empties, so
naming a key once per checkpoint cadence is as complete as naming it per row:
every later row of a cadence moves state the first row already named. The anchor
map stamps each entry with the cadence it was last named in, and `processRow()`
holds that entry's value for its own anchor comparison, so reading the answer
costs one load off a value the row path had in hand already.

`markPartitionAlive()` now takes that answer as `isFirstCadenceTouch`, and
`BasePartitionedWindowFunction` gates its `markCheckpointPartitionDirty()` call
on it. Two things stay as they were. The tombstone clear is not on the flag:
`resetPartition()` sets the bit and this method cancels it on the same
anchor-cross row, and its guard is a field load rather than a probe, so there is
nothing to save and a relationship to break. And the four overrides that
deliberately keep no dirty set ignore the flag, so which functions can freeze
incrementally is unchanged.

`processRow()` writes the cadence stamp after the function loop rather than
before it. A function allocates its dirty set on first use through the per-view
memory tracker, so the mark can throw on a breach of
`cairo.live.view.refresh.memory.limit.bytes`; a stamp already standing would
have the retry read the row as marked and leave that function's set one key
short of what its rows moved, which the seal cannot tell from a complete set.

One stamp can stand for `F + 1` separate sets only because no row is processed
between a function's dirty set being emptied and the cadence counter moving on.
The seal, the checkpoint restore, the repair overlay and the head-miss replay
all empty the functions first and the anchor last. A function rebound on its own
frees its dirty set without reaching the window, but that path pins it to a
complete freeze until the next seal, which resyncs the pair; the partial set it
builds in between is one no seal reads.

### Measurements

`LiveViewSteadyStateBenchmark`, `--shape=dispersion` (five window functions),
500,000-row batches with one seal each, `refresh_ms` excluding the checkpoint,
mean over the steady batches of an eight-batch run.

| shape | before | after |
|---|---:|---:|
| 1,000 accounts, 500 rows per key per cadence | 331.9 ms | 258.5 ms |
| new account per row, 1 row per key | 603.1 ms | 612.6-643.2 ms |

The low-cardinality arm is where a cadence repeats keys, and it is the shape the
change is for. The one-row-per-key arm raises the flag on every row and so does
the same work as before; its numbers are not resolvable at this precision.
Three runs of one build span 612.6 to 643.2 ms there - 5.0% - which brackets the
baseline, so the apparent difference between the arms is inside the noise rather
than a measured regression.

## 8. Deferred

- The pre-existing division-by-zero behavior for a bounded ROWS frame at
  `9223372036854775807 PRECEDING` remains pinned by a regression test and
  tracked in #7522. Rejecting that width correctly changes which large finite
  widths compile today, so it remains separate.
- The duplicate argument read on dense input, described at the end of section
  1. It needs a typed contributor entry point or a reusable primitive buffer,
  and the dense cells are already ahead of the control.

## 9. Review follow-ups from this PR's review

Accuracy fixes on this branch's own comments, plus the coverage gap the review
found. No production behavior changes: every change under `core/src/main` is a
comment or javadoc edit, and `core/pom.xml` returns byte-for-byte to its
pre-PR content.

- `LiveViewWindow`'s checkpoint-gating comment offered two supporting claims
  the code does not make good on. The seal hands `onCheckpointPersisted` to the
  anchor first, not the functions first, and the cursor-stack `toTop()`
  preserves the anchor map rather than emptying it alongside each function's
  dirty set. The comment now states the invariant that does hold - every path
  that empties a function's dirty set either advances `checkpointDirtyEpoch` in
  the same synchronous block or latches that function onto a full scan - names
  `LiveViewCheckpointScratchOverlay` as the repair overlay, and scopes each
  clause to checkpoint-capable functions, which is what the three loops iterate.
- `LiveViewPageFrameCursor` and `SqlCodeGenerator` claimed every shipped
  artifact runs with `-ea`. The Windows service wrapper does not:
  `win64svc/src/questdb.c` hard-codes its JVM options and reads no JVM-args
  environment variable. The clamp and the lead-only degrade therefore read as
  production guards on Windows rather than as courtesies to an embedding.
- `WindowMapState.reopen()` frees the map when the identity buffer's malloc
  fails, and no test covered that unwind. A new test arms the global RSS
  ceiling and sweeps it until the identity buffer is the allocation that
  breaches, classifying the breach by its memory tag.
- `MarkCountingFunctionStub` reimplemented the production cadence gate instead
  of observing it, so the gate went unasserted. It now inherits
  `markPartitionAlive` and counts inside `markCheckpointPartitionDirty`, which
  makes the existing third-row assertion fail if the gate breaks.
- Three unused locals left by the counter removal are dropped, keeping the
  `drain` calls that walk the cursor, and a comment moves to the assertion it
  describes.

## 10. Review follow-ups from the second review pass

### 10.1 Seed the cadence stamp when `processRow` creates an anchor entry

Section 7 moved the `SLOT_DIRTY_EPOCH` write to the end of `processRow`, after
the `markPartitionAlive` loop, so that a function whose mark throws leaves the
stamp unwritten and the retry re-marks. The `isNewPartition` block seeded
`SLOT_TOMBSTONE` but not the stamp, so on a retry `value.isNew()` answers false
and the flag comes off whatever bytes the map's heap already held. Where those
bytes match the live cadence, every function skips its mark for that key and the
next incremental seal publishes a root that omits it.

The block now seeds both flag slots immediately after `createValue()` publishes
the entry. The one-line fix the review suggested was not sufficient on its own:
the block sat after `markCheckpointPartitionDirty()`, which can throw, so
`SLOT_TOMBSTONE` was exposed the same way. Hoisting the whole block covers both.

The write is one `putShort` per new partition, not per row, and on every
non-throwing path it is overwritten later in the same call, so the happy path is
unchanged.

Reachability is narrower than the slot's raw exposure suggests. `windowStateDirty`
is raised inside the drain loop body, so only a throw on the first row of a turn
skips `rebuildWindowStateAfterMidDrainFailure` and leaves the anchor map standing
for a retry. A later-row throw discards the map and the stale entry with it.

### 10.2 Drop an assertion that could not fail

`testAFailedOpenLeavesNoGroupHoldingBacking` asserted that a failed open left no
group holding an identity buffer. `WindowMapState.reopen()` allocates that buffer
last and through the untracked `Unsafe.malloc` overload, which answers to the
global RSS ceiling rather than the per-query cap the test sets, so under a 64-byte
cap the group's own map malloc always breaks first. The assertion read back the
zero it started from on every iteration.

This removes an assertion rather than repairing one, and that is a real reduction
in what the method asserts. Arming a global RSS ceiling here instead was rejected
because it would duplicate what
`testAnIdentityBufferThatCannotBeAllocatedGivesTheMapBack` already proves and add
a second process-global window of the kind 10.3 narrows. The buffer's free path
remains covered by that test and by `testAPartitionRefusedWholeStaysOutOfTheMap`.

### 10.3 Narrow the RSS-ceiling search

`testAnIdentityBufferThatCannotBeAllocatedGivesTheMapBack` walked a process-global
RSS ceiling upward one byte at a time from zero, arming it 2581 times per run and
holding it below real usage for 10.3 ms in total. Any QuestDB thread allocating
inside one of those windows would fail on an unrelated stack.

The identity buffer is the only `NATIVE_DEFAULT` allocation in that `reopen()`, so
that tag's counter measures the map/buffer split directly. The walk now seeds on
the measured split and converges in two probes, arming the ceiling for 71 us.

The tradeoff is a narrower tolerance for a moving counter. The old sweep started
from zero and could not miss the transition; the new walk tolerates about 62 bytes
of drift between calibration and the probes before its 64-probe budget runs out.
Exceeding it fails the test rather than passing it silently, and the assertion
messages name the budget, the probe count and the final slack so the two causes are
distinguishable. A search over a bracket rather than a seeded walk would converge
from both directions and remove that asymmetry; it is not implemented here.

### 10.4 Minor corrections

- `WindowMapStateTest.testAnExpressionKeyAndItsColumnsAreTwoGroups` asserts the
  drain it had left unasserted.
- The `compileBucket` comment no longer implies the resume removes the quadratic
  term. The resume telescopes within one bucket, but `cursor` is a per-call local,
  so N single-member buckets still cost n(n+1)/2 between them. Compile time only.

### 10.5 Considered and not taken

The review proposed replacing the per-slot rebuild in `resetIdentityValue()` with
a template built once in `reopen()` and copied per miss via `Vect.memcpy`,
allocating `2 * identityValueSize`.

Measured in isolation at the shape that actually reaches the path (one component,
two slots, 16 bytes): the current rebuild costs 2.27 ns, a memcpy from a separate
template 1.62 ns, and a memcpy from a template placed at `addr + size` - the layout
the review specified - 4.10 ns. The suggested layout is slower than what is there.

End to end on `WindowMapFusionBenchmark` at `--null-pct=100 --cursor=cached`, four
JVMs, the noise floor is about 1.3 ns/row, so the 0.65 ns/row a separate-template
variant could save is not resolvable. Only a `sum(x) over w, count(y) over w` shape
with correlated nullness reaches a measurable 6-9%.

The reachability bound behind this: only `AvgOverPartitionFunction`,
`SumOverPartitionFunction` and `CountOverPartitionFunction` declare a TWO_PASS
family, so a skipping group holds one or two components in practice.

### 10.6 Known limits, not addressed here

Both predate this PR and behave identically on its merge base, so neither is
introduced or worsened by this branch. Recording them rather than fixing them here
keeps the diff scoped.

- `processRow` writes `SLOT_ANCHOR_VALUE` and `SLOT_INITIALIZED` only inside the
  `shouldReset` block, after the throwing `resetPartition` loop. A retry reads both
  off heap residue; if `initialized` reads non-zero and the stale anchor happens to
  equal the current one, `shouldReset` is false and a first-seen partition skips its
  reset and its bucket move.
- `OrderedMap.asNew()` publishes the entry and increments `size` before `rehash()`,
  whose malloc can throw. `createValue()` can therefore publish and throw, and no
  seeding placed inside `processRow` can run for that entry.

## Validation

- `io.questdb.test.griffin.engine.window.*Test`: 2,121 tests passed, which
  includes `WindowFunctionTest`, `WindowFunctionFusionDisabledTest`,
  `WindowDecimalFunctionTest` and both fuzz suites.
- `LiveViewProjectionTest` and `LiveViewKeyedStatelessLastValueTest` passed.
- New coverage for section 2: the pass-2 test now carries two partitions
  refused whole rather than one - a single buffer serves both - and asserts
  that they stay out of the map, that pass 2 reads one key per row, and that a
  second drain answers the same off an unchanged map.
  `testRefusedPartitionProjectsSumCountIdentityBesideResidualOutputs` drives a
  whole-partition query of eleven outputs over a partition pass 1 refuses
  whole, and asserts the group's plan shape: one `FAMILY_DOUBLE_SUM_COUNT`
  component, two slots, three projections, and three of the eleven functions
  left bound. The other eight - `ksum`, `max`, `min`,
  `first_value ... IGNORE NULLS` and the four Welford outputs - decline fusion
  under a whole-partition frame, because their `*OverPartitionFunction` classes
  declare no accumulator projection; they answer the same partition through
  their own maps, which is what the reference arm compares against.
- Coverage limit for section 2, stated rather than implied:
  `WindowAccumulatorDescriptor.isRefusedRowInert()` admits seven families, and
  only `FAMILY_DOUBLE_SUM_COUNT` and `FAMILY_NON_NULL_COUNT` can reach a
  skipping group in this build. The skip needs a two-pass group, and the only
  two-pass functions that declare an accumulator family are the whole-partition
  `avg`, `sum` and `count`; every class declaring `DOUBLE_MAX`, `DOUBLE_MIN`,
  `DOUBLE_WELFORD`, `DOUBLE_KAHAN_SUM_COUNT` or `DOUBLE_FIRST_NOT_NULL_VALUE`
  sits on a cumulative `*OverUnboundedPartitionRowsFrame*` frame and reports
  `ZERO_PASS`. Those five identity encodings run where `WindowMapState`
  resets a new entry, but no caller reaches them through the skip's identity
  buffer, so covering that path takes a production change rather than a test.
- The failed-open test drives a skipping group as well, so a failed open is
  asserted to leave both kinds of group holding nothing - a map alone for a
  cumulative group, a map and an identity buffer for a skipping one. That
  test's cap is the per-query one, which reaches only allocations carrying the
  per-query tracker, so it does not reach the identity buffer's untracked
  malloc. `testAnIdentityBufferThatCannotBeAllocatedGivesTheMapBack` covers
  that failure separately: it drives `WindowMapState.reopen()` directly under a
  global RSS ceiling swept up a byte at a time until the buffer's malloc is the
  allocation that breaches, and asserts `reopen()` handed the map back rather
  than stranding it on a half-open group. Deleting the
  `catch { map.close(); throw th; }` in `reopen()` turns that test red and no
  other.
- Mutation proof for section 2: removing the identity reset fails both the
  pass-2 test and the refused-partition identity test.
- Counter-removal regression was proven property-off before the edit: the old
  counter-dependent test failed with `WindowMapState structural counters are
  off`; the same focused suite passes after removal with no property.
- Fuzz-liveness proof: seed `137 / 6332386243550679140` failed before the
  safeguard with zero skip-enabled groups, then passed with 33 fused
  iterations, 36 bound groups, and one skip-enabled group.
- Benchmark runs at both revisions produced matching fused and unfused
  checksums in every arm.

Section 7:

- Five cases added to `LiveViewCheckpointIncrementalSealTest`: repeat rows in
  one cadence, an anchor cross after the key was already marked, sweep eviction
  and revival in one cadence, dirty-epoch wraparound, and a failed function mark
  followed by a retry.
- Each new case was checked against a mutation of the code it covers. Stamping
  the cadence before the function loop fails the retry case; passing
  `isNewPartition` in place of the flag fails three of the four end-to-end
  cases; never raising the flag fails the fourth.
- `mvn -pl core -Dtest='LiveView*Test' test` - 1633 tests, no failures.
- `mvn -pl core -Dtest='WindowFunctionTest,WindowMapStateTest,CachedWindowMapFusionTest,WindowMapFusionFuzzTest,WindowAccumulatorPlanTest' test`
  - 717 tests, no failures.

Follow-up validation for section 9:

- `mvn -pl core -Dtest=CachedWindowMapFusionTest,WindowMapStateTest,WindowMapFusionFuzzTest,WindowFunctionFusionDisabledTest,LiveViewCheckpointIncrementalSealTest,LiveViewKeyedStatelessLastValueTest,LiveViewProjectionTest,WindowRangeFrameOverflowTest test`
  - 782 tests, no failures. Running the eight classes in one JVM also checks
  that the new test's global RSS ceiling does not leak into sibling classes.

Validation for section 10:

- `mvn -pl core -Dtest=LiveViewCheckpointIncrementalSealTest test` - 27 tests, no
  failures.
- `mvn -pl core -Dtest=CachedWindowMapFusionTest test` - 20 tests, no failures.
- `mvn -pl core -Dtest=WindowMapStateTest test` - 40 tests, no failures.
- Both new live view cases were checked against a revert of the code they cover.
  Reverting the hoist reds `testAThrownWindowMarkLeavesNoStaleFlagOnTheKeyItCreated`
  and leaves the section 7 case green, which is what says the placement had no
  cover before.
- Both poison the stamp slot through `OrderedMap`, whose `clear()` keeps the heap
  it wrote, rather than relying on fresh pages reading as zero. Each asserts the
  map implementation it depends on.
