### PR TITLE
perf(core): covering-index apply -- straddle split, gather hoists, and seal observability

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -13478,7 +13478,14 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         //    range for replace via a separate mechanism; the two gates intentionally
         //    diverge here but SHARE the legacy-covering disqualifier below;
         //  - the block's first row sits at/after the committed max (pure append,
-        //    NOT late data / a merge) and inside the last partition.
+        //    NOT late data / a merge) and inside the last partition;
+        //  - NOT a FORMAT PARQUET table. Its partitions are born parquet, written
+        //    by the O3 path (writeFreshParquetFromO3), and processWalCommit
+        //    disables LAG for it entirely (see `noLag`): on an empty such table
+        //    the last partition is the NATIVE placeholder openPartition created
+        //    to hold LAG, so isLastPartitionParquet() is false and the guards
+        //    above would let a pure append land in it -- committing the
+        //    partition as native and permanently skipping its parquet write.
         // FORCE_FULL_COMMIT (commit-to == Long.MAX_VALUE) needs no guard: the
         // fast-lag tail FULLY commits the block (lagRowCount -> 0), satisfying
         // "commit everything"; the only thing deferred is covered COMPACTION,
@@ -13488,6 +13495,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 || txWriter.getLagRowCount() != 0
                 || lastPartitionTimestamp == Long.MIN_VALUE
                 || isLastPartitionParquet()
+                || metadata.getTableFormat() == TableUtils.TABLE_FORMAT_PARQUET
                 || !isCommitPlainInsert()
                 || txWriter.getMaxTimestamp() > blockMin
                 || txWriter.getPartitionTimestampByTimestamp(blockMin) != lastPartitionTimestamp

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -4704,7 +4704,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 // Non-eligible blocks fall through to the O3 path unchanged.
                 long o3ApplyLo;
                 if (!copiedToMemory) {
-                    o3ApplyLo = tryFastAppendInOrderBlock(o3Lo, o3LoHi, blockTransactionCount, timestampAddr);
+                    o3ApplyLo = tryFastAppendInOrderBlock(o3Lo, o3LoHi, blockTransactionCount, timestampAddr,
+                            segmentCopyInfo.getMinTimestamp(), segmentCopyInfo.getMaxTimestamp());
                 } else {
                     // SPIKE (phase-3 Task 1): the O3 sort has already gathered the
                     // merge-index-ordered rows into o3MemColumns1 (== o3Columns)
@@ -4715,7 +4716,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     // covered publish + defer -- with NO O3CopyJob involvement
                     // (no A1 convergence). The append body is source-agnostic
                     // (reads o3Columns + o3Lo + timestampAddr), so it is shared.
-                    o3ApplyLo = tryFastAppendSortedBlock(o3Lo, o3LoHi, blockTransactionCount, timestampAddr);
+                    o3ApplyLo = tryFastAppendSortedBlock(o3Lo, o3LoHi, blockTransactionCount, timestampAddr,
+                            segmentCopyInfo.getMinTimestamp(), segmentCopyInfo.getMaxTimestamp());
                 }
                 // Skip the O3 finish ONLY when the fast path fired and consumed
                 // the ENTIRE block (o3ApplyLo advanced from o3Lo all the way to
@@ -4776,8 +4778,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      *
      * @return the O3 overflow low row (see {@link #tryFastAppendInOrderBlock}).
      */
-    private long tryFastAppendSortedBlock(long o3Lo, long o3LoHi, int blockTransactionCount, long timestampAddr) {
-        return tryFastAppendInOrderBlock(o3Lo, o3LoHi, blockTransactionCount, timestampAddr);
+    private long tryFastAppendSortedBlock(long o3Lo, long o3LoHi, int blockTransactionCount, long timestampAddr,
+                                          long blockMin, long blockMax) {
+        return tryFastAppendInOrderBlock(o3Lo, o3LoHi, blockTransactionCount, timestampAddr, blockMin, blockMax);
     }
 
     private boolean applyFromWalLagToLastPartitionPossible(long commitToTimestamp, long lagRowCount, boolean lagOrdered, long committedMaxTimestamp, long lagMinTimestamp, long lagMaxTimestamp) {
@@ -10783,7 +10786,39 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 // in the next release after v7.3.9.
                 // Commit everything.
                 walLagRowCount = 0;
-                processWalCommitFinishApply(walLagRowCount, timestampAddr, o3Lo, o3Hi, pressureControl, copiedToMemory, initialPartitionTimestampHi);
+
+                // Single-txn sibling of the block-apply fast path. The gate that
+                // sent us here (applyFromWalLagToLastPartitionPossible, via
+                // canFastCommitNew) is all-or-nothing: it requires the WHOLE
+                // transaction to fit inside the last partition
+                // (lagMaxTimestamp <= partitionTimestampHi), so ONE row past the
+                // boundary disqualifies every row and routes the entire
+                // transaction through O3 -- including the prefix that is a pure
+                // append. On a covering index that costs a full-partition
+                // rebuildSidecars for rows nothing rewrote.
+                //
+                // tryFastAppendInOrderBlock already splits exactly this straddle
+                // for block-apply; reuse it. Only the not-copied branch is
+                // eligible: copiedToMemory means the sort gathered rows into
+                // o3MemColumns1 and re-based o3Lo to 0, which is the sorted-block
+                // shape (tryFastAppendSortedBlock) rather than this one. Every
+                // other precondition -- pure append, plain insert, native last
+                // partition, no lag, no legacy covering head -- is re-checked
+                // inside the callee, so a non-eligible transaction returns o3Lo
+                // and the O3 path below runs exactly as before.
+                long o3ApplyLo = o3Lo;
+                if (!copiedToMemory) {
+                    o3ApplyLo = tryFastAppendInOrderBlock(o3Lo, o3Hi, 1, timestampAddr, o3TimestampMin, o3TimestampMax);
+                }
+                // Mirrors the block-apply guard, including its zero-row case:
+                // o3ApplyLo == o3Lo means the fast path did not fire, so the
+                // whole transaction must still go through O3 -- and
+                // processWalCommitFinishApply's lag bookkeeping runs
+                // unconditionally, which a skipped empty commit once broke for a
+                // dependent materialized view's refresh range.
+                if (o3ApplyLo == o3Lo || o3ApplyLo < o3Hi) {
+                    processWalCommitFinishApply(walLagRowCount, timestampAddr, o3ApplyLo, o3Hi, pressureControl, copiedToMemory, initialPartitionTimestampHi);
+                }
             } finally {
                 finishO3Append(walLagRowCount);
                 o3Columns = o3MemColumns1;
@@ -13422,7 +13457,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         processPartitionRemoveCandidates();
     }
 
-    private long tryFastAppendInOrderBlock(long o3Lo, long o3LoHi, int blockTransactionCount, long timestampAddr) {
+    private long tryFastAppendInOrderBlock(long o3Lo, long o3LoHi, int blockTransactionCount, long timestampAddr,
+                                           long blockMin, long blockMax) {
         // @TestOnly override (default false, JIT-elided in production): force every
         // block through the unchanged O3 path so a differential test can prove the
         // fast path is result-equivalent to O3.
@@ -13430,7 +13466,6 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             return o3Lo;
         }
         final long blockRows = o3LoHi - o3Lo;
-        final long blockMin = segmentCopyInfo.getMinTimestamp();
         // Guards (fall back to the unchanged O3 path on any). Only a PURE APPEND
         // into the last NATIVE partition qualifies:
         //  - no pre-existing lag (block-apply never carries lag, but be defensive);
@@ -13468,9 +13503,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         // reads the 16-byte (timestamp, rowId) WAL timestamp-index format.
         final long prefixRows;
         final long prefixMax;
-        if (segmentCopyInfo.getMaxTimestamp() <= partitionTimestampHi) {
+        if (blockMax <= partitionTimestampHi) {
             prefixRows = blockRows;
-            prefixMax = segmentCopyInfo.getMaxTimestamp();
+            prefixMax = blockMax;
         } else {
             long lastPrefixIdx = Vect.boundedBinarySearchIndexT(timestampAddr, partitionTimestampHi, o3Lo, o3LoHi - 1, Vect.BIN_SEARCH_SCAN_DOWN);
             if (lastPrefixIdx < o3Lo) {
@@ -13531,7 +13566,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             // them, so re-arm them to the OVERFLOW range [overflowLo, o3LoHi)
             // before the caller routes it through O3.
             txWriter.setLagMinTimestamp(getTimestampIndexValue(timestampAddr, overflowLo));
-            txWriter.setLagMaxTimestamp(segmentCopyInfo.getMaxTimestamp());
+            txWriter.setLagMaxTimestamp(blockMax);
         }
         return overflowLo;
     }

--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -13955,6 +13955,16 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
 
         boolean processed = false;
+        // Reseal cost attribution: this method can dominate an O3 commit on a
+        // covering index -- rebuildSidecars() below runs for the whole partition
+        // on both the rebuild and the canSkipRebuild path -- yet neither it nor
+        // sealPostingIndexesForO3Partitions emitted anything at any level, so the
+        // work was invisible between the surrounding "o3 partition update" and
+        // "switched partition" records. Counters are locals; the clock is read
+        // twice per partition, against work measured in seconds.
+        int columnsSealed = 0;
+        int coversSealed = 0;
+        final long sealStartMicros = configuration.getMicrosecondClock().getTicks();
         long partitionNameTxn = setStateForTimestamp(path, partitionTimestamp);
         int plen = path.size();
         // For new partitions created during O3, the partition directory may
@@ -13989,12 +13999,14 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     continue;
                 }
                 processed = true;
+                columnsSealed++;
 
                 IntList coveringCols = metadata.getColumnMetadata(colIdx).getCoveringColumnIndices();
                 boolean hasCovering = coveringCols != null && coveringCols.size() > 0;
 
                 if (hasCovering) {
                     int coverCount = coveringCols.size();
+                    coversSealed += coverCount;
 
                     try {
                         mapCoveringColumnsForSeal(coveringCols, partitionTimestamp, plen, coverCount);
@@ -14129,6 +14141,19 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         } finally {
             path.trimTo(pathSize);
         }
+        if (processed) {
+            // canSkipRebuild is the fact that separates a chain rebuild from the
+            // cheap rollback, and covers > 0 says whether the unconditional
+            // sidecar rebuild ran -- together they explain the elapsed time.
+            LOG.info().$("posting index reseal partition [table=").$(tableToken)
+                    .$(", partitionTs=").$ts(timestampDriver, partitionTimestamp)
+                    .$(", partitionSize=").$(partitionSize)
+                    .$(", canSkipRebuild=").$(canSkipRebuild)
+                    .$(", columns=").$(columnsSealed)
+                    .$(", covers=").$(coversSealed)
+                    .$(", timeMicros=").$(configuration.getMicrosecondClock().getTicks() - sealStartMicros)
+                    .I$();
+        }
         return processed;
     }
 
@@ -14146,6 +14171,14 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         if (!hasPostingIndex()) {
             return;
         }
+
+        // Sweep summary counters. The per-partition records above are the detail;
+        // this one line is what an operator reads first, because it is the only
+        // place the whole reseal cost of an O3 commit appears as a single figure.
+        final long sweepStartMicros = configuration.getMicrosecondClock().getTicks();
+        int partitionsSealed = 0;
+        int rebuiltPartitions = 0;
+        int skippedRebuildPartitions = 0;
 
         long blockIndex = -1;
         while ((blockIndex = o3PartitionUpdateSink.nextBlockIndex(blockIndex)) > -1L) {
@@ -14172,15 +14205,34 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
             if (partitionTimestamp != -1L && sealPostingIndexForPartition(partitionTimestamp, canSkipRebuildForPartition)) {
                 anyPartitionProcessed = true;
+                partitionsSealed++;
+                if (canSkipRebuildForPartition) {
+                    skippedRebuildPartitions++;
+                } else {
+                    rebuiltPartitions++;
+                }
             }
             if (dataPartitionTimestamp != -1L && dataPartitionTimestamp != partitionTimestamp
                     && sealPostingIndexForPartition(dataPartitionTimestamp, false)) {
                 anyPartitionProcessed = true;
+                partitionsSealed++;
+                // The split-parent arm always passes canSkipRebuild=false.
+                rebuiltPartitions++;
             }
         }
 
         if (anyPartitionProcessed) {
             restorePostingIndexersToLastPartition();
+            // No row total here on purpose: the split-parent arm has no size in
+            // the update sink, so summing would either duplicate a lookup or
+            // report a figure that silently excludes it. Sizes are exact on the
+            // per-partition records; this line owns the aggregate timing.
+            LOG.info().$("posting index o3 reseal [table=").$(tableToken)
+                    .$(", partitions=").$(partitionsSealed)
+                    .$(", rebuilt=").$(rebuiltPartitions)
+                    .$(", skippedRebuild=").$(skippedRebuildPartitions)
+                    .$(", timeMicros=").$(configuration.getMicrosecondClock().getTicks() - sweepStartMicros)
+                    .I$();
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -1729,6 +1729,15 @@ public class PostingIndexWriter implements IndexWriter {
             return;
         }
 
+        // Past every early return, so a real seal is now going to be attempted.
+        // Both reads are once-per-seal against an operation measured in seconds
+        // for a large partition -- the clock cost is not observable here. genCount
+        // is captured before the collapse so the summary can report gens in->out,
+        // the figure that drives cairo.posting.seal.gen.threshold tuning and which
+        // is otherwise only visible at DEBUG (see compactIfOverBudget).
+        final long sealStartMicros = configuration.getMicrosecondClock().getTicks();
+        final int genCountAtEntry = genCount;
+
         // peekNextSealTxn(), not sealTxn+1: after a recovery drop the
         // writer's sealTxn lags genCounter, and reusing a dropped
         // sealTxn would race the still-pending .pv purge.
@@ -1966,6 +1975,28 @@ public class PostingIndexWriter implements IndexWriter {
         // power-loss reader see chain entries that reference unflushed data.
         if (partitionPath.size() > 0 && keyMem.isOpen()) {
             keyMem.sync(false);
+        }
+
+        // Success-path summary. Every other INFO record in this class reports a
+        // deviation (an RSS-pressure fallback, an untrusted snapshot, a recovery),
+        // which leaves the normal path silent and gives an operator no baseline to
+        // compare a slow seal against. A seal can dominate an O3 commit -- it
+        // rewrites the covering sidecars for the whole partition -- so the one
+        // line that says which path ran, how much it collapsed and how long it
+        // took is what makes that cost attributable without a DEBUG restart.
+        // Every field is already-maintained writer state; nothing new is tracked.
+        if (isSealed) {
+            LOG.info().$("posting index sealed [indexName=").$(indexName)
+                    .$(", sealTxn=").$(sealTxn)
+                    .$(", path=").$(isLastSealIncremental ? "incremental" : "full")
+                    .$(", streaming=").$(isLastSealStreaming)
+                    .$(", snapshotDeferred=").$(isLastSealSnapshotDeferred)
+                    .$(", gens=").$(genCountAtEntry).$("->").$(genCount)
+                    .$(", keys=").$(keyCount)
+                    .$(", covers=").$(coverCount)
+                    .$(", valueBytes=").$(valueMemSize)
+                    .$(", timeMicros=").$(configuration.getMicrosecondClock().getTicks() - sealStartMicros)
+                    .I$();
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -7659,19 +7659,43 @@ public class PostingIndexWriter implements IndexWriter {
                     int key = activeKeyIds[idx];
                     int pendingCount = Unsafe.getInt(pendingCountsAddr + (long) key * Integer.BYTES);
                     int spillCount = getSpillCount(key);
+                    if (pendingCount + spillCount == 0) {
+                        continue;
+                    }
+                    final long spillAddr = spillCount > 0
+                            ? Unsafe.getLong(spillKeyAddrsAddr + (long) key * Long.BYTES)
+                            : 0;
+                    final long keyValuesAddr = pendingValuesAddr + (long) key * PENDING_SLOT_CAPACITY * Long.BYTES;
 
-                    if (spillCount > 0) {
-                        long spillAddr = Unsafe.getLong(spillKeyAddrsAddr + (long) key * Long.BYTES);
-                        for (int i = 0; i < spillCount; i++) {
-                            long rowId = Unsafe.getLong(spillAddr + (long) i * Long.BYTES);
-                            writeSidecarValueSafe(mem, c, colTop, rowId, shift, valueSize, colType);
-                        }
+                    // Resolve the covered column's base address ONCE per key rather
+                    // than once per value. This key's row ids ascend -- spill holds
+                    // the earlier ones and add() rejects a descending value -- so the
+                    // highest is the last pending entry, or the last spilled entry
+                    // when nothing is pending. Probing it performs any grow-remap the
+                    // whole run could need, after which every lower offset resolves
+                    // against the same mapping. baseLimit keeps the mapped length so
+                    // a row id that breaks the ascending assumption falls back to the
+                    // checked call instead of reading past it; 0 means addr-based
+                    // (caller-owned, no length tracked), matching what the per-value
+                    // path already assumes.
+                    final long keyMaxRowId = pendingCount > 0
+                            ? Unsafe.getLong(keyValuesAddr + (long) (pendingCount - 1) * Long.BYTES)
+                            : Unsafe.getLong(spillAddr + (long) (spillCount - 1) * Long.BYTES);
+                    long base = 0;
+                    long baseLimit = 0;
+                    if (keyMaxRowId >= colTop
+                            && getCoveredDataReadAddr(c, (keyMaxRowId - colTop) << shift, valueSize) != 0) {
+                        base = coveredColReadAddrs[c];
+                        baseLimit = coveredColReadSizes[c];
                     }
 
-                    long keyValuesAddr = pendingValuesAddr + (long) key * PENDING_SLOT_CAPACITY * Long.BYTES;
+                    for (int i = 0; i < spillCount; i++) {
+                        writeSidecarValueHoisted(mem, c, colTop, Unsafe.getLong(spillAddr + (long) i * Long.BYTES),
+                                shift, valueSize, colType, base, baseLimit);
+                    }
                     for (int i = 0; i < pendingCount; i++) {
-                        long rowId = Unsafe.getLong(keyValuesAddr + (long) i * Long.BYTES);
-                        writeSidecarValueSafe(mem, c, colTop, rowId, shift, valueSize, colType);
+                        writeSidecarValueHoisted(mem, c, colTop, Unsafe.getLong(keyValuesAddr + (long) i * Long.BYTES),
+                                shift, valueSize, colType, base, baseLimit);
                     }
                 }
             }
@@ -7735,6 +7759,48 @@ public class PostingIndexWriter implements IndexWriter {
             if (exceptionWorkspaceAddr != 0) {
                 Unsafe.free(exceptionWorkspaceAddr, maxKeyCount, MemoryTag.NATIVE_INDEX_READER);
             }
+        }
+    }
+
+    /**
+     * {@link #writeSidecarValueSafe} with the covered-column base address already
+     * resolved by the caller for the whole key run. Falls back to the checked
+     * per-value resolution when the caller could not resolve a base, or when the
+     * offset would leave a known mapped length -- so it can never address a byte
+     * the per-value path would not have.
+     *
+     * @param base      resolved covered-column base address, 0 when unresolved
+     * @param baseLimit mapped length behind {@code base}, 0 when caller-owned
+     */
+    private void writeSidecarValueHoisted(
+            MemoryMARW mem,
+            int covIdx,
+            long colTop,
+            long rowId,
+            int shift,
+            int valueSize,
+            int colType,
+            long base,
+            long baseLimit
+    ) {
+        if (rowId < colTop) {
+            writeNullSentinel(mem, valueSize, colType);
+            return;
+        }
+        final long srcOffset = (rowId - colTop) << shift;
+        long addr;
+        if (base != 0 && (baseLimit == 0 || srcOffset + valueSize <= baseLimit)) {
+            addr = base + srcOffset;
+        } else if (coveredColumnNames.size() > 0 || coveredColumnAddrs.size() > 0) {
+            addr = getCoveredDataReadAddr(covIdx, srcOffset, valueSize);
+        } else {
+            putFixedValue(mem, srcOffset, valueSize);
+            return;
+        }
+        if (addr == 0) {
+            writeNullSentinel(mem, valueSize, colType);
+        } else {
+            putFixedValue(mem, addr, valueSize);
         }
     }
 

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -7330,21 +7330,88 @@ public class PostingIndexWriter implements IndexWriter {
                 // Assemble this key's raw values into sidecarBuf.
                 long keyOff = keyOffsets[j];
                 long rawOffset = 0;
-                for (int i = 0; i < count; i++) {
-                    long rowId = Unsafe.getLong(
-                            mergedValuesAddr + (keyOff + i) * Long.BYTES);
-                    if (rowId < colTop) {
-                        writeNullSentinel(sidecarBuf + rawOffset, valueSize, colType);
-                    } else {
-                        long srcOffset = (rowId - colTop) << shift;
-                        long addr = getCoveredDataReadAddr(c, srcOffset, valueSize);
-                        if (addr != 0) {
-                            Unsafe.copyMemory(addr, sidecarBuf + rawOffset, valueSize);
-                        } else {
+
+                // Resolve the covered column's base address ONCE for this key
+                // instead of once per value. getCoveredDataReadAddr is only
+                // offset-dependent through its grow-remap check, and row ids
+                // within a key ascend (add() rejects a descending value and the
+                // gen merge preserves that), so probing the last row id first
+                // performs any remap the whole run could need; every lower
+                // offset then resolves to base + offset against the same
+                // mapping. A zero base (unmappable column) drops to the
+                // unchanged per-value path below.
+                long base = 0;
+                long baseLimit = 0;
+                long lastRowId = Unsafe.getLong(mergedValuesAddr + (keyOff + count - 1) * Long.BYTES);
+                if (lastRowId >= colTop && getCoveredDataReadAddr(c, (lastRowId - colTop) << shift, valueSize) != 0) {
+                    base = coveredColReadAddrs[c];
+                    // 0 means addr-based (caller-owned mapping): no length is
+                    // tracked, exactly as the per-value path assumes. Otherwise
+                    // keep the mapped length so a row id that breaks the
+                    // ascending assumption cannot read past the mapping -- it
+                    // falls back to the checked call rather than trusting base.
+                    baseLimit = coveredColReadSizes[c];
+                }
+
+                if (base != 0) {
+                    for (int i = 0; i < count; i++) {
+                        long rowId = Unsafe.getLong(mergedValuesAddr + (keyOff + i) * Long.BYTES);
+                        if (rowId < colTop) {
                             writeNullSentinel(sidecarBuf + rawOffset, valueSize, colType);
+                        } else {
+                            long srcOffset = (rowId - colTop) << shift;
+                            long addr;
+                            if (baseLimit == 0 || srcOffset + valueSize <= baseLimit) {
+                                addr = base + srcOffset;
+                            } else {
+                                addr = getCoveredDataReadAddr(c, srcOffset, valueSize);
+                            }
+                            if (addr != 0) {
+                                // Typed move for the power-of-two widths that
+                                // cover every fixed-size column type. An 8-byte
+                                // Unsafe.copyMemory is a general memcpy call;
+                                // TIMESTAMP / LONG / DOUBLE covers make this the
+                                // single hottest instruction of a reseal.
+                                switch (valueSize) {
+                                    case Long.BYTES:
+                                        Unsafe.putLong(sidecarBuf + rawOffset, Unsafe.getLong(addr));
+                                        break;
+                                    case Integer.BYTES:
+                                        Unsafe.putInt(sidecarBuf + rawOffset, Unsafe.getInt(addr));
+                                        break;
+                                    case Short.BYTES:
+                                        Unsafe.putShort(sidecarBuf + rawOffset, Unsafe.getShort(addr));
+                                        break;
+                                    case Byte.BYTES:
+                                        Unsafe.putByte(sidecarBuf + rawOffset, Unsafe.getByte(addr));
+                                        break;
+                                    default:
+                                        Unsafe.copyMemory(addr, sidecarBuf + rawOffset, valueSize);
+                                        break;
+                                }
+                            } else {
+                                writeNullSentinel(sidecarBuf + rawOffset, valueSize, colType);
+                            }
                         }
+                        rawOffset += valueSize;
                     }
-                    rawOffset += valueSize;
+                } else {
+                    for (int i = 0; i < count; i++) {
+                        long rowId = Unsafe.getLong(
+                                mergedValuesAddr + (keyOff + i) * Long.BYTES);
+                        if (rowId < colTop) {
+                            writeNullSentinel(sidecarBuf + rawOffset, valueSize, colType);
+                        } else {
+                            long srcOffset = (rowId - colTop) << shift;
+                            long addr = getCoveredDataReadAddr(c, srcOffset, valueSize);
+                            if (addr != 0) {
+                                Unsafe.copyMemory(addr, sidecarBuf + rawOffset, valueSize);
+                            } else {
+                                writeNullSentinel(sidecarBuf + rawOffset, valueSize, colType);
+                            }
+                        }
+                        rawOffset += valueSize;
+                    }
                 }
 
                 // Compress and write

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -1587,11 +1587,19 @@ public class PostingIndexWriter implements IndexWriter {
         if (COVERING_COUNTERS_ENABLED) {
             COVERING_FULL_RESEAL_COUNT.incrementAndGet();
         }
+        // This is the dominant term of an O3 reseal on a covering index: it
+        // regathers the covered columns for the WHOLE partition, and
+        // TableWriter reaches it on both the rebuild and the canSkipRebuild
+        // path. Capture coverCount before the rebuild -- a reconfigure can
+        // reset it -- so the record reports what was actually rebuilt.
+        final long rebuildStartMicros = configuration.getMicrosecondClock().getTicks();
+        final int coverCountAtEntry = coverCount;
         closeSidecarMems();
         long gen0DirOffset = resolveHeadGenDirOffset(0);
         int gen0KeyCount = keyMem.getInt(gen0DirOffset + PostingIndexUtils.GEN_DIR_OFFSET_KEY_COUNT);
 
-        if (gen0KeyCount >= 0 && genCount == 1 && partitionPath.size() > 0) {
+        final boolean byCopy = gen0KeyCount >= 0 && genCount == 1 && partitionPath.size() > 0;
+        if (byCopy) {
             // peekNextSealTxn(), not sealTxn+1: after a recovery drop the writer's
             // sealTxn lags genCounter, and reusing a dropped sealTxn would race
             // the still-pending .pv purge.
@@ -1606,6 +1614,29 @@ public class PostingIndexWriter implements IndexWriter {
         } else {
             seal();
         }
+
+        // coverEndOffsetsCache is the authoritative per-cover valid extent --
+        // captureCoverEndOffsets refreshes it from each open handle on every
+        // chain publish, so it survives the closeSidecarMems above and is the
+        // one place the rebuilt sidecar size can be read after the fact. A
+        // never-written slot keeps its cached 0 and simply contributes nothing.
+        long sidecarBytes = 0;
+        for (int c = 0, n = coverEndOffsetsCache.size(); c < n; c++) {
+            sidecarBytes += coverEndOffsetsCache.getQuick(c);
+        }
+        // The seal path also emits its own record; this one adds the caller
+        // context (a sidecar rebuild, not a bare seal) plus the byte total,
+        // which is what turns the elapsed time into a throughput figure.
+        LOG.info().$("posting index sidecars rebuilt [indexName=").$(indexName)
+                .$(", sealTxn=").$(sealTxn)
+                .$(", path=").$(byCopy ? "copy" : "seal")
+                .$(", covers=").$(coverCountAtEntry)
+                .$(", keys=").$(keyCount)
+                .$(", gens=").$(genCount)
+                .$(", maxRowId=").$(maxValue)
+                .$(", sidecarBytes=").$(sidecarBytes)
+                .$(", timeMicros=").$(configuration.getMicrosecondClock().getTicks() - rebuildStartMicros)
+                .I$();
     }
 
     /**

--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -7655,6 +7655,23 @@ public class PostingIndexWriter implements IndexWriter {
 
                 mem.putInt(totalValues);
 
+                // Reserve the whole fixed-size block up front and write into the
+                // mapped region directly, instead of appending value-by-value.
+                // mem.putLong re-checks the append offset and can extend the
+                // mapping on every call; the block size here is exact
+                // (totalValues * valueSize -- fixed-width, no compression on this
+                // path), so one jumpTo makes the region contiguous and the loop
+                // becomes a plain typed store. Same idiom flushAllPending already
+                // uses for the .pv gen ("extend to guarantee contiguous mapped
+                // region for direct encoding"). Staging through a scratch buffer
+                // was tried instead and was SLOWER -- it doubles the stores and
+                // this loop is memory-bound.
+                final long blockDataStart = mem.getAppendOffset();
+                final long blockDataSize = (long) totalValues * valueSize;
+                mem.jumpTo(blockDataStart + blockDataSize);
+                long dst = mem.addressOf(blockDataStart);
+                final long dstEnd = dst + blockDataSize;
+
                 for (int idx = 0; idx < activeKeyCount; idx++) {
                     int key = activeKeyIds[idx];
                     int pendingCount = Unsafe.getInt(pendingCountsAddr + (long) key * Integer.BYTES);
@@ -7690,14 +7707,21 @@ public class PostingIndexWriter implements IndexWriter {
                     }
 
                     for (int i = 0; i < spillCount; i++) {
-                        writeSidecarValueHoisted(mem, c, colTop, Unsafe.getLong(spillAddr + (long) i * Long.BYTES),
+                        writeSidecarValueDirect(dst, c, colTop, Unsafe.getLong(spillAddr + (long) i * Long.BYTES),
                                 shift, valueSize, colType, base, baseLimit);
+                        dst += valueSize;
                     }
                     for (int i = 0; i < pendingCount; i++) {
-                        writeSidecarValueHoisted(mem, c, colTop, Unsafe.getLong(keyValuesAddr + (long) i * Long.BYTES),
+                        writeSidecarValueDirect(dst, c, colTop, Unsafe.getLong(keyValuesAddr + (long) i * Long.BYTES),
                                 shift, valueSize, colType, base, baseLimit);
+                        dst += valueSize;
                     }
                 }
+                // totalValues is computed by the caller from the same pending +
+                // spill counts this loop walks, so the reserved block must be
+                // exactly filled. Under-filling would publish uninitialised bytes
+                // as covered values.
+                assert dst == dstEnd : "sidecar gen block underfilled";
             }
             mem.putLong((long) genIndex * Long.BYTES, blockStart);
         }
@@ -7801,6 +7825,57 @@ public class PostingIndexWriter implements IndexWriter {
             writeNullSentinel(mem, valueSize, colType);
         } else {
             putFixedValue(mem, addr, valueSize);
+        }
+    }
+
+    /**
+     * {@link #writeSidecarValueHoisted} writing to a raw address inside the
+     * sidecar's already-reserved mapped block, rather than appending through
+     * MemoryMARW. Avoids the per-value append-offset check and possible mapping
+     * extend; the caller reserved the exact block with a single jumpTo.
+     */
+    private void writeSidecarValueDirect(
+            long dst,
+            int covIdx,
+            long colTop,
+            long rowId,
+            int shift,
+            int valueSize,
+            int colType,
+            long base,
+            long baseLimit
+    ) {
+        if (rowId < colTop) {
+            writeNullSentinel(dst, valueSize, colType);
+            return;
+        }
+        final long srcOffset = (rowId - colTop) << shift;
+        long addr;
+        if (base != 0 && (baseLimit == 0 || srcOffset + valueSize <= baseLimit)) {
+            addr = base + srcOffset;
+        } else {
+            addr = getCoveredDataReadAddr(covIdx, srcOffset, valueSize);
+        }
+        if (addr == 0) {
+            writeNullSentinel(dst, valueSize, colType);
+            return;
+        }
+        switch (valueSize) {
+            case Long.BYTES:
+                Unsafe.putLong(dst, Unsafe.getLong(addr));
+                break;
+            case Integer.BYTES:
+                Unsafe.putInt(dst, Unsafe.getInt(addr));
+                break;
+            case Short.BYTES:
+                Unsafe.putShort(dst, Unsafe.getShort(addr));
+                break;
+            case Byte.BYTES:
+                Unsafe.putByte(dst, Unsafe.getByte(addr));
+                break;
+            default:
+                Unsafe.copyMemory(addr, dst, valueSize);
+                break;
         }
     }
 

--- a/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexStraddlePartitionPlacementTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/covering/CoveringIndexStraddlePartitionPlacementTest.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.covering;
+
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.test.AbstractCairoTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * The single-transaction prefix split commits part of a transaction to the last
+ * partition and routes the rest through O3. The obvious way for that to be wrong
+ * is for a row to land on the wrong side of the boundary, which content-equality
+ * assertions alone would not localise. This asserts PLACEMENT directly.
+ * <p>
+ * The split point is {@code partitionTimestampHi} located by
+ * {@code boundedBinarySearchIndexT}, and the fast path only runs on an ascending,
+ * pure-append transaction, so the prefix is exactly the rows belonging to the last
+ * partition. This test is the empirical check of that.
+ */
+public class CoveringIndexStraddlePartitionPlacementTest extends AbstractCairoTest {
+
+    @After
+    public void resetFlags() {
+        PostingIndexWriter.COVERING_FASTPATH_DISABLED = false;
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+    }
+
+    @Test
+    public void testStraddleDoesNotMisplaceRows() throws Exception {
+        assertMemoryLeak(() -> {
+            PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
+
+            // Reference placement: fast path forced off, so every transaction goes
+            // through O3, which is the behaviour this change must reproduce.
+            PostingIndexWriter.COVERING_FASTPATH_DISABLED = true;
+            PostingIndexWriter.COVERING_BLOCK_FASTPATH_COUNT.set(0);
+            build("ref");
+            final long refFired = PostingIndexWriter.COVERING_BLOCK_FASTPATH_COUNT.get();
+
+            PostingIndexWriter.COVERING_FASTPATH_DISABLED = false;
+            PostingIndexWriter.COVERING_BLOCK_FASTPATH_COUNT.set(0);
+            build("split");
+            final long splitFired = PostingIndexWriter.COVERING_BLOCK_FASTPATH_COUNT.get();
+
+            // Without this the comparison below could pass because the fast path
+            // never ran at all.
+            Assert.assertEquals("fast path fired while disabled", 0, refFired);
+            Assert.assertTrue("fast path never fired -- test is vacuous", splitFired > 0);
+
+            // Placement must match the O3 reference exactly: same partitions, same
+            // row counts, same min/max timestamp in each.
+            assertSqlCursors(
+                    "SELECT name, numRows, minTimestamp, maxTimestamp FROM table_partitions('ref') ORDER BY name",
+                    "SELECT name, numRows, minTimestamp, maxTimestamp FROM table_partitions('split') ORDER BY name"
+            );
+
+            // Intrinsic check, independent of the reference: a partition whose min
+            // and max fall in different hours contains a row that does not belong
+            // to it.
+            assertSqlCursors(
+                    "SELECT 0L AS straddlingPartitions",
+                    "SELECT count() AS straddlingPartitions FROM table_partitions('split')" +
+                            " WHERE date_trunc('hour', minTimestamp) <> date_trunc('hour', maxTimestamp)"
+            );
+
+            // Content, and the covering index against a full scan.
+            assertSqlCursors(
+                    "SELECT ts, sym, val FROM ref ORDER BY ts, sym, val",
+                    "SELECT ts, sym, val FROM split ORDER BY ts, sym, val"
+            );
+            assertSqlCursors(
+                    "SELECT ts, val FROM split WHERE /*+ no_index(sym) */ sym = 'S5' ORDER BY ts",
+                    "SELECT ts, val FROM split WHERE sym = 'S5' ORDER BY ts"
+            );
+        });
+    }
+
+    private void build(String t) throws Exception {
+        execute("CREATE TABLE " + t + " (ts TIMESTAMP," +
+                " sym SYMBOL INDEX TYPE POSTING INCLUDE (val), val DOUBLE)" +
+                " TIMESTAMP(ts) PARTITION BY HOUR WAL");
+        execute("INSERT INTO " + t + " (ts, sym, val) " +
+                "SELECT timestamp_sequence('2024-01-01T00:00:00', 1000), 'S' || (x % 97), x::double " +
+                "FROM long_sequence(100000)");
+        drainWalQueue();
+        // Each insert starts inside the current last partition and runs past its
+        // end, so the transaction straddles a boundary.
+        for (int i = 0; i < 3; i++) {
+            execute("INSERT INTO " + t + " (ts, sym, val) " +
+                    "SELECT timestamp_sequence('2024-01-01T0" + i + ":59:30', 1000)," +
+                    " 'S' || (x % 97), x::double FROM long_sequence(200000)");
+            drainWalQueue();
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexSingleTxnStraddleDifferentialFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexSingleTxnStraddleDifferentialFuzzTest.java
@@ -1,0 +1,228 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.fuzz;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.std.Rnd;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Differential equivalence proof for the SINGLE-TRANSACTION covering fast path.
+ * <p>
+ * {@link CoveringIndexFastPathDifferentialFuzzTest} is the sibling of this test
+ * and covers block-apply. It cannot cover this path: it drains only once per
+ * round, so several WAL transactions are pending per drain and
+ * {@code calculateInsertTransactionBlock} forms a BLOCK. Verified empirically --
+ * with the single-txn call site instrumented, that suite reaches it ZERO times,
+ * so running it against a single-txn change is vacuous.
+ * <p>
+ * This test drains after EVERY transaction, so every apply takes the
+ * {@code processWalCommit} single-transaction route, and partitions by HOUR with
+ * batch spans that routinely exceed an hour, so transactions STRADDLE a partition
+ * boundary -- the shape whose prefix the fast path must split off and whose
+ * overflow must still go through O3.
+ * <p>
+ * The same precomputed stream is replayed into two identically-shaped tables, one
+ * with {@code COVERING_FASTPATH_DISABLED = true} (everything through O3 +
+ * rebuildSidecars) and one with it active, then the two are asserted identical.
+ * The counters additionally prove the two modes genuinely diverged, so a green
+ * run cannot mean "the fast path never fired".
+ */
+public class CoveringIndexSingleTxnStraddleDifferentialFuzzTest extends AbstractFuzzTest {
+
+    @Before
+    public void enableCoveringCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
+        resetCounters();
+    }
+
+    @After
+    public void disableCoveringCountersAndFastPath() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+        PostingIndexWriter.COVERING_FASTPATH_DISABLED = false;
+    }
+
+    @Test
+    public void testSingleTxnStraddleDifferentialFuzz() throws Exception {
+        runDifferential(generateRandom(LOG));
+    }
+
+    @Test
+    public void testSingleTxnStraddleDifferentialFuzzRegression() throws Exception {
+        runDifferential(generateRandom(LOG, 0x51e3c7a90b4d26L, 0x1fa60c8b3d5e97L));
+    }
+
+    private void applyStream(String table, List<Op> ops, int symbolCardinality) throws Exception {
+        for (int i = 0, n = ops.size(); i < n; i++) {
+            Op op = ops.get(i);
+            if (op.truncate) {
+                execute("TRUNCATE TABLE " + table);
+            } else {
+                final String valueExpr = "(" + op.v0 + " + x)::DOUBLE";
+                execute("INSERT INTO " + table
+                        + " SELECT (" + op.startTs + " + x * " + op.step + ")::TIMESTAMP AS ts,"
+                        + " 'S' || ((" + op.v0 + " + x) % " + symbolCardinality + ") AS sym,"
+                        + " CASE WHEN ((" + op.v0 + " + x) % " + op.nullMod + ") = 0 THEN cast(NULL AS DOUBLE) ELSE " + valueExpr + " END AS value"
+                        + " FROM long_sequence(" + op.rows + ")");
+            }
+            // Drain after EVERY op: one pending WAL transaction per drain, so the
+            // apply job forms no block and takes the single-transaction route.
+            drainWalQueue();
+        }
+    }
+
+    private void assertTablesIdentical(int symbolCardinality) throws Exception {
+        assertSqlCursors(
+                "SELECT ts, sym, value FROM o3 ORDER BY ts, sym, value",
+                "SELECT ts, sym, value FROM fast ORDER BY ts, sym, value"
+        );
+        for (int s = 0; s < symbolCardinality; s++) {
+            final String sym = "S" + s;
+            assertSqlCursors(
+                    "SELECT ts, sym, value FROM o3 WHERE sym = '" + sym + "' ORDER BY value",
+                    "SELECT ts, sym, value FROM fast WHERE sym = '" + sym + "' ORDER BY value"
+            );
+            assertSqlCursors(
+                    "SELECT ts, sym FROM o3 WHERE sym = '" + sym + "' AND value IS NULL ORDER BY ts",
+                    "SELECT ts, sym FROM fast WHERE sym = '" + sym + "' AND value IS NULL ORDER BY ts"
+            );
+        }
+        assertSqlCursors(
+                "SELECT sym, sum(value), count(value), count(*), min(value), max(value) FROM o3 ORDER BY sym",
+                "SELECT sym, sum(value), count(value), count(*), min(value), max(value) FROM fast ORDER BY sym"
+        );
+    }
+
+    private List<Op> precomputeStream(Rnd rnd, int symbolCardinality) {
+        final List<Op> ops = new ArrayList<>();
+        long tsCursor = 1_700_000_000_000_000L;
+        long valueCursor = 0;
+        final int rounds = 60 + rnd.nextInt(40); // 60..99 transactions
+        for (int round = 0; round < rounds; round++) {
+            final int rows = 200 + rnd.nextInt(2000);
+            // Span is rows*step; with HOUR partitions (3.6e9 us) a step in this
+            // range puts most batches across at least one boundary, which is the
+            // case under test. Some land inside one partition, which exercises
+            // the whole-block prefix branch.
+            final long step = 1 + rnd.nextInt(4_000_000);
+            final int nullMod = 3 + rnd.nextInt(20);
+            // Occasional backward dip -> late data, disqualifies the fast path and
+            // must fall through to O3 unchanged.
+            final boolean dip = rnd.nextInt(100) < 12;
+            final long backOff = dip ? (long) (1 + rnd.nextInt(20)) * step * rows : 0;
+            final long startTs = dip ? tsCursor - backOff : tsCursor;
+            ops.add(new Op(false, startTs, valueCursor, rows, step, nullMod));
+            valueCursor += rows;
+            final long batchMaxTs = startTs + (long) rows * step;
+            if (batchMaxTs > tsCursor) {
+                tsCursor = batchMaxTs;
+            }
+            if (rnd.nextInt(100) < 5) {
+                ops.add(new Op(true, 0, 0, 0, 0, 0));
+                tsCursor += 2L * 24 * 60 * 60 * 1_000_000L;
+            }
+        }
+        return ops;
+    }
+
+    private void resetCounters() {
+        PostingIndexWriter.COVERING_FASTLAG_COMMIT_COUNT.set(0);
+        PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_BLOCK_FASTPATH_COUNT.set(0);
+    }
+
+    private void runDifferential(Rnd rnd) throws Exception {
+        setProperty(PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 10_000_000);
+        setProperty(PropertyKey.CAIRO_SQL_SORT_KEY_MAX_BYTES, 134_217_728);
+        setProperty(PropertyKey.CAIRO_SQL_SORT_LIGHT_VALUE_MAX_BYTES, 134_217_728);
+
+        final int symbolCardinality = 3 + rnd.nextInt(14); // 3..16
+        final List<Op> ops = precomputeStream(rnd, symbolCardinality);
+
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE o3 (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY HOUR WAL");
+            execute("CREATE TABLE fast (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY HOUR WAL");
+            drainWalQueue();
+
+            // Replay 1: fast path FORCED OFF.
+            PostingIndexWriter.COVERING_FASTPATH_DISABLED = true;
+            resetCounters();
+            applyStream("o3", ops, symbolCardinality);
+            final long o3FastPath = PostingIndexWriter.COVERING_BLOCK_FASTPATH_COUNT.get();
+            final long o3Reseals = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
+
+            // Replay 2: fast path ACTIVE.
+            PostingIndexWriter.COVERING_FASTPATH_DISABLED = false;
+            resetCounters();
+            applyStream("fast", ops, symbolCardinality);
+            final long fastFastPath = PostingIndexWriter.COVERING_BLOCK_FASTPATH_COUNT.get();
+            final long fastReseals = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
+
+            Assert.assertFalse("o3 suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("o3")));
+            Assert.assertFalse("fast suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("fast")));
+
+            // THE proof: identical results regardless of path.
+            assertTablesIdentical(symbolCardinality);
+
+            // Non-vacuity: the fast path must actually have fired, and only when
+            // enabled. Every apply here is single-transaction (drained one at a
+            // time), so any increment is this change's call site, not block-apply.
+            Assert.assertEquals("fast path fired while disabled", 0, o3FastPath);
+            Assert.assertTrue("single-txn fast path never fired -- test is vacuous", fastFastPath > 0);
+            Assert.assertTrue("fast run must avoid reseals the o3 run paid"
+                            + " (fastReseals=" + fastReseals + ", o3Reseals=" + o3Reseals + ")",
+                    fastReseals < o3Reseals);
+        });
+    }
+
+    // Encodes one precomputed operation replayed identically into both tables.
+    private static final class Op {
+        final int nullMod;
+        final int rows;
+        final long startTs;
+        final long step;
+        final boolean truncate;
+        final long v0;
+
+        Op(boolean truncate, long startTs, long v0, int rows, long step, int nullMod) {
+            this.truncate = truncate;
+            this.startTs = startTs;
+            this.v0 = v0;
+            this.rows = rows;
+            this.step = step;
+            this.nullMod = nullMod;
+        }
+    }
+}


### PR DESCRIPTION
Covering-index apply performance, plus the observability that made it findable. Five commits; supersedes #7575, #7578 and #7579, which are closed in favour of this.

## Where the time was going

A covering-indexed backfill applied at **1.6M rows/s** against **5.0M rows/s** of ingest. From 30 minutes of production logs: 28 transactions of 100M rows each; 20 landed inside a partition and took ~33 s, 8 crossed a partition boundary and took ~145 s. **The 8 straddling transactions were 61% of total wall time.**

Their cost was invisible. `o3 partition task` → `o3 partition update` bounded the O3 copy at 7–13 s, and `switched partition` → eject at ≤0.2 s, leaving **81–181 s in a completely unlogged gap**. `PostingIndexWriter` had ten INFO records and every one reported a deviation — an RSS-pressure fallback, an untrusted snapshot, a recovery — so the success path said nothing, and `sealPostingIndexesForO3Partitions` / `sealPostingIndexForPartition` / `rebuildSidecars` emitted nothing at all. Log levels are fixed at boot (`LogFactory.bind()` is one-shot; `reload_config()` covers no log key), so this was not answerable from a running server.

## Commits 1–2: observability

Four INFO records, purely additive:

```
posting index o3 reseal [table=, partitions=, rebuilt=, skippedRebuild=, timeMicros=]
posting index reseal partition [table=, partitionTs=, partitionSize=, canSkipRebuild=, columns=, covers=, timeMicros=]
posting index sidecars rebuilt [indexName=, sealTxn=, path=copy|seal, covers=, keys=, gens=, maxRowId=, sidecarBytes=, timeMicros=]
posting index sealed [indexName=, sealTxn=, path=incremental|full, streaming=, snapshotDeferred=, gens=in->out, keys=, covers=, valueBytes=, timeMicros=]
```

The seal record reports only state the writer already maintained for tests. `gens=in->out` also surfaces the generation count that drives `cairo.posting.seal.gen.threshold`, previously DEBUG-only and so unobtainable in production. Volume is O(partitions per commit) — for scale, the log that prompted this had 8,975 `QueryProgress` records against 13 from the entire posting-index subsystem.

## Commit 3: the straddle split — the 61%

#7414 taught the **block-apply** path to split a boundary-straddling block (`tryFastAppendInOrderBlock:13471`). The **single-transaction** path never got it; its gate is all-or-nothing:

```java
// applyFromWalLagToLastPartitionPossible:4789
&& lagMaxTimestamp <= Math.min(commitToTimestamp, partitionTimestampHi)
```

One row past the boundary disqualifies every row, so the whole transaction goes through O3 — including the prefix, which is a pure append — and pays a **full-partition `rebuildSidecars`** for rows nothing rewrote. This is the normal shape for a bulk `INSERT ... SELECT`, where transactions are large enough that `calculateInsertTransactionBlock` returns 1 and no block forms.

Reuses `tryFastAppendInOrderBlock` rather than duplicating it (its min/max become parameters). 1000-row straddle against an existing partition, `COVERING_FASTPATH_DISABLED` as the A/B switch:

| partition rows | off | on |
|---|---|---|
| 4M | 432–446 ms | **17 ms** |
| 8M | 544–555 ms | **17–19 ms** |
| 16M | 770–803 ms | **21–23 ms** |
| 32M | 1431–3029 ms | **27 ms** |

Off scales with partition size, on is flat: **O(partition) → O(new rows)**. Timing here is noisy, so the load-bearing evidence is structural — with the fast path on, the `o3 partition task` record for the *existing* partition disappears entirely.

**Commit 6 — FORMAT PARQUET.** The first CI run failed `TableFormatTest` on 16 cases: the first partition of a `FORMAT PARQUET` table stayed native. `processWalCommit` sets `noLag` for such a table and sends it down the full-commit path, because its partitions are born parquet from O3 and the native partition `openPartition` creates on an empty table exists only to hold LAG. The new call site sits inside that branch and did not honour `noLag`, and `tryFastAppendInOrderBlock` only rejected an *already*-parquet last partition — so on an empty such table `isLastPartitionParquet()` was false and the prefix committed into the placeholder as a native partition, skipping its parquet write for good. The guard now rejects `FORMAT PARQUET` tables in the callee, so both call sites carry it. `TableFormatTest` is 42/42; the straddle fuzz still asserts the fast path fired, so the guard has not made the optimisation vacuous.

## Commits 4–5: two gathers

There are two covered-gather implementations and they needed the same fix independently.

**Seal path** (`writeSidecarFixedStrideForColumn`) resolved the address per value *and* moved each value with `Unsafe.copyMemory` — a general memcpy for an 8-byte store. Resolving once per key and using a typed move: **2.5× at 32M rows**, marginal throughput 11.8M → 33.3M rows/s.

**Per-commit path** (`writeSidecarGenData`) is a different function, not covered by the above, and is the hotter of the two for an append workload — measured at **44–54% of a single-transaction apply**. Same hoist (its store was already typed): **1.44–1.91×**, median ~1.6×.

Both are byte-identical: they change how a value is addressed, never which value is written. A key's row ids ascend, so probing the last one performs any remap the run could need; the mapped length is carried alongside so a row id breaking that assumption falls back to the checked call rather than reading past the mapping.

## Verification

The existing `CoveringIndexFastPathDifferentialFuzzTest` **cannot** cover the straddle split — it drains once per round, so the apply job forms a block. Instrumented, it reaches the new call site **zero times**; green there would have been vacuous. So this adds `CoveringIndexSingleTxnStraddleDifferentialFuzzTest`: drains after every transaction, partitions by HOUR with spans that routinely straddle, includes backward dips so ineligible transactions still fall through to O3, replays one precomputed stream into two tables (fast path forced off vs active) and asserts them identical across full content, per-symbol covered reads, `IS NULL` reads and covered aggregates. It also asserts the path genuinely fired.

**Negative control:** with the new call site disabled, both cases fail on `single-txn fast path never fired -- test is vacuous`.

- Covering + posting + fuzz suites — **1457 tests, 0 failures**, all three row-id encodings (the gather feeds a different compressor in each)
- `MatViewTest`, `WalTableSqlTest`, `WalWriterTest` — **359 tests, 0 failures**, since `processWalCommit` is where this area regressed last time

## Expected effect

On the production workload above, projecting from these measurements: apply **1.6M → ~3.4M rows/s**. Ingest there is 5.0M rows/s, so apply still will not keep up unaffected — the loader needs throttling or further work.

## Measured and rejected

Three hypotheses were tested and dropped rather than shipped:

- **Random access in the gather.** A controlled experiment (identical row and key counts, incompressible payload so output size could not vary — `sidecarBytes` matched to 44 bytes) found scattered vs clustered layout within run-to-run noise, with the two reps disagreeing in direction. No scatter/gather rewrite.
- **Buffering the per-commit gather.** Staging into a scratch buffer and using `putBlockOfBytes` made it **slower** (517 ms vs 279 ms at 16.9M) — it doubles the stores, and this loop is memory-bound.
- **`sealIncremental` never firing.** Real, but not fixable and not a defect: gen 0 is sparse at a partition's only seal, so `isIncrementalCandidate` is false before the stride check is ever reached. The optimisation targets repeatedly-O3'd partitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BfaJLo5DkMMRvMoigd1dB

