### PR TITLE
fix(concat): guard null lhs in addConcatArgs for single-arg concat

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -572,7 +572,9 @@ public class SqlParser {
             args.addAll(leaf.args);
         } else {
             args.add(leaf.rhs);
-            args.add(leaf.lhs);
+            if (leaf.lhs != null) {
+                args.add(leaf.lhs);
+            }
         }
     }
 


### PR DESCRIPTION
A single-argument `concat()` used as an operand of `||` makes the SQL compiler throw a raw `NullPointerException` instead of returning a result.

**Root cause**: `SqlParser.addConcatArgs` unconditionally adds `leaf.lhs` when `leaf.args.size() == 0`. QuestDB's `ExpressionNode` stores 1-2 argument function parameters in `rhs`/`lhs` (not `args`), so for a single-argument call like `concat('y')`, `leaf.lhs` is null and adding it injects null into the args list. This null later reaches `SqlOptimiser.emitLiterals` → `ArrayDeque.push(null)` → NPE.

**Fix**: guard `leaf.lhs` with a null check before adding.

Fixes #7545