### PR TITLE
fix(qwp): fix flaky QWP egress tests timing out on slow CI agents

### DIFF
--- a/core/src/test/java/io/questdb/test/cutlass/qwp/AbstractQwpBootstrapTest.java
+++ b/core/src/test/java/io/questdb/test/cutlass/qwp/AbstractQwpBootstrapTest.java
@@ -35,9 +35,9 @@ import org.junit.Before;
 
 /**
  * Bootstrap test base for QWP tests that need to exercise the HTTP fragmentation
- * code paths. Each test method gets a fresh pair of random recv / send chunk
- * sizes in [1, 500] derived from the JUnit-managed seed, so failures replay
- * deterministically from the seed log written by
+ * code paths. Each test method gets a fresh pair of random chunk sizes derived
+ * from the JUnit-managed seed -- recv in [1, 500] and send in [64, 500] -- so
+ * failures replay deterministically from the seed log written by
  * {@link TestUtils#generateRandom}. Subclasses launch the server via
  * {@link #startFragmented(String...)}, which threads the chunks through
  * {@code DEBUG_HTTP_FORCE_RECV_FRAGMENTATION_CHUNK_SIZE} and
@@ -53,14 +53,28 @@ public abstract class AbstractQwpBootstrapTest extends AbstractBootstrapTest {
     @Before
     public void setUpFragmentationChunks() {
         Rnd rnd = TestUtils.generateRandom(LOG);
+        // recvChunk drives the incremental request parser, which is offset
+        // sensitive, and requests are small -- keep the 1-byte draw.
         recvChunk = 1 + rnd.nextInt(500);
-        sendChunk = 1 + rnd.nextInt(500);
+        // sendChunk is floored. HttpResponseSink#sendBuffer ships at most
+        // sendChunk bytes per event-loop pass and parks in between, so egress
+        // pays one dispatcher round trip per chunk. A 1-byte draw made a
+        // 50k-row LONG projection (~400 KB) take 62.4 s on a hosted macOS
+        // agent, overrunning the 60 s query.timeout and aborting the query
+        // mid-stream. The floor still fragments every batch (~2k parks per
+        // 131 KB batch), and the send resume path only advances a byte pointer
+        // (ChunkUtf8Sink#onRead) rather than driving an offset-sensitive state
+        // machine, so a finer split adds no coverage. Tests that need a
+        // specific 1-byte split pin sendChunk themselves.
+        sendChunk = 64 + rnd.nextInt(437);
     }
 
     protected long firstBatchTimeoutMs(long baseMs) {
         // HttpResponseSink#sendBuffer parks every sendChunk bytes; a first batch
-        // can be ~131 KB (MAX_ROWS_PER_BATCH=16384 LONGs) plus framing, so at the
-        // worst random sendChunk=1 it needs tens of thousands of park-resume cycles.
+        // can be ~131 KB (MAX_ROWS_PER_BATCH=16384 LONGs) plus framing, so a small
+        // sendChunk needs tens of thousands of park-resume cycles. The default draw
+        // is floored at 64 and lands on baseMs; this still scales for a test that
+        // pins a smaller sendChunk itself.
         int effectiveChunk = Math.max(1, Math.min(sendChunk, 64));
         return baseMs * 64L / effectiveChunk;
     }


### PR DESCRIPTION
## Problem

`QwpEgressMetricsScrapeTest#testBatchAndRowCountersAdvanceWithLoad` failed on a hosted macOS CI agent:

```
must succeed: [-1] timeout, query aborted [fd=590558428668, runtime=62401ms, timeout=60000ms]
```

`AbstractQwpBootstrapTest` draws a fresh send fragmentation chunk size for each test method. That run drew `sendChunk=1` (seeds `2913669159062L, 1787085474004L`).

`HttpResponseSink#sendBuffer` ships at most `sendChunk` bytes per event-loop pass and parks the stream in between, so egress pays one dispatcher round trip per chunk. The test streams a 50k-row LONG projection — roughly 400 KB — which at `sendChunk=1` costs about 400k round trips.

## Measurements

Query duration for that projection, holding everything but `sendChunk` fixed (24-core Linux):

| sendChunk | 500 | 250 | 50 | 10 | 1 |
|---|---|---|---|---|---|
| query time | 0.02s | 0.02s | 0.07s | 0.24s | 2.16s |

The cost tracks `1/sendChunk`. The Linux box needs 2.16s at `sendChunk=1`; the 4-core macOS agent needed 62.4s, overrunning the 60s `query.timeout` default. The server aborts the query mid-stream, the client surfaces the abort through `onError`, and the test fails.

Machine speed rather than core count is what decides it — pinning the Linux run to 4 cores with `taskset` left it at 3.3s, so the macOS agent's per-round-trip latency is the real variable. That is why the failure appears only on that agent.

## Fix

Draw `sendChunk` from `[64, 500]` instead of `[1, 500]`.

`QwpEgressCreditFlowTest` already floors it the same way for the same reason ("blowing the global timeout on slow CI (the mac-other hang)"), and the two tests that want a 1-byte split pin `sendChunk` themselves rather than relying on the draw — `QwpEgressCacheResetWireTest` and this class's own `testConnectionGaugeDecrementsOnSendPathDisconnect`. This change follows that existing idiom.

`recvChunk` keeps its 1-byte draw: it feeds the incremental request parser, which is offset sensitive, and requests are small enough that the round trips stay cheap.

### Coverage

Batches still fragment — about 2k parks per 131 KB batch. The send resume path only advances a byte pointer (`ChunkUtf8Sink#onRead`) before re-parking, rather than driving an offset-sensitive state machine, so a finer split exercises the same code with more iterations rather than reaching new branches. The tests that do depend on a specific 1-byte split pin it explicitly and are unaffected.

### Tradeoffs

- This narrows the fuzz range. Draws in `[1, 63]` no longer occur by default, so if a send-path bug were reachable only at a sub-64 split and not covered by the tests that pin `sendChunk=1`, the randomised search would no longer find it. The argument above is that the send path has no offset-sensitive state, but it is a real reduction in search space.
- `firstBatchTimeoutMs()` now lands on `baseMs` for the default draw, since its scaling only engages below 64. It is left in place because it still scales for a test that pins a smaller `sendChunk`.
- `QwpEgressCreditFlowTest`'s own `sendChunk = Math.max(sendChunk, 64)` becomes redundant. It is left alone — it is self-documenting, and its `recvChunk` floor still applies.
- Eight classes stream more than `MAX_ROWS_PER_BATCH` rows under `startFragmented` and only one floored the chunk, so this removes the same latent failure from all of them rather than only the test that happened to fail.

## Test plan

- Reproduced the original failure locally by shrinking `query.timeout` to 2s at `sendChunk=1`, giving the same error and code path as CI: `timeout, query aborted [runtime=2200ms, timeout=2000ms]`
- Verified the new draw spans exactly `[64, 500]` over 200k seeds
- Full `io.questdb.test.cutlass.qwp.**` package: 1497 tests across 77 classes, 0 failures
- `QwpEgressCacheResetWireTest` (6 tests) and `testConnectionGaugeDecrementsOnSendPathDisconnect`, both of which pin `sendChunk=1`, pass
- `QwpEgressMetricsScrapeTest` wall time drops from 6.2s to 2.9s locally

Supersedes #7527, which fixed the same failure by scaling `query.timeout` up to 600s instead. That treated the symptom and diverged from the floor idiom already used in this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)