### PR TITLE
chore(build): stop GitHub clone throttling from failing fork PR and coverage builds

### DIFF
--- a/ci/git-auth-env.sh
+++ b/ci/git-auth-env.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Resolves a GitHub credential for child git processes and prints `export`
+# lines for GIT_CONFIG_{COUNT,KEY_0,VALUE_0}, which every git spawned from
+# the calling shell inherits -- including git run by tools like CMake
+# FetchContent, not just direct git commands. Eval the output:
+#
+#   set +x  # keep the header out of xtrace
+#   eval "$(bash ci/git-auth-env.sh)"
+#   set -x
+#
+# GitHub throttles anonymous git-over-HTTPS from the CI agents' shared
+# egress IPs with intermittent 401s that git reports as:
+#   fatal: could not read Username for 'https://github.com': terminal prompts disabled
+# even though the repos are public.
+#
+# Credential sources, tried in order:
+#
+#   1. GH_TOKEN, when it holds a real token. Azure leaves an undefined
+#      pipeline variable as its literal "$(VAR)" macro text, and fork PR
+#      builds never receive secret variables at all (Azure withholds them
+#      by design), so only a token-shaped value is used.
+#   2. The credential the checkout task persisted (persistCredentials: true
+#      on the job's checkout). The agent scopes it to the parent repo URL
+#      (http.https://github.com/questdb/questdb.extraheader); other repos
+#      live elsewhere on the same host, so this re-applies it to all of
+#      github.com. Unlike GH_TOKEN, this credential exists on fork PR
+#      builds too, because the checkout task itself needs it to fetch the
+#      merge ref.
+#
+# Prints nothing when neither source exists, so anonymous callers stay
+# anonymous. Progress messages go to stderr; stdout carries only the
+# export lines, and the credential value never appears in build logs.
+
+set -eu
+
+auth_header=""
+if [[ ${GH_TOKEN:-} =~ ^[A-Za-z0-9_-]+$ ]]; then
+  # x-access-token works as the basic-auth username for both PATs and GitHub
+  # App installation tokens. macOS base64 has no -w flag; tr strips the
+  # trailing newline portably.
+  auth_header="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+  echo "Authenticating github.com fetches with GH_TOKEN" >&2
+else
+  origin_url=$(git config --get remote.origin.url 2>/dev/null || true)
+  if [[ -n "$origin_url" ]]; then
+    for url in "$origin_url" "${origin_url%.git}" "$origin_url.git"; do
+      if auth_header=$(git config --get "http.$url.extraheader" 2>/dev/null) \
+          && [[ -n "$auth_header" ]]; then
+        echo "Reusing the checkout task's persisted credential for github.com fetches" >&2
+        break
+      fi
+      auth_header=""
+    done
+  fi
+fi
+
+if [[ -n "$auth_header" ]]; then
+  printf 'export GIT_CONFIG_COUNT=1\n'
+  printf 'export GIT_CONFIG_KEY_0=%q\n' "http.https://github.com/.extraheader"
+  printf 'export GIT_CONFIG_VALUE_0=%q\n' "$auth_header"
+else
+  echo "No token and no persisted checkout credential; github.com fetches stay anonymous" >&2
+fi

--- a/ci/submodule-update.sh
+++ b/ci/submodule-update.sh
@@ -18,9 +18,14 @@
 # backoff outlasts a burst without stalling a healthy build, whereas git's
 # own instant second attempt lands inside the same window and dies.
 #
-# The update deliberately fetches full history (no --depth): several
-# submodules pin a SHA that is not a branch tip, and a shallow fetch of an
-# unadvertised object is not guaranteed to be served.
+# Each attempt clones shallow (--depth 1) first: CI never needs submodule
+# history, only the pinned tree. Several submodules pin a SHA that is not a
+# branch tip; git then fetches that SHA directly, which github.com serves
+# for any ref-reachable commit (uploadpack.allowReachableSHA1InWant) -- the
+# same mechanism .gitmodules' existing shallow = true entries and every
+# exact-SHA CI fetch already rely on. Because the git protocol does not
+# guarantee that for arbitrary servers, a failed shallow pass falls back to
+# a full-history pass within the same attempt before any backoff.
 #
 # Usage: bash ci/submodule-update.sh [--recursive] <submodule-path>...
 
@@ -38,6 +43,11 @@ fi
 
 eval "$(bash "$(dirname "$0")/git-auth-env.sh")"
 
+update_args=(--init)
+if [[ -n "$recursive" ]]; then
+  update_args+=(--recursive)
+fi
+
 # A failed `git submodule update` is safe to rerun: git removes the target
 # directory of a failed clone, and submodules that already completed are
 # skipped on the next pass.
@@ -46,8 +56,11 @@ for delay in 0 15 30 60 120; do
     echo "git submodule update failed; retrying in ${delay}s" >&2
     sleep "$delay"
   fi
-  # shellcheck disable=SC2086  # $recursive is empty or a single flag
-  if git submodule update --init $recursive "$@"; then
+  if git submodule update "${update_args[@]}" --depth 1 "$@"; then
+    exit 0
+  fi
+  echo "shallow submodule update failed; trying full history" >&2
+  if git submodule update "${update_args[@]}" "$@"; then
     exit 0
   fi
 done

--- a/ci/submodule-update.sh
+++ b/ci/submodule-update.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Initializes git submodules with authentication when any credential is
+# available, and with bounded retry when none is. GitHub throttles anonymous
+# git-over-HTTPS from the CI agents' shared egress IPs with intermittent
+# 401s that git reports as:
+#   fatal: could not read Username for 'https://github.com': terminal prompts disabled
+# even though every submodule repo is public.
+#
+# Credential sources, tried in order:
+#
+#   1. GH_TOKEN, when it holds a real token. Azure leaves an undefined
+#      pipeline variable as its literal "$(VAR)" macro text, and fork PR
+#      builds never receive secret variables at all (Azure withholds them
+#      by design), so only a token-shaped value is used.
+#   2. The credential the checkout task persisted (persistCredentials: true
+#      on the job's checkout). The agent scopes it to the parent repo URL
+#      (http.https://github.com/questdb/questdb.extraheader); the submodules
+#      live elsewhere on the same host, so this script re-applies it to all
+#      of github.com for the child clones. Unlike GH_TOKEN, this credential
+#      exists on fork PR builds too, because the checkout task itself needs
+#      it to fetch the merge ref.
+#   3. Nothing: clone anonymously, but retry with backoff. GitHub's
+#      anonymous throttle windows are short; ~4 minutes of backoff outlasts
+#      a burst without stalling a healthy build, whereas git's own instant
+#      second attempt lands inside the same window and dies.
+#
+# The credential travels through GIT_CONFIG_{COUNT,KEY_0,VALUE_0}, which
+# every spawned submodule clone/fetch inherits (the same mechanism the
+# checkout task uses for its own submodule handling). Nothing is written to
+# disk and nothing appears on a command line or in xtrace output (this
+# script deliberately does not `set -x`).
+#
+# The update deliberately fetches full history (no --depth): several
+# submodules pin a SHA that is not a branch tip, and a shallow fetch of an
+# unadvertised object is not guaranteed to be served.
+#
+# Usage: bash ci/submodule-update.sh [--recursive] <submodule-path>...
+
+set -eu
+
+recursive=""
+if [[ "${1:-}" == "--recursive" ]]; then
+  recursive="--recursive"
+  shift
+fi
+if [[ $# -eq 0 ]]; then
+  echo "usage: bash ci/submodule-update.sh [--recursive] <submodule-path>..." >&2
+  exit 2
+fi
+
+auth_header=""
+if [[ ${GH_TOKEN:-} =~ ^[A-Za-z0-9_-]+$ ]]; then
+  # x-access-token works as the basic-auth username for both PATs and GitHub
+  # App installation tokens. macOS base64 has no -w flag; tr strips the
+  # trailing newline portably.
+  auth_header="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+  echo "Authenticating submodule fetch with GH_TOKEN"
+else
+  origin_url=$(git config --get remote.origin.url 2>/dev/null || true)
+  if [[ -n "$origin_url" ]]; then
+    for url in "$origin_url" "${origin_url%.git}" "$origin_url.git"; do
+      if auth_header=$(git config --get "http.$url.extraheader" 2>/dev/null) \
+          && [[ -n "$auth_header" ]]; then
+        echo "Reusing the checkout task's persisted credential for submodule fetch"
+        break
+      fi
+      auth_header=""
+    done
+  fi
+fi
+
+if [[ -n "$auth_header" ]]; then
+  export GIT_CONFIG_COUNT=1
+  export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
+  export GIT_CONFIG_VALUE_0="$auth_header"
+else
+  echo "No token and no persisted checkout credential; cloning submodules anonymously"
+fi
+
+# A failed `git submodule update` is safe to rerun: git removes the target
+# directory of a failed clone, and submodules that already completed are
+# skipped on the next pass.
+for delay in 0 15 30 60 120; do
+  if [[ "$delay" -gt 0 ]]; then
+    echo "git submodule update failed; retrying in ${delay}s" >&2
+    sleep "$delay"
+  fi
+  # shellcheck disable=SC2086  # $recursive is empty or a single flag
+  if git submodule update --init $recursive "$@"; then
+    exit 0
+  fi
+done
+echo "git submodule update failed after all retries" >&2
+exit 1

--- a/ci/submodule-update.sh
+++ b/ci/submodule-update.sh
@@ -7,29 +7,16 @@
 #   fatal: could not read Username for 'https://github.com': terminal prompts disabled
 # even though every submodule repo is public.
 #
-# Credential sources, tried in order:
-#
-#   1. GH_TOKEN, when it holds a real token. Azure leaves an undefined
-#      pipeline variable as its literal "$(VAR)" macro text, and fork PR
-#      builds never receive secret variables at all (Azure withholds them
-#      by design), so only a token-shaped value is used.
-#   2. The credential the checkout task persisted (persistCredentials: true
-#      on the job's checkout). The agent scopes it to the parent repo URL
-#      (http.https://github.com/questdb/questdb.extraheader); the submodules
-#      live elsewhere on the same host, so this script re-applies it to all
-#      of github.com for the child clones. Unlike GH_TOKEN, this credential
-#      exists on fork PR builds too, because the checkout task itself needs
-#      it to fetch the merge ref.
-#   3. Nothing: clone anonymously, but retry with backoff. GitHub's
-#      anonymous throttle windows are short; ~4 minutes of backoff outlasts
-#      a burst without stalling a healthy build, whereas git's own instant
-#      second attempt lands inside the same window and dies.
-#
-# The credential travels through GIT_CONFIG_{COUNT,KEY_0,VALUE_0}, which
-# every spawned submodule clone/fetch inherits (the same mechanism the
-# checkout task uses for its own submodule handling). Nothing is written to
-# disk and nothing appears on a command line or in xtrace output (this
-# script deliberately does not `set -x`).
+# ci/git-auth-env.sh resolves the credential (GH_TOKEN, or the credential
+# the checkout task persisted with persistCredentials: true) and exports it
+# through GIT_CONFIG_{COUNT,KEY_0,VALUE_0}, which every spawned submodule
+# clone/fetch inherits (the same mechanism the checkout task uses for its
+# own submodule handling). Nothing is written to disk and nothing appears
+# on a command line or in xtrace output (neither script uses `set -x`).
+# With no credential at all the clone stays anonymous and relies on the
+# retry: GitHub's anonymous throttle windows are short, so ~4 minutes of
+# backoff outlasts a burst without stalling a healthy build, whereas git's
+# own instant second attempt lands inside the same window and dies.
 #
 # The update deliberately fetches full history (no --depth): several
 # submodules pin a SHA that is not a branch tip, and a shallow fetch of an
@@ -49,34 +36,7 @@ if [[ $# -eq 0 ]]; then
   exit 2
 fi
 
-auth_header=""
-if [[ ${GH_TOKEN:-} =~ ^[A-Za-z0-9_-]+$ ]]; then
-  # x-access-token works as the basic-auth username for both PATs and GitHub
-  # App installation tokens. macOS base64 has no -w flag; tr strips the
-  # trailing newline portably.
-  auth_header="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
-  echo "Authenticating submodule fetch with GH_TOKEN"
-else
-  origin_url=$(git config --get remote.origin.url 2>/dev/null || true)
-  if [[ -n "$origin_url" ]]; then
-    for url in "$origin_url" "${origin_url%.git}" "$origin_url.git"; do
-      if auth_header=$(git config --get "http.$url.extraheader" 2>/dev/null) \
-          && [[ -n "$auth_header" ]]; then
-        echo "Reusing the checkout task's persisted credential for submodule fetch"
-        break
-      fi
-      auth_header=""
-    done
-  fi
-fi
-
-if [[ -n "$auth_header" ]]; then
-  export GIT_CONFIG_COUNT=1
-  export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
-  export GIT_CONFIG_VALUE_0="$auth_header"
-else
-  echo "No token and no persisted checkout credential; cloning submodules anonymously"
-fi
+eval "$(bash "$(dirname "$0")/git-auth-env.sh")"
 
 # A failed `git submodule update` is safe to rerun: git removes the target
 # directory of a failed clone, and submodules that already completed are

--- a/ci/templates/aux-job.yml
+++ b/ci/templates/aux-job.yml
@@ -94,25 +94,6 @@ jobs:
           shouldRun: and(succeeded(), eq(variables['CXX_SOURCE_CODE_CHANGED'], 'true'))
       - bash: |
           set -eux
-          # The checkout task keeps no credentials (persistCredentials defaults to
-          # false), so this clone would reach github.com anonymously, and GitHub
-          # throttles anonymous git-over-HTTPS from the agents' shared egress IP
-          # with a 401 that git reports as
-          #   fatal: could not read Username for 'https://github.com'
-          # even though the submodule repos are public. `gh auth setup-git`
-          # registers gh as git's credential helper for github.com; gh reads the
-          # token from this step's environment, so the clone git runs for each submodule
-          # authenticates and no token is written to the agent.
-          #
-          # Azure leaves an undefined variable as its literal macro text, so drop
-          # GH_TOKEN when it is not token-shaped rather than handing gh a
-          # "$(GIT_GITHUB_TOKEN)" string to authenticate with.
-          [[ ${GH_TOKEN:-} =~ ^[A-Za-z0-9_-]+$ ]] || unset GH_TOKEN
-          if [[ -n "${GH_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
-            gh auth setup-git --hostname github.com
-          else
-            echo "No usable token or no gh; cloning submodules anonymously"
-          fi
           # gcc is already present (the core and Rust builds need it); add cmake and nasm (the
           # x86-64 asmlib) only when missing, as the client native build does.
           if ! command -v cmake >/dev/null 2>&1 || ! command -v nasm >/dev/null 2>&1; then
@@ -122,9 +103,11 @@ jobs:
           # The library embeds jni.h from JAVA_HOME.
           export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-25-openjdk-amd64}"
           # This job checks out without submodules; the questdb library the tests link needs these.
-          # No --depth: two of the four pin a SHA that is not a branch tip, and a shallow fetch of an
-          # unadvertised object is not guaranteed to be served.
-          git submodule update --init \
+          # ci/submodule-update.sh authenticates the clones when it can (GH_TOKEN, or
+          # the checkout task's persisted credential) and retries with backoff when
+          # it cannot; fork PR builds never receive GIT_GITHUB_TOKEN because Azure
+          # withholds secret variables from forks.
+          bash ci/submodule-update.sh \
             core/src/main/c/share/zlib \
             core/src/main/c/share/fsst \
             core/src/main/c/share/simdjson \

--- a/ci/templates/aux-job.yml
+++ b/ci/templates/aux-job.yml
@@ -102,11 +102,18 @@ jobs:
           fi
           # The library embeds jni.h from JAVA_HOME.
           export JAVA_HOME="${JAVA_HOME:-/usr/lib/jvm/java-25-openjdk-amd64}"
+          # CMake FetchContent clones questdb/asmjit at configure time with its own
+          # git, which inherits GIT_CONFIG_* from this shell; export the resolved
+          # credential here so that clone (and the submodule update below)
+          # authenticates instead of hitting GitHub's anonymous-clone throttle.
+          # xtrace stays off around the eval to keep the header out of the log.
+          set +x
+          eval "$(bash ci/git-auth-env.sh)"
+          set -x
           # This job checks out without submodules; the questdb library the tests link needs these.
-          # ci/submodule-update.sh authenticates the clones when it can (GH_TOKEN, or
-          # the checkout task's persisted credential) and retries with backoff when
-          # it cannot; fork PR builds never receive GIT_GITHUB_TOKEN because Azure
-          # withholds secret variables from forks.
+          # ci/submodule-update.sh retries with backoff when the fetch is anonymous;
+          # fork PR builds never receive GIT_GITHUB_TOKEN because Azure withholds
+          # secret variables from forks.
           bash ci/submodule-update.sh \
             core/src/main/c/share/zlib \
             core/src/main/c/share/fsst \
@@ -115,7 +122,26 @@ jobs:
           cd core
           # The static-library link step writes here and does not create the directory itself.
           mkdir -p target/classes/io/questdb/bin-local
-          cmake -B build/jittest -DCMAKE_BUILD_TYPE=Release -DJIT_TEST=TRUE
+          # Anonymous fallback (fork PRs): FetchContent's three instant clone retries
+          # all land inside the same throttle window, so back off and reconfigure
+          # from scratch instead. A failed configure can leave a half-populated
+          # FetchContent cache behind, hence the rm.
+          configured=""
+          for delay in 0 15 30 60 120; do
+            if [[ "$delay" -gt 0 ]]; then
+              echo "cmake configure failed; retrying in ${delay}s"
+              sleep "$delay"
+              rm -rf build/jittest
+            fi
+            if cmake -B build/jittest -DCMAKE_BUILD_TYPE=Release -DJIT_TEST=TRUE; then
+              configured=1
+              break
+            fi
+          done
+          if [[ -z "$configured" ]]; then
+            echo "cmake configure failed after all retries" >&2
+            exit 1
+          fi
           # An explicit job count: a bare --parallel passes make an unbounded -j, and this graph is
           # ~190 objects including four -O3 SIMD variants and the simdjson amalgamation.
           cmake --build build/jittest --target jittests --parallel "$(nproc)"

--- a/ci/templates/aux-job.yml
+++ b/ci/templates/aux-job.yml
@@ -132,7 +132,7 @@ jobs:
           fetched=""
           for delay in 0 15 30 60 120; do
             if [[ "$delay" -gt 0 ]]; then
-              echo "fetching JIT build dependencies failed; retrying in ${delay}s"
+              echo "JIT dependency fetch/configure failed; retrying in ${delay}s (a transient GitHub throttle heals here; a deterministic CMake error will just repeat)"
               sleep "$delay"
               rm -rf build/jittest
             fi
@@ -143,7 +143,7 @@ jobs:
             fi
           done
           if [[ -z "$fetched" ]]; then
-            echo "fetching JIT build dependencies failed after all retries" >&2
+            echo "cmake configure or dependency fetch failed after all retries; if the same error repeats identically above, it is a deterministic CMake/build error, not a network problem" >&2
             exit 1
           fi
           # An explicit job count: a bare --parallel passes make an unbounded -j, and this graph is

--- a/ci/templates/aux-job.yml
+++ b/ci/templates/aux-job.yml
@@ -122,24 +122,28 @@ jobs:
           cd core
           # The static-library link step writes here and does not create the directory itself.
           mkdir -p target/classes/io/questdb/bin-local
-          # Anonymous fallback (fork PRs): FetchContent's three instant clone retries
-          # all land inside the same throttle window, so back off and reconfigure
-          # from scratch instead. A failed configure can leave a half-populated
-          # FetchContent cache behind, hence the rm.
-          configured=""
+          # Anonymous fallback (fork PRs): FetchContent's and ExternalProject's own
+          # instant clone retries land inside the same throttle window, so back off
+          # and retry here instead. The configure clones asmjit (FetchContent); the
+          # liburing_git target clones and builds liburing (ExternalProject), which
+          # would otherwise happen mid-build with no retry around it. After this
+          # loop the jittests build needs no network. rm -rf: a failed configure
+          # can leave a half-populated FetchContent cache behind.
+          fetched=""
           for delay in 0 15 30 60 120; do
             if [[ "$delay" -gt 0 ]]; then
-              echo "cmake configure failed; retrying in ${delay}s"
+              echo "fetching JIT build dependencies failed; retrying in ${delay}s"
               sleep "$delay"
               rm -rf build/jittest
             fi
-            if cmake -B build/jittest -DCMAKE_BUILD_TYPE=Release -DJIT_TEST=TRUE; then
-              configured=1
+            if cmake -B build/jittest -DCMAKE_BUILD_TYPE=Release -DJIT_TEST=TRUE \
+                && cmake --build build/jittest --target liburing_git; then
+              fetched=1
               break
             fi
           done
-          if [[ -z "$configured" ]]; then
-            echo "cmake configure failed after all retries" >&2
+          if [[ -z "$fetched" ]]; then
+            echo "fetching JIT build dependencies failed after all retries" >&2
             exit 1
           fi
           # An explicit job count: a bare --parallel passes make an unbounded -j, and this graph is

--- a/ci/templates/build-client-native.yml
+++ b/ci/templates/build-client-native.yml
@@ -21,27 +21,12 @@
 steps:
   - bash: |
       set -eux
-      # The checkout task keeps no credentials (persistCredentials defaults to
-      # false), so this clone would reach github.com anonymously, and GitHub
-      # throttles anonymous git-over-HTTPS from the agents' shared egress IP
-      # with a 401 that git reports as
-      #   fatal: could not read Username for 'https://github.com'
-      # even though the submodule repos are public. `gh auth setup-git`
-      # registers gh as git's credential helper for github.com; gh reads the
-      # token from this step's environment, so the clone git runs for each submodule
-      # authenticates and no token is written to the agent.
-      #
-      # Azure leaves an undefined variable as its literal macro text, so drop
-      # GH_TOKEN when it is not token-shaped rather than handing gh a
-      # "$(GIT_GITHUB_TOKEN)" string to authenticate with.
-      [[ ${GH_TOKEN:-} =~ ^[A-Za-z0-9_-]+$ ]] || unset GH_TOKEN
-      if [[ -n "${GH_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
-        gh auth setup-git --hostname github.com
-      else
-        echo "No usable token or no gh; cloning submodules anonymously"
-      fi
       # zstd is a submodule of the client and is required by its CMake build.
-      git submodule update --init --recursive java-questdb-client
+      # ci/submodule-update.sh authenticates the clones when it can (GH_TOKEN, or
+      # the checkout task's persisted credential) and retries with backoff when
+      # it cannot; fork PR builds never receive GIT_GITHUB_TOKEN because Azure
+      # withholds secret variables from forks.
+      bash ci/submodule-update.sh --recursive java-questdb-client
       # gcc is already present (the core and Rust builds need it); add cmake and
       # nasm (the x86-64 asmlib) only when missing.
       if ! command -v cmake >/dev/null 2>&1 || ! command -v nasm >/dev/null 2>&1; then
@@ -66,26 +51,8 @@ steps:
 
   - bash: |
       set -eux
-      # The checkout task keeps no credentials (persistCredentials defaults to
-      # false), so this clone would reach github.com anonymously, and GitHub
-      # throttles anonymous git-over-HTTPS from the agents' shared egress IP
-      # with a 401 that git reports as
-      #   fatal: could not read Username for 'https://github.com'
-      # even though the submodule repos are public. `gh auth setup-git`
-      # registers gh as git's credential helper for github.com; gh reads the
-      # token from this step's environment, so the clone git runs for each submodule
-      # authenticates and no token is written to the agent.
-      #
-      # Azure leaves an undefined variable as its literal macro text, so drop
-      # GH_TOKEN when it is not token-shaped rather than handing gh a
-      # "$(GIT_GITHUB_TOKEN)" string to authenticate with.
-      [[ ${GH_TOKEN:-} =~ ^[A-Za-z0-9_-]+$ ]] || unset GH_TOKEN
-      if [[ -n "${GH_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
-        gh auth setup-git --hostname github.com
-      else
-        echo "No usable token or no gh; cloning submodules anonymously"
-      fi
-      git submodule update --init --recursive java-questdb-client
+      # See the Linux step above for why ci/submodule-update.sh does the clone.
+      bash ci/submodule-update.sh --recursive java-questdb-client
       # macOS legs run on Apple Silicon (macOS-15-arm64 in hosted-jobs.yml); x86-64
       # (Intel) macOS is not a supported platform, so there is no x86-64 branch here.
       # steps.yml already asserts arm64; this is the second guard, so an image swap
@@ -111,20 +78,10 @@ steps:
 
   - pwsh: |
       $ErrorActionPreference = "Stop"
-      # See the Linux step above: the clone is otherwise anonymous and GitHub
-      # answers 401 when it throttles the agents' shared egress IP. gh becomes
-      # git's credential helper for github.com and reads the token from this
-      # step's environment, so nothing is written to the agent. Azure leaves an
-      # undefined variable as its literal macro text, so clear the token when it
-      # is not token-shaped instead of handing it to gh.
-      if ($env:GH_TOKEN -notmatch '^[A-Za-z0-9_-]+$') { $env:GH_TOKEN = $null }
-      if ($env:GH_TOKEN -and (Get-Command gh -ErrorAction SilentlyContinue)) {
-        gh auth setup-git --hostname github.com
-        if ($LASTEXITCODE -ne 0) { throw "gh auth setup-git failed" }
-      } else {
-        Write-Host "No usable token or no gh; cloning submodules anonymously"
-      }
-      git submodule update --init --recursive java-questdb-client
+      # See the Linux step above for why ci/submodule-update.sh does the clone.
+      # windows-latest images ship Git Bash on PATH; the script reads GH_TOKEN
+      # from this step's environment.
+      bash ci/submodule-update.sh --recursive java-questdb-client
       if ($LASTEXITCODE -ne 0) { throw "submodule update failed" }
       # The client distributes a mingw-built Windows .dll; reproduce that here.
       # Ninja avoids the MinGW-Makefiles "sh.exe found in PATH" failure and the

--- a/ci/templates/detect-local-client.yml
+++ b/ci/templates/detect-local-client.yml
@@ -4,30 +4,16 @@
 steps:
   - bash: |
       set -e
-      # The checkout task keeps no credentials (persistCredentials defaults to
-      # false), so this clone would reach github.com anonymously, and GitHub
-      # throttles anonymous git-over-HTTPS from the agents' shared egress IP
-      # with a 401 that git reports as
-      #   fatal: could not read Username for 'https://github.com'
-      # even though the submodule repos are public. `gh auth setup-git`
-      # registers gh as git's credential helper for github.com; gh reads the
-      # token from this step's environment, so the clone git runs for the submodule
-      # authenticates and no token is written to the agent.
-      #
-      # Azure leaves an undefined variable as its literal macro text, so drop
-      # GH_TOKEN when it is not token-shaped rather than handing gh a
-      # "$(GIT_GITHUB_TOKEN)" string to authenticate with.
-      [[ ${GH_TOKEN:-} =~ ^[A-Za-z0-9_-]+$ ]] || unset GH_TOKEN
-      if [[ -n "${GH_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
-        gh auth setup-git --hostname github.com
-      else
-        echo "No usable token or no gh; cloning submodules anonymously"
-      fi
       CLIENT_VERSION=$(sed -n 's/.*<questdb.client.version>\(.*\)<\/questdb.client.version>.*/\1/p' core/pom.xml | head -1)
       echo "questdb.client.version=$CLIENT_VERSION"
       if echo "$CLIENT_VERSION" | grep -q '\-SNAPSHOT$'; then
         echo "SNAPSHOT version detected, activating local-client profile"
-        git submodule update --init java-questdb-client
+        # ci/submodule-update.sh authenticates the clone when it can (GH_TOKEN,
+        # or the checkout task's persisted credential) and retries with backoff
+        # when it cannot: GitHub throttles anonymous clones from the agents'
+        # shared egress IP, and fork PR builds never receive GIT_GITHUB_TOKEN
+        # because Azure withholds secret variables from forks.
+        bash ci/submodule-update.sh java-questdb-client
         echo "##vso[task.setvariable variable=CLIENT_PROFILE]-P local-client"
       else
         echo "Release version detected, using Maven Central"

--- a/ci/templates/rust-test-and-lint.yml
+++ b/ci/templates/rust-test-and-lint.yml
@@ -79,29 +79,14 @@ steps:
 
   - bash: |
       set -eux
-      # The checkout task keeps no credentials (persistCredentials defaults to
-      # false), so this clone would reach github.com anonymously, and GitHub
-      # throttles anonymous git-over-HTTPS from the agents' shared egress IP
-      # with a 401 that git reports as
-      #   fatal: could not read Username for 'https://github.com'
-      # even though the submodule repos are public. `gh auth setup-git`
-      # registers gh as git's credential helper for github.com; gh reads the
-      # token from this step's environment, so the clone git runs for the submodule
-      # authenticates and no token is written to the agent.
-      #
-      # Azure leaves an undefined variable as its literal macro text, so drop
-      # GH_TOKEN when it is not token-shaped rather than handing gh a
-      # "$(GIT_GITHUB_TOKEN)" string to authenticate with.
-      [[ ${GH_TOKEN:-} =~ ^[A-Za-z0-9_-]+$ ]] || unset GH_TOKEN
-      if [[ -n "${GH_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
-        gh auth setup-git --hostname github.com
-      else
-        echo "No usable token or no gh; cloning submodules anonymously"
-      fi
       export RUSTFLAGS="-C instrument-coverage -D warnings"
       export LLVM_PROFILE_FILE="$(Build.SourcesDirectory)/rust-lint-profraw/parquet2-%m.profraw"
       export PARQUET2_IGNORE_PYARROW_TESTS=1
-      git submodule update --init core/rust/parquet2/testing/parquet-testing
+      # ci/submodule-update.sh authenticates the clone when it can (GH_TOKEN, or
+      # the checkout task's persisted credential) and retries with backoff when
+      # it cannot; fork PR builds never receive GIT_GITHUB_TOKEN because Azure
+      # withholds secret variables from forks.
+      bash ci/submodule-update.sh core/rust/parquet2/testing/parquet-testing
       cd core/rust/parquet2
       cargo test --all-targets --no-fail-fast
     displayName: "parquet2: cargo test (coverage)"

--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -220,10 +220,17 @@ steps:
       goals: "compile"
       options: "-s $(MAVEN_SETTINGS_FILE) $(javadoc_step) -DskipTests -P build-web-console$(javadoc_profile) -P qdbr-release $(CLIENT_PROFILE) $(MAVEN_RUN_OPTS)"
       jdkVersionOption: $(jdk)
+    # succeeded() explicitly: a bare variable condition replaces Azure's implicit
+    # succeeded() guard, so without it this step runs after an earlier step (e.g.
+    # the submodule clone in detect-local-client) failed, and dies on the
+    # never-populated $(MAVEN_SETTINGS_FILE) -- burying the real error.
     condition: |
-      or(
-        eq(variables['testset'], 'none'),
-        eq(variables['SOURCE_CODE_CHANGED'], 'false')
+      and(
+        succeeded(),
+        or(
+          eq(variables['testset'], 'none'),
+          eq(variables['SOURCE_CODE_CHANGED'], 'false')
+        )
       )
   - task: Maven@3
     displayName: "Run tests"
@@ -244,8 +251,10 @@ steps:
     env:
       QDB_TEST_WINDOWS_SYMLINKS: "1"
     timeoutInMinutes: 55
+    # succeeded() explicitly: see "Compile with Maven" above.
     condition: |
       and(
+        succeeded(),
         eq(variables['testset'], 'all'),
         eq(variables['SOURCE_CODE_CHANGED'], 'true')
       )
@@ -269,8 +278,10 @@ steps:
         -P build-web-console
         $(CLIENT_PROFILE) $(MAVEN_RUN_OPTS)"
       jdkVersionOption: $(jdk)
+    # succeeded() explicitly: see "Compile with Maven" above.
     condition: |
       and(
+        succeeded(),
         startsWith(variables['testset'], 'coverage'),
         ne(variables['System.PullRequest.IsFork'], 'true'),
         or(
@@ -296,8 +307,10 @@ steps:
       QDB_TEST_WINDOWS_SYMLINKS: "1"
       LD_PRELOAD: $(Build.SourcesDirectory)/core/src/main/bin/linux-x86-64/libjemalloc.so
     timeoutInMinutes: 55
+    # succeeded() explicitly: see "Compile with Maven" above.
     condition: |
       and(
+        succeeded(),
         startsWith(variables['testset'], 'coverage'),
         ne(variables['System.PullRequest.IsFork'], 'true'),
         or(

--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -144,7 +144,13 @@ steps:
     displayName: "Cache .m2/repository"
     continueOnError: true
     inputs:
-      key: '"questdb_main" | "$(Agent.OS)" | "$(jdk)" | "maven"'
+      # The pom hash in the key makes a dependency change save an updated cache
+      # (Azure skips the save on an exact key hit, so a static key freezes the
+      # cache at its first save); restoreKeys still restores the newest previous
+      # cache on a pom change, so only the delta comes from Maven Central.
+      key: '"questdb_main" | "$(Agent.OS)" | "$(jdk)" | "maven" | **/pom.xml'
+      restoreKeys: |
+        "questdb_main" | "$(Agent.OS)" | "$(jdk)" | "maven"
       path: $(MAVEN_CACHE_FOLDER)
     condition: |
       and(
@@ -168,10 +174,10 @@ steps:
         ne(variables['poolName'], 'hetzner-incus-arm'),
         ne(variables['poolName'], 'hetzner-incus-zfs')
       )
-  - pwsh: New-Item -Path "$HOME/.m2/repository" -ItemType Directory -Force
+  - pwsh: New-Item -Path "$(MAVEN_CACHE_FOLDER)" -ItemType Directory -Force
     displayName: "Ensure .m2/repository exists (PowerShell)"
     condition: eq(variables['os'], 'Windows')
-  - bash: mkdir -p "$HOME/.m2/repository"
+  - bash: mkdir -p "$(MAVEN_CACHE_FOLDER)"
     displayName: "Ensure .m2/repository exists (bash)"
     condition: ne(variables['os'], 'Windows')
   - script: "wget https://archive.apache.org/dist/maven/maven-3/$(MAVEN_VERSION)/binaries/apache-maven-$(MAVEN_VERSION)-bin.zip"

--- a/ci/templates/steps.yml
+++ b/ci/templates/steps.yml
@@ -152,12 +152,15 @@ steps:
       restoreKeys: |
         "questdb_main" | "$(Agent.OS)" | "$(jdk)" | "maven"
       path: $(MAVEN_CACHE_FOLDER)
-    condition: |
-      and(
-        ne(variables['poolName'], 'hetzner-incus'),
-        ne(variables['poolName'], 'hetzner-incus-arm'),
-        ne(variables['poolName'], 'hetzner-incus-zfs')
-      )
+    # Allowlist, not a hetzner-pool denylist: this cache only serves the hosted
+    # (Microsoft) agents, which cannot reach the Reposilite cache. The denylist
+    # failed open on the fuzz pipeline, which sets pool.name directly and defines
+    # no poolName variable, so ne('') passed and the task ran on its Hetzner
+    # agents -- harmless while the static key froze saves after the first one,
+    # but the pom-hashed key would have started re-saving the shared $HOME/.m2
+    # there on every pom change. A consumer without poolName now gets no cache
+    # instead of a surprise one.
+    condition: eq(variables['poolName'], 'Azure Pipelines')
   - task: Cache@2
     displayName: "Cache .cargo/registry"
     continueOnError: true

--- a/ci/test-fuzz.yml
+++ b/ci/test-fuzz.yml
@@ -60,27 +60,11 @@ stages:
           - template: templates/checkout-source.yml
           - bash: |
               set -eux
-              # The checkout task keeps no credentials (persistCredentials defaults to
-              # false), so this clone would reach github.com anonymously, and GitHub
-              # throttles anonymous git-over-HTTPS from the agents' shared egress IP
-              # with a 401 that git reports as
-              #   fatal: could not read Username for 'https://github.com'
-              # even though the client and its nested zstd repos are public.
-              # `gh auth setup-git` registers gh as git's credential helper for
-              # github.com; gh reads the token from this step's environment, so the
-              # clone git runs for each submodule authenticates and no token is
-              # written to the agent.
-              #
-              # Azure leaves an undefined variable as its literal macro text, so drop
-              # anything that is not token-shaped rather than handing gh a
-              # "$(GIT_GITHUB_TOKEN)" string to authenticate with.
-              [[ ${GH_TOKEN:-} =~ ^[A-Za-z0-9_-]+$ ]] || unset GH_TOKEN
-              if [[ -n "${GH_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
-                gh auth setup-git --hostname github.com
-              else
-                echo "No usable token or no gh; cloning submodules anonymously"
-              fi
-              git submodule update --init --recursive java-questdb-client
+              # ci/submodule-update.sh authenticates the clones when it can (GH_TOKEN,
+              # or the checkout task's persisted credential) and retries with backoff
+              # when it cannot; fork PR builds never receive GIT_GITHUB_TOKEN because
+              # Azure withholds secret variables from forks.
+              bash ci/submodule-update.sh --recursive java-questdb-client
             displayName: "Checkout client submodules"
             env:
               GH_TOKEN: $(GIT_GITHUB_TOKEN)

--- a/ci/test-hosted-pipeline.yml
+++ b/ci/test-hosted-pipeline.yml
@@ -62,10 +62,18 @@ variables:
   # off on 429/503 and obeys the server's Retry-After header (MRESOLVER-396,
   # resolver 1.9.16+); wagon's GET retries have no backoff, so this pipeline
   # must NOT pin transport=wagon the way test-pipeline.yml does for the
-  # Reposilite keepalive tuning. interval doubles per attempt and only applies
-  # when the server sends no Retry-After.
+  # Reposilite keepalive tuning.
+  #
+  # The backoff ramps linearly, interval x attempt number: 7.5s, 15s, ... and
+  # applies only when the server sends no Retry-After. intervalMax is a
+  # bail-out, not a clamp: a computed wait, or a server Retry-After, above it
+  # stops the retry chain (ResolverServiceUnavailableRetryStrategy returns
+  # null). 120s leaves headroom for a count bump up to 16 and obeys a
+  # Retry-After of up to two minutes instead of aborting on it; the cost is a
+  # slower failure when Central throttles persistently, still bounded by the
+  # job timeout.
   - name: MAVEN_RUN_OPTS
-    value: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Daether.connector.http.retryHandler.count=8 -Daether.connector.http.retryHandler.interval=7500 -Daether.connector.http.retryHandler.intervalMax=60000"
+    value: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Daether.connector.http.retryHandler.count=8 -Daether.connector.http.retryHandler.interval=7500 -Daether.connector.http.retryHandler.intervalMax=120000"
   - name: MAVEN_VERSION
     value: "version"
   - name: MAVEN_VERSION_OPTION

--- a/ci/test-hosted-pipeline.yml
+++ b/ci/test-hosted-pipeline.yml
@@ -34,8 +34,9 @@ schedules:
     always: true
 
 variables:
-  # Supplies GIT_GITHUB_TOKEN, which the submodule-clone steps hand to gh so the
-  # clones do not go out anonymously. See templates/detect-local-client.yml.
+  # Supplies GIT_GITHUB_TOKEN, which the fetch steps feed to ci/git-auth-env.sh
+  # (as GH_TOKEN) so github.com fetches do not go out anonymously. Fork PRs
+  # never receive it and rely on the scripts' backoff retry instead.
   - group: github-public-read
   - name: QDB_LOG_W_FILE_LOCATION
     value: "$(Build.BinariesDirectory)/tests.log"

--- a/ci/test-hosted-pipeline.yml
+++ b/ci/test-hosted-pipeline.yml
@@ -18,6 +18,21 @@ pr:
       - master
   drafts: false
 
+# Weekly run on master to seed the hosted .m2 caches. Azure pipeline caches are
+# branch-scoped: PR builds can only restore caches created on the default
+# branch, and this pipeline otherwise never runs on plain master (PR runs are
+# on-demand, merge-queue branches are one-shot, so their caches die with the
+# branch). Without a master-scoped cache every first macwin run of every PR
+# cold-downloads the whole dependency tree from Maven Central on ~16 hosted
+# agents at once, and Central answers the burst with HTTP 429 (build 266975).
+schedules:
+  - cron: "0 3 * * 1"
+    displayName: "Weekly master run to seed hosted .m2 caches"
+    branches:
+      include:
+        - master
+    always: true
+
 variables:
   # Supplies GIT_GITHUB_TOKEN, which the submodule-clone steps hand to gh so the
   # clones do not go out anonymously. See templates/detect-local-client.yml.
@@ -32,15 +47,25 @@ variables:
     value: ""
   - name: includeTests
     value: "%regex[.*[^o].class]"
+  # $(Pipeline.Workspace), not $(HOME): Windows agents define no HOME pipeline
+  # variable, so Azure left the macro as literal "$(HOME)" text and Maven wrote
+  # the repo to a directory literally named "$(HOME)" under the sources dir.
+  # Pipeline.Workspace exists on every hosted agent and is absolute on all OSes.
   - name: MAVEN_CACHE_FOLDER
-    value: $(HOME)/.m2/repository
+    value: $(Pipeline.Workspace)/.m2/repository
   - name: MAVEN_OPTS
     value: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Xmx3g -XX:+UseParallelGC"
-  # Kept in sync with test-pipeline.yml. These hosted (macOS/Windows) agents resolve from
-  # Maven Central, not the cache, so the retry is a harmless no-op for them; keeping
-  # MAVEN_RUN_OPTS identical across pipelines avoids drift. See test-pipeline.yml for rationale.
+  # Unlike the Hetzner pipeline, these hosted (macOS/Windows) agents cannot reach
+  # the private maven.internal Reposilite cache and resolve straight from Maven
+  # Central, whose rate limiter answers the fleet's cold-cache bursts with HTTP
+  # 429 (build 266975). Maven 3.9's default (native) resolver transport backs
+  # off on 429/503 and obeys the server's Retry-After header (MRESOLVER-396,
+  # resolver 1.9.16+); wagon's GET retries have no backoff, so this pipeline
+  # must NOT pin transport=wagon the way test-pipeline.yml does for the
+  # Reposilite keepalive tuning. interval doubles per attempt and only applies
+  # when the server sends no Retry-After.
   - name: MAVEN_RUN_OPTS
-    value: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Dmaven.resolver.transport=wagon -Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.http.retryHandler.nonRetryableClasses=java.io.NotSerializableException "
+    value: "-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER) -Daether.connector.http.retryHandler.count=8 -Daether.connector.http.retryHandler.interval=7500 -Daether.connector.http.retryHandler.intervalMax=60000"
   - name: MAVEN_VERSION
     value: "version"
   - name: MAVEN_VERSION_OPTION

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -309,7 +309,11 @@ stages:
 
           - task: Maven@3
             displayName: "Compile with Maven"
-            condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo'))
+            # succeeded() explicitly: a bare variable condition replaces Azure's
+            # implicit succeeded() guard; without it this step runs after e.g. a
+            # failed submodule clone and dies on the never-populated
+            # $(MAVEN_SETTINGS_FILE), burying the real error.
+            condition: and(succeeded(), eq(variables['SHOULD_RUN'], 'true'), eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo'))
             inputs:
               mavenPomFile: "pom.xml"
               mavenOptions: "$(MAVEN_OPTS)"
@@ -319,7 +323,8 @@ stages:
 
           - task: Maven@3
             displayName: "Merge partial JaCoCo reports"
-            condition: and(eq(variables['SHOULD_RUN'], 'true'), eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo'))
+            # succeeded() explicitly: see "Compile with Maven" above.
+            condition: and(succeeded(), eq(variables['SHOULD_RUN'], 'true'), eq(variables['CODE_COVERAGE_TOOL_OPTION'], 'JaCoCo'))
             inputs:
               mavenPomFile: "ci/jacoco-merge.xml"
               goals: "verify"
@@ -411,7 +416,9 @@ stages:
                 $COVER_ARGS --repo "questdb/questdb" --pr "$PR_NUMBER" \
                 -t $(DIFF_COVER_THRESHOLD_PCT) --github-token $(GH_TOKEN)
             displayName: "Post combined report to GitHub"
-            condition: eq(variables['SHOULD_RUN'], 'true')
+            # succeeded() explicitly: without it a failed merge step upstream does
+            # not stop this step from posting a report built from stale inputs.
+            condition: and(succeeded(), eq(variables['SHOULD_RUN'], 'true'))
             env:
               BUILD_SOURCEBRANCH: $(Build.SourceBranch)
               PR_NUMBER_MACRO: $(System.PullRequest.PullRequestNumber)

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -11,8 +11,9 @@ pr:
   drafts: false
 
 variables:
-  # Supplies GIT_GITHUB_TOKEN, which the submodule-clone steps hand to gh so the
-  # clones do not go out anonymously. See templates/detect-local-client.yml.
+  # Supplies GIT_GITHUB_TOKEN, which the fetch steps feed to ci/git-auth-env.sh
+  # (as GH_TOKEN) so github.com fetches do not go out anonymously. Fork PRs
+  # never receive it and rely on the scripts' backoff retry instead.
   - group: github-public-read
   - name: QDB_LOG_W_FILE_LOCATION
     value: "$(Build.BinariesDirectory)/tests.log"

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -379,18 +379,25 @@ stages:
               # A merge-queue build carries no PR context, so recover the PR and the base the
               # entry was built on from the queue ref. Diffing against that commit excludes
               # what other entries merged while this one waited.
+              # --recurse-submodules=no everywhere: the diff below never reads submodule
+              # content, but git's default on-demand recursion follows a moved
+              # java-questdb-client pointer (detect-local-client populated the submodule
+              # earlier in this job) and fetches it from github.com. The credential
+              # persistCredentials leaves behind is scoped to the questdb/questdb URL, so
+              # that submodule fetch goes out anonymously, and GitHub's throttling of
+              # anonymous git-over-HTTPS fails the whole step.
               if [[ "$BUILD_SOURCEBRANCH" =~ ^refs/heads/gh-readonly-queue/(.*)/pr-([0-9]+)-([0-9a-f]{40})$ ]]; then
                 BASE_BRANCH="${BASH_REMATCH[1]}"
                 PR_NUMBER="${BASH_REMATCH[2]}"
                 DIFF_BASE="${BASH_REMATCH[3]}"
                 # GitHub deletes the ref that made this commit reachable once that entry merges.
-                if ! git fetch --depth=1 origin "$DIFF_BASE"; then
-                  git fetch origin "$BASE_BRANCH"
+                if ! git fetch --recurse-submodules=no --depth=1 origin "$DIFF_BASE"; then
+                  git fetch --recurse-submodules=no origin "$BASE_BRANCH"
                   DIFF_BASE="origin/$BASE_BRANCH"
                 fi
               elif [[ "$PR_NUMBER_MACRO" =~ ^[0-9]+$ ]]; then
                 PR_NUMBER="$PR_NUMBER_MACRO"
-                git fetch origin "$TARGET_BRANCH"
+                git fetch --recurse-submodules=no origin "$TARGET_BRANCH"
                 DIFF_BASE="origin/$TARGET_BRANCH"
               else
                 echo "Neither a PR nor a merge-queue build ($BUILD_SOURCEBRANCH); skipping the diff coverage report"

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -397,12 +397,14 @@ stages:
                 DIFF_BASE="${BASH_REMATCH[3]}"
                 # GitHub deletes the ref that made this commit reachable once that entry merges.
                 if ! git fetch --recurse-submodules=no --depth=1 origin "$DIFF_BASE"; then
-                  git fetch --recurse-submodules=no origin "$BASE_BRANCH"
+                  git fetch --recurse-submodules=no --depth=1 origin "$BASE_BRANCH"
                   DIFF_BASE="origin/$BASE_BRANCH"
                 fi
               elif [[ "$PR_NUMBER_MACRO" =~ ^[0-9]+$ ]]; then
                 PR_NUMBER="$PR_NUMBER_MACRO"
-                git fetch --recurse-submodules=no origin "$TARGET_BRANCH"
+                # --depth=1: the two-dot git diff below compares the endpoint trees
+                # only, so the base branch's history is dead weight.
+                git fetch --recurse-submodules=no --depth=1 origin "$TARGET_BRANCH"
                 DIFF_BASE="origin/$TARGET_BRANCH"
               else
                 echo "Neither a PR nor a merge-queue build ($BUILD_SOURCEBRANCH); skipping the diff coverage report"

--- a/ci/test-pipeline.yml
+++ b/ci/test-pipeline.yml
@@ -267,6 +267,21 @@ stages:
             lfs: false
             submodules: false
             persistCredentials: true
+          # persistCredentials serves the non-fork paths: the diff-base fetch in
+          # "Post combined report" and ci/git-auth-env.sh's fallback. This job is a
+          # required check, so it also runs on fork PRs (with the real work
+          # SHOULD_RUN-gated off) while processing fork-controlled data -- pom.xml
+          # and .gitmodules in detect-local-client. Drop the on-disk credential
+          # there before any of that runs; the fork-side submodule clone then uses
+          # the same anonymous backoff path as every other fork clone. The
+          # condition fails safe: IsFork is unset on merge-queue and manual runs,
+          # which keep the credential their fetches legitimately need. || true:
+          # an absent key (persistCredentials flipped off later) exits 5 and must
+          # not fail the job. and(succeeded(), ...) because an explicit condition
+          # replaces the implicit succeeded() guard.
+          - bash: git config --unset-all "http.https://github.com/questdb/questdb.extraheader" || true
+            displayName: "Drop persisted checkout credential on fork PRs"
+            condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'true'))
           - template: templates/use-hetzner-apt-mirrors.yml
             parameters:
               shouldRun: and(succeeded(), eq(variables['SHOULD_RUN'], 'true'))

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -196,6 +196,9 @@ if (OS_LINUX)
             liburing_git
             GIT_REPOSITORY https://github.com/axboe/liburing.git
             GIT_TAG liburing-2.2
+            # The tag pin allows a shallow clone (asmjit above pins a raw SHA, which
+            # CMake cannot clone shallowly); CI never needs liburing's history.
+            GIT_SHALLOW TRUE
             BUILD_IN_SOURCE 1
             BUILD_BYPRODUCTS "<SOURCE_DIR>/src/liburing.a"
             BUILD_COMMAND make "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}" "AR=${CMAKE_AR}" "RANLIB=${CMAKE_RANLIB}"

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -194,7 +194,7 @@ if (OS_LINUX)
     MESSAGE("Downloading io_uring")
     ExternalProject_Add(
             liburing_git
-            GIT_REPOSITORY http://github.com/axboe/liburing.git
+            GIT_REPOSITORY https://github.com/axboe/liburing.git
             GIT_TAG liburing-2.2
             BUILD_IN_SOURCE 1
             BUILD_BYPRODUCTS "<SOURCE_DIR>/src/liburing.a"


### PR DESCRIPTION
## Problem

The intermittent `fatal: could not read Username for 'https://github.com'` CI failures continued after #7588 (e.g. [build 266879](https://dev.azure.com/questdb/questdb/_build/results?buildId=266879)). The token approach in #7588 has two gaps:

**1. Fork PRs never get the token.** Azure withholds secret variables from fork PR validation builds by design, so `GH_TOKEN` arrives as the literal macro text `$(GIT_GITHUB_TOKEN)`; #7588's sanity check correctly discards it and every submodule clone still goes out anonymously. The build trace shows it directly:

```
+ [[ $(GIT_GITHUB_TOKEN) =~ ^[A-Za-z0-9_-]+$ ]]
+ unset GH_TOKEN
No usable token or no gh; cloning submodules anonymously
```

Every post-#7588 build that failed in "Detect local client profile" / "Build client native library" (266902, 266909, 266910, 266911, 266912) has `pr.isFork: True`. Non-fork PRs authenticate fine.

**2. The coverage step fetches submodules implicitly.** In build 266879 (non-fork), "Post combined report to GitHub" ran `git fetch origin master`; git's default `fetch.recurseSubmodules=on-demand` followed the moved `java-questdb-client` pointer (detect-local-client had populated the submodule earlier in that job). The credential `persistCredentials: true` leaves behind is scoped to the `https://github.com/questdb/questdb` URL only, so the submodule leg went out anonymously and one throttled request failed the step. #7588 only covered explicit `git submodule update` calls.

## Change

New `ci/submodule-update.sh` replaces the six inline copies of the gh preamble and owns every manual submodule clone:

- With a token-shaped `GH_TOKEN`, it builds the basic-auth header itself (`x-access-token:<token>`), which also drops the dependency on the `gh` binary being installed.
- Without a token, it reuses the credential the checkout task persisted (`persistCredentials: true`), re-scoped from the parent-repo URL to all of `github.com`. Unlike pipeline secrets, that credential exists on fork builds too, because the checkout task itself needs it to fetch the merge ref. Today only the Coverage Report job persists credentials, so this path mainly future-proofs the script.
- With no credential at all (fork PRs on the test jobs), it retries with 15/30/60/120s backoff. GitHub's anonymous throttle windows are short; git's own instant second attempt lands inside the same window, which is why the current failures die immediately.

The header travels through `GIT_CONFIG_{COUNT,KEY_0,VALUE_0}` environment variables, which spawned submodule clones inherit — the same mechanism the agent uses for its own submodule handling — so the credential never lands on disk, on a command line, or in xtrace output.

The coverage step now passes `--recurse-submodules=no` to its three fetches: its diff never reads submodule content, so the on-demand recursion was pure downside.

## Tradeoffs and limitations

- Fork PR builds still clone anonymously; the backoff converts a hard failure into up to ~4 minutes of extra wall time on a throttled run, and a sustained throttle can still fail the build. Making fork builds fully authenticated needs one of two things, both with a security cost that deserves a deliberate decision rather than a silent flip: `persistCredentials: true` on the test jobs (fork-authored code could then read the service-connection credential from `.git/config` during the job) or the Azure "make secrets available to builds of forks" setting (exposes all pipeline secrets, including the comment-posting `GH_TOKEN`, to fork-authored YAML; Microsoft explicitly recommends against it).
- The Windows client-native leg now invokes the script via Git Bash (`bash` on `windows-latest` images resolves to Git Bash).
- An invalid/rotated `GIT_GITHUB_TOKEN` now fails the authenticated fetch after the retry loop instead of gh failing fast; the step log names the credential source on every run to keep that diagnosable.

## Test plan

- exercised all script paths locally against file-URL submodule fixtures: anonymous clone, token-shaped `GH_TOKEN`, literal `$(GIT_GITHUB_TOKEN)` macro text rejected, persisted `http.<url>.extraheader` credential picked up and re-scoped, retry loop backs off and exits non-zero after final failure, already-cloned submodules are skipped on rerun
- parsed all six edited YAML files
- CI on this PR exercises the token path end to end on all Linux legs plus the coverage-step fetches; the anonymous-with-retry path only triggers on fork builds under active throttling, so it is validated by observing fork PR builds after merge


## Also in this PR: stop Maven steps from burying the real failure

Build [266736](https://dev.azure.com/questdb/questdb/_build/results?buildId=266736) (pre-#7588) showed a second, independent defect. When the submodule clone in "Detect local client profile" failed, every job *also* failed in "Compile with Maven" with `The specified user settings file does not exist: .../$(MAVEN_SETTINGS_FILE)`. The Maven steps carry explicit variable `condition:`s, and an explicit condition replaces Azure's implicit `succeeded()` guard — so the failed clone did not stop them, while the "Select Maven settings" step it *did* stop never populated `MAVEN_SETTINGS_FILE`. Maven then died on the literal macro text, and the build's failure list pointed everywhere except the actual cause.

The four Maven steps in `steps.yml` and the coverage-stage Compile/Merge/Post steps in `test-pipeline.yml` now include `succeeded()` in their conditions. The `condition: failed()` cleanup steps (crash-dump rename, log upload) are intentionally unchanged. This changes no green-path behavior; it only stops doomed steps from running after the job is already failing.


## Also in this PR: authenticate CMake's asmjit clone in the JIT test job

Build [266938](https://dev.azure.com/questdb/questdb/_build/results?buildId=266938) surfaced a third anonymous-clone site: `core/CMakeLists.txt` fetches `questdb/asmjit` via CMake FetchContent, and the `git clone` CMake spawns at configure time knew nothing about the credential — anonymous again, and FetchContent's three instant retries all landed inside the same throttle window.

The credential resolution now lives in `ci/git-auth-env.sh`, which prints `export` lines for `GIT_CONFIG_{COUNT,KEY_0,VALUE_0}`; any git spawned from a shell that evals the output inherits the header, including git run by CMake. `ci/submodule-update.sh` evals the helper internally (no call-site changes), and the jittests step evals it before cmake, with xtrace off around the eval so the header never reaches the log. For the anonymous case (fork PRs touching C++), the configure retries with the same 15/30/60/120s backoff, wiping `build/jittest` between attempts since a failed configure can leave a half-populated FetchContent cache. The retry deliberately covers deterministic configure errors too (discriminating by output pattern-matching rots as tools reword their errors); its messages state that an identically repeating error is deterministic, not a network problem, so a broken CMakeLists costs ~4 bounded minutes of backoff rather than being misattributed to fetching.

An alternative worth considering separately: vendoring asmjit as a git submodule like the other native deps (jemalloc, simdjson, zlib, fsst) would remove the build-time network fetch entirely, but it changes the local developer build, so it is not part of this PR.


## Also in this PR: cover the liburing clone; full CI clone audit

A sweep of every Azure YAML in `ci/` (and everything they invoke: CMake configures, cargo, maven profiles, npm/pip in compat, helper scripts) found one more build-time git clone: `core/CMakeLists.txt` pulls `axboe/liburing` through `ExternalProject_Add` on Linux, and that clone runs in the middle of `cmake --build` — outside the configure retry loop, with no backoff of its own. The jittests step now prefetches the `liburing_git` target inside the same backoff loop as the configure, so the main build does no network I/O. The liburing URL also moves from `http://` to `https://`: the plain-http form only worked through GitHub's redirect, and the exported credential is scoped to `https://github.com/`, so it matches on the first request instead of relying on git re-applying config after a cross-scheme redirect.

Audited and found clean (no change needed): the check-changes GitHub API calls (token-optional with retry and a safe "test everything" fallback), the enterprise-trigger stage (skips forks, authenticated, benign fallback to main), compat suites (registry downloads only), the web-console profile (registry.npmjs.org), install-llvm (rustup), java-lint (jetbrains download; local-only git), rust toolchain bootstrap (rustup.rs), and the release pipelines (agent-authenticated `submodules: true` checkouts; GraalVM/preflight comes from GitHub release assets, a different rate-limit class, on rare master-only runs).


## Also in this PR: shield hosted macwin builds from Maven Central throttling

macwin build 266975 failed with HTTP 429 from `repo.maven.apache.org`. The hosted macOS/Windows agents cannot reach the private `maven.internal` Reposilite cache (Hetzner vSwitch only), so they resolve straight from Central, and a cold-cache run puts ~16 fresh VMs on Central at once. Three defects lined up, all fixed in the hosted pipeline only:

- `MAVEN_RUN_OPTS` pinned `transport=wagon` (Reposilite keepalive tuning the hosted agents never benefit from), whose GET retries have no backoff. The hosted pipeline now uses Maven 3.9's native transport, which backs off on 429/503 and obeys `Retry-After` (MRESOLVER-396), with count=8 and a linear 7.5s-per-attempt backoff (7.5s, 15s, …; the server's Retry-After is obeyed when present). intervalMax is a bail-out, not a clamp: a wait above it stops the retry chain, so it is set to 120s — a Retry-After of up to two minutes is waited out instead of aborting, at the cost of doomed runs failing more slowly (bounded by the job timeout).
- The `.m2` Cache@2 missed on every first macwin run of every PR: cross-branch cache restore only works from master-created caches, and this pipeline never runs on plain master. A weekly scheduled master run now seeds the caches; the key also hashes the poms (with `restoreKeys`) so dependency drift updates the cache instead of freezing it at first save.
- `MAVEN_CACHE_FOLDER` used `$(HOME)`, which Windows agents leave as literal macro text (Maven wrote to a directory literally named `$(HOME)`). Hosted pipeline now uses `$(Pipeline.Workspace)/.m2/repository`.

Tradeoffs: the weekly seed run costs a full macwin matrix on master once a week; the retry backoff can stretch a genuinely throttled cold run by a few minutes instead of failing it. The Hetzner pipeline keeps its wagon pinning and Reposilite routing unchanged. Longer-term, exposing the cache box's nginx front-end over public HTTPS would let the hosted agents share the same Reposilite cache (the settings file already anticipates an HTTPS front); that needs infra outside this repo and a hostname decision, so it is not part of this PR.


## Follow-up: the .m2 cache task now runs behind an allowlist

Review of the pom-hashed key found a latent fail-open in the cache task's pool condition: `test-fuzz.yml` is the one `steps.yml` consumer that sets `pool.name` directly without defining the `poolName` variable, so the `ne(poolName, 'hetzner-…')` denylist evaluated against an empty string and passed — fuzz build 266995 shows the task running on a Hetzner agent, hitting the frozen static key, and skipping the save. Harmless at base, but the pom-hashed key would have started re-saving the fuzz agent's shared `$HOME/.m2/repository` into the pipeline cache on the first post-merge cron run and on every pom change after that. The condition is now an allowlist (`eq(poolName, 'Azure Pipelines')`): hosted legs keep the cache, Hetzner legs stay excluded, and a future consumer that forgets `poolName` gets no cache instead of a surprise one. Separately worth doing someday: giving the fuzz jobs a real `poolName` would let the steps.yml JDK-activation step fire and retire its manual `apt-get install openjdk-25-jdk` workaround.




## Also in this PR: drop the persisted checkout credential on fork coverage runs

The CoverageReport job persists its checkout credential (`persistCredentials: true`, pre-existing) for the non-fork diff-base fetch and the `ci/git-auth-env.sh` fallback. Because the job is a required check, it also runs on fork PRs — real work SHOULD_RUN-gated off, but `detect-local-client` still processes fork-controlled data (`pom.xml`, `.gitmodules`) with the service-connection credential readable in `.git/config`. Review found no concrete exfiltration vector in the current step set (the re-scoped header only ever reaches github.com; git ignores command-mode update settings from `.gitmodules`; the version echo prefix blocks `##vso` injection), and every recent fork build skipped this stage only because it failed earlier on the very throttle bug this PR fixes — meaning the PR unmasks the path. A fork-only step now unsets the persisted extraheader immediately after checkout. Tradeoff: the fork-side submodule clone joins the anonymous-backoff risk pool, so a sustained throttle can red a fork's required check where the credential would have survived. The condition fails safe (IsFork is unset on merge-queue/manual runs, which keep the credential), and the scrub's positive path first executes on the first green fork PR after merge — it cannot be exercised from this branch PR.
