### PR TITLE
chore(core): strengthen POSTING index squash rollback coverage

### DIFF
--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -4805,7 +4805,8 @@ public class PostingIndexWriter implements IndexWriter {
             //     anywhere in the precondition. Both methods now arm
             //     upcomingTableTxn (which FrameAlgebra.append hands them before
             //     the call) ahead of rollbackConditionally. Pinned by
-            //     PostingIndexCriticalIssuesTest#testSquashAppendRollbackPublishesUpcomingTxnAtSeal.
+            //     PostingIndexCriticalIssuesTest#testSquashAppendRollbackPublishesUpcomingTxnAtSeal
+            //     and #testSquashAppendNullsRollbackPublishesUpcomingTxnAtSeal.
             //   - TableWriter.openPartition reached here the same way --
             //     configureFollowerAndWriter, whose of() resets this field, then
             //     rollbackConditionally(rowCount) -- so a partition whose index

--- a/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/PostingIndexCriticalIssuesTest.java
@@ -31,11 +31,13 @@ import io.questdb.cairo.CairoConfigurationWrapper;
 import io.questdb.cairo.CairoError;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.ColumnVersionReader;
 import io.questdb.cairo.PartitionBy;
 import io.questdb.cairo.PostingSealPurgeJob;
 import io.questdb.cairo.TableReader;
 import io.questdb.cairo.TableToken;
 import io.questdb.cairo.TableWriter;
+import io.questdb.cairo.TxReader;
 import io.questdb.cairo.idx.BitpackUtils;
 import io.questdb.cairo.idx.PostingIndexBwdReader;
 import io.questdb.cairo.idx.PostingIndexChainEntry;
@@ -9107,6 +9109,167 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
+     * The column-top twin of {@link #testSquashAppendRollbackPublishesUpcomingTxnAtSeal}, which
+     * covers the {@code append()} arming only: here the squash source carries a POSTING column
+     * top over its whole length, so {@code FrameAlgebra.append} routes the target through
+     * {@code ContiguousFileIndexedFrameColumn.appendNulls} and never calls {@code append()}.
+     * Same rationale for the arming order, same failure mode when it is wrong.
+     */
+    @Test
+    public void testSquashAppendNullsRollbackPublishesUpcomingTxnAtSeal() throws Exception {
+        // Let the O3 inserts split the partition and keep the split until the
+        // explicit squashPartitions() call below.
+        node1.setProperty(PropertyKey.CAIRO_O3_PARTITION_SPLIT_MIN_SIZE, 1);
+        node1.setProperty(PropertyKey.CAIRO_O3_LAST_PARTITION_MAX_SPLITS, 20);
+        node1.setProperty(PropertyKey.CAIRO_O3_MID_PARTITION_MAX_SPLITS, 20);
+
+        assertMemoryLeak(() -> {
+            execute("""
+                    CREATE TABLE t_squash_nulls_txn (
+                        ts TIMESTAMP,
+                        x INT
+                    ) TIMESTAMP(ts) PARTITION BY DAY BYPASS WAL
+                    """);
+            execute("""
+                    INSERT INTO t_squash_nulls_txn
+                    SELECT dateadd('s', x::INT, '2024-01-01T00:00:00.000000Z'::TIMESTAMP), x::INT
+                    FROM long_sequence(400)
+                    """);
+            // Extend the day to 20:00, then split it with an O3 row at 19:00.
+            execute("INSERT INTO t_squash_nulls_txn VALUES ('2024-01-01T20:00:00.000000Z', 1)");
+            execute("INSERT INTO t_squash_nulls_txn VALUES ('2024-01-01T19:00:00.000000Z', 2)");
+            // ADD COLUMN tops the ACTIVE sub-partition only, i.e. the split one
+            // the squash reads as its source.
+            execute("ALTER TABLE t_squash_nulls_txn ADD COLUMN sym SYMBOL INDEX TYPE POSTING");
+            // An O3 row that sorts before every row of the squash TARGET forces
+            // O3OpenColumnJob to materialize sym's null prefix there and drop the
+            // target's column top to 0. Without it the target's top would still
+            // equal its row count and FrameAlgebra.append would take the addTop
+            // shortcut instead of appendNulls.
+            execute("INSERT INTO t_squash_nulls_txn VALUES ('2024-01-01T00:00:00.000000Z', 3, 'm')");
+            assertQuery("SELECT count() FROM table_partitions('t_squash_nulls_txn')")
+                    .noLeakCheck()
+                    .expectSize()
+                    .noRandomAccess()
+                    .returns("""
+                            count
+                            2
+                            """);
+            engine.releaseAllWriters();
+
+            final TableToken token = engine.verifyTableName("t_squash_nulls_txn");
+            final long columnNameTxn;
+            final long sourceColumnTop;
+            final long targetColumnTop;
+            final long targetNameTxn;
+            final long targetRowCount;
+            final long targetTs;
+            final long txnBeforeSquash;
+            try (TableReader reader = engine.getReader(token)) {
+                final TxReader txFile = reader.getTxFile();
+                final ColumnVersionReader cvr = reader.getColumnVersionReader();
+                final int symIndex = reader.getMetadata().getColumnIndex("sym");
+                targetTs = txFile.getPartitionTimestampByIndex(0);
+                targetNameTxn = txFile.getPartitionNameTxn(0);
+                targetRowCount = txFile.getPartitionSize(0);
+                txnBeforeSquash = txFile.getTxn();
+                columnNameTxn = cvr.getColumnNameTxn(targetTs, symIndex);
+                // Resolve both tops the way FrameImpl.createColumn does: an absent
+                // record means the column does not exist in that partition, i.e. a
+                // top equal to the partition's row count.
+                final long targetTop = cvr.getColumnTop(targetTs, symIndex);
+                targetColumnTop = Math.min(targetTop < 0 ? targetRowCount : targetTop, targetRowCount);
+                final long sourceRowCount = txFile.getPartitionSize(1);
+                final long sourceTop = cvr.getColumnTop(txFile.getPartitionTimestampByIndex(1), symIndex);
+                sourceColumnTop = Math.min(sourceTop < 0 ? sourceRowCount : sourceTop, sourceRowCount);
+            }
+            // FrameAlgebra.append reaches appendNulls only when the source pads
+            // NULLs and the target's column top differs from its row count.
+            Assert.assertTrue(
+                    "test setup gap: the squash source carries no sym column top, so FrameAlgebra.append"
+                            + " pads no NULLs [sourceColumnTop=" + sourceColumnTop + ']',
+                    sourceColumnTop > 0
+            );
+            Assert.assertNotEquals(
+                    "test setup gap: the squash target's sym column top equals its row count, so"
+                            + " FrameAlgebra.append takes the addTop shortcut instead of appendNulls"
+                            + " [targetColumnTop=" + targetColumnTop + ']',
+                    targetRowCount,
+                    targetColumnTop
+            );
+
+            final long headOffsetBeforeSquash;
+            try (Path path = new Path()) {
+                path.of(configuration.getDbRoot()).concat(token);
+                setPathForNativePartition(path, ColumnType.TIMESTAMP, PartitionBy.DAY, targetTs, targetNameTxn);
+                final int plen = path.size();
+                // Strand rowids past the target's committed row count so that
+                // appendNulls' rollbackConditionally publishes. See the sibling
+                // test for why this bare writer's own entry is tagged 0 and why
+                // the walk below starts at the head watermark.
+                try (PostingIndexWriter planted = new PostingIndexWriter(configuration)) {
+                    planted.of(path.trimTo(plen), "sym", columnNameTxn, targetTs, targetNameTxn);
+                    for (int i = 0; i < 5; i++) {
+                        planted.add(0, targetRowCount + i);
+                    }
+                    planted.setMaxValue(targetRowCount + 4);
+                    planted.commit();
+                }
+                headOffsetBeforeSquash = readPostingChainHeadOffset(path.trimTo(plen), "sym", columnNameTxn);
+
+                try (TableWriter w = TestUtils.getWriter(engine, token)) {
+                    w.squashPartitions();
+                }
+                engine.releaseAllWriters();
+
+                final LongList newTags = new LongList();
+                readPostingChainTagsAbove(path.trimTo(plen), "sym", columnNameTxn, headOffsetBeforeSquash, newTags);
+                Assert.assertTrue(
+                        "the squash must have published two new chain entries: appendNulls'"
+                                + " rollbackConditionally republish and its terminal commit(). Fewer means"
+                                + " rollbackConditionally never published, so the assertions below cover"
+                                + " nothing [tags=" + newTags + ']',
+                        newTags.size() >= 2
+                );
+                for (int i = 0, n = newTags.size(); i < n; i++) {
+                    Assert.assertNotEquals(
+                            "a chain entry published by the squash carries TXN_AT_SEAL=0, i.e. publishToChain's"
+                                    + " pendingTxnAtSeal<0 fallback: ContiguousFileIndexedFrameColumn.appendNulls"
+                                    + " armed setNextTxnAtSeal only AFTER rollbackConditionally [tags=" + newTags + ']',
+                            0L,
+                            newTags.getQuick(i)
+                    );
+                }
+                Assert.assertTrue(
+                        "the squash's republish must carry the upcoming table txn FrameAlgebra was given"
+                                + " [tags=" + newTags + ", txnBeforeSquash=" + txnBeforeSquash + ']',
+                        newTags.indexOf(txnBeforeSquash + 1) >= 0
+                );
+            }
+
+            // The squashed partition must still answer indexed predicates: 'm' is
+            // the only non-NULL sym in the target, and the source's two rows are
+            // the NULLs appendNulls padded.
+            assertQuery("SELECT count() FROM t_squash_nulls_txn WHERE sym = 'm'")
+                    .noLeakCheck()
+                    .expectSize()
+                    .noRandomAccess()
+                    .returns("""
+                            count
+                            1
+                            """);
+            assertQuery("SELECT count() FROM t_squash_nulls_txn WHERE sym IS NULL")
+                    .noLeakCheck()
+                    .expectSize()
+                    .noRandomAccess()
+                    .returns("""
+                            count
+                            402
+                            """);
+        });
+    }
+
+    /**
      * A partition squash appends the source partition into the target through
      * {@code FrameAlgebra.append} -> {@code ContiguousFileIndexedFrameColumn.append},
      * which starts with {@code indexWriter.rollbackConditionally(appendOffsetRowCount)}
@@ -9190,7 +9353,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                     planted.setMaxValue(targetRowCount + 4);
                     planted.commit();
                 }
-                headOffsetBeforeSquash = readPostingChainHeadOffset(path.trimTo(plen), "sym");
+                headOffsetBeforeSquash = readPostingChainHeadOffset(path.trimTo(plen), "sym", COLUMN_NAME_TXN_NONE);
 
                 // The squash appends the split sub-partition into the target
                 // through FrameAlgebra.append, whose rollbackConditionally
@@ -9201,7 +9364,7 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
                 engine.releaseAllWriters();
 
                 final LongList newTags = new LongList();
-                readPostingChainTagsAbove(path.trimTo(plen), "sym", headOffsetBeforeSquash, newTags);
+                readPostingChainTagsAbove(path.trimTo(plen), "sym", COLUMN_NAME_TXN_NONE, headOffsetBeforeSquash, newTags);
                 Assert.assertTrue(
                         "the squash must have published at least one new chain entry",
                         newTags.size() > 0
@@ -12733,15 +12896,15 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
-     * Returns the chain head entry offset of the posting {@code .pk} for {@code name},
-     * read from a raw private mapping. Callers use it as a watermark: every entry
+     * Returns the chain head entry offset of the posting {@code .pk} for
+     * {@code (name, columnNameTxn)}, read from a raw private mapping. Callers use it as a watermark: every entry
      * published later sits above it in the chain. {@code path} is left trimmed to
      * {@code plen}.
      */
-    private long readPostingChainHeadOffset(Path path, CharSequence name) {
+    private long readPostingChainHeadOffset(Path path, CharSequence name, long columnNameTxn) {
         final FilesFacade ff = configuration.getFilesFacade();
         final int plen = path.size();
-        final LPSZ keyFile = PostingIndexUtils.keyFileName(path, name, COLUMN_NAME_TXN_NONE);
+        final LPSZ keyFile = PostingIndexUtils.keyFileName(path, name, columnNameTxn);
         try (MemoryCMARWImpl pk = new MemoryCMARWImpl(ff, keyFile, ff.getPageSize(),
                 ff.length(keyFile), MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
             PostingIndexChainWriter chain = new PostingIndexChainWriter();
@@ -12784,16 +12947,16 @@ public class PostingIndexCriticalIssuesTest extends AbstractCairoTest {
     }
 
     /**
-     * Collects the {@code TXN_AT_SEAL} of every chain entry published after the entry
-     * at {@code sinceEntryOffset}, walking back from the head through
+     * Collects the {@code TXN_AT_SEAL} of every chain entry of {@code (name, columnNameTxn)}
+     * published after the entry at {@code sinceEntryOffset}, walking back from the head through
      * {@code prevEntryOffset} and stopping at that watermark. {@code path} is left
      * trimmed to its size on entry.
      */
-    private void readPostingChainTagsAbove(Path path, CharSequence name, long sinceEntryOffset, LongList out) {
+    private void readPostingChainTagsAbove(Path path, CharSequence name, long columnNameTxn, long sinceEntryOffset, LongList out) {
         out.clear();
         final FilesFacade ff = configuration.getFilesFacade();
         final int plen = path.size();
-        final LPSZ keyFile = PostingIndexUtils.keyFileName(path, name, COLUMN_NAME_TXN_NONE);
+        final LPSZ keyFile = PostingIndexUtils.keyFileName(path, name, columnNameTxn);
         try (MemoryCMARWImpl pk = new MemoryCMARWImpl(ff, keyFile, ff.getPageSize(),
                 ff.length(keyFile), MemoryTag.MMAP_DEFAULT, /* opts */ 0)) {
             PostingIndexChainWriter chain = new PostingIndexChainWriter();


### PR DESCRIPTION
## Summary

- Add regression coverage for a partition squash that routes a POSTING-indexed column top through `appendNulls()`.
- Verify that rollback and commit chain entries carry the upcoming table transaction and that indexed NULL and non-NULL predicates remain correct after the squash.
- Extend the posting-chain test helpers to address a specific column-name transaction.

## Impact

This PR changes no runtime behavior. The new integration scenario adds targeted test execution time and some test-only setup complexity in exchange for covering the `appendNulls()` branch alongside the existing `append()` regression test.

## Test plan

- `mvn -pl core -Dtest=PostingIndexCriticalIssuesTest#testSquashAppendNullsRollbackPublishesUpcomingTxnAtSeal test`
