### PR TITLE
fix(sql): fix a parallel GROUP BY or horizon join failure being misreported as a timeout

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLongTopKJob.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByLongTopKJob.java
@@ -26,7 +26,6 @@ package io.questdb.griffin.engine.groupby;
 
 import io.questdb.MessageBus;
 import io.questdb.cairo.map.Map;
-import io.questdb.cairo.sql.AtomicBooleanCircuitBreaker;
 import io.questdb.cairo.sql.Function;
 import io.questdb.griffin.engine.table.AsyncGroupByAtom;
 import io.questdb.griffin.engine.table.AsyncGroupByRecordCursorFactory;
@@ -59,7 +58,7 @@ public class GroupByLongTopKJob extends AbstractQueueConsumerJob<GroupByLongTopK
             long cursor,
             AsyncGroupByAtom stealingAtom
     ) {
-        final AtomicBooleanCircuitBreaker circuitBreaker = task.getCircuitBreaker();
+        final PostAggregationCircuitBreaker circuitBreaker = task.getCircuitBreaker();
         final AtomicInteger startedCounter = task.getStartedCounter();
         final CountDownLatchSPI doneLatch = task.getDoneLatch();
         final AsyncGroupByAtom atom = task.getAtom();
@@ -88,7 +87,7 @@ public class GroupByLongTopKJob extends AbstractQueueConsumerJob<GroupByLongTopK
             }
         } catch (Throwable th) {
             LOG.error().$("long top K on shard failed [error=").$(th).I$();
-            circuitBreaker.cancel();
+            circuitBreaker.cancel(th);
         } finally {
             doneLatch.countDown();
         }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByMergeShardJob.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/GroupByMergeShardJob.java
@@ -25,7 +25,6 @@
 package io.questdb.griffin.engine.groupby;
 
 import io.questdb.MessageBus;
-import io.questdb.cairo.sql.AtomicBooleanCircuitBreaker;
 import io.questdb.griffin.engine.table.GroupByShardingContext;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
@@ -55,7 +54,7 @@ public class GroupByMergeShardJob extends AbstractQueueConsumerJob<GroupByMergeS
             long cursor,
             GroupByShardingContext stealingCtx
     ) {
-        final AtomicBooleanCircuitBreaker circuitBreaker = task.getCircuitBreaker();
+        final PostAggregationCircuitBreaker circuitBreaker = task.getCircuitBreaker();
         final AtomicInteger startedCounter = task.getStartedCounter();
         final CountDownLatchSPI doneLatch = task.getDoneLatch();
         final GroupByShardingContext ctx = task.getShardingContext();
@@ -79,7 +78,7 @@ public class GroupByMergeShardJob extends AbstractQueueConsumerJob<GroupByMergeS
             }
         } catch (Throwable th) {
             LOG.error().$("merge shard failed [error=").$(th).I$();
-            circuitBreaker.cancel();
+            circuitBreaker.cancel(th);
         } finally {
             doneLatch.countDown();
         }

--- a/core/src/main/java/io/questdb/griffin/engine/groupby/PostAggregationCircuitBreaker.java
+++ b/core/src/main/java/io/questdb/griffin/engine/groupby/PostAggregationCircuitBreaker.java
@@ -1,0 +1,118 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.griffin.engine.groupby;
+
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ImplicitCastException;
+import io.questdb.cairo.sql.AtomicBooleanCircuitBreaker;
+import io.questdb.cairo.sql.async.AsyncQueryErrorKind;
+import io.questdb.std.FlyweightMessageContainer;
+import io.questdb.std.NumericException;
+import io.questdb.std.str.StringSink;
+
+/**
+ * Cancellation channel between the owner thread and the detached workers of a GROUP BY
+ * post-aggregation phase - the parallel shard merge and the parallel long top K. Carries the
+ * first error a worker raised alongside the flag, so the owner can rethrow it verbatim. Mirrors
+ * {@link io.questdb.cairo.sql.async.UnorderedPageFrameSequence#setError(Throwable)} for the
+ * reduce phase.
+ */
+public class PostAggregationCircuitBreaker extends AtomicBooleanCircuitBreaker {
+    private final StringSink errorMsg = new StringSink();
+    private int errno = CairoException.NON_CRITICAL;
+    private byte errorKind = AsyncQueryErrorKind.KIND_NONE;
+    private int errorMessagePosition;
+    private boolean isErrorCancellation;
+    private boolean isErrorInterruption;
+    private boolean isErrorOutOfMemory;
+
+    public PostAggregationCircuitBreaker(CairoEngine engine) {
+        super(engine);
+    }
+
+    /**
+     * Rebuilds the captured error. Call only when {@link #hasError()} returns true.
+     */
+    public synchronized RuntimeException buildError() {
+        return switch (errorKind) {
+            case AsyncQueryErrorKind.KIND_IMPLICIT_CAST ->
+                    ImplicitCastException.instance().position(errorMessagePosition).put(errorMsg);
+            case AsyncQueryErrorKind.KIND_NUMERIC ->
+                    NumericException.instance().position(errorMessagePosition).put(errorMsg);
+            default -> CairoException.critical(errno)
+                    .position(errorMessagePosition)
+                    .put(errorMsg)
+                    .setCancellation(isErrorCancellation)
+                    .setInterruption(isErrorInterruption)
+                    .setOutOfMemory(isErrorOutOfMemory);
+        };
+    }
+
+    /**
+     * Records the error and trips the breaker. The first error wins. An error raised once the
+     * breaker is already down is collateral - {@code PerWorkerLocks.acquireSlot} throws "query
+     * aborted" purely because it observed the trip - and would mask the real reason, so it is
+     * dropped. Thread-safe.
+     */
+    public synchronized void cancel(Throwable th) {
+        if (errorMsg.isEmpty() && !checkIfTripped()) {
+            errorKind = AsyncQueryErrorKind.of(th);
+            if (th instanceof CairoException e) {
+                errorMsg.put(e.getFlyweightMessage());
+                errorMessagePosition = e.getPosition();
+                errno = e.getErrno();
+                isErrorCancellation = e.isCancellation();
+                isErrorInterruption = e.isInterruption();
+                isErrorOutOfMemory = e.isOutOfMemory();
+            } else if (th instanceof FlyweightMessageContainer fmc) {
+                errorMsg.put(fmc.getFlyweightMessage());
+                errorMessagePosition = fmc.getPosition();
+            } else {
+                errorMsg.put("unexpected post-aggregation error");
+                if (th.getMessage() != null) {
+                    errorMsg.put(": ").put(th.getMessage());
+                }
+            }
+        }
+        cancel();
+    }
+
+    public synchronized boolean hasError() {
+        return !errorMsg.isEmpty();
+    }
+
+    @Override
+    public synchronized void reset() {
+        super.reset();
+        errorMsg.clear();
+        errorKind = AsyncQueryErrorKind.KIND_NONE;
+        errorMessagePosition = 0;
+        errno = CairoException.NON_CRITICAL;
+        isErrorCancellation = false;
+        isErrorInterruption = false;
+        isErrorOutOfMemory = false;
+    }
+}

--- a/core/src/main/java/io/questdb/griffin/engine/table/AdaptiveSymbolPatternRecordCursorFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AdaptiveSymbolPatternRecordCursorFactory.java
@@ -900,13 +900,11 @@ public class AdaptiveSymbolPatternRecordCursorFactory extends AbstractRecordCurs
         }
 
         @Override
-        public boolean hasParquetFormatPartitions(SqlExecutionContext executionContext) {
-            return delegate.hasParquetFormatPartitions(executionContext);
-        }
-
-        @Override
-        public void setPushdownFilterCondition(ObjList<PushdownFilterExtractor.PushdownFilterCondition> conditions) {
-            delegate.setPushdownFilterCondition(conditions);
+        public void setPushdownFilterCondition(
+                long partitionTableVersion,
+                @Nullable ObjList<PushdownFilterExtractor.PushdownFilterCondition> conditions
+        ) {
+            delegate.setPushdownFilterCondition(partitionTableVersion, conditions);
         }
 
         @Override

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
@@ -347,7 +347,6 @@ class AsyncGroupByRecordCursor implements RecordCursor {
     }
 
     private void throwPostAggregationException() {
-        // Precedence: the query's own breaker, then the worker's error, then the bare flag.
         circuitBreaker.statefulThrowExceptionIfTrippedNoThrottle();
         if (postAggregationCircuitBreaker.hasError()) {
             throw postAggregationCircuitBreaker.buildError();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncGroupByRecordCursor.java
@@ -31,7 +31,6 @@ import io.questdb.cairo.CairoException;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapRecordCursor;
 import io.questdb.cairo.map.ShardedMapCursor;
-import io.questdb.cairo.sql.AtomicBooleanCircuitBreaker;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
@@ -45,6 +44,7 @@ import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.SymbolFunction;
 import io.questdb.griffin.engine.groupby.GroupByLongTopKJob;
 import io.questdb.griffin.engine.groupby.GroupByUtils;
+import io.questdb.griffin.engine.groupby.PostAggregationCircuitBreaker;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.MCSequence;
@@ -68,7 +68,7 @@ class AsyncGroupByRecordCursor implements RecordCursor {
     private final MessageBus messageBus;
     // Borrowed non-group-by views into recordFunctions; the factory owns and closes the functions.
     private final ObjList<Function> nonGroupByFunctions;
-    private final AtomicBooleanCircuitBreaker postAggregationCircuitBreaker; // used to signal cancellation to merge shard workers
+    private final PostAggregationCircuitBreaker postAggregationCircuitBreaker; // used to signal cancellation to merge shard workers
     private final SOUnboundedCountDownLatch postAggregationDoneLatch = new SOUnboundedCountDownLatch(); // used for merge shard workers
     private final AtomicInteger postAggregationStartedCounter = new AtomicInteger();
     private final VirtualRecord recordA;
@@ -94,7 +94,7 @@ class AsyncGroupByRecordCursor implements RecordCursor {
         this.nonGroupByFunctions = GroupByUtils.extractNonGroupByFunctions(recordFunctions);
         recordA = new VirtualRecord(recordFunctions);
         recordB = new VirtualRecord(recordFunctions);
-        postAggregationCircuitBreaker = new AtomicBooleanCircuitBreaker(engine);
+        postAggregationCircuitBreaker = new PostAggregationCircuitBreaker(engine);
         // Start closed so the first of() runs atom.reopen(), which opens the lazy
         // (openOnInit=false) allocators and binds the per-query tracker before any
         // allocation. Skipping reopen() on the first cursor would leave the allocator's
@@ -222,7 +222,7 @@ class AsyncGroupByRecordCursor implements RecordCursor {
                     postAggregationStartedCounter
             );
             if (postAggregationCircuitBreaker.checkIfTripped()) {
-                throwTimeoutException();
+                throwPostAggregationException();
             }
             // The shards contain non-intersecting row groups, so we can return what's in the shards without merging them.
             shardedCursor.of(shards);
@@ -317,7 +317,7 @@ class AsyncGroupByRecordCursor implements RecordCursor {
         }
 
         if (postAggregationCircuitBreaker.checkIfTripped()) {
-            throwTimeoutException();
+            throwPostAggregationException();
         }
 
         // Now merge everything into the destination list.
@@ -346,12 +346,16 @@ class AsyncGroupByRecordCursor implements RecordCursor {
                 .I$();
     }
 
-    private void throwTimeoutException() {
+    private void throwPostAggregationException() {
+        // Precedence: the query's own breaker, then the worker's error, then the bare flag.
+        circuitBreaker.statefulThrowExceptionIfTrippedNoThrottle();
+        if (postAggregationCircuitBreaker.hasError()) {
+            throw postAggregationCircuitBreaker.buildError();
+        }
         if (frameSequence.getCancelReason() == SqlExecutionCircuitBreaker.STATE_CANCELLED) {
             throw CairoException.queryCancelled();
-        } else {
-            throw CairoException.queryTimedOut();
         }
+        throw CairoException.queryTimedOut();
     }
 
     void buildMapConditionally() {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinRecordCursor.java
@@ -250,7 +250,6 @@ class AsyncHorizonJoinRecordCursor implements RecordCursor {
     }
 
     private void throwPostAggregationException() {
-        // Precedence: the query's own breaker, then the worker's error, then the bare flag.
         circuitBreaker.statefulThrowExceptionIfTrippedNoThrottle();
         if (postAggregationCircuitBreaker.hasError()) {
             throw postAggregationCircuitBreaker.buildError();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncHorizonJoinRecordCursor.java
@@ -30,7 +30,6 @@ import io.questdb.cairo.CairoException;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapRecordCursor;
 import io.questdb.cairo.map.ShardedMapCursor;
-import io.questdb.cairo.sql.AtomicBooleanCircuitBreaker;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
@@ -43,6 +42,7 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.SymbolFunction;
 import io.questdb.griffin.engine.groupby.GroupByUtils;
+import io.questdb.griffin.engine.groupby.PostAggregationCircuitBreaker;
 import io.questdb.mp.SOUnboundedCountDownLatch;
 import io.questdb.std.Misc;
 import io.questdb.std.ObjList;
@@ -55,7 +55,7 @@ class AsyncHorizonJoinRecordCursor implements RecordCursor {
     private final MessageBus messageBus;
     // Borrowed non-group-by views into recordFunctions; the factory owns and closes the functions.
     private final ObjList<Function> nonGroupByFunctions;
-    private final AtomicBooleanCircuitBreaker postAggregationCircuitBreaker;
+    private final PostAggregationCircuitBreaker postAggregationCircuitBreaker;
     private final SOUnboundedCountDownLatch postAggregationDoneLatch = new SOUnboundedCountDownLatch();
     private final AtomicInteger postAggregationStartedCounter = new AtomicInteger();
     private final VirtualRecord recordA;
@@ -85,7 +85,7 @@ class AsyncHorizonJoinRecordCursor implements RecordCursor {
             this.isOpen = true;
             this.slaveTimeFrameState = new ConcurrentTimeFrameState();
             this.messageBus = messageBus;
-            this.postAggregationCircuitBreaker = new AtomicBooleanCircuitBreaker(engine);
+            this.postAggregationCircuitBreaker = new PostAggregationCircuitBreaker(engine);
             this.recordFunctions = recordFunctions;
             this.nonGroupByFunctions = GroupByUtils.extractNonGroupByFunctions(recordFunctions);
             this.slaveFactory = slaveFactory;
@@ -206,7 +206,7 @@ class AsyncHorizonJoinRecordCursor implements RecordCursor {
                     postAggregationStartedCounter
             );
             if (postAggregationCircuitBreaker.checkIfTripped()) {
-                throwTimeoutException();
+                throwPostAggregationException();
             }
             shardedCursor.of(shards);
             mapCursor = shardedCursor;
@@ -249,12 +249,16 @@ class AsyncHorizonJoinRecordCursor implements RecordCursor {
         }
     }
 
-    private void throwTimeoutException() {
+    private void throwPostAggregationException() {
+        // Precedence: the query's own breaker, then the worker's error, then the bare flag.
+        circuitBreaker.statefulThrowExceptionIfTrippedNoThrottle();
+        if (postAggregationCircuitBreaker.hasError()) {
+            throw postAggregationCircuitBreaker.buildError();
+        }
         if (frameSequence.getCancelReason() == SqlExecutionCircuitBreaker.STATE_CANCELLED) {
             throw CairoException.queryCancelled();
-        } else {
-            throw CairoException.queryTimedOut();
         }
+        throw CairoException.queryTimedOut();
     }
 
     void of(UnorderedPageFrameSequence<AsyncHorizonJoinAtom> frameSequence, SqlExecutionContext executionContext) throws SqlException {

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinRecordCursor.java
@@ -281,7 +281,6 @@ class AsyncMultiHorizonJoinRecordCursor implements RecordCursor {
     }
 
     private void throwPostAggregationException() {
-        // Precedence: the query's own breaker, then the worker's error, then the bare flag.
         circuitBreaker.statefulThrowExceptionIfTrippedNoThrottle();
         if (postAggregationCircuitBreaker.hasError()) {
             throw postAggregationCircuitBreaker.buildError();

--- a/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinRecordCursor.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/AsyncMultiHorizonJoinRecordCursor.java
@@ -30,7 +30,6 @@ import io.questdb.cairo.CairoException;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapRecordCursor;
 import io.questdb.cairo.map.ShardedMapCursor;
-import io.questdb.cairo.sql.AtomicBooleanCircuitBreaker;
 import io.questdb.cairo.sql.Function;
 import io.questdb.cairo.sql.Record;
 import io.questdb.cairo.sql.RecordCursor;
@@ -44,6 +43,7 @@ import io.questdb.griffin.SqlException;
 import io.questdb.griffin.SqlExecutionContext;
 import io.questdb.griffin.engine.functions.SymbolFunction;
 import io.questdb.griffin.engine.groupby.GroupByUtils;
+import io.questdb.griffin.engine.groupby.PostAggregationCircuitBreaker;
 import io.questdb.mp.SOUnboundedCountDownLatch;
 import io.questdb.std.Misc;
 import io.questdb.std.ObjList;
@@ -60,7 +60,7 @@ class AsyncMultiHorizonJoinRecordCursor implements RecordCursor {
     private final MessageBus messageBus;
     // Borrowed non-group-by views into recordFunctions; the factory owns and closes the functions.
     private final ObjList<Function> nonGroupByFunctions;
-    private final AtomicBooleanCircuitBreaker postAggregationCircuitBreaker;
+    private final PostAggregationCircuitBreaker postAggregationCircuitBreaker;
     private final SOUnboundedCountDownLatch postAggregationDoneLatch = new SOUnboundedCountDownLatch();
     private final AtomicInteger postAggregationStartedCounter = new AtomicInteger();
     private final VirtualRecord recordA;
@@ -91,7 +91,7 @@ class AsyncMultiHorizonJoinRecordCursor implements RecordCursor {
             // cursor and free what was already allocated.
             this.isOpen = true;
             this.messageBus = messageBus;
-            this.postAggregationCircuitBreaker = new AtomicBooleanCircuitBreaker(engine);
+            this.postAggregationCircuitBreaker = new PostAggregationCircuitBreaker(engine);
             this.recordFunctions = recordFunctions;
             this.nonGroupByFunctions = GroupByUtils.extractNonGroupByFunctions(recordFunctions);
             this.slaveFactories = slaveFactories;
@@ -222,7 +222,7 @@ class AsyncMultiHorizonJoinRecordCursor implements RecordCursor {
                     postAggregationStartedCounter
             );
             if (postAggregationCircuitBreaker.checkIfTripped()) {
-                throwTimeoutException();
+                throwPostAggregationException();
             }
             shardedCursor.of(shards);
             mapCursor = shardedCursor;
@@ -280,12 +280,16 @@ class AsyncMultiHorizonJoinRecordCursor implements RecordCursor {
         }
     }
 
-    private void throwTimeoutException() {
+    private void throwPostAggregationException() {
+        // Precedence: the query's own breaker, then the worker's error, then the bare flag.
+        circuitBreaker.statefulThrowExceptionIfTrippedNoThrottle();
+        if (postAggregationCircuitBreaker.hasError()) {
+            throw postAggregationCircuitBreaker.buildError();
+        }
         if (frameSequence.getCancelReason() == SqlExecutionCircuitBreaker.STATE_CANCELLED) {
             throw CairoException.queryCancelled();
-        } else {
-            throw CairoException.queryTimedOut();
         }
+        throw CairoException.queryTimedOut();
     }
 
     void of(UnorderedPageFrameSequence<AsyncMultiHorizonJoinAtom> frameSequence, SqlExecutionContext executionContext) throws SqlException {

--- a/core/src/main/java/io/questdb/griffin/engine/table/GroupByShardingContext.java
+++ b/core/src/main/java/io/questdb/griffin/engine/table/GroupByShardingContext.java
@@ -29,13 +29,13 @@ import io.questdb.cairo.CairoConfiguration;
 import io.questdb.cairo.ColumnTypes;
 import io.questdb.cairo.map.Map;
 import io.questdb.cairo.map.MapFactory;
-import io.questdb.cairo.sql.AtomicBooleanCircuitBreaker;
 import io.questdb.cairo.sql.ExecutionCircuitBreaker;
 import io.questdb.cairo.sql.SqlExecutionCircuitBreaker;
 import io.questdb.cairo.sql.async.WorkStealingStrategy;
 import io.questdb.griffin.engine.PerWorkerLocks;
 import io.questdb.griffin.engine.groupby.GroupByFunctionsUpdater;
 import io.questdb.griffin.engine.groupby.GroupByMergeShardJob;
+import io.questdb.griffin.engine.groupby.PostAggregationCircuitBreaker;
 import io.questdb.log.Log;
 import io.questdb.log.LogFactory;
 import io.questdb.mp.MCSequence;
@@ -367,7 +367,7 @@ public class GroupByShardingContext implements QuietCloseable, Mutable {
             MessageBus messageBus,
             WorkStealingStrategy workStealingStrategy,
             SqlExecutionCircuitBreaker circuitBreaker,
-            AtomicBooleanCircuitBreaker postAggregationCircuitBreaker,
+            PostAggregationCircuitBreaker postAggregationCircuitBreaker,
             SOUnboundedCountDownLatch postAggregationDoneLatch,
             AtomicInteger postAggregationStartedCounter
     ) {

--- a/core/src/main/java/io/questdb/tasks/GroupByLongTopKTask.java
+++ b/core/src/main/java/io/questdb/tasks/GroupByLongTopKTask.java
@@ -24,8 +24,8 @@
 
 package io.questdb.tasks;
 
-import io.questdb.cairo.sql.AtomicBooleanCircuitBreaker;
 import io.questdb.cairo.sql.Function;
+import io.questdb.griffin.engine.groupby.PostAggregationCircuitBreaker;
 import io.questdb.griffin.engine.table.AsyncGroupByAtom;
 import io.questdb.mp.CountDownLatchSPI;
 import io.questdb.std.Mutable;
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class GroupByLongTopKTask implements Mutable {
     private AsyncGroupByAtom atom;
-    private AtomicBooleanCircuitBreaker circuitBreaker;
+    private PostAggregationCircuitBreaker circuitBreaker;
     private CountDownLatchSPI doneLatch;
     private Function func;
     private int limit = -1;
@@ -58,7 +58,7 @@ public class GroupByLongTopKTask implements Mutable {
         return atom;
     }
 
-    public AtomicBooleanCircuitBreaker getCircuitBreaker() {
+    public PostAggregationCircuitBreaker getCircuitBreaker() {
         return circuitBreaker;
     }
 
@@ -87,7 +87,7 @@ public class GroupByLongTopKTask implements Mutable {
     }
 
     public void of(
-            AtomicBooleanCircuitBreaker circuitBreaker,
+            PostAggregationCircuitBreaker circuitBreaker,
             AtomicInteger startedCounter,
             CountDownLatchSPI doneLatch,
             AsyncGroupByAtom atom,

--- a/core/src/main/java/io/questdb/tasks/GroupByMergeShardTask.java
+++ b/core/src/main/java/io/questdb/tasks/GroupByMergeShardTask.java
@@ -24,7 +24,7 @@
 
 package io.questdb.tasks;
 
-import io.questdb.cairo.sql.AtomicBooleanCircuitBreaker;
+import io.questdb.griffin.engine.groupby.PostAggregationCircuitBreaker;
 import io.questdb.griffin.engine.table.GroupByShardingContext;
 import io.questdb.mp.CountDownLatchSPI;
 import io.questdb.std.Mutable;
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class GroupByMergeShardTask implements Mutable {
     private GroupByShardingContext shardingCtx;
-    private AtomicBooleanCircuitBreaker circuitBreaker;
+    private PostAggregationCircuitBreaker circuitBreaker;
     private CountDownLatchSPI doneLatch;
     private int shardIndex = -1;
     private AtomicInteger startedCounter;
@@ -51,7 +51,7 @@ public class GroupByMergeShardTask implements Mutable {
         return shardingCtx;
     }
 
-    public AtomicBooleanCircuitBreaker getCircuitBreaker() {
+    public PostAggregationCircuitBreaker getCircuitBreaker() {
         return circuitBreaker;
     }
 
@@ -68,7 +68,7 @@ public class GroupByMergeShardTask implements Mutable {
     }
 
     public void of(
-            AtomicBooleanCircuitBreaker circuitBreaker,
+            PostAggregationCircuitBreaker circuitBreaker,
             AtomicInteger startedCounter,
             CountDownLatchSPI doneLatch,
             GroupByShardingContext shardingCtx,

--- a/core/src/test/java/io/questdb/test/griffin/ParallelGroupByMemoryTrackerTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/ParallelGroupByMemoryTrackerTest.java
@@ -60,16 +60,15 @@ import org.junit.Test;
  * per-query limit is therefore read fresh by every test and can be set in
  * {@link #setUp()}.
  * <p>
- * Breaches are asserted only for the reduce phase (per-worker map growth, shard
- * fill, and per-worker allocator growth) and the owner-side merge, where the
- * offending {@code CairoException} surfaces verbatim through
- * {@code UnorderedPageFrameSequence.dispatchAndAwait} with {@code isOutOfMemory()}
- * set. A breach inside the parallel shard-merge job is caught there and converted
- * to a cancellation, so it is intentionally not used as a breach probe. The
- * sharded path's allocation accounting is exercised instead by a success + leak
- * loop, and more broadly by {@code ParallelGroupByFuzzTest}, whose
- * {@code recordPerQueryMemAlloc} assertion is live on the default (unlimited)
- * tracker.
+ * A breach surfaces with {@code isOutOfMemory()} set from every phase. The reduce phase
+ * and the owner-side merge rethrow the offending {@code CairoException} through
+ * {@code UnorderedPageFrameSequence.dispatchAndAwait}; the detached shard-merge and long
+ * top K workers record it on the {@code PostAggregationCircuitBreaker} instead, and the
+ * owner rebuilds it there. Which phase trips first depends on how the page frames fan out
+ * across the pool - see {@link #testParallelKeyedGroupByBreachSurfacesFromEitherPhase()}.
+ * The sharded path's allocation accounting is exercised by a success + leak loop, and more
+ * broadly by {@code ParallelGroupByFuzzTest}, whose {@code recordPerQueryMemAlloc}
+ * assertion is live on the default (unlimited) tracker.
  */
 public class ParallelGroupByMemoryTrackerTest extends AbstractCairoTest {
 
@@ -95,12 +94,56 @@ public class ParallelGroupByMemoryTrackerTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testParallelKeyedGroupByBreachSurfacesFromEitherPhase() throws Exception {
+        // The parallel shard merge peaks roughly twice as high as the reduce, since the
+        // destination shards grow while the source fragments are still alive. Sweeping the limit
+        // across that band breaches in the reduce at the low end, in the merge in the middle, and
+        // completes at the high end; every breach must name the limit and carry isOutOfMemory().
+        assertMemoryLeak(() -> {
+            final WorkerPool pool = new WorkerPool(() -> 4);
+            TestUtils.execute(
+                    pool,
+                    (engine, compiler, sqlExecutionContext) -> {
+                        engine.execute(
+                                "CREATE TABLE tab (ts TIMESTAMP, k VARCHAR, v LONG) timestamp(ts) PARTITION BY DAY",
+                                sqlExecutionContext
+                        );
+                        engine.execute(
+                                "INSERT INTO tab SELECT (x * 1_000_000)::timestamp, x::varchar, x FROM long_sequence(200_000)",
+                                sqlExecutionContext
+                        );
+                        for (long limit = 4 * 1024 * 1024L; limit <= 32 * 1024 * 1024L; limit += 2 * 1024 * 1024L) {
+                            // The provider reads the limit when it acquires the tracker.
+                            setProperty(PropertyKey.CAIRO_QUERY_MEMORY_LIMIT_BYTES, limit);
+                            try (RecordCursorFactory factory = compiler.compile("SELECT k, count(*) FROM tab GROUP BY k", sqlExecutionContext).getRecordCursorFactory()) {
+                                assertInTree(factory, AsyncGroupByRecordCursorFactory.class);
+                                try (RecordCursor cursor = factory.getCursor(sqlExecutionContext)) {
+                                    long rows = 0;
+                                    while (cursor.hasNext()) {
+                                        rows++;
+                                    }
+                                    Assert.assertEquals("wrong row count at limit " + limit, 200_000, rows);
+                                } catch (CairoException e) {
+                                    Assert.assertTrue("expected isOutOfMemory() at limit " + limit + ", got: " + e.getFlyweightMessage(), e.isOutOfMemory());
+                                    TestUtils.assertContains(e.getFlyweightMessage(), "query memory limit exceeded");
+                                    TestUtils.assertContains(e.getFlyweightMessage(), "workload=QUERY");
+                                }
+                            }
+                        }
+                    },
+                    configuration,
+                    LOG
+            );
+        });
+    }
+
+    @Test
     public void testParallelKeyedGroupByFailsOnLargeKeySet() throws Exception {
         // High-cardinality VARCHAR-keyed GROUP BY routes through the parallel
         // AsyncGroupByRecordCursorFactory (VARCHAR keys are not vectorized). The
         // per-worker fragment maps grow with the key set, shard once they cross the
-        // threshold, and the combined growth trips the per-query limit during the
-        // reduce - the breach surfaces with isOutOfMemory() set.
+        // threshold, and the combined growth trips the per-query limit - in the reduce,
+        // or in the shard merge when the reduce finishes just under it.
         assertMemoryLeak(() -> {
             final WorkerPool pool = new WorkerPool(() -> 4);
             TestUtils.execute(

--- a/core/src/test/java/io/questdb/test/griffin/engine/groupby/PostAggregationCircuitBreakerTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/groupby/PostAggregationCircuitBreakerTest.java
@@ -1,0 +1,212 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.griffin.engine.groupby;
+
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.ImplicitCastException;
+import io.questdb.griffin.engine.groupby.GroupByLongTopKJob;
+import io.questdb.griffin.engine.groupby.GroupByMergeShardJob;
+import io.questdb.griffin.engine.groupby.PostAggregationCircuitBreaker;
+import io.questdb.mp.RingQueue;
+import io.questdb.mp.SCSequence;
+import io.questdb.mp.SOUnboundedCountDownLatch;
+import io.questdb.mp.SPSequence;
+import io.questdb.std.NumericException;
+import io.questdb.tasks.GroupByLongTopKTask;
+import io.questdb.tasks.GroupByMergeShardTask;
+import io.questdb.test.AbstractCairoTest;
+import io.questdb.test.tools.TestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Unit tests for the error slot the detached merge shard and long top K workers use to hand
+ * their failure to the owner thread.
+ */
+public class PostAggregationCircuitBreakerTest extends AbstractCairoTest {
+
+    @Test
+    public void testCancelWithoutErrorTripsWithNoErrorRecorded() {
+        final PostAggregationCircuitBreaker breaker = new PostAggregationCircuitBreaker(engine);
+        breaker.cancel();
+        Assert.assertTrue(breaker.checkIfTripped());
+        Assert.assertFalse(breaker.hasError());
+    }
+
+    @Test
+    public void testCollateralErrorAfterTripIsDropped() {
+        // A worker spinning in PerWorkerLocks.acquireSlot throws "query aborted" purely because
+        // it observed the trip; that must not become the reported reason.
+        final PostAggregationCircuitBreaker breaker = new PostAggregationCircuitBreaker(engine);
+        breaker.cancel();
+        breaker.cancel(CairoException.nonCritical().put("query aborted").setInterruption(true));
+        Assert.assertFalse(breaker.hasError());
+    }
+
+    @Test
+    public void testFirstErrorWins() {
+        final PostAggregationCircuitBreaker breaker = new PostAggregationCircuitBreaker(engine);
+        breaker.cancel(CairoException.nonCritical().put("first"));
+        breaker.cancel(CairoException.nonCritical().put("second"));
+        TestUtils.assertContains(((CairoException) breaker.buildError()).getFlyweightMessage(), "first");
+    }
+
+    @Test
+    public void testPreservesCairoExceptionFlags() {
+        final PostAggregationCircuitBreaker breaker = new PostAggregationCircuitBreaker(engine);
+        breaker.cancel(
+                CairoException.nonCritical()
+                        .put("query memory limit exceeded [workload=QUERY]")
+                        .position(42)
+                        .setOutOfMemory(true)
+        );
+
+        Assert.assertTrue(breaker.checkIfTripped());
+        Assert.assertTrue(breaker.hasError());
+
+        final RuntimeException error = breaker.buildError();
+        Assert.assertTrue(error instanceof CairoException);
+        final CairoException e = (CairoException) error;
+        Assert.assertTrue(e.isOutOfMemory());
+        Assert.assertFalse(e.isCritical());
+        Assert.assertEquals(42, e.getPosition());
+        TestUtils.assertContains(e.getFlyweightMessage(), "query memory limit exceeded [workload=QUERY]");
+    }
+
+    @Test
+    public void testPreservesCancellationAndErrno() {
+        final PostAggregationCircuitBreaker breaker = new PostAggregationCircuitBreaker(engine);
+        breaker.cancel(CairoException.critical(13).put("boom").setCancellation(true).setInterruption(true));
+
+        final CairoException e = (CairoException) breaker.buildError();
+        Assert.assertEquals(13, e.getErrno());
+        Assert.assertTrue(e.isCritical());
+        Assert.assertTrue(e.isCancellation());
+        Assert.assertTrue(e.isInterruption());
+        TestUtils.assertContains(e.getFlyweightMessage(), "boom");
+    }
+
+    @Test
+    public void testRebuildsImplicitCastException() {
+        final PostAggregationCircuitBreaker breaker = new PostAggregationCircuitBreaker(engine);
+        breaker.cancel(ImplicitCastException.instance().put("inconvertible value").position(7));
+
+        final RuntimeException error = breaker.buildError();
+        Assert.assertTrue(error instanceof ImplicitCastException);
+        final ImplicitCastException e = (ImplicitCastException) error;
+        Assert.assertEquals(7, e.getPosition());
+        TestUtils.assertContains(e.getFlyweightMessage(), "inconvertible value");
+    }
+
+    @Test
+    public void testRebuildsNumericException() {
+        final PostAggregationCircuitBreaker breaker = new PostAggregationCircuitBreaker(engine);
+        breaker.cancel(NumericException.instance().put("not a number").position(3));
+
+        final RuntimeException error = breaker.buildError();
+        Assert.assertTrue(error instanceof NumericException);
+        final NumericException e = (NumericException) error;
+        Assert.assertEquals(3, e.getPosition());
+        TestUtils.assertContains(e.getFlyweightMessage(), "not a number");
+    }
+
+    @Test
+    public void testResetClearsErrorAndFlag() {
+        final PostAggregationCircuitBreaker breaker = new PostAggregationCircuitBreaker(engine);
+        breaker.cancel(CairoException.nonCritical().put("stale").setOutOfMemory(true));
+        Assert.assertTrue(breaker.hasError());
+
+        breaker.reset();
+        Assert.assertFalse(breaker.checkIfTripped());
+        Assert.assertFalse(breaker.hasError());
+
+        breaker.cancel(CairoException.nonCritical().put("fresh"));
+        final CairoException e = (CairoException) breaker.buildError();
+        Assert.assertFalse(e.isOutOfMemory());
+        TestUtils.assertContains(e.getFlyweightMessage(), "fresh");
+    }
+
+    @Test
+    public void testWrapsUnexpectedThrowable() {
+        final PostAggregationCircuitBreaker breaker = new PostAggregationCircuitBreaker(engine);
+        breaker.cancel(new IllegalStateException("slot already released"));
+
+        final RuntimeException error = breaker.buildError();
+        Assert.assertTrue(error instanceof CairoException);
+        final CairoException e = (CairoException) error;
+        TestUtils.assertContains(e.getFlyweightMessage(), "unexpected post-aggregation error: slot already released");
+    }
+
+    @Test
+    public void testLongTopKJobHandsWorkerFailureToTheOwner() {
+        // A null atom stands in for any failure inside the top-K body.
+        final PostAggregationCircuitBreaker breaker = new PostAggregationCircuitBreaker(engine);
+        final SOUnboundedCountDownLatch doneLatch = new SOUnboundedCountDownLatch();
+        final AtomicInteger startedCounter = new AtomicInteger();
+        final RingQueue<GroupByLongTopKTask> queue = new RingQueue<>(GroupByLongTopKTask::new, 4);
+        final SPSequence pubSeq = new SPSequence(4);
+        final SCSequence subSeq = new SCSequence();
+        pubSeq.then(subSeq).then(pubSeq);
+
+        final long pubCursor = pubSeq.next();
+        queue.get(pubCursor).of(breaker, startedCounter, doneLatch, null, null, 0, 0, 1);
+        pubSeq.done(pubCursor);
+
+        final long subCursor = subSeq.next();
+        GroupByLongTopKJob.run(-1, queue.get(subCursor), subSeq, subCursor, null);
+
+        Assert.assertTrue("the worker must count down even on failure", doneLatch.done(1));
+        Assert.assertTrue(breaker.checkIfTripped());
+        Assert.assertTrue("the worker's error must reach the owner", breaker.hasError());
+        TestUtils.assertContains(((CairoException) breaker.buildError()).getFlyweightMessage(), "unexpected post-aggregation error");
+    }
+
+    @Test
+    public void testMergeShardJobHandsWorkerFailureToTheOwner() {
+        // A null sharding context stands in for any failure inside the merge body.
+        final PostAggregationCircuitBreaker breaker = new PostAggregationCircuitBreaker(engine);
+        final SOUnboundedCountDownLatch doneLatch = new SOUnboundedCountDownLatch();
+        final AtomicInteger startedCounter = new AtomicInteger();
+        final RingQueue<GroupByMergeShardTask> queue = new RingQueue<>(GroupByMergeShardTask::new, 4);
+        final SPSequence pubSeq = new SPSequence(4);
+        final SCSequence subSeq = new SCSequence();
+        pubSeq.then(subSeq).then(pubSeq);
+
+        final long pubCursor = pubSeq.next();
+        queue.get(pubCursor).of(breaker, startedCounter, doneLatch, null, 0);
+        pubSeq.done(pubCursor);
+
+        final long subCursor = subSeq.next();
+        GroupByMergeShardJob.run(-1, queue.get(subCursor), subSeq, subCursor, null);
+
+        Assert.assertEquals(1, startedCounter.get());
+        Assert.assertTrue("the worker must count down even on failure", doneLatch.done(1));
+        Assert.assertTrue(breaker.checkIfTripped());
+        Assert.assertTrue("the worker's error must reach the owner", breaker.hasError());
+        TestUtils.assertContains(((CairoException) breaker.buildError()).getFlyweightMessage(), "unexpected post-aggregation error");
+    }
+}


### PR DESCRIPTION
## What changes for users

A parallel GROUP BY or horizon join that failed inside the shard-merge phase reported `timeout, query aborted` regardless of the actual cause. A per-query memory limit breach, an mmap failure and an IO error all produced the same message, which points the user at query timeouts rather than at the limit they hit. The query now reports the failure it actually hit, for example `query memory limit exceeded [workload=QUERY, limit=..., used=...]`.

Cancelling such a query during that phase also reported `timeout, query aborted`. It now reports `cancelled by user` and carries the cancellation classification.

## Cause

The parallel shard merge (`GroupByMergeShardJob`) and the parallel long top K (`GroupByLongTopKJob`) run on detached workers that cannot throw to the owner thread. Both signalled failure through a bare `AtomicBoolean` on a shared circuit breaker: the catch logged the exception and dropped it. The owner saw a tripped flag with no reason attached, and fell back to a timeout.

## Fix

`PostAggregationCircuitBreaker` keeps the message, position, errno, error kind and the cancellation / interruption / out-of-memory flags next to the flag they explain, so the owner rebuilds and rethrows the worker's exception verbatim. It mirrors `UnorderedPageFrameSequence.setError()`, which already does this for the reduce phase. Overriding `reset()` clears the flag and the error together, so the two cannot drift apart across executions.

The breaker drops an error that arrives once it is already tripped. `PerWorkerLocks.acquireSlot` raises `query aborted` when it stops spinning for a slot, purely because it observed the trip; recording that would mask the real reason.

`throwPostAggregationException()` answers in precedence order: the query's own circuit breaker, then the worker's recorded error, then the previous fallback. The first step also corrects a pre-existing misreport, since `frameSequence.getCancelReason()` is only ever set during the reduce.

`AsyncHorizonJoinRecordCursor` and `AsyncMultiHorizonJoinRecordCursor` publish through the same merge-shard queue and carried the same swallow, so they get the same treatment.

## Flaky test this resolves

`ParallelGroupByMemoryTrackerTest.testParallelKeyedGroupByFailsOnLargeKeySet` failed intermittently in CI. With 200_000 keys under an 8 MiB limit, the reduce phase can finish just under the limit and leave the merge phase to trip it; the test then saw `timeout, query aborted` where it asserted `isOutOfMemory()`. Which phase trips first depends on how page frames fan out across the pool, so the outcome varied per run and per machine.

## Tradeoffs and limitations

- The breaker records only the first error and drops any error arriving after it trips. When a cancellation trips it first, a genuine worker failure occurring afterwards is not surfaced. That ordering is intended, since the cancellation is the primary reason, but it does mean not every worker failure reaches the user.
- The cancellation message during the merge phase changes from `timeout, query aborted` to `cancelled by user`. Tooling that matches on the old text will see a different string.
- `GroupByMergeShardTask` and `GroupByLongTopKTask` narrow their circuit-breaker field from `AtomicBooleanCircuitBreaker` to the subclass. The change is mechanical, but it touches plumbing shared by GROUP BY and horizon joins.
- The two job wiring tests pass a null sharding context / atom to produce the throwable. `GroupByShardingContext`'s constructor is package-private, so a test in `io.questdb.test.*` cannot subclass it to fail realistically. The tests pin the hand-off, not a realistic failure.
- No deterministic test covers a cancellation arriving during the shard merge. The map is built inside a single `hasNext()` call, so a test thread has no point at which to interpose. The precedence rule is covered at unit level only.
- The new sweep test walks the memory limit across a range and asserts the invariant at each step. It reaches a merge-phase breach in practice but does not guarantee one, so it complements the wiring tests rather than replacing them.

## Test plan

- `PostAggregationCircuitBreakerTest` (new, 11 tests) covers error capture and rebuild for `CairoException` (flags, errno, position), `ImplicitCastException`, `NumericException` and an unexpected `Throwable`; first-error-wins; the collateral-error drop; `reset()` clearing both the flag and the error; and the hand-off from both jobs.
- Mutation check: reverting `cancel(th)` to `cancel()` in both jobs fails `testMergeShardJobHandsWorkerFailureToTheOwner` and `testLongTopKJobHandsWorkerFailureToTheOwner`; restoring it returns 11 of 11 passing.
- `ParallelGroupByMemoryTrackerTest` (9 tests, one new) sweeps the per-query limit from 4 MiB to 32 MiB and asserts every breach carries `isOutOfMemory()` and names the limit, whichever phase trips.
- `HorizonJoinTest` (172), `ParallelHorizonJoinMemoryTrackerTest` (14) and `SyncHorizonJoinMemoryTrackerTest` (12) pass.
- `ParallelGroupByFuzzTest` (201 tests, 17 skipped) passes.
