### PR TITLE
perf(core): hoist per-value address resolution out of the per-commit gather

### DIFF
--- a/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
+++ b/core/src/main/java/io/questdb/cairo/idx/PostingIndexWriter.java
@@ -7530,19 +7530,43 @@ public class PostingIndexWriter implements IndexWriter {
                     int key = activeKeyIds[idx];
                     int pendingCount = Unsafe.getInt(pendingCountsAddr + (long) key * Integer.BYTES);
                     int spillCount = getSpillCount(key);
+                    if (pendingCount + spillCount == 0) {
+                        continue;
+                    }
+                    final long spillAddr = spillCount > 0
+                            ? Unsafe.getLong(spillKeyAddrsAddr + (long) key * Long.BYTES)
+                            : 0;
+                    final long keyValuesAddr = pendingValuesAddr + (long) key * PENDING_SLOT_CAPACITY * Long.BYTES;
 
-                    if (spillCount > 0) {
-                        long spillAddr = Unsafe.getLong(spillKeyAddrsAddr + (long) key * Long.BYTES);
-                        for (int i = 0; i < spillCount; i++) {
-                            long rowId = Unsafe.getLong(spillAddr + (long) i * Long.BYTES);
-                            writeSidecarValueSafe(mem, c, colTop, rowId, shift, valueSize, colType);
-                        }
+                    // Resolve the covered column's base address ONCE per key rather
+                    // than once per value. This key's row ids ascend -- spill holds
+                    // the earlier ones and add() rejects a descending value -- so the
+                    // highest is the last pending entry, or the last spilled entry
+                    // when nothing is pending. Probing it performs any grow-remap the
+                    // whole run could need, after which every lower offset resolves
+                    // against the same mapping. baseLimit keeps the mapped length so
+                    // a row id that breaks the ascending assumption falls back to the
+                    // checked call instead of reading past it; 0 means addr-based
+                    // (caller-owned, no length tracked), matching what the per-value
+                    // path already assumes.
+                    final long keyMaxRowId = pendingCount > 0
+                            ? Unsafe.getLong(keyValuesAddr + (long) (pendingCount - 1) * Long.BYTES)
+                            : Unsafe.getLong(spillAddr + (long) (spillCount - 1) * Long.BYTES);
+                    long base = 0;
+                    long baseLimit = 0;
+                    if (keyMaxRowId >= colTop
+                            && getCoveredDataReadAddr(c, (keyMaxRowId - colTop) << shift, valueSize) != 0) {
+                        base = coveredColReadAddrs[c];
+                        baseLimit = coveredColReadSizes[c];
                     }
 
-                    long keyValuesAddr = pendingValuesAddr + (long) key * PENDING_SLOT_CAPACITY * Long.BYTES;
+                    for (int i = 0; i < spillCount; i++) {
+                        writeSidecarValueHoisted(mem, c, colTop, Unsafe.getLong(spillAddr + (long) i * Long.BYTES),
+                                shift, valueSize, colType, base, baseLimit);
+                    }
                     for (int i = 0; i < pendingCount; i++) {
-                        long rowId = Unsafe.getLong(keyValuesAddr + (long) i * Long.BYTES);
-                        writeSidecarValueSafe(mem, c, colTop, rowId, shift, valueSize, colType);
+                        writeSidecarValueHoisted(mem, c, colTop, Unsafe.getLong(keyValuesAddr + (long) i * Long.BYTES),
+                                shift, valueSize, colType, base, baseLimit);
                     }
                 }
             }
@@ -7606,6 +7630,48 @@ public class PostingIndexWriter implements IndexWriter {
             if (exceptionWorkspaceAddr != 0) {
                 Unsafe.free(exceptionWorkspaceAddr, maxKeyCount, MemoryTag.NATIVE_INDEX_READER);
             }
+        }
+    }
+
+    /**
+     * {@link #writeSidecarValueSafe} with the covered-column base address already
+     * resolved by the caller for the whole key run. Falls back to the checked
+     * per-value resolution when the caller could not resolve a base, or when the
+     * offset would leave a known mapped length -- so it can never address a byte
+     * the per-value path would not have.
+     *
+     * @param base      resolved covered-column base address, 0 when unresolved
+     * @param baseLimit mapped length behind {@code base}, 0 when caller-owned
+     */
+    private void writeSidecarValueHoisted(
+            MemoryMARW mem,
+            int covIdx,
+            long colTop,
+            long rowId,
+            int shift,
+            int valueSize,
+            int colType,
+            long base,
+            long baseLimit
+    ) {
+        if (rowId < colTop) {
+            writeNullSentinel(mem, valueSize, colType);
+            return;
+        }
+        final long srcOffset = (rowId - colTop) << shift;
+        long addr;
+        if (base != 0 && (baseLimit == 0 || srcOffset + valueSize <= baseLimit)) {
+            addr = base + srcOffset;
+        } else if (coveredColumnNames.size() > 0 || coveredColumnAddrs.size() > 0) {
+            addr = getCoveredDataReadAddr(covIdx, srcOffset, valueSize);
+        } else {
+            putFixedValue(mem, srcOffset, valueSize);
+            return;
+        }
+        if (addr == 0) {
+            writeNullSentinel(mem, valueSize, colType);
+        } else {
+            putFixedValue(mem, addr, valueSize);
         }
     }
 


### PR DESCRIPTION
## Measured first, then written

There are **two** covered-gather implementations in `PostingIndexWriter`, and #7575 only touched one:

| path | function | when it runs |
|---|---|---|
| seal / reseal | `writeSidecarFixedStrideForColumn` | only when a partition is resealed — #7575 |
| **every commit** | `writeSidecarGenData` → per-value | **every commit** — this PR |

Instrumenting the apply of a single in-partition transaction (which is what `job ejected time=` reports in production) shows the per-commit publish is the largest single component:

| rows | `writeSidecarGenData` | total apply | share |
|---|---|---|---|
| 8M | 143 ms | 325 ms | **44%** |
| 16M | 313 ms | 600 ms | **52%** |
| 32M | 622 ms (2 flushes) | 1150 ms | **54%** |

## The change

`writeSidecarGenData` walks each active key's spilled and pending row ids and appends the covered value for each, resolving the address with `getCoveredDataReadAddr` **per value** — re-entering `ensureCoveredColumnReadMaps`, reloading two array slots and re-testing the grow-remap condition, all loop-invariant for the key.

Resolve it once per key instead. A key's row ids ascend (spill holds the earlier ones, `add()` rejects a descending value), so the highest is the last pending entry — or the last spilled entry when nothing is pending. Probing it performs any grow-remap the run could need; every lower offset then resolves against the same mapping. The mapped length is carried alongside, so a row id that broke the ascending assumption falls back to the checked call rather than reading past the mapping — **the fast path can never address a byte the per-value path would not have**.

Unlike the seal path, `putFixedValue` here already did a typed store, so there is no memcpy to remove; the address resolution is the whole of it.

## Measured

Apply of one in-partition transaction; 2058 symbols, 2 covers (auto-included designated timestamp + `DOUBLE`), tmpfs. Medians of **three runs each arm**, A/B by swapping only this loop and keeping the timing instrumentation identical in both:

| values | before | after | speedup |
|---|---|---|---|
| 8,000,000 | 191.1 ms | 125.1 ms | **1.53×** |
| 15,122,362 | 382.1 ms | 200.1 ms | **1.91×** |
| 16,000,000 | 387.1 ms | 225.9 ms | **1.71×** |
| 16,877,638 | 402.3 ms | 279.2 ms | **1.44×** |

At ~50% of apply time, ~1.6× here is **~1.2× on apply overall**.

Output is byte-identical — this changes how a value is addressed, never which value is written or where it lands.

## Verification

`CoveringIndexTest` / `Delta` / `Ef`, `CoveringIndexBlockApplySealTest`, `CoveringIndexSidecarFaultTest`, `CoveringCompressorTest`, `CoveringIndexMultiKeyOrderingTest`, `PostingIndexCriticalIssuesTest`, `CoveringIndexFastPathDifferentialFuzzTest`, `CoveringIndexFastPathConcurrentReadFuzzTest` — **1455 tests, 0 failures**. All three row-id encodings are exercised, since the gather feeds a different compressor in each.

## Left on the table

After the hoist the remaining per-value cost is the `MemoryMARW` append itself — this path writes value-by-value where the seal path assembles into a scratch buffer and does one `putBlockOfBytes`. At ~7 ns/value there is probably another 1.5–2× in buffering it. That is a larger change and I would rather land and measure this one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BfaJLo5DkMMRvMoigd1dB
