### PR TITLE
fix(core): make metadata swaps crash durable

### DIFF
--- a/core/src/main/java/io/questdb/cairo/TableWriter.java
+++ b/core/src/main/java/io/questdb/cairo/TableWriter.java
@@ -514,7 +514,24 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
                 repairMetaRename(todoMem);
             }
             this.metadata = new TableWriterMetadata(this.tableToken);
-            openMetaFile(ff, path, pathSize, ddlMem, metadata);
+            if (metadataFileIsMissingOrTooShort()) {
+                repairCommittedMetadataFromSwap(Long.MIN_VALUE, true);
+            }
+            try {
+                openMetaFile(ff, path, pathSize, ddlMem, metadata);
+            } catch (CairoException e) {
+                ddlMem.close(false);
+                if (!repairCommittedMetadataFromSwap(Long.MIN_VALUE, false)) {
+                    throw e;
+                }
+                openMetaFile(ff, path, pathSize, ddlMem, metadata);
+            }
+            if (metadata.getMetadataVersion() != txWriter.getMetadataVersion()) {
+                final long currentVersion = metadata.getMetadataVersion();
+                ddlMem.close(false);
+                repairCommittedMetadataFromSwap(currentVersion, true);
+                openMetaFile(ff, path, pathSize, ddlMem, metadata);
+            }
             this.metadata.setTxReader(txWriter);
             this.timestampType = metadata.getTimestampType();
             this.timestampDriver = ColumnType.getTimestampDriver(timestampType);
@@ -12823,6 +12840,9 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
     private void recoverFromTodoWriteFailure() {
         restoreMetaFrom(META_PREV_FILE_NAME, metaPrevIndex);
+        // The rollback rename is the on-disk state _txn still describes. Make
+        // that directory entry durable before the caller clears _todo_.
+        syncTableDirectoryAfterMetadataRename();
         openMetaFile(ff, path, pathSize, ddlMem, metadata);
         columnCount = metadata.getColumnCount();
     }
@@ -13292,6 +13312,45 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
     }
 
+    private boolean metadataFileIsMissingOrTooShort() {
+        try {
+            path.concat(META_FILE_NAME).$();
+            return !ff.exists(path.$()) || ff.length(path.$()) < META_OFFSET_COLUMN_TYPES;
+        } finally {
+            path.trimTo(pathSize);
+        }
+    }
+
+    private boolean repairCommittedMetadataFromSwap(long currentVersion, boolean failIfNoMatch) {
+        final long expectedVersion = txWriter.getMetadataVersion();
+        for (int index = 0, n = configuration.getMaxSwapFileCount(); index < n; index++) {
+            final long swapVersion = readValidatedMetadataVersion(META_SWAP_FILE_NAME, index);
+            if (swapVersion == expectedVersion) {
+                LOG.info()
+                        .$("recovering committed metadata from swap [table=").$(tableToken)
+                        .$(", expectedVersion=").$(expectedVersion)
+                        .$(", currentVersion=").$(currentVersion)
+                        .$(", swapIndex=").$(index)
+                        .I$();
+                ff.remove(other.concat(META_FILE_NAME).$());
+                other.trimTo(pathSize);
+                restoreMetaFrom(META_SWAP_FILE_NAME, index);
+                syncTableDirectoryAfterMetadataRename();
+                clearTodoLog();
+                return true;
+            }
+        }
+
+        if (failIfNoMatch) {
+            throw CairoException.critical(0)
+                    .put("unrecoverable metadata version mismatch [table=").put(tableToken)
+                    .put(", txnVersion=").put(expectedVersion)
+                    .put(", metaVersion=").put(currentVersion)
+                    .put(", no valid metadata swap matches the committed transaction]");
+        }
+        return false;
+    }
+
     private long repairDataGaps(final long timestamp) {
         if (txWriter.getMaxTimestamp() != Numbers.LONG_NULL && PartitionBy.isPartitioned(partitionBy)) {
             long fixedRowCount = 0;
@@ -13384,6 +13443,36 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
         }
 
         return timestamp;
+    }
+
+    private long readValidatedMetadataVersion(CharSequence fileName, int index) {
+        try {
+            path.concat(fileName);
+            if (index > 0) {
+                path.put('.').put(index);
+            }
+            path.$();
+            if (!ff.exists(path.$())) {
+                return Long.MIN_VALUE;
+            }
+
+            final long len = ff.length(path.$());
+            if (len < 1) {
+                return Long.MIN_VALUE;
+            }
+
+            ddlMem.of(ff, path.$(), ff.getPageSize(), len, MemoryTag.MMAP_TABLE_WRITER, CairoConfiguration.O_NONE, POSIX_MADV_RANDOM);
+            validationMap.clear();
+            validateMeta(path, ddlMem, validationMap, ColumnType.VERSION);
+            return ddlMem.getLong(META_OFFSET_METADATA_VERSION);
+        } catch (CairoException e) {
+            LOG.info().$("ignoring invalid metadata recovery candidate [path=").$(path)
+                    .$(", error=").$safe(e.getFlyweightMessage()).I$();
+            return Long.MIN_VALUE;
+        } finally {
+            ddlMem.close(false);
+            path.trimTo(pathSize);
+        }
     }
 
     private void repairMetaRename(MemoryMARW todoMem) {
@@ -13712,6 +13801,22 @@ public class TableWriter implements TableWriterAPI, MetadataService, Closeable {
 
         // rename _meta.swp to _meta
         renameSwapMetaToMeta();
+
+        // The following _txn commit publishes the metadata version to readers.
+        // Persist both renames before that commit can become durable, otherwise a
+        // power loss may restore the old _meta while retaining the new _txn.
+        // Readers then wait forever for a metadata version that does not exist.
+        try {
+            syncTableDirectoryAfterMetadataRename();
+        } catch (CairoException e) {
+            runFragile(RECOVER_FROM_SWAP_RENAME_FAILURE, e);
+        }
+    }
+
+    private void syncTableDirectoryAfterMetadataRename() {
+        if (!Os.isWindows() && configuration.getCommitMode() != CommitMode.NOSYNC) {
+            ff.fsyncAndClose(openRONoCache(ff, path.trimTo(pathSize).$(), LOG));
+        }
     }
 
     private int rewriteMetadata(TableWriterMetadata metadata) {

--- a/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/TableWriterTest.java
@@ -30,6 +30,7 @@ import io.questdb.cairo.CairoError;
 import io.questdb.cairo.CairoException;
 import io.questdb.cairo.ColumnPurgeJob;
 import io.questdb.cairo.ColumnType;
+import io.questdb.cairo.CommitMode;
 import io.questdb.cairo.DefaultCairoConfiguration;
 import io.questdb.cairo.EntryUnavailableException;
 import io.questdb.cairo.GeoHashes;
@@ -74,6 +75,7 @@ import io.questdb.std.Misc;
 import io.questdb.std.Numbers;
 import io.questdb.std.NumericException;
 import io.questdb.std.ObjList;
+import io.questdb.std.Os;
 import io.questdb.std.Rnd;
 import io.questdb.std.Rows;
 import io.questdb.std.Unsafe;
@@ -452,6 +454,241 @@ public class TableWriterTest extends AbstractCairoTest {
                 return (!Utf8s.containsAscii(from, TableUtils.META_PREV_FILE_NAME) || --count <= 0)
                         && (!Utf8s.containsAscii(to, TableUtils.META_PREV_FILE_NAME) || --toCount <= 0)
                         && super.rename(from, to) == Files.FILES_RENAME_OK ? Files.FILES_RENAME_OK : Files.FILES_RENAME_ERR_OTHER;
+            }
+        });
+    }
+
+    @Test
+    public void testAddColumnFsyncsMetadataRenamesInSyncMode() throws Exception {
+        if (Os.isWindows()) {
+            return;
+        }
+
+        MetadataDirectorySyncFacade ff = new MetadataDirectorySyncFacade();
+        create(ff, PartitionBy.DAY, 10);
+
+        try (TableWriter writer = newOffPoolWriter(new DefaultTestCairoConfiguration(root) {
+            @Override
+            public int getCommitMode() {
+                return CommitMode.SYNC;
+            }
+
+            @Override
+            public @NotNull FilesFacade getFilesFacade() {
+                return ff;
+            }
+        }, PRODUCT)) {
+            ff.activate();
+            writer.addColumn("durable", ColumnType.LONG, AllowAllSecurityContext.INSTANCE);
+        }
+
+        Assert.assertTrue("the metadata swap must complete", ff.swapRenamed);
+        Assert.assertTrue(
+                "the table directory must be opened only after _meta.swp becomes _meta",
+                ff.directoryOpenedAfterSwap
+        );
+        Assert.assertTrue(
+                "the metadata rename directory entry must be durable before _txn publishes its version",
+                ff.directorySynced
+        );
+    }
+
+    @Test
+    public void testMetadataDirectoryFsyncFailureDurablyRollsBackBeforeTxnCommit() throws Exception {
+        if (Os.isWindows()) {
+            return;
+        }
+
+        MetadataDirectorySyncFailingFacade ff = new MetadataDirectorySyncFailingFacade();
+        create(ff, PartitionBy.DAY, 10);
+        DefaultTestCairoConfiguration syncConfiguration = new DefaultTestCairoConfiguration(root) {
+            @Override
+            public int getCommitMode() {
+                return CommitMode.SYNC;
+            }
+
+            @Override
+            public @NotNull FilesFacade getFilesFacade() {
+                return ff;
+            }
+        };
+
+        try (TableWriter writer = newOffPoolWriter(syncConfiguration, PRODUCT)) {
+            ff.activate();
+            try {
+                writer.addColumn("not_committed", ColumnType.LONG, AllowAllSecurityContext.INSTANCE);
+                Assert.fail("metadata publication must fail when its directory fsync fails");
+            } catch (CairoException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "test metadata directory fsync failure");
+            }
+            Assert.assertFalse(
+                    "a successful rollback should keep the writer usable",
+                    writer.isDistressed()
+            );
+        }
+
+        Assert.assertTrue("the pre-transaction directory fsync must be attempted", ff.failedPublishSync);
+        Assert.assertTrue(
+                "the rollback rename must be synced before _todo_ can be cleared",
+                ff.rollbackSynced
+        );
+        try (TableWriter writer = newOffPoolWriter(syncConfiguration, PRODUCT)) {
+            Assert.assertEquals(
+                    "the failed metadata change must not survive reopen",
+                    -1,
+                    writer.getMetadata().getColumnIndexQuiet("not_committed")
+            );
+        }
+    }
+
+    @Test
+    public void testRecoverCommittedMetadataFromSwapAfterLostRenames() throws Exception {
+        assertMemoryLeak(() -> {
+            create(FF, PartitionBy.DAY, 10);
+            java.nio.file.Path tableDir = java.nio.file.Path.of(root, PRODUCT_FS);
+            java.nio.file.Path meta = tableDir.resolve(TableUtils.META_FILE_NAME);
+            java.nio.file.Path swap = tableDir.resolve(TableUtils.META_SWAP_FILE_NAME);
+            java.nio.file.Path previous = tableDir.resolve(TableUtils.META_PREV_FILE_NAME);
+            java.nio.file.Path oldMeta = tableDir.resolve("_meta.issue23.old");
+            java.nio.file.Files.copy(meta, oldMeta);
+
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
+                writer.addColumn("durable", ColumnType.LONG, AllowAllSecurityContext.INSTANCE);
+            }
+
+            // Reconstruct the namespace observed after the power loss: _txn has
+            // committed metadata version 1, while the directory entries recovered
+            // to old _meta version 0 and new _meta.swp version 1, with no prev.
+            java.nio.file.Files.copy(
+                    meta,
+                    swap,
+                    java.nio.file.StandardCopyOption.REPLACE_EXISTING
+            );
+            java.nio.file.Files.copy(
+                    oldMeta,
+                    meta,
+                    java.nio.file.StandardCopyOption.REPLACE_EXISTING
+            );
+            java.nio.file.Files.deleteIfExists(previous);
+            java.nio.file.Files.deleteIfExists(oldMeta);
+
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
+                Assert.assertTrue(
+                        "writer recovery must promote the metadata matching committed _txn",
+                        writer.getMetadata().getColumnIndexQuiet("durable") > -1
+                );
+            }
+            Assert.assertFalse(
+                    "the matching swap must have been consumed",
+                    java.nio.file.Files.exists(swap)
+            );
+
+            try (TableReader reader = newOffPoolReader(configuration, PRODUCT)) {
+                Assert.assertTrue(
+                        "readers must open after recovery instead of timing out on a frozen version mismatch",
+                        reader.getMetadata().getColumnIndexQuiet("durable") > -1
+                );
+            }
+        });
+    }
+
+    @Test
+    public void testCommittedMetadataMismatchRejectsInvalidSwap() throws Exception {
+        assertMemoryLeak(() -> {
+            create(FF, PartitionBy.DAY, 10);
+            java.nio.file.Path tableDir = java.nio.file.Path.of(root, PRODUCT_FS);
+            java.nio.file.Path meta = tableDir.resolve(TableUtils.META_FILE_NAME);
+            java.nio.file.Path swap = tableDir.resolve(TableUtils.META_SWAP_FILE_NAME);
+            java.nio.file.Path previous = tableDir.resolve(TableUtils.META_PREV_FILE_NAME);
+            java.nio.file.Path oldMeta = tableDir.resolve("_meta.issue23.old");
+            java.nio.file.Files.copy(meta, oldMeta);
+
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
+                writer.addColumn("durable", ColumnType.LONG, AllowAllSecurityContext.INSTANCE);
+            }
+            java.nio.file.Files.copy(
+                    oldMeta,
+                    meta,
+                    java.nio.file.StandardCopyOption.REPLACE_EXISTING
+            );
+            java.nio.file.Files.write(swap, new byte[]{1, 2, 3, 4});
+            java.nio.file.Files.deleteIfExists(previous);
+            java.nio.file.Files.deleteIfExists(oldMeta);
+
+            try (TableWriter ignored = newOffPoolWriter(configuration, PRODUCT)) {
+                Assert.fail("an invalid swap must not be promoted over mismatched metadata");
+            } catch (CairoException e) {
+                TestUtils.assertContains(e.getFlyweightMessage(), "unrecoverable metadata version mismatch");
+            }
+            Assert.assertTrue(
+                    "a rejected recovery candidate must remain available for diagnosis",
+                    java.nio.file.Files.exists(swap)
+            );
+        });
+    }
+
+    @Test
+    public void testRecoverCommittedMetadataFromSwapWhenMetaIsMissing() throws Exception {
+        assertMemoryLeak(() -> {
+            create(FF, PartitionBy.DAY, 10);
+            java.nio.file.Path tableDir = java.nio.file.Path.of(root, PRODUCT_FS);
+            java.nio.file.Path meta = tableDir.resolve(TableUtils.META_FILE_NAME);
+            java.nio.file.Path swap = tableDir.resolve(TableUtils.META_SWAP_FILE_NAME);
+            java.nio.file.Path previous = tableDir.resolve(TableUtils.META_PREV_FILE_NAME);
+
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
+                writer.addColumn("durable", ColumnType.LONG, AllowAllSecurityContext.INSTANCE);
+            }
+            java.nio.file.Files.copy(
+                    meta,
+                    swap,
+                    java.nio.file.StandardCopyOption.REPLACE_EXISTING
+            );
+            java.nio.file.Files.delete(meta);
+            java.nio.file.Files.deleteIfExists(previous);
+
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
+                Assert.assertTrue(
+                        "a missing _meta must recover from the swap matching committed _txn",
+                        writer.getMetadata().getColumnIndexQuiet("durable") > -1
+                );
+            }
+            Assert.assertFalse(java.nio.file.Files.exists(swap));
+
+            try (TableReader reader = newOffPoolReader(configuration, PRODUCT)) {
+                Assert.assertTrue(reader.getMetadata().getColumnIndexQuiet("durable") > -1);
+            }
+        });
+    }
+
+    @Test
+    public void testRecoverCommittedMetadataFromSwapWhenMetaIsCorrupt() throws Exception {
+        assertMemoryLeak(() -> {
+            create(FF, PartitionBy.DAY, 10);
+            java.nio.file.Path tableDir = java.nio.file.Path.of(root, PRODUCT_FS);
+            java.nio.file.Path meta = tableDir.resolve(TableUtils.META_FILE_NAME);
+            java.nio.file.Path swap = tableDir.resolve(TableUtils.META_SWAP_FILE_NAME);
+            java.nio.file.Path previous = tableDir.resolve(TableUtils.META_PREV_FILE_NAME);
+
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
+                writer.addColumn("durable", ColumnType.LONG, AllowAllSecurityContext.INSTANCE);
+            }
+            java.nio.file.Files.copy(
+                    meta,
+                    swap,
+                    java.nio.file.StandardCopyOption.REPLACE_EXISTING
+            );
+            java.nio.file.Files.write(meta, new byte[]{1, 2, 3, 4});
+            java.nio.file.Files.deleteIfExists(previous);
+
+            try (TableWriter writer = newOffPoolWriter(configuration, PRODUCT)) {
+                Assert.assertTrue(
+                        "a corrupt _meta must recover from the validated matching swap",
+                        writer.getMetadata().getColumnIndexQuiet("durable") > -1
+                );
+            }
+            try (TableReader reader = newOffPoolReader(configuration, PRODUCT)) {
+                Assert.assertTrue(reader.getMetadata().getColumnIndexQuiet("durable") > -1);
             }
         });
     }
@@ -5032,6 +5269,76 @@ public class TableWriterTest extends AbstractCairoTest {
         @Override
         public boolean wasCalled() {
             return active;
+        }
+    }
+
+    private static class MetadataDirectorySyncFacade extends LazyTestFilesFacade {
+        private boolean directoryOpenedAfterSwap;
+        private boolean directorySynced;
+        private long tableDirectoryFd = -1;
+        private boolean swapRenamed;
+
+        @Override
+        public void fsyncAndClose(long fd) {
+            if (active && fd == tableDirectoryFd) {
+                directorySynced = true;
+            }
+            super.fsyncAndClose(fd);
+        }
+
+        @Override
+        public long openRONoCache(LPSZ name) {
+            long fd = super.openRONoCache(name);
+            if (active && Utf8s.endsWithAscii(name, PRODUCT_FS)) {
+                Assert.assertTrue(
+                        "the table directory cannot be synced before the metadata swap rename",
+                        swapRenamed
+                );
+                directoryOpenedAfterSwap = true;
+                tableDirectoryFd = fd;
+            }
+            return fd;
+        }
+
+        @Override
+        public int rename(LPSZ from, LPSZ to) {
+            int result = super.rename(from, to);
+            if (active
+                    && result == Files.FILES_RENAME_OK
+                    && Utf8s.endsWithAscii(from, TableUtils.META_SWAP_FILE_NAME)
+                    && Utf8s.endsWithAscii(to, TableUtils.META_FILE_NAME)) {
+                swapRenamed = true;
+            }
+            return result;
+        }
+    }
+
+    private static class MetadataDirectorySyncFailingFacade extends LazyTestFilesFacade {
+        private boolean failedPublishSync;
+        private boolean rollbackSynced;
+        private long tableDirectoryFd = -1;
+
+        @Override
+        public void fsyncAndClose(long fd) {
+            if (active && fd == tableDirectoryFd) {
+                tableDirectoryFd = -1;
+                if (!failedPublishSync) {
+                    failedPublishSync = true;
+                    super.close(fd);
+                    throw CairoException.critical(0).put("test metadata directory fsync failure");
+                }
+                rollbackSynced = true;
+            }
+            super.fsyncAndClose(fd);
+        }
+
+        @Override
+        public long openRONoCache(LPSZ name) {
+            long fd = super.openRONoCache(name);
+            if (active && Utf8s.endsWithAscii(name, PRODUCT_FS)) {
+                tableDirectoryFd = fd;
+            }
+            return fd;
         }
     }
 


### PR DESCRIPTION
## Summary

- fsync the table directory after `_meta -> _meta.prev` and `_meta.swp -> _meta`, before publishing the matching metadata version through `_txn`
- fsync a rollback rename before clearing `_todo_`
- recover an already-committed metadata version from a validated `_meta.swp[.N]` when `_meta` is old, missing, short, or corrupt
- fail explicitly when no validated swap candidate matches committed `_txn`

## Problem

A Firecracker SIGKILL followed by host/guest reboot produced this durable namespace:

```text
_txn.metadata/structure version  1
_meta metadata version           0
_meta.swp metadata version       1
_meta.prev                        absent
_todo_                            present
```

`_meta.swp` contents were explicitly synced, but the two rename directory entries were not synced before `_txn` committed version 1. A power loss could therefore retain the new `_txn` while recovering the old `_meta` namespace. Every reader then waited to its metadata timeout for a version pairing that could never occur.

The existing TODO recovery could only roll back from `_meta.prev`; with no prev it cleared TODO and left the mismatch unchanged.

Downstream incident and evidence: https://github.com/nwoolmer/qdb-fleet/issues/23

## Ordering after this change

For SYNC/ASYNC metadata changes on non-Windows:

```text
write + sync _meta.swp
rename _meta -> _meta.prev
write TODO_RESTORE_META
rename _meta.swp -> _meta
fsync(table directory)
commit matching metadata version in _txn
clear _todo_
```

A directory-fsync failure runs the existing swap rollback. That rollback now also fsyncs the restored `_meta` directory entry before TODO is cleared. `NOSYNC` retains its existing durability semantics; Windows retains its existing behavior because directory fsync is not supported there.

On startup, the healthy path still opens `_meta` once. Recovery scanning is entered only when `_meta` cannot open, is missing/short, or its metadata version differs from `_txn`. Candidates are fully validated with `validateMeta`; only an exact committed-version match is promoted.

## Validation

```text
mvn -pl core -Dtest=io.questdb.test.cairo.TableWriterTest test
165 tests passed
```

New coverage includes:

- directory sync occurs after swap rename in SYNC mode
- directory-fsync failure rolls back and syncs the rollback before `_txn` advances
- exact incident state (old `_meta`, matching `_meta.swp`, no prev)
- missing and short/corrupt `_meta`
- invalid swap rejected rather than promoted
- writer and reader reopen successfully after recovery
