### PR TITLE
feat(sql): support bracket lists as DECLARE variable values

### DIFF
--- a/core/src/main/java/io/questdb/griffin/ExpressionParser.java
+++ b/core/src/main/java/io/questdb/griffin/ExpressionParser.java
@@ -800,6 +800,12 @@ public class ExpressionParser {
             node.type = ExpressionNode.FUNCTION;
             argStackDepth = onNode(listener, node, argStackDepth, prevBranch);
             opStack.pop();
+        } else if (localParamCount > 1 && node.type == ExpressionNode.OPERATION && Chars.equals(node.token, ":=")) {
+            // DECLARE @x := (a, b, c): the list items become arguments of the assignment,
+            // SqlParser.parseDeclare folds them into a LIST node
+            node.paramCount = localParamCount + 1;
+            argStackDepth = onNode(listener, node, argStackDepth, prevBranch);
+            opStack.pop();
         }
         return argStackDepth;
     }

--- a/core/src/main/java/io/questdb/griffin/SqlParser.java
+++ b/core/src/main/java/io/questdb/griffin/SqlParser.java
@@ -430,7 +430,81 @@ public class SqlParser {
             }
         }
 
+        spliceDeclaredLists(node);
         return visitor.visit(node);
+    }
+
+    private static boolean isDeclaredList(ExpressionNode node) {
+        return node != null && node.type == ExpressionNode.LIST;
+    }
+
+    private static SqlException listMisuse(int position) {
+        return SqlException.$(position, "list variable can only be used with IN");
+    }
+
+    private static void spliceDeclaredLists(ExpressionNode node) throws SqlException {
+        final boolean isIn = node.token != null && isInKeyword(node.token);
+        switch (node.paramCount) {
+            case 0:
+                break;
+            case 1:
+                if (isDeclaredList(node.rhs)) {
+                    throw listMisuse(node.rhs.position);
+                }
+                break;
+            case 2:
+                if (isDeclaredList(node.lhs)) {
+                    throw listMisuse(node.lhs.position);
+                }
+                if (isDeclaredList(node.rhs)) {
+                    if (!isIn) {
+                        throw listMisuse(node.rhs.position);
+                    }
+                    final ExpressionNode list = node.rhs;
+                    final ExpressionNode column = node.lhs;
+                    node.args.clear();
+                    for (int i = 0, n = list.args.size(); i < n; i++) {
+                        node.args.add(list.args.getQuick(i));
+                    }
+                    node.args.add(column);
+                    node.paramCount = node.args.size();
+                    node.lhs = null;
+                    node.rhs = null;
+                    node.type = ExpressionNode.FUNCTION;
+                }
+                break;
+            default:
+                final int last = node.paramCount - 1;
+                boolean hasList = false;
+                for (int i = 0; i <= last; i++) {
+                    final ExpressionNode arg = node.args.getQuick(i);
+                    if (isDeclaredList(arg)) {
+                        if (!isIn || i == last) {
+                            throw listMisuse(arg.position);
+                        }
+                        hasList = true;
+                    }
+                }
+                if (hasList) {
+                    final ObjList<ExpressionNode> spliced = new ObjList<>();
+                    for (int i = 0; i <= last; i++) {
+                        final ExpressionNode arg = node.args.getQuick(i);
+                        if (isDeclaredList(arg)) {
+                            for (int j = 0, n = arg.args.size(); j < n; j++) {
+                                spliced.add(arg.args.getQuick(j));
+                            }
+                        } else {
+                            spliced.add(arg);
+                        }
+                    }
+                    node.args.clear();
+                    for (int i = 0, n = spliced.size(); i < n; i++) {
+                        node.args.add(spliced.getQuick(i));
+                    }
+                    node.paramCount = node.args.size();
+                }
+                break;
+        }
     }
 
     public static void validateMatViewEveryUnit(char unit, int pos) throws SqlException {
@@ -3586,6 +3660,24 @@ public class SqlParser {
         return parseCreateViewExt(lexer, executionContext, sqlParserCallback, tok, vOpBuilder);
     }
 
+    private void foldDeclaredList(ExpressionNode assignment, CharSequence name, GenericLexer lexer) throws SqlException {
+        // the expression parser emits arguments in reverse order: [itemN, ..., item1, @name]
+        final int last = assignment.args.size() - 1;
+        final ExpressionNode nameNode = assignment.args.getQuick(last);
+        if (nameNode.type != ExpressionNode.LITERAL || !Chars.equalsIgnoreCase(nameNode.token, name)) {
+            throw errUnexpected(lexer, name, "unexpected bind expression");
+        }
+        final ExpressionNode list = expressionNodePool.next().of(ExpressionNode.LIST, "list", 0, assignment.position);
+        for (int i = 0; i < last; i++) {
+            list.args.add(assignment.args.getQuick(i));
+        }
+        list.paramCount = last;
+        assignment.args.clear();
+        assignment.paramCount = 2;
+        assignment.lhs = nameNode;
+        assignment.rhs = list;
+    }
+
     private void parseDeclare(GenericLexer lexer, IQueryModel model, SqlParserCallback sqlParserCallback) throws SqlException {
         int contentLength = lexer.getContent().length();
         while (lexer.getPosition() < contentLength) {
@@ -3638,9 +3730,10 @@ public class SqlParser {
                 throw errUnexpected(lexer, tok, "declaration was empty or could not be parsed");
             }
 
-            if (!Chars.equalsIgnoreCase(expr.lhs.token, tok)) {
-                // could be a `DECLARE @x := (1,2,3)` situation
-                throw errUnexpected(lexer, tok, "unexpected bind expression - bracket lists are not supported");
+            if (expr.paramCount > 2) {
+                foldDeclaredList(expr, tok, lexer);
+            } else if (expr.lhs == null || !Chars.equalsIgnoreCase(expr.lhs.token, tok)) {
+                throw errUnexpected(lexer, tok, "unexpected bind expression");
             }
 
             model.getDecls().put(tok, expr);
@@ -5626,7 +5719,11 @@ public class SqlParser {
         if (model.getDecls().contains(expr.token)) {
             if (expr.type == ExpressionNode.LITERAL) {
                 // replace it if so
-                expr = model.getDecls().get(expr.token).rhs;
+                final ExpressionNode value = model.getDecls().get(expr.token).rhs;
+                if (isDeclaredList(value)) {
+                    throw listMisuse(expr.position);
+                }
+                expr = value;
             } else {
                 throw SqlException.$(lexer.lastTokenPosition(), "expected literal table name or subquery");
             }
@@ -6230,10 +6327,14 @@ public class SqlParser {
         if (decls == null || decls.size() == 0) { // short circuit null case
             return expr;
         }
-        return recursiveReplace(
+        final ExpressionNode rewritten = recursiveReplace(
                 expr,
-                rewriteDeclaredVariablesInExpressionVisitor.of(decls, exprTargetVariableName)
+                rewriteDeclaredVariablesInExpressionVisitor.of(decls, exprTargetVariableName, expressionNodePool)
         );
+        if (isDeclaredList(rewritten)) {
+            throw listMisuse(rewritten.position);
+        }
+        return rewritten;
     }
 
     /**
@@ -6981,6 +7082,7 @@ public class SqlParser {
         public LowerCaseCharSequenceObjHashMap<ExpressionNode> decls;
         public CharSequence exprTargetVariableName;
         public boolean hasAtChar;
+        public ObjectPool<ExpressionNode> pool;
 
         @Override
         public ExpressionNode visit(ExpressionNode node) throws SqlException {
@@ -6993,7 +7095,8 @@ public class SqlParser {
             }
 
             if (node.token != null && node.type == ExpressionNode.LITERAL && decls.contains(node.token)) {
-                return decls.get(node.token).rhs;
+                final ExpressionNode value = decls.get(node.token).rhs;
+                return isDeclaredList(value) ? positionedListCopy(value, node.position) : value;
             } else if (hasAtChar) {
                 throw SqlException.$(node.position, "tried to use undeclared variable `" + node.token + '`');
             }
@@ -7001,12 +7104,21 @@ public class SqlParser {
             return node;
         }
 
+        private ExpressionNode positionedListCopy(ExpressionNode list, int position) {
+            final ExpressionNode copy = pool.next().of(ExpressionNode.LIST, list.token, 0, position);
+            copy.args.addAll(list.args);
+            copy.paramCount = list.paramCount;
+            return copy;
+        }
+
         ReplacingVisitor of(
                 @NotNull LowerCaseCharSequenceObjHashMap<ExpressionNode> decls,
-                @Nullable CharSequence exprTargetVariableName
+                @Nullable CharSequence exprTargetVariableName,
+                @NotNull ObjectPool<ExpressionNode> pool
         ) {
             this.decls = decls;
             this.exprTargetVariableName = exprTargetVariableName;
+            this.pool = pool;
             return this;
         }
     }

--- a/core/src/main/java/io/questdb/griffin/model/ExpressionNode.java
+++ b/core/src/main/java/io/questdb/griffin/model/ExpressionNode.java
@@ -52,6 +52,7 @@ public class ExpressionNode implements Mutable, Sinkable {
     public static final int OPERATION = MEMBER_ACCESS + 1;
     public static final int QUERY = OPERATION + 1;
     public static final int SET_OPERATION = QUERY + 1;
+    public static final int LIST = SET_OPERATION + 1;
     public static final ExpressionNodeFactory FACTORY = new ExpressionNodeFactory();
     public static final int UNKNOWN = 0;
     public final ObjList<ExpressionNode> args = new ObjList<>(4);
@@ -490,6 +491,17 @@ public class ExpressionNode implements Mutable, Sinkable {
 
     @Override
     public void toSink(@NotNull CharSink<?> sink) {
+        if (type == LIST) {
+            sink.putAscii('(');
+            for (int i = args.size() - 1; i >= 0; i--) {
+                toSink(sink, args.getQuick(i));
+                if (i > 0) {
+                    sink.putAscii(", ");
+                }
+            }
+            sink.putAscii(')');
+            return;
+        }
         // note: it's safe to take any registry (new or old) because we don't use precedence here
         OperatorRegistry registry = OperatorExpression.getRegistry();
         char openBracket = '(';

--- a/core/src/test/java/io/questdb/test/griffin/DeclareTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/DeclareTest.java
@@ -852,7 +852,7 @@ public class DeclareTest extends AbstractSqlParserTest {
             execute(TRADES_DDL);
             assertQuery("DECLARE @symbols := ('ETH-USD', 'BTC-USD') " +
                     "SELECT * FROM trades WHERE @symbols IN @symbols")
-                    .fails(43, "bracket lists");
+                    .fails(70, "list variable can only be used with IN");
 
         });
     }
@@ -1069,7 +1069,149 @@ public class DeclareTest extends AbstractSqlParserTest {
                     .noLeakCheck()
                     .assertsPlan(plan);
             assertQuery("declare @ts := ('2024-01-01', '2024-08-23') select timestamp, count() from trades where timestamp IN @ts")
-                    .fails(44, "bracket lists are not supported");
+                    .noLeakCheck()
+                    .assertsPlan(plan);
+        });
+    }
+
+    @Test
+    public void testDeclareListInSymbolColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t as (select rnd_symbol('a', 'b', 'c', 'd') s, x from long_sequence(40))");
+            assertSqlCursors(
+                    "select * from t where s in ('a', 'c')",
+                    "declare @l := ('a', 'c') select * from t where s in @l"
+            );
+        });
+    }
+
+    @Test
+    public void testDeclareListInVarcharColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t as (select rnd_varchar('a', 'b', 'c', 'd') v, x from long_sequence(40))");
+            assertSqlCursors(
+                    "select * from t where v in ('a', 'c')",
+                    "declare @l := ('a', 'c') select * from t where v in @l"
+            );
+        });
+    }
+
+    @Test
+    public void testDeclareListInLongColumn() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t as (select x from long_sequence(40))");
+            assertSqlCursors(
+                    "select * from t where x in (3, 7, 11)",
+                    "declare @l := (3, 7, 11) select * from t where x in @l"
+            );
+        });
+    }
+
+    @Test
+    public void testDeclareListNotIn() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t as (select x from long_sequence(40))");
+            assertSqlCursors(
+                    "select * from t where x not in (3, 7, 11)",
+                    "declare @l := (3, 7, 11) select * from t where x not in @l"
+            );
+        });
+    }
+
+    @Test
+    public void testDeclareListMixedWithLiterals() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t as (select x from long_sequence(40))");
+            assertSqlCursors(
+                    "select * from t where x in (40, 3, 7, 1)",
+                    "declare @l := (3, 7) select * from t where x in (40, @l, 1)"
+            );
+        });
+    }
+
+    @Test
+    public void testDeclareListReferencingScalarVariables() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t as (select x from long_sequence(40))");
+            assertSqlCursors(
+                    "select * from t where x in (3, 7)",
+                    "declare @a := 3, @b := 7, @l := (@a, @b) select * from t where x in @l"
+            );
+        });
+    }
+
+    @Test
+    public void testDeclareListUsedTwice() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t as (select x, x * 2 y from long_sequence(40))");
+            assertSqlCursors(
+                    "select * from t where x in (2, 4) or y in (2, 4)",
+                    "declare @l := (2, 4) select * from t where x in @l or y in @l"
+            );
+        });
+    }
+
+    @Test
+    public void testDeclareListOutsideInFails() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t as (select x from long_sequence(4))");
+            assertQuery("declare @l := (1, 2) select @l from t")
+                    .fails(28, "list variable can only be used with IN");
+            assertQuery("declare @l := (1, 2) select * from t where x = @l")
+                    .fails(47, "list variable can only be used with IN");
+            assertQuery("declare @l := (1, 2) select * from t where @l in (1, 2)")
+                    .fails(43, "list variable can only be used with IN");
+            assertQuery("declare @l := (1, 2) select * from @l")
+                    .fails(35, "list variable can only be used with IN");
+            assertQuery("declare @l := (1, 2), @m := (@l, 3) select * from t where x in @m")
+                    .fails(29, "list variable can only be used with IN");
+        });
+    }
+
+    @Test
+    public void testDeclareListEmptyFails() throws Exception {
+        assertMemoryLeak(() -> assertQuery("declare @l := () select 1")
+                .failsWith("too few arguments for ':='"));
+    }
+
+    @Test
+    public void testDeclareListWithOneItemIsScalar() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t as (select rnd_symbol('a', 'b', 'c', 'd') s, x from long_sequence(40))");
+            assertSqlCursors(
+                    "select * from t where s in ('a')",
+                    "declare @l := ('a') select * from t where s in @l"
+            );
+            assertSqlCursors(
+                    "select * from t where s = 'a'",
+                    "declare @l := ('a') select * from t where s = @l"
+            );
+        });
+    }
+
+    @Test
+    public void testDeclareListWithBindVariables() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t as (select x from long_sequence(40))");
+            bindVariableService.setLong(0, 3);
+            bindVariableService.setLong(1, 7);
+            assertSqlCursors(
+                    "select * from t where x in (3, 7)",
+                    "declare @l := ($1, $2) select * from t where x in @l"
+            );
+        });
+    }
+
+    @Test
+    public void testDeclareListOverridableInView() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("create table t (x long, ts timestamp) timestamp(ts) partition by day wal");
+            execute("insert into t select x, timestamp_sequence('2024-01-01', 1000000) from long_sequence(10)");
+            drainWalQueue();
+            execute("create view v as (declare overridable @l := (1, 2) select x from t where x in @l)");
+            drainWalAndViewQueues();
+            assertSqlCursors("select x from t where x in (1, 2)", "select * from v");
+            assertSqlCursors("select x from t where x in (3, 4, 5)", "declare @l := (3, 4, 5) select * from v");
         });
     }
 


### PR DESCRIPTION
## Summary

`DECLARE` variables can now hold a bracket list, and the variable can be used wherever `IN` / `NOT IN` accepts a literal list:

```sql
DECLARE @symbols := ('BTC-USDT', 'ETH-USDT')
SELECT * FROM trades WHERE symbol IN @symbols;
```

This works for every column type a literal `IN (...)` works for: SYMBOL, VARCHAR/STRING, numeric and TIMESTAMP, including the designated-timestamp interval-scan intrinsic:

```sql
DECLARE @days := ('2024-01-01', '2024-08-23')
SELECT count() FROM trades WHERE timestamp IN @days;
-- Interval forward scan on: trades, two intervals
```

Until now this failed with `unexpected bind expression - bracket lists are not supported`, the guard added in #5207. The alternatives for a multi-value filter, `IN (SELECT ...)` or a `DECLARE` subquery, only work for SYMBOL columns.

Motivation: the Web Console notebook variables need multi-select variables that expand to `col IN @var` for any column type, without text substitution on the client.

## How it works

The expression parser has no list node. A bracket list only exists as extra arguments of the token in front of it: a function call, or a set operator like `IN`. `:=` is a plain binary operator, so `@x := (1, 2, 3)` parsed into `2 := 3` with leftovers, which the old guard detected.

- `ExpressionParser`: a bracket list after `:=` is absorbed as arguments of the assignment, the same way `IN (...)` is.
- `SqlParser.parseDeclare` folds that into `@name := LIST(items)`, using a new `ExpressionNode.LIST` type.
- `SqlParser.recursiveReplace`, whose single caller is the DECLARE rewrite, splices a `LIST` child of an `IN` node into that node's argument list. The result is the same tree a literal `IN (...)` produces, so filters, JIT and intrinsics are unchanged. A list anywhere else fails with `list variable can only be used with IN`, reported at the usage position.
- `ExpressionNode.toSink` prints a `LIST` as `(a, b, c)`.

## Behaviour

| Query | Result |
|---|---|
| `col IN @list`, `col NOT IN @list` | same as the literal list |
| `col IN (40, @list, 1)` | list spliced among literals |
| `@l := (@a, @b)` | items may reference earlier scalar variables |
| `@l := ($1, $2)` | bind variables as items |
| view with `DECLARE OVERRIDABLE @l := (1, 2)`, caller runs `DECLARE @l := (3, 4, 5) SELECT * FROM v` | override applies |
| `@l := ('a')` | one-item list is a parenthesised scalar; works with `=` and `IN` |
| `SELECT @l`, `col = @l`, `@l IN (...)`, `FROM @l`, `@m := (@l, 3)` | `list variable can only be used with IN` |
| `@l := ()` | `too few arguments for ':='` |

## Tests

`DeclareTest`: 13 new tests, results asserted cursor by cursor against the literal form. Two existing assertions that pinned the old error are updated; `testDeclareWorksWithIntrinsics09` now asserts the interval-scan plan for the list form.

Run locally, all green: DeclareTest (89), SqlParserTest (1083), WhereClauseParserTest (896), ExpressionParserTest (304), ViewQueryTest (38). Also verified against a packaged server over HTTP.

## Follow-ups

- Docs: `documentation/query/sql/declare.md` lists "Bracket lists" under "Disallowed expressions". That block needs removing and the new form needs an example. Separate PR to questdb/documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
