### PR TITLE
fix(core): resurrect released sequencers with the current table token; add table rename to the shared WAL fuzz harness

### DIFF
--- a/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
+++ b/core/src/main/java/io/questdb/cairo/wal/seq/TableSequencerAPI.java
@@ -538,11 +538,22 @@ public class TableSequencerAPI implements QuietCloseable {
     }
 
     private TableSequencerImpl openSequencerInstance(CharSequence tableDir, Object tableToken) {
+        TableToken token = (TableToken) tableToken;
+        // The caller's token may be stale: a job or writer holding a pre-rename token can
+        // resurrect a sequencer that was released after the rename. The name registry owns
+        // the current token of a live dir; resurrecting with a stale one would fail the
+        // nextTxn token check for up-to-date writers until the entry is recycled again.
+        // Fall back to the caller's token when the registry has no live mapping for the
+        // dir, e.g. when the sequencer of a dropped table is opened to check its state.
+        TableToken registryToken = engine.getTableTokenByDirName(tableDir);
+        if (registryToken != null && registryToken.getTableId() == token.getTableId()) {
+            token = registryToken;
+        }
         return new TableSequencerImpl(
                 this,
                 this.engine,
-                (TableToken) tableToken,
-                getSeqTxnTracker((TableToken) tableToken),
+                token,
+                getSeqTxnTracker(token),
                 0,
                 null
         );

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunner.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunner.java
@@ -41,6 +41,7 @@ import io.questdb.cairo.pool.ex.EntryLockedException;
 import io.questdb.cairo.sql.PartitionFormat;
 import io.questdb.cairo.sql.TableMetadata;
 import io.questdb.cairo.sql.TableRecordMetadata;
+import io.questdb.cairo.sql.TableReferenceOutOfDateException;
 import io.questdb.cairo.vm.api.MemoryR;
 import io.questdb.cairo.wal.ApplyWal2TableJob;
 import io.questdb.cairo.wal.CheckWalTransactionsJob;
@@ -1224,28 +1225,100 @@ public class FuzzRunner {
                     walWriter.goActive(transaction.structureVersion);
                     if (walWriter.getMetadataVersion() != transaction.structureVersion) {
                         throw CairoException.critical(0)
-                                .put("cannot update wal writer to correct structure version");
+                                .put("cannot update wal writer to correct structure version [table=").put(tableName)
+                                .put(", writerTableName=").put(walWriter.getTableToken().getTableName())
+                                .put(", writerVersion=").put(walWriter.getMetadataVersion())
+                                .put(", expectedVersion=").put(transaction.structureVersion)
+                                .put(", opIndex=").put(opIndex)
+                                .put(']');
                     }
 
                     boolean increment = false;
+                    final String walDirName;
 
                     if (transaction.reopenTable) {
-                        TableToken updatedTableToken = engine.getTableTokenByDirName(walWriter.getTableToken().getDirName());
+                        walDirName = walWriter.getTableToken().getDirName();
+                        TableToken updatedTableToken = engine.getTableTokenByDirName(walDirName);
                         if (updatedTableToken == null) {
                             throw new IllegalStateException("table is missing after reopen [table=" + tableName + "]");
                         }
                         updatedTableName = updatedTableToken.getTableName();
+                    } else {
+                        walDirName = null;
                     }
 
-                    for (int operationIndex = 0; operationIndex < transaction.operationList.size(); operationIndex++) {
-                        FuzzTransactionOperation operation = transaction.operationList.getQuick(operationIndex);
-                        increment |= operation.apply(tempRnd, engine, walWriter, -1, null);
+                    for (int attempt = 0; ; attempt++) {
+                        try {
+                            increment = false;
+                            for (int operationIndex = 0; operationIndex < transaction.operationList.size(); operationIndex++) {
+                                FuzzTransactionOperation operation = transaction.operationList.getQuick(operationIndex);
+                                increment |= operation.apply(tempRnd, engine, walWriter, -1, null);
+                            }
+
+                            if (!transaction.reopenTable) {
+                                if (transaction.rollback) {
+                                    assert !transaction.hasReplaceRange();
+                                    walWriter.rollback();
+                                } else {
+                                    if (transaction.hasReplaceRange()) {
+                                        walWriter.commitWithParams(
+                                                transaction.getReplaceLoTs(),
+                                                transaction.getReplaceHiTs(),
+                                                WAL_DEDUP_MODE_REPLACE_RANGE
+                                        );
+                                        increment = true;
+                                    } else {
+                                        walWriter.commit();
+                                    }
+                                }
+                            }
+                            break;
+                        } catch (TableReferenceOutOfDateException ex) {
+                            // Product contract on rename races: the writer marks itself distressed and
+                            // the caller re-resolves the table and retries with a fresh writer, same as
+                            // the ILP path does. The commit never allocated a txn, so re-applying the
+                            // operations keeps single application. A concurrently released and reopened
+                            // sequencer can also resurrect with a stale token; resync it like the
+                            // replica rename apply does before retrying.
+                            if (transaction.reopenTable || attempt >= 2) {
+                                throw ex;
+                            }
+                            TableToken currentToken = engine.getTableTokenByDirName(walWriter.getTableToken().getDirName());
+                            if (currentToken == null) {
+                                throw ex;
+                            }
+                            LOG.info().$("retrying transaction after table reference out of date [table=").$(currentToken)
+                                    .$(", opIndex=").$(opIndex)
+                                    .$(", attempt=").$(attempt)
+                                    .I$();
+                            engine.getTableSequencerAPI().applyRename(currentToken);
+                            synchronized (writers) {
+                                writers.get(writerIndex).close();
+                                walWriter = (WalWriter) engine.getTableWriterAPI(currentToken.getTableName(), "apply trans test");
+                                writers.setQuick(writerIndex, walWriter);
+                            }
+                        }
                     }
 
                     if (transaction.reopenTable) {
+                        // The operation may have changed the table identity:
+                        // - drop/create keeps the table name, the dir name changes;
+                        // - rename keeps the dir name, the table name changes.
+                        // Re-resolve by dir name after the operation to pick up renames. When the
+                        // dir is gone, the table was dropped and recreated under the pre-apply name.
+                        TableToken postApplyToken = engine.getTableTokenByDirName(walDirName);
+                        boolean renamed = postApplyToken != null && !postApplyToken.getTableName().equals(updatedTableName);
+                        if (renamed) {
+                            updatedTableName = postApplyToken.getTableName();
+                        }
                         synchronized (writers) {
                             for (int ii = 0; ii < writers.size(); ii++) {
-                                if (writers.get(ii).getTableToken().getTableName().equals(updatedTableName)) {
+                                // After a rename writer tokens are stale, match by dir name; table
+                                // names can be reused, another table may own the old name by now.
+                                boolean match = renamed
+                                        ? writers.get(ii).getTableToken().getDirName().equals(walDirName)
+                                        : writers.get(ii).getTableToken().getTableName().equals(updatedTableName);
+                                if (match) {
                                     writers.get(ii).close();
                                     writers.setQuick(ii, (WalWriter) engine.getTableWriterAPI(updatedTableName, "apply trans test"));
                                 }
@@ -1253,22 +1326,6 @@ public class FuzzRunner {
                         }
                         forceReaderReload.incrementAndGet();
                         engine.releaseInactive();
-                    } else {
-                        if (transaction.rollback) {
-                            assert !transaction.hasReplaceRange();
-                            walWriter.rollback();
-                        } else {
-                            if (transaction.hasReplaceRange()) {
-                                walWriter.commitWithParams(
-                                        transaction.getReplaceLoTs(),
-                                        transaction.getReplaceHiTs(),
-                                        WAL_DEDUP_MODE_REPLACE_RANGE
-                                );
-                                increment = true;
-                            } else {
-                                walWriter.commit();
-                            }
-                        }
                     }
                     if (increment || transaction.waitAllDone) {
                         waitBarrierVersion.incrementAndGet();

--- a/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunnerTest.java
+++ b/core/src/test/java/io/questdb/test/cairo/fuzz/FuzzRunnerTest.java
@@ -33,6 +33,7 @@ import io.questdb.std.ObjList;
 import io.questdb.std.Rnd;
 import io.questdb.test.AbstractCairoTest;
 import io.questdb.test.fuzz.FuzzTransaction;
+import io.questdb.test.fuzz.FuzzTransactionGenerator;
 import io.questdb.test.tools.TestUtils;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
@@ -214,6 +215,77 @@ public class FuzzRunnerTest extends AbstractCairoTest {
         );
         Assert.assertEquals("reader", reader);
         Assert.assertEquals(3, attempts.get());
+    }
+
+    @Test
+    public void testTableRenameCrossAliasedParallelApply() throws Exception {
+        // Regression test for the shared harness handling of table renames: two tables
+        // are renamed concurrently and the rename targets collide with the original
+        // names, i.e. tbl_0 -> tbl_1 while tbl_1 -> tbl_2. Writers hold stale tokens
+        // after a rename; without the reopenTable refresh the product-side stale-token
+        // recovery fast-forwards writer metadata past the harness version ladder and
+        // the run fails with "cannot update wal writer to correct structure version".
+        assertMemoryLeak(() -> {
+            Rnd rnd = fuzzer.generateRandom(LOG);
+            fuzzer.withDb(engine, sqlExecutionContext);
+            fuzzer.setFuzzProbabilities(
+                    0.05, // cancelRowsProb
+                    0.1,  // notSetProb
+                    0.1,  // nullSetProb
+                    0.01, // rollbackProb
+                    0.3,  // colAddProb
+                    0.3,  // colRemoveProb
+                    0.3,  // colRenameProb
+                    0.2,  // colTypeChangeProb
+                    0.8,  // dataAddProb
+                    0.1,  // equalTsRowsProb
+                    0.0,  // partitionDropProb
+                    0.05, // truncateProb
+                    0.0,  // tableDropProb, keep 0 to isolate the rename identity change
+                    0.0,  // setTtlProb
+                    0.0,  // replaceInsertProb
+                    0.0   // symbolAccessValidationProb
+            );
+            fuzzer.setFuzzCounts(
+                    rnd.nextBoolean(), // isO3
+                    1000,              // fuzzRowCount
+                    30,                // transactionCount
+                    10,                // strLen
+                    10,                // symbolStrLenMax
+                    10,                // symbolCountMax
+                    5000,              // initialRowCount
+                    3                  // partitionCount
+            );
+
+            String tableNameBase = testName.getMethodName();
+            int tableCount = 2;
+            ObjList<ObjList<FuzzTransaction>> fuzzTransactions = new ObjList<>();
+            try {
+                for (int i = 0; i < tableCount; i++) {
+                    String tableName = FuzzRunner.getWalParallelApplyTableName(tableNameBase, i);
+                    fuzzer.createInitialTableWal(tableName);
+                    ObjList<FuzzTransaction> transactions = fuzzer.generateTransactions(tableName, rnd);
+                    // rename each table to the next (+1) table name: the target of table N
+                    // is the original name of table N+1, exercising colliding renames and
+                    // the writer reopen path
+                    String newTableName = FuzzRunner.getWalParallelApplyTableName(tableNameBase, i + 1);
+                    int renameIndex = 1 + rnd.nextInt(transactions.size() - 1);
+                    FuzzTransactionGenerator.insertTableRename(transactions, renameIndex, newTableName);
+                    fuzzTransactions.add(transactions);
+                }
+
+                fuzzer.applyManyWalParallel(fuzzTransactions, rnd, tableNameBase, true, true);
+                fuzzer.checkNoSuspendedTables();
+
+                for (int i = 0; i < tableCount; i++) {
+                    engine.verifyTableName(FuzzRunner.getWalParallelApplyTableName(tableNameBase, i + 1));
+                }
+            } finally {
+                for (int i = 0, n = fuzzTransactions.size(); i < n; i++) {
+                    Misc.freeObjListAndClear(fuzzTransactions.getQuick(i));
+                }
+            }
+        });
     }
 
     @Test

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzTableRenameOperation.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzTableRenameOperation.java
@@ -1,0 +1,101 @@
+/*+*****************************************************************************
+ *     ___                  _   ____  ____
+ *    / _ \ _   _  ___  ___| |_|  _ \| __ )
+ *   | | | | | | |/ _ \/ __| __| | | |  _ \
+ *   | |_| | |_| |  __/\__ \ |_| |_| | |_) |
+ *    \__\_\\__,_|\___||___/\__|____/|____/
+ *
+ *  Copyright (c) 2014-2019 Appsicle
+ *  Copyright (c) 2019-2026 QuestDB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ******************************************************************************/
+
+package io.questdb.test.fuzz;
+
+import io.questdb.cairo.CairoEngine;
+import io.questdb.cairo.CairoException;
+import io.questdb.cairo.TableToken;
+import io.questdb.cairo.TableWriterAPI;
+import io.questdb.cairo.security.AllowAllSecurityContext;
+import io.questdb.cairo.vm.Vm;
+import io.questdb.cairo.vm.api.MemoryMARW;
+import io.questdb.log.Log;
+import io.questdb.log.LogFactory;
+import io.questdb.std.Chars;
+import io.questdb.std.LongList;
+import io.questdb.std.Os;
+import io.questdb.std.Rnd;
+import io.questdb.std.str.Path;
+
+/**
+ * Renames the table the given WAL writer belongs to. Insert into a transaction
+ * list via {@link FuzzTransactionGenerator#insertTableRename(io.questdb.std.ObjList, int, String)}
+ * so that the rename is serialized against concurrent transactions and the WAL
+ * writers are reopened afterwards; writer table tokens are stale after a rename.
+ * <p>
+ * Colliding renames are supported: when the target name is still in use, e.g.
+ * table1 -&gt; table2 is requested while table2 -&gt; table3 has not been applied
+ * yet, the rename is retried until the sibling rename frees the name or the
+ * retry budget runs out.
+ */
+public class FuzzTableRenameOperation implements FuzzTransactionOperation {
+    private static final Log LOG = LogFactory.getLog(FuzzTableRenameOperation.class);
+    private static final long RENAME_RETRY_TIMEOUT_MS = 60_000;
+    private final String newTableName;
+
+    public FuzzTableRenameOperation(String newTableName) {
+        this.newTableName = newTableName;
+    }
+
+    @Override
+    public boolean apply(Rnd rnd, CairoEngine engine, TableWriterAPI tableWriter, int virtualTimestampIndex, LongList excludedTsIntervals) {
+        try (
+                Path fromPath = new Path();
+                Path toPath = new Path();
+                MemoryMARW mem = Vm.getCMARWInstance()
+        ) {
+            engine.releaseInactive();
+            long deadline = System.currentTimeMillis() + RENAME_RETRY_TIMEOUT_MS;
+            while (true) {
+                // Resolve the current table name by dir name; the writer token can be stale
+                // after a previous rename and table names can be reused across tables.
+                TableToken token = engine.getTableTokenByDirName(tableWriter.getTableToken().getDirName());
+                if (token == null) {
+                    throw new IllegalStateException("table is missing before rename [table=" + tableWriter.getTableToken() + "]");
+                }
+                LOG.info().$("fuzz rename table [from=").$safe(token.getTableName()).$(", to=").$safe(newTableName).I$();
+                try {
+                    engine.rename(
+                            AllowAllSecurityContext.INSTANCE,
+                            fromPath,
+                            mem,
+                            token.getTableName(),
+                            toPath,
+                            newTableName
+                    );
+                    return true;
+                } catch (CairoException ex) {
+                    if (!Chars.contains(ex.getFlyweightMessage(), "cannot rename table, new name is already in use")
+                            || System.currentTimeMillis() > deadline) {
+                        throw ex;
+                    }
+                    // The target name is owned by a sibling table that is about to be renamed
+                    // itself; wait for the colliding rename to free the name.
+                    Os.sleep(10);
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/questdb/test/fuzz/FuzzTransactionGenerator.java
+++ b/core/src/test/java/io/questdb/test/fuzz/FuzzTransactionGenerator.java
@@ -610,6 +610,38 @@ public class FuzzTransactionGenerator {
         transactionList.add(transaction);
     }
 
+    /**
+     * Inserts a table rename transaction into an already generated transaction list.
+     * The rename is serialized against all in-flight transactions of the table
+     * (waitAllDone) and the WAL writers are reopened afterwards (reopenTable), since
+     * writer table tokens go stale when the table name changes. Structure and barrier
+     * versions of all subsequent transactions are shifted by one to account for the
+     * rename being an extra structural change.
+     *
+     * @param transactionList generated transactions of a single table
+     * @param insertIndex     index to insert the rename at, [0, transactionList.size())
+     * @param newTableName    new table name; if the name belongs to another table that
+     *                        is renamed concurrently, the rename operation waits for the
+     *                        colliding rename to free the name
+     */
+    public static void insertTableRename(ObjList<FuzzTransaction> transactionList, int insertIndex, String newTableName) {
+        assert insertIndex >= 0 && insertIndex < transactionList.size();
+        FuzzTransaction displaced = transactionList.getQuick(insertIndex);
+        FuzzTransaction renameTransaction = new FuzzTransaction();
+        // the rename applies at the structure version the displaced transaction expected
+        renameTransaction.structureVersion = displaced.structureVersion;
+        renameTransaction.waitBarrierVersion = displaced.waitBarrierVersion;
+        renameTransaction.waitAllDone = true;
+        renameTransaction.reopenTable = true;
+        renameTransaction.operationList.add(new FuzzTableRenameOperation(newTableName));
+        transactionList.insert(insertIndex, 1, renameTransaction);
+        for (int i = insertIndex + 1, n = transactionList.size(); i < n; i++) {
+            FuzzTransaction transaction = transactionList.getQuick(i);
+            transaction.structureVersion++;
+            transaction.waitBarrierVersion++;
+        }
+    }
+
     private static void generateTableDropCreate(ObjList<FuzzTransaction> transactionList, int metadataVersion, int waitBarrierVersion) {
         FuzzTransaction transaction = new FuzzTransaction();
         transaction.waitBarrierVersion = waitBarrierVersion;


### PR DESCRIPTION
**Tandem:** questdb/questdb-enterprise#1205

### Context

Enterprise `ReplicationFuzzTest#testFuzzReplication2TableWithRename` flaked in enterprise CI (build 267901) with:

```
CairoException: [0] cannot update wal writer to correct structure version
    at FuzzRunner.lambda$createWalWriteThread$0(FuzzRunner.java:1226)
```

Root cause chain:

1. The enterprise test inserted its own table-rename transaction into the fuzz stream **without** the harness's `reopenTable` writer refresh — the mechanism drop/create, `SET TTL` and `SET FORMAT` transactions already use. After the rename, all fuzz writers kept stale `TableToken`s.
2. `WalWriter`'s legitimate stale-token recovery (catch-up to latest on `NO_TXN` / `TableReferenceOutOfDateException`) then fast-forwarded writer metadata past the harness's precomputed structure-version ladder, tripping the strict `goActive(V) == V` assert.
3. While reproducing this upstream, the new regression test exposed a second, **product-level** race (details below).

### Product fix

`TableSequencerAPI.openSequencerInstance` trusted the **caller's** `TableToken` when a released sequencer entry was recreated on demand. A caller still holding a pre-rename token (background job, pooled writer that had not observed the rename) would resurrect the sequencer with the stale token. From then on the `nextTxn` token equality check threw `TableReferenceOutOfDateException` for writers holding the **current** token, distressing healthy writers commit after commit until the entry happened to be recycled by an up-to-date caller.

Fix: resolve the current token from the table name registry by dir name on resurrection — the registry owns the live dir → token mapping. The caller's token is kept when the registry has no live mapping (e.g. opening the sequencer of a dropped table to check its state), guarded by a table-id match. The table-creation path registers its sequencer separately and is unaffected.

### Harness changes

Table-rename support moves into the shared fuzz harness so identity changes are handled in one place:

- **`FuzzTableRenameOperation`** — renames via the engine, resolves the current name by dir (immune to stale tokens), waits out colliding renames (`tbl1 → tbl2` requested while `tbl2 → tbl3` is still pending)
- **`FuzzTransactionGenerator.insertTableRename`** — inserts a serialized (`waitAllDone`) rename transaction with `reopenTable` set and shifts the structure/barrier version ladder of subsequent transactions
- **Rename-aware writer reopen** in `FuzzRunner` — the token is re-resolved by dir name *after* the operation (rename keeps the dir and changes the name; drop/create keeps the name and changes the dir), and writers are matched by dir name after a rename since table names can be reused across tables
- **`TableReferenceOutOfDateException` retry** on commit, mirroring the ILP product contract: resync the sequencer token via `TableSequencerAPI.applyRename`, replace the distressed writer, retry the transaction (the failed commit never allocated a txn, so re-applying keeps single application). With the product fix in place this path no longer triggers and stays as a safety net.
- **Ladder assert diagnostics** — the failure now reports table, writer token, actual vs expected version and opIndex

### Regression test

`FuzzRunnerTest#testTableRenameCrossAliasedParallelApply` reproduces the enterprise scenario upstream: two tables renamed concurrently with colliding targets (`tbl_0 → tbl_1` while `tbl_1 → tbl_2`) under parallel WAL writers. Before the product fix it hit the stale sequencer resurrection roughly every fifth run on a laptop.

### Validation

| Suite | Result |
|---|---|
| `FuzzRunnerTest#testTableRenameCrossAliasedParallelApply` × 10 | 10/10, zero `TableReferenceOutOfDateException` retries (was ~2/10 before the product fix) |
| `FuzzRunnerTest` (full) | 12/12 |
| `WalTableSqlTest` + `TableSequencerImplTest` | 48/48 + 32/32 |
| `WalWriterFuzzTest#testWalAddRemoveCommitDropFuzz` + `#testWalWriteFullRandomMultipleTables` (drop/create + multi-table reopen paths) | 2/2 |
| Enterprise `ReplicationFuzzTest#testFuzzReplication2TableWithRename` × 8 (against this branch) | 8/8 |
