### PR TITLE
fix(sql): stop UNION ALL silently dropping rows in time-series joins

### DIFF
--- a/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
+++ b/core/src/main/java/io/questdb/griffin/SqlCodeGenerator.java
@@ -382,6 +382,7 @@ import io.questdb.std.Decimals;
 import io.questdb.std.IntHashSet;
 import io.questdb.std.IntList;
 import io.questdb.std.IntObjHashMap;
+import io.questdb.std.IntStack;
 import io.questdb.std.LongList;
 import io.questdb.std.LowerCaseCharSequenceIntHashMap;
 import io.questdb.std.MemoryTag;
@@ -541,6 +542,17 @@ public class SqlCodeGenerator implements Mutable, Closeable {
     private final ObjList<VectorAggregateFunction> tempVaf = new ObjList<>();
     private final IntList tempVecConstructorArgIndexes = new IntList();
     private final ObjList<VectorAggregateFunctionConstructor> tempVecConstructors = new ObjList<>();
+    // Tracks whether the cursor currently being generated is an operand of a time-series join
+    // (ASOF / LT / SPLICE / WINDOW / HORIZON). Those joins walk their operands as monotonically
+    // ascending designated-timestamp streams, so that ordering is a correctness precondition,
+    // not an optimisation.
+    //
+    // This is deliberately separate from the execution context's timestamp-required flag. That
+    // flag asks whether a designated timestamp *column* must exist, and generateSelectChoose()
+    // clears it as soon as a model re-designates one with an explicit TIMESTAMP(ts) — which is
+    // exactly the shape that needs the ordering signal to survive:
+    //   ... LT JOIN (SELECT * FROM (a UNION ALL b ORDER BY ts) TIMESTAMP(ts)) ON (key)
+    private final IntStack timestampOrderRequiredStack = new IntStack();
     private final PostOrderTreeTraversalAlgo traversalAlgo;
     private final boolean validateSampleByFillType;
     private final ArrayColumnTypes valueTypes = new ArrayColumnTypes();
@@ -727,6 +739,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
             whereClauseParsers.remove(MAX_RETAINED_WHERE_CLAUSE_PARSERS, whereClauseParsers.size() - 1);
         }
         whereClauseParserDepth = 0;
+        timestampOrderRequiredStack.clear();
         symbolEstimator.clear();
         intListPool.clear();
         pushdownFilterExtractor.clear();
@@ -1313,6 +1326,13 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         // timestamp order is requested directly via order-by advice on this union model or transitively
         final boolean isTsOrderRequested =
                 isTimestampOrderRequested(model, metadataA, timestampIndex, scanDirection)
+                        // An enclosing time-series join walks this cursor as an ascending
+                        // designated-timestamp stream. Concatenating the branches would hand it a
+                        // cursor that steps backwards at the seam, and every row past the seam would
+                        // silently fail to match. Order-by advice does not reach here: the join slave
+                        // subtree is never visited by pushDownOrderByAdviceToJoinModels(), which only
+                        // ever descends into the master.
+                        || (isTimestampOrderRequiredByJoin() && scanDirection == RecordCursorFactory.SCAN_DIRECTION_FORWARD)
                         || factoryA instanceof MergeUnionAllRecordCursorFactory
                         || (factoryA instanceof UnionSymbolCastRecordCursorFactory symbolCastFactory
                         && symbolCastFactory.getBaseFactory() instanceof MergeUnionAllRecordCursorFactory);
@@ -1581,6 +1601,14 @@ public class SqlCodeGenerator implements Mutable, Closeable {
         return advice.size() == 1
                 && metadataA.getColumnIndexQuiet(advice.getQuick(0).token) == timestampIndex
                 && directionMatchesScan(getOrderByDirectionOrDefault(model, 0), scanDirection);
+    }
+
+    /**
+     * True when the cursor being generated is an operand of an enclosing time-series join, which
+     * consumes it as a monotonically ascending designated-timestamp stream.
+     */
+    private boolean isTimestampOrderRequiredByJoin() {
+        return timestampOrderRequiredStack.notEmpty() && timestampOrderRequiredStack.peek() == 1;
     }
 
     private static long tolerance(IQueryModel slaveModel, int leftTimestamp, int rightTimestampType) throws SqlException {
@@ -6010,6 +6038,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
 
                 if (i > 0) {
                     executionContext.pushTimestampRequiredFlag(joinsRequiringTimestamp[slaveModel.getJoinType()]);
+                    timestampOrderRequiredStack.push(joinsRequiringTimestamp[slaveModel.getJoinType()] ? 1 : 0);
                     executionContext.popHasInterval();
                     executionContext.pushHasInterval(1);
                 } else { // i == 0
@@ -6024,6 +6053,9 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                         }
                     }
                     executionContext.pushTimestampRequiredFlag(isTimestampRequired);
+                    // Both operands of a time-series join are walked in ascending designated-timestamp
+                    // order, so the master carries the same ordering precondition as the slaves.
+                    timestampOrderRequiredStack.push(isTimestampRequired ? 1 : 0);
                     // For successive JOIN operations, if the left table requires timestamp,
                     // it must be the timestamp from the first table in the JOIN chain
                     executionContext.pushHasInterval(0);
@@ -7010,6 +7042,7 @@ public class SqlCodeGenerator implements Mutable, Closeable {
                     throw th;
                 } finally {
                     executionContext.popTimestampRequiredFlag();
+                    timestampOrderRequiredStack.pop();
                 }
 
                 // check if there are post-filters

--- a/core/src/test/java/io/questdb/test/griffin/MergeUnionAllTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/MergeUnionAllTest.java
@@ -38,6 +38,28 @@ import org.junit.Test;
 public class MergeUnionAllTest extends AbstractCairoTest {
 
     @Test
+    public void testAsofJoinOverUnionAllWithoutOrderByResolvesAllBranches() throws Exception {
+        assertMemoryLeak(() -> {
+            createTimeSeriesJoinUnionTables();
+            // No user-written ORDER BY at all. The ordering requirement comes from the ASOF JOIN
+            // itself, so the merge must still be selected rather than a concatenating UNION ALL.
+            assertQuery("SELECT sum(CASE WHEN p.price IS NOT NULL THEN 1 ELSE 0 END) resolved " +
+                    "FROM trades t " +
+                    "ASOF JOIN (SELECT * FROM (" +
+                    "SELECT ts, token, price FROM px_bridge " +
+                    "UNION ALL " +
+                    "SELECT ts, token, price FROM px_tail" +
+                    ") TIMESTAMP(ts)) p ON (t.token = p.token)")
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("""
+                            resolved
+                            4
+                            """);
+        });
+    }
+
+    @Test
     public void testCalculateSizeHonorsCircuitBreakerAfterHasNext() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table a (px double, ts timestamp) timestamp(ts) partition by day");
@@ -307,6 +329,30 @@ public class MergeUnionAllTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testInnerJoinOverUnionAllKeepsConcat() throws Exception {
+        assertMemoryLeak(() -> {
+            createTimeSeriesJoinUnionTables();
+            // A hash join imposes no ordering requirement on its operands, so the cheaper
+            // concatenating UNION ALL must survive. Guards against the merge being selected
+            // for every join rather than the time-series ones.
+            assertQuery("SELECT count() FROM trades t " +
+                    "JOIN (SELECT * FROM (" +
+                    "SELECT ts, token, price FROM px_bridge " +
+                    "UNION ALL " +
+                    "SELECT ts, token, price FROM px_tail" +
+                    ") TIMESTAMP(ts)) p ON (t.token = p.token)")
+                    .withPlanContaining("Hash Join", "Union All")
+                    .withPlanNotContaining("Union All Merge")
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("""
+                            count
+                            40
+                            """);
+        });
+    }
+
+    @Test
     public void testInnerUnionAsBranchMergesFully() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table a (px double, ts timestamp) timestamp(ts) partition by day");
@@ -349,6 +395,118 @@ public class MergeUnionAllTest extends AbstractCairoTest {
                             30.0
                             20.0
                             10.0
+                            """);
+        });
+    }
+
+    @Test
+    public void testLtJoinOverOrderedUnionAllResolvesAllBranches() throws Exception {
+        assertMemoryLeak(() -> {
+            createTimeSeriesJoinUnionTables();
+            // Every trade must resolve a price: both tokens are priced across the whole range,
+            // one in each UNION ALL branch. Concatenating the branches without a merge leaves
+            // the right-hand cursor non-monotonic, and the join silently drops the second branch.
+            assertQuery("SELECT sum(CASE WHEN p.price IS NOT NULL THEN 1 ELSE 0 END) resolved " +
+                    "FROM trades t " +
+                    "LT JOIN (SELECT * FROM (" +
+                    "SELECT ts, token, price FROM px_bridge " +
+                    "UNION ALL " +
+                    "SELECT ts, token, price FROM px_tail " +
+                    "ORDER BY ts" +
+                    ") TIMESTAMP(ts)) p ON (t.token = p.token)")
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("""
+                            resolved
+                            4
+                            """);
+        });
+    }
+
+    @Test
+    public void testLtJoinOverThreeBranchUnionAllResolvesAllBranches() throws Exception {
+        assertMemoryLeak(() -> {
+            execute("CREATE TABLE px_bridge (ts TIMESTAMP, token SYMBOL, price DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE px_tail (ts TIMESTAMP, token SYMBOL, price DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE px_third (ts TIMESTAMP, token SYMBOL, price DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("CREATE TABLE trades (ts TIMESTAMP, token SYMBOL) TIMESTAMP(ts) PARTITION BY DAY");
+            execute("INSERT INTO px_bridge SELECT timestamp_sequence(0, 1000000), 'BRIDGE', 600.0 FROM long_sequence(10)");
+            execute("INSERT INTO px_tail SELECT timestamp_sequence(0, 1000000), 'TAIL', 1.5 FROM long_sequence(10)");
+            execute("INSERT INTO px_third SELECT timestamp_sequence(0, 1000000), 'THIRD', 9.0 FROM long_sequence(10)");
+            execute("INSERT INTO trades SELECT timestamp_sequence(5000000, 1000000), " +
+                    "CASE WHEN x % 3 = 0 THEN 'BRIDGE' WHEN x % 3 = 1 THEN 'TAIL' ELSE 'THIRD' END " +
+                    "FROM long_sequence(6)");
+
+            // Concatenation resolves only the first branch, so branches two and three both
+            // return nothing. Every trade must resolve.
+            assertQuery("SELECT sum(CASE WHEN p.price IS NOT NULL THEN 1 ELSE 0 END) resolved " +
+                    "FROM trades t " +
+                    "LT JOIN (SELECT * FROM (" +
+                    "SELECT ts, token, price FROM px_bridge " +
+                    "UNION ALL " +
+                    "SELECT ts, token, price FROM px_tail " +
+                    "UNION ALL " +
+                    "SELECT ts, token, price FROM px_third" +
+                    ") TIMESTAMP(ts)) p ON (t.token = p.token)")
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("""
+                            resolved
+                            6
+                            """);
+        });
+    }
+
+    @Test
+    public void testLtJoinOverUnionAllSelectsMerge() throws Exception {
+        assertMemoryLeak(() -> {
+            createTimeSeriesJoinUnionTables();
+            // Pin the plan: the union feeding a time-series join must be a merge, not a concat.
+            assertQuery("SELECT t.ts, p.price " +
+                    "FROM trades t " +
+                    "LT JOIN (SELECT * FROM (" +
+                    "SELECT ts, token, price FROM px_bridge " +
+                    "UNION ALL " +
+                    "SELECT ts, token, price FROM px_tail " +
+                    "ORDER BY ts" +
+                    ") TIMESTAMP(ts)) p ON (t.token = p.token)")
+                    .withPlanContaining("Union All Merge")
+                    .noRandomAccess()
+                    .expectSize()
+                    .timestampAsc("ts")
+                    .returns("""
+                            ts\tprice
+                            1970-01-01T00:00:05.000000Z\t1.5
+                            1970-01-01T00:00:06.000000Z\t600.0
+                            1970-01-01T00:00:07.000000Z\t1.5
+                            1970-01-01T00:00:08.000000Z\t600.0
+                            """);
+        });
+    }
+
+    @Test
+    public void testLtJoinOverUnionAllViewResolvesAllBranches() throws Exception {
+        assertMemoryLeak(() -> {
+            createTimeSeriesJoinUnionTables();
+            // The shape reported from the field: the two price sources are combined by a view,
+            // and the view is the right-hand side of the join. Wrapping in a view changes
+            // nothing about the requirement - the join still needs an ascending stream.
+            execute("CREATE VIEW v_prices AS (SELECT * FROM (" +
+                    "SELECT ts, token, price FROM px_bridge " +
+                    "UNION ALL " +
+                    "SELECT ts, token, price FROM px_tail" +
+                    ") TIMESTAMP(ts))");
+            drainWalAndViewQueues();
+
+            assertQuery("SELECT sum(CASE WHEN p.price IS NOT NULL THEN 1 ELSE 0 END) resolved " +
+                    "FROM trades t " +
+                    "LT JOIN v_prices p ON (t.token = p.token)")
+                    .noLeakCheck()
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("""
+                            resolved
+                            4
                             """);
         });
     }
@@ -1120,6 +1278,18 @@ public class MergeUnionAllTest extends AbstractCairoTest {
             offset += term.length();
         }
         return count;
+    }
+
+    // Two price sources with disjoint token sets over the same time range, one per UNION ALL
+    // branch, plus trades that alternate between them.
+    private void createTimeSeriesJoinUnionTables() throws Exception {
+        execute("CREATE TABLE px_bridge (ts TIMESTAMP, token SYMBOL, price DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+        execute("CREATE TABLE px_tail (ts TIMESTAMP, token SYMBOL, price DOUBLE) TIMESTAMP(ts) PARTITION BY DAY");
+        execute("CREATE TABLE trades (ts TIMESTAMP, token SYMBOL) TIMESTAMP(ts) PARTITION BY DAY");
+        execute("INSERT INTO px_bridge SELECT timestamp_sequence(0, 1000000), 'BRIDGE', 600.0 FROM long_sequence(10)");
+        execute("INSERT INTO px_tail SELECT timestamp_sequence(0, 1000000), 'TAIL', 1.5 FROM long_sequence(10)");
+        execute("INSERT INTO trades SELECT timestamp_sequence(5000000, 1000000), " +
+                "CASE WHEN x % 2 = 0 THEN 'BRIDGE' ELSE 'TAIL' END FROM long_sequence(4)");
     }
 
     private void createLongUnionTable() throws Exception {

--- a/core/src/test/java/io/questdb/test/griffin/MergeUnionAllTest.java
+++ b/core/src/test/java/io/questdb/test/griffin/MergeUnionAllTest.java
@@ -512,6 +512,29 @@ public class MergeUnionAllTest extends AbstractCairoTest {
     }
 
     @Test
+    public void testLtJoinWithToleranceOverUnionAllResolvesAllBranches() throws Exception {
+        assertMemoryLeak(() -> {
+            createTimeSeriesJoinUnionTables();
+            // The field report joined with TOLERANCE. It reaches the same join factory and carries
+            // the same ordering requirement, and the bound must not hide a branch either: every
+            // price here is well inside 300s of its trade.
+            assertQuery("SELECT sum(CASE WHEN p.price IS NOT NULL THEN 1 ELSE 0 END) resolved " +
+                    "FROM trades t " +
+                    "LT JOIN (SELECT * FROM (" +
+                    "SELECT ts, token, price FROM px_bridge " +
+                    "UNION ALL " +
+                    "SELECT ts, token, price FROM px_tail" +
+                    ") TIMESTAMP(ts)) p ON (t.token = p.token) TOLERANCE 300s")
+                    .noRandomAccess()
+                    .expectSize()
+                    .returns("""
+                            resolved
+                            4
+                            """);
+        });
+    }
+
+    @Test
     public void testMergePreservesDesignatedTimestamp() throws Exception {
         assertMemoryLeak(() -> {
             execute("create table a (px double, ts timestamp) timestamp(ts) partition by day");


### PR DESCRIPTION
## The bug

A time-series join whose right-hand operand is a `UNION ALL` **silently returns no match** for every key that lives only in the second branch. First-branch keys resolve normally, so the result reads as partial data coverage rather than a failure.

```sql
-- px_bridge prices token 'BRIDGE', px_tail prices 'TAIL': same time range, disjoint keys.
SELECT sum(CASE WHEN p.price IS NOT NULL THEN 1 ELSE 0 END) resolved
FROM trades t
LT JOIN (SELECT * FROM (
    SELECT ts, token, price FROM px_bridge
    UNION ALL
    SELECT ts, token, price FROM px_tail
    ORDER BY ts
) TIMESTAMP(ts)) p ON (t.token = p.token);
```

Every trade is priced, so this must return `4`. On `master` it returns `2` — every `TAIL` row is dropped. With three branches only the first resolves.

Found against a real dataset: 38,676 of 1.8M trades came back unpriceable purely because the second price source sat in branch two of a `UNION ALL` view.

Two things make this worse than a missed optimisation:

- **`TIMESTAMP()` buys past the safety check.** Without it the engine correctly refuses with `right side of time series join has no timestamp`. Adding it asserts an ordering the concatenating cursor does not have, and the query then runs and returns wrong answers instead of erroring.
- **The documented remedy does not work.** `ORDER BY` before `TIMESTAMP()` makes no difference, and neither does a multi-column `ORDER BY`, a `LIMIT`, `ASOF` in place of `LT`, or wrapping the union in a view. The only workarounds are materialising the ordered union into a table, or joining each source separately.

## Root cause

The plan is **position-dependent**. The identical subquery compiles two different ways.

Standalone — correct, and the output really is sorted:
```
Union All Merge
  order: [ts asc]
    PageFrame ... px_bridge
    PageFrame ... px_tail
```

As a time-series join operand — no merge node, no sort node:
```
Lt Join
  condition: p.token=t.token
    PageFrame ... trades
    SelectedRecord
        UnionSymbolCast
            Union All            <-- plain concat
                PageFrame ... px_bridge
                PageFrame ... px_tail
```

`MergeUnionAllRecordCursorFactory` (#7339) is selected by `canMergeUnionAll()`, which fires only when timestamp order is *requested* — and the only signal it consults is order-by advice on the union model. That advice never reaches a join slave: `pushDownOrderByAdviceToJoinModels()` only ever recurses into the master (`jm1`), so the slave subtree is never handed to `optimiseOrderBy()`.

`SqlExecutionContext.isTimestampRequired()` cannot be reused as the signal: `generateSelectChoose()` clears it the moment a model re-designates a timestamp with an explicit `TIMESTAMP(ts)` — which is exactly the shape that needs it. That flag answers "must a designated timestamp *column* exist", not "must this cursor arrive in timestamp order".

For the window planner, failing to select the merge is a perf fallback to `CachedWindow`. For a time-series join, ordering is a **correctness precondition**, so the same miss produces wrong results.

## The fix

Track the ordering requirement separately from the column requirement.

`SqlCodeGenerator` gains a `timestampOrderRequiredStack`, pushed alongside the existing `pushTimestampRequiredFlag()` calls in `generateJoins()` for both operands of a timestamp-requiring join (`ASOF` / `LT` / `SPLICE` / `WINDOW` / `HORIZON`), popped in the same `finally`, and cleared in `clear()`. `canMergeUnionAll()` treats that flag plus a forward scan as a timestamp-order request.

Both operands are pushed because an ASOF-family join walks the master in ascending timestamp order too.

## Tests

`MergeUnionAllTest`. All but the last fail on `master` (verified by disabling the new clause: 5 of 6 fail):

- `testLtJoinOverOrderedUnionAllResolvesAllBranches` — the reported shape.
- `testAsofJoinOverUnionAllWithoutOrderByResolvesAllBranches` — **no user-written `ORDER BY` at all**. The requirement comes from the join, so the merge must still be selected. The most dangerous variant: nothing in the SQL hints that ordering matters.
- `testLtJoinOverUnionAllViewResolvesAllBranches` — the union wrapped in a `CREATE VIEW`, as reported from the field.
- `testLtJoinOverThreeBranchUnionAllResolvesAllBranches` — with three branches, only the first resolved.
- `testLtJoinOverUnionAllSelectsMerge` — pins `Union All Merge` in the plan under the join.
- `testInnerJoinOverUnionAllKeepsConcat` — a hash join imposes no ordering requirement, so the cheaper concat must survive. Passes with and without the fix, by design: it guards against over-reach.

Regression: `MergeUnionAllTest`, `SqlOptimiserTest`, `UnionTest`, `UnionAllCastTest`, `UnionCastTest`, `AsOfJoinTest`, `LtJoinTest`, `SpliceJoinLongTest`, `ExplainPlanTest`, `NestedSetOperationTest` — 1145 green. Full `io.questdb.test.griffin.**` sweep — 26,341 tests, 0 failures (4 errors are local port-9000 bind collisions, unrelated).

## Why this is silent rather than an error, and how it relates to #7428

An ordering guard already exists and is bypassed rather than missing. `generateSelect()` rejects an operand whose `getScanDirection()` is not `SCAN_DIRECTION_FORWARD` with `ASC order over TIMESTAMP column is required but not provided`, and `validateBothTimestampOrders()` backs it up inside `generateJoins()`. Both fire correctly for `ORDER BY ts DESC`. Both pass vacuously here, because `RecordCursorFactory.getScanDirection()` **defaults to `SCAN_DIRECTION_FORWARD`** and `UnionAllRecordCursorFactory` does not override it.

That default hides a family of silent wrong answers, not just this one. Also measured wrong on `master` against 10.0.1, and *not* fixed by this PR:

```sql
LT JOIN (SELECT * FROM (a UNION b) TIMESTAMP(ts)) ...              -- second branch resolves 0
LT JOIN (SELECT * FROM (... ORDER BY price, ts) TIMESTAMP(ts)) ... -- 2 of 4 rows resolve
```

**#7428** makes those factories report `SCAN_DIRECTION_OTHER`, which arms the existing guard. Verified on that branch: all of the above — plus a keyed `GROUP BY` operand — now raise `ASC order over TIMESTAMP column is required but not provided` instead of returning wrong rows, while an ascending operand still joins. It is pinned there by `SortTsAscJoinReproTest.testUnorderedTimeSeriesJoinOperandIsRejected`.

The two are complementary and compose cleanly — `MergeUnionAllRecordCursorFactory` is a sibling of `UnionAllRecordCursorFactory` (both extend `AbstractSetRecordCursorFactory`) and reports FORWARD when ascending, so #7428's override does not touch it:

| | `UNION ALL` operand today |
|---|---|
| `master` | silently wrong rows |
| #7428 only | clean error |
| this PR only | correct rows via merge |
| both | correct rows via merge |
