### PR TITLE
fix(cast): handle null constants when casting numbers to string (#2799)

### DIFF
--- a/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastIntToStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastIntToStrFunctionFactory.java
@@ -43,8 +43,12 @@ public class CastIntToStrFunctionFactory implements FunctionFactory {
     public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
         Function intFunc = args.getQuick(0);
         if (intFunc.isConstant()) {
+            final int value = intFunc.getInt(null);
+            if (value == Numbers.INT_NULL) {
+                return StrConstant.NULL;
+            }
             StringSink sink = Misc.getThreadLocalSink();
-            sink.put(intFunc.getInt(null));
+            sink.put(value);
             return new StrConstant(Chars.toString(sink));
         }
         return new Func(args.getQuick(0));

--- a/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastLongToStrFunctionFactory.java
+++ b/core/src/main/java/io/questdb/griffin/engine/functions/cast/CastLongToStrFunctionFactory.java
@@ -43,8 +43,12 @@ public class CastLongToStrFunctionFactory implements FunctionFactory {
     public Function newInstance(int position, ObjList<Function> args, IntList argPositions, CairoConfiguration configuration, SqlExecutionContext sqlExecutionContext) {
         Function func = args.getQuick(0);
         if (func.isConstant()) {
+            final long value = func.getLong(null);
+            if (value == Numbers.LONG_NULL) {
+                return StrConstant.NULL;
+            }
             StringSink sink = Misc.getThreadLocalSink();
-            sink.put(func.getLong(null));
+            sink.put(value);
             return new StrConstant(Chars.toString(sink));
         }
         return new Func(args.getQuick(0));

--- a/core/src/test/java/io/questdb/test/griffin/engine/functions/cast/CastTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/engine/functions/cast/CastTest.java
@@ -3618,6 +3618,20 @@ public class CastTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testIntToStrConstNull() throws Exception {
+        assertQuery("select a from tab")
+                .ddl("create table tab (a string)")
+                .mutateWith("insert into tab select cast(cast(null as int) as string) from long_sequence(3)")
+                .expectSize()
+                .returns("a\n", """
+                        a
+
+
+
+                        """);
+    }
+
+    @Test
     public void testIntToStrSort() throws Exception {
         assertQuery("select cast(a as string) x from tt order by x")
                 .ddl("create table tt as (select rnd_int(1,200,1) a from long_sequence(20))")
@@ -4308,6 +4322,34 @@ public class CastTest extends AbstractCairoTest {
                         334
                         334
                         334
+                        """);
+    }
+
+    @Test
+    public void testLongToStrConstNull() throws Exception {
+        assertQuery("select a from tab")
+                .ddl("create table tab (a string)")
+                .mutateWith("insert into tab select cast(cast(null as long) as string) from long_sequence(3)")
+                .expectSize()
+                .returns("a\n", """
+                        a
+
+
+
+                        """);
+    }
+
+    @Test
+    public void testLongToStrNullColumn() throws Exception {
+        assertQuery("select cast(a as string) x from tab")
+                .ddl("create table tab (a long)")
+                .mutateWith("insert into tab select cast(null as long) from long_sequence(3)")
+                .expectSize()
+                .returns("x\n", """
+                        x
+
+
+
                         """);
     }
 


### PR DESCRIPTION
**Description:**

Fixes #2799.

Constant-folded `CAST(... AS STRING)` returned `"NaN"` instead of SQL NULL when casting `LONG_NULL` or `INT_NULL`. The non-constant paths already handled these NULL sentinels correctly, but the constant branches wrote the sentinel directly to the string sink.

This change adds the corresponding `LONG_NULL` and `INT_NULL` checks to the constant-folded Long→String and Int→String cast paths and returns `StrConstant.NULL`.

**Tests:**

Added regression coverage for:

* constant `INT_NULL` → STRING
* constant `LONG_NULL` → STRING
* Long column NULL → STRING

The tests follow existing QuestDB `CastTest` conventions.

**Validation:**

`git diff --check` passes and the final diff contains only the two cast factories and `CastTest`.

The focused Maven tests were **not run locally** because this environment has Java 21 and no Maven/Maven Wrapper, while QuestDB requires Java 25 + Maven. No toolchain was installed or modified. CI should provide the required Java 25/Maven validation.

**Breaking Changes:**

None.
