### PR TITLE
fix(core): recalculate _meta format checksum when REBASE WAL / SET TYPE WAL reset metadataVersion

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableConverter.java
+++ b/core/src/main/java/io/questdb/cairo/TableConverter.java
@@ -126,6 +126,10 @@ public class TableConverter {
 
                                     // Reset structure version in _meta and _txn files
                                     metaMem.putLong(TableUtils.META_OFFSET_METADATA_VERSION, 0);
+                                    metaMem.putInt(
+                                            TableUtils.META_OFFSET_META_FORMAT_MINOR_VERSION,
+                                            TableUtils.calculateMetaFormatMinorVersionField(0, metaMem.getInt(TableUtils.META_OFFSET_COUNT))
+                                    );
                                     path.trimTo(rootLen).concat(dirNameSink);
                                     txWriter.resetStructureVersionUnsafe();
                                 } else {

--- a/core/src/main/java/io/questdb/cairo/wal/WalUtils.java
+++ b/core/src/main/java/io/questdb/cairo/wal/WalUtils.java
@@ -206,6 +206,10 @@ public class WalUtils {
             TableUtils.openSmallFile(ff, dstDir.trimTo(dstLen), dstLen, metaMem, TableUtils.META_FILE_NAME, MemoryTag.MMAP_TABLE_WRITER);
             metaMem.putInt(TableUtils.META_OFFSET_TABLE_ID, newTableId);
             metaMem.putLong(TableUtils.META_OFFSET_METADATA_VERSION, 0);
+            metaMem.putInt(
+                    TableUtils.META_OFFSET_META_FORMAT_MINOR_VERSION,
+                    TableUtils.calculateMetaFormatMinorVersionField(0, metaMem.getInt(TableUtils.META_OFFSET_COUNT))
+            );
             txWriter.resetStructureVersionUnsafe();
 
             TableUtils.openSmallFile(ff, dstDir.trimTo(dstLen), dstLen, metaMem, TableUtils.META_FILE_NAME, MemoryTag.MMAP_TABLE_WRITER);


### PR DESCRIPTION
## Problem

Fixes #7536.

`ALTER TABLE ... REBASE WAL` and the non-WAL -> WAL conversion (`ALTER TABLE ... SET TYPE WAL`) both rewrite `_meta`'s `metadataVersion` to 0 without recomputing the metadata-format minor-version field. That field carries a checksum over `(metadataVersion, columnCount)`, so zeroing the version invalidates it, and every `_meta` field gated on a minor version silently reads as absent afterwards.

Affected fields: TTL, table format (table-level parquet), per-column parquet encoding config, the symbol-capacity-in-`_meta` fast path, and the row-expiry policy.

Nothing errors, nothing is logged. The bytes are still in the file; the readers just stop trusting them.

## Root cause

- `WalUtils.cloneTableDirForRebase` (WalUtils.java) sets `META_OFFSET_METADATA_VERSION = 0`
- `TableConverter.convertTables` (TableConverter.java) does the same

Neither goes through `TableUtils.writeMetadata` / `TableWriter.rewriteMetadata`, so the stored checksum in `META_OFFSET_META_FORMAT_MINOR_VERSION` keeps describing the pre-reset version, and `isMetaFormatAtLeast` (which compares the checksum) silently reports galore fields as absent.

## Fix

After `putLong(META_OFFSET_METADATA_VERSION, 0)`, recompute the format-minor-version field via `TableUtils.calculateMetaFormatMinorVersionField(0, columnCount)`, keeping the checksum consistent with the new (zero) metadata version.

Two files changed:
- `core/src/main/java/io/questdb/cairo/wal/WalUtils.java`
- `core/src/main/java/io/questdb/cairo/TableConverter.java`