### PR TITLE
perf(core): hoist per-value address resolution out of the sidecar gather

### DIFF
--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -7268,21 +7268,88 @@ public class PostingIndexWriter implements IndexWriter {
                 // Assemble this key's raw values into sidecarBuf.
                 long keyOff = keyOffsets[j];
                 long rawOffset = 0;
-                for (int i = 0; i < count; i++) {
-                    long rowId = Unsafe.getLong(
-                            mergedValuesAddr + (keyOff + i) * Long.BYTES);
-                    if (rowId < colTop) {
-                        writeNullSentinel(sidecarBuf + rawOffset, valueSize, colType);
-                    } else {
-                        long srcOffset = (rowId - colTop) << shift;
-                        long addr = getCoveredDataReadAddr(c, srcOffset, valueSize);
-                        if (addr != 0) {
-                            Unsafe.copyMemory(addr, sidecarBuf + rawOffset, valueSize);
-                        } else {
+
+                // Resolve the covered column's base address ONCE for this key
+                // instead of once per value. getCoveredDataReadAddr is only
+                // offset-dependent through its grow-remap check, and row ids
+                // within a key ascend (add() rejects a descending value and the
+                // gen merge preserves that), so probing the last row id first
+                // performs any remap the whole run could need; every lower
+                // offset then resolves to base + offset against the same
+                // mapping. A zero base (unmappable column) drops to the
+                // unchanged per-value path below.
+                long base = 0;
+                long baseLimit = 0;
+                long lastRowId = Unsafe.getLong(mergedValuesAddr + (keyOff + count - 1) * Long.BYTES);
+                if (lastRowId >= colTop && getCoveredDataReadAddr(c, (lastRowId - colTop) << shift, valueSize) != 0) {
+                    base = coveredColReadAddrs[c];
+                    // 0 means addr-based (caller-owned mapping): no length is
+                    // tracked, exactly as the per-value path assumes. Otherwise
+                    // keep the mapped length so a row id that breaks the
+                    // ascending assumption cannot read past the mapping -- it
+                    // falls back to the checked call rather than trusting base.
+                    baseLimit = coveredColReadSizes[c];
+                }
+
+                if (base != 0) {
+                    for (int i = 0; i < count; i++) {
+                        long rowId = Unsafe.getLong(mergedValuesAddr + (keyOff + i) * Long.BYTES);
+                        if (rowId < colTop) {
                             writeNullSentinel(sidecarBuf + rawOffset, valueSize, colType);
+                        } else {
+                            long srcOffset = (rowId - colTop) << shift;
+                            long addr;
+                            if (baseLimit == 0 || srcOffset + valueSize <= baseLimit) {
+                                addr = base + srcOffset;
+                            } else {
+                                addr = getCoveredDataReadAddr(c, srcOffset, valueSize);
+                            }
+                            if (addr != 0) {
+                                // Typed move for the power-of-two widths that
+                                // cover every fixed-size column type. An 8-byte
+                                // Unsafe.copyMemory is a general memcpy call;
+                                // TIMESTAMP / LONG / DOUBLE covers make this the
+                                // single hottest instruction of a reseal.
+                                switch (valueSize) {
+                                    case Long.BYTES:
+                                        Unsafe.putLong(sidecarBuf + rawOffset, Unsafe.getLong(addr));
+                                        break;
+                                    case Integer.BYTES:
+                                        Unsafe.putInt(sidecarBuf + rawOffset, Unsafe.getInt(addr));
+                                        break;
+                                    case Short.BYTES:
+                                        Unsafe.putShort(sidecarBuf + rawOffset, Unsafe.getShort(addr));
+                                        break;
+                                    case Byte.BYTES:
+                                        Unsafe.putByte(sidecarBuf + rawOffset, Unsafe.getByte(addr));
+                                        break;
+                                    default:
+                                        Unsafe.copyMemory(addr, sidecarBuf + rawOffset, valueSize);
+                                        break;
+                                }
+                            } else {
+                                writeNullSentinel(sidecarBuf + rawOffset, valueSize, colType);
+                            }
                         }
+                        rawOffset += valueSize;
                     }
-                    rawOffset += valueSize;
+                } else {
+                    for (int i = 0; i < count; i++) {
+                        long rowId = Unsafe.getLong(
+                                mergedValuesAddr + (keyOff + i) * Long.BYTES);
+                        if (rowId < colTop) {
+                            writeNullSentinel(sidecarBuf + rawOffset, valueSize, colType);
+                        } else {
+                            long srcOffset = (rowId - colTop) << shift;
+                            long addr = getCoveredDataReadAddr(c, srcOffset, valueSize);
+                            if (addr != 0) {
+                                Unsafe.copyMemory(addr, sidecarBuf + rawOffset, valueSize);
+                            } else {
+                                writeNullSentinel(sidecarBuf + rawOffset, valueSize, colType);
+                            }
+                        }
+                        rawOffset += valueSize;
+                    }
                 }
 
                 // Compress and write


### PR DESCRIPTION
## Why

`writeSidecarFixedStrideForColumn` assembles each key's covered values with a call to `getCoveredDataReadAddr` **per value**. That call re-enters `ensureCoveredColumnReadMaps`, reloads two array slots and re-tests the grow-remap condition — all loop-invariant for the key; only the offset varies. It then moves the value with `Unsafe.copyMemory`, a general memcpy call, for what is an 8-byte load/store on the TIMESTAMP / LONG / DOUBLE covers that dominate real covering indexes.

Both run once per covered value per column on every covering reseal. For a 531M-row partition with two covers that is ~1.06 billion of each.

This matters because a covering reseal is not rare: `sealPostingIndexesForO3Partitions` reaches `rebuildSidecars()` for the whole partition on **both** the rebuild and the `canSkipRebuild` path, so an O3 commit adding a handful of rows past the partition boundary still regathers everything.

## What

Resolve the base address once per key. Row ids within a key ascend (`add()` rejects a descending value and the gen merge preserves that), so probing the **last** row id first performs any remap the whole run could need; every lower offset then resolves against the same mapping. The mapped length is kept alongside the base, so a row id that broke the ascending assumption falls back to the checked call rather than reading past the mapping — the fast loop can never resolve an address the per-value path would not have. An unmappable column keeps the original per-value loop verbatim.

The move becomes a typed load/store for the power-of-two widths, falling back to `copyMemory` for anything wider.

Output is byte-identical: this changes how a value is addressed and moved, never which value is written.

## Measured

O3 reseal of a pure-append commit — two covers (the auto-included designated timestamp plus a `DOUBLE`), 2058 symbols, tmpfs, two runs each:

| partition rows | before | after | speedup |
|---|---|---|---|
| 4,000,100 | 619 / 576 ms | 417 / 422 ms | 1.4× |
| 8,000,100 | 787 / 714 ms | 351 / 395 ms | 2.0× |
| 16,000,100 | 1358 / 1247 ms | 536 / 607 ms | 2.3× |
| 32,000,100 | 2673 / 2641 ms | **1042 / 1064 ms** | **2.5×** |

Marginal throughput over the 16M→32M step: **11.8M → 33.3M rows/s (2.8×)**. The speedup grows with partition size because the per-reseal fixed cost is unchanged.

A/B was run with the same harness and protocol, alternating via `git stash`, not against a remembered baseline.

## Verification

`CoveringIndexTest`, `CoveringIndexTestDelta`, `CoveringIndexTestEf`, `CoveringIndexBlockApplySealTest`, `PostingIndexCriticalIssuesTest`, `CoveringCompressorTest`, `CoveringIndexSidecarFaultTest`, `CoveringIndexMultiKeyOrderingTest` — **1445 tests, 0 failures**. All three row-id encodings are covered because the gather feeds a different compressor in each.

## Related, not in this PR

The gather is now ~2.5× faster, but the larger win is not doing it at all. #7414 taught the **block-apply** path to split a partition-straddling block and fast-append the prefix (`tryFastAppendInOrderBlock`, `TableWriter.java:13471`). The **single-transaction** path's gate is still all-or-nothing — `applyFromWalLagToLastPartitionPossible:4789` requires `lagMaxTimestamp <= partitionTimestampHi` — so one ordered transaction that crosses a partition boundary sends the whole thing through O3 and pays a full-partition sidecar rebuild for a pure append. Porting the prefix split to that gate looks like the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BfaJLo5DkMMRvMoigd1dB
