### PR TITLE
fix(qwp): fix flaky QWP egress tests aborting on the query timeout

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/qwp/AbstractQwpBootstrapTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/AbstractQwpBootstrapTest.java
@@ -43,6 +43,10 @@ import org.junit.Before;
  * {@code DEBUG_HTTP_FORCE_RECV_FRAGMENTATION_CHUNK_SIZE} and
  * {@code DEBUG_HTTP_FORCE_SEND_FRAGMENTATION_CHUNK_SIZE} alongside any extra
  * env vars the test wants to set.
+ * <p>
+ * {@link #startFragmented(String...)} also raises {@code query.timeout} to
+ * {@link #fragmentedQueryTimeoutMs()}, because the forced send fragmentation
+ * slows a streaming result far below what the production default budgets for.
  */
 public abstract class AbstractQwpBootstrapTest extends AbstractBootstrapTest {
 
@@ -65,13 +69,35 @@ public abstract class AbstractQwpBootstrapTest extends AbstractBootstrapTest {
         return baseMs * 64L / effectiveChunk;
     }
 
+    /**
+     * Server-side {@code query.timeout} budget for a fragmented run.
+     * <p>
+     * {@code HttpResponseSink#sendBuffer} ships at most {@code sendChunk} bytes
+     * per event-loop pass and parks the stream in between, so egress costs one
+     * full round trip per chunk. Streaming a 50k-row LONG projection (~400 KB)
+     * at the worst random {@code sendChunk=1} measured 2.2 s on a fast Linux box
+     * and 62.4 s on a hosted 4-core macOS agent -- past the 60 s production
+     * default, which aborts the query mid-stream and fails the test. The cost
+     * tracks 1/sendChunk, so scale the budget the same way
+     * {@link #firstBatchTimeoutMs(long)} does and cap it, keeping the timeout a
+     * backstop for genuinely stuck queries rather than a limit on throttled
+     * sends.
+     */
+    protected long fragmentedQueryTimeoutMs() {
+        int effectiveChunk = Math.max(1, Math.min(sendChunk, 64));
+        return Math.min(600_000L, 60_000L * 64L / effectiveChunk);
+    }
+
     protected TestServerMain startFragmented(String... extra) {
-        String[] all = new String[extra.length + 4];
+        String[] all = new String[extra.length + 6];
         all[0] = PropertyKey.DEBUG_HTTP_FORCE_RECV_FRAGMENTATION_CHUNK_SIZE.getEnvVarName();
         all[1] = Integer.toString(recvChunk);
         all[2] = PropertyKey.DEBUG_HTTP_FORCE_SEND_FRAGMENTATION_CHUNK_SIZE.getEnvVarName();
         all[3] = Integer.toString(sendChunk);
-        System.arraycopy(extra, 0, all, 4, extra.length);
+        // Ahead of extra, so a test that pins query.timeout itself still wins.
+        all[4] = PropertyKey.QUERY_TIMEOUT.getEnvVarName();
+        all[5] = fragmentedQueryTimeoutMs() + "ms";
+        System.arraycopy(extra, 0, all, 6, extra.length);
         return startWithEnvVariables(all);
     }
 }


### PR DESCRIPTION
## Problem

`QwpEgressMetricsScrapeTest#testBatchAndRowCountersAdvanceWithLoad` failed on a hosted macOS CI agent:

```
must succeed: [-1] timeout, query aborted [fd=590558428668, runtime=62401ms, timeout=60000ms]
```

`AbstractQwpBootstrapTest` draws a fresh send fragmentation chunk size in `[1, 500]` for each test method. That run drew `sendChunk=1` (seeds `2913669159062L, 1787085474004L`).

`HttpResponseSink#sendBuffer` ships at most `sendChunk` bytes per event-loop pass and parks the stream in between, so egress pays one full round trip per chunk. The test streams a 50k-row LONG projection — roughly 400 KB — which at `sendChunk=1` costs about 400k round trips.

## Measurements

Query duration for that projection, holding everything but `sendChunk` fixed (24-core Linux):

| sendChunk | 500 | 250 | 50 | 10 | 1 |
|---|---|---|---|---|---|
| query time | 0.02s | 0.02s | 0.07s | 0.24s | 2.16s |

The cost tracks `1/sendChunk`. The Linux box needs 2.16s at `sendChunk=1`; the 4-core macOS agent needed 62.4s, overrunning the 60s `query.timeout` default. The server aborts the query mid-stream, the client surfaces the abort through `onError`, and the test fails.

Machine speed rather than CPU count is what decides it — pinning the Linux run to 4 cores with `taskset` left it at 3.3s, so the macOS agent's per-round-trip latency is the real variable. This is why the failure shows up only on that agent.

## Fix

`startFragmented()` now raises `query.timeout` by the same factor `firstBatchTimeoutMs()` already applies to client-side waits, capped at 600s:

| sendChunk | 1 | 8 | 16 | 32 | >=64 |
|---|---|---|---|---|---|
| query.timeout | 600s | 480s | 240s | 120s | 60s |

At `sendChunk=1` that budgets 600s against the 62.4s actually observed. At `sendChunk>=64` the production 60s default is unchanged. The timeout remains a backstop for genuinely stuck queries rather than a limit on deliberately throttled sends.

The property goes in ahead of the caller's `extra` env vars, so a test that pins `query.timeout` itself still wins.

### Tradeoffs

- A genuinely hung query under a small `sendChunk` now takes up to 600s to abort instead of 60s, so such a failure surfaces later. These tests do not rely on `query.timeout` as their safety net — the client-side waits bound them — and no `startFragmented` caller asserts on it today.
- The change widens a timeout rather than making egress faster. The underlying per-chunk round trip cost is a property of the debug-only fragmentation setting and does not exist in production, where `DEBUG_HTTP_FORCE_SEND_FRAGMENTATION_CHUNK_SIZE` is unset.
- This is scaffolding shared by 20 test classes, several streaming 20k-50k rows, so it addresses the same latent failure across all of them rather than only the test that happened to fail.

## Test plan

- Reproduced the exact failure locally by shrinking `query.timeout` to 2s at `sendChunk=1`, yielding the same error and code path as CI: `timeout, query aborted [runtime=2200ms, timeout=2000ms]`
- Confirmed the new property reaches the server by temporarily pinning `fragmentedQueryTimeoutMs()` to 2000, which reproduced `timeout=2000ms`
- `QwpEgressMetricsScrapeTest` passes with the exact CI seeds `-Dfuzz.s0=2913669159062 -Dfuzz.s1=1787085474004` (8/8)
- Full `io.questdb.test.cutlass.qwp.**` package on this branch: 1497 tests across 77 classes, 0 failures
- `QwpEgressBootstrapTest` (46 tests), which asserts on `query.timeout` values of 500ms/1s/8s/30s, is unaffected — it extends a different base and never calls `startFragmented`

🤖 Generated with [Claude Code](https://claude.com/claude-code)