### PR TITLE
perf(core): split a partition-straddling single WAL transaction

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -4704,7 +4704,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 // Non-eligible blocks fall through to the O3 path unchanged.
                 long o3ApplyLo;
                 if (!copiedToMemory) {
-                    o3ApplyLo = tryFastAppendInOrderBlock(o3Lo, o3LoHi, blockTransactionCount, timestampAddr);
+                    o3ApplyLo = tryFastAppendInOrderBlock(o3Lo, o3LoHi, blockTransactionCount, timestampAddr,
+                            segmentCopyInfo.getMinTimestamp(), segmentCopyInfo.getMaxTimestamp());
                 } else {
                     // SPIKE (phase-3 Task 1): the O3 sort has already gathered the
                     // merge-index-ordered rows into o3MemColumns1 (== o3Columns)
@@ -4715,7 +4716,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                     // covered publish + defer -- with NO O3CopyJob involvement
                     // (no A1 convergence). The append body is source-agnostic
                     // (reads o3Columns + o3Lo + timestampAddr), so it is shared.
-                    o3ApplyLo = tryFastAppendSortedBlock(o3Lo, o3LoHi, blockTransactionCount, timestampAddr);
+                    o3ApplyLo = tryFastAppendSortedBlock(o3Lo, o3LoHi, blockTransactionCount, timestampAddr,
+                            segmentCopyInfo.getMinTimestamp(), segmentCopyInfo.getMaxTimestamp());
                 }
                 // Skip the O3 finish ONLY when the fast path fired and consumed
                 // the ENTIRE block (o3ApplyLo advanced from o3Lo all the way to
@@ -4776,8 +4778,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
      *
      * @return the O3 overflow low row (see {@link #tryFastAppendInOrderBlock}).
      */
-    private long tryFastAppendSortedBlock(long o3Lo, long o3LoHi, int blockTransactionCount, long timestampAddr) {
-        return tryFastAppendInOrderBlock(o3Lo, o3LoHi, blockTransactionCount, timestampAddr);
+    private long tryFastAppendSortedBlock(long o3Lo, long o3LoHi, int blockTransactionCount, long timestampAddr,
+                                          long blockMin, long blockMax) {
+        return tryFastAppendInOrderBlock(o3Lo, o3LoHi, blockTransactionCount, timestampAddr, blockMin, blockMax);
     }
 
     private boolean applyFromWalLagToLastPartitionPossible(long commitToTimestamp, long lagRowCount, boolean lagOrdered, long committedMaxTimestamp, long lagMinTimestamp, long lagMaxTimestamp) {
@@ -10783,7 +10786,39 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 // in the next release after v7.3.9.
                 // Commit everything.
                 walLagRowCount = 0;
-                processWalCommitFinishApply(walLagRowCount, timestampAddr, o3Lo, o3Hi, pressureControl, copiedToMemory, initialPartitionTimestampHi);
+
+                // Single-txn sibling of the block-apply fast path. The gate that
+                // sent us here (applyFromWalLagToLastPartitionPossible, via
+                // canFastCommitNew) is all-or-nothing: it requires the WHOLE
+                // transaction to fit inside the last partition
+                // (lagMaxTimestamp <= partitionTimestampHi), so ONE row past the
+                // boundary disqualifies every row and routes the entire
+                // transaction through O3 -- including the prefix that is a pure
+                // append. On a covering index that costs a full-partition
+                // rebuildSidecars for rows nothing rewrote.
+                //
+                // tryFastAppendInOrderBlock already splits exactly this straddle
+                // for block-apply; reuse it. Only the not-copied branch is
+                // eligible: copiedToMemory means the sort gathered rows into
+                // o3MemColumns1 and re-based o3Lo to 0, which is the sorted-block
+                // shape (tryFastAppendSortedBlock) rather than this one. Every
+                // other precondition -- pure append, plain insert, native last
+                // partition, no lag, no legacy covering head -- is re-checked
+                // inside the callee, so a non-eligible transaction returns o3Lo
+                // and the O3 path below runs exactly as before.
+                long o3ApplyLo = o3Lo;
+                if (!copiedToMemory) {
+                    o3ApplyLo = tryFastAppendInOrderBlock(o3Lo, o3Hi, 1, timestampAddr, o3TimestampMin, o3TimestampMax);
+                }
+                // Mirrors the block-apply guard, including its zero-row case:
+                // o3ApplyLo == o3Lo means the fast path did not fire, so the
+                // whole transaction must still go through O3 -- and
+                // processWalCommitFinishApply's lag bookkeeping runs
+                // unconditionally, which a skipped empty commit once broke for a
+                // dependent materialized view's refresh range.
+                if (o3ApplyLo == o3Lo || o3ApplyLo < o3Hi) {
+                    processWalCommitFinishApply(walLagRowCount, timestampAddr, o3ApplyLo, o3Hi, pressureControl, copiedToMemory, initialPartitionTimestampHi);
+                }
             } finally {
                 finishO3Append(walLagRowCount);
                 o3Columns = o3MemColumns1;
@@ -13422,7 +13457,8 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         processPartitionRemoveCandidates();
     }
 
-    private long tryFastAppendInOrderBlock(long o3Lo, long o3LoHi, int blockTransactionCount, long timestampAddr) {
+    private long tryFastAppendInOrderBlock(long o3Lo, long o3LoHi, int blockTransactionCount, long timestampAddr,
+                                           long blockMin, long blockMax) {
         // @TestOnly override (default false, JIT-elided in production): force every
         // block through the unchanged O3 path so a differential test can prove the
         // fast path is result-equivalent to O3.
@@ -13430,7 +13466,6 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             return o3Lo;
         }
         final long blockRows = o3LoHi - o3Lo;
-        final long blockMin = segmentCopyInfo.getMinTimestamp();
         // Guards (fall back to the unchanged O3 path on any). Only a PURE APPEND
         // into the last NATIVE partition qualifies:
         //  - no pre-existing lag (block-apply never carries lag, but be defensive);
@@ -13468,9 +13503,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         // reads the 16-byte (timestamp, rowId) WAL timestamp-index format.
         final long prefixRows;
         final long prefixMax;
-        if (segmentCopyInfo.getMaxTimestamp() <= partitionTimestampHi) {
+        if (blockMax <= partitionTimestampHi) {
             prefixRows = blockRows;
-            prefixMax = segmentCopyInfo.getMaxTimestamp();
+            prefixMax = blockMax;
         } else {
             long lastPrefixIdx = Vect.boundedBinarySearchIndexT(timestampAddr, partitionTimestampHi, o3Lo, o3LoHi - 1, Vect.BIN_SEARCH_SCAN_DOWN);
             if (lastPrefixIdx < o3Lo) {
@@ -13531,7 +13566,7 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
             // them, so re-arm them to the OVERFLOW range [overflowLo, o3LoHi)
             // before the caller routes it through O3.
             txWriter.setLagMinTimestamp(getTimestampIndexValue(timestampAddr, overflowLo));
-            txWriter.setLagMaxTimestamp(segmentCopyInfo.getMaxTimestamp());
+            txWriter.setLagMaxTimestamp(blockMax);
         }
         return overflowLo;
     }

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexSingleTxnStraddleDifferentialFuzzTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/CoveringIndexSingleTxnStraddleDifferentialFuzzTest.java
@@ -1,0 +1,228 @@
+/*******************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.cairo.fuzz;
+
+import io.questdb.PropertyKey;
+import io.questdb.cairo.idx.PostingIndexWriter;
+import io.questdb.std.Rnd;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Differential equivalence proof for the SINGLE-TRANSACTION covering fast path.
+ * <p>
+ * {@link CoveringIndexFastPathDifferentialFuzzTest} is the sibling of this test
+ * and covers block-apply. It cannot cover this path: it drains only once per
+ * round, so several WAL transactions are pending per drain and
+ * {@code calculateInsertTransactionBlock} forms a BLOCK. Verified empirically --
+ * with the single-txn call site instrumented, that suite reaches it ZERO times,
+ * so running it against a single-txn change is vacuous.
+ * <p>
+ * This test drains after EVERY transaction, so every apply takes the
+ * {@code processWalCommit} single-transaction route, and partitions by HOUR with
+ * batch spans that routinely exceed an hour, so transactions STRADDLE a partition
+ * boundary -- the shape whose prefix the fast path must split off and whose
+ * overflow must still go through O3.
+ * <p>
+ * The same precomputed stream is replayed into two identically-shaped tables, one
+ * with {@code COVERING_FASTPATH_DISABLED = true} (everything through O3 +
+ * rebuildSidecars) and one with it active, then the two are asserted identical.
+ * The counters additionally prove the two modes genuinely diverged, so a green
+ * run cannot mean "the fast path never fired".
+ */
+public class CoveringIndexSingleTxnStraddleDifferentialFuzzTest extends AbstractFuzzTest {
+
+    @Before
+    public void enableCoveringCounters() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = true;
+        resetCounters();
+    }
+
+    @After
+    public void disableCoveringCountersAndFastPath() {
+        PostingIndexWriter.COVERING_COUNTERS_ENABLED = false;
+        PostingIndexWriter.COVERING_FASTPATH_DISABLED = false;
+    }
+
+    @Test
+    public void testSingleTxnStraddleDifferentialFuzz() throws Exception {
+        runDifferential(generateRandom(LOG));
+    }
+
+    @Test
+    public void testSingleTxnStraddleDifferentialFuzzRegression() throws Exception {
+        runDifferential(generateRandom(LOG, 0x51e3c7a90b4d26L, 0x1fa60c8b3d5e97L));
+    }
+
+    private void applyStream(String table, List<Op> ops, int symbolCardinality) throws Exception {
+        for (int i = 0, n = ops.size(); i < n; i++) {
+            Op op = ops.get(i);
+            if (op.truncate) {
+                execute("TRUNCATE TABLE " + table);
+            } else {
+                final String valueExpr = "(" + op.v0 + " + x)::DOUBLE";
+                execute("INSERT INTO " + table
+                        + " SELECT (" + op.startTs + " + x * " + op.step + ")::TIMESTAMP AS ts,"
+                        + " 'S' || ((" + op.v0 + " + x) % " + symbolCardinality + ") AS sym,"
+                        + " CASE WHEN ((" + op.v0 + " + x) % " + op.nullMod + ") = 0 THEN cast(NULL AS DOUBLE) ELSE " + valueExpr + " END AS value"
+                        + " FROM long_sequence(" + op.rows + ")");
+            }
+            // Drain after EVERY op: one pending WAL transaction per drain, so the
+            // apply job forms no block and takes the single-transaction route.
+            drainWalQueue();
+        }
+    }
+
+    private void assertTablesIdentical(int symbolCardinality) throws Exception {
+        assertSqlCursors(
+                "SELECT ts, sym, value FROM o3 ORDER BY ts, sym, value",
+                "SELECT ts, sym, value FROM fast ORDER BY ts, sym, value"
+        );
+        for (int s = 0; s < symbolCardinality; s++) {
+            final String sym = "S" + s;
+            assertSqlCursors(
+                    "SELECT ts, sym, value FROM o3 WHERE sym = '" + sym + "' ORDER BY value",
+                    "SELECT ts, sym, value FROM fast WHERE sym = '" + sym + "' ORDER BY value"
+            );
+            assertSqlCursors(
+                    "SELECT ts, sym FROM o3 WHERE sym = '" + sym + "' AND value IS NULL ORDER BY ts",
+                    "SELECT ts, sym FROM fast WHERE sym = '" + sym + "' AND value IS NULL ORDER BY ts"
+            );
+        }
+        assertSqlCursors(
+                "SELECT sym, sum(value), count(value), count(*), min(value), max(value) FROM o3 ORDER BY sym",
+                "SELECT sym, sum(value), count(value), count(*), min(value), max(value) FROM fast ORDER BY sym"
+        );
+    }
+
+    private List<Op> precomputeStream(Rnd rnd, int symbolCardinality) {
+        final List<Op> ops = new ArrayList<>();
+        long tsCursor = 1_700_000_000_000_000L;
+        long valueCursor = 0;
+        final int rounds = 60 + rnd.nextInt(40); // 60..99 transactions
+        for (int round = 0; round < rounds; round++) {
+            final int rows = 200 + rnd.nextInt(2000);
+            // Span is rows*step; with HOUR partitions (3.6e9 us) a step in this
+            // range puts most batches across at least one boundary, which is the
+            // case under test. Some land inside one partition, which exercises
+            // the whole-block prefix branch.
+            final long step = 1 + rnd.nextInt(4_000_000);
+            final int nullMod = 3 + rnd.nextInt(20);
+            // Occasional backward dip -> late data, disqualifies the fast path and
+            // must fall through to O3 unchanged.
+            final boolean dip = rnd.nextInt(100) < 12;
+            final long backOff = dip ? (long) (1 + rnd.nextInt(20)) * step * rows : 0;
+            final long startTs = dip ? tsCursor - backOff : tsCursor;
+            ops.add(new Op(false, startTs, valueCursor, rows, step, nullMod));
+            valueCursor += rows;
+            final long batchMaxTs = startTs + (long) rows * step;
+            if (batchMaxTs > tsCursor) {
+                tsCursor = batchMaxTs;
+            }
+            if (rnd.nextInt(100) < 5) {
+                ops.add(new Op(true, 0, 0, 0, 0, 0));
+                tsCursor += 2L * 24 * 60 * 60 * 1_000_000L;
+            }
+        }
+        return ops;
+    }
+
+    private void resetCounters() {
+        PostingIndexWriter.COVERING_FASTLAG_COMMIT_COUNT.set(0);
+        PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_AUTOSEAL_COUNT.set(0);
+        PostingIndexWriter.COVERING_BLOCK_FASTPATH_COUNT.set(0);
+    }
+
+    private void runDifferential(Rnd rnd) throws Exception {
+        setProperty(PropertyKey.CAIRO_WAL_SEGMENT_ROLLOVER_ROW_COUNT, 10_000_000);
+        setProperty(PropertyKey.CAIRO_SQL_SORT_KEY_MAX_BYTES, 134_217_728);
+        setProperty(PropertyKey.CAIRO_SQL_SORT_LIGHT_VALUE_MAX_BYTES, 134_217_728);
+
+        final int symbolCardinality = 3 + rnd.nextInt(14); // 3..16
+        final List<Op> ops = precomputeStream(rnd, symbolCardinality);
+
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE o3 (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY HOUR WAL");
+            execute("CREATE TABLE fast (ts TIMESTAMP, sym SYMBOL INDEX TYPE POSTING INCLUDE (value), value DOUBLE)"
+                    + " TIMESTAMP(ts) PARTITION BY HOUR WAL");
+            drainWalQueue();
+
+            // Replay 1: fast path FORCED OFF.
+            PostingIndexWriter.COVERING_FASTPATH_DISABLED = true;
+            resetCounters();
+            applyStream("o3", ops, symbolCardinality);
+            final long o3FastPath = PostingIndexWriter.COVERING_BLOCK_FASTPATH_COUNT.get();
+            final long o3Reseals = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
+
+            // Replay 2: fast path ACTIVE.
+            PostingIndexWriter.COVERING_FASTPATH_DISABLED = false;
+            resetCounters();
+            applyStream("fast", ops, symbolCardinality);
+            final long fastFastPath = PostingIndexWriter.COVERING_BLOCK_FASTPATH_COUNT.get();
+            final long fastReseals = PostingIndexWriter.COVERING_FULL_RESEAL_COUNT.get();
+
+            Assert.assertFalse("o3 suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("o3")));
+            Assert.assertFalse("fast suspended", engine.getTableSequencerAPI().isSuspended(engine.verifyTableName("fast")));
+
+            // THE proof: identical results regardless of path.
+            assertTablesIdentical(symbolCardinality);
+
+            // Non-vacuity: the fast path must actually have fired, and only when
+            // enabled. Every apply here is single-transaction (drained one at a
+            // time), so any increment is this change's call site, not block-apply.
+            Assert.assertEquals("fast path fired while disabled", 0, o3FastPath);
+            Assert.assertTrue("single-txn fast path never fired -- test is vacuous", fastFastPath > 0);
+            Assert.assertTrue("fast run must avoid reseals the o3 run paid"
+                            + " (fastReseals=" + fastReseals + ", o3Reseals=" + o3Reseals + ")",
+                    fastReseals < o3Reseals);
+        });
+    }
+
+    // Encodes one precomputed operation replayed identically into both tables.
+    private static final class Op {
+        final int nullMod;
+        final int rows;
+        final long startTs;
+        final long step;
+        final boolean truncate;
+        final long v0;
+
+        Op(boolean truncate, long startTs, long v0, int rows, long step, int nullMod) {
+            this.truncate = truncate;
+            this.startTs = startTs;
+            this.v0 = v0;
+            this.rows = rows;
+            this.step = step;
+            this.nullMod = nullMod;
+        }
+    }
+}


### PR DESCRIPTION
## The gap

#7414 taught the **block-apply** path to split a transaction block at a partition boundary — `tryFastAppendInOrderBlock` binary-searches the prefix landing in the last partition, fast-appends it as lag, and sends only the overflow to O3 (`TableWriter.java:13471`).

The **single-transaction** path never got that. Its gate is all-or-nothing:

```java
// applyFromWalLagToLastPartitionPossible:4789
&& lagMaxTimestamp <= Math.min(commitToTimestamp, partitionTimestampHi)
```

One row past the boundary disqualifies every row. The whole transaction goes through O3 — including the prefix, which is a pure append into the last partition. On a covering index that costs a **full-partition `rebuildSidecars`** via `sealPostingIndexesForO3Partitions` for rows nothing rewrote (that sweep reaches `rebuildSidecars()` on the `canSkipRebuild` path too).

This bites whenever transactions are large enough that the apply job forms no block — `calculateInsertTransactionBlock` returns 1 — which is the normal shape for a bulk `INSERT ... SELECT` backfill.

## The change

Reuses `tryFastAppendInOrderBlock` rather than duplicating it. It read its min/max from `segmentCopyInfo`, which is block-apply state, so those become parameters: the two block call sites pass `segmentCopyInfo`, the new single-txn site passes `o3TimestampMin` / `o3TimestampMax`.

Every other precondition — pure append, plain insert, native last partition, no lag, no legacy covering head — is re-checked inside the callee, so an ineligible transaction returns `o3Lo` and the O3 path runs exactly as before. Only the `!copiedToMemory` branch is eligible; `copiedToMemory` is the sorted-block shape. The guard around `processWalCommitFinishApply` mirrors the block path's, including its zero-row case (the one that once left a stale lag timestamp and mis-scoped a mat view's refresh range).

## Measured

1000-row transaction straddling the boundary of an existing partition; 2058 symbols, 2 covers, tmpfs. `COVERING_FASTPATH_DISABLED` as the in-process A/B switch:

| partition rows | fast path off | fast path on |
|---|---|---|
| 4,000,000 | 432–446 ms | **17 ms** |
| 8,000,000 | 544–555 ms | **17–19 ms** |
| 16,000,000 | 770–803 ms | **21–23 ms** |
| 32,000,000 | 1431–3029 ms | **27 ms** |

Off scales with partition size; on is flat. **O(partition) → O(new rows).**

Timing on this path is noisy (two unreproduced 572/916 ms readings at 32M), so the load-bearing evidence is structural and noise-free — with the fast path on, the `o3 partition task` record for the *existing* partition disappears entirely:

```
off: o3 partition task [partitionTs=2024-01-01, append=true, srcOooLo=0, srcDataMax=32000000, newSize=32000100]
     o3 partition task [partitionTs=2024-01-02, srcOooLo=100]
on:  o3 partition task [partitionTs=2024-01-02, srcOooLo=100]
```

## Verification — and why the existing fuzz was not enough

`CoveringIndexFastPathDifferentialFuzzTest` **cannot** cover this. It drains once per round, so several transactions are pending per drain and the apply job forms a block. I instrumented the new call site and ran that suite: it reaches it **zero times**. Green there would have been vacuous.

So this adds `CoveringIndexSingleTxnStraddleDifferentialFuzzTest`, built on the same harness:

- drains after **every** transaction, so every apply takes the single-transaction route;
- partitions by **HOUR** with batch spans that routinely exceed an hour, so transactions genuinely straddle;
- includes backward dips, so ineligible transactions must still fall through to O3 unchanged;
- replays one precomputed stream into two tables — fast path forced off vs active — and asserts them identical across full content, per-symbol covered reads, `IS NULL` covered reads and covered aggregates;
- asserts non-vacuity: the fast path fired when enabled and never when disabled, and the enabled run paid strictly fewer reseals.

**Negative control:** with the new call site disabled, both cases fail on `single-txn fast path never fired -- test is vacuous`. The test discriminates.

Regression, all green:
- `CoveringIndexSingleTxnStraddleDifferentialFuzzTest`, `CoveringIndexFastPathDifferentialFuzzTest`, `CoveringIndexFastPathConcurrentReadFuzzTest`, `CoveringIndexBlockApplySealTest`, `CoveringIndexTest` / `Delta` / `Ef`, `PostingIndexCriticalIssuesTest` — **1400 tests**
- `MatViewTest`, `WalTableSqlTest`, `WalWriterTest` — **359 tests** (1 pre-existing skip), since `processWalCommit` is the shared surface that regressed last time this area changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BfaJLo5DkMMRvMoigd1dB
