### PR TITLE
fix(mp): decay worker back-off ticker instead of resetting it

### DIFF
--- a/core/src/main/java/io/questdb/mp/Worker.java
+++ b/core/src/main/java/io/questdb/mp/Worker.java
@@ -57,6 +57,9 @@ public class Worker extends Thread {
     // persists, periodic re-logging keeps the condition visible without flooding.
     private static final long YIELD_REFUSED_LOG_INTERVAL_MICROS = 2_000_000L;
     private final int affinity;
+    // Idle loop passes credited back to the backoff ticker each time a job on this
+    // worker reports work. See loopBody() for why this is a decay and not a reset.
+    private final long backoffCredit;
     // The pool's continuation queue. Used both as the sink for the worker's own
     // WorkerContinuation (so a yield from inside the loop body parks back into this
     // pool) and as the source of parked conts to remount in the outer driver.
@@ -69,6 +72,7 @@ public class Worker extends Thread {
     private final AtomicReference<WorkerLifecycle> lifecycle = new AtomicReference<>(WorkerLifecycle.BORN);
     private final Log log;
     private final Metrics metrics;
+    private final long napMs;
     private final long napThreshold;
     private final OnHaltAction onHaltAction;
     private final ObjList<Job> ownedJobClones = new ObjList<>();
@@ -113,13 +117,16 @@ public class Worker extends Thread {
             boolean haltOnError,
             long yieldThreshold,
             long napThreshold,
+            long napMs,
             long sleepThreshold,
             long sleepMs,
+            long backoffCredit,
             Metrics metrics,
             @Nullable ContinuationQueue continuationQueue,
             @Nullable Log log
     ) {
         assert yieldThreshold > 0L;
+        assert backoffCredit >= 0L;
         this.setName(poolName + '_' + workerId);
         this.poolName = poolName;
         this.workerId = workerId;
@@ -131,8 +138,10 @@ public class Worker extends Thread {
         this.criticalErrorLine = "0000-00-00T00:00:00.000000Z C Unhandled exception in worker " + getName();
         this.yieldThreshold = yieldThreshold;
         this.napThreshold = napThreshold;
+        this.napMs = napMs;
         this.sleepThreshold = sleepThreshold;
         this.sleepMs = sleepMs;
+        this.backoffCredit = backoffCredit;
         this.metrics = metrics;
         this.continuationQueue = continuationQueue;
         this.log = log;
@@ -481,7 +490,20 @@ public class Worker extends Thread {
             }
 
             if (runAsap) {
-                ticker = 0;
+                // Decay, not reset. A reset let ANY job doing ANY work wipe the whole
+                // ladder, so a worker handed a scrap more often than once per
+                // napThreshold passes could never reach a nap. That is the normal case
+                // for a SynchronizedJob assigned to every worker (an IODispatcher, say):
+                // the trylock winner rotates, so a trickle of work only one worker
+                // handles at a time kept the entire pool spinning at full rate.
+                //
+                // Crediting a fixed number of passes per unit of work makes back-off
+                // depend on how OFTEN this worker finds work rather than on whether it
+                // ever does: the ticker still climbs while work arrives less than once
+                // per backoffCredit passes, and stays pinned at 0 for a worker that is
+                // genuinely busy. Setting backoffCredit >= sleepThreshold restores the
+                // old reset behaviour exactly.
+                ticker = Math.max(0L, ticker - backoffCredit);
                 continue;
             }
             if (++ticker < 0) {
@@ -490,7 +512,7 @@ public class Worker extends Thread {
             if (ticker > sleepThreshold) {
                 Os.sleep(sleepMs);
             } else if (ticker > napThreshold) {
-                Os.sleep(1);
+                Os.sleep(napMs);
             } else if (ticker > yieldThreshold) {
                 Os.pause();
             }

--- a/core/src/main/java/io/questdb/mp/WorkerPool.java
+++ b/core/src/main/java/io/questdb/mp/WorkerPool.java
@@ -54,6 +54,7 @@ public class WorkerPool implements Closeable {
     // no-op default on caller-owned singletons and idempotent on recycled
     // clones, so the pool needs no blueprint-vs-clone bookkeeping to free them.
     private final ObjList<Job> assignedJobs = new ObjList<>();
+    private final long backoffCredit;
     @TestOnly
     private volatile Runnable beforeStartedSignalForTesting;
     @TestOnly
@@ -75,6 +76,7 @@ public class WorkerPool implements Closeable {
     // Jobs which key per-worker state by workerId at construction time.
     private final boolean legacy;
     private final Metrics metrics;
+    private final long napMs;
     private final long napThreshold;
     private final String poolName;
     private final int priority;
@@ -112,8 +114,10 @@ public class WorkerPool implements Closeable {
         this.poolName = configuration.getPoolName();
         this.yieldThreshold = configuration.getYieldThreshold();
         this.napThreshold = configuration.getNapThreshold();
+        this.napMs = configuration.getNapTimeout();
         this.sleepThreshold = configuration.getSleepThreshold();
         this.sleepMs = configuration.getSleepTimeout();
+        this.backoffCredit = configuration.getBackoffCredit();
         this.metrics = configuration.getMetrics();
         this.priority = configuration.workerPoolPriority();
 
@@ -393,8 +397,10 @@ public class WorkerPool implements Closeable {
                         haltOnError,
                         yieldThreshold,
                         napThreshold,
+                        napMs,
                         sleepThreshold,
                         sleepMs,
+                        backoffCredit,
                         metrics,
                         continuationQueue,
                         log

--- a/core/src/main/java/io/questdb/mp/WorkerPoolConfiguration.java
+++ b/core/src/main/java/io/questdb/mp/WorkerPoolConfiguration.java
@@ -28,12 +28,39 @@ import io.questdb.Metrics;
 
 public interface WorkerPoolConfiguration {
 
+    /**
+     * Number of idle loop passes credited back to a worker's back-off ticker each
+     * time one of its jobs reports having done work. The ticker decays by this
+     * amount rather than resetting to zero, so back-off depends on how OFTEN a
+     * worker finds work instead of on whether it ever does: it keeps climbing
+     * while work arrives less than once per {@code getBackoffCredit()} passes and
+     * stays pinned at zero for a worker that is genuinely busy.
+     * <p>
+     * The default keeps a worker busy on more than roughly 1.5% of its passes at
+     * full spin. Raising it makes back-off harder to reach; a value greater than
+     * or equal to {@link #getSleepThreshold()} reproduces the historical
+     * reset-to-zero behaviour.
+     */
+    default long getBackoffCredit() {
+        return 64;
+    }
+
     default Metrics getMetrics() {
         return Metrics.ENABLED;
     }
 
     default long getNapThreshold() {
         return 7000;
+    }
+
+    /**
+     * Milliseconds a worker sleeps on the nap rung, i.e. once its back-off ticker
+     * has passed {@link #getNapThreshold()} but not {@link #getSleepThreshold()}.
+     * Distinct from {@link #getSleepTimeout()}, which applies to the deeper sleep
+     * rung only.
+     */
+    default long getNapTimeout() {
+        return 1;
     }
 
     default String getPoolName() {

--- a/core/src/test/java/io/questdb/test/mp/WorkerBackoffDecayTest.java
+++ b/core/src/test/java/io/questdb/test/mp/WorkerBackoffDecayTest.java
@@ -1,0 +1,173 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.mp;
+
+import io.questdb.Metrics;
+import io.questdb.mp.Job;
+import io.questdb.mp.WorkerPoolConfiguration;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Back-off must depend on how OFTEN a worker finds work, not on whether it ever
+ * does.
+ * <p>
+ * The worker loop used to reset its back-off ticker to zero whenever any job
+ * reported work, so a worker handed a scrap more often than once per
+ * {@code napThreshold} passes could never reach a nap -- with the shipped
+ * default that meant 6,990 CONSECUTIVE idle passes. A {@code SynchronizedJob}
+ * assigned to every worker (an IODispatcher, say) rotates its trylock winner,
+ * so a trickle of work that only one worker handles at a time kept every worker
+ * in the pool spinning at full rate.
+ * <p>
+ * Both tests here are comparative -- they assert a ratio between two arms
+ * measured on the same machine in the same run -- so they do not encode any
+ * absolute throughput expectation.
+ */
+public class WorkerBackoffDecayTest {
+    private static final long NAP_THRESHOLD = 200;
+    private static final long RUN_MILLIS = 500;
+    private static final long SLEEP_THRESHOLD = 400;
+    // Work once per this many passes: far rarer than the credit below, so a
+    // decaying ticker still climbs, while a resetting one is wiped every time.
+    private static final int RARE_WORK_PERIOD = 100;
+    private static final long CREDIT = 8;
+
+    @Test
+    public void testAlwaysBusyWorkerStaysHot() throws Exception {
+        // Guards the other side of the trade: the decay must not throttle a
+        // worker that genuinely has work on every pass.
+        long busy = runFor(1, CREDIT);
+        long rare = runFor(RARE_WORK_PERIOD, CREDIT);
+
+        Assert.assertTrue(
+                "an always-busy worker was throttled by the back-off decay"
+                        + " (busy=" + busy + " passes, rare=" + rare + " passes)",
+                busy > 10 * rare
+        );
+    }
+
+    @Test
+    public void testRareWorkStillReachesBackoff() throws Exception {
+        long decay = runFor(RARE_WORK_PERIOD, CREDIT);
+        // A credit >= sleepThreshold can never leave the ticker above zero after
+        // work, so this arm reproduces the historical reset-to-zero behaviour.
+        long reset = runFor(RARE_WORK_PERIOD, SLEEP_THRESHOLD);
+
+        Assert.assertTrue(
+                "worker fed one scrap per " + RARE_WORK_PERIOD + " passes never backed off"
+                        + " (decay=" + decay + " passes, reset-equivalent=" + reset + " passes)",
+                reset > 10 * decay
+        );
+    }
+
+    /**
+     * Runs a single-worker pool for a fixed wall-clock window and returns how
+     * many loop passes the worker managed. A worker that backs off makes orders
+     * of magnitude fewer passes than one that spins.
+     */
+    private static long runFor(int workPeriod, long backoffCredit) throws Exception {
+        final PeriodicWorkJob job = new PeriodicWorkJob(workPeriod);
+        final TestWorkerPool pool = new TestWorkerPool(new WorkerPoolConfiguration() {
+            @Override
+            public long getBackoffCredit() {
+                return backoffCredit;
+            }
+
+            @Override
+            public Metrics getMetrics() {
+                return Metrics.DISABLED;
+            }
+
+            @Override
+            public long getNapThreshold() {
+                return NAP_THRESHOLD;
+            }
+
+            @Override
+            public long getNapTimeout() {
+                return 1;
+            }
+
+            @Override
+            public String getPoolName() {
+                return "backoff-decay-test";
+            }
+
+            @Override
+            public long getSleepThreshold() {
+                return SLEEP_THRESHOLD;
+            }
+
+            @Override
+            public long getSleepTimeout() {
+                return 5;
+            }
+
+            @Override
+            public int getWorkerCount() {
+                return 1;
+            }
+
+            @Override
+            public long getYieldThreshold() {
+                return 10;
+            }
+        });
+        pool.assign(job);
+        try {
+            pool.start();
+            Thread.sleep(RUN_MILLIS);
+            return job.passes.get();
+        } finally {
+            pool.halt();
+        }
+    }
+
+    /**
+     * Reports work on every {@code period}-th call, standing in for a worker's
+     * share of a rotating {@code SynchronizedJob}. A period of 1 is a job that
+     * always has work.
+     */
+    private static final class PeriodicWorkJob implements Job {
+        final AtomicLong passes = new AtomicLong();
+        private final int period;
+        // Read and written only by the single worker thread running this job.
+        private int calls;
+
+        PeriodicWorkJob(int period) {
+            this.period = period;
+        }
+
+        @Override
+        public boolean run(@NotNull WorkerContext workerContext) {
+            passes.incrementAndGet();
+            return period <= 1 || ++calls % period == 0;
+        }
+    }
+}


### PR DESCRIPTION
Addresses the root cause behind #7556: a lightly-loaded worker pool burning CPU asking for work it will not get.

## Problem

`Worker.loopBody` reset its back-off ticker to zero whenever **any** job on the worker reported work:

```java
if (runAsap) { ticker = 0; continue; }
```

`runAsap` is OR'd across every job on the worker, so reaching a nap required `napThreshold` **consecutive** idle passes — 6,990 with the shipped defaults (`nap.threshold` 7,000 minus `yield.threshold` 10).

That threshold is unreachable for a pool sharing a dispatcher. `WorkerPool.assign(Job)` clones per worker, but `Job.cloneInstance()` defaults to `return this`, and `AcceptGatedJob` (which wraps the `IODispatcher` at `HttpServer.java:121` and `PGServer.java:117`) does not override it — so every worker gets the same `SynchronizedJob` singleton. Its trylock winner rotates, so a trickle of work that only one worker handles at a time reset **every** worker's ticker. None of them could ever back off.

## Fix

Credit a fixed number of idle passes back per unit of work instead of resetting:

```java
ticker = Math.max(0L, ticker - backoffCredit);
```

Back-off now depends on how **often** a worker finds work rather than on whether it ever does. The ticker keeps climbing while work arrives less than once per `backoffCredit` passes, and stays pinned at zero for a genuinely busy worker.

## Evidence

Single-worker pool fed one scrap per 100 passes, 500 ms window (`WorkerBackoffDecayTest`):

| Arm | Loop passes / 500 ms |
|---|---:|
| rare work, old reset semantics | 3,677,367 |
| rare work, new decay | **475** (~7,700x fewer) |
| always busy, new decay | 22,770,440 (unaffected) |

Reverting just the `Math.max` line and re-running reproduces the bug exactly — both arms land at ~4.1M passes, i.e. the worker never backs off. The tests are comparative (ratio between two arms measured in the same run), so they encode no absolute throughput expectation.

## Risk and rollback

`backoffCredit` defaults to **64**, which is deliberately conservative: only a worker busy on less than roughly 1.5% of its passes will back off at all. The reported pathology (one scrap per ~1,400 passes) sits ~22x below that line.

It is configurable per pool, and **`backoffCredit >= sleepThreshold` reproduces the previous reset-to-zero behaviour exactly** — a one-value rollback that needs no redeploy of this change.

Also included: `getNapTimeout()` (default 1 ms) makes the nap rung's duration configurable. It was a hardcoded `Os.sleep(1)` that ignored `sleep.timeout` entirely, so the nap and sleep rungs could not be tuned independently.

## Testing

`WorkerBackoffDecayTest` (new, 2 tests) plus `WorkerContinuationTest`, `JobRotationTest`, `WorkerPoolManagerTest`, `WorkerPoolBootFailureTest`, `ConcurrentTest`, `TimerContTest`, `TimerShardsTest`, `SimpleLockTest`, `PropServerConfigurationTest` — 172 tests, all green.

## Scope

Deliberately limited to the ticker. #7556 also proposes pinning the dispatcher and blocking in `epoll_wait`; those are **not** here, for two reasons:

- `SynchronizedJob` trylock losers return `false` without calling `runSerially()`, so they never make an epoll syscall — the N-way assignment cost is one failed CAS per pass, and this change already cuts that traffic ~7,700x.
- The issue's own measurements report pinning *without* blocking as 60% worse on p50. Pinning removes the availability insurance the rotating winner provides, and only pays off paired with a real block.

Refs #7556